### PR TITLE
fix(web): refresh timeline thumbnail after full editor save

### DIFF
--- a/web/src/lib/managers/edit/edit-manager.spec.ts
+++ b/web/src/lib/managers/edit/edit-manager.spec.ts
@@ -101,7 +101,7 @@ describe('EditManager', () => {
 
     it('should return false and show error toast on failure', async () => {
       const asset = assetFactory.build();
-      vi.mocked(editAsset).mockRejectedValue(new Error('fail'));
+      vi.mocked(removeAssetEdits).mockRejectedValue(new Error('fail'));
 
       editManager.currentAsset = asset;
       const result = await editManager.applyEdits();

--- a/web/src/lib/managers/edit/edit-manager.spec.ts
+++ b/web/src/lib/managers/edit/edit-manager.spec.ts
@@ -1,0 +1,141 @@
+import { EditManager } from '$lib/managers/edit/edit-manager.svelte';
+import { eventManager } from '$lib/managers/event-manager.svelte';
+import { waitForWebsocketEvent } from '$lib/stores/websocket';
+import { getFormatter } from '$lib/utils/i18n';
+import { editAsset, getAssetInfo, removeAssetEdits } from '@immich/sdk';
+import { toastManager } from '@immich/ui';
+import { assetFactory } from '@test-data/factories/asset-factory';
+
+vi.mock('@immich/sdk');
+vi.mock('$lib/stores/websocket');
+vi.mock('$lib/utils/i18n', () => ({
+  getFormatter: vi.fn(),
+}));
+vi.mock('@immich/ui', () => ({
+  toastManager: { success: vi.fn(), danger: vi.fn() },
+  modalManager: { show: vi.fn() },
+  ConfirmModal: {},
+}));
+vi.mock('$lib/managers/event-manager.svelte', () => ({
+  eventManager: { emit: vi.fn(), on: vi.fn() },
+}));
+vi.mock('$lib/managers/edit/transform-manager.svelte', () => ({
+  transformManager: {
+    onActivate: vi.fn(),
+    onDeactivate: vi.fn(),
+    resetAllChanges: vi.fn(),
+    hasChanges: false,
+    canReset: false,
+    edits: [],
+  },
+}));
+vi.mock('$lib/components/asset-viewer/editor/transform-tool/transform-tool.svelte', () => ({
+  default: {},
+}));
+
+describe('EditManager', () => {
+  let editManager: EditManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getFormatter).mockResolvedValue(((key: string) => key) as any);
+    vi.mocked(waitForWebsocketEvent).mockResolvedValue(void 0 as any);
+    editManager = new EditManager();
+  });
+
+  describe('applyEdits', () => {
+    it('should return false if no current asset', async () => {
+      const result = await editManager.applyEdits();
+      expect(result).toBe(false);
+    });
+
+    it('should call editAsset and emit AssetUpdate on success', async () => {
+      const asset = assetFactory.build();
+      const refreshedAsset = assetFactory.build({ id: asset.id, thumbhash: 'new-thumbhash' });
+      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
+
+      editManager.currentAsset = asset;
+      const result = await editManager.applyEdits();
+
+      expect(result).toBe(true);
+      expect(getAssetInfo).toHaveBeenCalledWith({ id: asset.id });
+      expect(eventManager.emit).toHaveBeenCalledWith('AssetUpdate', refreshedAsset);
+      expect(eventManager.emit).toHaveBeenCalledWith('AssetEditsApplied', asset.id);
+      expect(toastManager.success).toHaveBeenCalled();
+    });
+
+    it('should emit AssetUpdate before AssetEditsApplied', async () => {
+      const asset = assetFactory.build();
+      const refreshedAsset = assetFactory.build({ id: asset.id });
+      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
+
+      const emitCalls: string[] = [];
+      vi.mocked(eventManager.emit).mockImplementation((event: string) => {
+        emitCalls.push(event);
+      });
+
+      editManager.currentAsset = asset;
+      await editManager.applyEdits();
+
+      expect(emitCalls).toEqual(['AssetUpdate', 'AssetEditsApplied']);
+    });
+
+    it('should call removeAssetEdits when edits are empty', async () => {
+      const asset = assetFactory.build();
+      const refreshedAsset = assetFactory.build({ id: asset.id });
+      vi.mocked(removeAssetEdits).mockResolvedValue(void 0 as any);
+      vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
+
+      editManager.currentAsset = asset;
+      // tools have empty edits by default from the mock
+      const result = await editManager.applyEdits();
+
+      expect(result).toBe(true);
+      expect(removeAssetEdits).toHaveBeenCalledWith({ id: asset.id });
+      expect(editAsset).not.toHaveBeenCalled();
+    });
+
+    it('should return false and show error toast on failure', async () => {
+      const asset = assetFactory.build();
+      vi.mocked(editAsset).mockRejectedValue(new Error('fail'));
+
+      editManager.currentAsset = asset;
+      const result = await editManager.applyEdits();
+
+      expect(result).toBe(false);
+      expect(toastManager.danger).toHaveBeenCalled();
+      expect(eventManager.emit).not.toHaveBeenCalled();
+    });
+
+    it('should set hasAppliedEdits to true on success', async () => {
+      const asset = assetFactory.build();
+      const refreshedAsset = assetFactory.build({ id: asset.id });
+      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
+
+      editManager.currentAsset = asset;
+      expect(editManager.hasAppliedEdits).toBe(false);
+
+      await editManager.applyEdits();
+      expect(editManager.hasAppliedEdits).toBe(true);
+    });
+
+    it('should set isApplyingEdits during the operation', async () => {
+      const asset = assetFactory.build();
+      const refreshedAsset = assetFactory.build({ id: asset.id });
+      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
+
+      editManager.currentAsset = asset;
+      expect(editManager.isApplyingEdits).toBe(false);
+
+      const promise = editManager.applyEdits();
+      expect(editManager.isApplyingEdits).toBe(true);
+
+      await promise;
+      expect(editManager.isApplyingEdits).toBe(false);
+    });
+  });
+});

--- a/web/src/lib/managers/edit/edit-manager.spec.ts
+++ b/web/src/lib/managers/edit/edit-manager.spec.ts
@@ -5,6 +5,7 @@ import { getFormatter } from '$lib/utils/i18n';
 import { editAsset, getAssetInfo, removeAssetEdits } from '@immich/sdk';
 import { toastManager } from '@immich/ui';
 import { assetFactory } from '@test-data/factories/asset-factory';
+import type { MessageFormatter } from 'svelte-i18n';
 
 vi.mock('@immich/sdk');
 vi.mock('$lib/stores/websocket');
@@ -38,8 +39,8 @@ describe('EditManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getFormatter).mockResolvedValue(((key: string) => key) as any);
-    vi.mocked(waitForWebsocketEvent).mockResolvedValue(void 0 as any);
+    vi.mocked(getFormatter).mockResolvedValue(((key: string) => key) as MessageFormatter);
+    vi.mocked(waitForWebsocketEvent).mockResolvedValue(undefined as never);
     editManager = new EditManager();
   });
 
@@ -52,7 +53,7 @@ describe('EditManager', () => {
     it('should call editAsset and emit AssetUpdate on success', async () => {
       const asset = assetFactory.build();
       const refreshedAsset = assetFactory.build({ id: asset.id, thumbhash: 'new-thumbhash' });
-      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(editAsset).mockResolvedValue(undefined as never);
       vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
 
       editManager.currentAsset = asset;
@@ -68,13 +69,13 @@ describe('EditManager', () => {
     it('should emit AssetUpdate before AssetEditsApplied', async () => {
       const asset = assetFactory.build();
       const refreshedAsset = assetFactory.build({ id: asset.id });
-      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(editAsset).mockResolvedValue(undefined as never);
       vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
 
       const emitCalls: string[] = [];
-      vi.mocked(eventManager.emit).mockImplementation((event: string) => {
+      vi.mocked(eventManager.emit).mockImplementation(((event: string) => {
         emitCalls.push(event);
-      });
+      }) as typeof eventManager.emit);
 
       editManager.currentAsset = asset;
       await editManager.applyEdits();
@@ -85,7 +86,7 @@ describe('EditManager', () => {
     it('should call removeAssetEdits when edits are empty', async () => {
       const asset = assetFactory.build();
       const refreshedAsset = assetFactory.build({ id: asset.id });
-      vi.mocked(removeAssetEdits).mockResolvedValue(void 0 as any);
+      vi.mocked(removeAssetEdits).mockResolvedValue(undefined as never);
       vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
 
       editManager.currentAsset = asset;
@@ -112,7 +113,7 @@ describe('EditManager', () => {
     it('should set hasAppliedEdits to true on success', async () => {
       const asset = assetFactory.build();
       const refreshedAsset = assetFactory.build({ id: asset.id });
-      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(editAsset).mockResolvedValue(undefined as never);
       vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
 
       editManager.currentAsset = asset;
@@ -125,7 +126,7 @@ describe('EditManager', () => {
     it('should set isApplyingEdits during the operation', async () => {
       const asset = assetFactory.build();
       const refreshedAsset = assetFactory.build({ id: asset.id });
-      vi.mocked(editAsset).mockResolvedValue(void 0 as any);
+      vi.mocked(editAsset).mockResolvedValue(undefined as never);
       vi.mocked(getAssetInfo).mockResolvedValue(refreshedAsset);
 
       editManager.currentAsset = asset;

--- a/web/src/lib/managers/edit/edit-manager.spec.ts
+++ b/web/src/lib/managers/edit/edit-manager.spec.ts
@@ -39,7 +39,7 @@ describe('EditManager', () => {
   let editManager: EditManager;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.mocked(getFormatter).mockResolvedValue(((key: string) => key) as MessageFormatter);
     vi.mocked(waitForWebsocketEvent).mockResolvedValue(undefined as never);
     editManager = new EditManager();

--- a/web/src/lib/managers/edit/edit-manager.spec.ts
+++ b/web/src/lib/managers/edit/edit-manager.spec.ts
@@ -11,6 +11,7 @@ vi.mock('@immich/sdk');
 vi.mock('$lib/stores/websocket');
 vi.mock('$lib/utils/i18n', () => ({
   getFormatter: vi.fn(),
+  getPreferredLocale: vi.fn(),
 }));
 vi.mock('@immich/ui', () => ({
   toastManager: { success: vi.fn(), danger: vi.fn() },

--- a/web/src/lib/managers/edit/edit-manager.svelte.ts
+++ b/web/src/lib/managers/edit/edit-manager.svelte.ts
@@ -3,7 +3,7 @@ import { transformManager } from '$lib/managers/edit/transform-manager.svelte';
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import { waitForWebsocketEvent } from '$lib/stores/websocket';
 import { getFormatter } from '$lib/utils/i18n';
-import { editAsset, removeAssetEdits, type AssetEditsCreateDto, type AssetResponseDto } from '@immich/sdk';
+import { editAsset, getAssetInfo, removeAssetEdits, type AssetEditsCreateDto, type AssetResponseDto } from '@immich/sdk';
 import { ConfirmModal, modalManager, toastManager } from '@immich/ui';
 import { mdiCropRotate } from '@mdi/js';
 import type { Component } from 'svelte';
@@ -140,6 +140,8 @@ export class EditManager {
 
       await editCompleted;
 
+      const refreshedAsset = await getAssetInfo({ id: assetId });
+      eventManager.emit('AssetUpdate', refreshedAsset);
       eventManager.emit('AssetEditsApplied', assetId);
 
       toastManager.success(t('editor_edits_applied_success'));

--- a/web/src/lib/managers/edit/edit-manager.svelte.ts
+++ b/web/src/lib/managers/edit/edit-manager.svelte.ts
@@ -3,7 +3,13 @@ import { transformManager } from '$lib/managers/edit/transform-manager.svelte';
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import { waitForWebsocketEvent } from '$lib/stores/websocket';
 import { getFormatter } from '$lib/utils/i18n';
-import { editAsset, getAssetInfo, removeAssetEdits, type AssetEditsCreateDto, type AssetResponseDto } from '@immich/sdk';
+import {
+  editAsset,
+  getAssetInfo,
+  removeAssetEdits,
+  type AssetEditsCreateDto,
+  type AssetResponseDto,
+} from '@immich/sdk';
 import { ConfirmModal, modalManager, toastManager } from '@immich/ui';
 import { mdiCropRotate } from '@mdi/js';
 import type { Component } from 'svelte';


### PR DESCRIPTION
## Summary
- `editManager.applyEdits()` only emitted `AssetEditsApplied` (cache invalidation) but not `AssetUpdate` (timeline refresh)
- When navigating back to the timeline after saving in the editor, `onDestroy` called `assetViewerManager.closeEditor()` directly, bypassing the `closeEditor` callback that fetches the updated asset
- Fix: fetch refreshed asset and emit `AssetUpdate` in `applyEdits()` after the websocket confirms thumbnail generation

## Test plan
- [x] Added unit tests for `applyEdits()` covering success, failure, event ordering, state transitions
- [ ] Manual: open asset viewer → editor → rotate → save → go back to timeline → thumbnail should be updated

## Changes
- `web/src/lib/managers/edit/edit-manager.svelte.ts` — emit `AssetUpdate` after edits applied
- `web/src/lib/managers/edit/edit-manager.spec.ts` — new test file (6 tests)