### PR TITLE
feat(ml): add yolo11s/m model options for pet detection

### DIFF
--- a/docs/plans/POTENTIAL-IMPROVEMENTS.md
+++ b/docs/plans/POTENTIAL-IMPROVEMENTS.md
@@ -2,25 +2,25 @@
 
 Top community feature requests from upstream Immich discussions and issues, ranked by upvotes.
 
-| Votes | Feature                                    | Notes                                                                 |
-| ----- | ------------------------------------------ | --------------------------------------------------------------------- |
-| 828   | Better sharing                             | Phase 1 (Shared Spaces) implemented in this fork. Phases 2-3 planned. |
-| 670   | Private/protected albums                   | Hidden/locked albums (NSFW, sensitive)                                |
-| 636   | Pet detection                              | ML model for cats, dogs, etc.                                         |
-| 479   | Image rotation                             | In-app rotate/crop                                                    |
-| 474   | "Add to Library" from shared links         | Save others' shared photos to your own library                        |
-| 374   | Automatic stacking                         | Auto-group burst shots, RAW+JPG pairs                                 |
-| 319   | OCR search                                 | Search photos by text in them (partially shipped but memory-leaky)    |
-| 275   | Duplicate detection                        | Find and merge duplicates (partially shipped)                         |
-| 273   | Hide albums from timeline                  | Exclude certain albums from main view                                 |
-| 249   | Choose libraries for partner sharing       | Share specific albums, not everything                                 |
-| 249   | Recently added section                     | Show "new uploads" separately                                         |
-| 212   | Folder view                                | Browse by folder structure, not just timeline                         |
-| 210   | Preserve album info from upload            | Keep album names from phone on import                                 |
-| 202   | More storage backends                      | Already implemented in this fork (S3 support)                         |
-| 197   | Auto-create albums from external libraries |                                                                       |
-| 184   | Metadata editor                            | Edit EXIF data in-app                                                 |
-| 184   | Delete from web, sync to mobile            | Two-way delete sync                                                   |
-| 182   | Push notifications for Memories            |                                                                       |
-| 179   | Auto-share albums to matched faces         |                                                                       |
-| 165   | Nested albums                              | Sub-albums / album hierarchy                                          |
+| Votes | Feature                                    | Notes                                                                                                                                   |
+| ----- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| 828   | Better sharing                             | Phase 1 (Shared Spaces) implemented in this fork. Phases 2-3 planned.                                                                   |
+| 670   | Private/protected albums                   | Hidden/locked albums (NSFW, sensitive)                                                                                                  |
+| 636   | Pet detection                              | Implemented (YOLO11 n/s/m). Next: two-stage detect+classify for breed-level labels (ViT on Oxford-IIIT Pets, 37 breeds, 94.6% accuracy) |
+| 479   | Image rotation                             | In-app rotate/crop                                                                                                                      |
+| 474   | "Add to Library" from shared links         | Save others' shared photos to your own library                                                                                          |
+| 374   | Automatic stacking                         | Auto-group burst shots, RAW+JPG pairs                                                                                                   |
+| 319   | OCR search                                 | Search photos by text in them (partially shipped but memory-leaky)                                                                      |
+| 275   | Duplicate detection                        | Find and merge duplicates (partially shipped)                                                                                           |
+| 273   | Hide albums from timeline                  | Exclude certain albums from main view                                                                                                   |
+| 249   | Choose libraries for partner sharing       | Share specific albums, not everything                                                                                                   |
+| 249   | Recently added section                     | Show "new uploads" separately                                                                                                           |
+| 212   | Folder view                                | Browse by folder structure, not just timeline                                                                                           |
+| 210   | Preserve album info from upload            | Keep album names from phone on import                                                                                                   |
+| 202   | More storage backends                      | Already implemented in this fork (S3 support)                                                                                           |
+| 197   | Auto-create albums from external libraries |                                                                                                                                         |
+| 184   | Metadata editor                            | Edit EXIF data in-app                                                                                                                   |
+| 184   | Delete from web, sync to mobile            | Two-way delete sync                                                                                                                     |
+| 182   | Push notifications for Memories            |                                                                                                                                         |
+| 179   | Auto-share albums to matched faces         |                                                                                                                                         |
+| 165   | Nested albums                              | Sub-albums / album hierarchy                                                                                                            |

--- a/machine-learning/immich_ml/models/constants.py
+++ b/machine-learning/immich_ml/models/constants.py
@@ -88,7 +88,7 @@ _PADDLE_MODELS = {
     "TH__PP-OCRv5_mobile",
 }
 
-_YOLO_MODELS = {"yolo11n"}
+_YOLO_MODELS = {"yolo11n", "yolo11s", "yolo11m"}
 
 SUPPORTED_PROVIDERS = [
     "CUDAExecutionProvider",

--- a/machine-learning/immich_ml/models/pet_detection/detection.py
+++ b/machine-learning/immich_ml/models/pet_detection/detection.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import cv2
@@ -36,6 +37,19 @@ class PetDetector(InferenceModel):
     def __init__(self, model_name: str, min_score: float = 0.6, **model_kwargs: Any) -> None:
         self.min_score = model_kwargs.pop("minScore", min_score)
         super().__init__(model_name, **model_kwargs)
+
+    @property
+    def model_path(self) -> Path:
+        # Support both conventions:
+        # 1. Standard: detection/model.onnx (matches base class)
+        # 2. Legacy: <model_name>.onnx at cache root (e.g. yolo11m.onnx)
+        standard = super().model_path
+        if standard.is_file():
+            return standard
+        alt = self.cache_dir / f"{self.model_name}.onnx"
+        if alt.is_file():
+            return alt
+        return standard
 
     def _download(self) -> None:
         from huggingface_hub import snapshot_download

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -280,7 +280,7 @@ export const defaults = Object.freeze<SystemConfig>({
     },
     petDetection: {
       enabled: false,
-      modelName: 'yolo11n',
+      modelName: 'yolo11s',
       minScore: 0.6,
     },
   },

--- a/server/src/repositories/machine-learning.repository.spec.ts
+++ b/server/src/repositories/machine-learning.repository.spec.ts
@@ -48,7 +48,7 @@ describe(MachineLearningRepository.name, () => {
       },
       petDetection: {
         enabled: false,
-        modelName: 'yolo11n',
+        modelName: 'yolo11s',
         minScore: 0.6,
       },
     });

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -115,7 +115,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     },
     petDetection: {
       enabled: false,
-      modelName: 'yolo11n',
+      modelName: 'yolo11s',
       minScore: 0.6,
     },
   },

--- a/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
+++ b/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
@@ -346,7 +346,11 @@
             desc={$t('admin.machine_learning_pet_detection_model_description')}
             name="pet-detection-model"
             bind:value={configToEdit.machineLearning.petDetection.modelName}
-            options={[{ value: 'yolo11n', text: 'yolo11n (fast, recommended)' }]}
+            options={[
+              { value: 'yolo11n', text: 'yolo11n (fast, least accurate)' },
+              { value: 'yolo11s', text: 'yolo11s (balanced, recommended)' },
+              { value: 'yolo11m', text: 'yolo11m (slow, most accurate)' },
+            ]}
             disabled={disabled ||
               !configToEdit.machineLearning.enabled ||
               !configToEdit.machineLearning.petDetection.enabled}


### PR DESCRIPTION
## Summary

- Change default pet detection model from yolo11n to yolo11s (47.0 vs 39.5 mAP, much better accuracy)
- Add yolo11n, yolo11s, yolo11m as selectable options in admin UI dropdown
- Register yolo11s and yolo11m in ML model constants
- Update potential improvements doc with two-stage detect+classify approach notes

## Test plan

- [ ] Verify admin settings shows 3 model options in pet detection dropdown
- [ ] Verify default model is yolo11s for new installations
- [ ] Verify yolo11s model downloads and runs correctly from HuggingFace
- [ ] Run server unit tests (`pnpm test`)
- [ ] Run web unit tests (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)