### PR TITLE
feat(e2e): add integration testing with fast local feedback loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,22 @@ e2e-update:
 e2e-down:
 	docker compose -f ./e2e/docker-compose.yml down --remove-orphans
 
+# Run e2e tests against the already-running dev stack (make dev)
+e2e-web-dev:
+	cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283 PLAYWRIGHT_DISABLE_WEBSERVER=1 pnpm exec playwright test --project=web
+
+e2e-web-dev-ui:
+	cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283 PLAYWRIGHT_DISABLE_WEBSERVER=1 pnpm exec playwright test --ui --project=web
+
+e2e-api-dev:
+	cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283 PLAYWRIGHT_DISABLE_WEBSERVER=1 pnpm test
+
+e2e-integration-dev:
+	cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283 PLAYWRIGHT_DISABLE_WEBSERVER=1 pnpm exec playwright test --project=integration
+
+e2e-integration-dev-ui:
+	cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283 PLAYWRIGHT_DISABLE_WEBSERVER=1 pnpm exec playwright test --ui --project=integration
+
 prod:
 	@trap 'make prod-down' EXIT; COMPOSE_BAKE=true docker compose -f ./docker/docker-compose.prod.yml up --build -V --remove-orphans
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,6 +14,8 @@
     "start:web": "pnpm exec playwright test --ui --project=web",
     "start:web:maintenance": "pnpm exec playwright test --ui --project=maintenance",
     "start:web:ui": "pnpm exec playwright test --ui --project=ui",
+    "start:integration": "pnpm exec playwright test --ui --project=integration",
+    "test:integration": "pnpm exec playwright test --project=integration",
     "format": "prettier --cache --check .",
     "format:fix": "prettier --cache --write --list-different .",
     "lint": "eslint \"src/**/*.ts\" --max-warnings 0",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 4 : 0,
-  reporter: 'html',
+  reporter: process.env.CI ? [['html'], ['github']] : 'html',
   use: {
     baseURL: playwriteBaseUrl,
     trace: 'on-first-retry',
@@ -44,6 +44,12 @@ const config: PlaywrightTestConfig = {
       testDir: './src/ui/specs',
       fullyParallel: true,
       workers: process.env.CI ? 3 : Math.max(1, Math.round(cpus().length * 0.75) - 1),
+    },
+    {
+      name: 'integration',
+      use: { ...devices['Desktop Chrome'] },
+      testDir: './src/specs/integration',
+      workers: 1,
     },
     {
       name: 'maintenance',

--- a/e2e/src/specs/integration/album-management.e2e-spec.ts
+++ b/e2e/src/specs/integration/album-management.e2e-spec.ts
@@ -1,0 +1,87 @@
+import { LoginResponseDto, createAlbum } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import type { Socket } from 'socket.io-client';
+import { asBearerAuth, utils } from 'src/utils';
+
+test.describe('Album Management Integration', () => {
+  let admin: LoginResponseDto;
+  let websocket: Socket;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+    websocket = await utils.connectWebsocket(admin.accessToken);
+  });
+
+  test.afterAll(() => {
+    utils.disconnectWebsocket(websocket);
+  });
+
+  test('create album and verify it appears in albums list', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+
+    await page.goto('/albums');
+    await page.getByRole('button', { name: 'Create album' }).click();
+
+    // Should navigate to the new album page
+    await expect(page).toHaveURL(/\/albums\//);
+    await page.getByRole('button', { name: 'Select photos' }).waitFor();
+
+    // Go back to albums list and verify it exists
+    await page.goto('/albums');
+    await page.getByText('Untitled').waitFor();
+  });
+
+  test('add asset to album and verify it appears', async ({ context, page }) => {
+    const asset = await utils.createAsset(admin.accessToken);
+    await utils.waitForWebsocketEvent({ event: 'assetUpload', id: asset.id });
+
+    const album = await createAlbum(
+      { createAlbumDto: { albumName: 'Integration Test Album', assetIds: [asset.id] } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(`/albums/${album.id}`);
+
+    await page.getByRole('heading', { name: 'Integration Test Album' }).waitFor();
+    await page.locator(`[data-asset-id="${asset.id}"]`).waitFor();
+    await expect(page.locator(`[data-asset-id="${asset.id}"]`)).toBeVisible();
+  });
+
+  test('rename album via UI and verify persistence', async ({ context, page }) => {
+    const album = await createAlbum(
+      { createAlbumDto: { albumName: 'Original Name' } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(`/albums/${album.id}`);
+
+    // Click album title to edit
+    await page.getByRole('heading', { name: 'Original Name' }).click();
+    const titleInput = page.getByRole('textbox');
+    await titleInput.clear();
+    await titleInput.fill('Renamed Album');
+    await titleInput.press('Enter');
+
+    // Reload and verify the name persisted
+    await page.reload();
+    await page.getByRole('heading', { name: 'Renamed Album' }).waitFor();
+  });
+
+  test('album is accessible from albums page after creation via API', async ({ context, page }) => {
+    const album = await createAlbum(
+      { createAlbumDto: { albumName: 'API Created Album' } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/albums');
+
+    await page.getByText('API Created Album').waitFor();
+    await page.getByText('API Created Album').click();
+    await expect(page).toHaveURL(`/albums/${album.id}`);
+  });
+});

--- a/e2e/src/specs/integration/asset-upload.e2e-spec.ts
+++ b/e2e/src/specs/integration/asset-upload.e2e-spec.ts
@@ -1,0 +1,65 @@
+import { LoginResponseDto } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import type { Socket } from 'socket.io-client';
+import { utils } from 'src/utils';
+
+test.describe('Asset Upload Integration', () => {
+  let admin: LoginResponseDto;
+  let websocket: Socket;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+    websocket = await utils.connectWebsocket(admin.accessToken);
+  });
+
+  test.afterAll(() => {
+    utils.disconnectWebsocket(websocket);
+  });
+
+  test('uploaded asset appears in timeline', async ({ context, page }) => {
+    const asset = await utils.createAsset(admin.accessToken);
+    await utils.waitForWebsocketEvent({ event: 'assetUpload', id: asset.id });
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+
+    await page.locator(`[data-asset-id="${asset.id}"]`).waitFor();
+    await expect(page.locator(`[data-asset-id="${asset.id}"]`)).toBeVisible();
+  });
+
+  test('asset detail view shows metadata', async ({ context, page }) => {
+    const asset = await utils.createAsset(admin.accessToken);
+    await utils.waitForWebsocketEvent({ event: 'assetUpload', id: asset.id });
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(`/photos/${asset.id}`);
+    await page.waitForSelector('#immich-asset-viewer');
+
+    await page.getByRole('button', { name: 'Info' }).click();
+    await expect(page.locator('#detail-panel')).toBeVisible();
+  });
+
+  test('asset can be deleted and disappears from timeline', async ({ context, page }) => {
+    const asset = await utils.createAsset(admin.accessToken);
+    await utils.waitForWebsocketEvent({ event: 'assetUpload', id: asset.id });
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+
+    await page.locator(`[data-asset-id="${asset.id}"]`).waitFor();
+
+    // Select and delete
+    await page.locator(`[data-asset-id="${asset.id}"]`).hover();
+    await page.waitForSelector(`[data-asset-id="${asset.id}"] [role="checkbox"]`);
+    await page.locator(`[data-asset-id="${asset.id}"] [role="checkbox"]`).click();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'Trash' }).click();
+
+    await utils.waitForWebsocketEvent({ event: 'assetDelete', id: asset.id });
+
+    // Asset should no longer be in timeline
+    await expect(page.locator(`[data-asset-id="${asset.id}"]`)).toHaveCount(0);
+  });
+});

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -16,10 +16,14 @@ import {
   QueueName,
   QueuesResponseLegacyDto,
   SharedLinkCreateDto,
+  SharedSpaceCreateDto,
+  SharedSpaceMemberCreateDto,
   UpdateLibraryDto,
   UserAdminCreateDto,
   UserPreferencesUpdateDto,
   ValidateLibraryDto,
+  addAssets as addSpaceAssets,
+  addMember as addSpaceMember,
   checkExistingAssets,
   createAlbum,
   createApiKey,
@@ -28,6 +32,7 @@ import {
   createPartner,
   createPerson,
   createSharedLink,
+  createSpace,
   createStack,
   createUserAdmin,
   deleteAssets,
@@ -323,6 +328,15 @@ export const utils = {
 
   updateAlbumUser: (accessToken: string, args: Parameters<typeof updateAlbumUser>[0]) =>
     updateAlbumUser(args, { headers: asBearerAuth(accessToken) }),
+
+  createSpace: (accessToken: string, dto: SharedSpaceCreateDto) =>
+    createSpace({ sharedSpaceCreateDto: dto }, { headers: asBearerAuth(accessToken) }),
+
+  addSpaceMember: (accessToken: string, spaceId: string, dto: SharedSpaceMemberCreateDto) =>
+    addSpaceMember({ id: spaceId, sharedSpaceMemberCreateDto: dto }, { headers: asBearerAuth(accessToken) }),
+
+  addSpaceAssets: (accessToken: string, spaceId: string, assetIds: string[]) =>
+    addSpaceAssets({ id: spaceId, sharedSpaceAssetAddDto: { assetIds } }, { headers: asBearerAuth(accessToken) }),
 
   createAsset: async (
     accessToken: string,


### PR DESCRIPTION
## Summary

- Add Makefile targets for running e2e tests against the local dev stack (`make dev`), eliminating Docker image rebuilds for each test run
- Add integration tests for asset upload/delete and album management that validate FE/BE contracts through the browser
- Add shared space utility helpers to e2e utils for future test use
- Add CI `github` reporter to Playwright for better annotation visibility

## Changes

**Makefile**: 5 new targets (`e2e-web-dev`, `e2e-web-dev-ui`, `e2e-api-dev`, `e2e-integration-dev`, `e2e-integration-dev-ui`)

**Integration tests** (`e2e/src/specs/integration/`):
- `asset-upload.e2e-spec.ts` — upload → timeline visibility, metadata panel, delete flow
- `album-management.e2e-spec.ts` — create via UI, add asset, rename with persistence, API-created album visibility

**Workflow**: Terminal 1 runs `make dev`, Terminal 2 runs `make e2e-integration-dev`

## Test plan

- [ ] `make e2e-integration-dev` runs successfully against local dev stack
- [ ] CI e2e tests pass (no regressions to existing tests)