### PR TITLE
feat: spaces P0 visual identity — colors, stat chips, role badges

### DIFF
--- a/docs/plans/2026-03-09-spaces-design-improvements.md
+++ b/docs/plans/2026-03-09-spaces-design-improvements.md
@@ -1,0 +1,295 @@
+# Shared Spaces — Design Analysis & Improvement Proposals
+
+## Current State Assessment
+
+### What exists today
+
+The Spaces UI is **functional but derivative** — it closely mirrors the Albums pattern with nearly identical card layouts, similar detail pages, and the same interaction patterns. The result feels like "albums with members" rather than a distinct collaborative experience.
+
+| Component | Current State | Issue |
+|-----------|---------------|-------|
+| **Space Cards** | Single thumbnail + name + stats | Identical to album cards; only difference is member avatars |
+| **Detail Page** | Flat icon button row, plain text stats | No visual hierarchy distinguishing spaces from albums |
+| **Members Modal** | Basic list with role dropdowns | Utilitarian/admin-like, not collaborative |
+| **Empty State** | Text + button | No personality, no guidance |
+| **Search** | Plain input, flat grid results | Minimal, no context |
+| **Create Flow** | Name + description modal | No visual identity setup |
+
+### What's missing
+
+- **No visual identity per space** — spaces are indistinguishable at a glance (no color, icon, or visual marker)
+- **No sense of life** — no activity indicators, no "who added what", no recency signals
+- **No collaborative feel** — members are managed in an admin panel, not surfaced as participants
+- **No emotional connection** — spaces for family, trips, projects all look the same
+
+---
+
+## Proposal 1: Space Cards — "Living Tiles"
+
+**Problem:** Cards look like album cards. Nothing communicates "this is a shared, active space."
+
+**Direction:** Make cards feel alive — show activity, show people, show variety.
+
+### Ideas
+
+#### A. Multi-image collage thumbnail
+Instead of a single cover photo, show a **2-4 image mosaic** of the most recent photos. This immediately communicates "collection with activity" vs. "static album."
+
+```
+┌──────────────────┐     ┌──────────────────┐
+│                  │     │  ┌─────┬────────┐ │
+│                  │     │  │     │        │ │
+│   Single Image   │     │  │ img │  img   │ │
+│   (current)      │  →  │  ├─────┴────────┤ │
+│                  │     │  │     │        │ │
+│                  │     │  │ img │  img   │ │
+└──────────────────┘     │  └─────┴────────┘ │
+                         └──────────────────┘
+```
+
+Layouts could vary by asset count:
+- 1 photo → single image (as today)
+- 2-3 photos → asymmetric split (one large, others small)
+- 4+ photos → 2x2 grid with rounded corners and small gaps
+
+#### B. Activity recency badge
+A small "2 new" badge or a subtle glow/ring when new photos have been added since the user last viewed the space.
+
+#### C. Last active member
+Below the space name, show "Pierre added 3 photos • 2h ago" instead of static counts. Makes the card feel like a conversation, not a filing cabinet.
+
+#### D. Member strip with contribution hints
+Instead of just overlapping avatars, show a thin colored bar under each avatar indicating their contribution ratio — who has added the most photos.
+
+---
+
+## Proposal 2: Space Detail — Hero Section
+
+**Problem:** The detail page opens with a small title, flat icon row, and plain text stats. It's utilitarian and forgettable.
+
+**Direction:** Create a strong first impression with a hero section that communicates the space's identity.
+
+### Ideas
+
+#### A. Cover hero with overlay
+When a cover photo is set, display it as a wide hero banner (200-300px) with a gradient overlay fading to the background color. Space name, description, and stats are overlaid.
+
+```
+┌──────────────────────────────────────────────┐
+│                                              │
+│          [Cover Photo — full width]          │
+│                                              │
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │
+│  ░ Family Trip to Japan                   ░  │
+│  ░ 342 photos · 5 members · Jan 2026     ░  │
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │
+├──────────────────────────────────────────────┤
+│  [Search] [Add Photos] [Members] [Map] [···] │
+│                                              │
+│  ── Timeline ──                              │
+```
+
+#### B. Stat chips instead of plain text
+Replace "342 photos · 5 members" with small rounded badges/chips with icons:
+
+```
+[📷 342 photos]  [👥 5 members]  [📍 12 locations]  [📅 Jan 2-15, 2026]
+```
+
+Each chip could be interactive — clicking "locations" opens the map, clicking "members" opens the members panel.
+
+#### C. Inline editable title
+Click the space name to edit it directly (like Notion). Saves on blur. Removes the need for a separate edit flow.
+
+#### D. Collapsible description
+Show first 2 lines of description with "Show more" expansion. Prevents long descriptions from pushing the timeline down.
+
+---
+
+## Proposal 3: Members Panel — From Admin to Social
+
+**Problem:** The members modal is a basic CRUD list. It doesn't encourage collaboration or show member activity.
+
+**Direction:** Make members feel like participants, not database rows.
+
+### Ideas
+
+#### A. Member contribution cards
+Instead of a flat list, show each member as a small card with:
+- Their avatar (larger)
+- Their name and role badge (colored pill: Owner / Editor / Viewer)
+- "Added 47 photos" — their contribution count
+- Their most recent photo (small thumbnail)
+
+```
+┌─────────────────────────────────────┐
+│  [Avatar]  Pierre (Owner)          │
+│            Added 127 photos         │
+│            Last active: 2h ago      │
+│            [🖼 recent thumb]        │
+├─────────────────────────────────────┤
+│  [Avatar]  Marie (Editor)          │
+│            Added 89 photos          │
+│            Last active: 1d ago      │
+└─────────────────────────────────────┘
+```
+
+#### B. Slide-out panel instead of modal
+Replace the modal with a slide-out panel from the right edge. This allows the user to see the space content while managing members, and feels less like an admin action.
+
+#### C. Invite link generation
+Add a "Copy invite link" button alongside user search. Simpler for sharing with people who may not have accounts yet.
+
+#### D. Role badges with visual distinction
+Use colored pills instead of plain dropdowns to show roles:
+- **Owner** — filled primary color
+- **Editor** — outlined primary
+- **Viewer** — subtle gray
+
+---
+
+## Proposal 4: Space Identity System
+
+**Problem:** All spaces look identical. Users can't distinguish "Family" from "Work Trip" at a glance.
+
+**Direction:** Let users give each space a visual identity.
+
+### Ideas
+
+#### A. Space colors
+Let users pick from a curated palette (8-12 colors). The color tints:
+- Card border/background on the list page
+- Hero gradient overlay on the detail page
+- Member avatar ring color
+- Notification badges
+
+#### B. Space emoji/icon
+Optional emoji or icon picker. Shown on the card and in the sidebar. Helps with instant recognition.
+
+```
+┌──────────────────┐    ┌──────────────────┐
+│  🏔️              │    │  👨‍👩‍👧‍👦             │
+│  [photo collage] │    │  [photo collage] │
+│  Alps Hiking     │    │  Family 2026     │
+│  12 photos · 3   │    │  342 photos · 5  │
+└──────────────────┘    └──────────────────┘
+```
+
+#### C. Auto-generated gradient fallback
+When no cover photo is set, instead of the gray placeholder icon, generate a **gradient background** from the space's name (deterministic hash → gradient stops). Every space gets a unique, attractive placeholder.
+
+---
+
+## Proposal 5: Activity & Collaboration Features
+
+**Problem:** Spaces feel static. There's no indication of what's happening.
+
+**Direction:** Surface activity to create a sense of shared experience.
+
+### Ideas
+
+#### A. Activity feed (lightweight)
+A small collapsible section at the top of the space detail page:
+
+```
+Recent Activity
+├─ Pierre added 12 photos                    2h ago
+├─ Marie set a new cover photo               yesterday
+├─ Alex joined the space                     3 days ago
+└─ Show more...
+```
+
+This doesn't require new server APIs immediately — it could be derived from existing audit/event data or added incrementally.
+
+#### B. "New since last visit" marker
+When opening a space, show a subtle divider in the timeline: "── 8 new photos since your last visit ──". Helps users catch up on what's been added by others.
+
+#### C. Contribution heatmap on members
+Show a tiny activity sparkline next to each member — visualizing when they were most active in the space.
+
+---
+
+## Proposal 6: Empty State & Onboarding
+
+**Problem:** Empty spaces show minimal text and a button. New users don't understand the value proposition.
+
+**Direction:** Guide users and make empty states feel intentional.
+
+### Ideas
+
+#### A. Illustrated empty state
+A custom illustration or icon composition that conveys "shared photo space." Different from the generic album empty state.
+
+#### B. Quick-start steps
+```
+┌──────────────────────────────────────────┐
+│                                          │
+│        🖼️ Get started with your space    │
+│                                          │
+│   1. [Add Photos] from your timeline     │
+│   2. [Invite Members] to collaborate     │
+│   3. [Set a Cover] to personalize        │
+│                                          │
+└──────────────────────────────────────────┘
+```
+
+Each step is a clickable action that triggers the relevant flow.
+
+#### C. Drag & drop zone
+Show a visual drop zone border (dashed) that lets users drag photos directly from their file system.
+
+---
+
+## Proposal 7: Space List Page Enhancements
+
+**Problem:** The list page is a flat grid with no filtering, sorting, or organization.
+
+### Ideas
+
+#### A. Sort & filter controls
+Add a toolbar with:
+- Sort by: Recent activity / Name / Date created / Member count
+- Filter by: My spaces / Spaces I'm in / All
+
+#### B. List/grid toggle
+Allow switching between the card grid and a compact table view (like albums have).
+
+#### C. Pinned spaces
+Let users pin their most-used spaces to the top of the list. Pin icon on hover.
+
+#### D. Section grouping
+Auto-group by "My Spaces" and "Shared with Me" with collapsible headers.
+
+---
+
+## Implementation Priority
+
+Ranked by **impact / effort** ratio:
+
+| Priority | Proposal | Effort | Impact |
+|----------|----------|--------|--------|
+| **P0** | Auto-generated gradient placeholders (4C) | Low | High — instant visual improvement |
+| **P0** | Stat chips with icons (2B) | Low | Medium — better information hierarchy |
+| **P0** | Role badges with visual distinction (3D) | Low | Medium — clearer member roles |
+| **P1** | Multi-image collage cards (1A) | Medium | High — distinctive from albums |
+| **P1** | Cover hero section (2A) | Medium | High — strong first impression |
+| **P1** | Sort & filter controls (7A) | Medium | Medium — usability improvement |
+| **P1** | Space colors (4A) | Medium | High — personal identity |
+| **P2** | Activity recency badge (1B) | Medium | Medium — sense of life |
+| **P2** | Member contribution cards (3A) | Medium | Medium — collaborative feel |
+| **P2** | Slide-out members panel (3B) | Medium | Medium — better UX pattern |
+| **P2** | Empty state onboarding (6B) | Low | Medium — better first experience |
+| **P3** | Space emoji/icon (4B) | Low | Low-Medium — nice-to-have identity |
+| **P3** | Activity feed (5A) | High | High — requires server changes |
+| **P3** | "New since last visit" marker (5B) | High | Medium — requires tracking |
+| **P3** | Contribution heatmap (5C) | High | Low — nice-to-have visualization |
+
+---
+
+## Design Principles
+
+1. **Spaces ≠ Albums** — every design choice should widen the gap between these features
+2. **People first** — spaces are about collaboration; members should be prominent, not hidden in a modal
+3. **Activity over static** — show what's happening, not just what exists
+4. **Identity matters** — each space should be visually recognizable at a glance
+5. **Progressive disclosure** — start simple, reveal complexity on demand

--- a/docs/plans/2026-03-09-spaces-design-improvements.md
+++ b/docs/plans/2026-03-09-spaces-design-improvements.md
@@ -6,14 +6,14 @@
 
 The Spaces UI is **functional but derivative** — it closely mirrors the Albums pattern with nearly identical card layouts, similar detail pages, and the same interaction patterns. The result feels like "albums with members" rather than a distinct collaborative experience.
 
-| Component | Current State | Issue |
-|-----------|---------------|-------|
-| **Space Cards** | Single thumbnail + name + stats | Identical to album cards; only difference is member avatars |
-| **Detail Page** | Flat icon button row, plain text stats | No visual hierarchy distinguishing spaces from albums |
-| **Members Modal** | Basic list with role dropdowns | Utilitarian/admin-like, not collaborative |
-| **Empty State** | Text + button | No personality, no guidance |
-| **Search** | Plain input, flat grid results | Minimal, no context |
-| **Create Flow** | Name + description modal | No visual identity setup |
+| Component         | Current State                          | Issue                                                       |
+| ----------------- | -------------------------------------- | ----------------------------------------------------------- |
+| **Space Cards**   | Single thumbnail + name + stats        | Identical to album cards; only difference is member avatars |
+| **Detail Page**   | Flat icon button row, plain text stats | No visual hierarchy distinguishing spaces from albums       |
+| **Members Modal** | Basic list with role dropdowns         | Utilitarian/admin-like, not collaborative                   |
+| **Empty State**   | Text + button                          | No personality, no guidance                                 |
+| **Search**        | Plain input, flat grid results         | Minimal, no context                                         |
+| **Create Flow**   | Name + description modal               | No visual identity setup                                    |
 
 ### What's missing
 
@@ -33,6 +33,7 @@ The Spaces UI is **functional but derivative** — it closely mirrors the Albums
 ### Ideas
 
 #### A. Multi-image collage thumbnail
+
 Instead of a single cover photo, show a **2-4 image mosaic** of the most recent photos. This immediately communicates "collection with activity" vs. "static album."
 
 ```
@@ -48,17 +49,21 @@ Instead of a single cover photo, show a **2-4 image mosaic** of the most recent 
 ```
 
 Layouts could vary by asset count:
+
 - 1 photo → single image (as today)
 - 2-3 photos → asymmetric split (one large, others small)
 - 4+ photos → 2x2 grid with rounded corners and small gaps
 
 #### B. Activity recency badge
+
 A small "2 new" badge or a subtle glow/ring when new photos have been added since the user last viewed the space.
 
 #### C. Last active member
+
 Below the space name, show "Pierre added 3 photos • 2h ago" instead of static counts. Makes the card feel like a conversation, not a filing cabinet.
 
 #### D. Member strip with contribution hints
+
 Instead of just overlapping avatars, show a thin colored bar under each avatar indicating their contribution ratio — who has added the most photos.
 
 ---
@@ -72,6 +77,7 @@ Instead of just overlapping avatars, show a thin colored bar under each avatar i
 ### Ideas
 
 #### A. Cover hero with overlay
+
 When a cover photo is set, display it as a wide hero banner (200-300px) with a gradient overlay fading to the background color. Space name, description, and stats are overlaid.
 
 ```
@@ -90,6 +96,7 @@ When a cover photo is set, display it as a wide hero banner (200-300px) with a g
 ```
 
 #### B. Stat chips instead of plain text
+
 Replace "342 photos · 5 members" with small rounded badges/chips with icons:
 
 ```
@@ -99,9 +106,11 @@ Replace "342 photos · 5 members" with small rounded badges/chips with icons:
 Each chip could be interactive — clicking "locations" opens the map, clicking "members" opens the members panel.
 
 #### C. Inline editable title
+
 Click the space name to edit it directly (like Notion). Saves on blur. Removes the need for a separate edit flow.
 
 #### D. Collapsible description
+
 Show first 2 lines of description with "Show more" expansion. Prevents long descriptions from pushing the timeline down.
 
 ---
@@ -115,7 +124,9 @@ Show first 2 lines of description with "Show more" expansion. Prevents long desc
 ### Ideas
 
 #### A. Member contribution cards
+
 Instead of a flat list, show each member as a small card with:
+
 - Their avatar (larger)
 - Their name and role badge (colored pill: Owner / Editor / Viewer)
 - "Added 47 photos" — their contribution count
@@ -135,13 +146,17 @@ Instead of a flat list, show each member as a small card with:
 ```
 
 #### B. Slide-out panel instead of modal
+
 Replace the modal with a slide-out panel from the right edge. This allows the user to see the space content while managing members, and feels less like an admin action.
 
 #### C. Invite link generation
+
 Add a "Copy invite link" button alongside user search. Simpler for sharing with people who may not have accounts yet.
 
 #### D. Role badges with visual distinction
+
 Use colored pills instead of plain dropdowns to show roles:
+
 - **Owner** — filled primary color
 - **Editor** — outlined primary
 - **Viewer** — subtle gray
@@ -157,13 +172,16 @@ Use colored pills instead of plain dropdowns to show roles:
 ### Ideas
 
 #### A. Space colors
+
 Let users pick from a curated palette (8-12 colors). The color tints:
+
 - Card border/background on the list page
 - Hero gradient overlay on the detail page
 - Member avatar ring color
 - Notification badges
 
 #### B. Space emoji/icon
+
 Optional emoji or icon picker. Shown on the card and in the sidebar. Helps with instant recognition.
 
 ```
@@ -176,6 +194,7 @@ Optional emoji or icon picker. Shown on the card and in the sidebar. Helps with 
 ```
 
 #### C. Auto-generated gradient fallback
+
 When no cover photo is set, instead of the gray placeholder icon, generate a **gradient background** from the space's name (deterministic hash → gradient stops). Every space gets a unique, attractive placeholder.
 
 ---
@@ -189,6 +208,7 @@ When no cover photo is set, instead of the gray placeholder icon, generate a **g
 ### Ideas
 
 #### A. Activity feed (lightweight)
+
 A small collapsible section at the top of the space detail page:
 
 ```
@@ -202,9 +222,11 @@ Recent Activity
 This doesn't require new server APIs immediately — it could be derived from existing audit/event data or added incrementally.
 
 #### B. "New since last visit" marker
+
 When opening a space, show a subtle divider in the timeline: "── 8 new photos since your last visit ──". Helps users catch up on what's been added by others.
 
 #### C. Contribution heatmap on members
+
 Show a tiny activity sparkline next to each member — visualizing when they were most active in the space.
 
 ---
@@ -218,9 +240,11 @@ Show a tiny activity sparkline next to each member — visualizing when they wer
 ### Ideas
 
 #### A. Illustrated empty state
+
 A custom illustration or icon composition that conveys "shared photo space." Different from the generic album empty state.
 
 #### B. Quick-start steps
+
 ```
 ┌──────────────────────────────────────────┐
 │                                          │
@@ -236,6 +260,7 @@ A custom illustration or icon composition that conveys "shared photo space." Dif
 Each step is a clickable action that triggers the relevant flow.
 
 #### C. Drag & drop zone
+
 Show a visual drop zone border (dashed) that lets users drag photos directly from their file system.
 
 ---
@@ -247,17 +272,22 @@ Show a visual drop zone border (dashed) that lets users drag photos directly fro
 ### Ideas
 
 #### A. Sort & filter controls
+
 Add a toolbar with:
+
 - Sort by: Recent activity / Name / Date created / Member count
 - Filter by: My spaces / Spaces I'm in / All
 
 #### B. List/grid toggle
+
 Allow switching between the card grid and a compact table view (like albums have).
 
 #### C. Pinned spaces
+
 Let users pin their most-used spaces to the top of the list. Pin icon on hover.
 
 #### D. Section grouping
+
 Auto-group by "My Spaces" and "Shared with Me" with collapsible headers.
 
 ---
@@ -266,23 +296,23 @@ Auto-group by "My Spaces" and "Shared with Me" with collapsible headers.
 
 Ranked by **impact / effort** ratio:
 
-| Priority | Proposal | Effort | Impact |
-|----------|----------|--------|--------|
-| **P0** | Auto-generated gradient placeholders (4C) | Low | High — instant visual improvement |
-| **P0** | Stat chips with icons (2B) | Low | Medium — better information hierarchy |
-| **P0** | Role badges with visual distinction (3D) | Low | Medium — clearer member roles |
-| **P1** | Multi-image collage cards (1A) | Medium | High — distinctive from albums |
-| **P1** | Cover hero section (2A) | Medium | High — strong first impression |
-| **P1** | Sort & filter controls (7A) | Medium | Medium — usability improvement |
-| **P1** | Space colors (4A) | Medium | High — personal identity |
-| **P2** | Activity recency badge (1B) | Medium | Medium — sense of life |
-| **P2** | Member contribution cards (3A) | Medium | Medium — collaborative feel |
-| **P2** | Slide-out members panel (3B) | Medium | Medium — better UX pattern |
-| **P2** | Empty state onboarding (6B) | Low | Medium — better first experience |
-| **P3** | Space emoji/icon (4B) | Low | Low-Medium — nice-to-have identity |
-| **P3** | Activity feed (5A) | High | High — requires server changes |
-| **P3** | "New since last visit" marker (5B) | High | Medium — requires tracking |
-| **P3** | Contribution heatmap (5C) | High | Low — nice-to-have visualization |
+| Priority | Proposal                                  | Effort | Impact                                |
+| -------- | ----------------------------------------- | ------ | ------------------------------------- |
+| **P0**   | Auto-generated gradient placeholders (4C) | Low    | High — instant visual improvement     |
+| **P0**   | Stat chips with icons (2B)                | Low    | Medium — better information hierarchy |
+| **P0**   | Role badges with visual distinction (3D)  | Low    | Medium — clearer member roles         |
+| **P1**   | Multi-image collage cards (1A)            | Medium | High — distinctive from albums        |
+| **P1**   | Cover hero section (2A)                   | Medium | High — strong first impression        |
+| **P1**   | Sort & filter controls (7A)               | Medium | Medium — usability improvement        |
+| **P1**   | Space colors (4A)                         | Medium | High — personal identity              |
+| **P2**   | Activity recency badge (1B)               | Medium | Medium — sense of life                |
+| **P2**   | Member contribution cards (3A)            | Medium | Medium — collaborative feel           |
+| **P2**   | Slide-out members panel (3B)              | Medium | Medium — better UX pattern            |
+| **P2**   | Empty state onboarding (6B)               | Low    | Medium — better first experience      |
+| **P3**   | Space emoji/icon (4B)                     | Low    | Low-Medium — nice-to-have identity    |
+| **P3**   | Activity feed (5A)                        | High   | High — requires server changes        |
+| **P3**   | "New since last visit" marker (5B)        | High   | Medium — requires tracking            |
+| **P3**   | Contribution heatmap (5C)                 | High   | Low — nice-to-have visualization      |
 
 ---
 

--- a/docs/plans/2026-03-09-spaces-p0-visual-identity-design.md
+++ b/docs/plans/2026-03-09-spaces-p0-visual-identity-design.md
@@ -33,6 +33,7 @@ Space detail page (`[spaceId]/+page.svelte`), replacing the current plain text s
 ### Rendering
 
 A horizontal `flex gap-2` row of pill-shaped badges. Each chip:
+
 - Small MDI icon (16px) on the left
 - Text label on the right
 - `rounded-full` shape, `bg-gray-100 dark:bg-gray-800`, `text-sm`, `px-3 py-1`
@@ -62,16 +63,16 @@ Add a small role badge below the stat chips row in `[spaceId]/+page.svelte`, sho
 
 ## Files Touched
 
-| Change | Files |
-|--------|-------|
-| Add `color` column | `server/src/schema/tables/`, new migration |
-| Update DTOs | `server/src/dtos/shared-space.dto.ts` |
-| Regenerate clients | `make open-api` |
-| Color picker in create modal | `web/src/lib/modals/SpaceCreateModal.svelte` |
-| Gradient placeholder | `web/src/lib/components/spaces/space-card.svelte` |
-| Stat chips | `web/src/routes/(user)/spaces/[spaceId]/.../+page.svelte` |
-| Role badges in modal | `web/src/lib/modals/SpaceMembersModal.svelte` |
-| Role badge in header | `web/src/routes/(user)/spaces/[spaceId]/.../+page.svelte` |
+| Change                       | Files                                                     |
+| ---------------------------- | --------------------------------------------------------- |
+| Add `color` column           | `server/src/schema/tables/`, new migration                |
+| Update DTOs                  | `server/src/dtos/shared-space.dto.ts`                     |
+| Regenerate clients           | `make open-api`                                           |
+| Color picker in create modal | `web/src/lib/modals/SpaceCreateModal.svelte`              |
+| Gradient placeholder         | `web/src/lib/components/spaces/space-card.svelte`         |
+| Stat chips                   | `web/src/routes/(user)/spaces/[spaceId]/.../+page.svelte` |
+| Role badges in modal         | `web/src/lib/modals/SpaceMembersModal.svelte`             |
+| Role badge in header         | `web/src/routes/(user)/spaces/[spaceId]/.../+page.svelte` |
 
 ## Out of Scope
 

--- a/docs/plans/2026-03-09-spaces-p0-visual-identity-design.md
+++ b/docs/plans/2026-03-09-spaces-p0-visual-identity-design.md
@@ -1,0 +1,81 @@
+# Spaces P0: Visual Identity & Information Hierarchy
+
+## Overview
+
+Three quick-win improvements to make Shared Spaces visually distinct from Albums and improve information hierarchy: space colors with gradient placeholders, stat chips, and role badges.
+
+## 1. Space Color System
+
+### Schema
+
+Add a `color` column to the `shared_spaces` table using the existing `UserAvatarColor` enum values: primary, pink, red, yellow, blue, green, purple, orange, gray, amber. Nullable, defaults to `primary`.
+
+### DTOs
+
+- `SharedSpaceCreateDto` — add optional `color: UserAvatarColor`
+- `SharedSpaceUpdateDto` — add optional `color: UserAvatarColor`
+- `SharedSpaceResponseDto` — add `color: UserAvatarColor`
+
+### Create modal
+
+Add a horizontal row of 10 color swatches below the description field in `SpaceCreateModal.svelte`. Each swatch is a small filled circle (~24px). Clicking selects it (checkmark overlay or ring). Defaults to `primary` pre-selected.
+
+### Gradient placeholder
+
+When a space has no cover photo (`thumbnailAssetId` is null), render a two-tone gradient using the space's color as the base instead of the current gray box with icon. For example, `blue` produces a gradient from `blue-400` to `blue-700`. Applied in `space-card.svelte` replacing the existing empty state `<div>`.
+
+## 2. Stat Chips
+
+### Location
+
+Space detail page (`[spaceId]/+page.svelte`), replacing the current plain text stats line.
+
+### Rendering
+
+A horizontal `flex gap-2` row of pill-shaped badges. Each chip:
+- Small MDI icon (16px) on the left
+- Text label on the right
+- `rounded-full` shape, `bg-gray-100 dark:bg-gray-800`, `text-sm`, `px-3 py-1`
+
+### Chips
+
+- Camera icon (`mdiCameraOutline`) + `"{count} photos"`
+- People icon (`mdiAccountMultipleOutline`) + `"{count} members"`
+
+Display only — no click handlers.
+
+## 3. Role Badges
+
+### Members modal
+
+Replace the plain capitalized role text and disabled owner dropdown in `SpaceMembersModal.svelte` with colored pill badges:
+
+- **Owner** — filled with space's color, white text
+- **Editor** — outlined with space's color, colored text
+- **Viewer** — `bg-gray-200 dark:bg-gray-700`, muted text
+
+The role change dropdown for non-owner members (when viewed by an owner) stays as-is. Only the display of the viewer's own role and the owner's row change to pills.
+
+### Detail page header
+
+Add a small role badge below the stat chips row in `[spaceId]/+page.svelte`, showing "Owner", "Editor", or "Viewer" with the same pill styling. Uses the existing `currentMember.role` derived value.
+
+## Files Touched
+
+| Change | Files |
+|--------|-------|
+| Add `color` column | `server/src/schema/tables/`, new migration |
+| Update DTOs | `server/src/dtos/shared-space.dto.ts` |
+| Regenerate clients | `make open-api` |
+| Color picker in create modal | `web/src/lib/modals/SpaceCreateModal.svelte` |
+| Gradient placeholder | `web/src/lib/components/spaces/space-card.svelte` |
+| Stat chips | `web/src/routes/(user)/spaces/[spaceId]/.../+page.svelte` |
+| Role badges in modal | `web/src/lib/modals/SpaceMembersModal.svelte` |
+| Role badge in header | `web/src/routes/(user)/spaces/[spaceId]/.../+page.svelte` |
+
+## Out of Scope
+
+- Click handlers on stat chips
+- Activity feeds, collage thumbnails, member contribution cards
+- Space emoji/icon picker
+- Slide-out members panel

--- a/docs/plans/2026-03-09-spaces-p0-visual-identity-plan.md
+++ b/docs/plans/2026-03-09-spaces-p0-visual-identity-plan.md
@@ -1,0 +1,948 @@
+# Spaces P0: Visual Identity & Information Hierarchy — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add space colors with gradient placeholders, stat chips, and role badges to make Shared Spaces visually distinct from Albums.
+
+**Architecture:** Add a `color` column (varchar, UserAvatarColor enum) to the `shared_spaces` table. Thread it through DTOs, service, OpenAPI, and render it in web components. All web changes are Svelte 5 with Tailwind CSS. Follow TDD — write failing tests first, then implement.
+
+**Tech Stack:** NestJS (server), Kysely (DB), Vitest (tests), Svelte 5 (web), Tailwind CSS 4, OpenAPI codegen
+
+---
+
+### Task 1: Database Migration — Add `color` column
+
+**Files:**
+- Create: `server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts`
+- Modify: `server/src/schema/tables/shared-space.table.ts`
+- Modify: `server/src/database.ts:320-330`
+
+**Step 1: Create the migration file**
+
+```typescript
+// server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "shared_space" ADD "color" character varying(20) DEFAULT 'primary'`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "shared_space" DROP COLUMN "color"`.execute(db);
+}
+```
+
+**Step 2: Add column to schema table**
+
+In `server/src/schema/tables/shared-space.table.ts`, add after the `thumbnailAssetId` column:
+
+```typescript
+@Column({ type: 'character varying', length: 20, default: "'primary'", nullable: true })
+color!: string | null;
+```
+
+**Step 3: Update database.ts types**
+
+In `server/src/database.ts`, add `color` to the `SharedSpace` type:
+
+```typescript
+export type SharedSpace = {
+  id: string;
+  name: string;
+  description: string | null;
+  createdById: string;
+  thumbnailAssetId: string | null;
+  color: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  createId: string;
+  updateId: string;
+};
+```
+
+**Step 4: Commit**
+
+```bash
+git add server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts server/src/schema/tables/shared-space.table.ts server/src/database.ts
+git commit -m "feat(server): add color column to shared_spaces table"
+```
+
+---
+
+### Task 2: Server DTOs — Add `color` to Create/Update/Response DTOs
+
+**Files:**
+- Modify: `server/src/dtos/shared-space.dto.ts`
+
+**Step 1: Add color to SharedSpaceCreateDto**
+
+Add after `description`:
+
+```typescript
+@ValidateEnum({
+  enum: UserAvatarColor,
+  name: 'UserAvatarColor',
+  description: 'Space color',
+  optional: true,
+  default: UserAvatarColor.Primary,
+})
+color?: UserAvatarColor;
+```
+
+Add `UserAvatarColor` to the import from `src/enum`.
+
+**Step 2: Add color to SharedSpaceUpdateDto**
+
+Add after `thumbnailAssetId`:
+
+```typescript
+@ValidateEnum({
+  enum: UserAvatarColor,
+  name: 'UserAvatarColor',
+  description: 'Space color',
+  optional: true,
+})
+color?: UserAvatarColor;
+```
+
+**Step 3: Add color to SharedSpaceResponseDto**
+
+Add after `thumbnailAssetId`:
+
+```typescript
+@ApiPropertyOptional({ description: 'Space color', enum: UserAvatarColor })
+color?: UserAvatarColor | null;
+```
+
+Import `UserAvatarColor` from `@immich/sdk` or `src/enum` (check existing pattern).
+
+**Step 4: Commit**
+
+```bash
+git add server/src/dtos/shared-space.dto.ts
+git commit -m "feat(server): add color field to shared space DTOs"
+```
+
+---
+
+### Task 3: Server Service — Thread `color` through create/update/mapSpace
+
+**Files:**
+- Modify: `server/src/services/shared-space.service.ts`
+- Test: `server/src/services/shared-space.service.spec.ts`
+
+**Step 1: Write failing test — create with color**
+
+Add to `server/src/services/shared-space.service.spec.ts` in the `create` describe block:
+
+```typescript
+it('should pass color when provided', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace({ createdById: auth.user.id, color: 'blue' });
+
+  mocks.sharedSpace.create.mockResolvedValue(space);
+  mocks.sharedSpace.addMember.mockResolvedValue(
+    factory.sharedSpaceMember({
+      spaceId: space.id,
+      userId: auth.user.id,
+      role: SharedSpaceRole.Owner,
+    }),
+  );
+
+  const result = await sut.create(auth, { name: 'Test Space', color: UserAvatarColor.Blue });
+
+  expect(result.color).toBe('blue');
+  expect(mocks.sharedSpace.create).toHaveBeenCalledWith({
+    name: 'Test Space',
+    description: null,
+    color: UserAvatarColor.Blue,
+    createdById: auth.user.id,
+  });
+});
+
+it('should default color to primary when not provided', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace({ createdById: auth.user.id, color: 'primary' });
+
+  mocks.sharedSpace.create.mockResolvedValue(space);
+  mocks.sharedSpace.addMember.mockResolvedValue(
+    factory.sharedSpaceMember({
+      spaceId: space.id,
+      userId: auth.user.id,
+      role: SharedSpaceRole.Owner,
+    }),
+  );
+
+  const result = await sut.create(auth, { name: 'Test Space' });
+
+  expect(result.color).toBe('primary');
+  expect(mocks.sharedSpace.create).toHaveBeenCalledWith({
+    name: 'Test Space',
+    description: null,
+    color: 'primary',
+    createdById: auth.user.id,
+  });
+});
+```
+
+Add `UserAvatarColor` to the import from `src/enum`.
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd server && pnpm test -- --run src/services/shared-space.service.spec.ts
+```
+
+Expected: FAIL — `create` doesn't pass `color` to repository, `mapSpace` doesn't return `color`.
+
+**Step 3: Write failing test — update color requires owner**
+
+Add to the `update` describe block:
+
+```typescript
+it('should allow owner to update color', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace();
+  const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Owner });
+  const updatedSpace = { ...space, color: 'blue' };
+
+  mocks.sharedSpace.getMember.mockResolvedValue(member);
+  mocks.sharedSpace.update.mockResolvedValue(updatedSpace);
+
+  const result = await sut.update(auth, space.id, { color: UserAvatarColor.Blue });
+
+  expect(result.color).toBe('blue');
+  expect(mocks.sharedSpace.update).toHaveBeenCalledWith(space.id, {
+    name: undefined,
+    description: undefined,
+    thumbnailAssetId: undefined,
+    color: UserAvatarColor.Blue,
+  });
+});
+
+it('should not allow editor to update color', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace();
+  const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(member);
+
+  await expect(sut.update(auth, space.id, { color: UserAvatarColor.Blue })).rejects.toBeInstanceOf(
+    ForbiddenException,
+  );
+});
+```
+
+**Step 4: Write failing test — getAll includes color**
+
+Add to the `getAll` describe block:
+
+```typescript
+it('should include color in response', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace({ name: 'Blue Space', color: 'blue' });
+
+  mocks.sharedSpace.getAllByUserId.mockResolvedValue([space]);
+  mocks.sharedSpace.getMembers.mockResolvedValue([]);
+  mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+
+  const result = await sut.getAll(auth);
+
+  expect(result[0].color).toBe('blue');
+});
+```
+
+**Step 5: Write failing test — get includes color**
+
+Add to the `get` describe block:
+
+```typescript
+it('should include color in response', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace({ color: 'green' });
+  const member = makeMemberResult({
+    spaceId: space.id,
+    userId: auth.user.id,
+    role: SharedSpaceRole.Viewer,
+  });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(member);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getMembers.mockResolvedValue([member]);
+  mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+  mocks.sharedSpace.getMostRecentAssetId.mockResolvedValue(void 0);
+
+  const result = await sut.get(auth, space.id);
+
+  expect(result.color).toBe('green');
+});
+```
+
+**Step 6: Run tests to verify they all fail**
+
+```bash
+cd server && pnpm test -- --run src/services/shared-space.service.spec.ts
+```
+
+Expected: Multiple FAILs related to color.
+
+**Step 7: Implement — update service**
+
+In `server/src/services/shared-space.service.ts`:
+
+1. In `create()`, change the repository call:
+```typescript
+const space = await this.sharedSpaceRepository.create({
+  name: dto.name,
+  description: dto.description ?? null,
+  color: dto.color ?? 'primary',
+  createdById: auth.user.id,
+});
+```
+
+2. In `update()`, add `color` to the metadata check and pass it through:
+```typescript
+const isMetadataUpdate = dto.name !== undefined || dto.description !== undefined || dto.color !== undefined;
+```
+And in the update call:
+```typescript
+const space = await this.sharedSpaceRepository.update(id, {
+  name: dto.name,
+  description: dto.description,
+  thumbnailAssetId: dto.thumbnailAssetId,
+  color: dto.color,
+});
+```
+
+3. In `mapSpace()`, add `color` to the type signature and return:
+```typescript
+private mapSpace(space: {
+  id: string;
+  name: string;
+  description: string | null;
+  createdById: string;
+  createdAt: unknown;
+  updatedAt: unknown;
+  thumbnailAssetId?: string | null;
+  color?: string | null;
+}): SharedSpaceResponseDto {
+  return {
+    id: space.id,
+    name: space.name,
+    description: space.description,
+    createdById: space.createdById,
+    createdAt: space.createdAt as unknown as string,
+    updatedAt: space.updatedAt as unknown as string,
+    thumbnailAssetId: space.thumbnailAssetId ?? null,
+    color: (space.color as UserAvatarColor) ?? null,
+  };
+}
+```
+
+Add `UserAvatarColor` to the import from `src/enum`.
+
+**Step 8: Update test factory**
+
+In `server/test/small.factory.ts`, add `color` to the `sharedSpaceFactory`:
+
+```typescript
+const sharedSpaceFactory = (data: Partial<SharedSpace> = {}): SharedSpace => ({
+  id: newUuid(),
+  name: 'Test Space',
+  description: null,
+  createdById: newUuid(),
+  thumbnailAssetId: null,
+  color: 'primary',
+  createdAt: newDate(),
+  updatedAt: newDate(),
+  createId: newUuid(),
+  updateId: newUuid(),
+  ...data,
+});
+```
+
+**Step 9: Run tests to verify they pass**
+
+```bash
+cd server && pnpm test -- --run src/services/shared-space.service.spec.ts
+```
+
+Expected: ALL PASS
+
+**Step 10: Verify existing tests still pass**
+
+```bash
+cd server && pnpm test -- --run src/services/shared-space.service.spec.ts 2>&1 | tail -20
+```
+
+Check that no existing tests broke (especially the `update` tests that check `isMetadataUpdate`).
+
+**Step 11: Commit**
+
+```bash
+git add server/src/services/shared-space.service.ts server/src/services/shared-space.service.spec.ts server/test/small.factory.ts
+git commit -m "feat(server): thread color through shared space service with TDD"
+```
+
+---
+
+### Task 4: Regenerate OpenAPI clients
+
+**Files:**
+- Modified by codegen: `open-api/immich-openapi-specs.json`, `open-api/typescript-sdk/src/fetch-client.ts`, `mobile/openapi/`
+
+**Step 1: Build server**
+
+```bash
+cd server && pnpm build
+```
+
+**Step 2: Sync OpenAPI spec**
+
+```bash
+cd server && pnpm sync:open-api
+```
+
+**Step 3: Regenerate clients**
+
+```bash
+make open-api
+```
+
+**Step 4: Verify TypeScript SDK has color**
+
+```bash
+grep -n "color" open-api/typescript-sdk/src/fetch-client.ts | head -20
+```
+
+Confirm `SharedSpaceCreateDto`, `SharedSpaceUpdateDto`, and `SharedSpaceResponseDto` all include `color`.
+
+**Step 5: Commit**
+
+```bash
+git add open-api/ mobile/openapi/
+git commit -m "chore: regenerate OpenAPI clients with space color field"
+```
+
+---
+
+### Task 5: Web — Color Swatch Picker Component
+
+**Files:**
+- Create: `web/src/lib/components/spaces/color-picker.svelte`
+
+**Step 1: Create the color picker component**
+
+```svelte
+<script lang="ts">
+  import { UserAvatarColor } from '@immich/sdk';
+  import { Icon } from '@immich/ui';
+  import { mdiCheck } from '@mdi/js';
+
+  interface Props {
+    value: UserAvatarColor;
+    onchange: (color: UserAvatarColor) => void;
+  }
+
+  let { value, onchange }: Props = $props();
+
+  const colors: { value: UserAvatarColor; class: string }[] = [
+    { value: UserAvatarColor.Primary, class: 'bg-primary' },
+    { value: UserAvatarColor.Pink, class: 'bg-pink-400' },
+    { value: UserAvatarColor.Red, class: 'bg-red-500' },
+    { value: UserAvatarColor.Yellow, class: 'bg-yellow-500' },
+    { value: UserAvatarColor.Blue, class: 'bg-blue-500' },
+    { value: UserAvatarColor.Green, class: 'bg-green-600' },
+    { value: UserAvatarColor.Purple, class: 'bg-purple-600' },
+    { value: UserAvatarColor.Orange, class: 'bg-orange-600' },
+    { value: UserAvatarColor.Gray, class: 'bg-gray-600' },
+    { value: UserAvatarColor.Amber, class: 'bg-amber-600' },
+  ];
+</script>
+
+<div class="flex gap-2 flex-wrap">
+  {#each colors as color (color.value)}
+    <button
+      type="button"
+      class="flex h-7 w-7 items-center justify-center rounded-full transition-transform {color.class}"
+      class:ring-2={value === color.value}
+      class:ring-offset-2={value === color.value}
+      class:ring-gray-800={value === color.value}
+      class:dark:ring-gray-200={value === color.value}
+      class:dark:ring-offset-gray-900={value === color.value}
+      class:scale-110={value === color.value}
+      onclick={() => onchange(color.value)}
+      aria-label={color.value}
+      data-testid="color-swatch-{color.value}"
+    >
+      {#if value === color.value}
+        <Icon icon={mdiCheck} size="14" class="text-white" />
+      {/if}
+    </button>
+  {/each}
+</div>
+```
+
+**Step 2: Commit**
+
+```bash
+git add web/src/lib/components/spaces/color-picker.svelte
+git commit -m "feat(web): add color picker component for spaces"
+```
+
+---
+
+### Task 6: Web — Update SpaceCreateModal with color picker
+
+**Files:**
+- Modify: `web/src/lib/modals/SpaceCreateModal.svelte`
+
+**Step 1: Add color picker to create modal**
+
+Import `ColorPicker` and `UserAvatarColor`, add state, pass to DTO:
+
+```svelte
+<script lang="ts">
+  import ColorPicker from '$lib/components/spaces/color-picker.svelte';
+  import { createSpace, UserAvatarColor, type SharedSpaceResponseDto } from '@immich/sdk';
+  import { Field, FormModal, Input, Textarea } from '@immich/ui';
+  import { mdiAccountGroup } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  type Props = {
+    onClose: (space?: SharedSpaceResponseDto) => void;
+  };
+
+  let { onClose }: Props = $props();
+
+  let name = $state('');
+  let description = $state('');
+  let color = $state<UserAvatarColor>(UserAvatarColor.Primary);
+
+  const onSubmit = async () => {
+    const space = await createSpace({
+      sharedSpaceCreateDto: {
+        name,
+        description: description || undefined,
+        color,
+      },
+    });
+    onClose(space);
+  };
+</script>
+
+<FormModal icon={mdiAccountGroup} title={$t('spaces_create')} size="small" {onClose} {onSubmit}>
+  <div class="flex flex-col gap-4 m-4">
+    <Field label={$t('name')} required>
+      <Input bind:value={name} autofocus />
+    </Field>
+    <Field label={$t('description')}>
+      <Textarea bind:value={description} />
+    </Field>
+    <Field label={$t('color')}>
+      <ColorPicker value={color} onchange={(c) => (color = c)} />
+    </Field>
+  </div>
+</FormModal>
+```
+
+**Step 2: Commit**
+
+```bash
+git add web/src/lib/modals/SpaceCreateModal.svelte
+git commit -m "feat(web): add color picker to space create modal"
+```
+
+---
+
+### Task 7: Web — Gradient Placeholder on Space Card
+
+**Files:**
+- Modify: `web/src/lib/components/spaces/space-card.svelte`
+
+**Step 1: Add gradient map and replace empty state**
+
+The space card needs a color-to-gradient mapping. Replace the gray placeholder `<div>` with a gradient.
+
+Add this to the `<script>` section:
+
+```typescript
+import { UserAvatarColor } from '@immich/sdk';
+
+const gradientClasses: Record<string, string> = {
+  [UserAvatarColor.Primary]: 'from-immich-primary/60 to-immich-primary',
+  [UserAvatarColor.Pink]: 'from-pink-300 to-pink-500',
+  [UserAvatarColor.Red]: 'from-red-400 to-red-600',
+  [UserAvatarColor.Yellow]: 'from-yellow-300 to-yellow-500',
+  [UserAvatarColor.Blue]: 'from-blue-400 to-blue-600',
+  [UserAvatarColor.Green]: 'from-green-400 to-green-700',
+  [UserAvatarColor.Purple]: 'from-purple-400 to-purple-700',
+  [UserAvatarColor.Orange]: 'from-orange-400 to-orange-600',
+  [UserAvatarColor.Gray]: 'from-gray-400 to-gray-600',
+  [UserAvatarColor.Amber]: 'from-amber-400 to-amber-600',
+};
+
+let gradientClass = $derived(gradientClasses[space.color ?? 'primary'] ?? gradientClasses[UserAvatarColor.Primary]);
+```
+
+Replace the empty state block (the `{:else}` after the thumbnail check):
+
+```svelte
+{:else}
+  <div
+    class="flex size-full items-center justify-center rounded-xl bg-gradient-to-br {gradientClass} aspect-square"
+    data-testid="space-no-cover"
+  >
+    <Icon icon={mdiImageMultipleOutline} size="4em" class="text-white/40" />
+  </div>
+{/if}
+```
+
+**Step 2: Commit**
+
+```bash
+git add web/src/lib/components/spaces/space-card.svelte
+git commit -m "feat(web): gradient placeholder on space card using space color"
+```
+
+---
+
+### Task 8: Web — Stat Chips on Space Detail Page
+
+**Files:**
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Step 1: Add icon imports**
+
+Add to existing icon imports:
+
+```typescript
+import { mdiCameraOutline } from '@mdi/js';
+```
+
+`mdiAccountMultipleOutline` is already imported.
+
+**Step 2: Replace plain stats with chips**
+
+Replace the existing stats `<div>`:
+
+```svelte
+<div class="flex gap-4 mt-2 text-sm text-immich-fg/60 dark:text-immich-dark-fg/60">
+  <span>{space.assetCount ?? 0} {$t('photos')}</span>
+  <span>{members.length} {$t('members')}</span>
+</div>
+```
+
+With:
+
+```svelte
+<div class="flex flex-wrap gap-2 mt-2">
+  <span
+    class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+  >
+    <Icon icon={mdiCameraOutline} size="16" />
+    {space.assetCount ?? 0} {$t('photos')}
+  </span>
+  <span
+    class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+  >
+    <Icon icon={mdiAccountMultipleOutline} size="16" />
+    {members.length} {$t('members')}
+  </span>
+</div>
+```
+
+**Step 3: Commit**
+
+```bash
+git add web/src/routes/\(user\)/spaces/\[spaceId\]/\[\[photos=photos\]\]/\[\[assetId=id\]\]/+page.svelte
+git commit -m "feat(web): add stat chips to space detail page"
+```
+
+---
+
+### Task 9: Web — Role Badge Component and Integration
+
+**Files:**
+- Create: `web/src/lib/components/spaces/role-badge.svelte`
+- Modify: `web/src/lib/modals/SpaceMembersModal.svelte`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Step 1: Create role badge component**
+
+```svelte
+<script lang="ts">
+  import type { UserAvatarColor } from '@immich/sdk';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    role: string;
+    spaceColor?: UserAvatarColor | string | null;
+    size?: 'sm' | 'md';
+  }
+
+  let { role, spaceColor = 'primary', size = 'md' }: Props = $props();
+
+  const colorMap: Record<string, { filled: string; outlined: string }> = {
+    primary: { filled: 'bg-primary text-white', outlined: 'border-primary text-primary' },
+    pink: { filled: 'bg-pink-400 text-white', outlined: 'border-pink-400 text-pink-400' },
+    red: { filled: 'bg-red-500 text-white', outlined: 'border-red-500 text-red-500' },
+    yellow: { filled: 'bg-yellow-500 text-white', outlined: 'border-yellow-500 text-yellow-600' },
+    blue: { filled: 'bg-blue-500 text-white', outlined: 'border-blue-500 text-blue-500' },
+    green: { filled: 'bg-green-600 text-white', outlined: 'border-green-600 text-green-600' },
+    purple: { filled: 'bg-purple-600 text-white', outlined: 'border-purple-600 text-purple-600' },
+    orange: { filled: 'bg-orange-600 text-white', outlined: 'border-orange-600 text-orange-600' },
+    gray: { filled: 'bg-gray-600 text-white', outlined: 'border-gray-600 text-gray-600' },
+    amber: { filled: 'bg-amber-600 text-white', outlined: 'border-amber-600 text-amber-600' },
+  };
+
+  const sizeClasses = {
+    sm: 'px-2 py-0.5 text-xs',
+    md: 'px-2.5 py-0.5 text-xs',
+  };
+
+  let colors = $derived(colorMap[spaceColor ?? 'primary'] ?? colorMap.primary);
+  let badgeClass = $derived.by(() => {
+    if (role === 'owner') {
+      return `${colors.filled} ${sizeClasses[size]}`;
+    }
+    if (role === 'editor') {
+      return `border ${colors.outlined} ${sizeClasses[size]}`;
+    }
+    return `bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300 ${sizeClasses[size]}`;
+  });
+
+  const roleLabel = $derived(
+    role === 'owner' ? $t('owner') : role === 'editor' ? $t('role_editor') : $t('role_viewer'),
+  );
+</script>
+
+<span
+  class="inline-flex items-center rounded-full font-medium capitalize {badgeClass}"
+  data-testid="role-badge-{role}"
+>
+  {roleLabel}
+</span>
+```
+
+**Step 2: Update SpaceMembersModal**
+
+In `web/src/lib/modals/SpaceMembersModal.svelte`:
+
+1. Add `spaceColor` prop:
+```typescript
+interface Props {
+  spaceId: string;
+  members: SharedSpaceMemberResponseDto[];
+  isOwner: boolean;
+  spaceColor?: string | null;
+  onClose: (updatedMembers?: SharedSpaceMemberResponseDto[]) => void;
+}
+
+let { spaceId, members: initialMembers, isOwner, spaceColor = 'primary', onClose }: Props = $props();
+```
+
+2. Import `RoleBadge`:
+```typescript
+import RoleBadge from '$lib/components/spaces/role-badge.svelte';
+```
+
+3. Replace the owner's disabled dropdown and the non-owner static text with `RoleBadge`. For the owner row:
+```svelte
+{#if isOwner && member.role === 'owner'}
+  <RoleBadge role="owner" {spaceColor} />
+```
+
+For non-owner viewing another member's role:
+```svelte
+{:else if !isOwner}
+  <RoleBadge role={member.role} {spaceColor} />
+{/if}
+```
+
+Keep the `Select` dropdown as-is for owners viewing non-owner members.
+
+**Step 3: Update space detail page — pass spaceColor to modal**
+
+In the `handleShowMembers` function:
+
+```typescript
+const updatedMembers = await modalManager.show(SpaceMembersModal, {
+  spaceId: space.id,
+  members,
+  isOwner,
+  spaceColor: space.color,
+});
+```
+
+**Step 4: Add role badge to space detail header**
+
+After the stat chips `<div>`, add:
+
+```svelte
+{#if currentMember}
+  <div class="mt-2">
+    <RoleBadge role={currentMember.role} spaceColor={space.color} />
+  </div>
+{/if}
+```
+
+Import `RoleBadge`:
+```typescript
+import RoleBadge from '$lib/components/spaces/role-badge.svelte';
+```
+
+**Step 5: Commit**
+
+```bash
+git add web/src/lib/components/spaces/role-badge.svelte web/src/lib/modals/SpaceMembersModal.svelte web/src/routes/\(user\)/spaces/\[spaceId\]/\[\[photos=photos\]\]/\[\[assetId=id\]\]/+page.svelte
+git commit -m "feat(web): add role badges to space detail page and members modal"
+```
+
+---
+
+### Task 10: Server Unit Tests — Comprehensive coverage for color field
+
+**Files:**
+- Modify: `server/src/services/shared-space.service.spec.ts`
+
+This task adds additional edge case tests beyond the basic ones in Task 3.
+
+**Step 1: Write additional tests**
+
+Add to the existing test file:
+
+```typescript
+// In 'create' describe
+it('should create space with color set to primary by default when no color specified', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace({ createdById: auth.user.id });
+
+  mocks.sharedSpace.create.mockResolvedValue(space);
+  mocks.sharedSpace.addMember.mockResolvedValue(
+    factory.sharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Owner }),
+  );
+
+  await sut.create(auth, { name: 'No Color Space' });
+
+  expect(mocks.sharedSpace.create).toHaveBeenCalledWith(
+    expect.objectContaining({ color: 'primary' }),
+  );
+});
+
+// In 'update' describe
+it('should treat color update as metadata change (owner-only)', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace();
+  const viewer = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(viewer);
+
+  await expect(sut.update(auth, space.id, { color: UserAvatarColor.Red })).rejects.toBeInstanceOf(
+    ForbiddenException,
+  );
+});
+
+// In 'getAll' describe
+it('should return null color when space has no color set', async () => {
+  const auth = factory.auth();
+  const space = factory.sharedSpace({ color: null });
+
+  mocks.sharedSpace.getAllByUserId.mockResolvedValue([space]);
+  mocks.sharedSpace.getMembers.mockResolvedValue([]);
+  mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+
+  const result = await sut.getAll(auth);
+
+  expect(result[0].color).toBeNull();
+});
+```
+
+**Step 2: Run all shared space tests**
+
+```bash
+cd server && pnpm test -- --run src/services/shared-space.service.spec.ts
+```
+
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git add server/src/services/shared-space.service.spec.ts
+git commit -m "test(server): add comprehensive color field coverage for shared spaces"
+```
+
+---
+
+### Task 11: Lint, Format, Type Check
+
+**Files:** All modified files
+
+**Step 1: Format server**
+
+```bash
+make format-server
+```
+
+**Step 2: Lint server**
+
+```bash
+make lint-server
+```
+
+**Step 3: Type check server**
+
+```bash
+make check-server
+```
+
+**Step 4: Format web**
+
+```bash
+make format-web
+```
+
+**Step 5: Lint web**
+
+```bash
+make lint-web
+```
+
+**Step 6: Type check web**
+
+```bash
+make check-web
+```
+
+**Step 7: Fix any issues and commit**
+
+```bash
+git add -u
+git commit -m "chore: fix lint and formatting issues"
+```
+
+---
+
+### Task 12: Run full server test suite
+
+**Step 1: Run all server unit tests**
+
+```bash
+cd server && pnpm test -- --run
+```
+
+Expected: All 3100+ tests pass
+
+**Step 2: If any tests fail, fix them**
+
+Common issues:
+- The existing `update` tests may need `color: undefined` added to `toHaveBeenCalledWith` expectations
+- Factory changes may affect other test files
+
+**Step 3: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "fix(server): update existing tests for color field"
+```

--- a/docs/plans/2026-03-09-spaces-p0-visual-identity-plan.md
+++ b/docs/plans/2026-03-09-spaces-p0-visual-identity-plan.md
@@ -13,6 +13,7 @@
 ### Task 1: Database Migration — Add `color` column
 
 **Files:**
+
 - Create: `server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts`
 - Modify: `server/src/schema/tables/shared-space.table.ts`
 - Modify: `server/src/database.ts:320-330`
@@ -72,6 +73,7 @@ git commit -m "feat(server): add color column to shared_spaces table"
 ### Task 2: Server DTOs — Add `color` to Create/Update/Response DTOs
 
 **Files:**
+
 - Modify: `server/src/dtos/shared-space.dto.ts`
 
 **Step 1: Add color to SharedSpaceCreateDto**
@@ -128,6 +130,7 @@ git commit -m "feat(server): add color field to shared space DTOs"
 ### Task 3: Server Service — Thread `color` through create/update/mapSpace
 
 **Files:**
+
 - Modify: `server/src/services/shared-space.service.ts`
 - Test: `server/src/services/shared-space.service.spec.ts`
 
@@ -227,9 +230,7 @@ it('should not allow editor to update color', async () => {
 
   mocks.sharedSpace.getMember.mockResolvedValue(member);
 
-  await expect(sut.update(auth, space.id, { color: UserAvatarColor.Blue })).rejects.toBeInstanceOf(
-    ForbiddenException,
-  );
+  await expect(sut.update(auth, space.id, { color: UserAvatarColor.Blue })).rejects.toBeInstanceOf(ForbiddenException);
 });
 ```
 
@@ -291,6 +292,7 @@ Expected: Multiple FAILs related to color.
 In `server/src/services/shared-space.service.ts`:
 
 1. In `create()`, change the repository call:
+
 ```typescript
 const space = await this.sharedSpaceRepository.create({
   name: dto.name,
@@ -301,10 +303,13 @@ const space = await this.sharedSpaceRepository.create({
 ```
 
 2. In `update()`, add `color` to the metadata check and pass it through:
+
 ```typescript
 const isMetadataUpdate = dto.name !== undefined || dto.description !== undefined || dto.color !== undefined;
 ```
+
 And in the update call:
+
 ```typescript
 const space = await this.sharedSpaceRepository.update(id, {
   name: dto.name,
@@ -315,6 +320,7 @@ const space = await this.sharedSpaceRepository.update(id, {
 ```
 
 3. In `mapSpace()`, add `color` to the type signature and return:
+
 ```typescript
 private mapSpace(space: {
   id: string;
@@ -389,6 +395,7 @@ git commit -m "feat(server): thread color through shared space service with TDD"
 ### Task 4: Regenerate OpenAPI clients
 
 **Files:**
+
 - Modified by codegen: `open-api/immich-openapi-specs.json`, `open-api/typescript-sdk/src/fetch-client.ts`, `mobile/openapi/`
 
 **Step 1: Build server**
@@ -429,6 +436,7 @@ git commit -m "chore: regenerate OpenAPI clients with space color field"
 ### Task 5: Web — Color Swatch Picker Component
 
 **Files:**
+
 - Create: `web/src/lib/components/spaces/color-picker.svelte`
 
 **Step 1: Create the color picker component**
@@ -495,6 +503,7 @@ git commit -m "feat(web): add color picker component for spaces"
 ### Task 6: Web — Update SpaceCreateModal with color picker
 
 **Files:**
+
 - Modify: `web/src/lib/modals/SpaceCreateModal.svelte`
 
 **Step 1: Add color picker to create modal**
@@ -558,6 +567,7 @@ git commit -m "feat(web): add color picker to space create modal"
 ### Task 7: Web — Gradient Placeholder on Space Card
 
 **Files:**
+
 - Modify: `web/src/lib/components/spaces/space-card.svelte`
 
 **Step 1: Add gradient map and replace empty state**
@@ -610,6 +620,7 @@ git commit -m "feat(web): gradient placeholder on space card using space color"
 ### Task 8: Web — Stat Chips on Space Detail Page
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
 
 **Step 1: Add icon imports**
@@ -664,6 +675,7 @@ git commit -m "feat(web): add stat chips to space detail page"
 ### Task 9: Web — Role Badge Component and Integration
 
 **Files:**
+
 - Create: `web/src/lib/components/spaces/role-badge.svelte`
 - Modify: `web/src/lib/modals/SpaceMembersModal.svelte`
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
@@ -730,6 +742,7 @@ git commit -m "feat(web): add stat chips to space detail page"
 In `web/src/lib/modals/SpaceMembersModal.svelte`:
 
 1. Add `spaceColor` prop:
+
 ```typescript
 interface Props {
   spaceId: string;
@@ -743,17 +756,20 @@ let { spaceId, members: initialMembers, isOwner, spaceColor = 'primary', onClose
 ```
 
 2. Import `RoleBadge`:
+
 ```typescript
 import RoleBadge from '$lib/components/spaces/role-badge.svelte';
 ```
 
 3. Replace the owner's disabled dropdown and the non-owner static text with `RoleBadge`. For the owner row:
+
 ```svelte
 {#if isOwner && member.role === 'owner'}
   <RoleBadge role="owner" {spaceColor} />
 ```
 
 For non-owner viewing another member's role:
+
 ```svelte
 {:else if !isOwner}
   <RoleBadge role={member.role} {spaceColor} />
@@ -788,6 +804,7 @@ After the stat chips `<div>`, add:
 ```
 
 Import `RoleBadge`:
+
 ```typescript
 import RoleBadge from '$lib/components/spaces/role-badge.svelte';
 ```
@@ -804,6 +821,7 @@ git commit -m "feat(web): add role badges to space detail page and members modal
 ### Task 10: Server Unit Tests — Comprehensive coverage for color field
 
 **Files:**
+
 - Modify: `server/src/services/shared-space.service.spec.ts`
 
 This task adds additional edge case tests beyond the basic ones in Task 3.
@@ -825,9 +843,7 @@ it('should create space with color set to primary by default when no color speci
 
   await sut.create(auth, { name: 'No Color Space' });
 
-  expect(mocks.sharedSpace.create).toHaveBeenCalledWith(
-    expect.objectContaining({ color: 'primary' }),
-  );
+  expect(mocks.sharedSpace.create).toHaveBeenCalledWith(expect.objectContaining({ color: 'primary' }));
 });
 
 // In 'update' describe
@@ -838,9 +854,7 @@ it('should treat color update as metadata change (owner-only)', async () => {
 
   mocks.sharedSpace.getMember.mockResolvedValue(viewer);
 
-  await expect(sut.update(auth, space.id, { color: UserAvatarColor.Red })).rejects.toBeInstanceOf(
-    ForbiddenException,
-  );
+  await expect(sut.update(auth, space.id, { color: UserAvatarColor.Red })).rejects.toBeInstanceOf(ForbiddenException);
 });
 
 // In 'getAll' describe
@@ -937,6 +951,7 @@ Expected: All 3100+ tests pass
 **Step 2: If any tests fail, fix them**
 
 Common issues:
+
 - The existing `update` tests may need `color: undefined` added to `toHaveBeenCalledWith` expectations
 - Factory changes may affect other test files
 

--- a/mobile/openapi/lib/model/shared_space_create_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_create_dto.dart
@@ -13,9 +13,13 @@ part of openapi.api;
 class SharedSpaceCreateDto {
   /// Returns a new [SharedSpaceCreateDto] instance.
   SharedSpaceCreateDto({
+    this.color = UserAvatarColor.primary,
     this.description,
     required this.name,
   });
+
+  /// Space color
+  UserAvatarColor color;
 
   /// Space description
   ///
@@ -31,20 +35,23 @@ class SharedSpaceCreateDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SharedSpaceCreateDto &&
+    other.color == color &&
     other.description == description &&
     other.name == name;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (color.hashCode) +
     (description == null ? 0 : description!.hashCode) +
     (name.hashCode);
 
   @override
-  String toString() => 'SharedSpaceCreateDto[description=$description, name=$name]';
+  String toString() => 'SharedSpaceCreateDto[color=$color, description=$description, name=$name]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+      json[r'color'] = this.color;
     if (this.description != null) {
       json[r'description'] = this.description;
     } else {
@@ -63,6 +70,7 @@ class SharedSpaceCreateDto {
       final json = value.cast<String, dynamic>();
 
       return SharedSpaceCreateDto(
+        color: UserAvatarColor.fromJson(json[r'color']) ?? UserAvatarColor.primary,
         description: mapValueOfType<String>(json, r'description'),
         name: mapValueOfType<String>(json, r'name')!,
       );

--- a/mobile/openapi/lib/model/shared_space_response_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_response_dto.dart
@@ -14,6 +14,7 @@ class SharedSpaceResponseDto {
   /// Returns a new [SharedSpaceResponseDto] instance.
   SharedSpaceResponseDto({
     this.assetCount,
+    this.color,
     required this.createdAt,
     required this.createdById,
     this.description,
@@ -33,6 +34,9 @@ class SharedSpaceResponseDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   num? assetCount;
+
+  /// Space color
+  SharedSpaceResponseDtoColorEnum? color;
 
   /// Creation date
   String createdAt;
@@ -70,6 +74,7 @@ class SharedSpaceResponseDto {
   @override
   bool operator ==(Object other) => identical(this, other) || other is SharedSpaceResponseDto &&
     other.assetCount == assetCount &&
+    other.color == color &&
     other.createdAt == createdAt &&
     other.createdById == createdById &&
     other.description == description &&
@@ -84,6 +89,7 @@ class SharedSpaceResponseDto {
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (assetCount == null ? 0 : assetCount!.hashCode) +
+    (color == null ? 0 : color!.hashCode) +
     (createdAt.hashCode) +
     (createdById.hashCode) +
     (description == null ? 0 : description!.hashCode) +
@@ -95,7 +101,7 @@ class SharedSpaceResponseDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'SharedSpaceResponseDto[assetCount=$assetCount, createdAt=$createdAt, createdById=$createdById, description=$description, id=$id, memberCount=$memberCount, members=$members, name=$name, thumbnailAssetId=$thumbnailAssetId, updatedAt=$updatedAt]';
+  String toString() => 'SharedSpaceResponseDto[assetCount=$assetCount, color=$color, createdAt=$createdAt, createdById=$createdById, description=$description, id=$id, memberCount=$memberCount, members=$members, name=$name, thumbnailAssetId=$thumbnailAssetId, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -103,6 +109,11 @@ class SharedSpaceResponseDto {
       json[r'assetCount'] = this.assetCount;
     } else {
     //  json[r'assetCount'] = null;
+    }
+    if (this.color != null) {
+      json[r'color'] = this.color;
+    } else {
+    //  json[r'color'] = null;
     }
       json[r'createdAt'] = this.createdAt;
       json[r'createdById'] = this.createdById;
@@ -140,6 +151,7 @@ class SharedSpaceResponseDto {
         assetCount: json[r'assetCount'] == null
             ? null
             : num.parse('${json[r'assetCount']}'),
+        color: SharedSpaceResponseDtoColorEnum.fromJson(json[r'color']),
         createdAt: mapValueOfType<String>(json, r'createdAt')!,
         createdById: mapValueOfType<String>(json, r'createdById')!,
         description: mapValueOfType<String>(json, r'description'),
@@ -205,4 +217,102 @@ class SharedSpaceResponseDto {
     'updatedAt',
   };
 }
+
+/// Space color
+class SharedSpaceResponseDtoColorEnum {
+  /// Instantiate a new enum with the provided [value].
+  const SharedSpaceResponseDtoColorEnum._(this.value);
+
+  /// The underlying value of this enum member.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  String toJson() => value;
+
+  static const primary = SharedSpaceResponseDtoColorEnum._(r'primary');
+  static const pink = SharedSpaceResponseDtoColorEnum._(r'pink');
+  static const red = SharedSpaceResponseDtoColorEnum._(r'red');
+  static const yellow = SharedSpaceResponseDtoColorEnum._(r'yellow');
+  static const blue = SharedSpaceResponseDtoColorEnum._(r'blue');
+  static const green = SharedSpaceResponseDtoColorEnum._(r'green');
+  static const purple = SharedSpaceResponseDtoColorEnum._(r'purple');
+  static const orange = SharedSpaceResponseDtoColorEnum._(r'orange');
+  static const gray = SharedSpaceResponseDtoColorEnum._(r'gray');
+  static const amber = SharedSpaceResponseDtoColorEnum._(r'amber');
+
+  /// List of all possible values in this [enum][SharedSpaceResponseDtoColorEnum].
+  static const values = <SharedSpaceResponseDtoColorEnum>[
+    primary,
+    pink,
+    red,
+    yellow,
+    blue,
+    green,
+    purple,
+    orange,
+    gray,
+    amber,
+  ];
+
+  static SharedSpaceResponseDtoColorEnum? fromJson(dynamic value) => SharedSpaceResponseDtoColorEnumTypeTransformer().decode(value);
+
+  static List<SharedSpaceResponseDtoColorEnum> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <SharedSpaceResponseDtoColorEnum>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = SharedSpaceResponseDtoColorEnum.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+}
+
+/// Transformation class that can [encode] an instance of [SharedSpaceResponseDtoColorEnum] to String,
+/// and [decode] dynamic data back to [SharedSpaceResponseDtoColorEnum].
+class SharedSpaceResponseDtoColorEnumTypeTransformer {
+  factory SharedSpaceResponseDtoColorEnumTypeTransformer() => _instance ??= const SharedSpaceResponseDtoColorEnumTypeTransformer._();
+
+  const SharedSpaceResponseDtoColorEnumTypeTransformer._();
+
+  String encode(SharedSpaceResponseDtoColorEnum data) => data.value;
+
+  /// Decodes a [dynamic value][data] to a SharedSpaceResponseDtoColorEnum.
+  ///
+  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
+  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
+  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
+  ///
+  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
+  /// and users are still using an old app with the old code.
+  SharedSpaceResponseDtoColorEnum? decode(dynamic data, {bool allowNull = true}) {
+    if (data != null) {
+      switch (data) {
+        case r'primary': return SharedSpaceResponseDtoColorEnum.primary;
+        case r'pink': return SharedSpaceResponseDtoColorEnum.pink;
+        case r'red': return SharedSpaceResponseDtoColorEnum.red;
+        case r'yellow': return SharedSpaceResponseDtoColorEnum.yellow;
+        case r'blue': return SharedSpaceResponseDtoColorEnum.blue;
+        case r'green': return SharedSpaceResponseDtoColorEnum.green;
+        case r'purple': return SharedSpaceResponseDtoColorEnum.purple;
+        case r'orange': return SharedSpaceResponseDtoColorEnum.orange;
+        case r'gray': return SharedSpaceResponseDtoColorEnum.gray;
+        case r'amber': return SharedSpaceResponseDtoColorEnum.amber;
+        default:
+          if (!allowNull) {
+            throw ArgumentError('Unknown enum value to decode: $data');
+          }
+      }
+    }
+    return null;
+  }
+
+  /// Singleton [SharedSpaceResponseDtoColorEnumTypeTransformer] instance.
+  static SharedSpaceResponseDtoColorEnumTypeTransformer? _instance;
+}
+
 

--- a/mobile/openapi/lib/model/shared_space_update_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_update_dto.dart
@@ -13,10 +13,20 @@ part of openapi.api;
 class SharedSpaceUpdateDto {
   /// Returns a new [SharedSpaceUpdateDto] instance.
   SharedSpaceUpdateDto({
+    this.color,
     this.description,
     this.name,
     this.thumbnailAssetId,
   });
+
+  /// Space color
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  UserAvatarColor? color;
 
   /// Space description
   ///
@@ -41,6 +51,7 @@ class SharedSpaceUpdateDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SharedSpaceUpdateDto &&
+    other.color == color &&
     other.description == description &&
     other.name == name &&
     other.thumbnailAssetId == thumbnailAssetId;
@@ -48,15 +59,21 @@ class SharedSpaceUpdateDto {
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (color == null ? 0 : color!.hashCode) +
     (description == null ? 0 : description!.hashCode) +
     (name == null ? 0 : name!.hashCode) +
     (thumbnailAssetId == null ? 0 : thumbnailAssetId!.hashCode);
 
   @override
-  String toString() => 'SharedSpaceUpdateDto[description=$description, name=$name, thumbnailAssetId=$thumbnailAssetId]';
+  String toString() => 'SharedSpaceUpdateDto[color=$color, description=$description, name=$name, thumbnailAssetId=$thumbnailAssetId]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+    if (this.color != null) {
+      json[r'color'] = this.color;
+    } else {
+    //  json[r'color'] = null;
+    }
     if (this.description != null) {
       json[r'description'] = this.description;
     } else {
@@ -84,6 +101,7 @@ class SharedSpaceUpdateDto {
       final json = value.cast<String, dynamic>();
 
       return SharedSpaceUpdateDto(
+        color: UserAvatarColor.fromJson(json[r'color']),
         description: mapValueOfType<String>(json, r'description'),
         name: mapValueOfType<String>(json, r'name'),
         thumbnailAssetId: mapValueOfType<String>(json, r'thumbnailAssetId'),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -23172,6 +23172,15 @@
       },
       "SharedSpaceCreateDto": {
         "properties": {
+          "color": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserAvatarColor"
+              }
+            ],
+            "default": "primary",
+            "description": "Space color"
+          },
           "description": {
             "description": "Space description",
             "maxLength": 500,
@@ -23298,6 +23307,23 @@
             "description": "Number of assets",
             "type": "number"
           },
+          "color": {
+            "description": "Space color",
+            "enum": [
+              "primary",
+              "pink",
+              "red",
+              "yellow",
+              "blue",
+              "green",
+              "purple",
+              "orange",
+              "gray",
+              "amber"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
           "createdAt": {
             "description": "Creation date",
             "type": "string"
@@ -23360,6 +23386,14 @@
       },
       "SharedSpaceUpdateDto": {
         "properties": {
+          "color": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UserAvatarColor"
+              }
+            ],
+            "description": "Space color"
+          },
           "description": {
             "description": "Space description",
             "maxLength": 500,

--- a/open-api/templates/mobile/serialization/native/native_class.mustache.rej
+++ b/open-api/templates/mobile/serialization/native/native_class.mustache.rej
@@ -1,6 +1,6 @@
 --- native_class.mustache
 +++ native_class.mustache
-@@ -32,7 +32,7 @@ class {{{classname}}} {
+@@ -32,7 +32,7 @@
        {{/required}}
      {{/isNullable}}
    {{/isEnum}}
@@ -9,3 +9,23 @@
  
  {{/vars}}
    @override
+@@ -191,7 +191,7 @@
+             {{/isEnum}}
+             {{^isEnum}}
+         {{{name}}}: json[r'{{{baseName}}}'] is Iterable
+-            ? (json[r'{{{baseName}}}'] as Iterable).cast<{{{items.datatype}}}>().{{#uniqueItems}}toSet(){{/uniqueItems}}{{^uniqueItems}}toList(growable: false){{/uniqueItems}}
++            ? (json[r'{{{baseName}}}'] as Iterable).cast<{{{items.datatype}}}{{#items.isNullable}}?{{/items.isNullable}}>().{{#uniqueItems}}toSet(){{/uniqueItems}}{{^uniqueItems}}toList(growable: false){{/uniqueItems}}
+             : {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}},
+             {{/isEnum}}
+           {{/isArray}}
+@@ -203,7 +203,9 @@
+               {{#isNumber}}
+         {{{name}}}: {{#isNullable}}json[r'{{{baseName}}}'] == null
+             ? {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}
+-            : {{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
++            : {{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}json[r'{{{baseName}}}'] == null
++            ? null
++            : {{/defaultValue}}{{/required}}{{/isNullable}}{{{datatypeWithEnum}}}.parse('${json[r'{{{baseName}}}']}'),
+               {{/isNumber}}
+               {{#isDouble}}
+         {{{name}}}: (mapValueOfType<num>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}}){{#isNullable}}?{{/isNullable}}.toDouble(),

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2366,6 +2366,8 @@ export type SharedSpaceMemberResponseDto = {
 export type SharedSpaceResponseDto = {
     /** Number of assets */
     assetCount?: number;
+    /** Space color */
+    color?: Color | null;
     /** Creation date */
     createdAt: string;
     /** Creator user ID */
@@ -2386,12 +2388,16 @@ export type SharedSpaceResponseDto = {
     updatedAt: string;
 };
 export type SharedSpaceCreateDto = {
+    /** Space color */
+    color?: UserAvatarColor;
     /** Space description */
     description?: string;
     /** Space name */
     name: string;
 };
 export type SharedSpaceUpdateDto = {
+    /** Space color */
+    color?: UserAvatarColor;
     /** Space description */
     description?: string;
     /** Space name */
@@ -7618,6 +7624,18 @@ export enum Error2 {
     Duplicate = "duplicate",
     NoPermission = "no_permission",
     NotFound = "not_found"
+}
+export enum Color {
+    Primary = "primary",
+    Pink = "pink",
+    Red = "red",
+    Yellow = "yellow",
+    Blue = "blue",
+    Green = "green",
+    Purple = "purple",
+    Orange = "orange",
+    Gray = "gray",
+    Amber = "amber"
 }
 export enum Role {
     Owner = "owner",

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -323,6 +323,7 @@ export type SharedSpace = {
   description: string | null;
   createdById: string;
   thumbnailAssetId: string | null;
+  color: string | null;
   createdAt: Date;
   updatedAt: Date;
   createId: string;

--- a/server/src/dtos/shared-space.dto.ts
+++ b/server/src/dtos/shared-space.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
-import { SharedSpaceRole } from 'src/enum';
+import { SharedSpaceRole, UserAvatarColor } from 'src/enum';
 import { ValidateEnum, ValidateUUID } from 'src/validation';
 
 export class SharedSpaceCreateDto {
@@ -15,6 +15,15 @@ export class SharedSpaceCreateDto {
   @IsOptional()
   @MaxLength(500)
   description?: string;
+
+  @ValidateEnum({
+    enum: UserAvatarColor,
+    name: 'UserAvatarColor',
+    description: 'Space color',
+    optional: true,
+    default: UserAvatarColor.Primary,
+  })
+  color?: UserAvatarColor;
 }
 
 export class SharedSpaceUpdateDto {
@@ -33,6 +42,14 @@ export class SharedSpaceUpdateDto {
 
   @ValidateUUID({ optional: true, nullable: true, description: 'Thumbnail asset ID' })
   thumbnailAssetId?: string | null;
+
+  @ValidateEnum({
+    enum: UserAvatarColor,
+    name: 'UserAvatarColor',
+    description: 'Space color',
+    optional: true,
+  })
+  color?: UserAvatarColor;
 }
 
 export class SharedSpaceMemberCreateDto {
@@ -110,6 +127,9 @@ export class SharedSpaceResponseDto {
 
   @ApiPropertyOptional({ description: 'Thumbnail asset ID' })
   thumbnailAssetId?: string | null;
+
+  @ApiPropertyOptional({ description: 'Space color', enum: UserAvatarColor })
+  color?: UserAvatarColor | null;
 
   @ApiPropertyOptional({ description: 'Space members (summary)', type: [SharedSpaceMemberResponseDto] })
   members?: SharedSpaceMemberResponseDto[];

--- a/server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts
+++ b/server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "shared_space" ADD "color" character varying(20) DEFAULT 'primary'`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "shared_space" DROP COLUMN "color"`.execute(db);
+}

--- a/server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts
+++ b/server/src/schema/migrations/1772270000000-AddColorToSharedSpace.ts
@@ -1,7 +1,8 @@
 import { Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
-  await sql`ALTER TABLE "shared_space" ADD "color" character varying(20) DEFAULT 'primary'`.execute(db);
+  await sql`ALTER TABLE "shared_space" ADD "color" character varying(20)`.execute(db);
+  await sql`UPDATE "shared_space" SET "color" = 'primary' WHERE "color" IS NULL`.execute(db);
 }
 
 export async function down(db: Kysely<any>): Promise<void> {

--- a/server/src/schema/tables/shared-space.table.ts
+++ b/server/src/schema/tables/shared-space.table.ts
@@ -30,7 +30,7 @@ export class SharedSpaceTable {
   @ForeignKeyColumn(() => AssetTable, { onDelete: 'SET NULL', nullable: true })
   thumbnailAssetId!: string | null;
 
-  @Column({ type: 'character varying', length: 20, default: "'primary'", nullable: true })
+  @Column({ type: 'character varying', length: 20, nullable: true })
   color!: string | null;
 
   @CreateDateColumn()

--- a/server/src/schema/tables/shared-space.table.ts
+++ b/server/src/schema/tables/shared-space.table.ts
@@ -30,6 +30,9 @@ export class SharedSpaceTable {
   @ForeignKeyColumn(() => AssetTable, { onDelete: 'SET NULL', nullable: true })
   thumbnailAssetId!: string | null;
 
+  @Column({ type: 'character varying', length: 20, default: "'primary'", nullable: true })
+  color!: string | null;
+
   @CreateDateColumn()
   createdAt!: Generated<Timestamp>;
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { MapMarkerResponseDto } from 'src/dtos/map.dto';
-import { SharedSpaceRole } from 'src/enum';
+import { SharedSpaceRole, UserAvatarColor } from 'src/enum';
 import { SharedSpaceService } from 'src/services/shared-space.service';
 import { factory, newDate, newUuid } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
@@ -52,6 +52,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.create).toHaveBeenCalledWith({
         name: 'Test Space',
         description: null,
+        color: 'primary',
         createdById: auth.user.id,
       });
 
@@ -81,6 +82,55 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.create).toHaveBeenCalledWith({
         name: 'Test Space',
         description: 'A cool space',
+        color: 'primary',
+        createdById: auth.user.id,
+      });
+    });
+
+    it('should pass color when provided', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ createdById: auth.user.id, color: 'blue' });
+
+      mocks.sharedSpace.create.mockResolvedValue(space);
+      mocks.sharedSpace.addMember.mockResolvedValue(
+        factory.sharedSpaceMember({
+          spaceId: space.id,
+          userId: auth.user.id,
+          role: SharedSpaceRole.Owner,
+        }),
+      );
+
+      const result = await sut.create(auth, { name: 'Test Space', color: UserAvatarColor.Blue });
+
+      expect(result.color).toBe('blue');
+      expect(mocks.sharedSpace.create).toHaveBeenCalledWith({
+        name: 'Test Space',
+        description: null,
+        color: UserAvatarColor.Blue,
+        createdById: auth.user.id,
+      });
+    });
+
+    it('should default color to primary when not provided', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ createdById: auth.user.id, color: 'primary' });
+
+      mocks.sharedSpace.create.mockResolvedValue(space);
+      mocks.sharedSpace.addMember.mockResolvedValue(
+        factory.sharedSpaceMember({
+          spaceId: space.id,
+          userId: auth.user.id,
+          role: SharedSpaceRole.Owner,
+        }),
+      );
+
+      const result = await sut.create(auth, { name: 'Test Space' });
+
+      expect(result.color).toBe('primary');
+      expect(mocks.sharedSpace.create).toHaveBeenCalledWith({
+        name: 'Test Space',
+        description: null,
+        color: 'primary',
         createdById: auth.user.id,
       });
     });
@@ -137,6 +187,19 @@ describe(SharedSpaceService.name, () => {
       expect(result[0].members).toHaveLength(2);
       expect(result[0].members![0].name).toBe('User 1');
       expect(result[0].members![1].name).toBe('User 2');
+    });
+
+    it('should include color in response', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ name: 'Blue Space', color: 'blue' });
+
+      mocks.sharedSpace.getAllByUserId.mockResolvedValue([space]);
+      mocks.sharedSpace.getMembers.mockResolvedValue([]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+
+      const result = await sut.getAll(auth);
+
+      expect(result[0].color).toBe('blue');
     });
   });
 
@@ -234,6 +297,26 @@ describe(SharedSpaceService.name, () => {
 
       await expect(sut.get(auth, newUuid())).rejects.toBeInstanceOf(ForbiddenException);
     });
+
+    it('should include color in response', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ color: 'green' });
+      const member = makeMemberResult({
+        spaceId: space.id,
+        userId: auth.user.id,
+        role: SharedSpaceRole.Viewer,
+      });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getMembers.mockResolvedValue([member]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+      mocks.sharedSpace.getMostRecentAssetId.mockResolvedValue(void 0);
+
+      const result = await sut.get(auth, space.id);
+
+      expect(result.color).toBe('green');
+    });
   });
 
   describe('update', () => {
@@ -252,6 +335,8 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.update).toHaveBeenCalledWith(space.id, {
         name: 'Updated Name',
         description: undefined,
+        thumbnailAssetId: undefined,
+        color: undefined,
       });
     });
 
@@ -272,6 +357,7 @@ describe(SharedSpaceService.name, () => {
         name: undefined,
         description: undefined,
         thumbnailAssetId,
+        color: undefined,
       });
     });
 
@@ -291,6 +377,7 @@ describe(SharedSpaceService.name, () => {
         name: undefined,
         description: undefined,
         thumbnailAssetId: null,
+        color: undefined,
       });
     });
 
@@ -326,6 +413,38 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getMember.mockResolvedValue(member);
 
       await expect(sut.update(auth, space.id, { description: 'New Description' })).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('should allow owner to update color', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace();
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Owner });
+      const updatedSpace = { ...space, color: 'blue' };
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.update.mockResolvedValue(updatedSpace);
+
+      const result = await sut.update(auth, space.id, { color: UserAvatarColor.Blue });
+
+      expect(result.color).toBe('blue');
+      expect(mocks.sharedSpace.update).toHaveBeenCalledWith(space.id, {
+        name: undefined,
+        description: undefined,
+        thumbnailAssetId: undefined,
+        color: UserAvatarColor.Blue,
+      });
+    });
+
+    it('should not allow editor to update color', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace();
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+
+      await expect(sut.update(auth, space.id, { color: UserAvatarColor.Blue })).rejects.toBeInstanceOf(
         ForbiddenException,
       );
     });

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -201,6 +201,19 @@ describe(SharedSpaceService.name, () => {
 
       expect(result[0].color).toBe('blue');
     });
+
+    it('should return null color when space has no color set', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ color: null });
+
+      mocks.sharedSpace.getAllByUserId.mockResolvedValue([space]);
+      mocks.sharedSpace.getMembers.mockResolvedValue([]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+
+      const result = await sut.getAll(auth);
+
+      expect(result[0].color).toBeNull();
+    });
   });
 
   describe('get', () => {
@@ -445,6 +458,18 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getMember.mockResolvedValue(member);
 
       await expect(sut.update(auth, space.id, { color: UserAvatarColor.Blue })).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('should treat color update as metadata change (owner-only)', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace();
+      const viewer = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(viewer);
+
+      await expect(sut.update(auth, space.id, { color: UserAvatarColor.Red })).rejects.toBeInstanceOf(
         ForbiddenException,
       );
     });

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -11,7 +11,7 @@ import {
   SharedSpaceResponseDto,
   SharedSpaceUpdateDto,
 } from 'src/dtos/shared-space.dto';
-import { Permission, SharedSpaceRole } from 'src/enum';
+import { Permission, SharedSpaceRole, UserAvatarColor } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
 
 const ROLE_HIERARCHY: Record<SharedSpaceRole, number> = {
@@ -26,6 +26,7 @@ export class SharedSpaceService extends BaseService {
     const space = await this.sharedSpaceRepository.create({
       name: dto.name,
       description: dto.description ?? null,
+      color: dto.color ?? 'primary',
       createdById: auth.user.id,
     });
 
@@ -81,7 +82,7 @@ export class SharedSpaceService extends BaseService {
   }
 
   async update(auth: AuthDto, id: string, dto: SharedSpaceUpdateDto): Promise<SharedSpaceResponseDto> {
-    const isMetadataUpdate = dto.name !== undefined || dto.description !== undefined;
+    const isMetadataUpdate = dto.name !== undefined || dto.description !== undefined || dto.color !== undefined;
     const minimumRole = isMetadataUpdate ? SharedSpaceRole.Owner : SharedSpaceRole.Editor;
     await this.requireRole(auth, id, minimumRole);
 
@@ -89,6 +90,7 @@ export class SharedSpaceService extends BaseService {
       name: dto.name,
       description: dto.description,
       thumbnailAssetId: dto.thumbnailAssetId,
+      color: dto.color,
     });
 
     return this.mapSpace(space);
@@ -265,6 +267,7 @@ export class SharedSpaceService extends BaseService {
     createdAt: unknown;
     updatedAt: unknown;
     thumbnailAssetId?: string | null;
+    color?: string | null;
   }): SharedSpaceResponseDto {
     return {
       id: space.id,
@@ -274,6 +277,7 @@ export class SharedSpaceService extends BaseService {
       createdAt: space.createdAt as unknown as string,
       updatedAt: space.updatedAt as unknown as string,
       thumbnailAssetId: space.thumbnailAssetId ?? null,
+      color: (space.color as UserAvatarColor) ?? null,
     };
   }
 }

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -519,6 +519,7 @@ const sharedSpaceFactory = (data: Partial<SharedSpace> = {}): SharedSpace => ({
   description: null,
   createdById: newUuid(),
   thumbnailAssetId: null,
+  color: 'primary',
   createdAt: newDate(),
   updatedAt: newDate(),
   createId: newUuid(),

--- a/web/src/lib/components/spaces/color-picker.svelte
+++ b/web/src/lib/components/spaces/color-picker.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { UserAvatarColor } from '@immich/sdk';
+  import { Icon } from '@immich/ui';
+  import { mdiCheck } from '@mdi/js';
+
+  interface Props {
+    value: UserAvatarColor;
+    onchange: (color: UserAvatarColor) => void;
+  }
+
+  let { value, onchange }: Props = $props();
+
+  const colors: { value: UserAvatarColor; class: string }[] = [
+    { value: UserAvatarColor.Primary, class: 'bg-primary' },
+    { value: UserAvatarColor.Pink, class: 'bg-pink-400' },
+    { value: UserAvatarColor.Red, class: 'bg-red-500' },
+    { value: UserAvatarColor.Yellow, class: 'bg-yellow-500' },
+    { value: UserAvatarColor.Blue, class: 'bg-blue-500' },
+    { value: UserAvatarColor.Green, class: 'bg-green-600' },
+    { value: UserAvatarColor.Purple, class: 'bg-purple-600' },
+    { value: UserAvatarColor.Orange, class: 'bg-orange-600' },
+    { value: UserAvatarColor.Gray, class: 'bg-gray-600' },
+    { value: UserAvatarColor.Amber, class: 'bg-amber-600' },
+  ];
+</script>
+
+<div class="flex gap-2 flex-wrap">
+  {#each colors as color (color.value)}
+    <button
+      type="button"
+      class="flex h-7 w-7 items-center justify-center rounded-full transition-transform {color.class}"
+      class:ring-2={value === color.value}
+      class:ring-offset-2={value === color.value}
+      class:ring-gray-800={value === color.value}
+      class:dark:ring-gray-200={value === color.value}
+      class:dark:ring-offset-gray-900={value === color.value}
+      class:scale-110={value === color.value}
+      onclick={() => onchange(color.value)}
+      aria-label={color.value}
+      data-testid="color-swatch-{color.value}"
+    >
+      {#if value === color.value}
+        <Icon icon={mdiCheck} size="14" class="text-white" />
+      {/if}
+    </button>
+  {/each}
+</div>

--- a/web/src/lib/components/spaces/role-badge.svelte
+++ b/web/src/lib/components/spaces/role-badge.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import type { UserAvatarColor } from '@immich/sdk';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    role: string;
+    spaceColor?: UserAvatarColor | string | null;
+    size?: 'sm' | 'md';
+  }
+
+  let { role, spaceColor = 'primary', size = 'md' }: Props = $props();
+
+  const colorMap: Record<string, { filled: string; outlined: string }> = {
+    primary: { filled: 'bg-primary text-white', outlined: 'border-primary text-primary' },
+    pink: { filled: 'bg-pink-400 text-white', outlined: 'border-pink-400 text-pink-400' },
+    red: { filled: 'bg-red-500 text-white', outlined: 'border-red-500 text-red-500' },
+    yellow: { filled: 'bg-yellow-500 text-white', outlined: 'border-yellow-500 text-yellow-600' },
+    blue: { filled: 'bg-blue-500 text-white', outlined: 'border-blue-500 text-blue-500' },
+    green: { filled: 'bg-green-600 text-white', outlined: 'border-green-600 text-green-600' },
+    purple: { filled: 'bg-purple-600 text-white', outlined: 'border-purple-600 text-purple-600' },
+    orange: { filled: 'bg-orange-600 text-white', outlined: 'border-orange-600 text-orange-600' },
+    gray: { filled: 'bg-gray-600 text-white', outlined: 'border-gray-600 text-gray-600' },
+    amber: { filled: 'bg-amber-600 text-white', outlined: 'border-amber-600 text-amber-600' },
+  };
+
+  const sizeClasses = {
+    sm: 'px-2 py-0.5 text-xs',
+    md: 'px-2.5 py-0.5 text-xs',
+  };
+
+  let colors = $derived(colorMap[spaceColor ?? 'primary'] ?? colorMap.primary);
+  let badgeClass = $derived.by(() => {
+    if (role === 'owner') {
+      return `${colors.filled} ${sizeClasses[size]}`;
+    }
+    if (role === 'editor') {
+      return `border ${colors.outlined} ${sizeClasses[size]}`;
+    }
+    return `bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300 ${sizeClasses[size]}`;
+  });
+
+  const roleLabel = $derived(
+    role === 'owner' ? $t('owner') : role === 'editor' ? $t('role_editor') : $t('role_viewer'),
+  );
+</script>
+
+<span
+  class="inline-flex items-center rounded-full font-medium capitalize {badgeClass}"
+  data-testid="role-badge-{role}"
+>
+  {roleLabel}
+</span>

--- a/web/src/lib/components/spaces/role-badge.svelte
+++ b/web/src/lib/components/spaces/role-badge.svelte
@@ -44,9 +44,6 @@
   );
 </script>
 
-<span
-  class="inline-flex items-center rounded-full font-medium capitalize {badgeClass}"
-  data-testid="role-badge-{role}"
->
+<span class="inline-flex items-center rounded-full font-medium capitalize {badgeClass}" data-testid="role-badge-{role}">
   {roleLabel}
 </span>

--- a/web/src/lib/components/spaces/space-card.svelte
+++ b/web/src/lib/components/spaces/space-card.svelte
@@ -3,7 +3,7 @@
   import UserAvatar from '$lib/components/shared-components/user-avatar.svelte';
   import { Route } from '$lib/route';
   import { getAssetMediaUrl } from '$lib/utils';
-  import type { SharedSpaceResponseDto, UserAvatarColor } from '@immich/sdk';
+  import { UserAvatarColor, type SharedSpaceResponseDto } from '@immich/sdk';
   import { Icon } from '@immich/ui';
   import { mdiImageMultipleOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -16,6 +16,21 @@
   let { space, preload = false }: Props = $props();
 
   const MAX_AVATARS = 4;
+
+  const gradientClasses: Record<string, string> = {
+    [UserAvatarColor.Primary]: 'from-immich-primary/60 to-immich-primary',
+    [UserAvatarColor.Pink]: 'from-pink-300 to-pink-500',
+    [UserAvatarColor.Red]: 'from-red-400 to-red-600',
+    [UserAvatarColor.Yellow]: 'from-yellow-300 to-yellow-500',
+    [UserAvatarColor.Blue]: 'from-blue-400 to-blue-600',
+    [UserAvatarColor.Green]: 'from-green-400 to-green-700',
+    [UserAvatarColor.Purple]: 'from-purple-400 to-purple-700',
+    [UserAvatarColor.Orange]: 'from-orange-400 to-orange-600',
+    [UserAvatarColor.Gray]: 'from-gray-400 to-gray-600',
+    [UserAvatarColor.Amber]: 'from-amber-400 to-amber-600',
+  };
+
+  let gradientClass = $derived(gradientClasses[space.color ?? 'primary'] ?? gradientClasses[UserAvatarColor.Primary]);
 
   let thumbnailUrl = $derived(space.thumbnailAssetId ? getAssetMediaUrl({ id: space.thumbnailAssetId }) : null);
   let visibleMembers = $derived((space.members ?? []).slice(0, MAX_AVATARS));
@@ -32,10 +47,10 @@
       <AssetCover alt={space.name} class="transition-all duration-300 hover:shadow-lg" src={thumbnailUrl} {preload} />
     {:else}
       <div
-        class="flex size-full items-center justify-center rounded-xl bg-gray-100 aspect-square dark:bg-gray-800"
+        class="flex size-full items-center justify-center rounded-xl bg-gradient-to-br {gradientClass} aspect-square"
         data-testid="space-no-cover"
       >
-        <Icon icon={mdiImageMultipleOutline} size="4em" class="text-gray-300 dark:text-gray-600" />
+        <Icon icon={mdiImageMultipleOutline} size="4em" class="text-white/40" />
       </div>
     {/if}
 

--- a/web/src/lib/modals/SpaceCreateModal.svelte
+++ b/web/src/lib/modals/SpaceCreateModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { createSpace, type SharedSpaceResponseDto } from '@immich/sdk';
+  import ColorPicker from '$lib/components/spaces/color-picker.svelte';
+  import { createSpace, UserAvatarColor, type SharedSpaceResponseDto } from '@immich/sdk';
   import { Field, FormModal, Input, Textarea } from '@immich/ui';
   import { mdiAccountGroup } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -12,12 +13,14 @@
 
   let name = $state('');
   let description = $state('');
+  let color = $state<UserAvatarColor>(UserAvatarColor.Primary);
 
   const onSubmit = async () => {
     const space = await createSpace({
       sharedSpaceCreateDto: {
         name,
         description: description || undefined,
+        color,
       },
     });
     onClose(space);
@@ -31,6 +34,9 @@
     </Field>
     <Field label={$t('description')}>
       <Textarea bind:value={description} />
+    </Field>
+    <Field label={$t('color')}>
+      <ColorPicker value={color} onchange={(c) => (color = c)} />
     </Field>
   </div>
 </FormModal>

--- a/web/src/lib/modals/SpaceMembersModal.spec.ts
+++ b/web/src/lib/modals/SpaceMembersModal.spec.ts
@@ -103,7 +103,7 @@ describe('SpaceMembersModal', () => {
     expect(screen.queryByText('spaces_add_member')).not.toBeInTheDocument();
   });
 
-  it('should show role select triggers for owners viewing members', () => {
+  it('should show role badge for owner and select triggers for other members', () => {
     render(SpaceMembersModal, {
       spaceId,
       members: [ownerMember, editorMember, viewerMember],
@@ -111,10 +111,12 @@ describe('SpaceMembersModal', () => {
       onClose,
     });
 
-    // Owner's disabled dropdown shows "owner", editor/viewer show translated role labels
-    const ownerTrigger = screen.getByRole('button', { name: 'owner' });
-    expect(ownerTrigger).toHaveAttribute('aria-expanded', 'false');
+    // Owner shows a static role badge (not a dropdown)
+    const ownerBadge = screen.getByTestId('role-badge-owner');
+    expect(ownerBadge).toBeInTheDocument();
+    expect(ownerBadge.tagName).toBe('SPAN');
 
+    // Editor/viewer still show select dropdowns
     const editorTrigger = screen.getByRole('button', { name: 'role_editor' });
     expect(editorTrigger).toBeInTheDocument();
 
@@ -122,7 +124,7 @@ describe('SpaceMembersModal', () => {
     expect(viewerTrigger).toBeInTheDocument();
   });
 
-  it('should disable the owner role dropdown', () => {
+  it('should show owner role badge instead of dropdown', () => {
     render(SpaceMembersModal, {
       spaceId,
       members: [ownerMember, editorMember],
@@ -130,8 +132,10 @@ describe('SpaceMembersModal', () => {
       onClose,
     });
 
-    const ownerTrigger = screen.getByRole('button', { name: 'owner' });
-    expect(ownerTrigger).toBeDisabled();
+    // Owner row has a role badge, not a button/dropdown
+    const ownerBadge = screen.getByTestId('role-badge-owner');
+    expect(ownerBadge).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'owner' })).not.toBeInTheDocument();
   });
 
   it('should show static role text for non-owners viewing members', () => {
@@ -142,9 +146,9 @@ describe('SpaceMembersModal', () => {
       onClose,
     });
 
-    // Non-owners should see plain text role labels, not dropdown triggers
-    expect(screen.getByText('owner')).toBeInTheDocument();
-    expect(screen.getByText('editor')).toBeInTheDocument();
+    // Non-owners should see role badges, not dropdown triggers
+    expect(screen.getByTestId('role-badge-owner')).toBeInTheDocument();
+    expect(screen.getByTestId('role-badge-editor')).toBeInTheDocument();
     // Should not have select triggers (no aria-haspopup=listbox buttons)
     expect(screen.queryByRole('button', { name: 'owner' })).not.toBeInTheDocument();
   });

--- a/web/src/lib/modals/SpaceMembersModal.svelte
+++ b/web/src/lib/modals/SpaceMembersModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import UserAvatar from '$lib/components/shared-components/user-avatar.svelte';
+  import RoleBadge from '$lib/components/spaces/role-badge.svelte';
   import SpaceAddMemberModal from '$lib/modals/SpaceAddMemberModal.svelte';
   import { handleError } from '$lib/utils/handle-error';
   import {
@@ -17,10 +18,11 @@
     spaceId: string;
     members: SharedSpaceMemberResponseDto[];
     isOwner: boolean;
+    spaceColor?: string | null;
     onClose: (updatedMembers?: SharedSpaceMemberResponseDto[]) => void;
   }
 
-  let { spaceId, members: initialMembers, isOwner, onClose }: Props = $props();
+  let { spaceId, members: initialMembers, isOwner, spaceColor = 'primary', onClose }: Props = $props();
   let members = $state([...initialMembers]);
 
   const toAvatarUser = (member: SharedSpaceMemberResponseDto) => ({
@@ -96,9 +98,7 @@
           <Text size="tiny" color="muted">{member.email}</Text>
         </div>
         {#if isOwner && member.role === 'owner'}
-          <Field disabled class="w-32 shrink-0">
-            <Select options={[{ label: $t('owner'), value: 'owner' }]} value="owner" />
-          </Field>
+          <RoleBadge role="owner" {spaceColor} />
         {:else if isOwner}
           <Field class="w-32 shrink-0">
             <Select
@@ -112,7 +112,7 @@
             />
           </Field>
         {:else}
-          <span class="text-sm text-immich-fg/60 dark:text-immich-dark-fg/60 capitalize">{member.role}</span>
+          <RoleBadge role={member.role} {spaceColor} />
         {/if}
       </div>
     {/each}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -4,6 +4,7 @@
   import UserPageLayout from '$lib/components/layouts/user-page-layout.svelte';
   import ControlAppBar from '$lib/components/shared-components/control-app-bar.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
+  import RoleBadge from '$lib/components/spaces/role-badge.svelte';
   import SpaceMap from '$lib/components/spaces/space-map.svelte';
   import SpaceSearch from '$lib/components/spaces/space-search.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
@@ -153,6 +154,7 @@
       spaceId: space.id,
       members,
       isOwner,
+      spaceColor: space.color,
     });
     if (updatedMembers) {
       members = updatedMembers;
@@ -272,6 +274,12 @@
           {members.length} {$t('members')}
         </span>
       </div>
+
+      {#if currentMember}
+        <div class="mt-2">
+          <RoleBadge role={currentMember.role} spaceColor={space.color} />
+        </div>
+      {/if}
 
       <SpaceSearch bind:this={spaceSearch} spaceId={space.id} bind:showSearchResults />
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -40,6 +40,7 @@
   import { Icon, IconButton, modalManager, toastManager } from '@immich/ui';
   import {
     mdiAccountMultipleOutline,
+    mdiCameraOutline,
     mdiDeleteOutline,
     mdiDotsVertical,
     mdiEyeOffOutline,
@@ -257,9 +258,19 @@
 
   {#if viewMode !== 'select-assets'}
     <section class="px-4 pt-4">
-      <div class="flex gap-4 mt-2 text-sm text-immich-fg/60 dark:text-immich-dark-fg/60">
-        <span>{space.assetCount ?? 0} {$t('photos')}</span>
-        <span>{members.length} {$t('members')}</span>
+      <div class="flex flex-wrap gap-2 mt-2">
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+        >
+          <Icon icon={mdiCameraOutline} size="16" />
+          {space.assetCount ?? 0} {$t('photos')}
+        </span>
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+        >
+          <Icon icon={mdiAccountMultipleOutline} size="16" />
+          {members.length} {$t('members')}
+        </span>
       </div>
 
       <SpaceSearch bind:this={spaceSearch} spaceId={space.id} bind:showSearchResults />

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -265,13 +265,15 @@
           class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300"
         >
           <Icon icon={mdiCameraOutline} size="16" />
-          {space.assetCount ?? 0} {$t('photos')}
+          {space.assetCount ?? 0}
+          {$t('photos')}
         </span>
         <span
           class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-300"
         >
           <Icon icon={mdiAccountMultipleOutline} size="16" />
-          {members.length} {$t('members')}
+          {members.length}
+          {$t('members')}
         </span>
       </div>
 


### PR DESCRIPTION
## Summary
- Add `color` column to shared spaces (uses existing `UserAvatarColor` enum)
- Color swatch picker in space create modal (10 colors, defaults to primary)
- Gradient placeholders on space cards when no cover photo is set
- Stat chips with icons (camera + photo count, people + member count) on detail page
- Role badges (filled/outlined/gray pills for owner/editor/viewer) in members modal and detail header

## Details
- Server: migration, DTO updates, service threading with TDD (52 unit tests for shared spaces, 3191 total passing)
- Web: 3 new components (`color-picker.svelte`, `role-badge.svelte`, gradient on `space-card.svelte`), updated `SpaceCreateModal`, `SpaceMembersModal`, and space detail page
- OpenAPI clients regenerated for both TypeScript SDK and Dart

## Test plan
- [x] All 3191 server unit tests pass
- [x] Server lint, format, type check pass
- [x] Web lint, format, type check pass (svelte-check 0 errors, 0 warnings)
- [ ] CI checks pass
- [ ] Manual: create space with color picker, verify gradient placeholder
- [ ] Manual: verify stat chips render on space detail page
- [ ] Manual: verify role badges in members modal and detail header

🤖 Generated with [Claude Code](https://claude.com/claude-code)