### PR TITLE
fix: add tsx dependency to e2e for storage migration tests

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -53,6 +53,7 @@
     "sharp": "^0.34.5",
     "socket.io-client": "^4.7.4",
     "supertest": "^7.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.28.0",
     "utimes": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.3.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- The nightly `storage-migration-e2e` workflow fails every run with `tsx: not found` (exit code 127)
- The e2e shell script calls `npx tsx src/storage-migration.ts` but `tsx` was never added to `e2e/package.json`
- Adds `tsx` as a dev dependency so CI's `pnpm install --frozen-lockfile` installs it

## Test plan
- [ ] Trigger workflow manually: `gh workflow run storage-migration-e2e.yml --ref fix/storage-migration-tsx`
- [ ] Verify the "tsx: not found" error is resolved and the test proceeds past phase setup