### PR TITLE
fix: run mobile regression tests individually to prevent hanging

### DIFF
--- a/.github/workflows/mobile-regression-tests.yml
+++ b/.github/workflows/mobile-regression-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -58,13 +58,27 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          emulator-boot-timeout: 300
+          emulator-boot-timeout: 600
           working-directory: ./mobile
           script: |
-            patrol test integration_test/ \
-              --dart-define=TEST_SERVER_URL=http://10.0.2.2:2285 \
-              --dart-define=TEST_EMAIL=admin@immich.app \
-              --dart-define=TEST_PASSWORD=admin
+            # Run each test file individually to avoid Android Test Orchestrator
+            # hanging after the first test (known Patrol issue on CI emulators).
+            DART_DEFINES="--dart-define=TEST_SERVER_URL=http://10.0.2.2:2285 --dart-define=TEST_EMAIL=admin@immich.app --dart-define=TEST_PASSWORD=admin"
+            FAILED=0
+            for test_file in integration_test/tests/*_test.dart; do
+              echo ""
+              echo "========================================="
+              echo "  Running: $test_file"
+              echo "========================================="
+              if ! patrol test --target "$test_file" $DART_DEFINES; then
+                echo "FAILED: $test_file"
+                FAILED=1
+              fi
+            done
+            if [ $FAILED -ne 0 ]; then
+              echo "One or more test files failed"
+              exit 1
+            fi
 
       - name: Upload failure screenshots
         if: failure()


### PR DESCRIPTION
## Summary
- The nightly mobile regression suite hangs after the first test completes — the Android Test Orchestrator + Patrol IPC breaks on slow CI emulators ([known issue](https://github.com/leancodepl/patrol/issues/2184))
- Fix: run each test file as a separate `patrol test --target` invocation so the orchestrator only manages one test per process
- Increase job timeout from 60 → 120 minutes (sequential runs take longer)
- Increase emulator boot timeout from 300 → 600 seconds (CI emulator boot is variable)

## Test plan
- [ ] Trigger manually: `gh workflow run mobile-regression-tests.yml`
- [ ] Verify all 8 tests across 7 files execute (previously only 1 ran before hanging)