### PR TITLE
fix: move mobile test loop to shell script for emulator-runner

### DIFF
--- a/.github/workflows/mobile-regression-tests.yml
+++ b/.github/workflows/mobile-regression-tests.yml
@@ -61,24 +61,8 @@ jobs:
           emulator-boot-timeout: 600
           working-directory: ./mobile
           script: |
-            # Run each test file individually to avoid Android Test Orchestrator
-            # hanging after the first test (known Patrol issue on CI emulators).
-            DART_DEFINES="--dart-define=TEST_SERVER_URL=http://10.0.2.2:2285 --dart-define=TEST_EMAIL=admin@immich.app --dart-define=TEST_PASSWORD=admin"
-            FAILED=0
-            for test_file in integration_test/tests/*_test.dart; do
-              echo ""
-              echo "========================================="
-              echo "  Running: $test_file"
-              echo "========================================="
-              if ! patrol test --target "$test_file" $DART_DEFINES; then
-                echo "FAILED: $test_file"
-                FAILED=1
-              fi
-            done
-            if [ $FAILED -ne 0 ]; then
-              echo "One or more test files failed"
-              exit 1
-            fi
+            chmod +x integration_test/scripts/run-tests.sh
+            integration_test/scripts/run-tests.sh
 
       - name: Upload failure screenshots
         if: failure()

--- a/mobile/integration_test/scripts/run-tests.sh
+++ b/mobile/integration_test/scripts/run-tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run each test file individually to avoid Android Test Orchestrator
+# hanging after the first test (known Patrol issue on CI emulators).
+
+DART_DEFINES="--dart-define=TEST_SERVER_URL=${TEST_SERVER_URL:-http://10.0.2.2:2285} --dart-define=TEST_EMAIL=${TEST_EMAIL:-admin@immich.app} --dart-define=TEST_PASSWORD=${TEST_PASSWORD:-admin}"
+FAILED=0
+
+for test_file in integration_test/tests/*_test.dart; do
+  echo ""
+  echo "========================================="
+  echo "  Running: $test_file"
+  echo "========================================="
+  if ! patrol test --target "$test_file" $DART_DEFINES; then
+    echo "FAILED: $test_file"
+    FAILED=1
+  fi
+done
+
+if [ $FAILED -ne 0 ]; then
+  echo "One or more test files failed"
+  exit 1
+fi
+
+echo ""
+echo "All tests passed!"


### PR DESCRIPTION
## Summary
- Follow-up to #71 — the `android-emulator-runner` action runs each line of `script` as a separate `sh -c`, breaking the multiline `for` loop
- Move the test loop into `mobile/integration_test/scripts/run-tests.sh`

## Test plan
- [ ] Trigger manually and verify the script executes correctly