### PR TITLE
fix: shellcheck-clean mobile regression test script

### DIFF
--- a/mobile/integration_test/scripts/run-tests.sh
+++ b/mobile/integration_test/scripts/run-tests.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 # Run each test file individually to avoid Android Test Orchestrator
 # hanging after the first test (known Patrol issue on CI emulators).
 
-DART_DEFINES="--dart-define=TEST_SERVER_URL=${TEST_SERVER_URL:-http://10.0.2.2:2285} --dart-define=TEST_EMAIL=${TEST_EMAIL:-admin@immich.app} --dart-define=TEST_PASSWORD=${TEST_PASSWORD:-admin}"
+DART_DEFINES=(
+  "--dart-define=TEST_SERVER_URL=${TEST_SERVER_URL:-http://10.0.2.2:2285}"
+  "--dart-define=TEST_EMAIL=${TEST_EMAIL:-admin@immich.app}"
+  "--dart-define=TEST_PASSWORD=${TEST_PASSWORD:-admin}"
+)
 FAILED=0
 
 for test_file in integration_test/tests/*_test.dart; do
@@ -12,7 +16,7 @@ for test_file in integration_test/tests/*_test.dart; do
   echo "========================================="
   echo "  Running: $test_file"
   echo "========================================="
-  if ! patrol test --target "$test_file" $DART_DEFINES; then
+  if ! patrol test --target "$test_file" "${DART_DEFINES[@]}"; then
     echo "FAILED: $test_file"
     FAILED=1
   fi


### PR DESCRIPTION
## Summary
- Follow-up to #72 — fix SC2086 shellcheck warning by using bash array for DART_DEFINES

## Test plan
- [ ] Trigger mobile-regression-tests workflow