### PR TITLE
fix: use --no-build on subsequent patrol runs

### DIFF
--- a/mobile/integration_test/scripts/run-tests.sh
+++ b/mobile/integration_test/scripts/run-tests.sh
@@ -18,15 +18,24 @@ DART_DEFINES=(
 )
 FAILED=0
 PASSED=0
+BUILD_COUNT=0
 
 for test_file in integration_test/tests/*_test.dart; do
+  BUILD_COUNT=$((BUILD_COUNT + 1))
   echo ""
   echo "========================================="
-  echo "  Running: $test_file"
+  echo "  Running: $test_file (build #${BUILD_COUNT})"
   echo "========================================="
 
+  # Build on first iteration only to avoid KSP cache corruption on subsequent builds.
+  # Reuse the first build's APK for all remaining tests.
+  PATROL_ARGS=(--target "$test_file" "${DART_DEFINES[@]}")
+  if [ $BUILD_COUNT -gt 1 ]; then
+    PATROL_ARGS+=(--no-build)
+  fi
+
   set +e
-  timeout "${PER_TEST_TIMEOUT_MIN}m" patrol test --target "$test_file" "${DART_DEFINES[@]}"
+  timeout "${PER_TEST_TIMEOUT_MIN}m" patrol test "${PATROL_ARGS[@]}"
   exit_code=$?
   set -e
 


### PR DESCRIPTION
## Summary
Follow-up to #74 — running multiple Gradle builds in quick succession causes KSP cache corruption: "Storage for [.../file-to-id.tab] is already registered"

Only build the APK on the first test run, then use `patrol test --no-build` for remaining tests to reuse the cached APK.

## Test plan
- [ ] Trigger mobile-regression-tests and verify all 7 tests execute without Gradle cache errors