### PR TITLE
feat: match upstream release tagging pattern with v3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Release
 
 on:
   workflow_dispatch:
@@ -24,6 +24,7 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      major: ${{ steps.version.outputs.major }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -79,7 +80,10 @@ jobs:
               patch) echo "version=v${major}.${minor}.$((patch + 1))" >> "$GITHUB_OUTPUT" ;;
             esac
           fi
-          echo "Version: $(grep version "$GITHUB_OUTPUT" | cut -d= -f2)"
+          version=$(grep version "$GITHUB_OUTPUT" | cut -d= -f2)
+          major=$(echo "$version" | sed 's/^v//' | cut -d. -f1)
+          echo "major=v${major}" >> "$GITHUB_OUTPUT"
+          echo "Version: $version (major: v${major})"
 
   build-server:
     name: Build & Push Server
@@ -112,7 +116,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/open-noodle/gallery-server:${{ needs.version.outputs.version }}
-            ghcr.io/open-noodle/gallery-server:latest
+            ghcr.io/open-noodle/gallery-server:${{ needs.version.outputs.major }}
+            ghcr.io/open-noodle/gallery-server:release
           build-args: |
             DEVICE=cpu
             BUILD_ID=${{ github.run_id }}
@@ -160,7 +165,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/open-noodle/gallery-ml:${{ needs.version.outputs.version }}${{ matrix.suffix }}
-            ghcr.io/open-noodle/gallery-ml:latest${{ matrix.suffix }}
+            ghcr.io/open-noodle/gallery-ml:${{ needs.version.outputs.major }}${{ matrix.suffix }}
+            ghcr.io/open-noodle/gallery-ml:release${{ matrix.suffix }}
           build-args: |
             DEVICE=${{ matrix.device }}
           cache-from: type=gha
@@ -178,9 +184,19 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: Create tag
+      - name: Create tags
         env:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
+          major=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f1)
+
+          # Create version tag (e.g. v3.0.1)
           git tag "$VERSION"
-          git push origin "$VERSION"
+
+          # Update major version tag (e.g. v3) — floats to latest release
+          git tag -f "v${major}"
+
+          # Update release tag — always points to latest build
+          git tag -f "release"
+
+          git push origin "$VERSION" "v${major}" "release" --force

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Added support for structured JSON log output (`IMMICH_LOG_FORMAT=json`), making 
 
 ## Switching to This Fork
 
-Switching is simple — just change your Docker image names. Your existing database, configuration, and media files are fully compatible. The current version is **v3.0.0**.
+Switching is simple — just change your Docker image names. Your existing database, configuration, and media files are fully compatible.
 
 ### Step 1: Back Up Your Database
 
@@ -68,7 +68,7 @@ docker exec -t immich_postgres pg_dumpall -c -U postgres | gzip > immich-db-back
 Set the version in your `.env` file:
 
 ```bash
-IMMICH_VERSION=v3.0.0
+IMMICH_VERSION=v3
 ```
 
 Change the image references in your `docker-compose.yml`:
@@ -77,17 +77,17 @@ Change the image references in your `docker-compose.yml`:
 services:
   immich-server:
 -   image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
-+   image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-v3.0.0}
++   image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-release}
 
   immich-machine-learning:
 -   image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
-+   image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-v3.0.0}
++   image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}
 ```
 
 For NVIDIA GPU acceleration on the ML container, use the `-cuda` tag variant:
 
 ```yaml
-image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-v3.0.0}-cuda
+image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}-cuda
 ```
 
 ### Step 3: Restart
@@ -207,12 +207,13 @@ Pre-built Docker images are published to GitHub Container Registry (GHCR) under 
 
 ### Tags
 
-- **`latest`** / **`latest-cuda`** — most recent published build
-- **`v*`** (e.g. `v3.0.0`) — pinned version release using [semantic versioning](https://semver.org/)
+- **`release`** / **`release-cuda`** — most recent published build (like upstream's `release` tag)
+- **`v3`** — floats to the latest v3.x.x release (set `IMMICH_VERSION=v3` to auto-update within major version)
+- **`v3.0.1`** — pinned version using [semantic versioning](https://semver.org/)
 
 ### Publishing
 
-Images are automatically built and published on every push to `main` via the **Docker** GitHub Actions workflow (`.github/workflows/docker.yml`).
+Images are automatically built and published on every push to `main` via the **Release** GitHub Actions workflow (`.github/workflows/docker.yml`).
 
 **How it works:**
 1. Every merged PR triggers an automatic build
@@ -221,8 +222,8 @@ Images are automatically built and published on every push to `main` via the **D
    - `BREAKING CHANGE` in commit body → **major** bump (e.g. `v3.1.0` → `v4.0.0`)
    - Everything else (`fix:`, `docs:`, `chore:`, etc.) → **patch** bump (e.g. `v3.0.0` → `v3.0.1`)
 3. Three jobs run in parallel: server, ML (CPU), and ML (CUDA)
-4. Each image is tagged with both the version and `latest`
-5. A git tag is created after successful builds
+4. Each image is tagged with the version, the major version (e.g. `v3`), and `release`
+5. Git tags are created after successful builds
 6. Images are pushed to GHCR using the built-in `GITHUB_TOKEN` — no extra secrets needed
 
 **To manually publish a specific version:**
@@ -231,4 +232,4 @@ Images are automatically built and published on every push to `main` via the **D
 gh workflow run docker.yml --ref main -f version=v3.0.1
 ```
 
-Or use the GitHub Actions UI: Actions > Docker > Run workflow > enter version > Run.
+Or use the GitHub Actions UI: Actions > Release > Run workflow > enter version > Run.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ name: immich
 services:
   immich-server:
     container_name: immich_server
-    image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-latest}
+    image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-release}
     # extends:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
@@ -35,7 +35,7 @@ services:
     container_name: immich_machine_learning
     # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn] to the image tag.
     # Example tag: ${IMMICH_VERSION:-release}-cuda
-    image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-latest}
+    image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}
     # extends: # uncomment this section for hardware acceleration - see https://docs.immich.app/features/ml-hardware-acceleration
     #   file: hwaccel.ml.yml
     #   service: cpu # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable

--- a/docker/example.env
+++ b/docker/example.env
@@ -9,8 +9,8 @@ DB_DATA_LOCATION=./postgres
 # To set a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # TZ=Etc/UTC
 
-# The Immich version to use. You can pin this to a specific version like "v2.1.0"
-IMMICH_VERSION=v2
+# The Immich version to use. You can pin this to a specific version like "v3.0.1"
+IMMICH_VERSION=v3
 
 # Connection secret for postgres. You should change it to a random password
 # Please use only the characters `A-Za-z0-9`, without special characters or spaces


### PR DESCRIPTION
## Summary
- Rename Docker workflow to "Release"
- Tag images with version (`v3.0.1`), major (`v3`), and `release` — matching upstream Immich's pattern
- Update `docker-compose.yml` default to `${IMMICH_VERSION:-release}`
- Update `example.env` to `IMMICH_VERSION=v3`
- Update README to document `release`/`v3`/pinned version tags

## Test plan
- [ ] Verify CI passes
- [ ] After merge, confirm Release workflow tags images with `v3.x.x`, `v3`, and `release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)