### PR TITLE
test: add specs for color-picker and role-badge components

### DIFF
--- a/web/src/lib/components/spaces/color-picker.spec.ts
+++ b/web/src/lib/components/spaces/color-picker.spec.ts
@@ -1,0 +1,79 @@
+import ColorPicker from '$lib/components/spaces/color-picker.svelte';
+import type { UserAvatarColor } from '@immich/sdk';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+
+// UserAvatarColor enum values are just lowercase strings
+const Primary = 'primary' as UserAvatarColor;
+const Pink = 'pink' as UserAvatarColor;
+const Red = 'red' as UserAvatarColor;
+const Yellow = 'yellow' as UserAvatarColor;
+const Blue = 'blue' as UserAvatarColor;
+const Green = 'green' as UserAvatarColor;
+const Purple = 'purple' as UserAvatarColor;
+const Orange = 'orange' as UserAvatarColor;
+const Gray = 'gray' as UserAvatarColor;
+const Amber = 'amber' as UserAvatarColor;
+
+const allColors = [Primary, Pink, Red, Yellow, Blue, Green, Purple, Orange, Gray, Amber];
+
+describe('ColorPicker', () => {
+  it('should render all 10 color swatches', () => {
+    render(ColorPicker, { value: Primary, onchange: vi.fn() });
+    const swatches = screen.getAllByRole('button');
+    expect(swatches).toHaveLength(10);
+  });
+
+  it('should render a swatch for each color value', () => {
+    render(ColorPicker, { value: Primary, onchange: vi.fn() });
+    for (const color of allColors) {
+      expect(screen.getByTestId(`color-swatch-${color}`)).toBeInTheDocument();
+    }
+  });
+
+  it('should apply ring classes to the selected color', () => {
+    render(ColorPicker, { value: Blue, onchange: vi.fn() });
+    const selected = screen.getByTestId(`color-swatch-${Blue}`);
+    expect(selected.className).toContain('ring-2');
+    expect(selected.className).toContain('scale-110');
+  });
+
+  it('should not apply ring classes to unselected colors', () => {
+    render(ColorPicker, { value: Blue, onchange: vi.fn() });
+    const unselected = screen.getByTestId(`color-swatch-${Red}`);
+    expect(unselected.className).not.toContain('ring-2');
+    expect(unselected.className).not.toContain('scale-110');
+  });
+
+  it('should show check icon only on the selected color', () => {
+    render(ColorPicker, { value: Green, onchange: vi.fn() });
+    const selectedButton = screen.getByTestId(`color-swatch-${Green}`);
+    const unselectedButton = screen.getByTestId(`color-swatch-${Red}`);
+    expect(selectedButton.querySelector('svg')).not.toBeNull();
+    expect(unselectedButton.querySelector('svg')).toBeNull();
+  });
+
+  it('should set aria-label to the color value', () => {
+    render(ColorPicker, { value: Primary, onchange: vi.fn() });
+    const swatch = screen.getByTestId(`color-swatch-${Purple}`);
+    expect(swatch).toHaveAttribute('aria-label', Purple);
+  });
+
+  it('should call onchange with the clicked color value', async () => {
+    const user = userEvent.setup();
+    const onchange = vi.fn();
+    render(ColorPicker, { value: Primary, onchange });
+
+    await user.click(screen.getByTestId(`color-swatch-${Orange}`));
+    expect(onchange).toHaveBeenCalledWith(Orange);
+  });
+
+  it('should call onchange when clicking the already-selected color', async () => {
+    const user = userEvent.setup();
+    const onchange = vi.fn();
+    render(ColorPicker, { value: Red, onchange });
+
+    await user.click(screen.getByTestId(`color-swatch-${Red}`));
+    expect(onchange).toHaveBeenCalledWith(Red);
+  });
+});

--- a/web/src/lib/components/spaces/role-badge.spec.ts
+++ b/web/src/lib/components/spaces/role-badge.spec.ts
@@ -1,0 +1,110 @@
+import RoleBadge from '$lib/components/spaces/role-badge.svelte';
+import { render, screen } from '@testing-library/svelte';
+
+describe('RoleBadge', () => {
+  it('should render owner badge with data-testid', () => {
+    render(RoleBadge, { role: 'owner' });
+    expect(screen.getByTestId('role-badge-owner')).toBeInTheDocument();
+  });
+
+  it('should render editor badge with data-testid', () => {
+    render(RoleBadge, { role: 'editor' });
+    expect(screen.getByTestId('role-badge-editor')).toBeInTheDocument();
+  });
+
+  it('should render viewer badge with data-testid', () => {
+    render(RoleBadge, { role: 'viewer' });
+    expect(screen.getByTestId('role-badge-viewer')).toBeInTheDocument();
+  });
+
+  it('should display translated label for owner', () => {
+    render(RoleBadge, { role: 'owner' });
+    expect(screen.getByTestId('role-badge-owner')).toHaveTextContent('owner');
+  });
+
+  it('should display translated label for editor', () => {
+    render(RoleBadge, { role: 'editor' });
+    expect(screen.getByTestId('role-badge-editor')).toHaveTextContent('role_editor');
+  });
+
+  it('should display translated label for viewer', () => {
+    render(RoleBadge, { role: 'viewer' });
+    expect(screen.getByTestId('role-badge-viewer')).toHaveTextContent('role_viewer');
+  });
+
+  it('should apply filled styling for owner role', () => {
+    render(RoleBadge, { role: 'owner' });
+    const badge = screen.getByTestId('role-badge-owner');
+    expect(badge.className).toContain('bg-primary');
+    expect(badge.className).toContain('text-white');
+  });
+
+  it('should apply outlined styling for editor role', () => {
+    render(RoleBadge, { role: 'editor' });
+    const badge = screen.getByTestId('role-badge-editor');
+    expect(badge.className).toContain('border');
+    expect(badge.className).toContain('border-primary');
+    expect(badge.className).toContain('text-primary');
+  });
+
+  it('should apply gray styling for viewer role', () => {
+    render(RoleBadge, { role: 'viewer' });
+    const badge = screen.getByTestId('role-badge-viewer');
+    expect(badge.className).toContain('bg-gray-200');
+    expect(badge.className).toContain('text-gray-600');
+  });
+
+  it('should use space color for owner filled style', () => {
+    render(RoleBadge, { role: 'owner', spaceColor: 'blue' });
+    const badge = screen.getByTestId('role-badge-owner');
+    expect(badge.className).toContain('bg-blue-500');
+  });
+
+  it('should use space color for editor outlined style', () => {
+    render(RoleBadge, { role: 'editor', spaceColor: 'blue' });
+    const badge = screen.getByTestId('role-badge-editor');
+    expect(badge.className).toContain('border-blue-500');
+    expect(badge.className).toContain('text-blue-500');
+  });
+
+  it('should fall back to primary when spaceColor is null', () => {
+    render(RoleBadge, { role: 'owner', spaceColor: null });
+    const badge = screen.getByTestId('role-badge-owner');
+    expect(badge.className).toContain('bg-primary');
+  });
+
+  it('should fall back to primary for unknown color', () => {
+    render(RoleBadge, { role: 'owner', spaceColor: 'nonexistent' });
+    const badge = screen.getByTestId('role-badge-owner');
+    expect(badge.className).toContain('bg-primary');
+  });
+
+  it('should apply sm size classes', () => {
+    render(RoleBadge, { role: 'owner', size: 'sm' });
+    const badge = screen.getByTestId('role-badge-owner');
+    expect(badge.className).toContain('px-2');
+    expect(badge.className).toContain('py-0.5');
+    expect(badge.className).toContain('text-xs');
+  });
+
+  it('should apply md size classes by default', () => {
+    render(RoleBadge, { role: 'owner' });
+    const badge = screen.getByTestId('role-badge-owner');
+    expect(badge.className).toContain('px-2.5');
+    expect(badge.className).toContain('text-xs');
+  });
+
+  it('should always have rounded-full and font-medium', () => {
+    render(RoleBadge, { role: 'viewer' });
+    const badge = screen.getByTestId('role-badge-viewer');
+    expect(badge.className).toContain('rounded-full');
+    expect(badge.className).toContain('font-medium');
+  });
+
+  it('should ignore space color for viewer role (always gray)', () => {
+    render(RoleBadge, { role: 'viewer', spaceColor: 'red' });
+    const badge = screen.getByTestId('role-badge-viewer');
+    expect(badge.className).toContain('bg-gray-200');
+    expect(badge.className).not.toContain('bg-red');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `color-picker.svelte` (8 tests): rendering all swatches, selected state ring/scale classes, check icon visibility, aria-labels, onchange callback
- Add unit tests for `role-badge.svelte` (17 tests): role text labels, filled/outlined/gray styling per role, spaceColor variants, null/unknown color fallback, size classes, viewer ignoring spaceColor

## Test plan
- [x] All 25 tests pass locally (`pnpm vitest run`)
- [x] Tests render real components with no mocks of the components themselves
- [x] Assertions match actual `data-testid` attrs and CSS classes from component source

🤖 Generated with [Claude Code](https://claude.com/claude-code)