### PR TITLE
fix(e2e): remove encodedVideoPath from storage migration test

### DIFF
--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -244,7 +244,7 @@ export async function disconnectDb(): Promise<void> {
 }
 
 export interface MigrationState {
-  assets: { id: string; originalPath: string; encodedVideoPath: string | null }[];
+  assets: { id: string; originalPath: string }[];
   assetFiles: { id: string; path: string; type: string }[];
   persons: { id: string; thumbnailPath: string }[];
   users: { id: string; profileImagePath: string }[];
@@ -253,9 +253,7 @@ export interface MigrationState {
 
 export async function captureState(): Promise<MigrationState> {
   const [assets, assetFiles, persons, users, migrationLogs] = await Promise.all([
-    queryDb<{ id: string; originalPath: string; encodedVideoPath: string | null }>(
-      'SELECT id, "originalPath", "encodedVideoPath" FROM asset ORDER BY id',
-    ),
+    queryDb<{ id: string; originalPath: string }>('SELECT id, "originalPath" FROM asset ORDER BY id'),
     queryDb<{ id: string; path: string; type: string }>('SELECT id, path, type FROM asset_file ORDER BY id'),
     queryDb<{ id: string; thumbnailPath: string }>(
       'SELECT id, "thumbnailPath" FROM person WHERE "thumbnailPath" != \'\' ORDER BY id',


### PR DESCRIPTION
## Description

The `encodedVideoPath` column was removed from the `asset` table in the upstream merge (moved to `asset_file` table via `EncodedVideoAssetFiles` migration). The storage migration e2e test was still querying this column directly with `SELECT id, "originalPath", "encodedVideoPath" FROM asset`, causing the test to fail with:

```
error: column "encodedVideoPath" does not exist
```

Removes `encodedVideoPath` from the query and interface. Encoded video paths are already covered by the `asset_file` query in the same `captureState()` function.

## How Has This Been Tested?

- `tsc --noEmit` passes
- Prettier check passes
- The fix is a 2-line change removing a reference to a column that no longer exists

## Checklist:

- [x] Code follows project conventions
- [x] Tested with relevant checks

## Please describe to which degree you have tested your changes

Type-checked and formatted locally. CI will validate the full e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)