### PR TITLE
fix(e2e): improve waitForMigration for CI reliability

### DIFF
--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -271,27 +271,41 @@ export async function startMigration(
 }
 
 export async function waitForMigration(token: string, timeoutMs = 120_000): Promise<void> {
-  // Give the orchestrator job time to queue worker jobs
-  await sleep(2000);
+  // Give the orchestrator job time to be picked up by BullMQ workers.
+  // On CI after a server restart, workers may take several seconds to connect.
+  await sleep(5000);
+
   const deadline = Date.now() + timeoutMs;
+  let sawActivity = false;
+
   while (Date.now() < deadline) {
     const status = await api('GET', '/storage-migration/status', { token });
 
+    const active = status.active ?? 0;
+    const waiting = status.waiting ?? 0;
+    const completed = status.completed ?? 0;
+    const failed = status.failed ?? 0;
+
     console.log(
-      `  migration status: isActive=${status.isActive} active=${status.active ?? 0} waiting=${status.waiting ?? 0} completed=${status.completed ?? 0} failed=${status.failed ?? 0}`,
+      `  migration status: isActive=${status.isActive} active=${active} waiting=${waiting} completed=${completed} failed=${failed}`,
     );
 
-    if (!status.isActive && (status.waiting ?? 0) === 0 && (status.active ?? 0) === 0) {
-      if ((status.failed ?? 0) > 0) {
-        throw new Error(`Storage migration completed with ${status.failed} failed jobs`);
+    if (status.isActive || active > 0 || waiting > 0 || completed > 0 || failed > 0) {
+      sawActivity = true;
+    }
+
+    if (sawActivity && !status.isActive && waiting === 0 && active === 0) {
+      if (failed > 0) {
+        throw new Error(`Storage migration completed with ${failed} failed jobs`);
       }
       return;
     }
 
+    // If we haven't seen any activity yet, keep waiting — the job may not have been picked up
     await sleep(1000);
   }
 
-  throw new Error(`waitForMigration timed out after ${timeoutMs}ms`);
+  throw new Error(`waitForMigration timed out after ${timeoutMs}ms (sawActivity=${sawActivity})`);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix `waitForMigration` in the storage migration e2e tests to handle slow BullMQ worker startup on CI.

After a server restart, BullMQ workers may take several seconds to connect to Redis. The previous 2-second initial delay was insufficient, causing `waitForMigration` to return immediately (seeing `isActive=false, waiting=0`) before the orchestrator job was picked up.

Changes:
- Increase initial delay from 2s to 5s
- Track `sawActivity` flag — only consider migration "complete" after we've observed at least one non-zero counter
- Include `sawActivity` in timeout error message for debugging

## How Has This Been Tested?

- [x] TypeScript compilation passes
- [x] Prettier formatting passes
- [ ] Nightly storage migration workflow (will verify after merge)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Fully generated with Claude Code.