### PR TITLE
fix(ci): create MinIO bucket for storage migration tests

### DIFF
--- a/.github/workflows/storage-migration-tests.yml
+++ b/.github/workflows/storage-migration-tests.yml
@@ -47,6 +47,11 @@ jobs:
           IMMICH_STORAGE_BACKEND=disk \
           docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
 
+      - name: Create MinIO bucket
+        run: |
+          docker compose exec -T minio mc alias set local http://localhost:9000 minioadmin minioadmin
+          docker compose exec -T minio mc mb local/immich-test --ignore-existing
+
       - name: 'Phase: setup'
         run: pnpm tsx src/storage-migration.ts setup
 


### PR DESCRIPTION
## Description

The MinIO container in the storage migration e2e workflow starts empty. The `immich-test` bucket must be created explicitly before the server can migrate files to S3. Without it, all migration jobs fail with `NoSuchBucket`.

Adds a step after stack startup to create the bucket via `mc mb`.

## How Has This Been Tested?

- [x] Diagnosed from CI failure logs showing `NoSuchBucket` errors
- [ ] Will verify with nightly workflow after merge

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Fully generated with Claude Code.