### PR TITLE
fix(e2e): add debug logging for storage migration API failures

### DIFF
--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -596,7 +596,10 @@ async function phaseMigrateToS3(): Promise<void> {
       headers: { Authorization: `Bearer ${token}` },
       redirect: 'follow',
     });
-    assert.ok(res.status === 200, `Expected 200 for asset ${asset.id} original, got ${res.status}`);
+    if (res.status !== 200) {
+      const body = await res.text();
+      assert.fail(`Expected 200 for asset ${asset.id} original, got ${res.status}: ${body}`);
+    }
     await res.arrayBuffer();
   }
 
@@ -747,7 +750,10 @@ async function phaseMigrateToDisk(): Promise<void> {
       headers: { Authorization: `Bearer ${token}` },
       redirect: 'follow',
     });
-    assert.ok(res.status === 200, `Expected 200 for asset ${asset.id} original, got ${res.status}`);
+    if (res.status !== 200) {
+      const body = await res.text();
+      assert.fail(`Expected 200 for asset ${asset.id} original, got ${res.status}: ${body}`);
+    }
     await res.arrayBuffer();
   }
 
@@ -1299,7 +1305,10 @@ async function phaseDeleteSourceFalse(): Promise<void> {
       headers: { Authorization: `Bearer ${token}` },
       redirect: 'follow',
     });
-    assert.ok(res.status === 200, `Expected 200 for asset ${asset.id} original, got ${res.status}`);
+    if (res.status !== 200) {
+      const body = await res.text();
+      assert.fail(`Expected 200 for asset ${asset.id} original, got ${res.status}: ${body}`);
+    }
     await res.arrayBuffer();
   }
 


### PR DESCRIPTION
## Description

Log response body when asset API calls return non-200 status during storage migration e2e tests. This helps diagnose why `/assets/:id/original` returns 400 after migration.

## How Has This Been Tested?

- [x] TypeScript compilation passes
- [x] Prettier formatting passes

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Fully generated with Claude Code.