### PR TITLE
docs: add live demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 </picture>
 </p>
 <h3 align="center">High performance self-hosted photo and video management solution</h3>
+<h4 align="center"><a href="https://demo.opennoodle.de">Try the live demo</a></h4>
 <br/>
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
- Adds a "Try the live demo" link (https://demo.opennoodle.de) to the README, below the tagline