### PR TITLE
fix: add validation checks to shared spaces operations

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -12702,7 +12702,7 @@
             "state": "Beta"
           }
         ],
-        "x-immich-permission": "sharedSpaceAsset.create",
+        "x-immich-permission": "sharedSpace.update",
         "x-immich-state": "Beta"
       },
       "get": {
@@ -12834,7 +12834,7 @@
             "state": "Beta"
           }
         ],
-        "x-immich-permission": "sharedSpaceAsset.create",
+        "x-immich-permission": "sharedSpace.update",
         "x-immich-state": "Beta"
       }
     },
@@ -13086,7 +13086,7 @@
             "state": "Beta"
           }
         ],
-        "x-immich-permission": "sharedSpaceAsset.create",
+        "x-immich-permission": "sharedSpace.update",
         "x-immich-state": "Beta"
       }
     },

--- a/server/src/controllers/shared-space.controller.ts
+++ b/server/src/controllers/shared-space.controller.ts
@@ -290,7 +290,7 @@ export class SharedSpaceController {
   }
 
   @Put(':id/people/:personId')
-  @Authenticated({ permission: Permission.SharedSpaceAssetCreate })
+  @Authenticated({ permission: Permission.SharedSpaceUpdate })
   @Endpoint({
     summary: 'Update a person in a shared space',
     description: 'Update the name, visibility, birth date, or representative face of a person.',
@@ -306,7 +306,7 @@ export class SharedSpaceController {
   }
 
   @Delete(':id/people/:personId')
-  @Authenticated({ permission: Permission.SharedSpaceAssetCreate })
+  @Authenticated({ permission: Permission.SharedSpaceUpdate })
   @HttpCode(HttpStatus.NO_CONTENT)
   @Endpoint({
     summary: 'Delete a person from a shared space',
@@ -322,7 +322,7 @@ export class SharedSpaceController {
   }
 
   @Post(':id/people/:personId/merge')
-  @Authenticated({ permission: Permission.SharedSpaceAssetCreate })
+  @Authenticated({ permission: Permission.SharedSpaceUpdate })
   @HttpCode(HttpStatus.NO_CONTENT)
   @Endpoint({
     summary: 'Merge people in a shared space',

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -425,7 +425,7 @@ where
   "spaceId" = $1
   and "assetId" = $2
 limit
-  1
+  $3
 
 -- SharedSpaceRepository.isFaceInSpace
 select
@@ -438,7 +438,7 @@ where
   and "asset_face"."id" = $2
   and "asset_face"."deletedAt" is null
 limit
-  1
+  $3
 
 -- SharedSpaceRepository.getAssetIdsInSpace
 select

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -416,6 +416,30 @@ where
   "asset_face"."assetId" = $1
   and "asset_face"."deletedAt" is null
 
+-- SharedSpaceRepository.isAssetInSpace
+select
+  "assetId"
+from
+  "shared_space_asset"
+where
+  "spaceId" = $1
+  and "assetId" = $2
+limit
+  1
+
+-- SharedSpaceRepository.isFaceInSpace
+select
+  "asset_face"."id"
+from
+  "shared_space_asset"
+  inner join "asset_face" on "asset_face"."assetId" = "shared_space_asset"."assetId"
+where
+  "shared_space_asset"."spaceId" = $1
+  and "asset_face"."id" = $2
+  and "asset_face"."deletedAt" is null
+limit
+  1
+
 -- SharedSpaceRepository.getAssetIdsInSpace
 select
   "assetId"

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -535,6 +535,32 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
+  async isAssetInSpace(spaceId: string, assetId: string): Promise<boolean> {
+    const result = await this.db
+      .selectFrom('shared_space_asset')
+      .select('assetId')
+      .where('spaceId', '=', spaceId)
+      .where('assetId', '=', assetId)
+      .limit(1)
+      .executeTakeFirst();
+    return !!result;
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
+  async isFaceInSpace(spaceId: string, faceId: string): Promise<boolean> {
+    const result = await this.db
+      .selectFrom('shared_space_asset')
+      .innerJoin('asset_face', 'asset_face.assetId', 'shared_space_asset.assetId')
+      .select('asset_face.id')
+      .where('shared_space_asset.spaceId', '=', spaceId)
+      .where('asset_face.id', '=', faceId)
+      .where('asset_face.deletedAt', 'is', null)
+      .limit(1)
+      .executeTakeFirst();
+    return !!result;
+  }
+
   @GenerateSql({ params: [DummyValue.UUID] })
   getAssetIdsInSpace(spaceId: string) {
     return this.db.selectFrom('shared_space_asset').select('assetId').where('spaceId', '=', spaceId).execute();

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -659,6 +659,7 @@ describe(SharedSpaceService.name, () => {
       const updatedSpace = { ...space, thumbnailAssetId };
 
       mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(updatedSpace);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
@@ -705,6 +706,7 @@ describe(SharedSpaceService.name, () => {
       const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
 
       mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue({ ...space, thumbnailAssetId });
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
@@ -712,6 +714,22 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.update(auth, space.id, { thumbnailAssetId });
 
       expect(result.thumbnailAssetId).toBe(thumbnailAssetId);
+    });
+
+    it('should reject thumbnailAssetId that is not in the space', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace();
+      const foreignAssetId = newUuid();
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(false);
+
+      await expect(sut.update(auth, space.id, { thumbnailAssetId: foreignAssetId })).rejects.toThrow(
+        'Thumbnail asset must belong to the space',
+      );
+
+      expect(mocks.sharedSpace.update).not.toHaveBeenCalled();
     });
 
     it('should not allow editor to update name', async () => {
@@ -839,6 +857,7 @@ describe(SharedSpaceService.name, () => {
       const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
 
       mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue({ ...space, thumbnailAssetId: newUuid(), thumbnailCropY: null });
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
@@ -890,6 +909,7 @@ describe(SharedSpaceService.name, () => {
     it('should log cover_change when thumbnailAssetId changes', async () => {
       const space = factory.sharedSpace({ thumbnailAssetId: null });
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Editor }));
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue({ ...space, thumbnailAssetId: 'asset-1' });
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
@@ -1409,6 +1429,7 @@ describe(SharedSpaceService.name, () => {
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId1, assetId2]));
       mocks.sharedSpace.addAssets.mockResolvedValue([]);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
@@ -1422,6 +1443,26 @@ describe(SharedSpaceService.name, () => {
       ]);
     });
 
+    it('should reject adding assets the user does not have access to', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const ownedAssetId = newUuid();
+      const foreignAssetId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([ownedAssetId]));
+      mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set());
+      mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set());
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set());
+
+      await expect(
+        sut.addAssets(auth, spaceId, { assetIds: [ownedAssetId, foreignAssetId] }),
+      ).rejects.toThrow();
+
+      expect(mocks.sharedSpace.addAssets).not.toHaveBeenCalled();
+    });
+
     it('should NOT auto-set thumbnailAssetId when space has no thumbnail', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
@@ -1430,6 +1471,7 @@ describe(SharedSpaceService.name, () => {
       const space = factory.sharedSpace({ id: spaceId, thumbnailAssetId: null, faceRecognitionEnabled: false });
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId1]));
       mocks.sharedSpace.addAssets.mockResolvedValue([]);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
@@ -1448,6 +1490,7 @@ describe(SharedSpaceService.name, () => {
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
       mocks.sharedSpace.addAssets.mockResolvedValue([]);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
@@ -1476,6 +1519,7 @@ describe(SharedSpaceService.name, () => {
       const auth = factory.auth();
       const space = factory.sharedSpace({ faceRecognitionEnabled: false });
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Editor }));
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['a1', 'a2', 'a3']));
       mocks.sharedSpace.addAssets.mockResolvedValue([]);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
@@ -1500,6 +1544,7 @@ describe(SharedSpaceService.name, () => {
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId1, assetId2]));
       mocks.sharedSpace.addAssets.mockResolvedValue([]);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
@@ -1525,6 +1570,7 @@ describe(SharedSpaceService.name, () => {
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
       mocks.sharedSpace.addAssets.mockResolvedValue([]);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
@@ -2404,6 +2450,46 @@ describe(SharedSpaceService.name, () => {
 
       expect(result.name).toBe('New Name');
       expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(personId, { name: 'New Name' });
+    });
+
+    it('should reject representativeFaceId that does not belong to an asset in the space', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const foreignFaceId = newUuid();
+      const person = factory.sharedSpacePerson({ id: personId, spaceId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Editor }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue(person);
+      mocks.sharedSpace.isFaceInSpace.mockResolvedValue(false);
+
+      await expect(
+        sut.updateSpacePerson(auth, spaceId, personId, { representativeFaceId: foreignFaceId }),
+      ).rejects.toThrow('Representative face must belong to an asset in the space');
+
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+    });
+
+    it('should allow representativeFaceId that belongs to an asset in the space', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const faceId = newUuid();
+      const person = factory.sharedSpacePerson({ id: personId, spaceId });
+      const updatedPerson = factory.sharedSpacePerson({ id: personId, spaceId, representativeFaceId: faceId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Editor }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue(person);
+      mocks.sharedSpace.isFaceInSpace.mockResolvedValue(true);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(updatedPerson);
+      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(5);
+      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(3);
+      mocks.sharedSpace.getAlias.mockResolvedValue(void 0);
+
+      const result = await sut.updateSpacePerson(auth, spaceId, personId, { representativeFaceId: faceId });
+
+      expect(result.representativeFaceId).toBe(faceId);
+      expect(mocks.sharedSpace.isFaceInSpace).toHaveBeenCalledWith(spaceId, faceId);
     });
   });
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -1456,9 +1456,7 @@ describe(SharedSpaceService.name, () => {
       mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set());
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set());
 
-      await expect(
-        sut.addAssets(auth, spaceId, { assetIds: [ownedAssetId, foreignAssetId] }),
-      ).rejects.toThrow();
+      await expect(sut.addAssets(auth, spaceId, { assetIds: [ownedAssetId, foreignAssetId] })).rejects.toThrow();
 
       expect(mocks.sharedSpace.addAssets).not.toHaveBeenCalled();
     });

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -150,6 +150,14 @@ export class SharedSpaceService extends BaseService {
     const minimumRole = isMetadataUpdate ? SharedSpaceRole.Owner : SharedSpaceRole.Editor;
     await this.requireRole(auth, id, minimumRole);
 
+    // Validate thumbnail asset belongs to the space
+    if (dto.thumbnailAssetId !== undefined && dto.thumbnailAssetId !== null) {
+      const isInSpace = await this.sharedSpaceRepository.isAssetInSpace(id, dto.thumbnailAssetId);
+      if (!isInSpace) {
+        throw new BadRequestException('Thumbnail asset must belong to the space');
+      }
+    }
+
     // Reset crop position when cover photo changes
     const thumbnailCropY = dto.thumbnailAssetId === undefined ? dto.thumbnailCropY : null;
 
@@ -350,6 +358,7 @@ export class SharedSpaceService extends BaseService {
 
   async addAssets(auth: AuthDto, spaceId: string, dto: SharedSpaceAssetAddDto): Promise<void> {
     await this.requireRole(auth, spaceId, SharedSpaceRole.Editor);
+    await this.requireAccess({ auth, permission: Permission.AssetRead, ids: dto.assetIds });
     await this.sharedSpaceRepository.addAssets(
       dto.assetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),
     );
@@ -506,6 +515,13 @@ export class SharedSpaceService extends BaseService {
     const person = await this.sharedSpaceRepository.getPersonById(personId);
     if (!person || person.spaceId !== spaceId) {
       throw new BadRequestException('Person not found');
+    }
+
+    if (dto.representativeFaceId) {
+      const isInSpace = await this.sharedSpaceRepository.isFaceInSpace(spaceId, dto.representativeFaceId);
+      if (!isInSpace) {
+        throw new BadRequestException('Representative face must belong to an asset in the space');
+      }
     }
 
     const updated = await this.sharedSpaceRepository.updatePerson(personId, {


### PR DESCRIPTION
## Summary

- Validate asset access before adding assets to a space (users can only add assets they have access to)
- Validate thumbnail asset belongs to the space when updating cover photo
- Validate representative face belongs to an asset in the space when updating a person
- Fix controller permissions for person update/delete/merge endpoints (use `SharedSpaceUpdate` instead of `SharedSpaceAssetCreate`)
- Add `isAssetInSpace` and `isFaceInSpace` repository methods for the new validations
- Add tests for all new validation checks

## Test plan

- [x] All 3321 existing unit tests pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes with zero warnings
- [ ] Verify adding assets to a space requires access to those assets
- [ ] Verify setting a thumbnail rejects assets not in the space
- [ ] Verify setting a representative face rejects faces not in the space

🤖 Generated with [Claude Code](https://claude.com/claude-code)