### PR TITLE
feat(mobile): update application ID to de.opennoodle.gallery

### DIFF
--- a/branding/config.json
+++ b/branding/config.json
@@ -21,14 +21,14 @@
   },
 
   "mobile": {
-    "bundle_id": "app.noodle.gallery",
-    "bundle_id_debug": "app.noodle.gallery.debug",
-    "bundle_id_profile": "app.noodle.gallery.profile",
+    "bundle_id": "de.opennoodle.gallery",
+    "bundle_id_debug": "de.opennoodle.gallery.debug",
+    "bundle_id_profile": "de.opennoodle.gallery.profile",
     "deep_link_scheme": "noodle-gallery",
-    "oauth_callback": "app.noodle.gallery:///oauth-callback",
-    "shared_group": "group.app.noodle.gallery.share",
+    "oauth_callback": "de.opennoodle.gallery:///oauth-callback",
+    "shared_group": "group.de.opennoodle.gallery.share",
     "download_dir": "DCIM/NoodleGallery",
-    "background_task_prefix": "app.noodle.gallery.background"
+    "background_task_prefix": "de.opennoodle.gallery.background"
   },
 
   "docker": {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -54,7 +54,7 @@ android {
   }
 
   defaultConfig {
-    applicationId "app.alextran.immich"
+    applicationId "de.opennoodle.gallery"
     minSdkVersion 26
     targetSdkVersion 35
     versionCode flutterVersionCode.toInteger()

--- a/mobile/android/fastlane/Appfile
+++ b/mobile/android/fastlane/Appfile
@@ -1,2 +1,2 @@
-json_key_file("/Users/alex/Documents/immich-play-store-key.json")
-package_name("app.alextran.immich")
+json_key_file("fastlane/play-store-key.json")
+package_name("de.opennoodle.gallery")


### PR DESCRIPTION
## Summary

- Renames the Android/iOS application identifier from `app.alextran.immich` to `de.opennoodle.gallery` for Play Store publishing under our own identity
- Updates Kotlin package structure (`app/alextran/immich/` → `de/opennoodle/gallery/`), including package declarations, imports, JNI function names, and directory layout
- Updates all references across branding config, Fastlane, pigeon codegen, Dart constants, web/server store links, iOS configs, and docs

## Test plan

- [ ] Verify Android build compiles: `cd mobile && flutter build apk --debug`
- [ ] Verify iOS build compiles: `cd mobile && flutter build ios --no-codesign`
- [ ] Confirm widget functionality works with new package references
- [ ] Confirm background sync task IDs match between Info.plist and Swift source

🤖 Generated with [Claude Code](https://claude.com/claude-code)