### PR TITLE
fix: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -116,7 +116,7 @@ jobs:
           key: build-mobile-gradle-${{ runner.os }}-main
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
+        uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0.21.0
         with:
           channel: 'stable'
           flutter-version-file: ./mobile/pubspec.yaml
@@ -195,7 +195,7 @@ jobs:
       - uses: ./.github/actions/apply-branding
 
       - name: Setup Flutter SDK
-        uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
+        uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
         with:
           channel: 'stable'
           flutter-version-file: ./mobile/pubspec.yaml
@@ -214,7 +214,7 @@ jobs:
         working-directory: ./mobile
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/org-pr-require-conventional-commit.yml
+++ b/.github/workflows/org-pr-require-conventional-commit.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   validate-pr-title:
     name: Validate PR Title (conventional commit)
-    uses: immich-app/devtools/.github/workflows/shared-pr-require-conventional-commit.yml@main
+    uses: immich-app/devtools/.github/workflows/shared-pr-require-conventional-commit.yml@f852dea251d00397830d83977184b6551e84589c # main
     permissions:
       pull-requests: write

--- a/.github/workflows/org-zizmor.yml
+++ b/.github/workflows/org-zizmor.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   zizmor:
     name: Zizmor
-    uses: immich-app/devtools/.github/workflows/shared-zizmor.yml@main
+    uses: immich-app/devtools/.github/workflows/shared-zizmor.yml@f852dea251d00397830d83977184b6551e84589c # main
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary
- Pin `ruby/setup-ruby` to commit SHA in build-mobile.yml
- Pin `immich-app/devtools` reusable workflows to commit SHA
- Fix version comment mismatch for `subosito/flutter-action`

## Test plan
- [ ] CI workflows still trigger correctly
- [ ] Mobile build workflow runs successfully