### PR TITLE
fix(server): validate redirect URL protocol

### DIFF
--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -137,6 +137,54 @@ describe('sendFile with ImmichMediaResponse', () => {
     expect(res.redirect).toHaveBeenCalledWith('https://example.com');
   });
 
+  it('should reject redirect with javascript: protocol', async () => {
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      redirect: vi.fn(),
+      headersSent: false,
+    } as any;
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichRedirectResponse({
+          url: 'javascript:alert(1)',
+          cacheControl: CacheControl.None,
+        }),
+      mockLogger,
+    );
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(HttpException));
+  });
+
+  it('should reject redirect with invalid URL', async () => {
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      redirect: vi.fn(),
+      headersSent: false,
+    } as any;
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichRedirectResponse({
+          url: '//evil.com/path',
+          cacheControl: CacheControl.None,
+        }),
+      mockLogger,
+    );
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(HttpException));
+  });
+
   it('should send file response for ImmichFileResponse', async () => {
     const res = {
       set: vi.fn(),

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -79,6 +79,17 @@ export const sendFile = async (
     const file = await handler();
 
     if (file instanceof ImmichRedirectResponse) {
+      let parsed: URL;
+      try {
+        parsed = new URL(file.url);
+      } catch {
+        throw new HttpException('Invalid redirect URL', 500);
+      }
+
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        throw new HttpException('Invalid redirect URL protocol', 500);
+      }
+
       const cacheControlHeader = cacheControlHeaders[file.cacheControl];
       if (cacheControlHeader) {
         res.set('Cache-Control', cacheControlHeader);


### PR DESCRIPTION
## Summary
- Validates redirect URLs use only `http:`/`https:` protocol before calling `res.redirect()`, preventing open redirect via `javascript:`, `data:`, or other schemes
- Malformed URLs are also rejected (non-parseable strings)
- Adds two test cases covering both `javascript:` protocol and invalid URL rejection

## Test plan
- [x] Existing redirect tests still pass (14 tests in `file.spec.ts`)
- [x] Full server unit test suite passes (3343 tests)
- [ ] Verify Aikido no longer flags `server/src/utils/file.ts:86`

🤖 Generated with [Claude Code](https://claude.com/claude-code)