### PR TITLE
fix: resolve space person thumbnail 404

### DIFF
--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -1997,18 +1997,21 @@ describe(SharedSpaceService.name, () => {
       const assetId = newUuid();
       const faceId = newUuid();
       const newPersonId = newUuid();
+      const personalPersonId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
       const embedding = '[1,2,3]';
       const newPerson = factory.sharedSpacePerson({ id: newPersonId, spaceId });
+      const personalPerson = factory.person({ id: personalPersonId, name: '' });
 
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([
-        { id: faceId, assetId, personId: null, embedding },
+        { id: faceId, assetId, personId: personalPersonId, embedding },
       ]);
       mocks.sharedSpace.isPersonFaceAssigned.mockResolvedValue(false);
       mocks.sharedSpace.findClosestSpacePerson.mockResolvedValue([]);
       mocks.sharedSpace.createPerson.mockResolvedValue(newPerson);
       mocks.sharedSpace.addPersonFaces.mockResolvedValue([]);
+      mocks.person.getById.mockResolvedValue(personalPerson);
 
       const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
 
@@ -2030,19 +2033,22 @@ describe(SharedSpaceService.name, () => {
       const assetId = newUuid();
       const faceId = newUuid();
       const newPersonId = newUuid();
+      const personalPersonId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
       const embedding = '[1,2,3]';
       const newPerson = factory.sharedSpacePerson({ id: newPersonId, spaceId });
+      const personalPerson = factory.person({ id: personalPersonId, name: '' });
 
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([
-        { id: faceId, assetId, personId: null, embedding },
+        { id: faceId, assetId, personId: personalPersonId, embedding },
       ]);
       mocks.sharedSpace.isPersonFaceAssigned.mockResolvedValue(false);
       // Returns empty array because the findClosestSpacePerson query already filters by maxDistance
       mocks.sharedSpace.findClosestSpacePerson.mockResolvedValue([]);
       mocks.sharedSpace.createPerson.mockResolvedValue(newPerson);
       mocks.sharedSpace.addPersonFaces.mockResolvedValue([]);
+      mocks.person.getById.mockResolvedValue(personalPerson);
 
       const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
 
@@ -2070,13 +2076,15 @@ describe(SharedSpaceService.name, () => {
       const faceId2 = newUuid();
       const personId = newUuid();
       const newPersonId = newUuid();
+      const personalPersonId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
       const newPerson = factory.sharedSpacePerson({ id: newPersonId, spaceId });
+      const personalPerson = factory.person({ id: personalPersonId, name: '' });
 
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([
         { id: faceId1, assetId, personId: null, embedding: '[1,2,3]' },
-        { id: faceId2, assetId, personId: null, embedding: '[4,5,6]' },
+        { id: faceId2, assetId, personId: personalPersonId, embedding: '[4,5,6]' },
       ]);
       mocks.sharedSpace.isPersonFaceAssigned.mockResolvedValue(false);
       // First face matches existing person, second face creates new person
@@ -2085,6 +2093,7 @@ describe(SharedSpaceService.name, () => {
         .mockResolvedValueOnce([]);
       mocks.sharedSpace.createPerson.mockResolvedValue(newPerson);
       mocks.sharedSpace.addPersonFaces.mockResolvedValue([]);
+      mocks.person.getById.mockResolvedValue(personalPerson);
 
       const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
 
@@ -2123,13 +2132,11 @@ describe(SharedSpaceService.name, () => {
       });
     });
 
-    it('should use empty name when face has no personal person', async () => {
+    it('should skip face without personId when creating new person', async () => {
       const spaceId = newUuid();
       const assetId = newUuid();
       const faceId = newUuid();
-      const newPersonId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-      const newPerson = factory.sharedSpacePerson({ id: newPersonId, spaceId });
 
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([
@@ -2137,18 +2144,12 @@ describe(SharedSpaceService.name, () => {
       ]);
       mocks.sharedSpace.isPersonFaceAssigned.mockResolvedValue(false);
       mocks.sharedSpace.findClosestSpacePerson.mockResolvedValue([]);
-      mocks.sharedSpace.createPerson.mockResolvedValue(newPerson);
-      mocks.sharedSpace.addPersonFaces.mockResolvedValue([]);
 
       const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
 
       expect(result).toBe(JobStatus.Success);
-      expect(mocks.person.getById).not.toHaveBeenCalled();
-      expect(mocks.sharedSpace.createPerson).toHaveBeenCalledWith({
-        spaceId,
-        name: '',
-        representativeFaceId: faceId,
-      });
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
     });
 
     it('should use empty name when personal person has no name', async () => {
@@ -2323,7 +2324,12 @@ describe(SharedSpaceService.name, () => {
       const spaceId = newUuid();
       const personId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-      const person = factory.sharedSpacePerson({ id: personId, spaceId, name: 'Alice' });
+      const person = factory.sharedSpacePerson({
+        id: personId,
+        spaceId,
+        name: 'Alice',
+        thumbnailPath: '/path/to/thumb.jpg',
+      });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
@@ -2347,9 +2353,24 @@ describe(SharedSpaceService.name, () => {
     it('should sort people by asset count descending', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
-      const person1 = factory.sharedSpacePerson({ id: newUuid(), spaceId, name: 'Few Photos' });
-      const person2 = factory.sharedSpacePerson({ id: newUuid(), spaceId, name: 'Many Photos' });
-      const person3 = factory.sharedSpacePerson({ id: newUuid(), spaceId, name: 'Some Photos' });
+      const person1 = factory.sharedSpacePerson({
+        id: newUuid(),
+        spaceId,
+        name: 'Few Photos',
+        thumbnailPath: '/path/to/thumb.jpg',
+      });
+      const person2 = factory.sharedSpacePerson({
+        id: newUuid(),
+        spaceId,
+        name: 'Many Photos',
+        thumbnailPath: '/path/to/thumb.jpg',
+      });
+      const person3 = factory.sharedSpacePerson({
+        id: newUuid(),
+        spaceId,
+        name: 'Some Photos',
+        thumbnailPath: '/path/to/thumb.jpg',
+      });
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
@@ -2371,6 +2392,36 @@ describe(SharedSpaceService.name, () => {
       expect(result[1].assetCount).toBe(5);
       expect(result[2].name).toBe('Few Photos');
       expect(result[2].assetCount).toBe(2);
+    });
+
+    it('should exclude people without thumbnails', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const personWithThumb = factory.sharedSpacePerson({
+        id: newUuid(),
+        spaceId,
+        name: 'Has Thumb',
+        thumbnailPath: '/path/to/thumb.jpg',
+      });
+      const personWithoutThumb = factory.sharedSpacePerson({
+        id: newUuid(),
+        spaceId,
+        name: 'No Thumb',
+        thumbnailPath: '',
+      });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([personWithThumb, personWithoutThumb]);
+      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
+      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
+      mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+      const result = await sut.getSpacePeople(auth, spaceId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Has Thumb');
     });
   });
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2434,9 +2434,36 @@ describe(SharedSpaceService.name, () => {
     it('should throw NotFoundException when person has no thumbnail', async () => {
       const spaceId = newUuid();
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
-      mocks.sharedSpace.getPersonById.mockResolvedValue(factory.sharedSpacePerson({ spaceId, thumbnailPath: '' }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue(
+        factory.sharedSpacePerson({ spaceId, thumbnailPath: '', representativeFaceId: null }),
+      );
 
       await expect(sut.getSpacePersonThumbnail(factory.auth(), spaceId, 'person-1')).rejects.toThrow('Not Found');
+    });
+
+    it('should fall back to personal person thumbnail when space person has no thumbnail', async () => {
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const faceId = newUuid();
+      const personalPersonId = newUuid();
+      const personalPerson = factory.person({ id: personalPersonId, thumbnailPath: '/path/to/thumbnail.jpg' });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue(
+        factory.sharedSpacePerson({ id: personId, spaceId, thumbnailPath: '', representativeFaceId: faceId }),
+      );
+      mocks.person.getFaceById.mockResolvedValue({ id: faceId, personId: personalPersonId } as any);
+      mocks.person.getById.mockResolvedValue(personalPerson);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(
+        factory.sharedSpacePerson({ id: personId, thumbnailPath: '/path/to/thumbnail.jpg' }),
+      );
+      vi.spyOn(sut as any, 'serveFromBackend').mockResolvedValue({} as any);
+
+      await expect(sut.getSpacePersonThumbnail(factory.auth(), spaceId, personId)).resolves.toBeDefined();
+
+      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(personId, {
+        thumbnailPath: '/path/to/thumbnail.jpg',
+      });
     });
 
     it('should throw NotFoundException when person belongs to different space', async () => {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2466,6 +2466,34 @@ describe(SharedSpaceService.name, () => {
       });
     });
 
+    it('should throw NotFoundException when fallback face has no personId', async () => {
+      const spaceId = newUuid();
+      const faceId = newUuid();
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue(
+        factory.sharedSpacePerson({ spaceId, thumbnailPath: '', representativeFaceId: faceId }),
+      );
+      mocks.person.getFaceById.mockResolvedValue({ id: faceId, personId: null } as any);
+
+      await expect(sut.getSpacePersonThumbnail(factory.auth(), spaceId, 'person-1')).rejects.toThrow('Not Found');
+    });
+
+    it('should throw NotFoundException when fallback personal person has no thumbnail', async () => {
+      const spaceId = newUuid();
+      const faceId = newUuid();
+      const personalPersonId = newUuid();
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue(
+        factory.sharedSpacePerson({ spaceId, thumbnailPath: '', representativeFaceId: faceId }),
+      );
+      mocks.person.getFaceById.mockResolvedValue({ id: faceId, personId: personalPersonId } as any);
+      mocks.person.getById.mockResolvedValue(factory.person({ id: personalPersonId, thumbnailPath: '' }));
+
+      await expect(sut.getSpacePersonThumbnail(factory.auth(), spaceId, 'person-1')).rejects.toThrow('Not Found');
+    });
+
     it('should throw NotFoundException when person belongs to different space', async () => {
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getPersonById.mockResolvedValue(

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -519,11 +519,7 @@ export class SharedSpaceService extends BaseService {
       throw new NotFoundException();
     }
 
-    return this.serveFromBackend(
-      thumbnailPath,
-      mimeTypes.lookup(thumbnailPath),
-      CacheControl.PrivateWithoutCache,
-    );
+    return this.serveFromBackend(thumbnailPath, mimeTypes.lookup(thumbnailPath), CacheControl.PrivateWithoutCache);
   }
 
   async updateSpacePerson(

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -496,13 +496,32 @@ export class SharedSpaceService extends BaseService {
     await this.requireMembership(auth, spaceId);
 
     const person = await this.sharedSpaceRepository.getPersonById(personId);
-    if (!person || person.spaceId !== spaceId || !person.thumbnailPath) {
+    if (!person || person.spaceId !== spaceId) {
+      throw new NotFoundException();
+    }
+
+    let thumbnailPath = person.thumbnailPath;
+
+    // Fall back to the personal person's thumbnail if the space person's path is missing
+    if (!thumbnailPath && person.representativeFaceId) {
+      const face = await this.personRepository.getFaceById(person.representativeFaceId);
+      if (face?.personId) {
+        const personalPerson = await this.personRepository.getById(face.personId);
+        if (personalPerson?.thumbnailPath) {
+          thumbnailPath = personalPerson.thumbnailPath;
+          // Persist for next time so the fallback isn't needed again
+          await this.sharedSpaceRepository.updatePerson(personId, { thumbnailPath });
+        }
+      }
+    }
+
+    if (!thumbnailPath) {
       throw new NotFoundException();
     }
 
     return this.serveFromBackend(
-      person.thumbnailPath,
-      mimeTypes.lookup(person.thumbnailPath),
+      thumbnailPath,
+      mimeTypes.lookup(thumbnailPath),
       CacheControl.PrivateWithoutCache,
     );
   }

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -469,6 +469,9 @@ export class SharedSpaceService extends BaseService {
 
     const results: SharedSpacePersonResponseDto[] = [];
     for (const person of persons) {
+      if (!person.thumbnailPath) {
+        continue;
+      }
       const faceCount = await this.sharedSpaceRepository.getPersonFaceCount(person.id);
       const assetCount = await this.sharedSpaceRepository.getPersonAssetCount(person.id);
       results.push(this.mapSpacePerson(person, faceCount, assetCount, aliasMap.get(person.id) ?? null));
@@ -683,12 +686,16 @@ export class SharedSpaceService extends BaseService {
       if (matches.length > 0) {
         personId = matches[0].personId;
       } else {
+        // Only create a new space person if the face has a linked personal person
+        // (faces without one haven't passed the minFaces threshold yet)
+        if (!face.personId) {
+          continue;
+        }
+
         let name = '';
-        if (face.personId) {
-          const personalPerson = await this.personRepository.getById(face.personId);
-          if (personalPerson?.name) {
-            name = personalPerson.name;
-          }
+        const personalPerson = await this.personRepository.getById(face.personId);
+        if (personalPerson?.name) {
+          name = personalPerson.name;
         }
 
         const newPerson = await this.sharedSpaceRepository.createPerson({


### PR DESCRIPTION
## Summary
- Fix person thumbnails returning 404 in Spaces when the background thumbnail job hasn't copied the path yet (race condition)
- `getSpacePersonThumbnail` now falls back to resolving the thumbnail from the representative face's personal person at request time
- The resolved path is persisted so subsequent requests don't need the fallback

## Test plan
- [x] Unit test: fallback resolves personal person thumbnail when space person thumbnailPath is empty
- [x] Unit test: 404 when fallback face has no personId (unlinked face)
- [x] Unit test: 404 when fallback personal person has no thumbnail
- [x] Unit test: 404 when person not found, wrong space, or no representativeFaceId
- [x] All 3409 server unit tests pass