### PR TITLE
ci: add ARM64 Docker image support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,12 +91,20 @@ jobs:
           echo "Version: $version (major: v${major})"
 
   build-server:
-    name: Build & Push Server
+    name: Build Server (${{ matrix.platform }})
     needs: version
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -118,28 +126,82 @@ jobs:
         with:
           version: ${{ needs.version.outputs.latest_tag }}
 
-      - name: Build and push
+      - name: Prepare platform pair
+        id: prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "platform-pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: server/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/open-noodle/gallery-server:${{ needs.version.outputs.version }}
-            ghcr.io/open-noodle/gallery-server:${{ needs.version.outputs.major }}
-            ghcr.io/open-noodle/gallery-server:release
+          platforms: ${{ matrix.platform }}
           build-args: |
             DEVICE=cpu
             BUILD_ID=${{ github.run_id }}
             BUILD_SOURCE_REF=${{ github.ref_name }}
             BUILD_SOURCE_COMMIT=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,"name=ghcr.io/open-noodle/gallery-server",push-by-digest=true,name-resolution=short,push=true
+          cache-from: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }}
+          cache-to: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }},mode=max
+
+      - name: Export digest
+        run: | # zizmor: ignore[template-injection]
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: server-digests-${{ steps.prepare.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-server:
+    name: Merge Server Manifest
+    needs: [version, build-server]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: server-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ghcr.io/open-noodle/gallery-server
+          VERSION: ${{ needs.version.outputs.version }}
+          MAJOR: ${{ needs.version.outputs.major }}
+        run: |
+          tags="-t ${IMAGE}:${VERSION} -t ${IMAGE}:${MAJOR} -t ${IMAGE}:release"
+          sources=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create ${tags} ${sources}
 
   build-ml:
-    name: Build & Push ML (${{ matrix.device }})
+    name: Build ML ${{ matrix.device }} (${{ matrix.platform }})
     needs: version
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -148,9 +210,14 @@ jobs:
       matrix:
         include:
           - device: cpu
-            suffix: ''
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - device: cpu
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
           - device: cuda
-            suffix: '-cuda'
+            platform: linux/amd64
+            runner: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -172,24 +239,87 @@ jobs:
         with:
           version: ${{ needs.version.outputs.latest_tag }}
 
-      - name: Build and push
+      - name: Prepare platform pair
+        id: prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "platform-pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: machine-learning
           file: machine-learning/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/open-noodle/gallery-ml:${{ needs.version.outputs.version }}${{ matrix.suffix }}
-            ghcr.io/open-noodle/gallery-ml:${{ needs.version.outputs.major }}${{ matrix.suffix }}
-            ghcr.io/open-noodle/gallery-ml:release${{ matrix.suffix }}
+          platforms: ${{ matrix.platform }}
           build-args: |
             DEVICE=${{ matrix.device }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,"name=ghcr.io/open-noodle/gallery-ml",push-by-digest=true,name-resolution=short,push=true
+          cache-from: type=gha,scope=ml-${{ matrix.device }}-${{ steps.prepare.outputs.platform-pair }}
+          cache-to: type=gha,scope=ml-${{ matrix.device }}-${{ steps.prepare.outputs.platform-pair }},mode=max
+
+      - name: Export digest
+        run: | # zizmor: ignore[template-injection]
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ml-${{ matrix.device }}-digests-${{ steps.prepare.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-ml:
+    name: Merge ML Manifest (${{ matrix.device }})
+    needs: [version, build-ml]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - device: cpu
+            suffix: ''
+          - device: cuda
+            suffix: '-cuda'
+            # CUDA only builds for linux/amd64 — nvidia/cuda base image is amd64-only
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: ml-${{ matrix.device }}-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ghcr.io/open-noodle/gallery-ml
+          VERSION: ${{ needs.version.outputs.version }}
+          MAJOR: ${{ needs.version.outputs.major }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          tags="-t ${IMAGE}:${VERSION}${SUFFIX} -t ${IMAGE}:${MAJOR}${SUFFIX} -t ${IMAGE}:release${SUFFIX}"
+          sources=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create ${tags} ${sources}
 
   tag:
     name: Create Git Tag
-    needs: [version, build-server, build-ml]
+    needs: [version, merge-server, merge-ml]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/plans/2026-03-09-docker-publishing-design.md
+++ b/docs/plans/2026-03-09-docker-publishing-design.md
@@ -1,59 +1,83 @@
-# Docker Publishing Workflow Design
+# Docker Publishing Workflow
 
-## Goal
+## Overview
 
-Re-enable Docker image publishing for the Noodle Gallery fork so users can pull pre-built images from GHCR.
+The Release workflow (`.github/workflows/docker.yml`) builds and publishes multi-arch Docker images to GHCR on every push to `main` or via manual `workflow_dispatch`.
 
-## Design
+## Images
 
-### Trigger
+| Image               | Registry               | Platforms                    | Tags                                             |
+| ------------------- | ---------------------- | ---------------------------- | ------------------------------------------------ |
+| `gallery-server`    | `ghcr.io/open-noodle/` | `linux/amd64`, `linux/arm64` | `<version>`, `<major>`, `release`                |
+| `gallery-ml` (CPU)  | `ghcr.io/open-noodle/` | `linux/amd64`, `linux/arm64` | `<version>`, `<major>`, `release`                |
+| `gallery-ml` (CUDA) | `ghcr.io/open-noodle/` | `linux/amd64` only           | `<version>-cuda`, `<major>-cuda`, `release-cuda` |
 
-- `workflow_dispatch` with a required `version` input (e.g. `v2.5.6-noodle.1`)
-- Commented-out `push: branches: [main]` for easy future auto-publish
+CUDA stays amd64-only because the `nvidia/cuda` base image does not support ARM.
 
-### Images
+## How Multi-Arch Builds Work
 
-| Image                      | Registry               | Tags                            |
-| -------------------------- | ---------------------- | ------------------------------- |
-| `noodle-gallery-server`    | `ghcr.io/open-noodle/` | `<version>`, `latest`           |
-| `noodle-gallery-ml` (CPU)  | `ghcr.io/open-noodle/` | `<version>`, `latest`           |
-| `noodle-gallery-ml` (CUDA) | `ghcr.io/open-noodle/` | `<version>-cuda`, `latest-cuda` |
-
-When auto-publish is enabled later, pushes to main tag as `main` / `main-cuda` instead of a version.
-
-### Workflow structure
+The workflow uses the same pattern as upstream Immich: **per-platform native builds + manifest merge**.
 
 ```
-workflow_dispatch (input: version)
-  ├── build-server (builds & pushes server image)
-  └── build-ml (matrix: [cpu, cuda], builds & pushes ML images)
+version (compute next semver tag)
+  ├── build-server (matrix: amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm)
+  │     └── pushes single-platform image by digest, uploads digest as artifact
+  ├── build-ml (matrix: device × platform)
+  │     └── same pattern — pushes by digest, uploads artifact
+  ├── merge-server (downloads digests, creates multi-arch manifest with version tags)
+  ├── merge-ml (per device: downloads digests, creates multi-arch manifest)
+  └── tag (creates git tags: vX.Y.Z, vX, release)
 ```
 
-### Actions used
+### Why native runners instead of QEMU?
 
-- `docker/login-action` — login to GHCR with `GITHUB_TOKEN`
-- `docker/setup-buildx-action` — enable BuildKit
-- `docker/build-push-action` — build and push
+- `ubuntu-24.04-arm` runners are free for public repos
+- Native ARM builds are 3-4x faster than QEMU-emulated builds
+- Matches upstream Immich's approach
 
-No `immich-app/devtools` dependencies. No extra secrets.
+### Push-by-digest pattern
 
-### What gets removed from current workflow
+Each platform build uses `docker/build-push-action` with:
 
-- `immich-app/devtools` action references (token creation, pre-job, success-check)
-- Smart change-detection pre-job
-- Re-tag jobs
-- ROCm, OpenVINO, ARMNN, RKNN build variants
-- DockerHub push
+```
+outputs: type=image,"name=ghcr.io/open-noodle/gallery-server",push-by-digest=true,name-resolution=short,push=true
+```
 
-### Testing
+This pushes the image without any tag, returning only a digest (sha256 hash). The digest is saved as an empty file and uploaded as a GitHub Actions artifact. The merge job then downloads all digest artifacts and runs:
 
-Trigger with a test version (e.g. `v0.0.0-test.1`) to validate the workflow without creating a real release.
+```bash
+docker buildx imagetools create -t <tag1> -t <tag2> ... <image>@sha256:<digest1> <image>@sha256:<digest2>
+```
 
-## Implementation steps
+This creates a single manifest list (multi-arch image) pointing to both platform-specific images.
 
-1. Replace `.github/workflows/docker.yml` with self-contained workflow
-2. Re-enable the workflow: `gh workflow enable docker.yml`
-3. Push to a branch, trigger manually with `v0.0.0-test.1`
-4. Verify images appear at `ghcr.io/open-noodle/noodle-gallery-*`
-5. Update `docker/docker-compose.yml` to reference fork images
-6. Update `docker/example.env` with a note about fork versioning
+### Cache scoping
+
+Each platform gets its own GHA cache scope to prevent cross-platform cache pollution:
+
+- `scope=server-linux-amd64`, `scope=server-linux-arm64`
+- `scope=ml-cpu-linux-amd64`, `scope=ml-cpu-linux-arm64`
+- `scope=ml-cuda-linux-amd64`
+
+## Version Computation
+
+When triggered without an explicit version:
+
+1. Finds the latest `v*.*.*` git tag
+2. Checks the merge commit message and PR labels for bump type:
+   - `BREAKING CHANGE` -> major bump
+   - `feat` prefix or `changelog:feat` label -> minor bump
+   - Everything else -> patch bump
+3. Tags the resulting images and creates git tags after all builds succeed
+
+Manual override: pass a `version` input (e.g. `v4.9.0`) to `workflow_dispatch`.
+
+## Triggering a Test Build
+
+To test without affecting the release tag:
+
+```bash
+gh workflow run docker.yml --ref <branch> -f version=v0.0.0-test.1
+```
+
+This builds and pushes images tagged `v0.0.0-test.1` but also creates git tags, so use a throwaway version string.


### PR DESCRIPTION
## Summary
- Split server and ML Docker builds into per-platform jobs using native ARM runners (`ubuntu-24.04-arm`) instead of QEMU emulation
- Each platform builds natively, pushes by digest, then a merge job combines into a multi-arch manifest
- CUDA ML variant stays amd64-only (nvidia/cuda base image is amd64-only)

**Result:** `gallery-server` and `gallery-ml` (CPU) now publish `linux/amd64` + `linux/arm64` manifests, matching upstream Immich's image structure.

## Test plan
- [ ] Trigger a release workflow run and verify multi-arch manifests are created
- [ ] Verify with `docker buildx imagetools inspect` that both platforms appear
- [ ] Pull and run on an ARM64 machine (e.g. Mac M2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)