### PR TITLE
fix(ci): queue release workflows instead of cancelling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Change release workflow concurrency from `cancel-in-progress: true` to `false`
- Prevents version collisions when multiple PRs merge in quick succession — each release now waits for the previous one to finish before computing its version

## Test plan
- [ ] Merge two PRs in quick succession and verify both get unique version numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)