### PR TITLE
fix: restore 644 permissions on files modified by branding script

### DIFF
--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -59,6 +59,7 @@ patch_i18n() {
     local tmp
     tmp=$(mktemp)
     jq -s '.[0] * .[1]' "$target" "$overrides" > "$tmp"
+    chmod 644 "$tmp"
     mv "$tmp" "$target"
     echo "  Merged $(jq 'length' "$overrides") override keys into en.json"
   fi
@@ -86,6 +87,7 @@ patch_web() {
     jq --arg name "$NAME" --arg short "$NAME_SHORT" --arg desc "$DESCRIPTION" \
       '.name = $name | .short_name = $short | .description = $desc' \
       "$manifest" > "$tmp"
+    chmod 644 "$tmp"
     mv "$tmp" "$manifest"
     echo "  Patched manifest.json"
   fi
@@ -113,6 +115,7 @@ patch_web() {
     jq --arg name "$NAME" --arg desc "${NAME} API" \
       '.info.title = $name | .info.description = $desc' \
       "$openapi" > "$tmp"
+    chmod 644 "$tmp"
     mv "$tmp" "$openapi"
     # Replace remaining user-facing "Immich" in API descriptions
     sed -i "s/Immich/${NAME}/g" "$openapi"
@@ -142,6 +145,7 @@ patch_help_modal() {
   local tmp
   tmp=$(mktemp)
   awk 'BEGIN{u=0} /BRANDING:UPSTREAM_START/{u=1} /BRANDING:UPSTREAM_END/{u=0; print; next} u==0 && /discord\.immich\.app/{next} {print}' "$help_modal" > "$tmp"
+  chmod 644 "$tmp"
   mv "$tmp" "$help_modal"
 
   echo "  Patched HelpAndFeedbackModal.svelte"
@@ -390,6 +394,7 @@ patch_cli() {
     jq --arg bin "$CLI_BIN_NAME" \
       '.bin = { ($bin): "./bin/immich" } | .description = "Command Line Interface (CLI) for Noodle Gallery"' \
       "$cli_pkg" > "$tmp"
+    chmod 644 "$tmp"
     mv "$tmp" "$cli_pkg"
     echo "  Patched cli/package.json bin name"
   fi
@@ -452,6 +457,7 @@ patch_versions() {
       local tmp
       tmp=$(mktemp)
       jq --arg v "$FORK_VERSION" '.version = $v' "$pkg" > "$tmp"
+      chmod 644 "$tmp"
       mv "$tmp" "$pkg"
       echo "  Patched $(realpath --relative-to="$REPO_ROOT" "$pkg")"
     fi


### PR DESCRIPTION
## Summary
- `mktemp` creates files with `0600` permissions, and `mv` preserves source permissions — so `package.json` and other patched files ended up unreadable by non-owner users
- This broke rootless Docker setups where the app runs as a non-root user
- Adds `chmod 644 "$tmp"` before each `mv` in the branding script (6 sites: `patch_i18n`, `patch_web` x2, `patch_help_modal`, `patch_cli`, `patch_versions`)


## Test plan
- [ ] Build Docker image and verify `/usr/src/app/server/package.json` and `/usr/src/app/cli/package.json` have `0644` permissions
- [ ] Verify rootless Docker container can read all patched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)