### PR TITLE
fix: show stacked photos in shared spaces

### DIFF
--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -128,6 +128,27 @@ describe(TimelineService.name, () => {
           new Set(['space-id']),
         );
       });
+
+      it('should pass withStacked to asset repository when spaceId is provided', async () => {
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
+        mocks.asset.getTimeBuckets.mockResolvedValue([{ timeBucket: 'bucket', count: 1 }]);
+
+        await sut.getTimeBuckets(authStub.admin, { spaceId: 'space-id', withStacked: true });
+
+        expect(mocks.asset.getTimeBuckets).toHaveBeenCalledWith(
+          expect.objectContaining({ spaceId: 'space-id', withStacked: true }),
+        );
+      });
+
+      it('should not include withStacked when it is not provided with spaceId', async () => {
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
+        mocks.asset.getTimeBuckets.mockResolvedValue([{ timeBucket: 'bucket', count: 1 }]);
+
+        await sut.getTimeBuckets(authStub.admin, { spaceId: 'space-id' });
+
+        const calledWith = mocks.asset.getTimeBuckets.mock.calls[0][0];
+        expect(calledWith.withStacked).toBeUndefined();
+      });
     });
 
     describe('withSharedSpaces', () => {
@@ -196,6 +217,24 @@ describe(TimelineService.name, () => {
             isTrashed: true,
           }),
         ).rejects.toThrow(BadRequestException);
+      });
+
+      it('should pass withStacked through to asset repository when combined with withSharedSpaces', async () => {
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId: 'space-1' }]);
+        mocks.asset.getTimeBuckets.mockResolvedValue([{ timeBucket: 'bucket', count: 1 }]);
+
+        await sut.getTimeBuckets(authStub.admin, {
+          withSharedSpaces: true,
+          withStacked: true,
+          visibility: AssetVisibility.Timeline,
+        });
+
+        expect(mocks.asset.getTimeBuckets).toHaveBeenCalledWith(
+          expect.objectContaining({
+            withStacked: true,
+            timelineSpaceIds: ['space-1'],
+          }),
+        );
       });
     });
   });
@@ -497,6 +536,31 @@ describe(TimelineService.name, () => {
 
         expect(mocks.access.album.checkOwnerAccess).not.toHaveBeenCalled();
         expect(mocks.access.album.checkSharedAlbumAccess).not.toHaveBeenCalled();
+      });
+
+      it('should pass withStacked to asset repository when spaceId is provided', async () => {
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
+        const json = `[{ id: ['asset-id'] }]`;
+        mocks.asset.getTimeBucket.mockResolvedValue({ assets: json });
+
+        await sut.getTimeBucket(authStub.admin, { timeBucket: 'bucket', spaceId: 'space-id', withStacked: true });
+
+        expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
+          'bucket',
+          expect.objectContaining({ spaceId: 'space-id', withStacked: true }),
+          authStub.admin,
+        );
+      });
+
+      it('should not include withStacked when it is not provided with spaceId', async () => {
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
+        const json = `[{ id: ['asset-id'] }]`;
+        mocks.asset.getTimeBucket.mockResolvedValue({ assets: json });
+
+        await sut.getTimeBucket(authStub.admin, { timeBucket: 'bucket', spaceId: 'space-id' });
+
+        const calledWith = mocks.asset.getTimeBucket.mock.calls[0][1];
+        expect(calledWith.withStacked).toBeUndefined();
       });
     });
   });

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -742,4 +742,84 @@ describe('TimelineManager', () => {
       expect(b.showAssetOwners).toBe(true);
     });
   });
+
+  describe('space timeline with stacked photos', () => {
+    let timelineManager: TimelineManager;
+    const stackedAssets: Record<string, TimelineAsset[]> = {
+      '2024-02-01T00:00:00.000Z': [
+        deriveLocalDateTimeFromFileCreatedAt(
+          timelineAssetFactory.build({
+            fileCreatedAt: fromISODateTimeUTCToObject('2024-02-10T12:00:00.000Z'),
+            stack: { id: 'stack-1', primaryAssetId: 'primary-1', assetCount: 3 },
+          }),
+        ),
+        deriveLocalDateTimeFromFileCreatedAt(
+          timelineAssetFactory.build({
+            fileCreatedAt: fromISODateTimeUTCToObject('2024-02-05T12:00:00.000Z'),
+            stack: null,
+          }),
+        ),
+      ],
+    };
+    const stackedAssetsResponse: Record<string, TimeBucketAssetResponseDto> = Object.fromEntries(
+      Object.entries(stackedAssets).map(([key, assets]) => [key, toResponseDto(...assets)]),
+    );
+
+    beforeEach(async () => {
+      timelineManager = new TimelineManager();
+      sdkMock.getTimeBuckets.mockResolvedValue([{ count: 2, timeBucket: '2024-02-01T00:00:00.000Z' }]);
+      sdkMock.getTimeBucket.mockImplementation(({ timeBucket }) =>
+        Promise.resolve(stackedAssetsResponse[timeBucket]),
+      );
+    });
+
+    it('passes spaceId and withStacked to getTimeBuckets', async () => {
+      await timelineManager.updateOptions({ spaceId: 'space-1', withStacked: true });
+      await timelineManager.updateViewport({ width: 1588, height: 0 });
+
+      expect(sdkMock.getTimeBuckets).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'space-1', withStacked: true }),
+      );
+    });
+
+    it('passes spaceId and withStacked to getTimeBucket when loading a month', async () => {
+      await timelineManager.updateOptions({ spaceId: 'space-1', withStacked: true });
+      await timelineManager.updateViewport({ width: 1588, height: 0 });
+      await timelineManager.loadMonthGroup({ year: 2024, month: 2 });
+
+      expect(sdkMock.getTimeBucket).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'space-1', withStacked: true }),
+        expect.anything(),
+      );
+    });
+
+    it('loads stacked assets with stack data preserved', async () => {
+      await timelineManager.updateOptions({ spaceId: 'space-1', withStacked: true });
+      await timelineManager.updateViewport({ width: 1588, height: 0 });
+      await timelineManager.loadMonthGroup({ year: 2024, month: 2 });
+
+      const month = getMonthGroupByDate(timelineManager, { year: 2024, month: 2 });
+      expect(month).not.toBeUndefined();
+      const assets = month!.getAssets();
+      expect(assets.length).toEqual(2);
+
+      const stackedAsset = assets.find((a) => a.stack !== null);
+      expect(stackedAsset).toBeDefined();
+      expect(stackedAsset!.stack!.assetCount).toEqual(3);
+
+      const nonStackedAsset = assets.find((a) => a.stack === null);
+      expect(nonStackedAsset).toBeDefined();
+    });
+
+    it('does not pass withStacked when it is not set in options', async () => {
+      await timelineManager.updateOptions({ spaceId: 'space-1' });
+      await timelineManager.updateViewport({ width: 1588, height: 0 });
+
+      expect(sdkMock.getTimeBuckets).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'space-1' }),
+      );
+      const calledWith = sdkMock.getTimeBuckets.mock.calls[0][0];
+      expect(calledWith.withStacked).toBeUndefined();
+    });
+  });
 });

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -765,12 +765,10 @@ describe('TimelineManager', () => {
       Object.entries(stackedAssets).map(([key, assets]) => [key, toResponseDto(...assets)]),
     );
 
-    beforeEach(async () => {
+    beforeEach(() => {
       timelineManager = new TimelineManager();
       sdkMock.getTimeBuckets.mockResolvedValue([{ count: 2, timeBucket: '2024-02-01T00:00:00.000Z' }]);
-      sdkMock.getTimeBucket.mockImplementation(({ timeBucket }) =>
-        Promise.resolve(stackedAssetsResponse[timeBucket]),
-      );
+      sdkMock.getTimeBucket.mockImplementation(({ timeBucket }) => Promise.resolve(stackedAssetsResponse[timeBucket]));
     });
 
     it('passes spaceId and withStacked to getTimeBuckets', async () => {
@@ -815,9 +813,7 @@ describe('TimelineManager', () => {
       await timelineManager.updateOptions({ spaceId: 'space-1' });
       await timelineManager.updateViewport({ width: 1588, height: 0 });
 
-      expect(sdkMock.getTimeBuckets).toHaveBeenCalledWith(
-        expect.objectContaining({ spaceId: 'space-1' }),
-      );
+      expect(sdkMock.getTimeBuckets).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }));
       const calledWith = sdkMock.getTimeBuckets.mock.calls[0][0];
       expect(calledWith.withStacked).toBeUndefined();
     });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -192,7 +192,7 @@
     if (viewMode === 'select-assets') {
       return { visibility: AssetVisibility.Timeline, timelineSpaceId: space.id };
     }
-    const base: Record<string, unknown> = { spaceId: space.id };
+    const base: Record<string, unknown> = { spaceId: space.id, withStacked: true };
     // Apply filter state — personIds maps to spacePersonIds for Spaces context
     if (filters.personIds.length > 0) {
       base.spacePersonIds = filters.personIds;


### PR DESCRIPTION
## Summary
- Space timeline was not passing `withStacked: true` when querying assets, so stacked photos appeared as individual photos without the stack indicator
- One-line fix: add `withStacked: true` to the space timeline options

## Test plan
- [x] Server unit tests: `withStacked` passthrough for `spaceId` and `withSharedSpaces`
- [x] Web unit tests: stack data preserved in space timeline loading
- [x] All 106 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)