### PR TITLE
fix: prevent uploaded photos from appearing in unrelated space views

### DIFF
--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -73,6 +73,14 @@ describe('TimelineManager', () => {
       expect(sdkMock.getTimeBucket).toHaveBeenCalledTimes(2);
     });
 
+    it('connects websocket events for main timeline', async () => {
+      const freshManager = new TimelineManager();
+      const connectSpy = vi.spyOn(freshManager, 'connect');
+      sdkMock.getTimeBuckets.mockResolvedValue([]);
+      await freshManager.updateViewport({ width: 1588, height: 1000 });
+      expect(connectSpy).toHaveBeenCalled();
+    });
+
     it('calculates month height', () => {
       const plainMonths = timelineManager.months.map((month) => ({
         year: month.yearMonth.year,
@@ -807,6 +815,14 @@ describe('TimelineManager', () => {
 
       const nonStackedAsset = assets.find((a) => a.stack === null);
       expect(nonStackedAsset).toBeDefined();
+    });
+
+    it('does not connect websocket events for space timelines', async () => {
+      const connectSpy = vi.spyOn(timelineManager, 'connect');
+      await timelineManager.updateOptions({ spaceId: 'space-1', withStacked: true });
+      await timelineManager.updateViewport({ width: 1588, height: 1000 });
+
+      expect(connectSpy).not.toHaveBeenCalled();
     });
 
     it('does not pass withStacked when it is not set in options', async () => {

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -76,7 +76,7 @@ export class TimelineManager extends VirtualScrollManager {
   initTask = new CancellableTask(
     () => {
       this.isInitialized = true;
-      if (this.#options.albumId || this.#options.personId) {
+      if (this.#options.albumId || this.#options.personId || this.#options.spaceId) {
         return;
       }
       this.connect();


### PR DESCRIPTION
## Summary
- The websocket `on_upload_success` handler was blindly adding uploaded assets to whichever `TimelineManager` was active, including space views — causing phantom photos to appear in newly created spaces during uploads
- Spaces already handle their own asset updates via `SpaceAddAssets` events, so skip websocket connection for space timelines (matching existing behavior for albums and person views)
- Added tests verifying websocket connection behavior for both main timeline and space timelines

## Test plan
- [x] Unit tests pass (`pnpm test` in web/)
- [ ] Manual: start uploading photos from timeline, create a new space, verify uploads don't appear in the space
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)