### PR TITLE
ci: add changelog:skip label to skip releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
     outputs:
+      skip: ${{ steps.version.outputs.skip }}
       version: ${{ steps.version.outputs.version }}
       major: ${{ steps.version.outputs.major }}
       latest_tag: ${{ steps.version.outputs.latest_tag }}
@@ -43,6 +44,21 @@ jobs:
           # Always output the latest tag for branding version stamp
           latest_tag=$(git tag --list 'v*.*.*' --sort=-version:refname | head -n1)
           echo "latest_tag=${latest_tag:-v0.0.0}" >> "$GITHUB_OUTPUT"
+
+          # Check for changelog:skip label on the merged PR (skip for manual dispatch)
+          if [[ -z "$INPUT_VERSION" ]]; then
+            commit_msg_check=$(git log -1 --pretty=%B)
+            pr_num=$(echo "$commit_msg_check" | grep -oP '#\K[0-9]+' | head -1)
+            if [[ -n "$pr_num" ]]; then
+              pr_labels=$(gh pr view "$pr_num" --json labels --jq '.labels[].name' 2>/dev/null || true)
+              if echo "$pr_labels" | grep -q 'changelog:skip'; then
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                echo "Skipping release — changelog:skip label found on PR #${pr_num}"
+                exit 0
+              fi
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
           if [[ -n "$INPUT_VERSION" ]]; then
             echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
@@ -93,6 +109,7 @@ jobs:
   build-server:
     name: Build Server (${{ matrix.platform }})
     needs: version
+    if: needs.version.outputs.skip != 'true'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -165,6 +182,7 @@ jobs:
   merge-server:
     name: Merge Server Manifest
     needs: [version, build-server]
+    if: needs.version.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -201,6 +219,7 @@ jobs:
   build-ml:
     name: Build ML ${{ matrix.device }} (${{ matrix.platform }})
     needs: version
+    if: needs.version.outputs.skip != 'true'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -275,6 +294,7 @@ jobs:
   merge-ml:
     name: Merge ML Manifest (${{ matrix.device }})
     needs: [version, build-ml]
+    if: needs.version.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -320,6 +340,7 @@ jobs:
   tag:
     name: Create Git Tag
     needs: [version, merge-server, merge-ml]
+    if: needs.version.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ Images are automatically built and published on every push to `main` via the **R
 
 **How it works:**
 
-1. Every merged PR triggers an automatic build
+1. Every merged PR triggers an automatic build (unless the PR has the `changelog:skip` label)
 2. The version is computed from the latest git tag using semantic versioning:
+   - `changelog:skip` PR label → **no release** (skips build, tag, and push entirely)
    - `feat:` commit or `changelog:feat` PR label → **minor** bump (e.g. `v4.2.6` → `v4.3.0`)
    - `BREAKING CHANGE` in commit body → **major** bump (e.g. `v4.3.0` → `v5.0.0`)
    - Everything else (`fix:`, `docs:`, `chore:`, etc.) → **patch** bump (e.g. `v4.2.6` → `v4.2.7`)


### PR DESCRIPTION
## Summary
- PRs with the `changelog:skip` label skip the entire Docker build + tag pipeline
- The version job detects the label and sets `skip=true`, gating all downstream jobs
- Manual `workflow_dispatch` runs are never skipped
- Updated README publishing docs to mention the new label
- Updated babysit skill to use `changelog:skip` for `docs:` prefixed PRs

## Test plan
- [ ] Merge a PR with `changelog:skip` label → Release workflow should exit early
- [ ] Merge a PR without the label → normal version bump and build
- [ ] Manual dispatch still works regardless of labels