### PR TITLE
fix: exclude videos from space thumbnail collage

### DIFF
--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -159,6 +159,22 @@ describe('/shared-spaces', () => {
       expect(status).toBe(403);
     });
 
+    it('should exclude videos from recentAssetIds', async () => {
+      const space = await utils.createSpace(user1.accessToken, { name: 'Video Exclude' });
+      const videoAsset = await utils.createAsset(user1.accessToken, {
+        assetData: { filename: 'example.mp4' },
+      });
+      const imageAsset = await utils.createAsset(user1.accessToken);
+      await utils.addSpaceAssets(user1.accessToken, space.id, [videoAsset.id, imageAsset.id]);
+
+      const { body } = await request(app)
+        .get(`/shared-spaces/${space.id}`)
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+
+      expect(body.recentAssetIds).toContain(imageAsset.id);
+      expect(body.recentAssetIds).not.toContain(videoAsset.id);
+    });
+
     it('should include asset count and member count', async () => {
       const space = await utils.createSpace(user1.accessToken, { name: 'Counts Space' });
       await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId, role: SharedSpaceRole.Editor });

--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -160,16 +160,16 @@ describe('/shared-spaces', () => {
     });
 
     it('should exclude videos from recentAssetIds', async () => {
-      const space = await utils.createSpace(user1.accessToken, { name: 'Video Exclude' });
-      const videoAsset = await utils.createAsset(user1.accessToken, {
+      const space = await utils.createSpace(user3.accessToken, { name: 'Video Exclude' });
+      const videoAsset = await utils.createAsset(user3.accessToken, {
         assetData: { filename: 'example.mp4' },
       });
-      const imageAsset = await utils.createAsset(user1.accessToken);
-      await utils.addSpaceAssets(user1.accessToken, space.id, [videoAsset.id, imageAsset.id]);
+      const imageAsset = await utils.createAsset(user3.accessToken);
+      await utils.addSpaceAssets(user3.accessToken, space.id, [videoAsset.id, imageAsset.id]);
 
       const { body } = await request(app)
         .get(`/shared-spaces/${space.id}`)
-        .set('Authorization', `Bearer ${user1.accessToken}`);
+        .set('Authorization', `Bearer ${user3.accessToken}`);
 
       expect(body.recentAssetIds).toContain(imageAsset.id);
       expect(body.recentAssetIds).not.toContain(videoAsset.id);

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -193,6 +193,7 @@ from
       "shared_space_asset"."spaceId" = $1
       and "asset"."deletedAt" is null
       and "asset"."isOffline" = $2
+      and "asset"."type" = $3
     union
     select
       "asset"."id",
@@ -202,14 +203,15 @@ from
       "shared_space_library"
       inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
     where
-      "shared_space_library"."spaceId" = $3
+      "shared_space_library"."spaceId" = $4
       and "asset"."deletedAt" is null
-      and "asset"."isOffline" = $4
+      and "asset"."isOffline" = $5
+      and "asset"."type" = $6
   ) as "combined"
 order by
   "combined"."fileCreatedAt" desc
 limit
-  $5
+  $7
 
 -- SharedSpaceRepository.getLastAssetAddedAt
 select

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Insertable, Kysely, sql, Updateable } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
-import { VectorIndex } from 'src/enum';
+import { AssetType, VectorIndex } from 'src/enum';
 import { probes } from 'src/repositories/database.repository';
 import { DB } from 'src/schema';
 import { SharedSpaceAssetTable } from 'src/schema/tables/shared-space-asset.table';
@@ -275,6 +275,7 @@ export class SharedSpaceRepository {
           .where('shared_space_asset.spaceId', '=', spaceId)
           .where('asset.deletedAt', 'is', null)
           .where('asset.isOffline', '=', false)
+          .where('asset.type', '=', AssetType.Image)
           .union(
             this.db
               .selectFrom('shared_space_library')
@@ -282,7 +283,8 @@ export class SharedSpaceRepository {
               .select(['asset.id', 'asset.thumbhash', 'asset.fileCreatedAt'])
               .where('shared_space_library.spaceId', '=', spaceId)
               .where('asset.deletedAt', 'is', null)
-              .where('asset.isOffline', '=', false),
+              .where('asset.isOffline', '=', false)
+              .where('asset.type', '=', AssetType.Image),
           )
           .as('combined'),
       )


### PR DESCRIPTION
## Summary
- Filter `getRecentAssets()` query to only return `IMAGE` type assets, excluding videos from the space card collage
- Videos rendered as `<img>` tags showed blank spots in the thumbnail grid
- Added e2e test verifying videos are excluded from `recentAssetIds`

## Test plan
- [ ] E2e test: space with video + image asset returns only image in `recentAssetIds`
- [ ] Manual: upload a video to a space, verify the space card collage doesn't show a blank thumbnail