### PR TITLE
fix: include library-linked assets in space search and filters

### DIFF
--- a/docs/plans/2026-03-23-spaces-permissions-matrix.md
+++ b/docs/plans/2026-03-23-spaces-permissions-matrix.md
@@ -85,6 +85,39 @@ Generated 2026-03-23 from codebase analysis.
 | Add assets    | `POST /shared-spaces/:id/assets`   | SharedSpaceAssetCreate (editor) | N      | Y      | Y     | N          |
 | Remove assets | `DELETE /shared-spaces/:id/assets` | SharedSpaceAssetDelete (editor) | N      | Y      | Y     | N          |
 
+## Library Management in Space
+
+| Interaction    | Endpoint                                     | Permission                         | Viewer | Editor | Owner | Non-member |
+| -------------- | -------------------------------------------- | ---------------------------------- | ------ | ------ | ----- | ---------- |
+| Link library   | `PUT /shared-spaces/:id/libraries`           | Admin + SharedSpaceUpdate (editor) | N      | Y      | Y     | N          |
+| Unlink library | `DELETE /shared-spaces/:id/libraries/:libId` | Admin + SharedSpaceUpdate (editor) | N      | Y      | Y     | N          |
+
+### Library-Linked Asset Access
+
+Library-linked assets (assets belonging to a library linked via `shared_space_library`) must be included in all space-scoped queries. The correct pattern uses `OR EXISTS` to check both `shared_space_asset` (direct) and `shared_space_library` (library-linked) paths.
+
+| Query                      | Method                     | Includes Library Assets | Notes                                            |
+| -------------------------- | -------------------------- | ----------------------- | ------------------------------------------------ |
+| Timeline (buckets/detail)  | `getTimeBuckets/Bucket`    | Y                       | OR EXISTS pattern                                |
+| Asset count                | `getAssetCount`            | Y                       | UNION pattern                                    |
+| Recent assets / hero       | `getRecentAssets`          | Y                       | UNION pattern                                    |
+| New asset count            | `getNewAssetCount`         | Y                       | UNION (uses asset.createdAt for lib assets)      |
+| Map markers                | `getMapMarkers`            | Y                       | UNION pattern                                    |
+| Access control (view)      | `checkSpaceAccess`         | Y                       | UNION + livePhotoVideoId handling                |
+| Access control (edit)      | `checkSpaceEditAccess`     | Y                       | UNION + role filter                              |
+| Asset-in-space check       | `isAssetInSpace`           | Y                       | UNION pattern                                    |
+| Face-in-space check        | `isFaceInSpace`            | Y                       | UNION pattern                                    |
+| All asset IDs              | `getAssetIdsInSpace`       | Y                       | UNION pattern                                    |
+| Space IDs for asset        | `getSpaceIdsForAsset`      | Y                       | UNION pattern                                    |
+| People / faces             | `shared_space_person_face` | Y                       | Populated by face sync job                       |
+| Person assets              | `getPersonAssetIds`        | Y                       | Via shared_space_person_face                     |
+| Search (smart/metadata)    | `searchAssetBuilder`       | Y                       | OR EXISTS; skips userIds filter when spaceId set |
+| Filter suggestions         | `getExifField`             | Y                       | OR EXISTS; skips ownerId filter when spaceId set |
+| Contribution counts        | `getContributionCounts`    | N (by design)           | Tracks manual contributions only                 |
+| Member activity            | `getMemberActivity`        | N (by design)           | Tracks manual contributions only                 |
+| Last contributor           | `getLastContributor`       | N (by design)           | Tracks manual contributions only                 |
+| Last asset added timestamp | `getLastAssetAddedAt`      | N (by design)           | Used in removeAssets() only                      |
+
 ## People / Face Recognition
 
 | Interaction          | Endpoint                                            | Permission                 | Viewer | Editor | Owner | Non-member |
@@ -107,16 +140,9 @@ Generated 2026-03-23 from codebase analysis.
 
 ---
 
-## Known Bugs (as of 2026-03-23)
-
-| #   | Bug                                                          | Impact                                                | Status      |
-| --- | ------------------------------------------------------------ | ----------------------------------------------------- | ----------- |
-| 1   | `checkSpaceAccess()` missing `livePhotoVideoId`              | Live photo playback fails for non-owner space members | Fix planned |
-| 2   | `getSearchSuggestions()` missing `requireAccess` for spaceId | Non-members can query filter metadata for any space   | Fix planned |
-| 3   | `getExifField()` filters by `ownerId` even with spaceId      | Non-owner space members see empty filter suggestions  | Fix planned |
-
 ## Known Limitations (not bugs)
 
 - Bulk download by spaceId not supported (must use individual assetIds)
 - Search random/explore/cities not space-scoped
 - Asset edits/delete/copy are owner-only regardless of space role
+- Contribution counts/member activity track manual additions only (library-linked assets excluded by design)

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -162,20 +162,6 @@ where
   "spaceId" = $1
   and "libraryId" = $2
 
--- SharedSpaceRepository.getMostRecentAssetId
-select
-  "asset"."id"
-from
-  "shared_space_asset"
-  inner join "asset" on "asset"."id" = "shared_space_asset"."assetId"
-where
-  "shared_space_asset"."spaceId" = $1
-  and "asset"."deletedAt" is null
-order by
-  "shared_space_asset"."addedAt" desc
-limit
-  $2
-
 -- SharedSpaceRepository.getRecentAssets
 select
   "combined"."id",

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -531,12 +531,20 @@ export class SearchRepository {
       .where(field, 'is not', null)
       .$if(!!options?.spaceId, (qb) =>
         qb.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('shared_space_asset')
-              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-              .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
-          ),
+          eb.or([
+            eb.exists(
+              eb
+                .selectFrom('shared_space_asset')
+                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
+            ),
+            eb.exists(
+              eb
+                .selectFrom('shared_space_library')
+                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+            ),
+          ]),
         ),
       );
   }

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -250,20 +250,6 @@ export class SharedSpaceRepository {
       .then((row) => !!row);
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  async getMostRecentAssetId(spaceId: string): Promise<string | undefined> {
-    const result = await this.db
-      .selectFrom('shared_space_asset')
-      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
-      .where('shared_space_asset.spaceId', '=', spaceId)
-      .where('asset.deletedAt', 'is', null)
-      .orderBy('shared_space_asset.addedAt', 'desc')
-      .select('asset.id')
-      .limit(1)
-      .executeTakeFirst();
-    return result?.id;
-  }
-
   @GenerateSql({ params: [DummyValue.UUID, 4] })
   getRecentAssets(spaceId: string, limit = 4) {
     return this.db

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -357,7 +357,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getMembers.mockResolvedValue([member, makeMemberResult()]);
       mocks.sharedSpace.getAssetCount.mockResolvedValue(5);
-      mocks.sharedSpace.getMostRecentAssetId.mockResolvedValue(void 0);
+
       mocks.sharedSpace.getRecentAssets.mockResolvedValue([]);
 
       const result = await sut.get(auth, space.id);
@@ -408,7 +408,6 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.get(auth, space.id);
 
       expect(result.thumbnailAssetId).toBe(thumbnailAssetId);
-      expect(mocks.sharedSpace.getMostRecentAssetId).not.toHaveBeenCalled();
     });
 
     it('should return null thumbnailAssetId when not explicitly set', async () => {
@@ -429,7 +428,6 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.get(auth, space.id);
 
       expect(result.thumbnailAssetId).toBeNull();
-      expect(mocks.sharedSpace.getMostRecentAssetId).not.toHaveBeenCalled();
     });
 
     it('should clear thumbnailAssetId when the cover asset has been deleted', async () => {
@@ -563,7 +561,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getMembers.mockResolvedValue([member]);
       mocks.sharedSpace.getAssetCount.mockResolvedValue(10);
-      mocks.sharedSpace.getMostRecentAssetId.mockResolvedValue(void 0);
+
       mocks.sharedSpace.getRecentAssets.mockResolvedValue(recentAssets);
 
       const result = await sut.get(auth, space.id);
@@ -582,7 +580,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getMembers.mockResolvedValue([member]);
       mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
-      mocks.sharedSpace.getMostRecentAssetId.mockResolvedValue(void 0);
+
       mocks.sharedSpace.getRecentAssets.mockResolvedValue([]);
 
       const result = await sut.get(auth, space.id);
@@ -611,7 +609,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getMembers.mockResolvedValue([member]);
       mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
-      mocks.sharedSpace.getMostRecentAssetId.mockResolvedValue(void 0);
+
       mocks.sharedSpace.getRecentAssets.mockResolvedValue([]);
 
       const result = await sut.get(auth, space.id);

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -356,12 +356,20 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(!!options.albumIds && options.albumIds.length > 0, (qb) => inAlbums(qb, options.albumIds!))
     .$if(!!options.spaceId, (qb) =>
       qb.where((eb) =>
-        eb.exists(
-          eb
-            .selectFrom('shared_space_asset')
-            .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-            .where('shared_space_asset.spaceId', '=', asUuid(options.spaceId!)),
-        ),
+        eb.or([
+          eb.exists(
+            eb
+              .selectFrom('shared_space_asset')
+              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+              .where('shared_space_asset.spaceId', '=', asUuid(options.spaceId!)),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_library')
+              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+              .where('shared_space_library.spaceId', '=', asUuid(options.spaceId!)),
+          ),
+        ]),
       ),
     )
     .$if(!!options.tagIds && options.tagIds.length > 0, (qb) => hasTags(qb, options.tagIds!))
@@ -417,7 +425,7 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(!!options.deviceId, (qb) => qb.where('asset.deviceId', '=', options.deviceId!))
     .$if(!!options.id, (qb) => qb.where('asset.id', '=', asUuid(options.id!)))
     .$if(!!options.libraryId, (qb) => qb.where('asset.libraryId', '=', asUuid(options.libraryId!)))
-    .$if(!!options.userIds, (qb) => qb.where('asset.ownerId', '=', anyUuid(options.userIds!)))
+    .$if(!!options.userIds && !options.spaceId, (qb) => qb.where('asset.ownerId', '=', anyUuid(options.userIds!)))
     .$if(!!options.encodedVideoPath, (qb) =>
       qb
         .innerJoin('asset_file', (join) =>

--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -322,6 +322,33 @@ export class MediumTestContext<S extends BaseService = BaseService> {
     return { member: result, result };
   }
 
+  async newLibrary(dto: { ownerId: string; name?: string }) {
+    const result = await this.database
+      .insertInto('library')
+      .values({
+        name: dto.name ?? 'Test Library',
+        ownerId: dto.ownerId,
+        importPaths: ['/import'],
+        exclusionPatterns: [],
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return { library: result, result };
+  }
+
+  async newSharedSpaceLibrary(dto: { spaceId: string; libraryId: string; addedById?: string | null }) {
+    const result = await this.database
+      .insertInto('shared_space_library')
+      .values({
+        spaceId: dto.spaceId,
+        libraryId: dto.libraryId,
+        addedById: dto.addedById ?? null,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return { spaceLibrary: result, result };
+  }
+
   async newSharedSpaceAsset(dto: { spaceId: string; assetId: string; addedById?: string | null }) {
     const spaceAsset = {
       spaceId: dto.spaceId,

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -1,4 +1,5 @@
 import { Kysely } from 'kysely';
+import { SearchSuggestionType } from 'src/dtos/search.dto';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
@@ -6,6 +7,7 @@ import { LoggingRepository } from 'src/repositories/logging.repository';
 import { PartnerRepository } from 'src/repositories/partner.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { DB } from 'src/schema';
 import { SearchService } from 'src/services/search.service';
 import { newMediumService } from 'test/medium.factory';
@@ -22,6 +24,7 @@ const setup = (db?: Kysely<DB>) => {
       AssetRepository,
       DatabaseRepository,
       SearchRepository,
+      SharedSpaceRepository,
       PartnerRepository,
       PersonRepository,
     ],
@@ -86,6 +89,126 @@ describe(SearchService.name, () => {
       const result = await sut.searchStatistics(auth, { personIds: [person.id] });
 
       expect(result).toEqual({ total: 0 });
+    });
+  });
+
+  describe('library-linked space assets', () => {
+    it('should include library-linked assets in searchMetadata when filtering by spaceId', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      // Create a library and an asset belonging to that library
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { asset: libraryAsset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+
+      // Create a space, add member, link the library
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+      const auth = factory.auth({ user: { id: member.id } });
+
+      const result = await sut.searchMetadata(auth, { spaceId: space.id });
+
+      expect(result.assets.items).toEqual([expect.objectContaining({ id: libraryAsset.id })]);
+    });
+
+    it('should include library-linked assets in searchLargeAssets when filtering by spaceId', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { asset: libraryAsset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+      await ctx.newExif({ assetId: libraryAsset.id, fileSizeInByte: 999_999 });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+      const auth = factory.auth({ user: { id: member.id } });
+
+      const result = await sut.searchLargeAssets(auth, { spaceId: space.id });
+
+      expect(result).toEqual([expect.objectContaining({ id: libraryAsset.id })]);
+    });
+
+    it('should include library-linked assets in getSearchSuggestions for countries', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { asset: libraryAsset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+      await ctx.newExif({ assetId: libraryAsset.id, country: 'Germany' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+      const auth = factory.auth({ user: { id: member.id } });
+
+      const result = await sut.getSearchSuggestions(auth, {
+        type: SearchSuggestionType.COUNTRY,
+        spaceId: space.id,
+        includeNull: false,
+      });
+
+      expect(result).toContain('Germany');
+    });
+
+    it('should include library-linked assets in getSearchSuggestions for cities', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { asset: libraryAsset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+      await ctx.newExif({ assetId: libraryAsset.id, city: 'Berlin', country: 'Germany' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+      const auth = factory.auth({ user: { id: member.id } });
+
+      const result = await sut.getSearchSuggestions(auth, {
+        type: SearchSuggestionType.CITY,
+        spaceId: space.id,
+        includeNull: false,
+      });
+
+      expect(result).toContain('Berlin');
+    });
+
+    it('should include library-linked assets in getSearchSuggestions for camera makes', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { asset: libraryAsset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+      await ctx.newExif({ assetId: libraryAsset.id, make: 'Sony' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+      const auth = factory.auth({ user: { id: member.id } });
+
+      const result = await sut.getSearchSuggestions(auth, {
+        type: SearchSuggestionType.CAMERA_MAKE,
+        spaceId: space.id,
+        includeNull: false,
+      });
+
+      expect(result).toContain('Sony');
     });
   });
 


### PR DESCRIPTION
## Summary

- **Search**: `searchAssetBuilder()` now includes library-linked assets via `OR EXISTS` on `shared_space_library`, and skips the `userIds` owner filter when `spaceId` is set (space membership handles access control)
- **Filter suggestions**: `getExifField()` now includes library-linked assets for country/state/city/camera suggestions within a space
- **Dead code**: Removed unused `getMostRecentAssetId()` from shared-space repository
- **Permissions matrix**: Added library-linked asset access table documenting all query paths

## Test plan

- [x] 5 new medium tests covering library-linked assets in `searchMetadata`, `searchLargeAssets`, and `getSearchSuggestions` (country, city, camera make)
- [x] All 3509 unit tests pass
- [x] Lint + type check clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)