### PR TITLE
docs: update README links to opennoodle.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,13 @@ That's it. To switch back to upstream Immich, reverse the image names and restor
 > Always follow [3-2-1](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) backup plan for your precious photos and videos!
 
 > [!NOTE]
-> You can find the main documentation, including installation guides, at https://immich.app/.
-
 ## Links
 
-- [Documentation](https://docs.immich.app/)
-- [About](https://docs.immich.app/overview/introduction)
-- [Installation](https://docs.immich.app/install/requirements)
-- [Roadmap](https://immich.app/roadmap)
+- [Website](https://opennoodle.de)
+- [Installation](https://opennoodle.de/install)
+- [API Documentation](https://demo.opennoodle.de/doc) — interactive Swagger UI with all endpoints (including fork-specific ones like Shared Spaces, User Groups, and Pet Detection)
+- [Roadmap](https://opennoodle.de/roadmap)
 - [Features](#features)
-- [Translations](https://docs.immich.app/developer/translations)
-- [Contributing](https://docs.immich.app/overview/support-the-project)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ That's it. To switch back to upstream Immich, reverse the image names and restor
 
 - [Website](https://opennoodle.de)
 - [Installation](https://opennoodle.de/install)
-- [API Documentation](https://demo.opennoodle.de/doc) — interactive Swagger UI with all endpoints (including fork-specific ones like Shared Spaces, User Groups, and Pet Detection)
+- [API Documentation](https://demo.opennoodle.de/doc) — interactive Swagger UI with all endpoints including fork-specific ones. Also available on your own instance at `/doc`
 - [Roadmap](https://opennoodle.de/roadmap)
 - [Features](#features)
 


### PR DESCRIPTION
## Summary
- Replace upstream Immich docs/roadmap links with opennoodle.de equivalents
- Add API documentation link pointing to the live demo Swagger UI at demo.opennoodle.de/doc
- Remove stale note pointing to immich.app

## Test plan
- [ ] Verify all links in README resolve correctly