### PR TITLE
fix: auto-collapse hero bar on timeline filter

### DIFF
--- a/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
@@ -39,17 +39,21 @@ describe('FilterState utilities', () => {
     expect(getActiveFilterCount(state)).toBe(3);
   });
 
-  it('should not count selectedYear or selectedMonth as active filters', () => {
+  it('should count selectedYear as an active filter', () => {
     const state = createFilterState();
     state.selectedYear = 2023;
-    expect(getActiveFilterCount(state)).toBe(0);
+    expect(getActiveFilterCount(state)).toBe(1);
+  });
 
+  it('should count selectedMonth as an active filter alongside selectedYear', () => {
+    const state = createFilterState();
+    state.selectedYear = 2023;
     state.selectedMonth = 8;
-    expect(getActiveFilterCount(state)).toBe(0);
+    expect(getActiveFilterCount(state)).toBe(1); // year+month counts as one temporal filter
 
     // Other filters should still count normally
     state.personIds = ['p1'];
-    expect(getActiveFilterCount(state)).toBe(1);
+    expect(getActiveFilterCount(state)).toBe(2);
   });
 
   it('should not double-count country when city is set', () => {

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -67,7 +67,8 @@ export function getActiveFilterCount(state: FilterState): number {
     (state.make ? 1 : 0) +
     (state.tagIds.length > 0 ? 1 : 0) +
     (state.rating === undefined ? 0 : 1) +
-    (state.mediaType === 'all' ? 0 : 1)
+    (state.mediaType === 'all' ? 0 : 1) +
+    (state.selectedYear !== undefined ? 1 : 0)
   );
 }
 

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -68,7 +68,7 @@ export function getActiveFilterCount(state: FilterState): number {
     (state.tagIds.length > 0 ? 1 : 0) +
     (state.rating === undefined ? 0 : 1) +
     (state.mediaType === 'all' ? 0 : 1) +
-    (state.selectedYear !== undefined ? 1 : 0)
+    (state.selectedYear === undefined ? 0 : 1)
   );
 }
 


### PR DESCRIPTION
## Summary
- Include `selectedYear` in `getActiveFilterCount()` so timeline/temporal filters trigger hero bar auto-collapse like all other filter types
- Year+month counts as one temporal filter (month always implies year)

## Test plan
- [x] Updated existing tests to assert temporal filters are counted
- [x] All 104 filter-panel tests pass
- [x] Manual: open a space, select a year in the timeline filter → hero collapses
- [ ] Manual: clear the timeline filter → hero stays collapsed (matches other filter behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)