### PR TITLE
ci: speed up ARM e2e tests with Docker caching and parallel suites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -452,8 +452,8 @@ jobs:
           name: e2e-server-docker-logs-${{ matrix.runner }}
           path: e2e/docker-compose-logs.txt
   e2e-tests-web:
-    name: End-to-End Tests (Web)
-    needs: pre-job
+    name: End-to-End Tests (Web - ${{ matrix.suite.name }})
+    needs: [pre-job, docker-build-e2e]
     if: ${{ fromJSON(needs.pre-job.outputs.should_run).e2e == true || fromJSON(needs.pre-job.outputs.should_run).web == true }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -464,6 +464,10 @@ jobs:
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
+        suite:
+          - { name: web, cmd: 'pnpm test:web' }
+          - { name: ui, cmd: 'pnpm test:web:ui' }
+          - { name: maintenance, cmd: 'pnpm test:web:maintenance' }
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -488,51 +492,36 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install chromium --only-shell
         if: ${{ !cancelled() }}
-      - name: Docker build
-        run: docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
+      - name: Download server image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-server-image-${{ runner.arch }}
+          path: /tmp
+      - name: Load server image
+        run: docker load < /tmp/immich-server.tar
+      - name: Start Docker Compose
+        run: docker compose build e2e-auth-server && docker compose up -d --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
         if: ${{ !cancelled() }}
-      - name: Run e2e tests (web)
+      - name: Run e2e tests (${{ matrix.suite.name }})
         env:
           PLAYWRIGHT_DISABLE_WEBSERVER: true
-        run: pnpm test:web
+        run: ${{ matrix.suite.cmd }}
         if: ${{ !cancelled() }}
-      - name: Archive e2e test (web) results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      - name: Archive test results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: success() || failure()
         with:
-          name: e2e-web-test-results-${{ matrix.runner }}
-          path: e2e/playwright-report/
-      - name: Run ui tests (web)
-        env:
-          PLAYWRIGHT_DISABLE_WEBSERVER: true
-        run: pnpm test:web:ui
-        if: ${{ !cancelled() }}
-      - name: Archive ui test (web) results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: success() || failure()
-        with:
-          name: e2e-ui-test-results-${{ matrix.runner }}
-          path: e2e/playwright-report/
-      - name: Run maintenance tests
-        env:
-          PLAYWRIGHT_DISABLE_WEBSERVER: true
-        run: pnpm test:web:maintenance
-        if: ${{ !cancelled() }}
-      - name: Archive maintenance tests (web) results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: success() || failure()
-        with:
-          name: e2e-maintenance-isolated-test-results-${{ matrix.runner }}
+          name: e2e-${{ matrix.suite.name }}-test-results-${{ matrix.runner }}
           path: e2e/playwright-report/
       - name: Capture Docker logs
         if: always()
         run: docker compose logs --no-color > docker-compose-logs.txt
         working-directory: ./e2e
       - name: Archive Docker logs
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
-          name: e2e-web-docker-logs-${{ matrix.runner }}
+          name: e2e-${{ matrix.suite.name }}-docker-logs-${{ matrix.runner }}
           path: e2e/docker-compose-logs.txt
   success-check-e2e:
     name: End-to-End Tests Success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,7 +381,7 @@ jobs:
           if-no-files-found: error
   e2e-tests-server-cli:
     name: End-to-End Tests (Server & CLI)
-    needs: pre-job
+    needs: [pre-job, docker-build-e2e]
     if: ${{ fromJSON(needs.pre-job.outputs.should_run).e2e == true || fromJSON(needs.pre-job.outputs.should_run).server == true || fromJSON(needs.pre-job.outputs.should_run).cli == true }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -421,8 +421,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         if: ${{ !cancelled() }}
+      - name: Download server image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-server-image-${{ runner.arch }}
+          path: /tmp
+      - name: Load server image
+        run: docker load < /tmp/immich-server.tar
       - name: Start Docker Compose
-        run: docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
+        run: docker compose build e2e-auth-server && docker compose up -d --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
         if: ${{ !cancelled() }}
       - name: Run e2e tests (api & cli)
         env:
@@ -439,7 +446,7 @@ jobs:
         run: docker compose logs --no-color > docker-compose-logs.txt
         working-directory: ./e2e
       - name: Archive Docker logs
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: e2e-server-docker-logs-${{ matrix.runner }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -336,6 +336,49 @@ jobs:
       - name: Run medium tests
         run: pnpm test:medium
         if: ${{ !cancelled() }}
+  docker-build-e2e:
+    name: Build E2E Docker Image (${{ matrix.runner }})
+    needs: pre-job
+    if: ${{ fromJSON(needs.pre-job.outputs.should_run).e2e == true || fromJSON(needs.pre-job.outputs.should_run).server == true || fromJSON(needs.pre-job.outputs.should_run).cli == true || fromJSON(needs.pre-job.outputs.should_run).web == true }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: 'recursive'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build server image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: server/Dockerfile
+          build-args: |
+            BUILD_ID=1234567890
+            BUILD_IMAGE=e2e
+            BUILD_SOURCE_REF=e2e
+            BUILD_SOURCE_COMMIT=e2eeeeeeeeeeeeeeeeee
+          outputs: type=docker,dest=/tmp/immich-server.tar
+          tags: immich-server:latest
+          cache-from: type=gha,scope=e2e-${{ runner.arch }}
+          cache-to: type=gha,scope=e2e-${{ runner.arch }},mode=min
+
+      - name: Upload server image
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: e2e-server-image-${{ runner.arch }}
+          path: /tmp/immich-server.tar
+          retention-days: 1
+          if-no-files-found: error
   e2e-tests-server-cli:
     name: End-to-End Tests (Server & CLI)
     needs: pre-job

--- a/docs/plans/2026-03-24-e2e-ci-speedup-design.md
+++ b/docs/plans/2026-03-24-e2e-ci-speedup-design.md
@@ -1,0 +1,86 @@
+# E2E CI Speedup Design
+
+## Problem
+
+ARM e2e tests take ~15.5 min (web) and ~8.5 min (server). The two bottlenecks are:
+
+1. **Docker image build from scratch every run (~5 min)** — the `cache_from` in docker-compose.yml points to upstream's `ghcr.io/immich-app/` registry, which the fork can't pull from
+2. **Three Playwright suites running sequentially (~9.5 min)** — web, ui, and maintenance run back-to-back in a single job
+
+## Optimization 1: Docker Build Layer Caching
+
+### Approach
+
+Add a new `docker-build-e2e` job that builds `immich-server:latest` once per architecture using `docker/build-push-action` with GitHub Actions cache backend, then shares the image as an artifact.
+
+### New job: `docker-build-e2e`
+
+- **Matrix:** `{runner: [ubuntu-latest, ubuntu-24.04-arm]}`
+- **Actions:** `docker/setup-buildx-action` + `docker/build-push-action`
+- **Cache:** `type=gha,scope=e2e-${{ runner.arch }},mode=min`
+  - `mode=min` (not `mode=max`) to stay within 10GB GHA cache budget — multi-stage Dockerfile with 2 architectures could blow it otherwise
+  - Scoped by `runner.arch` to separate ARM/x86 caches
+- **Output:** `type=docker,dest=/tmp/immich-server.tar` (no `load: true` — mutually exclusive with `outputs`)
+- **Artifact:** Upload tar with `retention-days: 1` (only needed within same workflow run)
+
+### Downstream changes
+
+Both `e2e-tests-server-cli` and `e2e-tests-web` gain `needs: docker-build-e2e` and replace the `--build` step with:
+
+1. Download image artifact matching their architecture
+2. `docker load < /tmp/immich-server.tar`
+3. `docker compose build e2e-auth-server` (tiny Node alpine image, ~3s)
+4. `docker compose up -d --wait --wait-timeout 300 ...` (no `--build`)
+
+### Cache hit behavior
+
+- **e2e-only or web-only PRs:** Full cache hit, build drops from ~5 min to ~1 min
+- **Server-touching PRs:** Server Dockerfile stage misses cache (COPY invalidation), still takes a few minutes — same as today but with cache for unchanged stages
+- **Cache eviction:** Falls back to uncached build (same as today)
+
+## Optimization 2: Parallel Playwright Suites
+
+### Approach
+
+Expand `e2e-tests-web` matrix to include a `suite` dimension. Each matrix entry runs one Playwright project independently.
+
+### Matrix structure
+
+```yaml
+strategy:
+  matrix:
+    runner: [ubuntu-latest, ubuntu-24.04-arm]
+    suite:
+      - { name: web, cmd: 'pnpm test:web' }
+      - { name: ui, cmd: 'pnpm test:web:ui' }
+      - { name: maintenance, cmd: 'pnpm test:web:maintenance' }
+```
+
+### Per-job flow
+
+1. Download pre-built Docker image artifact
+2. Load image + build e2e-auth-server + start Docker Compose
+3. Install Playwright browsers
+4. Run ONE suite via `${{ matrix.suite.cmd }}`
+5. Upload Playwright report as `e2e-${{ matrix.suite.name }}-test-results-${{ matrix.runner }}`
+
+### Impact
+
+- 6 web e2e jobs instead of 2 (each with own Docker Compose stack)
+- Wall-clock drops from sum(9.5 min) to max(5.5 min = ui on ARM)
+
+## Expected Impact
+
+| Metric               | Before (ARM)  | After (ARM)         |
+| -------------------- | ------------- | ------------------- |
+| Docker build         | ~5 min        | ~1 min (cache hit)  |
+| Playwright           | ~9.5 min      | ~5.5 min (parallel) |
+| **Total Web E2E**    | **~15.5 min** | **~8 min**          |
+| **Total Server E2E** | **~8.5 min**  | **~5 min**          |
+
+## Trade-offs
+
+- Job count goes from 4 e2e jobs to 10 (2 build + 2 server + 6 web) — more runner-minutes but less wall-clock
+- GHA cache is best-effort with 10GB limit — eviction is graceful fallback
+- Artifact upload/download adds ~30-60s overhead per job, still net positive
+- Each Playwright suite job runs its own Docker Compose stack (postgres, redis, server) — correct for isolation since suites mutate state

--- a/docs/plans/2026-03-24-e2e-ci-speedup.md
+++ b/docs/plans/2026-03-24-e2e-ci-speedup.md
@@ -1,0 +1,286 @@
+# E2E CI Speedup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Cut ARM e2e CI wall-clock from ~15.5 min to ~8 min via Docker layer caching and parallel Playwright suites.
+
+**Architecture:** Add a `docker-build-e2e` job that builds `immich-server:latest` once per arch with GHA cache and shares it as an artifact. Split `e2e-tests-web` into a `{runner, suite}` matrix so web/ui/maintenance Playwright suites run in parallel.
+
+**Tech Stack:** GitHub Actions, docker/build-push-action, docker/setup-buildx-action, actions/upload-artifact v7, actions/download-artifact v8
+
+**Design doc:** `docs/plans/2026-03-24-e2e-ci-speedup-design.md`
+
+---
+
+### Task 1: Add `docker-build-e2e` job
+
+**Files:**
+
+- Modify: `.github/workflows/test.yml` (insert new job after `server-medium-tests`, before `e2e-tests-server-cli`)
+
+**Step 1: Add the new job**
+
+Insert after line 338 (end of `server-medium-tests`) in `test.yml`:
+
+```yaml
+docker-build-e2e:
+  name: Build E2E Docker Image (${{ matrix.runner }})
+  needs: pre-job
+  if: ${{ fromJSON(needs.pre-job.outputs.should_run).e2e == true || fromJSON(needs.pre-job.outputs.should_run).server == true || fromJSON(needs.pre-job.outputs.should_run).cli == true || fromJSON(needs.pre-job.outputs.should_run).web == true }}
+  runs-on: ${{ matrix.runner }}
+  permissions:
+    contents: read
+  strategy:
+    fail-fast: false
+    matrix:
+      runner: [ubuntu-latest, ubuntu-24.04-arm]
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+        submodules: 'recursive'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+    - name: Build server image
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      with:
+        context: .
+        file: server/Dockerfile
+        build-args: |
+          BUILD_ID=1234567890
+          BUILD_IMAGE=e2e
+          BUILD_SOURCE_REF=e2e
+          BUILD_SOURCE_COMMIT=e2eeeeeeeeeeeeeeeeee
+        outputs: type=docker,dest=/tmp/immich-server.tar
+        tags: immich-server:latest
+        cache-from: type=gha,scope=e2e-${{ runner.arch }}
+        cache-to: type=gha,scope=e2e-${{ runner.arch }},mode=min
+
+    - name: Upload server image
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: e2e-server-image-${{ runner.arch }}
+        path: /tmp/immich-server.tar
+        retention-days: 1
+        if-no-files-found: error
+```
+
+**Step 2: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`
+Expected: No output (valid YAML)
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: add docker-build-e2e job with GHA layer cache"
+```
+
+---
+
+### Task 2: Update `e2e-tests-server-cli` to use pre-built image
+
+**Files:**
+
+- Modify: `.github/workflows/test.yml` — the `e2e-tests-server-cli` job
+
+**Step 1: Update `needs` and replace Docker build step**
+
+Change the job to depend on `docker-build-e2e` (in addition to `pre-job`):
+
+```yaml
+e2e-tests-server-cli:
+  name: End-to-End Tests (Server & CLI)
+  needs: [pre-job, docker-build-e2e]
+  if: ${{ fromJSON(needs.pre-job.outputs.should_run).e2e == true || fromJSON(needs.pre-job.outputs.should_run).server == true || fromJSON(needs.pre-job.outputs.should_run).cli == true }}
+```
+
+Replace the "Start Docker Compose" step (currently `docker compose up -d --build ...`) with three steps:
+
+```yaml
+- name: Download server image
+  uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  with:
+    name: e2e-server-image-${{ runner.arch }}
+    path: /tmp
+- name: Load server image
+  run: docker load < /tmp/immich-server.tar
+- name: Start Docker Compose
+  run: docker compose build e2e-auth-server && docker compose up -d --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
+  if: ${{ !cancelled() }}
+```
+
+Also upgrade the existing "Archive Docker logs" step's action from v6 to v7:
+
+```yaml
+- name: Archive Docker logs
+  uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+```
+
+**Step 2: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: use pre-built Docker image in server e2e"
+```
+
+---
+
+### Task 3: Split `e2e-tests-web` into parallel suite matrix
+
+**Files:**
+
+- Modify: `.github/workflows/test.yml` — the `e2e-tests-web` job
+
+**Note:** All `actions/upload-artifact` refs in this job are upgraded from v6 (`@b7c566a772e6b6bfb58ed0dc250532a479d7789f`) to v7 (`@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f`) to match the v8 download-artifact used in the image download step.
+
+**Step 1: Update needs, matrix, and collapse suite steps**
+
+Change the job to depend on `docker-build-e2e` and add the suite matrix:
+
+```yaml
+e2e-tests-web:
+  name: End-to-End Tests (Web - ${{ matrix.suite.name }})
+  needs: [pre-job, docker-build-e2e]
+  if: ${{ fromJSON(needs.pre-job.outputs.should_run).e2e == true || fromJSON(needs.pre-job.outputs.should_run).web == true }}
+  runs-on: ${{ matrix.runner }}
+  permissions:
+    contents: read
+  defaults:
+    run:
+      working-directory: ./e2e
+  strategy:
+    matrix:
+      runner: [ubuntu-latest, ubuntu-24.04-arm]
+      suite:
+        - { name: web, cmd: 'pnpm test:web' }
+        - { name: ui, cmd: 'pnpm test:web:ui' }
+        - { name: maintenance, cmd: 'pnpm test:web:maintenance' }
+```
+
+Replace the Docker build step with image download/load (same as Task 2):
+
+```yaml
+- name: Download server image
+  uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  with:
+    name: e2e-server-image-${{ runner.arch }}
+    path: /tmp
+- name: Load server image
+  run: docker load < /tmp/immich-server.tar
+- name: Start Docker Compose
+  run: docker compose build e2e-auth-server && docker compose up -d --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
+  if: ${{ !cancelled() }}
+```
+
+Replace the three sequential test+archive blocks (web, ui, maintenance) with a single pair:
+
+```yaml
+- name: Run e2e tests (${{ matrix.suite.name }})
+  env:
+    PLAYWRIGHT_DISABLE_WEBSERVER: true
+  run: ${{ matrix.suite.cmd }}
+  if: ${{ !cancelled() }}
+- name: Archive test results
+  uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+  if: success() || failure()
+  with:
+    name: e2e-${{ matrix.suite.name }}-test-results-${{ matrix.runner }}
+    path: e2e/playwright-report/
+```
+
+Keep the Docker logs capture and archive steps, updating the artifact name:
+
+```yaml
+- name: Capture Docker logs
+  if: always()
+  run: docker compose logs --no-color > docker-compose-logs.txt
+  working-directory: ./e2e
+- name: Archive Docker logs
+  uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+  if: always()
+  with:
+    name: e2e-${{ matrix.suite.name }}-docker-logs-${{ matrix.runner }}
+    path: e2e/docker-compose-logs.txt
+```
+
+**Step 2: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: split Playwright suites into parallel matrix jobs"
+```
+
+---
+
+### Task 4: Remove stale `cache_from` from docker-compose.yml
+
+**Files:**
+
+- Modify: `e2e/docker-compose.yml`
+
+**Step 1: Remove the `cache_from` block**
+
+Remove lines 17-24 from `e2e/docker-compose.yml` (the `cache_from` and `args` blocks referencing upstream's registry). These are no longer used since the image is pre-built.
+
+The `build:` key itself can also be removed from the `immich-server` service since downstream jobs load the pre-built image and never run `docker compose build` on it. However, keeping `build:` as a fallback for local `make e2e` usage is useful. Remove only `cache_from` and `args`:
+
+```yaml
+immich-server:
+  container_name: immich-e2e-server
+  image: immich-server:latest
+  build:
+    context: ../
+    dockerfile: server/Dockerfile
+```
+
+**Step 2: Commit**
+
+```bash
+git add e2e/docker-compose.yml
+git commit -m "ci: remove stale upstream cache_from refs in e2e compose"
+```
+
+---
+
+### Task 5: Validate full workflow end-to-end
+
+**Step 1: Review the complete workflow file**
+
+Read through the full `.github/workflows/test.yml` and verify:
+
+- `docker-build-e2e` `if:` condition is a superset of both downstream jobs' conditions (server || cli || e2e || web)
+- `e2e-tests-server-cli` has `needs: [pre-job, docker-build-e2e]`
+- `e2e-tests-web` has `needs: [pre-job, docker-build-e2e]`
+- `success-check-e2e` still references `needs: [e2e-tests-server-cli, e2e-tests-web]` (unchanged)
+- No `--build` flag remains in any `docker compose up` command in e2e jobs
+- Artifact names don't collide (each has unique `${{ matrix.suite.name }}-${{ matrix.runner }}` suffix)
+
+**Step 2: Push branch and verify CI passes**
+
+```bash
+git push -u origin ci/e2e-speedup
+```
+
+Open the Actions tab and verify:
+
+1. `docker-build-e2e` runs for both runners
+2. `e2e-tests-server-cli` waits for build, downloads artifact, runs tests
+3. `e2e-tests-web` spawns 6 matrix jobs (3 suites x 2 runners)
+4. `success-check-e2e` goes green
+
+**Step 3: Compare timings**
+
+Check ARM web e2e wall-clock time — should be ~8 min vs previous ~15.5 min.

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,14 +14,6 @@ services:
     build:
       context: ../
       dockerfile: server/Dockerfile
-      cache_from:
-        - type=registry,ref=ghcr.io/immich-app/immich-server-build-cache:linux-amd64-cc099f297acd18c924b35ece3245215b53d106eb2518e3af6415931d055746cd-main
-        - type=registry,ref=ghcr.io/immich-app/immich-server-build-cache:linux-arm64-cc099f297acd18c924b35ece3245215b53d106eb2518e3af6415931d055746cd-main
-      args:
-        - BUILD_ID=1234567890
-        - BUILD_IMAGE=e2e
-        - BUILD_SOURCE_REF=e2e
-        - BUILD_SOURCE_COMMIT=e2eeeeeeeeeeeeeeeeee
     environment:
       DB_HOSTNAME: database
       DB_USERNAME: postgres


### PR DESCRIPTION
## Summary

- Add `docker-build-e2e` job that builds `immich-server:latest` once per architecture with GitHub Actions layer cache, then shares the image as an artifact to downstream e2e jobs
- Split `e2e-tests-web` Playwright suites (web, ui, maintenance) into parallel matrix jobs instead of running sequentially
- Remove stale `cache_from` refs in `e2e/docker-compose.yml` pointing to upstream's unreachable registry
- Upgrade `upload-artifact` from v6 to v7 across all e2e jobs (paired with v8 `download-artifact`)

## Expected impact (ARM)

| Metric | Before | After |
|---|---|---|
| Docker build | ~5 min | ~1 min (cache hit) |
| Playwright wall-clock | ~9.5 min | ~5.5 min (parallel) |
| **Total Web E2E** | **~15.5 min** | **~8 min** |
| **Total Server E2E** | **~8.5 min** | **~5 min** |

## Trade-offs

- Job count goes from 4 e2e jobs to 10 (2 build + 2 server + 6 web) — more runner-minutes but much less wall-clock
- GHA cache is best-effort with 10GB limit — eviction falls back to uncached (same as today)

## Test plan

- [ ] `docker-build-e2e` runs for both ubuntu-latest and ubuntu-24.04-arm
- [ ] `e2e-tests-server-cli` downloads artifact and passes
- [ ] `e2e-tests-web` spawns 6 matrix jobs (3 suites × 2 runners) and passes
- [ ] `success-check-e2e` goes green
- [ ] Compare ARM web e2e wall-clock time vs previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)