### PR TITLE
fix: add missing space access checks and bulk download by spaceId

### DIFF
--- a/docs/plans/2026-03-23-spaces-permissions-matrix.md
+++ b/docs/plans/2026-03-23-spaces-permissions-matrix.md
@@ -28,13 +28,14 @@ Generated 2026-03-23 from codebase analysis.
 
 ## Search & Filters
 
-| Interaction        | Endpoint                  | Permission      | spaceId support    | Viewer  | Editor  | Owner | Non-member | Notes                                                   |
-| ------------------ | ------------------------- | --------------- | ------------------ | ------- | ------- | ----- | ---------- | ------------------------------------------------------- |
-| Search metadata    | `POST /search/metadata`   | SharedSpaceRead | Yes                | Y       | Y       | Y     | N          | Has requireAccess check                                 |
-| Smart search       | `POST /search/smart`      | SharedSpaceRead | Yes                | Y       | Y       | Y     | N          | Has requireAccess check                                 |
-| Search suggestions | `GET /search/suggestions` | **None**        | Yes (param exists) | **BUG** | **BUG** | Y     | **BUG**    | Missing requireAccess; ownerId filter blocks non-owners |
-| Search random      | `POST /search/random`     | N/A             | No                 | N/A     | N/A     | N/A   | N/A        | Not space-scoped                                        |
-| Explore data       | `GET /search/explore`     | N/A             | No                 | N/A     | N/A     | N/A   | N/A        | Not space-scoped                                        |
+| Interaction        | Endpoint                    | Permission      | spaceId support | Viewer | Editor | Owner | Non-member | Notes                                      |
+| ------------------ | --------------------------- | --------------- | --------------- | ------ | ------ | ----- | ---------- | ------------------------------------------ |
+| Search metadata    | `POST /search/metadata`     | SharedSpaceRead | Yes             | Y      | Y      | Y     | N          | Has requireAccess check                    |
+| Smart search       | `POST /search/smart`        | SharedSpaceRead | Yes             | Y      | Y      | Y     | N          | Has requireAccess check                    |
+| Search suggestions | `GET /search/suggestions`   | SharedSpaceRead | Yes             | Y      | Y      | Y     | N          | Has requireAccess check (fixed in PR #141) |
+| Search random      | `POST /search/random`       | SharedSpaceRead | Yes             | Y      | Y      | Y     | N          | Has requireAccess check                    |
+| Search large       | `POST /search/large-assets` | SharedSpaceRead | Yes             | Y      | Y      | Y     | N          | Has requireAccess check                    |
+| Explore data       | `GET /search/explore`       | N/A             | No              | N/A    | N/A    | N/A   | N/A        | Not space-scoped                           |
 
 ## Asset Modification
 
@@ -47,11 +48,11 @@ Generated 2026-03-23 from codebase analysis.
 
 ## Download & Archives
 
-| Interaction                 | Endpoint                 | Permission    | spaceId support    | Viewer | Editor | Owner | Non-member |
-| --------------------------- | ------------------------ | ------------- | ------------------ | ------ | ------ | ----- | ---------- |
-| Download info (by assetIds) | `POST /download/info`    | AssetDownload | No (assetIds only) | Y      | Y      | Y     | N          |
-| Download archive            | `POST /download/archive` | AssetDownload | No                 | Y      | Y      | Y     | N          |
-| Bulk download by space      | N/A                      | N/A           | **Missing**        | N/A    | N/A    | N/A   | N/A        |
+| Interaction                 | Endpoint                 | Permission      | spaceId support    | Viewer | Editor | Owner | Non-member |
+| --------------------------- | ------------------------ | --------------- | ------------------ | ------ | ------ | ----- | ---------- |
+| Download info (by assetIds) | `POST /download/info`    | AssetDownload   | No (assetIds only) | Y      | Y      | Y     | N          |
+| Download archive            | `POST /download/archive` | AssetDownload   | No                 | Y      | Y      | Y     | N          |
+| Bulk download by space      | `POST /download/info`    | SharedSpaceRead | Yes                | Y      | Y      | Y     | N          |
 
 ## Space Management
 
@@ -142,7 +143,6 @@ Library-linked assets (assets belonging to a library linked via `shared_space_li
 
 ## Known Limitations (not bugs)
 
-- Bulk download by spaceId not supported (must use individual assetIds)
-- Search random/explore/cities not space-scoped
+- Search explore/cities not space-scoped
 - Asset edits/delete/copy are owner-only regardless of space role
 - Contribution counts/member activity track manual additions only (library-linked assets excluded by design)

--- a/e2e/src/specs/server/api/download.e2e-spec.ts
+++ b/e2e/src/specs/server/api/download.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { AssetMediaResponseDto, LoginResponseDto } from '@immich/sdk';
+import { AssetMediaResponseDto, LoginResponseDto, SharedSpaceResponseDto, SharedSpaceRole } from '@immich/sdk';
 import { readFile, writeFile } from 'node:fs/promises';
 import { app, tempDir, utils } from 'src/utils';
 import request from 'supertest';
@@ -52,6 +52,98 @@ describe('/download', () => {
         const asset = await utils.getAssetInfo(admin.accessToken, id);
         expect(utils.sha1(bytes)).toBe(asset.checksum);
       }
+    });
+  });
+
+  describe('POST /download/info (spaceId)', () => {
+    let space: SharedSpaceResponseDto;
+    let viewer: LoginResponseDto;
+    let editor: LoginResponseDto;
+    let outsider: LoginResponseDto;
+
+    beforeAll(async () => {
+      viewer = await utils.userSetup(admin.accessToken, {
+        email: 'download-viewer@immich.cloud',
+        name: 'Download Viewer',
+        password: 'Password123!',
+      });
+      editor = await utils.userSetup(admin.accessToken, {
+        email: 'download-editor@immich.cloud',
+        name: 'Download Editor',
+        password: 'Password123!',
+      });
+      outsider = await utils.userSetup(admin.accessToken, {
+        email: 'download-outsider@immich.cloud',
+        name: 'Download Outsider',
+        password: 'Password123!',
+      });
+
+      space = await utils.createSpace(admin.accessToken, { name: 'Download Space' });
+      await utils.addSpaceAssets(admin.accessToken, space.id, [asset1.id, asset2.id]);
+      await utils.addSpaceMember(admin.accessToken, space.id, {
+        userId: viewer.userId,
+        role: SharedSpaceRole.Viewer,
+      });
+      await utils.addSpaceMember(admin.accessToken, space.id, {
+        userId: editor.userId,
+        role: SharedSpaceRole.Editor,
+      });
+    });
+
+    it('should return download info for space owner', async () => {
+      const { status, body } = await request(app)
+        .post('/download/info')
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .send({ spaceId: space.id });
+
+      expect(status).toBe(201);
+      expect(body.archives).toHaveLength(1);
+      expect(body.archives[0].assetIds).toContain(asset1.id);
+      expect(body.archives[0].assetIds).toContain(asset2.id);
+    });
+
+    it('should allow editor to download', async () => {
+      const { status, body } = await request(app)
+        .post('/download/info')
+        .set('Authorization', `Bearer ${editor.accessToken}`)
+        .send({ spaceId: space.id });
+
+      expect(status).toBe(201);
+      expect(body.archives).toHaveLength(1);
+      expect(body.archives[0].assetIds).toHaveLength(2);
+    });
+
+    it('should allow viewer to download', async () => {
+      const { status, body } = await request(app)
+        .post('/download/info')
+        .set('Authorization', `Bearer ${viewer.accessToken}`)
+        .send({ spaceId: space.id });
+
+      expect(status).toBe(201);
+      expect(body.archives).toHaveLength(1);
+      expect(body.archives[0].assetIds).toHaveLength(2);
+    });
+
+    it('should reject non-member', async () => {
+      const { status } = await request(app)
+        .post('/download/info')
+        .set('Authorization', `Bearer ${outsider.accessToken}`)
+        .send({ spaceId: space.id });
+
+      expect(status).toBe(400);
+    });
+
+    it('should return empty archives for empty space', async () => {
+      const emptySpace = await utils.createSpace(admin.accessToken, { name: 'Empty Download Space' });
+
+      const { status, body } = await request(app)
+        .post('/download/info')
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .send({ spaceId: emptySpace.id });
+
+      expect(status).toBe(201);
+      expect(body.totalSize).toBe(0);
+      expect(body.archives).toHaveLength(0);
     });
   });
 });

--- a/e2e/src/specs/server/api/search.e2e-spec.ts
+++ b/e2e/src/specs/server/api/search.e2e-spec.ts
@@ -964,4 +964,73 @@ describe('/search', () => {
       expect(status).toBe(400);
     });
   });
+
+  describe('POST /search/random (spaceId access)', () => {
+    let space: SharedSpaceResponseDto;
+    let outsider: LoginResponseDto;
+
+    beforeAll(async () => {
+      space = await utils.createSpace(admin.accessToken, { name: 'Random Search Space' });
+      await utils.addSpaceAssets(admin.accessToken, space.id, [assetFalcon.id]);
+
+      outsider = await utils.userSetup(admin.accessToken, {
+        email: 'random-search-outsider@immich.cloud',
+        name: 'Random Outsider',
+        password: 'Password123!',
+      });
+    });
+
+    it('should reject non-member', async () => {
+      const { status } = await request(app)
+        .post('/search/random')
+        .set('Authorization', `Bearer ${outsider.accessToken}`)
+        .send({ spaceId: space.id });
+
+      expect(status).toBe(400);
+    });
+
+    it('should return results for space member', async () => {
+      const { status, body } = await request(app)
+        .post('/search/random')
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .send({ spaceId: space.id, size: 10 });
+
+      expect(status).toBe(200);
+      expect(body.length).toBeGreaterThan(0);
+      expect(body.map((a: AssetResponseDto) => a.id)).toContain(assetFalcon.id);
+    });
+  });
+
+  describe('POST /search/large-assets (spaceId access)', () => {
+    let space: SharedSpaceResponseDto;
+    let outsider: LoginResponseDto;
+
+    beforeAll(async () => {
+      space = await utils.createSpace(admin.accessToken, { name: 'Large Assets Search Space' });
+      await utils.addSpaceAssets(admin.accessToken, space.id, [assetFalcon.id]);
+
+      outsider = await utils.userSetup(admin.accessToken, {
+        email: 'large-assets-outsider@immich.cloud',
+        name: 'Large Assets Outsider',
+        password: 'Password123!',
+      });
+    });
+
+    it('should reject non-member', async () => {
+      const { status } = await request(app)
+        .post(`/search/large-assets?spaceId=${space.id}`)
+        .set('Authorization', `Bearer ${outsider.accessToken}`);
+
+      expect(status).toBe(400);
+    });
+
+    it('should return results for space member', async () => {
+      const { status, body } = await request(app)
+        .post(`/search/large-assets?spaceId=${space.id}&size=10`)
+        .set('Authorization', `Bearer ${admin.accessToken}`);
+
+      expect(status).toBe(200);
+      expect(Array.isArray(body)).toBe(true);
+    });
+  });
 });

--- a/mobile/openapi/lib/model/download_info_dto.dart
+++ b/mobile/openapi/lib/model/download_info_dto.dart
@@ -16,6 +16,7 @@ class DownloadInfoDto {
     this.albumId,
     this.archiveSize,
     this.assetIds = const [],
+    this.spaceId,
     this.userId,
   });
 
@@ -42,6 +43,15 @@ class DownloadInfoDto {
   /// Asset IDs to download
   List<String> assetIds;
 
+  /// Shared space ID to download all assets from
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? spaceId;
+
   /// User ID to download assets from
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -56,6 +66,7 @@ class DownloadInfoDto {
     other.albumId == albumId &&
     other.archiveSize == archiveSize &&
     _deepEquality.equals(other.assetIds, assetIds) &&
+    other.spaceId == spaceId &&
     other.userId == userId;
 
   @override
@@ -64,10 +75,11 @@ class DownloadInfoDto {
     (albumId == null ? 0 : albumId!.hashCode) +
     (archiveSize == null ? 0 : archiveSize!.hashCode) +
     (assetIds.hashCode) +
+    (spaceId == null ? 0 : spaceId!.hashCode) +
     (userId == null ? 0 : userId!.hashCode);
 
   @override
-  String toString() => 'DownloadInfoDto[albumId=$albumId, archiveSize=$archiveSize, assetIds=$assetIds, userId=$userId]';
+  String toString() => 'DownloadInfoDto[albumId=$albumId, archiveSize=$archiveSize, assetIds=$assetIds, spaceId=$spaceId, userId=$userId]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -82,6 +94,11 @@ class DownloadInfoDto {
     //  json[r'archiveSize'] = null;
     }
       json[r'assetIds'] = this.assetIds;
+    if (this.spaceId != null) {
+      json[r'spaceId'] = this.spaceId;
+    } else {
+    //  json[r'spaceId'] = null;
+    }
     if (this.userId != null) {
       json[r'userId'] = this.userId;
     } else {
@@ -104,6 +121,7 @@ class DownloadInfoDto {
         assetIds: json[r'assetIds'] is Iterable
             ? (json[r'assetIds'] as Iterable).cast<String>().toList(growable: false)
             : const [],
+        spaceId: mapValueOfType<String>(json, r'spaceId'),
         userId: mapValueOfType<String>(json, r'userId'),
       );
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -20237,6 +20237,11 @@
             },
             "type": "array"
           },
+          "spaceId": {
+            "description": "Shared space ID to download all assets from",
+            "format": "uuid",
+            "type": "string"
+          },
           "userId": {
             "description": "User ID to download assets from",
             "format": "uuid",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -1147,6 +1147,8 @@ export type DownloadInfoDto = {
     archiveSize?: number;
     /** Asset IDs to download */
     assetIds?: string[];
+    /** Shared space ID to download all assets from */
+    spaceId?: string;
     /** User ID to download assets from */
     userId?: string;
 };

--- a/server/src/dtos/download.dto.ts
+++ b/server/src/dtos/download.dto.ts
@@ -13,6 +13,9 @@ export class DownloadInfoDto {
   @ValidateUUID({ optional: true, description: 'User ID to download assets from' })
   userId?: string;
 
+  @ValidateUUID({ optional: true, description: 'Shared space ID to download all assets from' })
+  spaceId?: string;
+
   @ApiPropertyOptional({ type: 'integer', description: 'Archive size limit in bytes' })
   @IsInt()
   @IsPositive()

--- a/server/src/repositories/download.repository.ts
+++ b/server/src/repositories/download.repository.ts
@@ -37,4 +37,19 @@ export class DownloadRepository {
       .where('asset.visibility', '!=', AssetVisibility.Hidden)
       .stream();
   }
+
+  downloadSpaceId(spaceId: string) {
+    const direct = builder(this.db)
+      .innerJoin('shared_space_asset', 'asset.id', 'shared_space_asset.assetId')
+      .where('shared_space_asset.spaceId', '=', spaceId);
+
+    const library = builder(this.db)
+      .innerJoin('shared_space_library', (join) =>
+        join.onRef('shared_space_library.libraryId', '=', 'asset.libraryId'),
+      )
+      .where('shared_space_library.spaceId', '=', spaceId)
+      .where('asset.isOffline', '=', false);
+
+    return direct.union(library).stream();
+  }
 }

--- a/server/src/repositories/download.repository.ts
+++ b/server/src/repositories/download.repository.ts
@@ -44,9 +44,7 @@ export class DownloadRepository {
       .where('shared_space_asset.spaceId', '=', spaceId);
 
     const library = builder(this.db)
-      .innerJoin('shared_space_library', (join) =>
-        join.onRef('shared_space_library.libraryId', '=', 'asset.libraryId'),
-      )
+      .innerJoin('shared_space_library', (join) => join.onRef('shared_space_library.libraryId', '=', 'asset.libraryId'))
       .where('shared_space_library.spaceId', '=', spaceId)
       .where('asset.isOffline', '=', false);
 

--- a/server/src/services/download.service.spec.ts
+++ b/server/src/services/download.service.spec.ts
@@ -5,6 +5,7 @@ import { DownloadService } from 'src/services/download.service';
 import { StorageService } from 'src/services/storage.service';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { authStub } from 'test/fixtures/auth.stub';
+import { newUuid } from 'test/small.factory';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
 import { vitest } from 'vitest';
 
@@ -359,6 +360,71 @@ describe(DownloadService.name, () => {
           { assetIds: ['asset-3', 'asset-4'], size: 146_456 },
         ],
       });
+    });
+
+    it('should return a list of archives (spaceId)', async () => {
+      const spaceId = newUuid();
+
+      mocks.user.getMetadata.mockResolvedValue([]);
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.downloadRepository.downloadSpaceId.mockReturnValue(
+        makeStream([
+          { id: 'asset-1', livePhotoVideoId: null, size: 100_000 },
+          { id: 'asset-2', livePhotoVideoId: null, size: 5000 },
+        ]),
+      );
+
+      await expect(sut.getDownloadInfo(authStub.admin, { spaceId })).resolves.toEqual(downloadResponse);
+
+      expect(mocks.access.sharedSpace.checkMemberAccess).toHaveBeenCalledWith(
+        authStub.admin.user.id,
+        new Set([spaceId]),
+      );
+      expect(mocks.downloadRepository.downloadSpaceId).toHaveBeenCalledWith(spaceId);
+    });
+
+    it('should reject non-member for spaceId download', async () => {
+      const spaceId = newUuid();
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set());
+
+      await expect(sut.getDownloadInfo(authStub.admin, { spaceId })).rejects.toThrow();
+    });
+
+    it('should return empty archives for space with no assets', async () => {
+      const spaceId = newUuid();
+
+      mocks.user.getMetadata.mockResolvedValue([]);
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.downloadRepository.downloadSpaceId.mockReturnValue(makeStream([]));
+
+      await expect(sut.getDownloadInfo(authStub.admin, { spaceId })).resolves.toEqual({
+        totalSize: 0,
+        archives: [],
+      });
+    });
+
+    it('should include live photo video for space download', async () => {
+      const spaceId = newUuid();
+
+      mocks.user.getMetadata.mockResolvedValue([]);
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.downloadRepository.downloadSpaceId.mockReturnValue(
+        makeStream([{ id: 'asset-1', livePhotoVideoId: 'motion-1', size: 5000 }]),
+      );
+      mocks.downloadRepository.downloadMotionAssetIds.mockReturnValue(
+        makeStream([{ id: 'motion-1', livePhotoVideoId: null, size: 2000, originalPath: '/path/to/file.mp4' }]),
+      );
+
+      const result = await sut.getDownloadInfo(authStub.admin, { spaceId });
+
+      expect(result.totalSize).toBe(7000);
+      expect(result.archives[0].assetIds).toEqual(['asset-1', 'motion-1']);
+    });
+
+    it('should include spaceId in error message for invalid dto', async () => {
+      await expect(sut.getDownloadInfo(authStub.admin, {})).rejects.toThrow(
+        'assetIds, albumId, userId, or spaceId is required',
+      );
     });
 
     it('should skip the video portion of an android live photo by default', async () => {

--- a/server/src/services/download.service.ts
+++ b/server/src/services/download.service.ts
@@ -27,8 +27,12 @@ export class DownloadService extends BaseService {
       const userId = dto.userId;
       await this.requireAccess({ auth, permission: Permission.TimelineDownload, ids: [userId] });
       assets = this.downloadRepository.downloadUserId(userId);
+    } else if (dto.spaceId) {
+      const spaceId = dto.spaceId;
+      await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [spaceId] });
+      assets = this.downloadRepository.downloadSpaceId(spaceId);
     } else {
-      throw new BadRequestException('assetIds, albumId, or userId is required');
+      throw new BadRequestException('assetIds, albumId, userId, or spaceId is required');
     }
 
     const targetSize = dto.archiveSize || HumanReadableSize.GiB * 4;

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -685,6 +685,37 @@ describe(SearchService.name, () => {
         'Elevated permission is required',
       );
     });
+
+    describe('shared space access (spaceId)', () => {
+      it('should check shared space access when spaceId is provided', async () => {
+        const spaceId = newUuid();
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+        mocks.search.searchLargeAssets.mockResolvedValue([]);
+
+        await sut.searchLargeAssets(authStub.user1, { spaceId });
+
+        expect(mocks.access.sharedSpace.checkMemberAccess).toHaveBeenCalledWith(
+          authStub.user1.user.id,
+          new Set([spaceId]),
+        );
+        expect(mocks.search.searchLargeAssets).toHaveBeenCalledWith(250, expect.objectContaining({ spaceId }));
+      });
+
+      it('should not check space access when spaceId is not provided', async () => {
+        mocks.search.searchLargeAssets.mockResolvedValue([]);
+
+        await sut.searchLargeAssets(authStub.user1, {});
+
+        expect(mocks.access.sharedSpace.checkMemberAccess).not.toHaveBeenCalled();
+      });
+
+      it('should throw when user is not a space member', async () => {
+        const spaceId = newUuid();
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set());
+
+        await expect(sut.searchLargeAssets(authStub.user1, { spaceId })).rejects.toThrow();
+      });
+    });
   });
 
   describe('getAssetsByCity', () => {

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -620,6 +620,37 @@ describe(SearchService.name, () => {
         'Elevated permission is required',
       );
     });
+
+    describe('shared space access (spaceId)', () => {
+      it('should check shared space access when spaceId is provided', async () => {
+        const spaceId = newUuid();
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+        mocks.search.searchRandom.mockResolvedValue([]);
+
+        await sut.searchRandom(authStub.user1, { spaceId });
+
+        expect(mocks.access.sharedSpace.checkMemberAccess).toHaveBeenCalledWith(
+          authStub.user1.user.id,
+          new Set([spaceId]),
+        );
+        expect(mocks.search.searchRandom).toHaveBeenCalledWith(250, expect.objectContaining({ spaceId }));
+      });
+
+      it('should not check space access when spaceId is not provided', async () => {
+        mocks.search.searchRandom.mockResolvedValue([]);
+
+        await sut.searchRandom(authStub.user1, {});
+
+        expect(mocks.access.sharedSpace.checkMemberAccess).not.toHaveBeenCalled();
+      });
+
+      it('should throw when user is not a space member', async () => {
+        const spaceId = newUuid();
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set());
+
+        await expect(sut.searchRandom(authStub.user1, { spaceId })).rejects.toThrow();
+      });
+    });
   });
 
   describe('searchLargeAssets', () => {

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -91,6 +91,10 @@ export class SearchService extends BaseService {
       requireElevatedPermission(auth);
     }
 
+    if (dto.spaceId) {
+      await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [dto.spaceId] });
+    }
+
     const userIds = await this.getUserIdsToSearch(auth);
     const items = await this.searchRepository.searchRandom(dto.size || 250, { ...dto, userIds });
     return items.map((item) => mapAsset(item, { auth }));

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -105,6 +105,10 @@ export class SearchService extends BaseService {
       requireElevatedPermission(auth);
     }
 
+    if (dto.spaceId) {
+      await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [dto.spaceId] });
+    }
+
     const userIds = await this.getUserIdsToSearch(auth);
     const items = await this.searchRepository.searchLargeAssets(dto.size || 250, { ...dto, userIds });
     return items.map((item) => mapAsset(item, { auth }));


### PR DESCRIPTION
## Summary
- Add `SharedSpaceRead` access guard to `searchRandom` and `searchLargeAssets` — both accepted `spaceId` via DTO but had no authorization check, allowing non-members to query space-scoped data
- Add bulk download by `spaceId` to the existing download flow — new `spaceId` field on `DownloadInfoDto`, UNION-based repository query (direct + library-linked assets), `SharedSpaceRead` permission check in service
- Two-layer download authorization: step 1 checks space membership, step 2 checks per-asset `AssetDownload` (already includes space access chain)

## Test plan
- [x] Unit tests for `searchRandom` space access (3 tests: guard called, no-op when absent, rejection)
- [x] Unit tests for `searchLargeAssets` space access (3 tests: same pattern)
- [x] Unit tests for download by `spaceId` (5 tests: happy path, rejection, empty space, live photo, error message)
- [x] E2E tests for `POST /search/random` with spaceId (non-member rejection, member access)
- [x] E2E tests for `POST /search/large-assets` with spaceId (non-member rejection, member access)
- [x] E2E tests for `POST /download/info` with spaceId (owner, editor, viewer, non-member, empty space)
- [x] OpenAPI regenerated with new `spaceId` field
- [x] Permissions matrix doc updated