### PR TITLE
feat: move connected libraries to discoverable modal

### DIFF
--- a/docs/plans/2026-03-24-connected-libraries-modal-design.md
+++ b/docs/plans/2026-03-24-connected-libraries-modal-design.md
@@ -1,0 +1,71 @@
+# Connected Libraries UI Improvement
+
+## Problem
+
+The "connected libraries" feature in shared spaces is hard to discover — it's buried as the 3rd tab in the members panel (Activity | Members | Libraries), admin-only.
+
+## Solution
+
+1. Remove the Libraries tab from `space-panel.svelte` (members panel goes back to Activity | Members)
+2. Add a "Link Libraries" menu item in the existing dropdown menu, next to "Add All Photos"
+3. Clicking "Link Libraries" opens a modal dialog containing the library linking UI
+
+## Changes
+
+### 1. Dropdown Menu Restructure (`+page.svelte`)
+
+New menu structure:
+
+```
+Show/Hide Timeline (all members)
+--- divider ---
+Add All Photos (editors+)
+Link Libraries (admin only, mdiBookshelf icon)
+--- divider ---
+People toggle (owners)
+Pets toggle (owners)
+--- divider ---
+Delete (owners)
+```
+
+No section label — the two items are grouped between existing dividers.
+
+### 2. New Modal (`SpaceLinkedLibrariesModal.svelte`)
+
+Create `web/src/lib/modals/SpaceLinkedLibrariesModal.svelte` using `Modal` + `ModalBody` from `@immich/ui` (not `FormModal`, which requires `onSubmit`).
+
+- Contains the existing `SpaceLinkedLibraries` component
+- Modal keeps local `spaceData = $state(space)` and re-fetches via `getSpace` on each link/unlink so the list updates live
+- `onChanged` callback calls both `refreshSpace()` and `loadActivities()` to keep the activity feed in sync
+
+### 3. Remove Libraries Tab from `space-panel.svelte`
+
+- Remove the Libraries tab button from the tab switcher
+- Remove the `{:else if activeTab === 'libraries'}` content block
+- Remove the `SpaceLinkedLibraries` import
+- Remove the `onLibrariesChanged` prop
+- Change `activeTab` type from `'activity' | 'members' | 'libraries'` to `'activity' | 'members'`
+
+### 4. Update `+page.svelte`
+
+- Add `handleLinkLibraries()` that opens the modal via `modalManager.show()`
+- Add the menu item with `mdiBookshelf` icon, gated on `isAdmin`
+- Remove `onLibrariesChanged` prop from `SpacePanel` usage
+
+## Files Touched
+
+- `web/src/lib/modals/SpaceLinkedLibrariesModal.svelte` — **new** (~30 lines)
+- `web/src/lib/components/spaces/space-panel.svelte` — remove libraries tab
+- `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte` — add menu item + modal handler
+
+## Not Changing
+
+- `space-linked-libraries.svelte` — reused as-is
+- No server/API changes
+- No new icons (reuse `mdiBookshelf`)
+
+## Edge Cases
+
+- `getAllLibraries()` API is admin-only — menu item must remain gated on `isAdmin`
+- Modal re-fetches space data after each link/unlink to keep the list reactive (modalManager passes static props)
+- No E2E tests reference `tab-libraries` testid, so removal is safe

--- a/docs/plans/2026-03-24-connected-libraries-modal.md
+++ b/docs/plans/2026-03-24-connected-libraries-modal.md
@@ -1,0 +1,416 @@
+# Connected Libraries Modal Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move the connected-libraries UI from a hidden panel tab into a discoverable dropdown menu item that opens a modal dialog.
+
+**Architecture:** Remove the Libraries tab from the existing 3-tab space panel. Add a "Link Libraries" menu item to the dropdown menu (next to "Add All Photos"). Clicking it opens a modal containing the existing `SpaceLinkedLibraries` component with a local re-fetch pattern for reactivity.
+
+**Tech Stack:** Svelte 5, `@immich/ui` (Modal, ModalBody), `@immich/sdk`
+
+---
+
+### Task 1: Create SpaceLinkedLibrariesModal with tests
+
+**Files:**
+
+- Create: `web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts`
+- Create: `web/src/lib/modals/SpaceLinkedLibrariesModal.svelte`
+
+**Step 1: Write failing tests**
+
+Create `web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts`:
+
+```typescript
+import { getAnimateMock } from '$lib/__mocks__/animate.mock';
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import '$lib/__mocks__/sdk.mock';
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { getVisualViewportMock } from '$lib/__mocks__/visual-viewport.mock';
+
+vi.mock('svelte-persisted-store', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    persisted: (_key: string, initialValue: unknown) => writable(initialValue),
+  };
+});
+
+vi.mock('$lib/utils/tunables', () => ({
+  TUNABLES: {
+    LAYOUT: { WASM: true },
+    TIMELINE: { INTERSECTION_EXPAND_TOP: 500, INTERSECTION_EXPAND_BOTTOM: 500 },
+  },
+}));
+
+import type { SharedSpaceResponseDto } from '@immich/sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import SpaceLinkedLibrariesModal from './SpaceLinkedLibrariesModal.svelte';
+
+const makeSpace = (overrides: Partial<SharedSpaceResponseDto> = {}): SharedSpaceResponseDto => ({
+  id: 'space-1',
+  name: 'Family Photos',
+  description: '',
+  createdById: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  memberCount: 1,
+  assetCount: 0,
+  thumbnailAssetId: null,
+  recentAssetIds: [],
+  recentAssetThumbhashes: [],
+  lastActivityAt: null,
+  newAssetCount: 0,
+  members: [],
+  linkedLibraries: [],
+  ...overrides,
+});
+
+describe('SpaceLinkedLibrariesModal', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+    vi.stubGlobal('visualViewport', getVisualViewportMock());
+    vi.resetAllMocks();
+    Element.prototype.animate = getAnimateMock();
+    sdkMock.getAllLibraries.mockResolvedValue([]);
+  });
+
+  afterAll(async () => {
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
+  });
+
+  it('should render modal with "Connected Libraries" title', () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    expect(screen.getByText('Connected Libraries')).toBeInTheDocument();
+  });
+
+  it('should render the SpaceLinkedLibraries component inside', () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    expect(screen.getByTestId('linked-libraries')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no libraries are linked', () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    expect(screen.getByText('No libraries connected yet')).toBeInTheDocument();
+  });
+
+  it('should show linked libraries when present', () => {
+    const space = makeSpace({
+      linkedLibraries: [{ libraryId: 'lib-1', libraryName: 'My Photos' }],
+    });
+    render(SpaceLinkedLibrariesModal, { space, onClose });
+    expect(screen.getByText('My Photos')).toBeInTheDocument();
+  });
+
+  it('should call onClose with false when closed without changes', async () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+    await fireEvent.click(closeButtons[0]);
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledWith(false);
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/modals/SpaceLinkedLibrariesModal.spec.ts`
+Expected: FAIL — `SpaceLinkedLibrariesModal` module not found.
+
+**Step 3: Create the modal component**
+
+Create `web/src/lib/modals/SpaceLinkedLibrariesModal.svelte`:
+
+```svelte
+<script lang="ts">
+  import SpaceLinkedLibraries from '$lib/components/spaces/space-linked-libraries.svelte';
+  import { getSpace, type SharedSpaceResponseDto } from '@immich/sdk';
+  import { Modal, ModalBody } from '@immich/ui';
+  import { mdiBookshelf } from '@mdi/js';
+
+  interface Props {
+    space: SharedSpaceResponseDto;
+    onClose: (changed?: boolean) => void;
+  }
+
+  let { space: initialSpace, onClose }: Props = $props();
+
+  let spaceData = $state(initialSpace);
+  let changed = $state(false);
+
+  const handleChanged = async () => {
+    changed = true;
+    spaceData = await getSpace({ id: spaceData.id });
+  };
+</script>
+
+<Modal title="Connected Libraries" icon={mdiBookshelf} onClose={() => onClose(changed)}>
+  <ModalBody>
+    <SpaceLinkedLibraries space={spaceData} onChanged={handleChanged} />
+  </ModalBody>
+</Modal>
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/modals/SpaceLinkedLibrariesModal.spec.ts`
+Expected: All 5 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts web/src/lib/modals/SpaceLinkedLibrariesModal.svelte
+git commit -m "feat: add SpaceLinkedLibrariesModal with tests"
+```
+
+---
+
+### Task 2: Remove Libraries tab from space-panel (test first)
+
+**Files:**
+
+- Modify: `web/src/lib/components/spaces/space-panel.spec.ts`
+- Modify: `web/src/lib/components/spaces/space-panel.svelte`
+
+**Step 1: Write failing regression test**
+
+Add the `user` store import at the top of `web/src/lib/components/spaces/space-panel.spec.ts`:
+
+```typescript
+import { user } from '$lib/stores/user.store';
+```
+
+Add these tests inside the existing `describe` block:
+
+```typescript
+it('should only render Activity and Members tabs for admin users', () => {
+  // Set user as admin to ensure the Libraries tab would render if it still existed
+  user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as any);
+  renderPanel(defaultProps);
+  const tabSwitcher = screen.getByTestId('tab-switcher');
+  const tabs = tabSwitcher.querySelectorAll('button');
+  expect(tabs).toHaveLength(2);
+  expect(tabs[0]).toHaveTextContent('Activity');
+  expect(tabs[1]).toHaveTextContent(/^Members/);
+});
+
+it('should not render a Libraries tab', () => {
+  user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as any);
+  renderPanel(defaultProps);
+  expect(screen.queryByTestId('tab-libraries')).not.toBeInTheDocument();
+});
+```
+
+**Step 2: Run tests to verify the tab count test fails**
+
+Run: `cd web && pnpm test -- --run src/lib/components/spaces/space-panel.spec.ts`
+Expected: "should only render Activity and Members tabs for admin users" FAILS — with `isAdmin: true`, 3 tabs render (Activity, Members, Libraries) but the test expects 2.
+
+**Step 3: Verify no E2E tests reference the Libraries tab**
+
+Run: `grep -r "tab-libraries" e2e/ || echo "No E2E references found"`
+Expected: No references found. Safe to remove.
+
+**Step 4: Remove Libraries tab from space-panel.svelte**
+
+In `web/src/lib/components/spaces/space-panel.svelte`:
+
+1. Remove the `SpaceLinkedLibraries` import (line 5)
+2. Remove `onLibrariesChanged` from Props interface (line 34) and destructuring (line 48-49: `onLibrariesChanged = () => {}`)
+3. Remove the `isAdmin` derived variable (line 54) — it is only used by the Libraries tab
+4. Change `activeTab` type (line 53):
+
+```typescript
+let activeTab = $state<'activity' | 'members'>('activity');
+```
+
+5. Remove the Libraries tab button — the entire `{#if isAdmin}` block (lines 173-184):
+
+```svelte
+<!-- DELETE THIS BLOCK -->
+{#if isAdmin}
+  <button
+    type="button"
+    class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {activeTab === 'libraries'
+      ? activeTabClass
+      : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+    onclick={() => (activeTab = 'libraries')}
+    data-testid="tab-libraries"
+  >
+    Libraries
+  </button>
+{/if}
+```
+
+6. Remove the libraries tab content (around line 207-208):
+
+```svelte
+<!-- DELETE THIS BLOCK -->
+{:else if activeTab === 'libraries'}
+  <SpaceLinkedLibraries {space} onChanged={onLibrariesChanged} />
+```
+
+7. Remove the `import { user } from '$lib/stores/user.store'` if it's no longer used (check if `$user` is referenced elsewhere in the file — it's used for `isAdmin` only, so remove it).
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/spaces/space-panel.spec.ts`
+Expected: All tests PASS including the new regression tests.
+
+**Step 6: Commit**
+
+```bash
+git add web/src/lib/components/spaces/space-panel.spec.ts web/src/lib/components/spaces/space-panel.svelte
+git commit -m "refactor: remove Libraries tab from space panel"
+```
+
+---
+
+### Task 3: Add "Link Libraries" menu item to dropdown
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Testing note:** The space page component (`+page.svelte`) has deep dependencies on routing, TimelineManager, Socket.IO, and other infrastructure that make unit testing impractical. The admin gating (`$user?.isAdmin`) follows the same pattern as other admin checks in the codebase. The modal itself is fully tested in Task 1. The admin gating behavior will be verified manually and covered by the type check in Task 4.
+
+**Step 1: Add imports**
+
+At the top of the `<script>` block, add:
+
+```typescript
+import SpaceLinkedLibrariesModal from '$lib/modals/SpaceLinkedLibrariesModal.svelte';
+```
+
+Add `mdiBookshelf` to the existing `@mdi/js` import.
+
+**Step 2: Add the handler function**
+
+Add after the `handleBulkAddAssets` function (which ends at line 419):
+
+```typescript
+const handleLinkLibraries = async () => {
+  const changed = await modalManager.show(SpaceLinkedLibrariesModal, { space });
+  if (changed) {
+    await refreshSpace();
+    await loadActivities();
+  }
+};
+```
+
+**Step 3: Restructure the dropdown menu**
+
+In the `ButtonContextMenu` (line 642), replace the current menu structure with:
+
+```svelte
+<ButtonContextMenu direction="left" align="top-right" color="secondary" title="More" icon={mdiDotsVertical}>
+  <MenuOption
+    text={showInTimeline ? $t('spaces_hide_from_timeline') : $t('spaces_show_on_timeline')}
+    icon={showInTimeline ? mdiEyeOutline : mdiEyeOffOutline}
+    onClick={handleToggleTimeline}
+  />
+  {#if isEditor || $user?.isAdmin}
+    <hr class="my-1 border-gray-300" />
+  {/if}
+  {#if isEditor}
+    <MenuOption text={$t('add_all_photos')} icon={mdiImageMultipleOutline} onClick={handleBulkAddAssets} />
+  {/if}
+  {#if $user?.isAdmin}
+    <MenuOption text="Link Libraries" icon={mdiBookshelf} onClick={handleLinkLibraries} />
+  {/if}
+  {#if isOwner}
+    <hr class="my-1 border-gray-300" />
+    <MenuOption
+      text="People"
+      icon={mdiFaceRecognition}
+      textColor={space.faceRecognitionEnabled ? 'text-immich-primary' : undefined}
+      onClick={handleToggleFaceRecognition}
+    />
+    {#if space.faceRecognitionEnabled}
+      <MenuOption
+        text="Pets"
+        icon={mdiPaw}
+        textColor={space.petsEnabled ? 'text-immich-primary' : undefined}
+        onClick={handleTogglePets}
+      />
+    {/if}
+    <hr class="my-1 border-gray-300" />
+    <MenuOption
+      text={$t('spaces_delete')}
+      icon={mdiDeleteOutline}
+      textColor="text-red-500"
+      onClick={handleDelete}
+    />
+  {/if}
+</ButtonContextMenu>
+```
+
+Notes:
+
+- The `<hr>` divider shows when either `isEditor` or `$user?.isAdmin` is true, so non-editor admins still get a visual separator before "Link Libraries".
+- `$user?.isAdmin` comes from the already-imported `user` store (line 39). There is no local `isAdmin` variable on this page.
+- The `handleLinkLibraries` handler calls `refreshSpace()` + `loadActivities()` only when the modal reports changes, keeping the activity feed in sync.
+
+**Step 4: Remove `onLibrariesChanged` from SpacePanel usage**
+
+At line 864, remove the `onLibrariesChanged` prop from the `<SpacePanel>` component:
+
+```svelte
+<SpacePanel
+  {space}
+  {members}
+  {activities}
+  currentUserId={$user.id}
+  {isOwner}
+  open={panelOpen}
+  onClose={() => (panelOpen = false)}
+  onMembersChanged={async () => {
+    members = await getMembers({ id: space.id });
+    await refreshSpace();
+    await loadActivities();
+  }}
+  onLoadMoreActivities={loadMoreActivities}
+  {hasMoreActivities}
+/>
+```
+
+**Step 5: Commit**
+
+```bash
+git add web/src/routes/\(user\)/spaces/\[spaceId\]/\[\[photos=photos\]\]/\[\[assetId=id\]\]/+page.svelte
+git commit -m "feat: add Link Libraries menu item to space dropdown"
+```
+
+---
+
+### Task 4: Lint, format, and verify all tests pass
+
+**Step 1: Run prettier**
+
+Run: `cd web && npx prettier --write src/lib/modals/SpaceLinkedLibrariesModal.svelte src/lib/modals/SpaceLinkedLibrariesModal.spec.ts src/lib/components/spaces/space-panel.svelte src/lib/components/spaces/space-panel.spec.ts "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte"`
+
+**Step 2: Run linter**
+
+Run: `cd web && npx eslint --max-warnings 0 src/lib/modals/SpaceLinkedLibrariesModal.svelte src/lib/modals/SpaceLinkedLibrariesModal.spec.ts src/lib/components/spaces/space-panel.svelte src/lib/components/spaces/space-panel.spec.ts "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte"`
+Expected: No errors or warnings.
+
+**Step 3: Run all web tests**
+
+Run: `cd web && pnpm test`
+Expected: All tests pass.
+
+**Step 4: Run type check**
+
+Run: `cd web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
+Expected: No new errors.
+
+**Step 5: Fix any issues and commit if needed**
+
+```bash
+git add -u
+git commit -m "chore: lint and format connected libraries changes"
+```

--- a/web/src/lib/components/spaces/space-panel.spec.ts
+++ b/web/src/lib/components/spaces/space-panel.spec.ts
@@ -1,7 +1,12 @@
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import SpacePanel from '$lib/components/spaces/space-panel.svelte';
 import { user } from '$lib/stores/user.store';
-import { Role, type SharedSpaceMemberResponseDto, type SharedSpaceResponseDto } from '@immich/sdk';
+import {
+  Role,
+  type SharedSpaceMemberResponseDto,
+  type SharedSpaceResponseDto,
+  type UserAdminResponseDto,
+} from '@immich/sdk';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 
@@ -115,7 +120,7 @@ describe('SpacePanel', () => {
 
   it('should only render Activity and Members tabs for admin users', () => {
     // Set user as admin to ensure the Libraries tab would render if it still existed
-    user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as any);
+    user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as UserAdminResponseDto);
     renderPanel(defaultProps);
     const tabSwitcher = screen.getByTestId('tab-switcher');
     const tabs = tabSwitcher.querySelectorAll('button');
@@ -125,7 +130,7 @@ describe('SpacePanel', () => {
   });
 
   it('should not render a Libraries tab', () => {
-    user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as any);
+    user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as UserAdminResponseDto);
     renderPanel(defaultProps);
     expect(screen.queryByTestId('tab-libraries')).not.toBeInTheDocument();
   });

--- a/web/src/lib/components/spaces/space-panel.spec.ts
+++ b/web/src/lib/components/spaces/space-panel.spec.ts
@@ -1,5 +1,6 @@
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import SpacePanel from '$lib/components/spaces/space-panel.svelte';
+import { user } from '$lib/stores/user.store';
 import { Role, type SharedSpaceMemberResponseDto, type SharedSpaceResponseDto } from '@immich/sdk';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import type { Component } from 'svelte';
@@ -110,5 +111,22 @@ describe('SpacePanel', () => {
     renderPanel(defaultProps);
     const membersTab = screen.getByTestId('tab-members');
     expect(membersTab).toHaveTextContent('Members (2)');
+  });
+
+  it('should only render Activity and Members tabs for admin users', () => {
+    // Set user as admin to ensure the Libraries tab would render if it still existed
+    user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as any);
+    renderPanel(defaultProps);
+    const tabSwitcher = screen.getByTestId('tab-switcher');
+    const tabs = tabSwitcher.querySelectorAll('button');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]).toHaveTextContent('Activity');
+    expect(tabs[1]).toHaveTextContent(/^Members/);
+  });
+
+  it('should not render a Libraries tab', () => {
+    user.set({ id: 'u1', isAdmin: true, name: 'Admin', email: 'admin@test.com' } as any);
+    renderPanel(defaultProps);
+    expect(screen.queryByTestId('tab-libraries')).not.toBeInTheDocument();
   });
 });

--- a/web/src/lib/components/spaces/space-panel.svelte
+++ b/web/src/lib/components/spaces/space-panel.svelte
@@ -2,8 +2,7 @@
   import UserAvatar from '$lib/components/shared-components/user-avatar.svelte';
   import RoleBadge from '$lib/components/spaces/role-badge.svelte';
   import SpaceActivityFeed from '$lib/components/spaces/space-activity-feed.svelte';
-  import SpaceLinkedLibraries from '$lib/components/spaces/space-linked-libraries.svelte';
-  import { user } from '$lib/stores/user.store';
+
   import { getAssetMediaUrl } from '$lib/utils';
   import { formatTimeAgo } from '$lib/utils/timesince';
   import { handleError } from '$lib/utils/handle-error';
@@ -31,7 +30,7 @@
     open: boolean;
     onClose: () => void;
     onMembersChanged: () => void;
-    onLibrariesChanged?: () => void;
+
     onLoadMoreActivities: () => void;
     hasMoreActivities: boolean;
   }
@@ -45,13 +44,11 @@
     open,
     onClose,
     onMembersChanged,
-    onLibrariesChanged = () => {},
     onLoadMoreActivities,
     hasMoreActivities,
   }: Props = $props();
 
-  let activeTab = $state<'activity' | 'members' | 'libraries'>('activity');
-  let isAdmin = $derived($user?.isAdmin ?? false);
+  let activeTab = $state<'activity' | 'members'>('activity');
 
   const tabBgClasses: Record<string, string> = {
     [UserAvatarColor.Primary]: 'bg-primary text-white',
@@ -170,18 +167,6 @@
       >
         Members ({members.length})
       </button>
-      {#if isAdmin}
-        <button
-          type="button"
-          class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {activeTab === 'libraries'
-            ? activeTabClass
-            : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
-          onclick={() => (activeTab = 'libraries')}
-          data-testid="tab-libraries"
-        >
-          Libraries
-        </button>
-      {/if}
     </div>
 
     <IconButton
@@ -204,8 +189,6 @@
         onLoadMore={onLoadMoreActivities}
         hasMore={hasMoreActivities}
       />
-    {:else if activeTab === 'libraries'}
-      <SpaceLinkedLibraries {space} onChanged={onLibrariesChanged} />
     {:else}
       <!-- Members content -->
       {#if isOwner}

--- a/web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts
+++ b/web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts
@@ -1,0 +1,93 @@
+import { getAnimateMock } from '$lib/__mocks__/animate.mock';
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import '$lib/__mocks__/sdk.mock';
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { getVisualViewportMock } from '$lib/__mocks__/visual-viewport.mock';
+
+vi.mock('svelte-persisted-store', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    persisted: (_key: string, initialValue: unknown) => writable(initialValue),
+  };
+});
+
+vi.mock('$lib/utils/tunables', () => ({
+  TUNABLES: {
+    LAYOUT: { WASM: true },
+    TIMELINE: { INTERSECTION_EXPAND_TOP: 500, INTERSECTION_EXPAND_BOTTOM: 500 },
+  },
+}));
+
+import type { SharedSpaceResponseDto } from '@immich/sdk';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import SpaceLinkedLibrariesModal from './SpaceLinkedLibrariesModal.svelte';
+
+const makeSpace = (overrides: Partial<SharedSpaceResponseDto> = {}): SharedSpaceResponseDto => ({
+  id: 'space-1',
+  name: 'Family Photos',
+  description: '',
+  createdById: 'user-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  memberCount: 1,
+  assetCount: 0,
+  thumbnailAssetId: null,
+  recentAssetIds: [],
+  recentAssetThumbhashes: [],
+  lastActivityAt: null,
+  newAssetCount: 0,
+  members: [],
+  linkedLibraries: [],
+  ...overrides,
+});
+
+describe('SpaceLinkedLibrariesModal', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+    vi.stubGlobal('visualViewport', getVisualViewportMock());
+    vi.resetAllMocks();
+    Element.prototype.animate = getAnimateMock();
+    sdkMock.getAllLibraries.mockResolvedValue([]);
+  });
+
+  afterAll(async () => {
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none');
+    });
+  });
+
+  it('should render modal with "Connected Libraries" title', () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    const elements = screen.getAllByText('Connected Libraries');
+    expect(elements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render the SpaceLinkedLibraries component inside', () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    expect(screen.getByTestId('linked-libraries')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no libraries are linked', () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    expect(screen.getByText('No libraries connected yet')).toBeInTheDocument();
+  });
+
+  it('should show linked libraries when present', () => {
+    const space = makeSpace({
+      linkedLibraries: [{ libraryId: 'lib-1', libraryName: 'My Photos' }],
+    });
+    render(SpaceLinkedLibrariesModal, { space, onClose });
+    expect(screen.getByText('My Photos')).toBeInTheDocument();
+  });
+
+  it('should call onClose with false when closed without changes', async () => {
+    render(SpaceLinkedLibrariesModal, { space: makeSpace(), onClose });
+    const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+    await fireEvent.click(closeButtons[0]);
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts
+++ b/web/src/lib/modals/SpaceLinkedLibrariesModal.spec.ts
@@ -76,7 +76,7 @@ describe('SpaceLinkedLibrariesModal', () => {
 
   it('should show linked libraries when present', () => {
     const space = makeSpace({
-      linkedLibraries: [{ libraryId: 'lib-1', libraryName: 'My Photos' }],
+      linkedLibraries: [{ libraryId: 'lib-1', libraryName: 'My Photos', createdAt: '2026-01-01T00:00:00.000Z' }],
     });
     render(SpaceLinkedLibrariesModal, { space, onClose });
     expect(screen.getByText('My Photos')).toBeInTheDocument();

--- a/web/src/lib/modals/SpaceLinkedLibrariesModal.svelte
+++ b/web/src/lib/modals/SpaceLinkedLibrariesModal.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import SpaceLinkedLibraries from '$lib/components/spaces/space-linked-libraries.svelte';
+  import { getSpace, type SharedSpaceResponseDto } from '@immich/sdk';
+  import { Modal, ModalBody } from '@immich/ui';
+  import { mdiBookshelf } from '@mdi/js';
+
+  interface Props {
+    space: SharedSpaceResponseDto;
+    onClose: (changed?: boolean) => void;
+  }
+
+  let { space: initialSpace, onClose }: Props = $props();
+
+  let spaceData = $state(initialSpace);
+  let changed = $state(false);
+
+  const handleChanged = async () => {
+    changed = true;
+    try {
+      spaceData = await getSpace({ id: spaceData.id });
+    } catch {
+      // Link/unlink already succeeded; caller will refresh on close via changed flag
+    }
+  };
+</script>
+
+<Modal title="Connected Libraries" icon={mdiBookshelf} onClose={() => onClose(changed)}>
+  <ModalBody>
+    <SpaceLinkedLibraries space={spaceData} onChanged={handleChanged} />
+  </ModalBody>
+</Modal>

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -874,10 +874,6 @@
     await refreshSpace();
     await loadActivities();
   }}
-  onLibrariesChanged={async () => {
-    await refreshSpace();
-    await loadActivities();
-  }}
   onLoadMoreActivities={loadMoreActivities}
   {hasMoreActivities}
 />

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -19,6 +19,7 @@
   import SpaceOnboardingBanner from '$lib/components/spaces/space-onboarding-banner.svelte';
   import SpacePanel from '$lib/components/spaces/space-panel.svelte';
   import SpacePeopleStrip from '$lib/components/spaces/space-people-strip.svelte';
+  import SpaceLinkedLibrariesModal from '$lib/modals/SpaceLinkedLibrariesModal.svelte';
   import SearchBar from '$lib/elements/SearchBar.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import ArchiveAction from '$lib/components/timeline/actions/ArchiveAction.svelte';
@@ -70,6 +71,7 @@
   import {
     mdiAccountMultipleOutline,
     mdiArrowLeft,
+    mdiBookshelf,
     mdiDeleteOutline,
     mdiDotsVertical,
     mdiEyeOffOutline,
@@ -418,6 +420,14 @@
     }
   };
 
+  const handleLinkLibraries = async () => {
+    const changed = await modalManager.show(SpaceLinkedLibrariesModal, { space });
+    if (changed) {
+      await refreshSpace();
+      await loadActivities();
+    }
+  };
+
   const handleDelete = async () => {
     const confirmed = await modalManager.showDialog({
       prompt: $t('spaces_delete_confirmation', { values: { name: space.name } }),
@@ -645,8 +655,14 @@
             icon={showInTimeline ? mdiEyeOutline : mdiEyeOffOutline}
             onClick={handleToggleTimeline}
           />
+          {#if isEditor || $user?.isAdmin}
+            <hr class="my-1 border-gray-300" />
+          {/if}
           {#if isEditor}
             <MenuOption text={$t('add_all_photos')} icon={mdiImageMultipleOutline} onClick={handleBulkAddAssets} />
+          {/if}
+          {#if $user?.isAdmin}
+            <MenuOption text="Link Libraries" icon={mdiBookshelf} onClick={handleLinkLibraries} />
           {/if}
           {#if isOwner}
             <hr class="my-1 border-gray-300" />


### PR DESCRIPTION
## Summary
- Moved connected-libraries management from a hidden 3rd tab in the space panel to a dedicated modal dialog
- Added "Link Libraries" menu item in the space dropdown (admin-only), grouped near "Add All Photos"
- Space panel now has only 2 tabs: Activity and Members (cleaner UX)

## Changes
- **New:** `SpaceLinkedLibrariesModal.svelte` — modal wrapping existing `SpaceLinkedLibraries` component with local re-fetch on changes
- **Modified:** `space-panel.svelte` — removed Libraries tab, `onLibrariesChanged` prop, `isAdmin` derived
- **Modified:** `+page.svelte` — added dropdown menu item with `mdiBookshelf` icon, gated on `$user?.isAdmin`

## Test plan
- [x] Unit tests for modal (5 tests: rendering, empty state, linked libraries, close behavior)
- [x] Regression tests for space panel (2 tests: only 2 tabs for admin, no Libraries tab)
- [x] All 980 web tests passing
- [x] ESLint + Prettier clean
- [ ] Manual: verify "Link Libraries" appears in dropdown for admin users
- [ ] Manual: verify modal opens and link/unlink works
- [ ] Manual: verify space panel only shows Activity and Members tabs