### PR TITLE
fix: add visual separation to collapsed filter panel

### DIFF
--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -349,7 +349,7 @@
 
 {#if collapsed}
   <div
-    class="flex w-8 flex-col items-center gap-3 border-r border-gray-200 bg-light py-2 dark:border-gray-700"
+    class="flex w-8 flex-shrink-0 flex-col items-center gap-3 border-r border-gray-200 bg-light py-2 shadow-sm dark:border-gray-700 dark:shadow-none"
     data-testid="collapsed-icon-strip"
   >
     <button


### PR DESCRIPTION
## Summary
The collapsed filter panel icon strip had no visual separation from the photo grid — photos appeared flush against the icons with no gap, especially noticeable on mobile.

Adds `shadow-sm` and `flex-shrink-0` to the collapsed icon strip, matching the expanded panel's styling.

## Test plan
- [ ] Open /photos page with filter panel collapsed — verify shadow/gap between icons and photos
- [ ] Open a Space — same check
- [ ] Expand/collapse filter panel — verify transition is smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)