### PR TITLE
fix: add left padding between filter panel and photos timeline

### DIFF
--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -189,7 +189,7 @@
       initialCollapsed={true}
       storageKey="gallery-filter-visible-sections-photos"
     />
-    <div class="flex-1 overflow-hidden">
+    <div class="flex-1 overflow-hidden pl-4">
       {#if hasActiveFilters}
         <ActiveFiltersBar
           {filters}


### PR DESCRIPTION
Photos rendered flush against the collapsed filter panel with no gap. Adds pl-4 to match the spaces page pattern.