### PR TITLE
fix: improve space menu people/pets toggle UX

### DIFF
--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -19,8 +19,8 @@ test.describe('Spaces FilterPanel', () => {
   ) {
     await utils.setAuthCookies(context, admin.accessToken);
     await page.goto(`/spaces/${spaceId}`);
-    // Wait for the discovery panel or collapsed strip to be present
-    await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="collapsed-icon-strip"]');
+    // Wait for the timeline container to be present (always rendered, even for empty spaces)
+    await page.waitForSelector('[data-testid="discovery-timeline"]');
   }
 
   // ─── Helper: create a space with diverse test data ───

--- a/mobile/openapi/lib/model/shared_space_response_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_response_dto.dart
@@ -19,6 +19,7 @@ class SharedSpaceResponseDto {
     required this.createdById,
     this.description,
     this.faceRecognitionEnabled,
+    this.hasPets,
     required this.id,
     this.lastActivityAt,
     this.lastContributor,
@@ -65,6 +66,15 @@ class SharedSpaceResponseDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? faceRecognitionEnabled;
+
+  /// Whether any pet-type persons exist in this space
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? hasPets;
 
   /// Space ID
   String id;
@@ -141,6 +151,7 @@ class SharedSpaceResponseDto {
     other.createdById == createdById &&
     other.description == description &&
     other.faceRecognitionEnabled == faceRecognitionEnabled &&
+    other.hasPets == hasPets &&
     other.id == id &&
     other.lastActivityAt == lastActivityAt &&
     other.lastContributor == lastContributor &&
@@ -166,6 +177,7 @@ class SharedSpaceResponseDto {
     (createdById.hashCode) +
     (description == null ? 0 : description!.hashCode) +
     (faceRecognitionEnabled == null ? 0 : faceRecognitionEnabled!.hashCode) +
+    (hasPets == null ? 0 : hasPets!.hashCode) +
     (id.hashCode) +
     (lastActivityAt == null ? 0 : lastActivityAt!.hashCode) +
     (lastContributor == null ? 0 : lastContributor!.hashCode) +
@@ -183,7 +195,7 @@ class SharedSpaceResponseDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'SharedSpaceResponseDto[assetCount=$assetCount, color=$color, createdAt=$createdAt, createdById=$createdById, description=$description, faceRecognitionEnabled=$faceRecognitionEnabled, id=$id, lastActivityAt=$lastActivityAt, lastContributor=$lastContributor, lastViewedAt=$lastViewedAt, linkedLibraries=$linkedLibraries, memberCount=$memberCount, members=$members, name=$name, newAssetCount=$newAssetCount, petsEnabled=$petsEnabled, recentAssetIds=$recentAssetIds, recentAssetThumbhashes=$recentAssetThumbhashes, thumbnailAssetId=$thumbnailAssetId, thumbnailCropY=$thumbnailCropY, updatedAt=$updatedAt]';
+  String toString() => 'SharedSpaceResponseDto[assetCount=$assetCount, color=$color, createdAt=$createdAt, createdById=$createdById, description=$description, faceRecognitionEnabled=$faceRecognitionEnabled, hasPets=$hasPets, id=$id, lastActivityAt=$lastActivityAt, lastContributor=$lastContributor, lastViewedAt=$lastViewedAt, linkedLibraries=$linkedLibraries, memberCount=$memberCount, members=$members, name=$name, newAssetCount=$newAssetCount, petsEnabled=$petsEnabled, recentAssetIds=$recentAssetIds, recentAssetThumbhashes=$recentAssetThumbhashes, thumbnailAssetId=$thumbnailAssetId, thumbnailCropY=$thumbnailCropY, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -208,6 +220,11 @@ class SharedSpaceResponseDto {
       json[r'faceRecognitionEnabled'] = this.faceRecognitionEnabled;
     } else {
     //  json[r'faceRecognitionEnabled'] = null;
+    }
+    if (this.hasPets != null) {
+      json[r'hasPets'] = this.hasPets;
+    } else {
+    //  json[r'hasPets'] = null;
     }
       json[r'id'] = this.id;
     if (this.lastActivityAt != null) {
@@ -276,6 +293,7 @@ class SharedSpaceResponseDto {
         createdById: mapValueOfType<String>(json, r'createdById')!,
         description: mapValueOfType<String>(json, r'description'),
         faceRecognitionEnabled: mapValueOfType<bool>(json, r'faceRecognitionEnabled'),
+        hasPets: mapValueOfType<bool>(json, r'hasPets'),
         id: mapValueOfType<String>(json, r'id')!,
         lastActivityAt: mapValueOfType<String>(json, r'lastActivityAt'),
         lastContributor: SharedSpaceResponseDtoLastContributor.fromJson(json[r'lastContributor']),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -25122,6 +25122,10 @@
             "description": "Whether face recognition is enabled for this space",
             "type": "boolean"
           },
+          "hasPets": {
+            "description": "Whether any pet-type persons exist in this space",
+            "type": "boolean"
+          },
           "id": {
             "description": "Space ID",
             "type": "string"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2400,6 +2400,8 @@ export type SharedSpaceResponseDto = {
     description?: string | null;
     /** Whether face recognition is enabled for this space */
     faceRecognitionEnabled?: boolean;
+    /** Whether any pet-type persons exist in this space */
+    hasPets?: boolean;
     /** Space ID */
     id: string;
     /** Last activity timestamp (most recent asset add) */

--- a/server/src/dtos/shared-space.dto.ts
+++ b/server/src/dtos/shared-space.dto.ts
@@ -177,6 +177,9 @@ export class SharedSpaceResponseDto {
   @ApiPropertyOptional({ description: 'Whether pets are shown in space people list' })
   petsEnabled?: boolean;
 
+  @ApiPropertyOptional({ description: 'Whether any pet-type persons exist in this space' })
+  hasPets?: boolean;
+
   @ApiPropertyOptional({ description: 'Last activity timestamp (most recent asset add)' })
   lastActivityAt?: string | null;
 

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -353,6 +353,15 @@ limit
 offset
   $3
 
+-- SharedSpaceRepository.hasPetsBySpaceId
+select
+  count(*) as "count"
+from
+  "shared_space_person"
+where
+  "spaceId" = $1
+  and "type" = $2
+
 -- SharedSpaceRepository.getPersonsBySpaceId
 select
   *

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -453,6 +453,17 @@ export class SharedSpaceRepository {
   // ==========================================
 
   @GenerateSql({ params: [DummyValue.UUID] })
+  async hasPetsBySpaceId(spaceId: string): Promise<boolean> {
+    const result = await this.db
+      .selectFrom('shared_space_person')
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .where('spaceId', '=', spaceId)
+      .where('type', '=', 'pet')
+      .executeTakeFirstOrThrow();
+    return result.count > 0;
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID] })
   getPersonsBySpaceId(spaceId: string) {
     return this.db
       .selectFrom('shared_space_person')

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -31,6 +31,7 @@ describe(SharedSpaceService.name, () => {
 
   beforeEach(() => {
     ({ sut, mocks } = newTestService(SharedSpaceService));
+    mocks.sharedSpace.hasPetsBySpaceId.mockResolvedValue(false);
   });
 
   it('should work', () => {
@@ -615,6 +616,57 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.get(auth, space.id);
 
       expect(result.color).toBe('green');
+    });
+
+    it('should include hasPets=true when space has pet-type persons', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ faceRecognitionEnabled: true });
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getMembers.mockResolvedValue([member]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+      mocks.sharedSpace.getRecentAssets.mockResolvedValue([]);
+      mocks.sharedSpace.hasPetsBySpaceId.mockResolvedValue(true);
+
+      const result = await sut.get(auth, space.id);
+
+      expect(result.hasPets).toBe(true);
+    });
+
+    it('should include hasPets=false when space has no pet-type persons', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ faceRecognitionEnabled: true });
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getMembers.mockResolvedValue([member]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+      mocks.sharedSpace.getRecentAssets.mockResolvedValue([]);
+      mocks.sharedSpace.hasPetsBySpaceId.mockResolvedValue(false);
+
+      const result = await sut.get(auth, space.id);
+
+      expect(result.hasPets).toBe(false);
+    });
+
+    it('should not query hasPets when face recognition is disabled', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace({ faceRecognitionEnabled: false });
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getMembers.mockResolvedValue([member]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(0);
+      mocks.sharedSpace.getRecentAssets.mockResolvedValue([]);
+
+      const result = await sut.get(auth, space.id);
+
+      expect(result.hasPets).toBeUndefined();
+      expect(mocks.sharedSpace.hasPetsBySpaceId).not.toHaveBeenCalled();
     });
 
     it('should include lastViewedAt in response', async () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -150,6 +150,11 @@ export class SharedSpaceService extends BaseService {
       newAssetCount = await this.sharedSpaceRepository.getNewAssetCount(id, membership.lastViewedAt);
     }
 
+    let hasPets: boolean | undefined;
+    if (space.faceRecognitionEnabled) {
+      hasPets = await this.sharedSpaceRepository.hasPetsBySpaceId(id);
+    }
+
     let linkedLibraries: SharedSpaceLinkedLibraryDto[] | undefined;
     if (auth.user.isAdmin) {
       const links = await this.sharedSpaceRepository.getLinkedLibraries(space.id);
@@ -180,6 +185,7 @@ export class SharedSpaceService extends BaseService {
       newAssetCount,
       lastViewedAt: membership.lastViewedAt ? (membership.lastViewedAt as unknown as Date).toISOString() : null,
       linkedLibraries,
+      hasPets,
     };
   }
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -775,16 +775,14 @@
           {#if isOwner}
             <hr class="my-1 border-gray-300" />
             <MenuOption
-              text="People"
+              text={space.faceRecognitionEnabled ? 'Hide people' : 'Show people'}
               icon={mdiFaceRecognition}
-              textColor={space.faceRecognitionEnabled ? 'text-immich-primary' : undefined}
               onClick={handleToggleFaceRecognition}
             />
-            {#if space.faceRecognitionEnabled}
+            {#if space.faceRecognitionEnabled && space.hasPets}
               <MenuOption
-                text="Pets"
+                text={space.petsEnabled ? 'Hide pets' : 'Show pets'}
                 icon={mdiPaw}
-                textColor={space.petsEnabled ? 'text-immich-primary' : undefined}
                 onClick={handleTogglePets}
               />
             {/if}


### PR DESCRIPTION
## Summary
- Change "People" / "Pets" menu items to "Show people" / "Hide people" and "Show pets" / "Hide pets" so the toggle function is immediately clear
- Add `hasPets` field to `SharedSpaceResponseDto` — pets toggle only appears when pet-type persons actually exist in the space
- Server queries `shared_space_person` for pet existence only when face recognition is enabled (no unnecessary DB calls)

## Test plan
- [ ] Open a space with face recognition enabled and pets present — menu shows both "Show/Hide people" and "Show/Hide pets"
- [ ] Open a space with face recognition enabled but no pets — menu shows only "Show/Hide people", no pets toggle
- [ ] Open a space with face recognition disabled — menu shows "Show people" only
- [ ] Toggle people off/on — label switches between "Show people" / "Hide people"
- [ ] Regenerate OpenAPI SDK (`make open-api-typescript`) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)