### PR TITLE
ci: disable ARM runner for web E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -481,7 +481,10 @@ jobs:
         working-directory: ./e2e
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        # ARM runner disabled — Playwright tests are architecture-independent
+        # and the ARM runner causes frequent timeouts on timing-sensitive UI tests.
+        # To re-enable: runner: [ubuntu-latest, ubuntu-24.04-arm]
+        runner: [ubuntu-latest]
     steps:
       - id: token
         uses: immich-app/devtools/actions/create-workflow-token@57ff6ebfd507b045514442683ff06ff1b2f6efbd # create-workflow-token-action-v1.0.2


### PR DESCRIPTION
## Summary

- Disable ARM64 runner (`ubuntu-24.04-arm`) for web Playwright E2E tests
- Server E2E tests remain on ARM to cover native module compatibility

## Why

Playwright tests are architecture-independent (browser behavior doesn't change between x86 and ARM). The ARM runner is significantly slower and causes frequent timeouts on timing-sensitive UI tests (e.g., keyboard navigation, animation waits), leading to flaky CI failures that require re-runs.

## Revert

Uncomment the line in `.github/workflows/test.yml` to restore: `runner: [ubuntu-latest, ubuntu-24.04-arm]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)