### PR TITLE
fix: exclude hidden persons from space people filter panel

### DIFF
--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -391,6 +391,7 @@ from
   left join "person" on "person"."id" = "asset_face"."personId"
 where
   "shared_space_person"."spaceId" = $1
+  and "shared_space_person"."isHidden" = $2
 order by
   "shared_space_person"."name" asc
 
@@ -405,6 +406,7 @@ from
   left join "person" on "person"."id" = "asset_face"."personId"
 where
   "shared_space_person"."spaceId" = $1
+  and "shared_space_person"."isHidden" = $2
   and exists (
     select
     from
@@ -413,8 +415,8 @@ where
       inner join "asset" on "asset"."id" = "af2"."assetId"
     where
       "shared_space_person_face"."personId" = "shared_space_person"."id"
-      and "asset"."fileCreatedAt" >= $2
-      and "asset"."fileCreatedAt" < $3
+      and "asset"."fileCreatedAt" >= $3
+      and "asset"."fileCreatedAt" < $4
   )
 order by
   "shared_space_person"."name" asc

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -494,6 +494,7 @@ export class SharedSpaceRepository {
       .selectAll('shared_space_person')
       .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
       .where('shared_space_person.spaceId', '=', spaceId)
+      .where('shared_space_person.isHidden', '=', false)
       .orderBy('shared_space_person.name', 'asc')
       .execute();
   }
@@ -507,6 +508,7 @@ export class SharedSpaceRepository {
       .selectAll('shared_space_person')
       .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
       .where('shared_space_person.spaceId', '=', spaceId)
+      .where('shared_space_person.isHidden', '=', false)
       .$if(!!options?.takenAfter || !!options?.takenBefore, (qb) =>
         qb.where((eb) =>
           eb.exists(

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2585,6 +2585,28 @@ describe(SharedSpaceService.name, () => {
       expect(result[0].type).toBe('person');
     });
 
+    it('should exclude hidden persons', async () => {
+      const spaceId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const visiblePerson = factory.sharedSpacePerson({ spaceId, isHidden: false });
+      const hiddenPerson = factory.sharedSpacePerson({ spaceId, isHidden: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
+        { ...visiblePerson, personalName: 'Visible', personalThumbnailPath: '/thumb.jpg' },
+        { ...hiddenPerson, personalName: 'Hidden', personalThumbnailPath: '/thumb.jpg' },
+      ]);
+      mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
+      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
+
+      const result = await sut.getSpacePeople(factory.auth(), spaceId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Visible');
+    });
+
     it('should include pets when petsEnabled is true', async () => {
       const spaceId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true, petsEnabled: true });

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -610,6 +610,9 @@ export class SharedSpaceService extends BaseService {
 
     const results: SharedSpacePersonResponseDto[] = [];
     for (const person of persons) {
+      if (person.isHidden) {
+        continue;
+      }
       if (!space.petsEnabled && person.type === 'pet') {
         continue;
       }


### PR DESCRIPTION
## Summary
- Hidden space persons were appearing in the People filter panel within spaces
- Added `isHidden = false` WHERE clause to both `getPersonsBySpaceId` and `getPersonsBySpaceIdWithTemporalFilter` repository queries
- Added service-level filtering as defense-in-depth in `getSpacePeople`

## Test plan
- [x] Unit test: `should exclude hidden persons` — verifies hidden persons are filtered from results
- [x] All 3569 existing tests pass