### PR TITLE
ci: drop ROCm ML build from Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suffix: ['', '-cuda', '-rocm', '-openvino', '-armnn', '-rknn']
+        suffix: ['', '-cuda', '-openvino', '-armnn', '-rknn']
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -128,10 +128,6 @@ jobs:
           - device: rknn
             suffixes: '-rknn'
             platforms: linux/arm64
-          - device: rocm
-            suffixes: '-rocm'
-            platforms: linux/amd64
-            runner-mapping: '{"linux/amd64": "pokedex-large"}'
     uses: immich-app/devtools/.github/workflows/multi-runner-build.yml@61a0fc2b41524edcc7c9fffb8bb178e6b0ccf21d # multi-runner-build-workflow-v2.3.0
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Remove ROCm from ML build and re-tag matrices in `docker.yml`
- The `pokedex-large` self-hosted runner doesn't exist in Gallery's CI, so ROCm builds hang forever
- When ML code doesn't change, the re-tag job fails because `main-rocm` was never pushed to the registry
- This was the cause of the Docker #187 failure on main

## Test plan
- [x] Docker workflow should no longer fail on Re-Tag ML (-rocm)
- [ ] Verify Docker CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)