### PR TITLE
ci: disable DockerHub push for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -143,7 +143,7 @@ jobs:
       platforms: ${{ matrix.platforms }}
       runner-mapping: ${{ matrix.runner-mapping }}
       suffixes: ${{ matrix.suffixes }}
-      dockerhub-push: ${{ github.event_name == 'release' }}
+      dockerhub-push: false
       build-args: |
         DEVICE=${{ matrix.device }}
 
@@ -163,7 +163,7 @@ jobs:
       image: immich-server
       context: .
       dockerfile: server/Dockerfile
-      dockerhub-push: ${{ github.event_name == 'release' }}
+      dockerhub-push: false
       build-args: |
         DEVICE=cpu
 


### PR DESCRIPTION
## Summary
- Set `dockerhub-push: false` for both ML and server builds
- Gallery serves images from GHCR, not DockerHub
- The `release` trigger was added in #207 but `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets were never configured, causing every release-triggered Docker build to fail at the merge step

## Test plan
- [x] Previous release builds failed with `Username and password required` on docker.io login
- [ ] Verify Docker CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)