### PR TITLE
perf: replace N+2 query loop with single aggregated query for space people

### DIFF
--- a/docs/plans/2026-03-29-space-people-performance-design.md
+++ b/docs/plans/2026-03-29-space-people-performance-design.md
@@ -1,0 +1,91 @@
+# Space People Performance Fix
+
+## Problem
+
+Loading people in a shared space with 11,000 people takes ~10 seconds. The `getSpacePeople` service method executes an N+2 query loop:
+
+1. 1 query to fetch all persons for a space
+2. N queries to `getPersonFaceCount` (one per person)
+3. N queries to `getPersonAssetCount` (one per person)
+
+For 11,000 people = 22,001 sequential database queries. The face/asset counts are only used for sorting (not displayed). Additionally, the web client makes two redundant API calls to `getSpacePeople`.
+
+## Design
+
+### Server - Repository
+
+New method `getPersonsBySpaceIdWithCounts(spaceId, options)`:
+
+- Single query with `GROUP BY` + `COUNT(DISTINCT asset_face.assetId)` and `COUNT(*)` for face count
+- JOINs: `shared_space_person` -> `shared_space_person_face` -> `asset_face` -> `person` (for thumbnailPath)
+- All filtering pushed into SQL: `isHidden`, `type` (pets), `personalThumbnailPath IS NOT NULL`
+- Optional `LIMIT` parameter for top-N queries
+- Optional temporal filter (`takenAfter`/`takenBefore`) merged in
+- Replaces: `getPersonsBySpaceId`, `getPersonsBySpaceIdWithTemporalFilter`
+- Note: `getPersonFaceCount` and `getPersonAssetCount` are kept — still used by `getSpacePerson` and `updateSpacePerson` for single-person detail views
+- Behavioral note: The INNER JOIN on `shared_space_person_face` naturally excludes persons with zero faces, which is desired (they have no photos to show)
+
+```sql
+SELECT
+  sp.*,
+  p.name as "personalName",
+  p."thumbnailPath" as "personalThumbnailPath",
+  COUNT(DISTINCT af."assetId") as "assetCount",
+  COUNT(*) as "faceCount"
+FROM shared_space_person sp
+JOIN shared_space_person_face spf ON spf."personId" = sp.id
+JOIN asset_face af ON af.id = spf."assetFaceId"
+LEFT JOIN person p ON p.id = af."personId"
+WHERE sp."spaceId" = $1
+  AND sp."isHidden" = false
+  AND p."thumbnailPath" IS NOT NULL
+  AND p."thumbnailPath" != ''
+GROUP BY sp.id, p.name, p."thumbnailPath"
+ORDER BY "assetCount" DESC
+LIMIT 10  -- optional
+```
+
+Index usage: PK on `shared_space_person_face` is `(personId, assetFaceId)` -- `personId` is leading column. `asset_face.id` is its PK. `shared_space_person.spaceId` has a dedicated index.
+
+### Server - DTO
+
+Add optional `top` parameter to `SpacePeopleQueryDto`:
+
+```typescript
+@IsOptional()
+@Type(() => Number)
+@IsInt()
+@Min(1)
+@Max(100)
+top?: number;
+```
+
+### Server - Service
+
+`getSpacePeople` simplified:
+
+- Calls `getPersonsBySpaceIdWithCounts` with `{ withHidden, petsEnabled, limit: query.top, takenAfter, takenBefore }`
+- Alias lookup narrowed to returned person IDs only
+- No more JS-side filtering loop
+
+### Web - Space Page
+
+- `loadSpacePeople()` calls `getSpacePeople({ id, top: 10 })` -- returns top 10 for the people strip
+- FilterPanel `people` provider calls `getSpacePeople({ id })` without `top` -- all named people with counts (still fast, single query)
+- Remove `peopleCount` from the hero badge (eliminates need for a separate count query)
+
+### Web - People Management Page
+
+`/spaces/[spaceId]/people` continues calling without `top` -- gets all people with real counts via the same aggregated query. Single query on 11,000 people with GROUP BY is fast (~50-100ms).
+
+## What Doesn't Change
+
+- `getSpacePerson` (single person detail) -- 2 count queries for 1 person, acceptable
+- `updateSpacePerson` -- unchanged
+- All write paths (face matching, merge, deletion) -- unchanged
+- No schema changes, no migrations
+
+## Performance Impact
+
+- Before: 22,001 queries, ~10 seconds
+- After: 1 query (strip, LIMIT 10) + 1 query (FilterPanel, no LIMIT), ~100ms total

--- a/docs/plans/2026-03-29-space-people-performance-plan.md
+++ b/docs/plans/2026-03-29-space-people-performance-plan.md
@@ -1,0 +1,590 @@
+# Space People Performance Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate the N+2 query loop when loading space people by replacing it with a single aggregated SQL query, and remove the people count badge from the hero.
+
+**Architecture:** Replace `getPersonsBySpaceId` + per-person `getPersonFaceCount`/`getPersonAssetCount` calls with a single `getPersonsBySpaceIdWithCounts` repository method that uses `GROUP BY` + `COUNT`. Add a `top` query parameter to limit results for the people strip. Remove `peopleCount` from the hero component.
+
+**Tech Stack:** Kysely (SQL query builder), NestJS DTOs with class-validator, SvelteKit, OpenAPI codegen
+
+---
+
+### Task 1: Add `top` parameter to SpacePeopleQueryDto
+
+**Files:**
+
+- Modify: `server/src/dtos/shared-space-person.dto.ts:5-14`
+
+**Step 1: Add the `top` field to SpacePeopleQueryDto**
+
+In `server/src/dtos/shared-space-person.dto.ts`, add the `top` parameter after the existing fields:
+
+```typescript
+export class SpacePeopleQueryDto {
+  @ValidateDate({ optional: true })
+  takenAfter?: Date;
+
+  @ValidateDate({ optional: true })
+  takenBefore?: Date;
+
+  @ValidateBoolean({ optional: true })
+  withHidden?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of people to return (sorted by asset count)',
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  top?: number;
+}
+```
+
+You'll need to add these imports at the top of the file (some may already exist):
+
+```typescript
+import { IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+```
+
+**Step 2: Verify build**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```
+feat: add top parameter to SpacePeopleQueryDto
+```
+
+---
+
+### Task 2: Add aggregated repository method
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts:489-596`
+
+**Step 1: Add `getPersonsBySpaceIdWithCounts` method**
+
+Add this new method in `server/src/repositories/shared-space.repository.ts` after the existing `getPersonsBySpaceIdWithTemporalFilter` method (after line 531). This replaces the N+2 query pattern with a single aggregated query:
+
+```typescript
+@GenerateSql({
+  params: [DummyValue.UUID, { withHidden: false, petsEnabled: true, limit: 10 }],
+})
+getPersonsBySpaceIdWithCounts(
+  spaceId: string,
+  options: {
+    withHidden?: boolean;
+    petsEnabled?: boolean;
+    limit?: number;
+    takenAfter?: Date;
+    takenBefore?: Date;
+  },
+) {
+  return this.db
+    .selectFrom('shared_space_person')
+    .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
+    .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+    .leftJoin('person', 'person.id', 'asset_face.personId')
+    .select([
+      'shared_space_person.id',
+      'shared_space_person.spaceId',
+      'shared_space_person.name',
+      'shared_space_person.isHidden',
+      'shared_space_person.type',
+      'shared_space_person.birthDate',
+      'shared_space_person.representativeFaceId',
+      'shared_space_person.createdAt',
+      'shared_space_person.updatedAt',
+    ])
+    .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
+    .select((eb) => [
+      eb.fn.countAll().as('faceCount'),
+      eb.fn.count(eb.fn('distinct', ['asset_face.assetId'])).as('assetCount'),
+    ])
+    .where('shared_space_person.spaceId', '=', spaceId)
+    .$if(!options.withHidden, (qb) => qb.where('shared_space_person.isHidden', '=', false))
+    .$if(!options.petsEnabled, (qb) => qb.where('shared_space_person.type', '!=', 'pet'))
+    .where('person.thumbnailPath', 'is not', null)
+    .where('person.thumbnailPath', '!=', '')
+    .$if(!!options.takenAfter || !!options.takenBefore, (qb) =>
+      qb.where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face as spf2')
+            .innerJoin('asset_face as af2', 'af2.id', 'spf2.assetFaceId')
+            .innerJoin('asset', 'asset.id', 'af2.assetId')
+            .whereRef('spf2.personId', '=', 'shared_space_person.id')
+            .$if(!!options.takenAfter, (qb2) => qb2.where('asset.fileCreatedAt', '>=', options.takenAfter!))
+            .$if(!!options.takenBefore, (qb2) => qb2.where('asset.fileCreatedAt', '<', options.takenBefore!)),
+        ),
+      ),
+    )
+    .groupBy([
+      'shared_space_person.id',
+      'person.name',
+      'person.thumbnailPath',
+    ])
+    .orderBy('assetCount', 'desc')
+    .$if(!!options.limit, (qb) => qb.limit(options.limit!))
+    .execute();
+}
+```
+
+**Step 2: Verify build**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```
+feat: add aggregated getPersonsBySpaceIdWithCounts repository method
+```
+
+---
+
+### Task 3: Update service to use aggregated query
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.ts:596-633`
+
+**Step 1: Rewrite `getSpacePeople` to use the new repository method**
+
+Replace the entire `getSpacePeople` method (lines 596-633) with:
+
+```typescript
+async getSpacePeople(
+  auth: AuthDto,
+  spaceId: string,
+  query?: SpacePeopleQueryDto,
+): Promise<SharedSpacePersonResponseDto[]> {
+  await this.requireMembership(auth, spaceId);
+
+  const space = await this.sharedSpaceRepository.getById(spaceId);
+  if (!space?.faceRecognitionEnabled) {
+    return [];
+  }
+
+  const withHidden = query?.withHidden ?? false;
+  const persons = await this.sharedSpaceRepository.getPersonsBySpaceIdWithCounts(spaceId, {
+    withHidden,
+    petsEnabled: space.petsEnabled,
+    limit: query?.top,
+    takenAfter: query?.takenAfter,
+    takenBefore: query?.takenBefore,
+  });
+
+  const aliases = persons.length > 0
+    ? await this.sharedSpaceRepository.getAliasesBySpaceAndUser(spaceId, auth.user.id)
+    : [];
+  const aliasMap = new Map(aliases.map((a) => [a.personId, a.alias]));
+
+  return persons.map((person) =>
+    this.mapSpacePerson(person, Number(person.faceCount), Number(person.assetCount), aliasMap.get(person.id) ?? null),
+  );
+}
+```
+
+Note: The `Number()` casts are needed because Kysely returns aggregate results as `string | number` depending on the driver.
+
+Note: The sorting is now done in SQL (`ORDER BY assetCount DESC`) so the JS `.toSorted()` is removed.
+
+Note: The filtering (isHidden, petsEnabled, personalThumbnailPath) is now in SQL, so the JS loop with `continue` statements is removed.
+
+**Step 2: Verify build**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors. If there are type mismatches on the `person` parameter to `mapSpacePerson`, the aggregate columns (`faceCount`, `assetCount`) may need to be excluded from the type or the `mapSpacePerson` signature adjusted to accept the wider type.
+
+**Step 3: Commit**
+
+```
+feat: use aggregated query in getSpacePeople service method
+```
+
+---
+
+### Task 4: Update unit tests for getSpacePeople
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.spec.ts:2437-2870`
+
+**Step 1: Update all getSpacePeople tests**
+
+Global pattern for all tests:
+
+1. Replace `mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([...])` with `mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([...])`
+2. Replace `mocks.sharedSpace.getPersonsBySpaceIdWithTemporalFilter.mockResolvedValue([...])` with `getPersonsBySpaceIdWithCounts` (temporal is now an option, not a separate method)
+3. Remove all `mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(...)` lines
+4. Remove all `mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(...)` lines
+5. Add `faceCount` and `assetCount` inline in mock person objects
+6. Filtering tests (hidden, pets, thumbnails) now verify correct options are passed to the repository instead of testing JS-side filtering
+
+**Complete test enumeration — every test and what changes:**
+
+| #   | Test (line)                                                                              | Change type                                                                                                                                                     |
+| --- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | "should require membership" (2438)                                                       | **No change** — doesn't reach repo                                                                                                                              |
+| 2   | "should return empty array when faceRecognitionEnabled is false" (2444)                  | **No change** — returns before repo call                                                                                                                        |
+| 3   | "should return enriched person list with face count, asset count, and alias" (2457)      | Replace mocks, inline counts                                                                                                                                    |
+| 4   | "should sort people by asset count descending" (2490)                                    | Replace mocks, pre-sort mock data (SQL does sorting now)                                                                                                        |
+| 5   | "should exclude people without thumbnails" (2535)                                        | **Restructure**: mock returns only people WITH thumbnails, verify options passed — SQL handles filtering                                                        |
+| 6   | "should filter out pets when petsEnabled is false" (2566)                                | **Restructure**: mock returns only non-pets, verify `petsEnabled: false` in options                                                                             |
+| 7   | "should exclude hidden persons" (2588)                                                   | **Restructure**: mock returns only visible, verify `withHidden: false` in options                                                                               |
+| 8   | "should include pets when petsEnabled is true" (2610)                                    | Replace mocks, verify `petsEnabled: true` in options                                                                                                            |
+| 9   | "should filter people by temporal range" (2632)                                          | Replace mock with `getPersonsBySpaceIdWithCounts`, verify `takenAfter`/`takenBefore` in options. Remove assertion about `getPersonsBySpaceId` not being called. |
+| 10  | "should return all people when no temporal params provided" (2665)                       | Replace mock, verify `takenAfter: undefined, takenBefore: undefined`. Remove assertion about `getPersonsBySpaceIdWithTemporalFilter` not being called.          |
+| 11  | "should exclude person with zero face assets in date range" (2691)                       | Replace mock — this is now a documentation test (SQL handles exclusion)                                                                                         |
+| 12  | "should resolve name from personal person when space person has no name override" (2724) | Replace mocks, inline counts                                                                                                                                    |
+| 13  | "should use space person name as override when set" (2748)                               | Replace mocks, inline counts                                                                                                                                    |
+| 14  | "should exclude persons with no thumbnail from personal person" (2771)                   | **Restructure**: same as #5, SQL handles filtering                                                                                                              |
+| 15  | "should exclude persons with null personal thumbnail" (2791)                             | **Restructure**: same as #5, SQL handles filtering                                                                                                              |
+| 16  | "should use space person name override even when personal person has no name" (2810)     | Replace mocks, inline counts                                                                                                                                    |
+| 17  | "should include hidden persons when withHidden is true" (2833)                           | Replace mocks, verify `withHidden: true` in options                                                                                                             |
+| 18  | "should exclude hidden persons by default" (2852)                                        | **Restructure**: mock returns empty (SQL filtered), verify `withHidden: false` in options                                                                       |
+
+**Tests that need fundamental restructuring (5, 6, 7, 14, 15, 18):**
+
+These tests currently verify JS-side filtering by returning filtered-out items from the mock and checking they don't appear in results. After the refactor, filtering is in SQL, so these tests should:
+
+1. Return only the expected results from the mock (SQL already filtered)
+2. Assert the correct options were passed to `getPersonsBySpaceIdWithCounts`
+3. Assert the returned results match
+
+Example for test #6 ("should filter out pets when petsEnabled is false"):
+
+```typescript
+it('should pass petsEnabled false to repository', async () => {
+  const spaceId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true, petsEnabled: false });
+  const humanPerson = factory.sharedSpacePerson({ spaceId, type: 'person' });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+    { ...humanPerson, personalName: 'Human', personalThumbnailPath: '/thumb.jpg', faceCount: 1, assetCount: 1 },
+  ]);
+  mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+  const result = await sut.getSpacePeople(factory.auth(), spaceId);
+
+  expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+    withHidden: false,
+    petsEnabled: false,
+    limit: undefined,
+    takenAfter: undefined,
+    takenBefore: undefined,
+  });
+  expect(result).toHaveLength(1);
+});
+```
+
+**Step 2: Add new tests**
+
+Add these new tests to the `getSpacePeople` describe block:
+
+```typescript
+it('should pass top limit to repository', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
+  mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+  await sut.getSpacePeople(auth, spaceId, { top: 10 });
+
+  expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+    withHidden: false,
+    petsEnabled: true,
+    limit: 10,
+    takenAfter: undefined,
+    takenBefore: undefined,
+  });
+});
+
+it('should handle string aggregate counts from database', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const person = factory.sharedSpacePerson({ spaceId });
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+    { ...person, personalName: 'Alice', personalThumbnailPath: '/thumb.jpg', faceCount: '5', assetCount: '3' },
+  ]);
+  mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+  const result = await sut.getSpacePeople(auth, spaceId);
+
+  expect(result[0].faceCount).toBe(5);
+  expect(result[0].assetCount).toBe(3);
+  expect(typeof result[0].faceCount).toBe('number');
+  expect(typeof result[0].assetCount).toBe('number');
+});
+
+it('should skip alias lookup when no persons returned', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+  mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
+
+  const result = await sut.getSpacePeople(auth, spaceId);
+
+  expect(result).toEqual([]);
+  expect(mocks.sharedSpace.getAliasesBySpaceAndUser).not.toHaveBeenCalled();
+});
+
+it('should pass combined options for hidden, temporal, and top', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true, petsEnabled: false });
+  const takenAfter = new Date('2025-06-01');
+
+  mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
+  mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+  await sut.getSpacePeople(auth, spaceId, { withHidden: true, takenAfter, top: 5 });
+
+  expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+    withHidden: true,
+    petsEnabled: false,
+    limit: 5,
+    takenAfter,
+    takenBefore: undefined,
+  });
+});
+```
+
+**Step 3: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```
+test: update getSpacePeople tests for aggregated query
+```
+
+---
+
+### Task 5: Remove old repository methods
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts`
+
+**Step 1: Check for other callers of the old methods**
+
+Search for all usages of `getPersonFaceCount`, `getPersonAssetCount`, `getPersonsBySpaceId`, and `getPersonsBySpaceIdWithTemporalFilter` across the codebase. The `getSpacePerson` (single person detail, line 635-652) and `updateSpacePerson` (line 671-714) still call `getPersonFaceCount` and `getPersonAssetCount` individually for a single person — these are fine (2 queries for 1 person).
+
+So only remove:
+
+- `getPersonsBySpaceId` (lines 489-500) — replaced by `getPersonsBySpaceIdWithCounts`
+- `getPersonsBySpaceIdWithTemporalFilter` (lines 502-531) — merged into `getPersonsBySpaceIdWithCounts`
+
+Keep:
+
+- `getPersonFaceCount` (lines 577-585) — still used by `getSpacePerson` and `updateSpacePerson`
+- `getPersonAssetCount` (lines 587-596) — still used by `getSpacePerson` and `updateSpacePerson`
+
+**Step 2: Remove the two methods**
+
+Delete `getPersonsBySpaceId` (lines 489-500) and `getPersonsBySpaceIdWithTemporalFilter` (lines 502-531).
+
+**Step 3: Verify build**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors. If there are compile errors from other files referencing the removed methods, investigate and update those callers.
+
+**Step 4: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts`
+Expected: All tests pass
+
+**Step 5: Commit**
+
+```
+refactor: remove replaced getPersonsBySpaceId methods
+```
+
+---
+
+### Task 6: Remove peopleCount from hero component
+
+**Files:**
+
+- Modify: `web/src/lib/components/spaces/space-hero.svelte:16-52, 159-169, 300-310`
+- Modify: `web/src/lib/components/spaces/space-hero.spec.ts` (tests referencing peopleCount)
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte:898`
+
+**Step 1: Remove peopleCount from space-hero.svelte**
+
+In `web/src/lib/components/spaces/space-hero.svelte`:
+
+1. Remove `peopleCount?: number;` from the Props interface (line ~28)
+2. Remove `peopleCount,` from the destructuring (line ~48)
+3. Remove the collapsed people count block (lines 159-169) — the entire `{#if faceRecognitionEnabled && peopleCount && peopleCount > 0}` block with `hero-collapsed-people-count`
+4. Remove the expanded people count block (lines 300-310) — the entire `{#if faceRecognitionEnabled && peopleCount && peopleCount > 0}` block with `hero-people-count`
+
+**Step 2: Remove peopleCount prop from page.svelte**
+
+In `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`, remove the `peopleCount={spacePeople.length}` prop (line 898) from the `<SpaceHero>` component.
+
+Also remove the `faceRecognitionEnabled={space.faceRecognitionEnabled}` and `spaceId={space.id}` props from `<SpaceHero>` if they were only used for the people count link. Check if they're used elsewhere in the hero component before removing.
+
+**Step 3: Update hero tests**
+
+In `web/src/lib/components/spaces/space-hero.spec.ts`, remove or update all tests that reference `peopleCount`:
+
+- Remove: "should show people count chip when faceRecognitionEnabled and peopleCount > 0" (line 188)
+- Remove: the test checking people count not shown when faceRecognition disabled (line ~205)
+- Remove: "should not show people chip when peopleCount is 0" (line 212)
+- Remove: the test checking people count links to people page (line ~228)
+- Remove: the collapsed people count test (line ~357)
+- Remove: the test checking collapsed people count not shown when not collapsed (line ~374)
+- Remove `peopleCount` from any remaining test props where it was incidental
+
+**Step 4: Run web tests**
+
+Run: `cd web && pnpm test -- --run src/lib/components/spaces/space-hero.spec.ts`
+Expected: All tests pass
+
+**Step 5: Commit**
+
+```
+feat: remove people count badge from space hero
+```
+
+---
+
+### Task 7: Update web to use `top` parameter for people strip
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte:352-362`
+
+**Step 1: Regenerate the OpenAPI SDK**
+
+The `top` parameter was added to the DTO in Task 1. The SDK needs regenerating so the web client can use it:
+
+```bash
+cd server && pnpm build
+cd server && pnpm sync:open-api
+make open-api-typescript
+```
+
+**Step 2: Update loadSpacePeople to pass `top: 10`**
+
+In `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`, update `loadSpacePeople` (line 358):
+
+**Before:**
+
+```typescript
+spacePeople = await getSpacePeople({ id: space.id });
+```
+
+**After:**
+
+```typescript
+spacePeople = await getSpacePeople({ id: space.id, top: 10 });
+```
+
+**Step 3: Verify other web callers need no changes**
+
+These callers of `getSpacePeople` were audited and need no changes (they continue calling without `top`):
+
+- `+page.svelte` line 169 — FilterPanel people provider (passes `takenAfter`/`takenBefore`, no `top` needed)
+- `/spaces/[spaceId]/people/+page.svelte` — People management page (needs all people with counts)
+- `/spaces/[spaceId]/people/[personId]/+page.ts` — Person detail/merge page
+- `web/src/lib/utils/map-filter-config.ts` — Map filter config
+
+**Step 4: Commit**
+
+```
+feat: load only top 10 people for space people strip
+```
+
+---
+
+### Task 8: Regenerate OpenAPI and SQL files
+
+**Files:**
+
+- Generated: `open-api/typescript-sdk/src/fetch-client.ts`
+- Generated: `open-api/immich-openapi-specs.json`
+- Generated: Various SQL query files
+
+**Step 1: Regenerate everything**
+
+```bash
+cd server && pnpm build
+cd server && pnpm sync:open-api
+make open-api
+make sql
+```
+
+**Step 2: Run linting**
+
+```bash
+make check-server
+make check-web
+make lint-server
+make lint-web
+```
+
+Fix any issues found.
+
+**Step 3: Commit**
+
+```
+chore: regenerate OpenAPI specs and SQL queries
+```
+
+---
+
+### Task 9: Final verification
+
+**Step 1: Run server tests**
+
+```bash
+cd server && pnpm test
+```
+
+Expected: All tests pass
+
+**Step 2: Run web tests**
+
+```bash
+cd web && pnpm test
+```
+
+Expected: All tests pass
+
+**Step 3: Manual smoke test (if dev stack is running)**
+
+1. Open a space with people
+2. Verify the people strip shows up to 10 people
+3. Verify the FilterPanel people section loads all named people
+4. Verify the hero no longer shows a people count badge
+5. Check browser network tab — should see two `getSpacePeople` calls, one with `?top=10`

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1571,6 +1571,7 @@
   "manage_media_access_settings": "Open settings",
   "manage_media_access_subtitle": "Allow the Immich app to manage and move media files.",
   "manage_media_access_title": "Media Management Access",
+  "manage_people": "Manage people",
   "manage_shared_links": "Manage shared links",
   "manage_sharing_with_partners": "Manage sharing with partners",
   "manage_the_app_settings": "Manage the app settings",

--- a/mobile/openapi/lib/api/shared_spaces_api.dart
+++ b/mobile/openapi/lib/api/shared_spaces_api.dart
@@ -660,8 +660,11 @@ class SharedSpacesApi {
   ///
   /// * [DateTime] takenBefore:
   ///
+  /// * [num] top:
+  ///   Maximum number of people to return (sorted by asset count)
+  ///
   /// * [bool] withHidden:
-  Future<Response> getSpacePeopleWithHttpInfo(String id, { DateTime? takenAfter, DateTime? takenBefore, bool? withHidden, }) async {
+  Future<Response> getSpacePeopleWithHttpInfo(String id, { DateTime? takenAfter, DateTime? takenBefore, num? top, bool? withHidden, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/shared-spaces/{id}/people'
       .replaceAll('{id}', id);
@@ -678,6 +681,9 @@ class SharedSpacesApi {
     }
     if (takenBefore != null) {
       queryParams.addAll(_queryParams('', 'takenBefore', takenBefore));
+    }
+    if (top != null) {
+      queryParams.addAll(_queryParams('', 'top', top));
     }
     if (withHidden != null) {
       queryParams.addAll(_queryParams('', 'withHidden', withHidden));
@@ -709,9 +715,12 @@ class SharedSpacesApi {
   ///
   /// * [DateTime] takenBefore:
   ///
+  /// * [num] top:
+  ///   Maximum number of people to return (sorted by asset count)
+  ///
   /// * [bool] withHidden:
-  Future<List<SharedSpacePersonResponseDto>?> getSpacePeople(String id, { DateTime? takenAfter, DateTime? takenBefore, bool? withHidden, }) async {
-    final response = await getSpacePeopleWithHttpInfo(id,  takenAfter: takenAfter, takenBefore: takenBefore, withHidden: withHidden, );
+  Future<List<SharedSpacePersonResponseDto>?> getSpacePeople(String id, { DateTime? takenAfter, DateTime? takenBefore, num? top, bool? withHidden, }) async {
+    final response = await getSpacePeopleWithHttpInfo(id,  takenAfter: takenAfter, takenBefore: takenBefore, top: top, withHidden: withHidden, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -13285,6 +13285,17 @@
             }
           },
           {
+            "name": "top",
+            "required": false,
+            "in": "query",
+            "description": "Maximum number of people to return (sorted by asset count)",
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "type": "number"
+            }
+          },
+          {
             "name": "withHidden",
             "required": false,
             "in": "query",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -6739,10 +6739,11 @@ export function updateMember({ id, userId, sharedSpaceMemberUpdateDto }: {
 /**
  * Get people in a shared space
  */
-export function getSpacePeople({ id, takenAfter, takenBefore, withHidden }: {
+export function getSpacePeople({ id, takenAfter, takenBefore, top, withHidden }: {
     id: string;
     takenAfter?: string;
     takenBefore?: string;
+    top?: number;
     withHidden?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
@@ -6751,6 +6752,7 @@ export function getSpacePeople({ id, takenAfter, takenBefore, withHidden }: {
     }>(`/shared-spaces/${encodeURIComponent(id)}/people${QS.query(QS.explode({
         takenAfter,
         takenBefore,
+        top,
         withHidden
     }))}`, {
         ...opts

--- a/server/src/dtos/shared-space-person.dto.ts
+++ b/server/src/dtos/shared-space-person.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 import { Optional, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
 
 export class SpacePeopleQueryDto {
@@ -11,6 +12,18 @@ export class SpacePeopleQueryDto {
 
   @ValidateBoolean({ optional: true })
   withHidden?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of people to return (sorted by asset count)',
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  top?: number;
 }
 
 export class SharedSpacePersonUpdateDto {

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -380,46 +380,40 @@ where
   "spaceId" = $1
   and "type" = $2
 
--- SharedSpaceRepository.getPersonsBySpaceId
+-- SharedSpaceRepository.getPersonsBySpaceIdWithCounts
 select
-  "shared_space_person".*,
+  "shared_space_person"."id",
+  "shared_space_person"."spaceId",
+  "shared_space_person"."name",
+  "shared_space_person"."isHidden",
+  "shared_space_person"."type",
+  "shared_space_person"."birthDate",
+  "shared_space_person"."representativeFaceId",
+  "shared_space_person"."createdAt",
+  "shared_space_person"."updatedAt",
+  "shared_space_person"."updateId",
   "person"."name" as "personalName",
-  "person"."thumbnailPath" as "personalThumbnailPath"
+  "person"."thumbnailPath" as "personalThumbnailPath",
+  count(*) as "faceCount",
+  count(distinct ("asset_face"."assetId")) as "assetCount"
 from
   "shared_space_person"
-  left join "asset_face" on "asset_face"."id" = "shared_space_person"."representativeFaceId"
+  inner join "shared_space_person_face" on "shared_space_person_face"."personId" = "shared_space_person"."id"
+  inner join "asset_face" on "asset_face"."id" = "shared_space_person_face"."assetFaceId"
   left join "person" on "person"."id" = "asset_face"."personId"
 where
   "shared_space_person"."spaceId" = $1
   and "shared_space_person"."isHidden" = $2
+  and "person"."thumbnailPath" is not null
+  and "person"."thumbnailPath" != $3
+group by
+  "shared_space_person"."id",
+  "person"."name",
+  "person"."thumbnailPath"
 order by
-  "shared_space_person"."name" asc
-
--- SharedSpaceRepository.getPersonsBySpaceIdWithTemporalFilter
-select
-  "shared_space_person".*,
-  "person"."name" as "personalName",
-  "person"."thumbnailPath" as "personalThumbnailPath"
-from
-  "shared_space_person"
-  left join "asset_face" on "asset_face"."id" = "shared_space_person"."representativeFaceId"
-  left join "person" on "person"."id" = "asset_face"."personId"
-where
-  "shared_space_person"."spaceId" = $1
-  and "shared_space_person"."isHidden" = $2
-  and exists (
-    select
-    from
-      "shared_space_person_face"
-      inner join "asset_face" as "af2" on "af2"."id" = "shared_space_person_face"."assetFaceId"
-      inner join "asset" on "asset"."id" = "af2"."assetId"
-    where
-      "shared_space_person_face"."personId" = "shared_space_person"."id"
-      and "asset"."fileCreatedAt" >= $3
-      and "asset"."fileCreatedAt" < $4
-  )
-order by
-  "shared_space_person"."name" asc
+  "assetCount" desc
+limit
+  $4
 
 -- SharedSpaceRepository.getPersonById
 select

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -530,6 +530,65 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  @GenerateSql({
+    params: [DummyValue.UUID, { withHidden: false, petsEnabled: true, limit: 10 }],
+  })
+  getPersonsBySpaceIdWithCounts(
+    spaceId: string,
+    options: {
+      withHidden?: boolean;
+      petsEnabled?: boolean;
+      limit?: number;
+      takenAfter?: Date;
+      takenBefore?: Date;
+    },
+  ) {
+    return this.db
+      .selectFrom('shared_space_person')
+      .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .leftJoin('person', 'person.id', 'asset_face.personId')
+      .select([
+        'shared_space_person.id',
+        'shared_space_person.spaceId',
+        'shared_space_person.name',
+        'shared_space_person.isHidden',
+        'shared_space_person.type',
+        'shared_space_person.birthDate',
+        'shared_space_person.representativeFaceId',
+        'shared_space_person.createdAt',
+        'shared_space_person.updatedAt',
+        'shared_space_person.updateId',
+      ])
+      .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
+      .select((eb) => [
+        eb.fn.countAll().as('faceCount'),
+        eb.fn.count(eb.fn('distinct', ['asset_face.assetId'])).as('assetCount'),
+      ])
+      .where('shared_space_person.spaceId', '=', spaceId)
+      .$if(!options.withHidden, (qb) => qb.where('shared_space_person.isHidden', '=', false))
+      .$if(!options.petsEnabled, (qb) => qb.where('shared_space_person.type', '!=', 'pet'))
+      .where('person.thumbnailPath', 'is not', null)
+      .where('person.thumbnailPath', '!=', '')
+      .$if(!!options.takenAfter || !!options.takenBefore, (qb) =>
+        qb.where((eb) =>
+          eb.exists(
+            eb
+              .selectFrom('shared_space_person_face as spf2')
+              .innerJoin('asset_face as af2', 'af2.id', 'spf2.assetFaceId')
+              .innerJoin('asset', 'asset.id', 'af2.assetId')
+              .whereRef('spf2.personId', '=', 'shared_space_person.id')
+              .$if(!!options.takenAfter, (qb2) => qb2.where('asset.fileCreatedAt', '>=', options.takenAfter!))
+              .$if(!!options.takenBefore, (qb2) => qb2.where('asset.fileCreatedAt', '<', options.takenBefore!)),
+          ),
+        ),
+      )
+      .groupBy(['shared_space_person.id', 'person.name', 'person.thumbnailPath'])
+      .orderBy('assetCount', 'desc')
+      .$if(!!options.limit, (qb) => qb.limit(options.limit!))
+      .execute();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID] })
   getPersonById(id: string) {
     return this.db

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -485,51 +485,6 @@ export class SharedSpaceRepository {
     return result.count > 0;
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, false] })
-  getPersonsBySpaceId(spaceId: string, withHidden = false) {
-    return this.db
-      .selectFrom('shared_space_person')
-      .leftJoin('asset_face', 'asset_face.id', 'shared_space_person.representativeFaceId')
-      .leftJoin('person', 'person.id', 'asset_face.personId')
-      .selectAll('shared_space_person')
-      .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
-      .where('shared_space_person.spaceId', '=', spaceId)
-      .$if(!withHidden, (qb) => qb.where('shared_space_person.isHidden', '=', false))
-      .orderBy('shared_space_person.name', 'asc')
-      .execute();
-  }
-
-  @GenerateSql({ params: [DummyValue.UUID, { takenAfter: DummyValue.DATE, takenBefore: DummyValue.DATE }, false] })
-  getPersonsBySpaceIdWithTemporalFilter(
-    spaceId: string,
-    options?: { takenAfter?: Date; takenBefore?: Date },
-    withHidden = false,
-  ) {
-    return this.db
-      .selectFrom('shared_space_person')
-      .leftJoin('asset_face', 'asset_face.id', 'shared_space_person.representativeFaceId')
-      .leftJoin('person', 'person.id', 'asset_face.personId')
-      .selectAll('shared_space_person')
-      .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
-      .where('shared_space_person.spaceId', '=', spaceId)
-      .$if(!withHidden, (qb) => qb.where('shared_space_person.isHidden', '=', false))
-      .$if(!!options?.takenAfter || !!options?.takenBefore, (qb) =>
-        qb.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('shared_space_person_face')
-              .innerJoin('asset_face as af2', 'af2.id', 'shared_space_person_face.assetFaceId')
-              .innerJoin('asset', 'asset.id', 'af2.assetId')
-              .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id')
-              .$if(!!options?.takenAfter, (qb2) => qb2.where('asset.fileCreatedAt', '>=', options!.takenAfter!))
-              .$if(!!options?.takenBefore, (qb2) => qb2.where('asset.fileCreatedAt', '<', options!.takenBefore!)),
-          ),
-        ),
-      )
-      .orderBy('shared_space_person.name', 'asc')
-      .execute();
-  }
-
   @GenerateSql({
     params: [DummyValue.UUID, { withHidden: false, petsEnabled: true, limit: 10 }],
   })

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2509,9 +2509,27 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       // Repository returns pre-sorted by asset count descending
       mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
-        { ...person1, personalName: 'Many Photos', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 10 },
-        { ...person2, personalName: 'Some Photos', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 5 },
-        { ...person3, personalName: 'Few Photos', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 2 },
+        {
+          ...person1,
+          personalName: 'Many Photos',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 1,
+          assetCount: 10,
+        },
+        {
+          ...person2,
+          personalName: 'Some Photos',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 1,
+          assetCount: 5,
+        },
+        {
+          ...person3,
+          personalName: 'Few Photos',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 1,
+          assetCount: 2,
+        },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
@@ -2540,7 +2558,13 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       // SQL already filters out persons without thumbnails
       mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
-        { ...personWithThumb, personalName: 'Has Thumb', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
+        {
+          ...personWithThumb,
+          personalName: 'Has Thumb',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 1,
+          assetCount: 1,
+        },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
@@ -2651,7 +2675,13 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
-        { ...person, personalName: 'Temporal Person', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 3, assetCount: 2 },
+        {
+          ...person,
+          personalName: 'Temporal Person',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 3,
+          assetCount: 2,
+        },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
@@ -2681,7 +2711,13 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
-        { ...person, personalName: 'All People', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
+        {
+          ...person,
+          personalName: 'All People',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 1,
+          assetCount: 1,
+        },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
@@ -2713,7 +2749,13 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
-        { ...personInRange, personalName: 'In Range', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
+        {
+          ...personInRange,
+          personalName: 'In Range',
+          personalThumbnailPath: '/path/to/thumb.jpg',
+          faceCount: 1,
+          assetCount: 1,
+        },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2467,11 +2467,9 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: 'Alice', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: 'Alice', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 5, assetCount: 3 },
       ]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(5);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(3);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([
         factory.sharedSpacePersonAlias({ personId, userId: auth.user.id, alias: 'My Alice' }),
       ]);
@@ -2493,32 +2491,28 @@ describe(SharedSpaceService.name, () => {
       const person1 = factory.sharedSpacePerson({
         id: newUuid(),
         spaceId,
-        name: 'Few Photos',
+        name: 'Many Photos',
       });
       const person2 = factory.sharedSpacePerson({
         id: newUuid(),
         spaceId,
-        name: 'Many Photos',
+        name: 'Some Photos',
       });
       const person3 = factory.sharedSpacePerson({
         id: newUuid(),
         spaceId,
-        name: 'Some Photos',
+        name: 'Few Photos',
       });
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person1, personalName: 'Few Photos', personalThumbnailPath: '/path/to/thumb.jpg' },
-        { ...person2, personalName: 'Many Photos', personalThumbnailPath: '/path/to/thumb.jpg' },
-        { ...person3, personalName: 'Some Photos', personalThumbnailPath: '/path/to/thumb.jpg' },
+      // Repository returns pre-sorted by asset count descending
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person1, personalName: 'Many Photos', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 10 },
+        { ...person2, personalName: 'Some Photos', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 5 },
+        { ...person3, personalName: 'Few Photos', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 2 },
       ]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount
-        .mockResolvedValueOnce(2) // person1: Few Photos
-        .mockResolvedValueOnce(10) // person2: Many Photos
-        .mockResolvedValueOnce(5); // person3: Some Photos
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
       const result = await sut.getSpacePeople(auth, spaceId);
@@ -2541,70 +2535,78 @@ describe(SharedSpaceService.name, () => {
         spaceId,
         name: 'Has Thumb',
       });
-      const personWithoutThumb = factory.sharedSpacePerson({
-        id: newUuid(),
-        spaceId,
-        name: 'No Thumb',
-      });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...personWithThumb, personalName: 'Has Thumb', personalThumbnailPath: '/path/to/thumb.jpg' },
-        { ...personWithoutThumb, personalName: 'No Thumb', personalThumbnailPath: '' },
+      // SQL already filters out persons without thumbnails
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...personWithThumb, personalName: 'Has Thumb', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
       const result = await sut.getSpacePeople(auth, spaceId);
 
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Has Thumb');
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should filter out pets when petsEnabled is false', async () => {
       const spaceId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true, petsEnabled: false });
       const humanPerson = factory.sharedSpacePerson({ spaceId, type: 'person' });
-      const petPerson = factory.sharedSpacePerson({ spaceId, type: 'pet' });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...humanPerson, personalName: 'Human', personalThumbnailPath: '/thumb.jpg' },
-        { ...petPerson, personalName: 'Pet', personalThumbnailPath: '/pet.jpg' },
+      // SQL already filters out pets when petsEnabled is false
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...humanPerson, personalName: 'Human', personalThumbnailPath: '/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
 
       const result = await sut.getSpacePeople(factory.auth(), spaceId);
 
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe('person');
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: false,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should exclude hidden persons', async () => {
       const spaceId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
       const visiblePerson = factory.sharedSpacePerson({ spaceId, isHidden: false });
-      const hiddenPerson = factory.sharedSpacePerson({ spaceId, isHidden: true });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...visiblePerson, personalName: 'Visible', personalThumbnailPath: '/thumb.jpg' },
-        { ...hiddenPerson, personalName: 'Hidden', personalThumbnailPath: '/thumb.jpg' },
+      // SQL already filters out hidden persons
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...visiblePerson, personalName: 'Visible', personalThumbnailPath: '/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
 
       const result = await sut.getSpacePeople(factory.auth(), spaceId);
 
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Visible');
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should include pets when petsEnabled is true', async () => {
@@ -2615,18 +2617,23 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...humanPerson, personalName: 'Human', personalThumbnailPath: '/thumb.jpg' },
-        { ...petPerson, personalName: 'Pet', personalThumbnailPath: '/pet.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...humanPerson, personalName: 'Human', personalThumbnailPath: '/thumb.jpg', faceCount: 1, assetCount: 1 },
+        { ...petPerson, personalName: 'Pet', personalThumbnailPath: '/pet.jpg', faceCount: 1, assetCount: 1 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
 
       const result = await sut.getSpacePeople(factory.auth(), spaceId);
 
       expect(result).toHaveLength(2);
       expect(result.map((r) => r.type)).toEqual(expect.arrayContaining(['person', 'pet']));
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should filter people by temporal range', async () => {
@@ -2643,23 +2650,22 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceIdWithTemporalFilter.mockResolvedValue([
-        { ...person, personalName: 'Temporal Person', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: 'Temporal Person', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 3, assetCount: 2 },
       ]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(3);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(2);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
       const result = await sut.getSpacePeople(auth, spaceId, { takenAfter, takenBefore });
 
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Temporal Person');
-      expect(mocks.sharedSpace.getPersonsBySpaceIdWithTemporalFilter).toHaveBeenCalledWith(
-        spaceId,
-        { takenAfter, takenBefore },
-        false,
-      );
-      expect(mocks.sharedSpace.getPersonsBySpaceId).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter,
+        takenBefore,
+      });
     });
 
     it('should return all people when no temporal params provided', async () => {
@@ -2674,18 +2680,21 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: 'All People', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: 'All People', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
       const result = await sut.getSpacePeople(auth, spaceId);
 
       expect(result).toHaveLength(1);
-      expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, false);
-      expect(mocks.sharedSpace.getPersonsBySpaceIdWithTemporalFilter).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should exclude person with zero face assets in date range', async () => {
@@ -2697,28 +2706,28 @@ describe(SharedSpaceService.name, () => {
         spaceId,
         name: 'In Range',
       });
-      // The temporal filter query naturally excludes persons with zero faces in range,
+      // The aggregated query naturally excludes persons with zero faces in range,
       // so only personInRange is returned by the repository
       const takenAfter = new Date('2025-06-01');
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceIdWithTemporalFilter.mockResolvedValue([
-        { ...personInRange, personalName: 'In Range', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...personInRange, personalName: 'In Range', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
       const result = await sut.getSpacePeople(auth, spaceId, { takenAfter });
 
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('In Range');
-      expect(mocks.sharedSpace.getPersonsBySpaceIdWithTemporalFilter).toHaveBeenCalledWith(
-        spaceId,
-        { takenAfter },
-        false,
-      );
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter,
+        takenBefore: undefined,
+      });
     });
 
     it('should resolve name from personal person when space person has no name override', async () => {
@@ -2733,12 +2742,10 @@ describe(SharedSpaceService.name, () => {
       });
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ faceRecognitionEnabled: true }));
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: 'Alice', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: 'Alice', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 3, assetCount: 2 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(3);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(2);
       const result = await sut.getSpacePeople(auth, spaceId);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Alice');
@@ -2757,12 +2764,10 @@ describe(SharedSpaceService.name, () => {
       });
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ faceRecognitionEnabled: true }));
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: 'Hans', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: 'Hans', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 3, assetCount: 2 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(3);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(2);
       const result = await sut.getSpacePeople(auth, spaceId);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Grandpa');
@@ -2771,40 +2776,47 @@ describe(SharedSpaceService.name, () => {
     it('should exclude persons with no thumbnail from personal person', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
-      const personId = newUuid();
-      const faceId = newUuid();
-      const person = factory.sharedSpacePerson({
-        id: personId,
-        name: '',
-        representativeFaceId: faceId,
-      });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
-      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ faceRecognitionEnabled: true }));
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: 'Alice', personalThumbnailPath: '' },
-      ]);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      // SQL already filters out persons without thumbnails
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
       const result = await sut.getSpacePeople(auth, spaceId);
+
       expect(result).toHaveLength(0);
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should exclude persons with null personal thumbnail (no linked personal person)', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
-      const personId = newUuid();
-      const person = factory.sharedSpacePerson({
-        id: personId,
-        name: '',
-        representativeFaceId: null,
-      });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
-      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ faceRecognitionEnabled: true }));
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: null, personalThumbnailPath: null },
-      ]);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      // SQL already filters out persons with null thumbnails
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
       const result = await sut.getSpacePeople(auth, spaceId);
+
       expect(result).toHaveLength(0);
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should use space person name override even when personal person has no name', async () => {
@@ -2819,12 +2831,10 @@ describe(SharedSpaceService.name, () => {
       });
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
       mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ faceRecognitionEnabled: true }));
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...person, personalName: '', personalThumbnailPath: '/path/to/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: '', personalThumbnailPath: '/path/to/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
       const result = await sut.getSpacePeople(auth, spaceId);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('Custom Name');
@@ -2837,33 +2847,122 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ spaceId }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...hiddenPerson, personalName: 'Hidden', personalThumbnailPath: '/thumb.jpg' },
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...hiddenPerson, personalName: 'Hidden', personalThumbnailPath: '/thumb.jpg', faceCount: 1, assetCount: 1 },
       ]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
-      mocks.sharedSpace.getPersonFaceCount.mockResolvedValue(1);
-      mocks.sharedSpace.getPersonAssetCount.mockResolvedValue(1);
 
       const result = await sut.getSpacePeople(factory.auth(), spaceId, { withHidden: true });
 
       expect(result).toHaveLength(1);
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: true,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
     });
 
     it('should exclude hidden persons by default', async () => {
       const spaceId = newUuid();
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-      const hiddenPerson = factory.sharedSpacePerson({ spaceId, isHidden: true });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ spaceId }));
       mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([
-        { ...hiddenPerson, personalName: 'Hidden', personalThumbnailPath: '/thumb.jpg' },
-      ]);
+      // SQL already filters out hidden persons with withHidden: false
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
       mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
 
       const result = await sut.getSpacePeople(factory.auth(), spaceId);
 
       expect(result).toHaveLength(0);
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: undefined,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
+    });
+
+    it('should pass top limit to repository', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
+      mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+      await sut.getSpacePeople(auth, spaceId, { top: 10 });
+
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: false,
+        petsEnabled: true,
+        limit: 10,
+        takenAfter: undefined,
+        takenBefore: undefined,
+      });
+    });
+
+    it('should handle string aggregate counts from database', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const person = factory.sharedSpacePerson({ spaceId });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([
+        { ...person, personalName: 'Alice', personalThumbnailPath: '/thumb.jpg', faceCount: '5', assetCount: '3' },
+      ]);
+      mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+      const result = await sut.getSpacePeople(auth, spaceId);
+
+      expect(result[0].faceCount).toBe(5);
+      expect(result[0].assetCount).toBe(3);
+      expect(typeof result[0].faceCount).toBe('number');
+      expect(typeof result[0].assetCount).toBe('number');
+    });
+
+    it('should skip alias lookup when no persons returned', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
+
+      const result = await sut.getSpacePeople(auth, spaceId);
+
+      expect(result).toEqual([]);
+      expect(mocks.sharedSpace.getAliasesBySpaceAndUser).not.toHaveBeenCalled();
+    });
+
+    it('should pass combined options for hidden, temporal, and top', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true, petsEnabled: false });
+      const takenAfter = new Date('2025-06-01');
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getPersonsBySpaceIdWithCounts.mockResolvedValue([]);
+      mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+      await sut.getSpacePeople(auth, spaceId, { withHidden: true, takenAfter, top: 5 });
+
+      expect(mocks.sharedSpace.getPersonsBySpaceIdWithCounts).toHaveBeenCalledWith(spaceId, {
+        withHidden: true,
+        petsEnabled: false,
+        limit: 5,
+        takenAfter,
+        takenBefore: undefined,
+      });
     });
   });
 

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -615,9 +615,7 @@ export class SharedSpaceService extends BaseService {
     });
 
     const aliases =
-      persons.length > 0
-        ? await this.sharedSpaceRepository.getAliasesBySpaceAndUser(spaceId, auth.user.id)
-        : [];
+      persons.length > 0 ? await this.sharedSpaceRepository.getAliasesBySpaceAndUser(spaceId, auth.user.id) : [];
     const aliasMap = new Map(aliases.map((a) => [a.personId, a.alias]));
 
     return persons.map((person) =>

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -606,30 +606,23 @@ export class SharedSpaceService extends BaseService {
     }
 
     const withHidden = query?.withHidden ?? false;
-    const hasTemporal = query?.takenAfter || query?.takenBefore;
-    const persons = hasTemporal
-      ? await this.sharedSpaceRepository.getPersonsBySpaceIdWithTemporalFilter(spaceId, query, withHidden)
-      : await this.sharedSpaceRepository.getPersonsBySpaceId(spaceId, withHidden);
-    const aliases = await this.sharedSpaceRepository.getAliasesBySpaceAndUser(spaceId, auth.user.id);
+    const persons = await this.sharedSpaceRepository.getPersonsBySpaceIdWithCounts(spaceId, {
+      withHidden,
+      petsEnabled: space.petsEnabled,
+      limit: query?.top,
+      takenAfter: query?.takenAfter,
+      takenBefore: query?.takenBefore,
+    });
+
+    const aliases =
+      persons.length > 0
+        ? await this.sharedSpaceRepository.getAliasesBySpaceAndUser(spaceId, auth.user.id)
+        : [];
     const aliasMap = new Map(aliases.map((a) => [a.personId, a.alias]));
 
-    const results: SharedSpacePersonResponseDto[] = [];
-    for (const person of persons) {
-      if (!withHidden && person.isHidden) {
-        continue;
-      }
-      if (!space.petsEnabled && person.type === 'pet') {
-        continue;
-      }
-      if (!person.personalThumbnailPath) {
-        continue;
-      }
-      const faceCount = await this.sharedSpaceRepository.getPersonFaceCount(person.id);
-      const assetCount = await this.sharedSpaceRepository.getPersonAssetCount(person.id);
-      results.push(this.mapSpacePerson(person, faceCount, assetCount, aliasMap.get(person.id) ?? null));
-    }
-
-    return results.toSorted((a, b) => b.assetCount - a.assetCount);
+    return persons.map((person) =>
+      this.mapSpacePerson(person, Number(person.faceCount), Number(person.assetCount), aliasMap.get(person.id) ?? null),
+    );
   }
 
   async getSpacePerson(auth: AuthDto, spaceId: string, personId: string): Promise<SharedSpacePersonResponseDto> {

--- a/web/src/lib/components/spaces/space-hero.spec.ts
+++ b/web/src/lib/components/spaces/space-hero.spec.ts
@@ -185,56 +185,6 @@ describe('SpaceHero component', () => {
     expect(onCancelReposition).toHaveBeenCalled();
   });
 
-  it('should show people count chip when faceRecognitionEnabled and peopleCount > 0', () => {
-    render(SpaceHero, {
-      space: makeSpace(),
-      memberCount: 3,
-      assetCount: 42,
-      faceRecognitionEnabled: true,
-      peopleCount: 5,
-      spaceId: 'space-1',
-    });
-    expect(screen.getByTestId('hero-people-count')).toHaveTextContent('5');
-  });
-
-  it('should not show people chip when faceRecognitionEnabled is false', () => {
-    render(SpaceHero, {
-      space: makeSpace(),
-      memberCount: 3,
-      assetCount: 42,
-      faceRecognitionEnabled: false,
-      peopleCount: 5,
-      spaceId: 'space-1',
-    });
-    expect(screen.queryByTestId('hero-people-count')).not.toBeInTheDocument();
-  });
-
-  it('should not show people chip when peopleCount is 0', () => {
-    render(SpaceHero, {
-      space: makeSpace(),
-      memberCount: 3,
-      assetCount: 42,
-      faceRecognitionEnabled: true,
-      peopleCount: 0,
-      spaceId: 'space-1',
-    });
-    expect(screen.queryByTestId('hero-people-count')).not.toBeInTheDocument();
-  });
-
-  it('should link to people sub-route', () => {
-    render(SpaceHero, {
-      space: makeSpace(),
-      memberCount: 3,
-      assetCount: 42,
-      faceRecognitionEnabled: true,
-      peopleCount: 5,
-      spaceId: 'space-1',
-    });
-    const link = screen.getByTestId('hero-people-count');
-    expect(link).toBeInTheDocument();
-    expect(link.getAttribute('href')).toBe('/spaces/space-1/people');
-  });
-
   // --- Collapse toggle in expanded mode ---
 
   it('should show collapse toggle button when onToggleCollapse is provided', () => {
@@ -345,36 +295,6 @@ describe('SpaceHero component', () => {
       currentRole: 'editor',
     });
     expect(screen.getByTestId('hero-collapsed-role')).toHaveTextContent('Editor');
-  });
-
-  it('should show people count as a link in collapsed bar', () => {
-    render(SpaceHero, {
-      space: makeSpace(),
-      memberCount: 3,
-      assetCount: 42,
-      collapsed: true,
-      onToggleCollapse: vi.fn(),
-      faceRecognitionEnabled: true,
-      peopleCount: 5,
-      spaceId: 'space-1',
-    });
-    const el = screen.getByTestId('hero-collapsed-people-count');
-    expect(el).toHaveTextContent('5');
-    expect(el.tagName).toBe('A');
-    expect(el.getAttribute('href')).toBe('/spaces/space-1/people');
-  });
-
-  it('should not show people count in collapsed bar when faceRecognitionEnabled is false', () => {
-    render(SpaceHero, {
-      space: makeSpace(),
-      memberCount: 3,
-      assetCount: 42,
-      collapsed: true,
-      onToggleCollapse: vi.fn(),
-      faceRecognitionEnabled: false,
-      peopleCount: 5,
-    });
-    expect(screen.queryByTestId('hero-collapsed-people-count')).not.toBeInTheDocument();
   });
 
   it('should show cover image behind collapsed bar when cover exists', () => {

--- a/web/src/lib/components/spaces/space-hero.spec.ts
+++ b/web/src/lib/components/spaces/space-hero.spec.ts
@@ -375,4 +375,72 @@ describe('SpaceHero component', () => {
     expect(screen.getByTestId('reposition-controls')).toBeInTheDocument();
     expect(screen.queryByTestId('hero-collapsed-bar')).not.toBeInTheDocument();
   });
+
+  // --- Member count clickable ---
+
+  it('should call onShowMembers when member count is clicked in expanded view', () => {
+    const onShowMembers = vi.fn();
+    render(SpaceHero, {
+      space: makeSpace(),
+      memberCount: 3,
+      assetCount: 42,
+      onShowMembers,
+    });
+    screen.getByTestId('hero-member-count').click();
+    expect(onShowMembers).toHaveBeenCalled();
+  });
+
+  it('should call onShowMembers when member count is clicked in collapsed view', () => {
+    const onShowMembers = vi.fn();
+    render(SpaceHero, {
+      space: makeSpace(),
+      memberCount: 3,
+      assetCount: 42,
+      collapsed: true,
+      onToggleCollapse: vi.fn(),
+      onShowMembers,
+    });
+    screen.getByTestId('hero-collapsed-member-count').click();
+    expect(onShowMembers).toHaveBeenCalled();
+  });
+
+  // --- Manage people link ---
+
+  it('should show manage people link when faceRecognitionEnabled', () => {
+    render(SpaceHero, {
+      space: makeSpace(),
+      memberCount: 3,
+      assetCount: 42,
+      faceRecognitionEnabled: true,
+      spaceId: 'space-1',
+    });
+    const link = screen.getByTestId('hero-manage-people');
+    expect(link).toHaveTextContent('manage_people');
+    expect(link).toHaveAttribute('href', '/spaces/space-1/people');
+  });
+
+  it('should not show manage people link when faceRecognitionEnabled is false', () => {
+    render(SpaceHero, {
+      space: makeSpace(),
+      memberCount: 3,
+      assetCount: 42,
+      faceRecognitionEnabled: false,
+      spaceId: 'space-1',
+    });
+    expect(screen.queryByTestId('hero-manage-people')).not.toBeInTheDocument();
+  });
+
+  it('should show manage people link in collapsed view', () => {
+    render(SpaceHero, {
+      space: makeSpace(),
+      memberCount: 3,
+      assetCount: 42,
+      collapsed: true,
+      onToggleCollapse: vi.fn(),
+      faceRecognitionEnabled: true,
+      spaceId: 'space-1',
+    });
+    const link = screen.getByTestId('hero-collapsed-manage-people');
+    expect(link).toHaveAttribute('href', '/spaces/space-1/people');
+  });
 });

--- a/web/src/lib/components/spaces/space-hero.svelte
+++ b/web/src/lib/components/spaces/space-hero.svelte
@@ -3,7 +3,6 @@
   import { AssetMediaSize, type SharedSpaceResponseDto } from '@immich/sdk';
   import { Icon } from '@immich/ui';
   import {
-    mdiAccountGroupOutline,
     mdiAccountMultipleOutline,
     mdiCameraOutline,
     mdiChevronDown,
@@ -24,9 +23,6 @@
     repositioning?: boolean;
     onSavePosition?: (cropY: number) => void;
     onCancelReposition?: () => void;
-    peopleCount?: number;
-    faceRecognitionEnabled?: boolean;
-    spaceId?: string;
     height?: number;
     collapsed?: boolean;
     onToggleCollapse?: () => void;
@@ -43,9 +39,6 @@
     repositioning = false,
     onSavePosition,
     onCancelReposition,
-    peopleCount,
-    faceRecognitionEnabled,
-    spaceId,
     height = 450,
     collapsed = false,
     onToggleCollapse,
@@ -156,17 +149,6 @@
         {memberCount}
         {$t('members')}
       </span>
-      {#if faceRecognitionEnabled && peopleCount && peopleCount > 0}
-        <a
-          href="/spaces/{spaceId}/people"
-          class="hidden items-center gap-1.5 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white backdrop-blur-sm transition-colors hover:bg-white/30 sm:inline-flex"
-          data-testid="hero-collapsed-people-count"
-        >
-          <Icon icon={mdiAccountGroupOutline} size="14" />
-          {peopleCount}
-          {$t('people')}
-        </a>
-      {/if}
       {#if currentRole}
         <span
           class="hidden items-center rounded-full bg-white/20 px-2 py-0.5 text-xs font-medium capitalize text-white backdrop-blur-sm sm:inline-flex"
@@ -297,17 +279,6 @@
           {memberCount}
           {$t('members')}
         </span>
-        {#if faceRecognitionEnabled && peopleCount && peopleCount > 0}
-          <a
-            href="/spaces/{spaceId}/people"
-            class="inline-flex items-center gap-1.5 rounded-full bg-white/20 px-3 py-1 text-sm backdrop-blur-sm hover:bg-white/30 transition-colors"
-            data-testid="hero-people-count"
-          >
-            <Icon icon={mdiAccountGroupOutline} size="16" />
-            {peopleCount}
-            {$t('people')}
-          </a>
-        {/if}
         {#if currentRole}
           <span
             class="inline-flex items-center rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-medium capitalize backdrop-blur-sm"

--- a/web/src/lib/components/spaces/space-hero.svelte
+++ b/web/src/lib/components/spaces/space-hero.svelte
@@ -3,6 +3,7 @@
   import { AssetMediaSize, type SharedSpaceResponseDto } from '@immich/sdk';
   import { Icon } from '@immich/ui';
   import {
+    mdiAccountGroupOutline,
     mdiAccountMultipleOutline,
     mdiCameraOutline,
     mdiChevronDown,
@@ -23,6 +24,9 @@
     repositioning?: boolean;
     onSavePosition?: (cropY: number) => void;
     onCancelReposition?: () => void;
+    faceRecognitionEnabled?: boolean;
+    spaceId?: string;
+    onShowMembers?: () => void;
     height?: number;
     collapsed?: boolean;
     onToggleCollapse?: () => void;
@@ -39,6 +43,9 @@
     repositioning = false,
     onSavePosition,
     onCancelReposition,
+    faceRecognitionEnabled,
+    spaceId,
+    onShowMembers,
     height = 450,
     collapsed = false,
     onToggleCollapse,
@@ -141,14 +148,26 @@
         {assetCount}
         {$t('photos')}
       </span>
-      <span
-        class="hidden items-center gap-1.5 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white backdrop-blur-sm sm:inline-flex"
+      <button
+        type="button"
+        class="hidden items-center gap-1.5 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white backdrop-blur-sm transition-colors hover:bg-white/30 sm:inline-flex"
+        onclick={() => onShowMembers?.()}
         data-testid="hero-collapsed-member-count"
       >
         <Icon icon={mdiAccountMultipleOutline} size="14" />
         {memberCount}
         {$t('members')}
-      </span>
+      </button>
+      {#if faceRecognitionEnabled && spaceId}
+        <a
+          href="/spaces/{spaceId}/people"
+          class="hidden items-center gap-1.5 rounded-full bg-white/20 px-2 py-0.5 text-xs text-white backdrop-blur-sm transition-colors hover:bg-white/30 sm:inline-flex"
+          data-testid="hero-collapsed-manage-people"
+        >
+          <Icon icon={mdiAccountGroupOutline} size="14" />
+          {$t('manage_people')}
+        </a>
+      {/if}
       {#if currentRole}
         <span
           class="hidden items-center rounded-full bg-white/20 px-2 py-0.5 text-xs font-medium capitalize text-white backdrop-blur-sm sm:inline-flex"
@@ -271,14 +290,26 @@
           {assetCount}
           {$t('photos')}
         </span>
-        <span
-          class="inline-flex items-center gap-1.5 rounded-full bg-white/20 px-3 py-1 text-sm backdrop-blur-sm"
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-full bg-white/20 px-3 py-1 text-sm backdrop-blur-sm transition-colors hover:bg-white/30"
+          onclick={() => onShowMembers?.()}
           data-testid="hero-member-count"
         >
           <Icon icon={mdiAccountMultipleOutline} size="16" />
           {memberCount}
           {$t('members')}
-        </span>
+        </button>
+        {#if faceRecognitionEnabled && spaceId}
+          <a
+            href="/spaces/{spaceId}/people"
+            class="inline-flex items-center gap-1.5 rounded-full bg-white/20 px-3 py-1 text-sm backdrop-blur-sm transition-colors hover:bg-white/30"
+            data-testid="hero-manage-people"
+          >
+            <Icon icon={mdiAccountGroupOutline} size="16" />
+            {$t('manage_people')}
+          </a>
+        {/if}
         {#if currentRole}
           <span
             class="inline-flex items-center rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-medium capitalize backdrop-blur-sm"

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -355,7 +355,7 @@
       return;
     }
     try {
-      spacePeople = await getSpacePeople({ id: space.id });
+      spacePeople = await getSpacePeople({ id: space.id, top: 10 });
     } catch (error) {
       handleError(error, 'Failed to load space people');
     }

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -895,6 +895,9 @@
                   {repositioning}
                   onSavePosition={handleSavePosition}
                   onCancelReposition={handleCancelReposition}
+                  faceRecognitionEnabled={space.faceRecognitionEnabled}
+                  spaceId={space.id}
+                  onShowMembers={handleShowMembers}
                   collapsed={heroCollapsed}
                   onToggleCollapse={() => (heroCollapsed = !heroCollapsed)}
                 />

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -895,9 +895,6 @@
                   {repositioning}
                   onSavePosition={handleSavePosition}
                   onCancelReposition={handleCancelReposition}
-                  peopleCount={spacePeople.length}
-                  faceRecognitionEnabled={space.faceRecognitionEnabled}
-                  spaceId={space.id}
                   collapsed={heroCollapsed}
                   onToggleCollapse={() => (heroCollapsed = !heroCollapsed)}
                 />


### PR DESCRIPTION
## Summary
- Replace sequential DB queries with a single `GROUP BY` + `COUNT` query when loading people for a shared space (~10s → ~100ms for 11k people)
- Add `top` query parameter to limit people returned (strip loads top 10, FilterPanel loads all)
- Remove people count badge from space hero component

## Test plan
- [x] Server unit tests pass (22 tests in getSpacePeople block, including 4 new edge cases)
- [x] Web unit tests pass (hero tests updated, 6 people-count tests removed)
- [x] Open a space with many people — people strip shows top 10, loads fast
- [x] FilterPanel people section loads all named people
- [x] Hero no longer shows people count badge
- [x] People management page (`/spaces/[id]/people`) still shows all people with counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)