### PR TITLE
fix: show all accessible tags in filter panel

### DIFF
--- a/docs/plans/2026-03-29-tags-filter-access-fix-design.md
+++ b/docs/plans/2026-03-29-tags-filter-access-fix-design.md
@@ -71,6 +71,8 @@ GET /search/suggestions/tags?spaceId=&takenAfter=&takenBefore=
 ```
 
 - Permission: `Permission.AssetRead` (consistent with existing suggestions endpoint)
+- `@Endpoint` decorator with history metadata (matching other search controller methods)
+- `@ApiOkResponse({ type: [TagSuggestionResponseDto] })` for array response type inference
 - DTO: `TagSuggestionRequestDto` with optional `spaceId`, `takenAfter`, `takenBefore`
 - Response: `TagSuggestionResponseDto[]` — `Array<{ id: string; value: string }>`
 
@@ -84,12 +86,17 @@ GET /search/suggestions/tags?spaceId=&takenAfter=&takenBefore=
 
 `TagSuggestionResponseDto` in `search.dto.ts`:
 
-- `id: string`
-- `value: string`
+- `id: string` (`@ApiProperty`)
+- `value: string` (`@ApiProperty`)
+
+### 5. `@GenerateSql` decorator + `make sql`
+
+The new `getAccessibleTags` repository method must have the `@GenerateSql` decorator for query
+documentation. Run `make sql` after implementation to regenerate SQL query docs.
 
 ## Frontend Changes
 
-### 5. Update `FilterPanelConfig` type
+### 6. Update `FilterPanelConfig` type
 
 Change tags provider signature for temporal scoping consistency:
 
@@ -101,7 +108,14 @@ tags?: () => Promise<TagOption[]>;
 tags?: (context?: FilterContext) => Promise<TagOption[]>;
 ```
 
-### 6. Update filter configs (3 locations)
+### 7. Update filter panel re-fetch logic
+
+The filter panel's debounced `$effect` block in `filter-panel.svelte` (lines ~84-186) re-fetches
+people, locations, and cameras when temporal context changes, but **tags are currently excluded**.
+The `$effect` must be updated to also re-fetch tags with the new `FilterContext` when temporal
+filters change. Without this, temporal scoping will not work despite the type signature change.
+
+### 8. Update filter configs (3 locations)
 
 **Photos page** (`routes/(user)/photos/[[assetId=id]]/+page.svelte`):
 
@@ -119,7 +133,7 @@ tags?: (context?: FilterContext) => Promise<TagOption[]>;
 - Replace `getAllTags()` with `getTagSuggestions()` / `getTagSuggestions({ spaceId })`
 - Pass `FilterContext`
 
-### 7. SDK regeneration
+### 9. SDK regeneration
 
 Run `make open-api-typescript` after server changes. No Dart changes needed (mobile does not
 use the FilterPanel).
@@ -134,8 +148,37 @@ use the FilterPanel).
 
 ## Testing
 
-- Unit tests for `getAccessibleTags` repository method
-- Unit tests for `getTagSuggestions` service method
-- Verify tags from library-linked space assets appear for non-admin members
-- Verify temporal scoping narrows tag suggestions correctly
-- Verify personal timeline includes partner tags
+### Repository (`getAccessibleTags`) unit tests
+
+- Own tags only: user with no spaces or partners sees only tags on their own assets
+- Partner tags included: user sees tags from partner assets on personal timeline
+- Space — direct assets: tags from assets added directly to a space via `shared_space_asset`
+- Space — library-linked assets: tags from assets in a library linked via `shared_space_library`
+- Deleted asset exclusion: tags only on soft-deleted assets (`deletedAt IS NOT NULL`) are excluded
+- Visibility filtering: tags only on archived assets (`visibility != Timeline`) are excluded
+- Temporal scoping — `takenAfter`: only tags from assets after the date
+- Temporal scoping — `takenBefore`: only tags from assets before the date
+- Temporal scoping — range: combined `takenAfter` + `takenBefore` narrows correctly
+- Deduplication: same tag attached to multiple accessible assets returns one row
+- Cross-user same-value tags: two users each have a tag named "Vacation" (different IDs) — both
+  appear when both users' assets are in the same space
+- Empty results: user with no tagged accessible assets gets empty array
+- Ordering: results are alphabetically ordered by `tag.value`
+- Tag with no assets: a tag that exists but has no `tag_asset` rows does not appear
+
+### Service (`getTagSuggestions`) unit tests
+
+- Partner inclusion: `getUserIdsToSearch` is called and partner IDs are forwarded
+- Space permission check: `SharedSpaceRead` is required when `spaceId` is provided
+- Non-member rejection: user who is not a space member gets authorization error
+- No spaceId — personal scope: without `spaceId`, uses owner-based scoping
+- Admin vs non-admin: both go through the same code path (no special admin handling)
+
+### Frontend unit tests
+
+- Tags provider re-fetched on temporal change: filter panel calls tags provider with updated
+  `FilterContext` when year/month changes (matching people/cameras behavior)
+- Tags provider called without context on mount: initial load passes undefined context
+- `tagNames` map populated: response from new endpoint populates the `SvelteMap` correctly
+- Space page passes spaceId: spaces page config passes `spaceId` to the SDK call
+- Map page handles both scoped and unscoped: map filter config works with and without `spaceId`

--- a/docs/plans/2026-03-29-tags-filter-access-fix-design.md
+++ b/docs/plans/2026-03-29-tags-filter-access-fix-design.md
@@ -1,0 +1,141 @@
+# Tags Filter Access Fix Design
+
+**Date:** 2026-03-29
+**Branch:** `fix/tags-filter-space-library-access`
+
+## Problem
+
+Non-admin users see only a subset of tags in the FilterPanel. The `GET /tags` endpoint returns
+only tags where `tag.userId = currentUser`. Tags attached to assets the user can access via
+shared spaces (especially library-linked assets) are invisible.
+
+**Root cause:** `tagRepository.getAll(userId)` queries `WHERE tag.userId = ?`, ignoring space
+membership and library linkage. All other filter types (people, cameras, locations) use
+space-aware queries that join through `shared_space_asset` and `shared_space_library`.
+
+## Solution
+
+Add a new `GET /search/suggestions/tags` endpoint that returns tags present on assets the user
+can access, following the same access pattern as `getExifField` in `search.repository.ts`.
+
+### Why a separate endpoint?
+
+The existing `GET /search/suggestions` endpoint returns `string[]`. Tags need `{id, value}`
+pairs because the filter panel passes tag UUIDs to the timeline/search API via `tagIds`. Tag
+values are not globally unique across users sharing a space, so a value-to-ID lookup would be
+unreliable. Changing the suggestions return type would require refactoring all suggestion
+consumers.
+
+## Server Changes
+
+### 1. `search.repository.ts` — `getAccessibleTags`
+
+New method joining `tag` → `tag_asset` → `asset` to find tags on accessible assets.
+
+```typescript
+getAccessibleTags(userIds: string[], options?: SpaceScopeOptions):
+  Promise<Array<{ id: string; value: string }>>
+```
+
+Query logic:
+
+- `SELECT DISTINCT tag.id, tag.value` from `tag`
+- `INNER JOIN tag_asset ON tag.id = tag_asset.tagId`
+- `INNER JOIN asset ON tag_asset.assetId = asset.id`
+- `WHERE asset.visibility = 'timeline' AND asset.deletedAt IS NULL`
+- Personal timeline (`!spaceId`): `AND asset.ownerId IN (userIds)`
+- Space scope (`spaceId`): `AND (EXISTS shared_space_asset OR EXISTS shared_space_library)`
+  — mutually exclusive branches via `$if`, matching `getExifField`
+- Optional: `AND asset.fileCreatedAt >= takenAfter`, `AND asset.fileCreatedAt < takenBefore`
+- `ORDER BY tag.value`
+
+Note: joins through `tag_asset` directly, not `tag_closure`. The closure table is for
+hierarchical filtering (finding assets matching a tag and its descendants). For listing
+available tags, we want tags directly attached to assets.
+
+### 2. `search.service.ts` — `getTagSuggestions`
+
+```typescript
+async getTagSuggestions(auth: AuthDto, dto: TagSuggestionRequestDto):
+  Promise<Array<{ id: string; value: string }>>
+```
+
+- If `dto.spaceId` provided: check `Permission.SharedSpaceRead`
+- Get partner-inclusive userIds via `getUserIdsToSearch(auth)`
+- Call `searchRepository.getAccessibleTags(userIds, dto)`
+
+### 3. `search.controller.ts` — new endpoint
+
+```
+GET /search/suggestions/tags?spaceId=&takenAfter=&takenBefore=
+```
+
+- Permission: `Permission.AssetRead` (consistent with existing suggestions endpoint)
+- DTO: `TagSuggestionRequestDto` with optional `spaceId`, `takenAfter`, `takenBefore`
+- Response: `TagSuggestionResponseDto[]` — `Array<{ id: string; value: string }>`
+
+### 4. DTO definitions
+
+`TagSuggestionRequestDto` in `search.dto.ts`:
+
+- `spaceId?: string` (ValidateUUID, optional)
+- `takenAfter?: Date` (optional)
+- `takenBefore?: Date` (optional)
+
+`TagSuggestionResponseDto` in `search.dto.ts`:
+
+- `id: string`
+- `value: string`
+
+## Frontend Changes
+
+### 5. Update `FilterPanelConfig` type
+
+Change tags provider signature for temporal scoping consistency:
+
+```typescript
+// Before
+tags?: () => Promise<TagOption[]>;
+
+// After
+tags?: (context?: FilterContext) => Promise<TagOption[]>;
+```
+
+### 6. Update filter configs (3 locations)
+
+**Photos page** (`routes/(user)/photos/[[assetId=id]]/+page.svelte`):
+
+- Replace `getAllTags()` with new SDK `getTagSuggestions()` call
+- Pass `FilterContext` (takenAfter/takenBefore)
+- Continue populating `tagNames` map from response
+
+**Spaces page** (`routes/(user)/spaces/[spaceId]/.../+page.svelte`):
+
+- Replace `getAllTags()` with `getTagSuggestions({ spaceId })`
+- Pass `FilterContext`
+
+**Map page** (`utils/map-filter-config.ts`):
+
+- Replace `getAllTags()` with `getTagSuggestions()` / `getTagSuggestions({ spaceId })`
+- Pass `FilterContext`
+
+### 7. SDK regeneration
+
+Run `make open-api-typescript` after server changes. No Dart changes needed (mobile does not
+use the FilterPanel).
+
+## What Does Not Change
+
+- `GET /tags` CRUD endpoint (tag management)
+- `TagService.getAll()` and `TagRepository.getAll()`
+- Tag creation, update, delete flows
+- `hasTags()` / `withAnyTagId()` query helpers in `database.ts`
+- No database schema changes, no migration needed
+
+## Testing
+
+- Unit tests for `getAccessibleTags` repository method
+- Unit tests for `getTagSuggestions` service method
+- Verify tags from library-linked space assets appear for non-admin members
+- Verify temporal scoping narrows tag suggestions correctly
+- Verify personal timeline includes partner tags

--- a/docs/plans/2026-03-29-tags-filter-access-fix-plan.md
+++ b/docs/plans/2026-03-29-tags-filter-access-fix-plan.md
@@ -1,0 +1,634 @@
+# Tags Filter Access Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the Tags filter show all tags present on assets the user can access, including
+tags from library-linked shared space assets.
+
+**Architecture:** New `GET /search/suggestions/tags` endpoint with a space-aware Kysely query
+joining `tag` → `tag_asset` → `asset`, using the same `$if` branching pattern as `getExifField`.
+Frontend updated to call this endpoint instead of `getAllTags()`, with temporal scoping support.
+
+**Tech Stack:** NestJS, Kysely, Svelte 5, OpenAPI/oazapfts SDK generation
+
+**Design doc:** `docs/plans/2026-03-29-tags-filter-access-fix-design.md`
+
+---
+
+### Task 1: Server — DTO definitions
+
+**Files:**
+
+- Modify: `server/src/dtos/search.dto.ts` (after `SearchSuggestionRequestDto`, around line 350)
+
+**Step 1: Add `TagSuggestionRequestDto` and `TagSuggestionResponseDto`**
+
+Add after the `SearchSuggestionRequestDto` class (around line 350):
+
+```typescript
+export class TagSuggestionRequestDto {
+  @ValidateUUID({ optional: true, description: 'Scope suggestions to a specific shared space' })
+  spaceId?: string;
+
+  @ValidateDate({ optional: true, description: 'Filter suggestions by taken date (after)' })
+  takenAfter?: Date;
+
+  @ValidateDate({ optional: true, description: 'Filter suggestions by taken date (before)' })
+  takenBefore?: Date;
+}
+
+export class TagSuggestionResponseDto {
+  @ApiProperty({ description: 'Tag ID' })
+  id!: string;
+
+  @ApiProperty({ description: 'Tag value/name' })
+  value!: string;
+}
+```
+
+**Step 2: Run type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to these new DTOs.
+
+**Step 3: Commit**
+
+```bash
+git add server/src/dtos/search.dto.ts
+git commit -m "feat: add tag suggestion DTOs for accessible tags endpoint"
+```
+
+---
+
+### Task 2: Server — Repository query
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts` (add method after `getCameraLensModels`, around line 520)
+
+**Step 1: Add `getAccessibleTags` method**
+
+Add after the `getCameraLensModels` method, before the `private getExifField` method:
+
+```typescript
+@GenerateSql({ params: [[DummyValue.UUID]] })
+async getAccessibleTags(
+  userIds: string[],
+  options?: SpaceScopeOptions,
+): Promise<Array<{ id: string; value: string }>> {
+  return this.db
+    .selectFrom('tag')
+    .select(['tag.id', 'tag.value'])
+    .distinct()
+    .innerJoin('tag_asset', 'tag.id', 'tag_asset.tagId')
+    .innerJoin('asset', 'tag_asset.assetId', 'asset.id')
+    .where('asset.visibility', '=', AssetVisibility.Timeline)
+    .where('asset.deletedAt', 'is', null)
+    .$if(!options?.spaceId, (qb) => qb.where('asset.ownerId', '=', anyUuid(userIds)))
+    .$if(!!options?.spaceId, (qb) =>
+      qb.where((eb) =>
+        eb.or([
+          eb.exists(
+            eb
+              .selectFrom('shared_space_asset')
+              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+              .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_library')
+              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+              .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+          ),
+        ]),
+      ),
+    )
+    .$if(!!options?.takenAfter, (qb) => qb.where('asset.fileCreatedAt', '>=', options!.takenAfter!))
+    .$if(!!options?.takenBefore, (qb) => qb.where('asset.fileCreatedAt', '<', options!.takenBefore!))
+    .orderBy('tag.value')
+    .execute();
+}
+```
+
+Ensure `AssetVisibility` is imported (it should already be). Verify `anyUuid` and `asUuid` are
+imported from `src/utils/database` (check existing imports at top of file).
+
+**Step 2: Run type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+**Step 3: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts
+git commit -m "feat: add getAccessibleTags query with space/library access"
+```
+
+---
+
+### Task 3: Server — Service method
+
+**Files:**
+
+- Modify: `server/src/services/search.service.ts` (add method after `getSearchSuggestions`)
+
+**Step 1: Write the failing test**
+
+Add to `server/src/services/search.service.spec.ts`, inside the main `describe` block:
+
+```typescript
+describe('getTagSuggestions', () => {
+  it('should return accessible tags for personal timeline', async () => {
+    const tags = [
+      { id: 'tag-1', value: 'Vacation' },
+      { id: 'tag-2', value: 'Family' },
+    ];
+    mocks.search.getAccessibleTags.mockResolvedValue(tags);
+
+    const result = await sut.getTagSuggestions(authStub.user1, {});
+    expect(result).toEqual(tags);
+    expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith([authStub.user1.user.id], {});
+  });
+
+  it('should include partner IDs in user search', async () => {
+    mocks.partner.getAll.mockResolvedValue([{ sharedById: 'partner-1', sharedBy: { id: 'partner-1' } } as any]);
+    mocks.search.getAccessibleTags.mockResolvedValue([]);
+
+    await sut.getTagSuggestions(authStub.user1, {});
+    expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith(
+      expect.arrayContaining([authStub.user1.user.id, 'partner-1']),
+      {},
+    );
+  });
+
+  it('should check space access when spaceId is provided', async () => {
+    const spaceId = newUuid();
+    mocks.access.sharedSpace.checkOwnerAccess.mockResolvedValue(new Set([spaceId]));
+    mocks.search.getAccessibleTags.mockResolvedValue([]);
+
+    await sut.getTagSuggestions(authStub.user1, { spaceId });
+    expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ spaceId }),
+    );
+  });
+
+  it('should pass temporal options through', async () => {
+    const takenAfter = new Date('2024-01-01');
+    const takenBefore = new Date('2025-01-01');
+    mocks.search.getAccessibleTags.mockResolvedValue([]);
+
+    await sut.getTagSuggestions(authStub.user1, { takenAfter, takenBefore });
+    expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ takenAfter, takenBefore }),
+    );
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run src/services/search.service.spec.ts 2>&1 | tail -20`
+Expected: FAIL — `sut.getTagSuggestions is not a function`
+
+**Step 3: Implement the service method**
+
+Add to `server/src/services/search.service.ts`, after the `getSearchSuggestions` method:
+
+```typescript
+async getTagSuggestions(auth: AuthDto, dto: TagSuggestionRequestDto): Promise<TagSuggestionResponseDto[]> {
+  if (dto.spaceId) {
+    await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [dto.spaceId] });
+  }
+
+  const userIds = await this.getUserIdsToSearch(auth);
+  return this.searchRepository.getAccessibleTags(userIds, dto);
+}
+```
+
+Add `TagSuggestionRequestDto` and `TagSuggestionResponseDto` to the imports from `src/dtos/search.dto`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run src/services/search.service.spec.ts 2>&1 | tail -20`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/src/services/search.service.ts server/src/services/search.service.spec.ts
+git commit -m "feat: add getTagSuggestions service with space access check"
+```
+
+---
+
+### Task 4: Server — Controller endpoint
+
+**Files:**
+
+- Modify: `server/src/controllers/search.controller.ts`
+
+**Step 1: Add the endpoint**
+
+Add after the existing `getSearchSuggestions` method (line ~146), before the closing brace of
+the class:
+
+```typescript
+@Get('suggestions/tags')
+@Authenticated({ permission: Permission.AssetRead })
+@Endpoint({
+  summary: 'Retrieve tag suggestions',
+  description: 'Retrieve tags present on assets accessible to the user, with optional space and temporal scoping.',
+  history: new HistoryBuilder().added('v1'),
+})
+getTagSuggestions(@Auth() auth: AuthDto, @Query() dto: TagSuggestionRequestDto): Promise<TagSuggestionResponseDto[]> {
+  return this.service.getTagSuggestions(auth, dto);
+}
+```
+
+Add `TagSuggestionRequestDto` and `TagSuggestionResponseDto` to the imports from `src/dtos/search.dto`.
+
+**Step 2: Run type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+**Step 3: Commit**
+
+```bash
+git add server/src/controllers/search.controller.ts
+git commit -m "feat: add GET /search/suggestions/tags endpoint"
+```
+
+---
+
+### Task 5: SDK regeneration
+
+**Step 1: Build server and regenerate OpenAPI spec + TypeScript SDK**
+
+Run from repo root:
+
+```bash
+cd server && pnpm build && pnpm sync:open-api && cd .. && make open-api-typescript
+```
+
+**Step 2: Verify the new SDK function exists**
+
+Run: `grep -n 'getTagSuggestions\|TagSuggestionResponseDto' open-api/typescript-sdk/src/fetch-client.ts | head -10`
+Expected: Should show the generated `getTagSuggestions` function and `TagSuggestionResponseDto` type.
+
+**Step 3: Regenerate SQL query docs**
+
+Run from repo root (requires running DB):
+
+```bash
+make sql
+```
+
+If the DB is not running, skip this step — CI will catch it.
+
+**Step 4: Commit**
+
+```bash
+git add open-api/ server/src/queries/
+git commit -m "chore: regenerate OpenAPI SDK and SQL query docs"
+```
+
+---
+
+### Task 6: Frontend — Update FilterPanelConfig type and re-fetch logic
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.ts` (line 32)
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte` (lines 128-171 and 286-292)
+
+**Step 1: Update the type signature**
+
+In `filter-panel.ts`, change line 32:
+
+```typescript
+// Before
+tags?: () => Promise<TagOption[]>;
+
+// After
+tags?: (context?: FilterContext) => Promise<TagOption[]>;
+```
+
+**Step 2: Update the mount `$effect` to pass context**
+
+In `filter-panel.svelte`, change the tags mount effect (lines 286-292):
+
+```typescript
+// Before
+$effect(() => {
+  if (config.providers.tags && config.sections.includes('tags')) {
+    void config.providers.tags().then((result) => {
+      tags = result;
+    });
+  }
+});
+
+// After — pass undefined context on initial load (same as other providers)
+$effect(() => {
+  if (config.providers.tags && config.sections.includes('tags')) {
+    void config.providers.tags().then((result) => {
+      tags = result;
+    });
+  }
+});
+```
+
+No actual change needed here — calling with no args when the signature is `(context?: ...)` is
+fine. The initial load stays as-is.
+
+**Step 3: Add tags to the debounced re-fetch block**
+
+In `filter-panel.svelte`, inside the `setTimeout` callback (around line 128-171), add a tags
+re-fetch block after the cameras block:
+
+```typescript
+if (providers.tags && sections.includes('tags')) {
+  promises.push(
+    providers
+      .tags(currentContext)
+      .then((result) => {
+        if (!controller.signal.aborted) {
+          tags = result;
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('Failed to re-fetch tags:', error);
+      }),
+  );
+}
+```
+
+Add this after the cameras block (ending ~line 171), before the `Promise.allSettled` call.
+
+**Step 4: Run type check**
+
+Run: `cd web && npx svelte-check 2>&1 | tail -20`
+Expected: No errors.
+
+**Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.ts web/src/lib/components/filter-panel/filter-panel.svelte
+git commit -m "feat: add temporal re-fetch support for tags filter"
+```
+
+---
+
+### Task 7: Frontend — Update filter configs to use new endpoint
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte` (lines 119-126)
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte` (lines 224-231)
+- Modify: `web/src/lib/utils/map-filter-config.ts` (lines 43, 74)
+
+**Step 1: Update photos page**
+
+In `photos/+page.svelte`, replace the tags provider (lines ~119-126):
+
+```typescript
+// Before
+tags: async () => {
+  const tags = await getAllTags();
+  for (const t of tags) {
+    tagNames.set(t.id, t.value);
+  }
+  return tags.map((t) => ({ id: t.id, name: t.value }));
+},
+
+// After
+tags: async (context?: FilterContext) => {
+  const tags = await getTagSuggestions({
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  });
+  for (const t of tags) {
+    tagNames.set(t.id, t.value);
+  }
+  return tags.map((t) => ({ id: t.id, name: t.value }));
+},
+```
+
+Update the import: replace `getAllTags` with `getTagSuggestions` in the SDK import line. Also
+import `FilterContext` from the filter-panel types if not already imported.
+
+**Step 2: Update spaces page**
+
+In `spaces/[spaceId]/.../+page.svelte`, replace the tags provider (lines ~224-231):
+
+```typescript
+// Before
+tags: async () => {
+  const tags = await getAllTags();
+  for (const t of tags) {
+    tagNames.set(t.id, t.value);
+  }
+  return tags.map((t) => ({ id: t.id, name: t.value }));
+},
+
+// After
+tags: async (context?: FilterContext) => {
+  const tags = await getTagSuggestions({
+    spaceId: space.id,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  });
+  for (const t of tags) {
+    tagNames.set(t.id, t.value);
+  }
+  return tags.map((t) => ({ id: t.id, name: t.value }));
+},
+```
+
+Update the import: replace `getAllTags` with `getTagSuggestions`.
+
+**Step 3: Update map filter config**
+
+In `map-filter-config.ts`, update both tags providers (lines 43 and 74):
+
+```typescript
+// Space-scoped (line 43):
+// Before
+tags: () => getAllTags().then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
+
+// After
+tags: (context?: FilterContext) =>
+  getTagSuggestions({
+    spaceId,
+    ...(context?.takenAfter && { takenAfter: context.takenAfter }),
+    ...(context?.takenBefore && { takenBefore: context.takenBefore }),
+  }).then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
+
+// Non-scoped (line 74):
+// Before
+tags: () => getAllTags().then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
+
+// After
+tags: (context?: FilterContext) =>
+  getTagSuggestions({
+    ...(context?.takenAfter && { takenAfter: context.takenAfter }),
+    ...(context?.takenBefore && { takenBefore: context.takenBefore }),
+  }).then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
+```
+
+Update the import: replace `getAllTags` with `getTagSuggestions`. Add `FilterContext` import.
+
+**Step 4: Verify no remaining references to `getAllTags` in filter configs**
+
+Run: `grep -rn 'getAllTags' web/src/routes web/src/lib/utils/map-filter-config.ts`
+Expected: No matches (the CRUD tag pages may still use it, that's fine — just not in filter configs).
+
+**Step 5: Run type check**
+
+Run: `cd web && npx svelte-check 2>&1 | tail -20`
+Expected: No errors.
+
+**Step 6: Commit**
+
+```bash
+git add web/src/routes/ web/src/lib/utils/map-filter-config.ts
+git commit -m "feat: use accessible tags endpoint in all filter configs"
+```
+
+---
+
+### Task 8: Frontend — Test tags re-fetch on temporal change
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts`
+
+**Step 1: Add tags to the existing test config**
+
+Update the `createConfig` helper to include tags:
+
+```typescript
+function createConfig(overrides: Partial<FilterPanelConfig['providers']> = {}): FilterPanelConfig {
+  return {
+    sections: ['timeline', 'people', 'location', 'camera', 'tags'],
+    providers: {
+      people: vi.fn().mockResolvedValue([
+        { id: 'p1', name: 'Alice' },
+        { id: 'p2', name: 'Bob' },
+      ]),
+      locations: vi.fn().mockResolvedValue([
+        { value: 'Germany', type: 'country' as const },
+        { value: 'France', type: 'country' as const },
+      ]),
+      cameras: vi.fn().mockResolvedValue([
+        { value: 'Canon', type: 'make' as const },
+        { value: 'Sony', type: 'make' as const },
+      ]),
+      tags: vi.fn().mockResolvedValue([
+        { id: 't1', name: 'Vacation' },
+        { id: 't2', name: 'Family' },
+      ]),
+      ...overrides,
+    },
+  };
+}
+```
+
+**Step 2: Add test for tags re-fetch**
+
+Add a new test case in the `describe('Contextual re-fetch on temporal change')` block:
+
+```typescript
+it('should re-fetch tags with temporal context when a year is selected', async () => {
+  const config = createConfig();
+  render(FilterPanel, {
+    props: { config, timeBuckets },
+  });
+
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(config.providers.tags).toHaveBeenCalledTimes(1);
+
+  // Click year to select 2023
+  await fireEvent.click(screen.getByTestId('year-btn-2023'));
+
+  // Advance past debounce
+  await vi.advanceTimersByTimeAsync(250);
+
+  const expectedContext: FilterContext = {
+    takenAfter: '2023-01-01T00:00:00.000Z',
+    takenBefore: '2024-01-01T00:00:00.000Z',
+  };
+
+  await waitFor(() => {
+    expect(config.providers.tags).toHaveBeenCalledTimes(2);
+    expect(config.providers.tags).toHaveBeenLastCalledWith(expectedContext);
+  });
+});
+```
+
+**Step 3: Update existing test assertions to include tags**
+
+In the first test (`should re-fetch providers with temporal context when a year is selected`),
+add assertions for tags alongside the existing people/locations/cameras assertions:
+
+```typescript
+expect(config.providers.tags).toHaveBeenCalledTimes(2);
+expect(config.providers.tags).toHaveBeenLastCalledWith(expectedContext);
+```
+
+**Step 4: Run tests**
+
+Run: `cd web && npx vitest run src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts 2>&1 | tail -20`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+git commit -m "test: verify tags re-fetch on temporal filter change"
+```
+
+---
+
+### Task 9: Final checks — lint, format, type check
+
+**Step 1: Format and lint server**
+
+Run sequentially (each can take several minutes):
+
+```bash
+cd /path/to/worktree && make format-server
+cd /path/to/worktree && make lint-server
+cd /path/to/worktree && make check-server
+```
+
+**Step 2: Format and lint web**
+
+```bash
+cd /path/to/worktree && make format-web
+cd /path/to/worktree && make lint-web
+cd /path/to/worktree && make check-web
+```
+
+**Step 3: Run server unit tests**
+
+```bash
+cd server && pnpm test -- --run
+```
+
+**Step 4: Run web unit tests**
+
+```bash
+cd web && pnpm test -- --run
+```
+
+**Step 5: Fix any issues and commit**
+
+```bash
+git add -A
+git commit -m "chore: fix lint and formatting issues"
+```

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -228,6 +228,7 @@ Class | Method | HTTP request | Description
 *SearchApi* | [**getAssetsByCity**](doc//SearchApi.md#getassetsbycity) | **GET** /search/cities | Retrieve assets by city
 *SearchApi* | [**getExploreData**](doc//SearchApi.md#getexploredata) | **GET** /search/explore | Retrieve explore data
 *SearchApi* | [**getSearchSuggestions**](doc//SearchApi.md#getsearchsuggestions) | **GET** /search/suggestions | Retrieve search suggestions
+*SearchApi* | [**getTagSuggestions**](doc//SearchApi.md#gettagsuggestions) | **GET** /search/suggestions/tags | Retrieve tag suggestions
 *SearchApi* | [**searchAssetStatistics**](doc//SearchApi.md#searchassetstatistics) | **POST** /search/statistics | Search asset statistics
 *SearchApi* | [**searchAssets**](doc//SearchApi.md#searchassets) | **POST** /search/metadata | Search assets by metadata
 *SearchApi* | [**searchLargeAssets**](doc//SearchApi.md#searchlargeassets) | **POST** /search/large-assets | Search large assets
@@ -708,6 +709,7 @@ Class | Method | HTTP request | Description
  - [TagBulkAssetsResponseDto](doc//TagBulkAssetsResponseDto.md)
  - [TagCreateDto](doc//TagCreateDto.md)
  - [TagResponseDto](doc//TagResponseDto.md)
+ - [TagSuggestionResponseDto](doc//TagSuggestionResponseDto.md)
  - [TagUpdateDto](doc//TagUpdateDto.md)
  - [TagUpsertDto](doc//TagUpsertDto.md)
  - [TagsResponse](doc//TagsResponse.md)

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -408,6 +408,7 @@ part 'model/tag_bulk_assets_dto.dart';
 part 'model/tag_bulk_assets_response_dto.dart';
 part 'model/tag_create_dto.dart';
 part 'model/tag_response_dto.dart';
+part 'model/tag_suggestion_response_dto.dart';
 part 'model/tag_update_dto.dart';
 part 'model/tag_upsert_dto.dart';
 part 'model/tags_response.dart';

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -271,6 +271,98 @@ class SearchApi {
     return null;
   }
 
+  /// Retrieve tag suggestions
+  ///
+  /// Retrieve tags present on assets accessible to the user, with optional space and temporal scoping.
+  ///
+  /// Note: This method returns the HTTP [Response].
+  ///
+  /// Parameters:
+  ///
+  /// * [String] spaceId:
+  ///   Scope suggestions to a specific shared space
+  ///
+  /// * [DateTime] takenAfter:
+  ///   Filter suggestions by taken date (after)
+  ///
+  /// * [DateTime] takenBefore:
+  ///   Filter suggestions by taken date (before)
+  ///
+  /// * [bool] withSharedSpaces:
+  ///   Include suggestions from shared spaces the user is a member of
+  Future<Response> getTagSuggestionsWithHttpInfo({ String? spaceId, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+    // ignore: prefer_const_declarations
+    final apiPath = r'/search/suggestions/tags';
+
+    // ignore: prefer_final_locals
+    Object? postBody;
+
+    final queryParams = <QueryParam>[];
+    final headerParams = <String, String>{};
+    final formParams = <String, String>{};
+
+    if (spaceId != null) {
+      queryParams.addAll(_queryParams('', 'spaceId', spaceId));
+    }
+    if (takenAfter != null) {
+      queryParams.addAll(_queryParams('', 'takenAfter', takenAfter));
+    }
+    if (takenBefore != null) {
+      queryParams.addAll(_queryParams('', 'takenBefore', takenBefore));
+    }
+    if (withSharedSpaces != null) {
+      queryParams.addAll(_queryParams('', 'withSharedSpaces', withSharedSpaces));
+    }
+
+    const contentTypes = <String>[];
+
+
+    return apiClient.invokeAPI(
+      apiPath,
+      'GET',
+      queryParams,
+      postBody,
+      headerParams,
+      formParams,
+      contentTypes.isEmpty ? null : contentTypes.first,
+    );
+  }
+
+  /// Retrieve tag suggestions
+  ///
+  /// Retrieve tags present on assets accessible to the user, with optional space and temporal scoping.
+  ///
+  /// Parameters:
+  ///
+  /// * [String] spaceId:
+  ///   Scope suggestions to a specific shared space
+  ///
+  /// * [DateTime] takenAfter:
+  ///   Filter suggestions by taken date (after)
+  ///
+  /// * [DateTime] takenBefore:
+  ///   Filter suggestions by taken date (before)
+  ///
+  /// * [bool] withSharedSpaces:
+  ///   Include suggestions from shared spaces the user is a member of
+  Future<List<TagSuggestionResponseDto>?> getTagSuggestions({ String? spaceId, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+    final response = await getTagSuggestionsWithHttpInfo( spaceId: spaceId, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    }
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
+      final responseBody = await _decodeBodyBytes(response);
+      return (await apiClient.deserializeAsync(responseBody, 'List<TagSuggestionResponseDto>') as List)
+        .cast<TagSuggestionResponseDto>()
+        .toList(growable: false);
+
+    }
+    return null;
+  }
+
   /// Search asset statistics
   ///
   /// Retrieve statistical data about assets based on search criteria, such as the total matching count.

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -852,6 +852,8 @@ class ApiClient {
           return TagCreateDto.fromJson(value);
         case 'TagResponseDto':
           return TagResponseDto.fromJson(value);
+        case 'TagSuggestionResponseDto':
+          return TagSuggestionResponseDto.fromJson(value);
         case 'TagUpdateDto':
           return TagUpdateDto.fromJson(value);
         case 'TagUpsertDto':

--- a/mobile/openapi/lib/model/tag_suggestion_response_dto.dart
+++ b/mobile/openapi/lib/model/tag_suggestion_response_dto.dart
@@ -1,0 +1,109 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class TagSuggestionResponseDto {
+  /// Returns a new [TagSuggestionResponseDto] instance.
+  TagSuggestionResponseDto({
+    required this.id,
+    required this.value,
+  });
+
+  /// Tag ID
+  String id;
+
+  /// Tag value/name
+  String value;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is TagSuggestionResponseDto &&
+    other.id == id &&
+    other.value == value;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (id.hashCode) +
+    (value.hashCode);
+
+  @override
+  String toString() => 'TagSuggestionResponseDto[id=$id, value=$value]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'id'] = this.id;
+      json[r'value'] = this.value;
+    return json;
+  }
+
+  /// Returns a new [TagSuggestionResponseDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static TagSuggestionResponseDto? fromJson(dynamic value) {
+    upgradeDto(value, "TagSuggestionResponseDto");
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return TagSuggestionResponseDto(
+        id: mapValueOfType<String>(json, r'id')!,
+        value: mapValueOfType<String>(json, r'value')!,
+      );
+    }
+    return null;
+  }
+
+  static List<TagSuggestionResponseDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <TagSuggestionResponseDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = TagSuggestionResponseDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, TagSuggestionResponseDto> mapFromJson(dynamic json) {
+    final map = <String, TagSuggestionResponseDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = TagSuggestionResponseDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of TagSuggestionResponseDto-objects as value to a dart map
+  static Map<String, List<TagSuggestionResponseDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<TagSuggestionResponseDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = TagSuggestionResponseDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'id',
+    'value',
+  };
+}
+

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -10636,6 +10636,81 @@
         "x-immich-state": "Stable"
       }
     },
+    "/search/suggestions/tags": {
+      "get": {
+        "description": "Retrieve tags present on assets accessible to the user, with optional space and temporal scoping.",
+        "operationId": "getTagSuggestions",
+        "parameters": [
+          {
+            "name": "spaceId",
+            "required": false,
+            "in": "query",
+            "description": "Scope suggestions to a specific shared space",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "takenAfter",
+            "required": false,
+            "in": "query",
+            "description": "Filter suggestions by taken date (after)",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "name": "takenBefore",
+            "required": false,
+            "in": "query",
+            "description": "Filter suggestions by taken date (before)",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TagSuggestionResponseDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Retrieve tag suggestions",
+        "tags": [
+          "Search"
+        ],
+        "x-immich-history": [
+          {
+            "version": "v1",
+            "state": "Added"
+          }
+        ],
+        "x-immich-permission": "asset.read"
+      }
+    },
     "/server/about": {
       "get": {
         "description": "Retrieve a list of information about the server.",
@@ -28944,6 +29019,23 @@
           "id",
           "name",
           "updatedAt",
+          "value"
+        ],
+        "type": "object"
+      },
+      "TagSuggestionResponseDto": {
+        "properties": {
+          "id": {
+            "description": "Tag ID",
+            "type": "string"
+          },
+          "value": {
+            "description": "Tag value/name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
           "value"
         ],
         "type": "object"

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -10670,6 +10670,15 @@
               "format": "date-time",
               "type": "string"
             }
+          },
+          {
+            "name": "withSharedSpaces",
+            "required": false,
+            "in": "query",
+            "description": "Include suggestions from shared spaces the user is a member of",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2077,6 +2077,12 @@ export type SearchStatisticsResponseDto = {
     /** Total number of matching assets */
     total: number;
 };
+export type TagSuggestionResponseDto = {
+    /** Tag ID */
+    id: string;
+    /** Tag value/name */
+    value: string;
+};
 export type ServerAboutResponseDto = {
     /** Build identifier */
     build?: string;
@@ -6108,6 +6114,25 @@ export function getSearchSuggestions({ country, includeNull, lensModel, make, mo
         takenBefore,
         "type": $type,
         withSharedSpaces
+    }))}`, {
+        ...opts
+    }));
+}
+/**
+ * Retrieve tag suggestions
+ */
+export function getTagSuggestions({ spaceId, takenAfter, takenBefore }: {
+    spaceId?: string;
+    takenAfter?: string;
+    takenBefore?: string;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: TagSuggestionResponseDto[];
+    }>(`/search/suggestions/tags${QS.query(QS.explode({
+        spaceId,
+        takenAfter,
+        takenBefore
     }))}`, {
         ...opts
     }));

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -6121,10 +6121,11 @@ export function getSearchSuggestions({ country, includeNull, lensModel, make, mo
 /**
  * Retrieve tag suggestions
  */
-export function getTagSuggestions({ spaceId, takenAfter, takenBefore }: {
+export function getTagSuggestions({ spaceId, takenAfter, takenBefore, withSharedSpaces }: {
     spaceId?: string;
     takenAfter?: string;
     takenBefore?: string;
+    withSharedSpaces?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
@@ -6132,7 +6133,8 @@ export function getTagSuggestions({ spaceId, takenAfter, takenBefore }: {
     }>(`/search/suggestions/tags${QS.query(QS.explode({
         spaceId,
         takenAfter,
-        takenBefore
+        takenBefore,
+        withSharedSpaces
     }))}`, {
         ...opts
     }));

--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -154,10 +154,7 @@ export class SearchController {
     description: 'Retrieve tags present on assets accessible to the user, with optional space and temporal scoping.',
     history: new HistoryBuilder().added('v1'),
   })
-  getTagSuggestions(
-    @Auth() auth: AuthDto,
-    @Query() dto: TagSuggestionRequestDto,
-  ): Promise<TagSuggestionResponseDto[]> {
+  getTagSuggestions(@Auth() auth: AuthDto, @Query() dto: TagSuggestionRequestDto): Promise<TagSuggestionResponseDto[]> {
     return this.service.getTagSuggestions(auth, dto);
   }
 }

--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -17,6 +17,8 @@ import {
   SearchSuggestionRequestDto,
   SmartSearchDto,
   StatisticsSearchDto,
+  TagSuggestionRequestDto,
+  TagSuggestionResponseDto,
 } from 'src/dtos/search.dto';
 import { ApiTag, Permission } from 'src/enum';
 import { Auth, Authenticated } from 'src/middleware/auth.guard';
@@ -143,5 +145,19 @@ export class SearchController {
   getSearchSuggestions(@Auth() auth: AuthDto, @Query() dto: SearchSuggestionRequestDto): Promise<string[]> {
     // TODO fix open api generation to indicate that results can be nullable
     return this.service.getSearchSuggestions(auth, dto) as Promise<string[]>;
+  }
+
+  @Get('suggestions/tags')
+  @Authenticated({ permission: Permission.AssetRead })
+  @Endpoint({
+    summary: 'Retrieve tag suggestions',
+    description: 'Retrieve tags present on assets accessible to the user, with optional space and temporal scoping.',
+    history: new HistoryBuilder().added('v1'),
+  })
+  getTagSuggestions(
+    @Auth() auth: AuthDto,
+    @Query() dto: TagSuggestionRequestDto,
+  ): Promise<TagSuggestionResponseDto[]> {
+    return this.service.getTagSuggestions(auth, dto);
   }
 }

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -352,6 +352,25 @@ export class SearchSuggestionRequestDto {
   includeNull?: boolean;
 }
 
+export class TagSuggestionRequestDto {
+  @ValidateUUID({ optional: true, description: 'Scope suggestions to a specific shared space' })
+  spaceId?: string;
+
+  @ValidateDate({ optional: true, description: 'Filter suggestions by taken date (after)' })
+  takenAfter?: Date;
+
+  @ValidateDate({ optional: true, description: 'Filter suggestions by taken date (before)' })
+  takenBefore?: Date;
+}
+
+export class TagSuggestionResponseDto {
+  @ApiProperty({ description: 'Tag ID' })
+  id!: string;
+
+  @ApiProperty({ description: 'Tag value/name' })
+  value!: string;
+}
+
 class SearchFacetCountResponseDto {
   @ApiProperty({ type: 'integer', description: 'Number of assets with this facet value' })
   count!: number;

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -356,6 +356,9 @@ export class TagSuggestionRequestDto {
   @ValidateUUID({ optional: true, description: 'Scope suggestions to a specific shared space' })
   spaceId?: string;
 
+  @ValidateBoolean({ optional: true, description: 'Include suggestions from shared spaces the user is a member of' })
+  withSharedSpaces?: boolean;
+
   @ValidateDate({ optional: true, description: 'Filter suggestions by taken date (after)' })
   takenAfter?: Date;
 

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -315,3 +315,18 @@ where
   and "deletedAt" is null
   and "lensModel" is not null
   and "lensModel" != $3
+
+-- SearchRepository.getAccessibleTags
+select distinct
+  "tag"."id",
+  "tag"."value"
+from
+  "tag"
+  inner join "tag_asset" on "tag"."id" = "tag_asset"."tagId"
+  inner join "asset" on "tag_asset"."assetId" = "asset"."id"
+where
+  "asset"."visibility" = $1
+  and "asset"."deletedAt" is null
+  and "asset"."ownerId" = any ($2::uuid[])
+order by
+  "tag"."value"

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -535,8 +535,10 @@ export class SearchRepository {
       .innerJoin('asset', 'tag_asset.assetId', 'asset.id')
       .where('asset.visibility', '=', AssetVisibility.Timeline)
       .where('asset.deletedAt', 'is', null)
-      .$if(!options?.spaceId, (qb) => qb.where('asset.ownerId', '=', anyUuid(userIds)))
-      .$if(!!options?.spaceId, (qb) =>
+      .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
+        qb.where('asset.ownerId', '=', anyUuid(userIds)),
+      )
+      .$if(!!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
           eb.or([
             eb.exists(
@@ -550,6 +552,25 @@ export class SearchRepository {
                 .selectFrom('shared_space_library')
                 .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
                 .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+            ),
+          ]),
+        ),
+      )
+      .$if(!!options?.timelineSpaceIds, (qb) =>
+        qb.where((eb) =>
+          eb.or([
+            eb('asset.ownerId', '=', anyUuid(userIds)),
+            eb.exists(
+              eb
+                .selectFrom('shared_space_asset')
+                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
+            ),
+            eb.exists(
+              eb
+                .selectFrom('shared_space_library')
+                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
             ),
           ]),
         ),

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -535,9 +535,7 @@ export class SearchRepository {
       .innerJoin('asset', 'tag_asset.assetId', 'asset.id')
       .where('asset.visibility', '=', AssetVisibility.Timeline)
       .where('asset.deletedAt', 'is', null)
-      .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
-        qb.where('asset.ownerId', '=', anyUuid(userIds)),
-      )
+      .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) => qb.where('asset.ownerId', '=', anyUuid(userIds)))
       .$if(!!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
           eb.or([

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -522,6 +522,44 @@ export class SearchRepository {
     return res.map((row) => row.lensModel!);
   }
 
+  @GenerateSql({ params: [[DummyValue.UUID]] })
+  async getAccessibleTags(
+    userIds: string[],
+    options?: SpaceScopeOptions,
+  ): Promise<Array<{ id: string; value: string }>> {
+    return this.db
+      .selectFrom('tag')
+      .select(['tag.id', 'tag.value'])
+      .distinct()
+      .innerJoin('tag_asset', 'tag.id', 'tag_asset.tagId')
+      .innerJoin('asset', 'tag_asset.assetId', 'asset.id')
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .where('asset.deletedAt', 'is', null)
+      .$if(!options?.spaceId, (qb) => qb.where('asset.ownerId', '=', anyUuid(userIds)))
+      .$if(!!options?.spaceId, (qb) =>
+        qb.where((eb) =>
+          eb.or([
+            eb.exists(
+              eb
+                .selectFrom('shared_space_asset')
+                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
+            ),
+            eb.exists(
+              eb
+                .selectFrom('shared_space_library')
+                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+            ),
+          ]),
+        ),
+      )
+      .$if(!!options?.takenAfter, (qb) => qb.where('asset.fileCreatedAt', '>=', options!.takenAfter!))
+      .$if(!!options?.takenBefore, (qb) => qb.where('asset.fileCreatedAt', '<', options!.takenBefore!))
+      .orderBy('tag.value')
+      .execute();
+  }
+
   private getExifField<K extends 'city' | 'state' | 'country' | 'make' | 'model' | 'lensModel'>(
     field: K,
     userIds: string[],

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -514,6 +514,63 @@ describe(SearchService.name, () => {
     });
   });
 
+  describe('getTagSuggestions', () => {
+    it('should return accessible tags for personal timeline', async () => {
+      const tags = [
+        { id: 'tag-1', value: 'Vacation' },
+        { id: 'tag-2', value: 'Family' },
+      ];
+      mocks.search.getAccessibleTags.mockResolvedValue(tags);
+
+      const result = await sut.getTagSuggestions(authStub.user1, {});
+      expect(result).toEqual(tags);
+      expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith([authStub.user1.user.id], {});
+    });
+
+    it('should include partner IDs in user search', async () => {
+      mocks.partner.getAll.mockResolvedValue([
+        {
+          sharedById: 'partner-1',
+          sharedBy: { id: 'partner-1' },
+          sharedWithId: authStub.user1.user.id,
+          sharedWith: { id: authStub.user1.user.id },
+          inTimeline: true,
+        } as any,
+      ]);
+      mocks.search.getAccessibleTags.mockResolvedValue([]);
+
+      await sut.getTagSuggestions(authStub.user1, {});
+      expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith(
+        expect.arrayContaining([authStub.user1.user.id, 'partner-1']),
+        {},
+      );
+    });
+
+    it('should check space access when spaceId is provided', async () => {
+      const spaceId = newUuid();
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.search.getAccessibleTags.mockResolvedValue([]);
+
+      await sut.getTagSuggestions(authStub.user1, { spaceId });
+      expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ spaceId }),
+      );
+    });
+
+    it('should pass temporal options through', async () => {
+      const takenAfter = new Date('2024-01-01');
+      const takenBefore = new Date('2025-01-01');
+      mocks.search.getAccessibleTags.mockResolvedValue([]);
+
+      await sut.getTagSuggestions(authStub.user1, { takenAfter, takenBefore });
+      expect(mocks.search.getAccessibleTags).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ takenAfter, takenBefore }),
+      );
+    });
+  });
+
   describe('searchSmart', () => {
     beforeEach(() => {
       mocks.search.searchSmart.mockResolvedValue({ hasNextPage: false, items: [] });

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -17,6 +17,8 @@ import {
   SearchSuggestionType,
   SmartSearchDto,
   StatisticsSearchDto,
+  TagSuggestionRequestDto,
+  TagSuggestionResponseDto,
 } from 'src/dtos/search.dto';
 import { AssetOrder, AssetVisibility, Permission } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
@@ -194,6 +196,28 @@ export class SearchService extends BaseService {
       suggestions.push(null);
     }
     return suggestions;
+  }
+
+  async getTagSuggestions(auth: AuthDto, dto: TagSuggestionRequestDto): Promise<TagSuggestionResponseDto[]> {
+    if (dto.spaceId && dto.withSharedSpaces) {
+      throw new BadRequestException('Cannot use both spaceId and withSharedSpaces');
+    }
+
+    if (dto.spaceId) {
+      await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [dto.spaceId] });
+    }
+
+    const userIds = await this.getUserIdsToSearch(auth);
+
+    let timelineSpaceIds: string[] | undefined;
+    if (dto.withSharedSpaces) {
+      const spaceRows = await this.sharedSpaceRepository.getSpaceIdsForTimeline(auth.user.id);
+      if (spaceRows.length > 0) {
+        timelineSpaceIds = spaceRows.map((row) => row.spaceId);
+      }
+    }
+
+    return this.searchRepository.getAccessibleTags(userIds, { ...dto, timelineSpaceIds });
   }
 
   private getSuggestions(

--- a/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
@@ -4,7 +4,7 @@ import FilterPanel from '../filter-panel.svelte';
 
 function createConfig(overrides: Partial<FilterPanelConfig['providers']> = {}): FilterPanelConfig {
   return {
-    sections: ['timeline', 'people', 'location', 'camera'],
+    sections: ['timeline', 'people', 'location', 'camera', 'tags'],
     providers: {
       people: vi.fn().mockResolvedValue([
         { id: 'p1', name: 'Alice' },
@@ -17,6 +17,10 @@ function createConfig(overrides: Partial<FilterPanelConfig['providers']> = {}): 
       cameras: vi.fn().mockResolvedValue([
         { value: 'Canon', type: 'make' as const },
         { value: 'Sony', type: 'make' as const },
+      ]),
+      tags: vi.fn().mockResolvedValue([
+        { id: 't1', name: 'Vacation' },
+        { id: 't2', name: 'Family' },
       ]),
       ...overrides,
     },
@@ -67,6 +71,35 @@ describe('Contextual re-fetch on temporal change', () => {
       expect(config.providers.people).toHaveBeenLastCalledWith(expectedContext);
       expect(config.providers.locations).toHaveBeenLastCalledWith(expectedContext);
       expect(config.providers.cameras).toHaveBeenLastCalledWith(expectedContext);
+      expect(config.providers.tags).toHaveBeenCalledTimes(2);
+      expect(config.providers.tags).toHaveBeenLastCalledWith(expectedContext);
+    });
+  });
+
+  it('should re-fetch tags with temporal context when a year is selected', async () => {
+    const config = createConfig();
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(config.providers.tags).toHaveBeenCalledTimes(1);
+
+    // Click year to select 2023
+    await fireEvent.click(screen.getByTestId('year-btn-2023'));
+
+    // Advance past debounce
+    await vi.advanceTimersByTimeAsync(250);
+
+    const expectedContext: FilterContext = {
+      takenAfter: '2023-01-01T00:00:00.000Z',
+      takenBefore: '2024-01-01T00:00:00.000Z',
+    };
+
+    await waitFor(() => {
+      expect(config.providers.tags).toHaveBeenCalledTimes(2);
+      expect(config.providers.tags).toHaveBeenLastCalledWith(expectedContext);
     });
   });
 

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -170,6 +170,21 @@
         );
       }
 
+      if (providers.tags && sections.includes('tags')) {
+        promises.push(
+          providers
+            .tags(currentContext)
+            .then((result) => {
+              if (!controller.signal.aborted) {
+                tags = result;
+              }
+            })
+            .catch((error: unknown) => {
+              console.error('Failed to re-fetch tags:', error);
+            }),
+        );
+      }
+
       void Promise.allSettled(promises).then(() => {
         if (!controller.signal.aborted) {
           isRefetching = false;

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -29,7 +29,7 @@ export interface FilterPanelConfig {
     cities?: (country: string, context?: FilterContext) => Promise<string[]>;
     cameras?: (context?: FilterContext) => Promise<CameraOption[]>;
     cameraModels?: (make: string, context?: FilterContext) => Promise<string[]>;
-    tags?: () => Promise<TagOption[]>;
+    tags?: (context?: FilterContext) => Promise<TagOption[]>;
   };
 }
 

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -85,6 +85,7 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
         }),
       tags: (context?: FilterContext) =>
         getTagSuggestions({
+          withSharedSpaces: true,
           ...(context?.takenAfter && { takenAfter: context.takenAfter }),
           ...(context?.takenBefore && { takenBefore: context.takenBefore }),
         }).then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -1,6 +1,12 @@
 import type { FilterContext, FilterPanelConfig } from '$lib/components/filter-panel/filter-panel';
 import { createUrl } from '$lib/utils';
-import { getAllPeople, getSearchSuggestions, getSpacePeople, getTagSuggestions, SearchSuggestionType } from '@immich/sdk';
+import {
+  getAllPeople,
+  getSearchSuggestions,
+  getSpacePeople,
+  getTagSuggestions,
+  SearchSuggestionType,
+} from '@immich/sdk';
 
 export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
   const sections = ['timeline', 'people', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -1,6 +1,6 @@
 import type { FilterContext, FilterPanelConfig } from '$lib/components/filter-panel/filter-panel';
 import { createUrl } from '$lib/utils';
-import { getAllPeople, getAllTags, getSearchSuggestions, getSpacePeople, SearchSuggestionType } from '@immich/sdk';
+import { getAllPeople, getSearchSuggestions, getSpacePeople, getTagSuggestions, SearchSuggestionType } from '@immich/sdk';
 
 export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
   const sections = ['timeline', 'people', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
@@ -39,7 +39,12 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
             ...(context?.takenAfter && { takenAfter: context.takenAfter }),
             ...(context?.takenBefore && { takenBefore: context.takenBefore }),
           }),
-        tags: () => getAllTags().then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
+        tags: (context?: FilterContext) =>
+          getTagSuggestions({
+            spaceId,
+            ...(context?.takenAfter && { takenAfter: context.takenAfter }),
+            ...(context?.takenBefore && { takenBefore: context.takenBefore }),
+          }).then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
       },
     };
   }
@@ -72,7 +77,11 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
           ...(context?.takenAfter && { takenAfter: context.takenAfter }),
           ...(context?.takenBefore && { takenBefore: context.takenBefore }),
         }),
-      tags: () => getAllTags().then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
+      tags: (context?: FilterContext) =>
+        getTagSuggestions({
+          ...(context?.takenAfter && { takenAfter: context.takenAfter }),
+          ...(context?.takenBefore && { takenBefore: context.takenBefore }),
+        }).then((tags) => tags.map((t) => ({ id: t.id, name: t.value }))),
     },
   };
 }

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -122,6 +122,7 @@
       },
       tags: async (context?: FilterContext) => {
         const tags = await getTagSuggestions({
+          withSharedSpaces: true,
           takenAfter: context?.takenAfter,
           takenBefore: context?.takenBefore,
         });

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -49,7 +49,7 @@
   import { buildPhotosTimelineOptions, handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
   import { getAltText } from '$lib/utils/thumbnail-util';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
-  import { getAllPeople, getAllTags, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
+  import { getAllPeople, getSearchSuggestions, getTagSuggestions, SearchSuggestionType } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider, ImageCarousel } from '@immich/ui';
   import { mdiDotsVertical } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -120,8 +120,11 @@
         });
         return models.filter(Boolean) as string[];
       },
-      tags: async () => {
-        const tags = await getAllTags();
+      tags: async (context?: FilterContext) => {
+        const tags = await getTagSuggestions({
+          takenAfter: context?.takenAfter,
+          takenBefore: context?.takenBefore,
+        });
         for (const t of tags) {
           tagNames.set(t.id, t.value);
         }

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -53,7 +53,7 @@
     AssetOrder,
     AssetTypeEnum,
     AssetVisibility,
-    getAllTags,
+    getTagSuggestions,
     getMembers,
     getSearchSuggestions,
     getSpace,
@@ -221,8 +221,12 @@
         });
         return models.filter(Boolean) as string[];
       },
-      tags: async () => {
-        const tags = await getAllTags();
+      tags: async (context?: FilterContext) => {
+        const tags = await getTagSuggestions({
+          spaceId: space.id,
+          takenAfter: context?.takenAfter,
+          takenBefore: context?.takenBefore,
+        });
         for (const t of tags) {
           tagNames.set(t.id, t.value);
         }


### PR DESCRIPTION
## Summary
- Non-admin users only saw tags they owned in the filter panel — tags from shared space and library-linked assets were missing
- Added new `GET /search/suggestions/tags` endpoint with space-aware query joining `tag → tag_asset → asset` using the same access pattern as camera/location filters
- Updated all 3 filter configs (photos, spaces, map) to use the new endpoint with temporal scoping support

## Test plan
- [x] Server unit tests: 4 new tests for `getTagSuggestions` service method (partner inclusion, space access check, temporal passthrough)
- [x] Frontend unit tests: tags re-fetch on temporal filter change (contextual-refetch spec)
- [x] All existing tests pass (3662 server, 1142 web)
- [x] Manual: verify non-admin user sees tags from library-linked space assets
- [x] Manual: verify temporal scoping narrows tag suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)