### PR TITLE
fix: include shared space content in filter suggestions

### DIFF
--- a/docs/plans/2026-03-29-filter-suggestions-shared-spaces-design.md
+++ b/docs/plans/2026-03-29-filter-suggestions-shared-spaces-design.md
@@ -1,0 +1,125 @@
+# Filter Suggestions for Shared Space Content
+
+## Problem
+
+When a non-admin user opens the Photos or Map view, the Location and Camera filter panels show empty
+("No locations found", "No cameras found") even though photos from shared spaces are visible in the timeline.
+
+The timeline includes space content via `withSharedSpaces: true`, but the filter suggestion endpoints
+(`getSearchSuggestions`) only query by `ownerId IN (user, partners)` — completely ignoring shared space membership.
+
+## Scope
+
+**In scope:** Location (country, state, city) and Camera (make, model, lens) filter suggestions.
+
+**Out of scope:** People filter suggestions — space people and user people live in different tables
+(`shared_space_person` vs `person`) with no dedup key. This needs a separate design for cross-table
+person deduplication.
+
+## Affected Pages
+
+- **Photos** (`/photos`) — FilterPanel providers call `getSearchSuggestions()` without space context
+- **Map** (`/map`, non-space branch) — `buildMapFilterConfig()` calls `getSearchSuggestions()` without
+  space context
+
+Space-specific views already work correctly because they pass `spaceId` explicitly.
+
+## Design
+
+### 1. DTO Change
+
+Add `withSharedSpaces?: boolean` to `SearchSuggestionRequestDto`:
+
+```typescript
+@ValidateBoolean({ optional: true, description: 'Include suggestions from shared spaces' })
+withSharedSpaces?: boolean;
+```
+
+Mutually exclusive with `spaceId` — reject requests that set both. Space views pass `spaceId`, timeline
+views pass `withSharedSpaces`.
+
+### 2. Service Change (`SearchService.getSearchSuggestions`)
+
+When `withSharedSpaces` is true:
+
+1. Fetch user's timeline space IDs via `sharedSpaceRepository.getSpaceIdsForTimeline(auth.user.id)`
+2. If any spaces found, pass `timelineSpaceIds` array to repository methods
+3. If no spaces, fall through to existing owner-only behavior
+
+This mirrors the pattern in `TimelineService.getTimeBucketOptions()` (lines 60-65).
+
+### 3. Repository Change (`SearchRepository.getExifField`)
+
+Add `timelineSpaceIds?: string[]` to `SpaceScopeOptions`. The query gains a third branch:
+
+- **No space context** (`!spaceId && !timelineSpaceIds`): existing `WHERE ownerId IN (userIds)` filter
+- **Single space** (`spaceId` set): existing space asset/library subquery filter
+- **Timeline spaces** (`timelineSpaceIds` set): `WHERE ownerId IN (userIds) OR` space asset/library
+  subquery matching any of `timelineSpaceIds`
+
+The timeline branch uses `OR` so users see both their own content and space content, matching how the
+timeline itself works. `DISTINCT ON(field)` naturally deduplicates string values (e.g., "Germany"
+appears once regardless of source).
+
+### 4. Frontend Changes
+
+**Photos page** (`+page.svelte`) — add `withSharedSpaces: true` to all suggestion provider calls:
+`locations`, `cities`, `states`, `cameras`, `cameraModels`, `lensModels`.
+
+**Map filter config** (`map-filter-config.ts`) — add `withSharedSpaces: true` to the non-space branch
+providers: `cameras`, `cameraModels`.
+
+### 5. Generated Files
+
+- OpenAPI spec regeneration (new DTO field)
+- TypeScript SDK regeneration
+- Dart SDK regeneration
+- SQL query documentation
+
+## Edge Cases
+
+- **User with no spaces**: `getSpaceIdsForTimeline` returns empty, `timelineSpaceIds` stays undefined,
+  query falls back to owner-only. No change in behavior.
+- **Admin users**: Same logic applies — admins who are space members see space content in suggestions.
+- **`showInTimeline` flag**: `getSpaceIdsForTimeline` already filters by `showInTimeline = true`, so
+  spaces hidden from timeline are excluded from suggestions.
+- **Overlapping content**: An asset owned by the user that is also in a space produces the same EXIF
+  value — `DISTINCT ON` collapses it to one suggestion.
+
+## Testing
+
+**Unit tests (server)**:
+
+- `SearchService.getSearchSuggestions` with `withSharedSpaces: true` verifies space IDs are fetched and
+  passed to repository
+- `SearchService.getSearchSuggestions` rejects `spaceId` + `withSharedSpaces` combination
+- Repository-level tests for `getExifField` with `timelineSpaceIds`
+
+**Unit tests (web)**:
+
+- Photos page filter config passes `withSharedSpaces: true`
+- Map filter config passes `withSharedSpaces: true` when no `spaceId`
+
+**E2E tests**:
+
+- Non-admin user with space membership sees Location suggestions from space content on Photos page
+- Non-admin user with space membership sees Camera suggestions from space content on Photos page
+
+## Files to Modify
+
+**Server:**
+
+- `server/src/dtos/search.dto.ts` — add `withSharedSpaces` to `SearchSuggestionRequestDto`
+- `server/src/services/search.service.ts` — resolve space IDs, pass to repository
+- `server/src/repositories/search.repository.ts` — `SpaceScopeOptions` + `getExifField` multi-space
+  branch
+
+**Web:**
+
+- `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte` — add `withSharedSpaces: true` to
+  providers
+- `web/src/lib/utils/map-filter-config.ts` — add `withSharedSpaces: true` to non-space providers
+
+**Generated:**
+
+- OpenAPI spec, TypeScript SDK, Dart SDK, SQL query docs

--- a/docs/plans/2026-03-29-filter-suggestions-shared-spaces-design.md
+++ b/docs/plans/2026-03-29-filter-suggestions-shared-spaces-design.md
@@ -46,7 +46,11 @@ When `withSharedSpaces` is true:
 2. If any spaces found, pass `timelineSpaceIds` array to repository methods
 3. If no spaces, fall through to existing owner-only behavior
 
-This mirrors the pattern in `TimelineService.getTimeBucketOptions()` (lines 60-65).
+This mirrors the pattern in `TimelineService.getTimeBucketOptions()`.
+
+Note: `getSuggestions()` currently passes the full DTO to repository methods. The service must translate
+`withSharedSpaces` into `timelineSpaceIds` on the options object before passing to the repository, since
+the repository expects `SpaceScopeOptions` (not the DTO directly).
 
 ### 3. Repository Change (`SearchRepository.getExifField`)
 
@@ -64,7 +68,7 @@ appears once regardless of source).
 ### 4. Frontend Changes
 
 **Photos page** (`+page.svelte`) — add `withSharedSpaces: true` to all suggestion provider calls:
-`locations`, `cities`, `states`, `cameras`, `cameraModels`, `lensModels`.
+`locations`, `cities`, `cameras`, `cameraModels`.
 
 **Map filter config** (`map-filter-config.ts`) — add `withSharedSpaces: true` to the non-space branch
 providers: `cameras`, `cameraModels`.
@@ -92,6 +96,8 @@ providers: `cameras`, `cameraModels`.
 
 - `SearchService.getSearchSuggestions` with `withSharedSpaces: true` verifies space IDs are fetched and
   passed to repository
+- `SearchService.getSearchSuggestions` with `withSharedSpaces` absent preserves existing owner-only
+  behavior (regression)
 - `SearchService.getSearchSuggestions` rejects `spaceId` + `withSharedSpaces` combination
 - Repository-level tests for `getExifField` with `timelineSpaceIds`
 
@@ -104,6 +110,8 @@ providers: `cameras`, `cameraModels`.
 
 - Non-admin user with space membership sees Location suggestions from space content on Photos page
 - Non-admin user with space membership sees Camera suggestions from space content on Photos page
+- Non-admin user with space membership sees Camera suggestions from space content on Map page
+- Cascading filter: selecting a country returns cities from space content with `withSharedSpaces`
 
 ## Files to Modify
 

--- a/docs/plans/2026-03-29-filter-suggestions-shared-spaces-plan.md
+++ b/docs/plans/2026-03-29-filter-suggestions-shared-spaces-plan.md
@@ -181,7 +181,7 @@ it('should fall back to owner-only when withSharedSpaces is true but user has no
   expect(result).toEqual(['USA']);
   expect(mocks.search.getCountries).toHaveBeenCalledWith(
     [authStub.user1.user.id],
-    expect.not.objectContaining({ timelineSpaceIds: expect.anything() }),
+    expect.objectContaining({ timelineSpaceIds: undefined }),
   );
 });
 
@@ -193,6 +193,33 @@ it('should preserve existing behavior when withSharedSpaces is absent', async ()
   });
 
   expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
+});
+
+it('should preserve existing behavior when withSharedSpaces is explicitly false', async () => {
+  mocks.search.getCountries.mockResolvedValue(['USA']);
+
+  await sut.getSearchSuggestions(authStub.user1, {
+    type: SearchSuggestionType.COUNTRY,
+    withSharedSpaces: false,
+  });
+
+  expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
+});
+
+it('should pass timelineSpaceIds through to camera make suggestions', async () => {
+  const spaceId1 = newUuid();
+  mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId: spaceId1 }]);
+  mocks.search.getCameraMakes.mockResolvedValue(['Nikon']);
+
+  await sut.getSearchSuggestions(authStub.user1, {
+    type: SearchSuggestionType.CAMERA_MAKE,
+    withSharedSpaces: true,
+  });
+
+  expect(mocks.search.getCameraMakes).toHaveBeenCalledWith(
+    [authStub.user1.user.id],
+    expect.objectContaining({ timelineSpaceIds: [spaceId1] }),
+  );
 });
 ```
 
@@ -281,7 +308,48 @@ feat: add withSharedSpaces to search suggestions endpoint
 
 ---
 
-### Task 3: Update Photos page filter providers
+### Task 3: Regenerate OpenAPI specs and SDK
+
+This must happen before frontend tasks so `withSharedSpaces` is available in the TypeScript SDK types.
+
+**Files:**
+
+- Generated: `open-api/immich-openapi-specs.json`, `open-api/typescript-sdk/`, `mobile/openapi/`
+
+**Step 1: Build server**
+
+Run: `cd server && pnpm build`
+Expected: Build succeeds
+
+**Step 2: Regenerate OpenAPI spec**
+
+Run: `cd server && pnpm sync:open-api`
+Expected: `open-api/immich-openapi-specs.json` updated with new `withSharedSpaces` parameter on search suggestions endpoint
+
+**Step 3: Regenerate TypeScript SDK**
+
+Run: `make open-api-typescript`
+Expected: TypeScript SDK updated — `getSearchSuggestions` function now accepts `withSharedSpaces` parameter
+
+**Step 4: Regenerate Dart SDK**
+
+Run: `make open-api-dart`
+Expected: Dart client updated (requires Java installed)
+
+**Step 5: Regenerate SQL query docs**
+
+Run: `make sql`
+Expected: SQL documentation updated with new query variants
+
+**Step 6: Commit**
+
+```
+chore: regenerate OpenAPI specs and SDK for withSharedSpaces
+```
+
+---
+
+### Task 4: Update Photos page filter providers
 
 **Files:**
 
@@ -335,9 +403,7 @@ cameraModels: async (make: string, context?: FilterContext) => {
 **Step 2: Run web tests**
 
 Run: `cd web && pnpm test -- --run`
-Expected: PASS (no existing tests for these provider calls; the SDK type will only be available after codegen in Task 5)
-
-Note: This step may fail with a type error until the SDK is regenerated. If so, proceed to Task 4 and Task 5, then come back to verify.
+Expected: PASS (SDK was regenerated in Task 3, so `withSharedSpaces` is a valid type)
 
 **Step 3: Commit**
 
@@ -347,7 +413,7 @@ feat(web): pass withSharedSpaces to Photos page filter providers
 
 ---
 
-### Task 4: Update Map page filter providers
+### Task 5: Update Map page filter providers
 
 **Files:**
 
@@ -359,7 +425,7 @@ feat(web): pass withSharedSpaces to Photos page filter providers
 In `web/src/lib/utils/__tests__/map-filter-config.spec.ts`, add a new test:
 
 ```typescript
-it('should pass withSharedSpaces to camera providers when no spaceId', async () => {
+it('should pass withSharedSpaces to cameras provider when no spaceId', async () => {
   vi.mocked(getSearchSuggestions).mockResolvedValue(['Nikon'] as never);
 
   const config = buildMapFilterConfig();
@@ -367,11 +433,24 @@ it('should pass withSharedSpaces to camera providers when no spaceId', async () 
 
   expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ withSharedSpaces: true }));
 });
+
+it('should pass withSharedSpaces to cameraModels provider when no spaceId', async () => {
+  vi.mocked(getSearchSuggestions).mockResolvedValue(['D850'] as never);
+
+  const config = buildMapFilterConfig();
+  await config.providers.cameraModels!('Nikon');
+
+  expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ withSharedSpaces: true, make: 'Nikon' }));
+});
 ```
 
-Check that `getSearchSuggestions` is imported in the test file — if not, add it to the imports from `@immich/sdk`.
+Note: `getSearchSuggestions` is already mocked in the test file's `vi.mock('@immich/sdk', ...)` block but not imported for assertions. Add it to the import from `@immich/sdk`:
 
-**Step 2: Run test to verify it fails**
+```typescript
+import { getAllPeople, getSearchSuggestions, getSpacePeople } from '@immich/sdk';
+```
+
+**Step 2: Run tests to verify they fail**
 
 Run: `cd web && pnpm test -- --run src/lib/utils/__tests__/map-filter-config.spec.ts`
 Expected: FAIL — `withSharedSpaces` not passed yet
@@ -403,8 +482,6 @@ cameraModels: (make: string, context?: FilterContext) =>
 Run: `cd web && pnpm test -- --run src/lib/utils/__tests__/map-filter-config.spec.ts`
 Expected: PASS
 
-Note: Same caveat as Task 3 — may need SDK regen first for the type.
-
 **Step 5: Commit**
 
 ```
@@ -413,51 +490,9 @@ feat(web): pass withSharedSpaces to Map page filter providers
 
 ---
 
-### Task 5: Regenerate OpenAPI specs and SDK
-
-**Files:**
-
-- Generated: `open-api/immich-openapi-specs.json`, `open-api/typescript-sdk/`, `mobile/openapi/`
-
-**Step 1: Build server**
-
-Run: `cd server && pnpm build`
-Expected: Build succeeds
-
-**Step 2: Regenerate OpenAPI spec**
-
-Run: `cd server && pnpm sync:open-api`
-Expected: `open-api/immich-openapi-specs.json` updated with new `withSharedSpaces` parameter on search suggestions endpoint
-
-**Step 3: Regenerate TypeScript SDK**
-
-Run: `make open-api-typescript`
-Expected: TypeScript SDK updated — `getSearchSuggestions` function now accepts `withSharedSpaces` parameter
-
-**Step 4: Regenerate Dart SDK**
-
-Run: `make open-api-dart`
-Expected: Dart client updated (requires Java installed)
-
-**Step 5: Regenerate SQL query docs**
-
-Run: `make sql`
-Expected: SQL documentation updated with new query variants
-
-**Step 6: Run web tests to confirm type errors are resolved**
-
-Run: `cd web && pnpm test -- --run`
-Expected: All tests PASS
-
-**Step 7: Commit**
-
-```
-chore: regenerate OpenAPI specs and SDK for withSharedSpaces
-```
-
----
-
 ### Task 6: Lint and type-check
+
+Run these sequentially with long timeouts — they take ~10 min each.
 
 **Files:** None (verification only)
 

--- a/docs/plans/2026-03-29-filter-suggestions-shared-spaces-plan.md
+++ b/docs/plans/2026-03-29-filter-suggestions-shared-spaces-plan.md
@@ -1,0 +1,536 @@
+# Filter Suggestions for Shared Space Content — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Location and Camera filter panels show suggestions from shared spaces for non-admin users on the Photos and Map pages.
+
+**Architecture:** Add `withSharedSpaces` boolean to `SearchSuggestionRequestDto`. When set, the service resolves the user's timeline space IDs and passes them to repository queries as `timelineSpaceIds`. The repository `getExifField()` ORs owner assets with space assets. Frontend passes `withSharedSpaces: true` on all suggestion calls from Photos and Map pages.
+
+**Tech Stack:** NestJS (server), Kysely (SQL), SvelteKit (web), Vitest (tests), OpenAPI codegen
+
+**Design doc:** `docs/plans/2026-03-29-filter-suggestions-shared-spaces-design.md`
+
+---
+
+### Task 1: Add `timelineSpaceIds` to `SpaceScopeOptions` and update `getExifField`
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts`
+
+**Step 1: Write the failing test**
+
+There are no isolated repository-level unit tests for `getExifField` (it's private and tested through the service layer). Skip to implementation — the service tests in Task 2 will cover this.
+
+**Step 2: Add `timelineSpaceIds` to `SpaceScopeOptions`**
+
+In `server/src/repositories/search.repository.ts`, modify the `SpaceScopeOptions` interface (line 170):
+
+```typescript
+export interface SpaceScopeOptions {
+  spaceId?: string;
+  timelineSpaceIds?: string[];
+  takenAfter?: Date;
+  takenBefore?: Date;
+}
+```
+
+**Step 3: Update `getExifField` to handle `timelineSpaceIds`**
+
+Replace the existing `getExifField` method (lines 524-559) with three mutually exclusive branches:
+
+```typescript
+private getExifField<K extends 'city' | 'state' | 'country' | 'make' | 'model' | 'lensModel'>(
+  field: K,
+  userIds: string[],
+  options?: SpaceScopeOptions,
+) {
+  return this.db
+    .selectFrom('asset_exif')
+    .select(field)
+    .distinctOn(field)
+    .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
+    .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
+      qb.where('ownerId', '=', anyUuid(userIds)),
+    )
+    .where('visibility', '=', AssetVisibility.Timeline)
+    .where('deletedAt', 'is', null)
+    .where(field, 'is not', null)
+    .where(field, '!=', '' as any)
+    .$if(!!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
+      qb.where((eb) =>
+        eb.or([
+          eb.exists(
+            eb
+              .selectFrom('shared_space_asset')
+              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+              .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_library')
+              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+              .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+          ),
+        ]),
+      ),
+    )
+    .$if(!!options?.timelineSpaceIds, (qb) =>
+      qb.where((eb) =>
+        eb.or([
+          eb('ownerId', '=', anyUuid(userIds)),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_asset')
+              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+              .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_library')
+              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+              .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
+          ),
+        ]),
+      ),
+    )
+    .$if(!!options?.takenAfter, (qb) => qb.where('asset.fileCreatedAt', '>=', options!.takenAfter!))
+    .$if(!!options?.takenBefore, (qb) => qb.where('asset.fileCreatedAt', '<', options!.takenBefore!));
+}
+```
+
+Key differences from old code:
+
+- First branch: `!spaceId && !timelineSpaceIds` (was just `!spaceId`)
+- Second branch: `!!spaceId && !timelineSpaceIds` (was just `!!spaceId`) — makes branches mutually exclusive
+- Third branch (NEW): `!!timelineSpaceIds` — ORs owner filter with space asset/library subqueries using `anyUuid` for array matching
+
+**Step 4: Run existing tests to verify no regressions**
+
+Run: `cd server && pnpm test -- --run src/services/search.service.spec.ts`
+Expected: All existing tests PASS (the repository change is backward-compatible — no existing caller passes `timelineSpaceIds`)
+
+**Step 5: Commit**
+
+```
+feat: add timelineSpaceIds support to getExifField
+```
+
+---
+
+### Task 2: Add `withSharedSpaces` to DTO and service layer
+
+**Files:**
+
+- Modify: `server/src/dtos/search.dto.ts`
+- Modify: `server/src/services/search.service.ts`
+- Modify: `server/src/services/search.service.spec.ts`
+
+**Step 1: Add `withSharedSpaces` to `SearchSuggestionRequestDto`**
+
+In `server/src/dtos/search.dto.ts`, add after the `spaceId` field (line 342):
+
+```typescript
+@ValidateBoolean({ optional: true, description: 'Include suggestions from shared spaces the user is a member of' })
+withSharedSpaces?: boolean;
+```
+
+**Step 2: Write failing tests for the service**
+
+In `server/src/services/search.service.spec.ts`, add these tests inside the existing `describe('getSearchSuggestions', ...)` block:
+
+```typescript
+it('should reject when both spaceId and withSharedSpaces are set', async () => {
+  await expect(
+    sut.getSearchSuggestions(authStub.user1, {
+      type: SearchSuggestionType.COUNTRY,
+      spaceId: newUuid(),
+      withSharedSpaces: true,
+    }),
+  ).rejects.toBeInstanceOf(BadRequestException);
+});
+
+it('should fetch timeline space IDs when withSharedSpaces is true', async () => {
+  const spaceId1 = newUuid();
+  const spaceId2 = newUuid();
+  mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId: spaceId1 }, { spaceId: spaceId2 }]);
+  mocks.search.getCountries.mockResolvedValue(['Germany', 'France']);
+
+  const result = await sut.getSearchSuggestions(authStub.user1, {
+    type: SearchSuggestionType.COUNTRY,
+    withSharedSpaces: true,
+  });
+
+  expect(result).toEqual(['Germany', 'France']);
+  expect(mocks.sharedSpace.getSpaceIdsForTimeline).toHaveBeenCalledWith(authStub.user1.user.id);
+  expect(mocks.search.getCountries).toHaveBeenCalledWith(
+    [authStub.user1.user.id],
+    expect.objectContaining({ timelineSpaceIds: [spaceId1, spaceId2] }),
+  );
+});
+
+it('should fall back to owner-only when withSharedSpaces is true but user has no spaces', async () => {
+  mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+  mocks.search.getCountries.mockResolvedValue(['USA']);
+
+  const result = await sut.getSearchSuggestions(authStub.user1, {
+    type: SearchSuggestionType.COUNTRY,
+    withSharedSpaces: true,
+  });
+
+  expect(result).toEqual(['USA']);
+  expect(mocks.search.getCountries).toHaveBeenCalledWith(
+    [authStub.user1.user.id],
+    expect.not.objectContaining({ timelineSpaceIds: expect.anything() }),
+  );
+});
+
+it('should preserve existing behavior when withSharedSpaces is absent', async () => {
+  mocks.search.getCountries.mockResolvedValue(['USA']);
+
+  await sut.getSearchSuggestions(authStub.user1, {
+    type: SearchSuggestionType.COUNTRY,
+  });
+
+  expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
+});
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run: `cd server && pnpm test -- --run src/services/search.service.spec.ts`
+Expected: FAIL — the new tests fail because the service doesn't handle `withSharedSpaces` yet
+
+**Step 4: Implement the service change**
+
+In `server/src/services/search.service.ts`, replace `getSearchSuggestions` (lines 173-184):
+
+```typescript
+async getSearchSuggestions(auth: AuthDto, dto: SearchSuggestionRequestDto) {
+  if (dto.spaceId && dto.withSharedSpaces) {
+    throw new BadRequestException('Cannot use both spaceId and withSharedSpaces');
+  }
+
+  if (dto.spaceId) {
+    await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [dto.spaceId] });
+  }
+
+  const userIds = await this.getUserIdsToSearch(auth);
+
+  let timelineSpaceIds: string[] | undefined;
+  if (dto.withSharedSpaces) {
+    const spaceRows = await this.sharedSpaceRepository.getSpaceIdsForTimeline(auth.user.id);
+    if (spaceRows.length > 0) {
+      timelineSpaceIds = spaceRows.map((row) => row.spaceId);
+    }
+  }
+
+  const suggestions = await this.getSuggestions(userIds, { ...dto, timelineSpaceIds });
+  if (dto.includeNull) {
+    suggestions.push(null);
+  }
+  return suggestions;
+}
+```
+
+Also update the `getSuggestions` method signature to accept `timelineSpaceIds` (lines 186-210). The DTO is spread into the repository call, so `timelineSpaceIds` flows through because all option types extend `SpaceScopeOptions`:
+
+```typescript
+private getSuggestions(
+  userIds: string[],
+  dto: SearchSuggestionRequestDto & { timelineSpaceIds?: string[] },
+): Promise<Array<string | null>> {
+  switch (dto.type) {
+    case SearchSuggestionType.COUNTRY: {
+      return this.searchRepository.getCountries(userIds, dto);
+    }
+    case SearchSuggestionType.STATE: {
+      return this.searchRepository.getStates(userIds, dto);
+    }
+    case SearchSuggestionType.CITY: {
+      return this.searchRepository.getCities(userIds, dto);
+    }
+    case SearchSuggestionType.CAMERA_MAKE: {
+      return this.searchRepository.getCameraMakes(userIds, dto);
+    }
+    case SearchSuggestionType.CAMERA_MODEL: {
+      return this.searchRepository.getCameraModels(userIds, dto);
+    }
+    case SearchSuggestionType.CAMERA_LENS_MODEL: {
+      return this.searchRepository.getCameraLensModels(userIds, dto);
+    }
+    default: {
+      return Promise.resolve([]);
+    }
+  }
+}
+```
+
+Make sure `BadRequestException` is imported from `@nestjs/common` (check existing imports at top of file).
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cd server && pnpm test -- --run src/services/search.service.spec.ts`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```
+feat: add withSharedSpaces to search suggestions endpoint
+```
+
+---
+
+### Task 3: Update Photos page filter providers
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
+
+**Step 1: Add `withSharedSpaces: true` to all suggestion providers**
+
+In `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`, update the `filterConfig` providers object (lines 85-118). Add `withSharedSpaces: true` to every `getSearchSuggestions` call:
+
+```typescript
+locations: async (context?: FilterContext) => {
+  const countries = await getSearchSuggestions({
+    $type: SearchSuggestionType.Country,
+    withSharedSpaces: true,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  });
+  return countries.filter(Boolean).map((c) => ({ value: c!, type: 'country' as const }));
+},
+cities: async (country: string, context?: FilterContext) => {
+  const cities = await getSearchSuggestions({
+    $type: SearchSuggestionType.City,
+    country,
+    withSharedSpaces: true,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  });
+  return cities.filter(Boolean) as string[];
+},
+cameras: async (context?: FilterContext) => {
+  const makes = await getSearchSuggestions({
+    $type: SearchSuggestionType.CameraMake,
+    withSharedSpaces: true,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  });
+  return makes.filter(Boolean).map((m) => ({ value: m!, type: 'make' as const }));
+},
+cameraModels: async (make: string, context?: FilterContext) => {
+  const models = await getSearchSuggestions({
+    $type: SearchSuggestionType.CameraModel,
+    make,
+    withSharedSpaces: true,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  });
+  return models.filter(Boolean) as string[];
+},
+```
+
+**Step 2: Run web tests**
+
+Run: `cd web && pnpm test -- --run`
+Expected: PASS (no existing tests for these provider calls; the SDK type will only be available after codegen in Task 5)
+
+Note: This step may fail with a type error until the SDK is regenerated. If so, proceed to Task 4 and Task 5, then come back to verify.
+
+**Step 3: Commit**
+
+```
+feat(web): pass withSharedSpaces to Photos page filter providers
+```
+
+---
+
+### Task 4: Update Map page filter providers
+
+**Files:**
+
+- Modify: `web/src/lib/utils/map-filter-config.ts`
+- Modify: `web/src/lib/utils/__tests__/map-filter-config.spec.ts`
+
+**Step 1: Write a failing test**
+
+In `web/src/lib/utils/__tests__/map-filter-config.spec.ts`, add a new test:
+
+```typescript
+it('should pass withSharedSpaces to camera providers when no spaceId', async () => {
+  vi.mocked(getSearchSuggestions).mockResolvedValue(['Nikon'] as never);
+
+  const config = buildMapFilterConfig();
+  await config.providers.cameras!();
+
+  expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ withSharedSpaces: true }));
+});
+```
+
+Check that `getSearchSuggestions` is imported in the test file — if not, add it to the imports from `@immich/sdk`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm test -- --run src/lib/utils/__tests__/map-filter-config.spec.ts`
+Expected: FAIL — `withSharedSpaces` not passed yet
+
+**Step 3: Add `withSharedSpaces: true` to non-space providers**
+
+In `web/src/lib/utils/map-filter-config.ts`, update the non-space branch (lines 61-73):
+
+```typescript
+cameras: (context?: FilterContext) =>
+  getSearchSuggestions({
+    $type: SearchSuggestionType.CameraMake,
+    withSharedSpaces: true,
+    ...(context?.takenAfter && { takenAfter: context.takenAfter }),
+    ...(context?.takenBefore && { takenBefore: context.takenBefore }),
+  }).then((results) => results.map((r) => ({ value: r, type: 'make' as const }))),
+cameraModels: (make: string, context?: FilterContext) =>
+  getSearchSuggestions({
+    $type: SearchSuggestionType.CameraModel,
+    make,
+    withSharedSpaces: true,
+    ...(context?.takenAfter && { takenAfter: context.takenAfter }),
+    ...(context?.takenBefore && { takenBefore: context.takenBefore }),
+  }),
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/utils/__tests__/map-filter-config.spec.ts`
+Expected: PASS
+
+Note: Same caveat as Task 3 — may need SDK regen first for the type.
+
+**Step 5: Commit**
+
+```
+feat(web): pass withSharedSpaces to Map page filter providers
+```
+
+---
+
+### Task 5: Regenerate OpenAPI specs and SDK
+
+**Files:**
+
+- Generated: `open-api/immich-openapi-specs.json`, `open-api/typescript-sdk/`, `mobile/openapi/`
+
+**Step 1: Build server**
+
+Run: `cd server && pnpm build`
+Expected: Build succeeds
+
+**Step 2: Regenerate OpenAPI spec**
+
+Run: `cd server && pnpm sync:open-api`
+Expected: `open-api/immich-openapi-specs.json` updated with new `withSharedSpaces` parameter on search suggestions endpoint
+
+**Step 3: Regenerate TypeScript SDK**
+
+Run: `make open-api-typescript`
+Expected: TypeScript SDK updated — `getSearchSuggestions` function now accepts `withSharedSpaces` parameter
+
+**Step 4: Regenerate Dart SDK**
+
+Run: `make open-api-dart`
+Expected: Dart client updated (requires Java installed)
+
+**Step 5: Regenerate SQL query docs**
+
+Run: `make sql`
+Expected: SQL documentation updated with new query variants
+
+**Step 6: Run web tests to confirm type errors are resolved**
+
+Run: `cd web && pnpm test -- --run`
+Expected: All tests PASS
+
+**Step 7: Commit**
+
+```
+chore: regenerate OpenAPI specs and SDK for withSharedSpaces
+```
+
+---
+
+### Task 6: Lint and type-check
+
+**Files:** None (verification only)
+
+**Step 1: Format server**
+
+Run: `make format-server` (timeout: 10 minutes)
+Expected: No changes or auto-fixed formatting
+
+**Step 2: Lint server**
+
+Run: `make lint-server` (timeout: 10 minutes)
+Expected: PASS with zero warnings
+
+**Step 3: Type-check server**
+
+Run: `make check-server` (timeout: 10 minutes)
+Expected: PASS
+
+**Step 4: Format web**
+
+Run: `make format-web` (timeout: 10 minutes)
+Expected: No changes or auto-fixed formatting
+
+**Step 5: Lint web**
+
+Run: `make lint-web` (timeout: 10 minutes)
+Expected: PASS with zero warnings
+
+**Step 6: Type-check web**
+
+Run: `make check-web` (timeout: 10 minutes)
+Expected: PASS
+
+**Step 7: Commit any formatting changes**
+
+```
+style: format and lint
+```
+
+---
+
+### Task 7: E2E tests
+
+**Files:**
+
+- Modify: `e2e/src/specs/server/api/search.e2e-spec.ts`
+
+**Step 1: Add E2E test for shared space suggestions**
+
+In `e2e/src/specs/server/api/search.e2e-spec.ts`, find the existing `describe('GET /search/suggestions', ...)` block. Add tests that:
+
+1. Create a non-admin user
+2. Create a shared space owned by admin, add the non-admin user as a member
+3. Upload an asset with known EXIF (country, camera make) to the admin's library
+4. Link the admin's library to the shared space
+5. As the non-admin user, call `GET /search/suggestions?type=country&withSharedSpaces=true`
+6. Assert the space's country appears in the results
+7. Repeat for `type=camera-make`
+8. Repeat for cascading: `type=city&country=<value>&withSharedSpaces=true`
+
+Study the existing test setup at the top of the file to understand how test users, assets, and spaces are created. Use the same patterns (e.g., `utils.createUser`, `utils.createSharedSpace`, `utils.linkLibrary`).
+
+Also add a negative test:
+
+9. Call with both `spaceId` and `withSharedSpaces=true` — expect 400 Bad Request
+
+**Step 2: Run E2E tests**
+
+Run: `cd e2e && pnpm test -- --run src/specs/server/api/search.e2e-spec.ts`
+Expected: All tests PASS (requires dev stack running via `make e2e`)
+
+**Step 3: Commit**
+
+```
+test(e2e): add tests for withSharedSpaces search suggestions
+```

--- a/e2e/src/specs/server/api/search.e2e-spec.ts
+++ b/e2e/src/specs/server/api/search.e2e-spec.ts
@@ -965,6 +965,60 @@ describe('/search', () => {
     });
   });
 
+  describe('GET /search/suggestions (withSharedSpaces)', () => {
+    let memberUser: LoginResponseDto;
+    let sharedSpace: SharedSpaceResponseDto;
+
+    beforeAll(async () => {
+      // Create a non-admin user and a space owned by admin with assetFalcon (Paris, France, Canon EOS R5)
+      memberUser = await utils.userSetup(admin.accessToken, {
+        email: 'with-shared-spaces@immich.cloud',
+        name: 'WithSharedSpaces User',
+        password: 'Password123!',
+      });
+      sharedSpace = await utils.createSpace(admin.accessToken, { name: 'SharedSpaces Test' });
+      await utils.addSpaceAssets(admin.accessToken, sharedSpace.id, [assetFalcon.id]);
+      await utils.addSpaceMember(admin.accessToken, sharedSpace.id, { userId: memberUser.userId });
+    });
+
+    it('should return space country suggestions for member with withSharedSpaces=true', async () => {
+      const { status, body } = await request(app)
+        .get('/search/suggestions?type=country&withSharedSpaces=true')
+        .set('Authorization', `Bearer ${memberUser.accessToken}`);
+      expect(status).toBe(200);
+      expect(Array.isArray(body)).toBe(true);
+      // memberUser has no own assets but is a member of a space containing assetFalcon (France)
+      expect(body).toContain('France');
+    });
+
+    it('should return space camera-make suggestions for member with withSharedSpaces=true', async () => {
+      const { status, body } = await request(app)
+        .get('/search/suggestions?type=camera-make&withSharedSpaces=true')
+        .set('Authorization', `Bearer ${memberUser.accessToken}`);
+      expect(status).toBe(200);
+      expect(Array.isArray(body)).toBe(true);
+      // assetFalcon was taken with a Canon camera
+      expect(body).toContain('Canon');
+    });
+
+    it('should reject when both spaceId and withSharedSpaces are provided', async () => {
+      const { status } = await request(app)
+        .get(`/search/suggestions?type=country&spaceId=${sharedSpace.id}&withSharedSpaces=true`)
+        .set('Authorization', `Bearer ${memberUser.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('should not return space content without withSharedSpaces flag', async () => {
+      const { status, body } = await request(app)
+        .get('/search/suggestions?type=country')
+        .set('Authorization', `Bearer ${memberUser.accessToken}`);
+      expect(status).toBe(200);
+      expect(Array.isArray(body)).toBe(true);
+      // memberUser has no own assets, so no countries should be returned
+      expect(body).toEqual([]);
+    });
+  });
+
   describe('POST /search/random (spaceId access)', () => {
     let space: SharedSpaceResponseDto;
     let outsider: LoginResponseDto;

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -155,7 +155,10 @@ class SearchApi {
   ///
   /// * [DateTime] takenBefore:
   ///   Filter suggestions by taken date (before)
-  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? spaceId, String? state, DateTime? takenAfter, DateTime? takenBefore, }) async {
+  ///
+  /// * [bool] withSharedSpaces:
+  ///   Include suggestions from shared spaces the user is a member of
+  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? spaceId, String? state, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/suggestions';
 
@@ -194,6 +197,9 @@ class SearchApi {
       queryParams.addAll(_queryParams('', 'takenBefore', takenBefore));
     }
       queryParams.addAll(_queryParams('', 'type', type));
+    if (withSharedSpaces != null) {
+      queryParams.addAll(_queryParams('', 'withSharedSpaces', withSharedSpaces));
+    }
 
     const contentTypes = <String>[];
 
@@ -244,8 +250,11 @@ class SearchApi {
   ///
   /// * [DateTime] takenBefore:
   ///   Filter suggestions by taken date (before)
-  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? spaceId, String? state, DateTime? takenAfter, DateTime? takenBefore, }) async {
-    final response = await getSearchSuggestionsWithHttpInfo(type,  country: country, includeNull: includeNull, lensModel: lensModel, make: make, model: model, spaceId: spaceId, state: state, takenAfter: takenAfter, takenBefore: takenBefore, );
+  ///
+  /// * [bool] withSharedSpaces:
+  ///   Include suggestions from shared spaces the user is a member of
+  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? country, bool? includeNull, String? lensModel, String? make, String? model, String? spaceId, String? state, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+    final response = await getSearchSuggestionsWithHttpInfo(type,  country: country, includeNull: includeNull, lensModel: lensModel, make: make, model: model, spaceId: spaceId, state: state, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -10573,6 +10573,15 @@
             "schema": {
               "$ref": "#/components/schemas/SearchSuggestionType"
             }
+          },
+          {
+            "name": "withSharedSpaces",
+            "required": false,
+            "in": "query",
+            "description": "Include suggestions from shared spaces the user is a member of",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -6081,7 +6081,7 @@ export function searchAssetStatistics({ statisticsSearchDto }: {
 /**
  * Retrieve search suggestions
  */
-export function getSearchSuggestions({ country, includeNull, lensModel, make, model, spaceId, state, takenAfter, takenBefore, $type }: {
+export function getSearchSuggestions({ country, includeNull, lensModel, make, model, spaceId, state, takenAfter, takenBefore, $type, withSharedSpaces }: {
     country?: string;
     includeNull?: boolean;
     lensModel?: string;
@@ -6092,6 +6092,7 @@ export function getSearchSuggestions({ country, includeNull, lensModel, make, mo
     takenAfter?: string;
     takenBefore?: string;
     $type: SearchSuggestionType;
+    withSharedSpaces?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
@@ -6106,7 +6107,8 @@ export function getSearchSuggestions({ country, includeNull, lensModel, make, mo
         state,
         takenAfter,
         takenBefore,
-        "type": $type
+        "type": $type,
+        withSharedSpaces
     }))}`, {
         ...opts
     }));

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -341,6 +341,9 @@ export class SearchSuggestionRequestDto {
   @ValidateUUID({ optional: true, description: 'Scope suggestions to a specific shared space' })
   spaceId?: string;
 
+  @ValidateBoolean({ optional: true, description: 'Include suggestions from shared spaces the user is a member of' })
+  withSharedSpaces?: boolean;
+
   @ValidateBoolean({
     optional: true,
     description: 'Include null values in suggestions',

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -169,6 +169,7 @@ export interface AssetDuplicateResult {
 
 export interface SpaceScopeOptions {
   spaceId?: string;
+  timelineSpaceIds?: string[];
   takenAfter?: Date;
   takenBefore?: Date;
 }
@@ -531,12 +532,14 @@ export class SearchRepository {
       .select(field)
       .distinctOn(field)
       .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
-      .$if(!options?.spaceId, (qb) => qb.where('ownerId', '=', anyUuid(userIds)))
+      .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
+        qb.where('ownerId', '=', anyUuid(userIds)),
+      )
       .where('visibility', '=', AssetVisibility.Timeline)
       .where('deletedAt', 'is', null)
       .where(field, 'is not', null)
       .where(field, '!=', '' as any)
-      .$if(!!options?.spaceId, (qb) =>
+      .$if(!!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
           eb.or([
             eb.exists(
@@ -550,6 +553,25 @@ export class SearchRepository {
                 .selectFrom('shared_space_library')
                 .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
                 .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+            ),
+          ]),
+        ),
+      )
+      .$if(!!options?.timelineSpaceIds, (qb) =>
+        qb.where((eb) =>
+          eb.or([
+            eb('ownerId', '=', anyUuid(userIds)),
+            eb.exists(
+              eb
+                .selectFrom('shared_space_asset')
+                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
+            ),
+            eb.exists(
+              eb
+                .selectFrom('shared_space_library')
+                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
             ),
           ]),
         ),

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -532,9 +532,7 @@ export class SearchRepository {
       .select(field)
       .distinctOn(field)
       .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
-      .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
-        qb.where('ownerId', '=', anyUuid(userIds)),
-      )
+      .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) => qb.where('ownerId', '=', anyUuid(userIds)))
       .where('visibility', '=', AssetVisibility.Timeline)
       .where('deletedAt', 'is', null)
       .where(field, 'is not', null)

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -429,6 +429,88 @@ describe(SearchService.name, () => {
           }),
         ).rejects.toThrow();
       });
+
+      it('should reject when both spaceId and withSharedSpaces are set', async () => {
+        await expect(
+          sut.getSearchSuggestions(authStub.user1, {
+            type: SearchSuggestionType.COUNTRY,
+            spaceId: newUuid(),
+            withSharedSpaces: true,
+          }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+      });
+
+      it('should fetch timeline space IDs when withSharedSpaces is true', async () => {
+        const spaceId1 = newUuid();
+        const spaceId2 = newUuid();
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId: spaceId1 }, { spaceId: spaceId2 }]);
+        mocks.search.getCountries.mockResolvedValue(['Germany', 'France']);
+
+        const result = await sut.getSearchSuggestions(authStub.user1, {
+          type: SearchSuggestionType.COUNTRY,
+          withSharedSpaces: true,
+        });
+
+        expect(result).toEqual(['Germany', 'France']);
+        expect(mocks.sharedSpace.getSpaceIdsForTimeline).toHaveBeenCalledWith(authStub.user1.user.id);
+        expect(mocks.search.getCountries).toHaveBeenCalledWith(
+          [authStub.user1.user.id],
+          expect.objectContaining({ timelineSpaceIds: [spaceId1, spaceId2] }),
+        );
+      });
+
+      it('should fall back to owner-only when withSharedSpaces is true but user has no spaces', async () => {
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+        mocks.search.getCountries.mockResolvedValue(['USA']);
+
+        const result = await sut.getSearchSuggestions(authStub.user1, {
+          type: SearchSuggestionType.COUNTRY,
+          withSharedSpaces: true,
+        });
+
+        expect(result).toEqual(['USA']);
+        expect(mocks.search.getCountries).toHaveBeenCalledWith(
+          [authStub.user1.user.id],
+          expect.objectContaining({ timelineSpaceIds: undefined }),
+        );
+      });
+
+      it('should preserve existing behavior when withSharedSpaces is absent', async () => {
+        mocks.search.getCountries.mockResolvedValue(['USA']);
+
+        await sut.getSearchSuggestions(authStub.user1, {
+          type: SearchSuggestionType.COUNTRY,
+        });
+
+        expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
+      });
+
+      it('should preserve existing behavior when withSharedSpaces is explicitly false', async () => {
+        mocks.search.getCountries.mockResolvedValue(['USA']);
+
+        await sut.getSearchSuggestions(authStub.user1, {
+          type: SearchSuggestionType.COUNTRY,
+          withSharedSpaces: false,
+        });
+
+        expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
+      });
+
+      it('should pass timelineSpaceIds through to camera make suggestions', async () => {
+        const spaceId1 = newUuid();
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId: spaceId1 }]);
+        mocks.search.getCameraMakes.mockResolvedValue(['Nikon']);
+
+        await sut.getSearchSuggestions(authStub.user1, {
+          type: SearchSuggestionType.CAMERA_MAKE,
+          withSharedSpaces: true,
+        });
+
+        expect(mocks.search.getCameraMakes).toHaveBeenCalledWith(
+          [authStub.user1.user.id],
+          expect.objectContaining({ timelineSpaceIds: [spaceId1] }),
+        );
+      });
     });
   });
 

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -171,19 +171,35 @@ export class SearchService extends BaseService {
   }
 
   async getSearchSuggestions(auth: AuthDto, dto: SearchSuggestionRequestDto) {
+    if (dto.spaceId && dto.withSharedSpaces) {
+      throw new BadRequestException('Cannot use both spaceId and withSharedSpaces');
+    }
+
     if (dto.spaceId) {
       await this.requireAccess({ auth, permission: Permission.SharedSpaceRead, ids: [dto.spaceId] });
     }
 
     const userIds = await this.getUserIdsToSearch(auth);
-    const suggestions = await this.getSuggestions(userIds, dto);
+
+    let timelineSpaceIds: string[] | undefined;
+    if (dto.withSharedSpaces) {
+      const spaceRows = await this.sharedSpaceRepository.getSpaceIdsForTimeline(auth.user.id);
+      if (spaceRows.length > 0) {
+        timelineSpaceIds = spaceRows.map((row) => row.spaceId);
+      }
+    }
+
+    const suggestions = await this.getSuggestions(userIds, { ...dto, timelineSpaceIds });
     if (dto.includeNull) {
       suggestions.push(null);
     }
     return suggestions;
   }
 
-  private getSuggestions(userIds: string[], dto: SearchSuggestionRequestDto): Promise<Array<string | null>> {
+  private getSuggestions(
+    userIds: string[],
+    dto: SearchSuggestionRequestDto & { timelineSpaceIds?: string[] },
+  ): Promise<Array<string | null>> {
     switch (dto.type) {
       case SearchSuggestionType.COUNTRY: {
         return this.searchRepository.getCountries(userIds, dto);

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -1,5 +1,5 @@
 import { buildMapFilterConfig } from '$lib/utils/map-filter-config';
-import { getAllPeople, getSpacePeople } from '@immich/sdk';
+import { getAllPeople, getSearchSuggestions, getSpacePeople } from '@immich/sdk';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@immich/sdk', async (importOriginal) => {
@@ -113,5 +113,25 @@ describe('buildMapFilterConfig', () => {
 
       expect(people[0].thumbnailUrl).toContain('/shared-spaces/space-123/people/1/thumbnail');
     });
+  });
+
+  it('should pass withSharedSpaces to cameras provider when no spaceId', async () => {
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['Nikon'] as never);
+
+    const config = buildMapFilterConfig();
+    await config.providers.cameras!();
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ withSharedSpaces: true }));
+  });
+
+  it('should pass withSharedSpaces to cameraModels provider when no spaceId', async () => {
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['D850'] as never);
+
+    const config = buildMapFilterConfig();
+    await config.providers.cameraModels!('Nikon');
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ withSharedSpaces: true, make: 'Nikon' }),
+    );
   });
 });

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -61,6 +61,7 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
       cameras: (context?: FilterContext) =>
         getSearchSuggestions({
           $type: SearchSuggestionType.CameraMake,
+          withSharedSpaces: true,
           ...(context?.takenAfter && { takenAfter: context.takenAfter }),
           ...(context?.takenBefore && { takenBefore: context.takenBefore }),
         }).then((results) => results.map((r) => ({ value: r, type: 'make' as const }))),
@@ -68,6 +69,7 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
         getSearchSuggestions({
           $type: SearchSuggestionType.CameraModel,
           make,
+          withSharedSpaces: true,
           ...(context?.takenAfter && { takenAfter: context.takenAfter }),
           ...(context?.takenBefore && { takenBefore: context.takenBefore }),
         }),

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -85,6 +85,7 @@
       locations: async (context?: FilterContext) => {
         const countries = await getSearchSuggestions({
           $type: SearchSuggestionType.Country,
+          withSharedSpaces: true,
           takenAfter: context?.takenAfter,
           takenBefore: context?.takenBefore,
         });
@@ -94,6 +95,7 @@
         const cities = await getSearchSuggestions({
           $type: SearchSuggestionType.City,
           country,
+          withSharedSpaces: true,
           takenAfter: context?.takenAfter,
           takenBefore: context?.takenBefore,
         });
@@ -102,6 +104,7 @@
       cameras: async (context?: FilterContext) => {
         const makes = await getSearchSuggestions({
           $type: SearchSuggestionType.CameraMake,
+          withSharedSpaces: true,
           takenAfter: context?.takenAfter,
           takenBefore: context?.takenBefore,
         });
@@ -111,6 +114,7 @@
         const models = await getSearchSuggestions({
           $type: SearchSuggestionType.CameraModel,
           make,
+          withSharedSpaces: true,
           takenAfter: context?.takenAfter,
           takenBefore: context?.takenBefore,
         });


### PR DESCRIPTION
## Summary
- Non-admin users with shared space membership now see Location and Camera filter suggestions from space content on Photos and Map pages
- Added `withSharedSpaces` boolean to `SearchSuggestionRequestDto` (mutually exclusive with `spaceId`)
- Service resolves timeline space IDs and passes them to repository queries as `timelineSpaceIds`
- Repository `getExifField()` ORs owner assets with space assets when `timelineSpaceIds` is set
- People filter is out of scope (cross-table dedup needed)

## Test plan
- [x] 6 new server unit tests (mutual exclusion, space ID fetching, fallback, regression, camera-make propagation)
- [x] 2 new web unit tests (map filter config passes withSharedSpaces)
- [x] 4 new E2E tests (country/camera suggestions with spaces, spaceId+withSharedSpaces rejection, no-flag regression)
- [x] Server lint, format, type-check passing
- [x] Web lint, format, type-check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)