### PR TITLE
fix(mobile): remove unused FOREGROUND_SERVICE_LOCATION permission

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
   <!-- Foreground service permission -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
   <application android:label="Noodle Gallery" android:name=".ImmichApp" android:usesCleartextTraffic="true"
     android:icon="@mipmap/ic_launcher" android:requestLegacyExternalStorage="true"


### PR DESCRIPTION
## Summary
- Remove `FOREGROUND_SERVICE_LOCATION` permission from Android manifest
- The app only uses `Geolocator.getCurrentPosition()` for one-time foreground location snapshots on the map page — no location-type foreground service is ever started
- Simplifies Google Play permission declarations

## Test plan
- [ ] Verify map "zoom to my location" still works on Android
- [ ] Verify background backup still works
- [ ] Verify CI passes