### PR TITLE
fix: add recountPersons after dedup merges

### DIFF
--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -4543,6 +4543,10 @@ describe(SharedSpaceService.name, () => {
   });
 
   describe('handleSharedSpacePersonDedup', () => {
+    beforeEach(() => {
+      mocks.sharedSpace.recountPersons.mockResolvedValue(void 0 as any);
+    });
+
     it('should skip when space does not exist', async () => {
       mocks.sharedSpace.getById.mockResolvedValue(void 0);
       const result = await sut.handleSharedSpacePersonDedup({ spaceId: newUuid() });
@@ -4599,6 +4603,7 @@ describe(SharedSpaceService.name, () => {
       expect(result).toBe(JobStatus.Success);
       expect(mocks.sharedSpace.reassignPersonFacesSafe).toHaveBeenCalledWith(personB, personA);
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith(personB);
+      expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([personA]);
     });
 
     it('should succeed with no merges when space has one person (self-exclusion)', async () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -915,6 +915,7 @@ export class SharedSpaceService extends BaseService {
       }
 
       const deletedIds = new Set<string>();
+      const targetIds = new Set<string>();
       let passMerges = 0;
 
       for (const person of persons) {
@@ -981,8 +982,13 @@ export class SharedSpaceService extends BaseService {
         }
 
         deletedIds.add(source.id);
+        targetIds.add(target.id);
         passMerges++;
         mergedAny = true;
+      }
+
+      if (targetIds.size > 0) {
+        await this.sharedSpaceRepository.recountPersons([...targetIds]);
       }
 
       totalMerges += passMerges;


### PR DESCRIPTION
## Summary

- After dedup merges space persons, the target's `faceCount` and `assetCount` columns were left stale because `recountPersons` was never called
- This affected merge-direction logic in subsequent passes (uses `person.faceCount`) and UI display
- The manual `mergeSpacePeople` already calls `recountPersons` — this aligns the dedup handler

## Changes

- Collect target person IDs during each dedup pass
- Call `recountPersons` at the end of each pass for all affected targets
- Added `beforeEach` mock and assertion in the basic merge test

## Test plan

- [x] Existing dedup tests still pass (3697 tests)
- [x] New assertion verifies `recountPersons` is called with the correct target ID after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)