### PR TITLE
refactor: move classification categories from DB tables to SystemConfig

### DIFF
--- a/server/src/services/classification.service.spec.ts
+++ b/server/src/services/classification.service.spec.ts
@@ -365,6 +365,18 @@ describe(ClassificationService.name, () => {
       });
     });
 
+    it('should skip DB update when only prompts change (no category fields)', async () => {
+      mocks.classification.getCategory.mockResolvedValue(existingCategory as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[0.5,0.5,0.5]');
+      mocks.classification.deletePromptEmbeddingsByCategory.mockResolvedValue(void 0 as any);
+      mocks.classification.upsertPromptEmbedding.mockResolvedValue(void 0 as any);
+      mocks.classification.getPromptEmbeddings.mockResolvedValue([{ prompt: 'new prompt' }] as any);
+
+      await sut.updateCategory(authStub.user1, 'cat-1', { prompts: ['new prompt'] });
+
+      expect(mocks.classification.updateCategory).not.toHaveBeenCalled();
+    });
+
     it('should NOT re-encode when only name/similarity/action change', async () => {
       mocks.classification.getCategory.mockResolvedValue(existingCategory as any);
       mocks.classification.updateCategory.mockResolvedValue({ ...existingCategory, name: 'New Name' } as any);

--- a/server/src/services/classification.service.ts
+++ b/server/src/services/classification.service.ts
@@ -104,7 +104,10 @@ export class ClassificationService extends BaseService {
       updateValues.enabled = dto.enabled;
     }
 
-    const category = await this.classificationRepository.updateCategory(id, updateValues);
+    const category =
+      Object.keys(updateValues).length > 0
+        ? await this.classificationRepository.updateCategory(id, updateValues)
+        : existing;
 
     if (dto.prompts !== void 0) {
       const { machineLearning } = await this.getConfig({ withCache: true });


### PR DESCRIPTION
## Summary
- Moves classification categories from dedicated DB tables (`classification_category`, `classification_prompt_embedding`) into Immich's SystemConfig system
- Categories can now be managed via YAML config file (`IMMICH_CONFIG_FILE`) as well as the Admin UI
- Prompt embeddings are computed lazily and cached in-memory (no DB table needed)
- ClassificationController reduced to a single scan endpoint at `POST /classification/scan`
- Migration reads existing categories from old tables, merges into `system_metadata`, then drops tables
- 37 unit tests covering config changes (similarity, prompts, action, enable/disable), embedding cache, and onConfigUpdate behavior

Closes #238

## Changes
- **server/src/config.ts** — Add `classification` section to SystemConfig type and defaults
- **server/src/dtos/system-config.dto.ts** — Add classification DTO with UniqueNames validator
- **server/src/services/classification.service.ts** — Rewrite to read from config, lazy embedding cache
- **server/src/controllers/classification.controller.ts** — Scan-only endpoint
- **server/src/repositories/classification.repository.ts** — Trimmed to non-table methods
- **server/src/schema/migrations-gallery/1778000000000** — Data migration + table drop
- **web/** — Admin UI rewritten to use getConfig/updateConfig, user settings view removed
- Deleted: classification-category.table.ts, classification-prompt-embedding.table.ts, classification.dto.ts

## Test plan
- [x] 37 unit tests pass (classification.service.spec.ts)
- [ ] CI: server lint, type check, medium tests
- [ ] CI: OpenAPI regen needed (CRUD endpoints removed, scan URL changed)
- [ ] CI: E2E tests need rewrite (old CRUD endpoints gone)
- [ ] Manual: Admin UI category CRUD via SystemConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)