### PR TITLE
feat: show tags and people to space members in asset detail view

### DIFF
--- a/docs/plans/2026-03-30-space-asset-metadata-design.md
+++ b/docs/plans/2026-03-30-space-asset-metadata-design.md
@@ -1,0 +1,277 @@
+# Show Tags and People to Space Members in Asset Detail View
+
+**Discussion:** [#194](https://github.com/open-noodle/gallery/discussions/194)
+**Date:** 2026-03-30
+
+## Problem
+
+Space members (Viewers and Editors) cannot see tags or recognized people when viewing an asset's detail panel. This metadata is visible only to the asset owner.
+
+Two layers cause this:
+
+1. **Server** (`asset.service.ts:111-113`): `data.people = []` for all non-owners, including space members
+2. **Frontend** (`detail-panel.svelte:189`, `detail-panel-tags.svelte:40`): Tags and people sections gated by `isOwner` check
+
+## Design
+
+### Approach
+
+The server keeps people data when the user has space access, and enriches the response with space person IDs for thumbnail/link resolution. The frontend threads `spaceId` from the space page through the asset viewer stack and uses it for visibility decisions, thumbnail URLs, and person links.
+
+### Server Changes
+
+#### 1. `asset.service.get()` — keep people for space members and enrich with space person IDs
+
+```typescript
+// Before:
+if (data.ownerId !== auth.user.id || auth.sharedLink) {
+  data.people = [];
+}
+
+// After:
+if (auth.sharedLink) {
+  data.people = [];
+} else if (data.ownerId !== auth.user.id) {
+  if (spaceId) {
+    // Validate user is a member of this specific space
+    const member = await this.sharedSpaceRepository.getMember(spaceId, auth.user.id);
+    if (!member) {
+      throw new ForbiddenException('Not a member of this space');
+    }
+
+    // Verify asset is in this specific space (scoped check)
+    const hasSpaceAccess = await this.accessRepository.asset.checkSpaceAccessForSpace(
+      auth.user.id,
+      spaceId,
+      new Set([id]),
+    );
+    if (hasSpaceAccess.size === 0) {
+      data.people = [];
+    } else {
+      // Batch-enrich with space person IDs, filter out unmapped and hidden persons
+      const globalPersonIds = data.people.map((p) => p.id);
+      const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+        spaceId,
+        globalPersonIds,
+      );
+      for (const person of data.people) {
+        const spacePerson = spacePersonMap.get(person.id);
+        person.spacePersonId = spacePerson?.id;
+      }
+      data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
+    }
+  } else {
+    // Non-owner without spaceId: partner, album member, or other non-space context
+    data.people = [];
+  }
+}
+```
+
+**Space membership check:** `SharedSpaceService.requireMembership()` is private. Instead, call `sharedSpaceRepository.getMember(spaceId, userId)` directly — this is the same underlying query and is already accessible via `BaseService`.
+
+**Scoped space access check:** The existing `checkSpaceAccess(userId, assetIds)` checks if the asset is in _any_ space the user belongs to. We need a new `checkSpaceAccessForSpace(userId, spaceId, assetIds)` variant that confirms the asset is in the _specific_ `spaceId`. This prevents a user from passing `spaceId=A` to get person mappings from space A when the asset is only in space B. The query is a straightforward modification of the existing one with an added `WHERE shared_space.id = $spaceId` clause.
+
+**Performance:** Adds one membership check + one scoped asset access check + one batch person lookup for non-owner views with `spaceId`. Without `spaceId`, behavior is identical to before (people stripped).
+
+**Partner/album access unchanged:** Partners and album members still get `data.people = []`. The existing behavior is intentional (explicit tests confirm it). Only space access with explicit `spaceId` is special-cased.
+
+**Important:** Omitting `spaceId` is the correct default for non-space contexts (photos page, albums, partner views). The space page is responsible for always providing it. Without `spaceId`, non-owners get empty people regardless of space membership.
+
+#### 2. Person thumbnails and links — the data model challenge
+
+Global persons (`person` table) and space persons (`shared_space_person` table) are separate entities linked indirectly through `shared_space_person_face` → `asset_face` → `person`. The `asset.people` response contains global `PersonResponseDto` objects, but:
+
+- The person thumbnail endpoint (`/people/{id}/thumbnail`) requires `PersonRead` (owner-only) — space members get 403
+- The global person page (`/people/{id}`) would either 403 or leak all the person's assets beyond the space
+- The space person thumbnail endpoint (`/shared-spaces/{spaceId}/people/{spacePersonId}/thumbnail`) requires a space person ID, not a global person ID
+
+**Solution:** The repository already has `findSpacePersonByLinkedPersonId(spaceId, personId)` which maps global person ID → space person ID for a given space. The server enrichment step above adds `spacePersonId` to each person in the response. The frontend uses this to construct space-scoped thumbnail URLs and person links.
+
+**New batch query:** Add `findSpacePersonsByLinkedPersonIds(spaceId, personIds[])` to the shared space repository. Straightforward extension of the existing `findSpacePersonByLinkedPersonId` with `WHERE asset_face.personId IN (...)`. Returns a `Map<string, SharedSpacePerson>` keyed by global person ID.
+
+**DTO change:** Add optional `spacePersonId?: string` to `PersonWithFacesResponseDto`. This is a fork-only field, unused by non-space contexts.
+
+**API change:** Add optional `spaceId` query parameter to `GET /assets/:id`. Requires: `@Query()` parameter in the controller, rebuilding OpenAPI spec (`pnpm sync:open-api`), and regenerating SDK clients (`make open-api`).
+
+#### 3. Hidden people filtering
+
+`asset.people[].isHidden` reflects the global person's hidden status set by the asset owner. Space persons have their own `isHidden` flag. For space members, the space-level `isHidden` applies:
+
+- People where the corresponding space person has `isHidden: true` are filtered out during the enrichment step above
+- People with no space person mapping (below face threshold or not yet synced) are also filtered out
+- The global `isHidden` flag is irrelevant in space context
+
+### Frontend Changes
+
+#### 1. Thread `spaceId` through the asset viewer stack
+
+The space page already has the space ID from the route. Thread it as a single optional prop through the component chain. This requires adding `spaceId?: string` to four component interfaces:
+
+1. **Timeline** — accepts `spaceId`, forwards to TimelineAssetViewer
+2. **TimelineAssetViewer** — forwards to AssetViewer
+3. **AssetViewer** — forwards to DetailPanel, passes to asset fetch calls
+4. **DetailPanel** — forwards to DetailPanelTags, uses for visibility and person links
+
+This matches the existing pattern of `album` and `isShared` being threaded through the same chain (Timeline → TimelineAssetViewer → AssetViewer). Note: `album`/`isShared` don't currently reach DetailPanel (it derives `isOwner` independently), so this extends the pattern one level deeper.
+
+Non-space pages (photos, albums, etc.) don't pass `spaceId`, so they require zero changes.
+
+Components derive:
+
+```typescript
+let isSpaceMember = $derived(!!spaceId);
+```
+
+#### 2. Pass `spaceId` to all asset fetch calls
+
+**AssetViewer / asset viewer manager:** Pass `spaceId` to `getAssetInfo()`:
+
+```typescript
+const asset = await getAssetInfo({ id, spaceId });
+```
+
+**AssetCacheManager:** The `AssetCacheManager.getAsset()` method currently accepts `{ id, key, slug }`. Extend it to accept `spaceId`:
+
+```typescript
+async getAsset({ id, key, slug, spaceId }, updateCache = true) {
+  return this.#assetCache.getOrFetch({ id, key, slug, spaceId }, updateCache);
+}
+```
+
+The cache key must include `spaceId` so that the same asset fetched from space context (with people) and non-space context (without people) are cached separately. The `invalidateAsset` method should clear all variants for a given `id`.
+
+**space-search-results.svelte:** This component calls `getAssetInfo()` directly in space context. It must also pass `spaceId`. The component is under `components/spaces/` and already has access to the space context.
+
+**detail-panel-tags.svelte:** Lines 25 and 31 re-fetch the asset after tag add/remove via `getAssetInfo({ id: asset.id })`. These calls must include `spaceId` to preserve people data in the re-fetched response. The component needs `spaceId` as a prop (already threaded from DetailPanel).
+
+#### 3. DetailPanel (`detail-panel.svelte`)
+
+**People section visibility** — change from `isOwner` to `isOwner || isSpaceMember`:
+
+```svelte
+{#if !authManager.isSharedLink && (isOwner || isSpaceMember)}
+```
+
+**Within the people section:**
+
+- Person thumbnails, names, ages: visible to all space members (read-only)
+- Face edit button: `isOwner` only
+- Show/hide hidden people toggle: `isOwner` only
+- "Tag people" button: `isOwner` only (person assignment is owner-scoped)
+
+**Person thumbnails:** When `spaceId` is present, use the space person thumbnail endpoint:
+
+```typescript
+const thumbnailUrl =
+  spaceId && person.spacePersonId
+    ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, {
+        updatedAt: person.updatedAt,
+      })
+    : getPeopleThumbnailUrl(person);
+```
+
+**Person links:** When `spaceId` is present, link to the space person page. Add a `viewSpacePerson` helper to `route.ts`:
+
+```typescript
+// In route.ts:
+viewSpacePerson: (spaceId: string, personId: string) => `/spaces/${spaceId}/people/${personId}`,
+```
+
+```svelte
+href={spaceId && person.spacePersonId
+  ? Route.viewSpacePerson(spaceId, person.spacePersonId)
+  : Route.viewPerson(person, { previousRoute })}
+```
+
+The space person page and API already exist and require only space membership.
+
+#### 4. DetailPanelTags (`detail-panel-tags.svelte`)
+
+**Props change:** Add `spaceId?: string` to the component's Props interface (needed for asset re-fetch after tag operations).
+
+**Tags visibility** — read-only for all space members:
+
+```svelte
+{#if (isOwner || isSpaceMember) && !authManager.isSharedLink}
+```
+
+**Read-only rendering:** Wrap each edit control individually in `{#if isOwner}` guards:
+
+- The `IconButton` (remove X) on each tag badge: `{#if isOwner}`
+- The `HeaderActionButton` (add tag): `{#if isOwner}`
+- The tag value `Link` and `Badge` remain visible to all members
+
+**Asset re-fetch:** Update lines 25 and 31 to include `spaceId`:
+
+```typescript
+asset = await getAssetInfo({ id: asset.id, spaceId });
+```
+
+**Tag editing deferred:** All space members (including Editors) see tags as read-only. The server's `TagAsset` permission checks tag ownership, not asset access. Space editors can only add/remove their own tags — not the owner's. Showing edit controls that partially work creates confusing UX. A follow-up should extend `TagAsset` or add tag-ownership-aware UI.
+
+#### 5. Asset owner views own asset through space context
+
+When the asset owner views their own asset through a space page, both `isOwner` and `isSpaceMember` are true. The `isOwner` path gives full edit controls. The `spacePersonId` enrichment still runs (harmless — owner already sees everything). No special handling needed.
+
+### Testing
+
+#### Server unit tests
+
+| Test                                                  | What it verifies                                                                                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Space member sees people (with spaceId)               | `checkSpaceAccessForSpace` hit + `findSpacePersonsByLinkedPersonIds` → people preserved with `spacePersonId` |
+| Non-member, non-owner sees no people                  | No owner/space access → `people` is `[]`                                                                     |
+| Partner still sees no people                          | `checkPartnerAccess` hit but no `spaceId` → `people` is `[]`                                                 |
+| Album member still sees no people                     | `checkAlbumAccess` hit but no `spaceId` → `people` is `[]`                                                   |
+| Shared link still sees no people                      | `auth.sharedLink` set → `people` is `[]` regardless                                                          |
+| Owner always sees people                              | `ownerId === auth.user.id` → people preserved (no space check)                                               |
+| Hidden space person filtered out                      | Space person with `isHidden: true` → excluded from people                                                    |
+| Person without space person filtered out              | Global person with no `shared_space_person` match → excluded                                                 |
+| User is space member but asset not in that space      | `checkSpaceAccessForSpace` returns empty → `people` is `[]`                                                  |
+| User passes spaceId for space they're not a member of | `getMember` returns null → 403                                                                               |
+
+#### Frontend unit tests
+
+| Test                                                          | What it verifies                          |
+| ------------------------------------------------------------- | ----------------------------------------- |
+| DetailPanel shows people when `spaceId` set                   | People section renders for space members  |
+| DetailPanel hides people when no `spaceId` and not owner      | People section hidden                     |
+| DetailPanel hides face edit for space members                 | Edit controls require `isOwner`           |
+| DetailPanelTags shows tags when `spaceId` set                 | Tags section renders for space members    |
+| DetailPanelTags hides add/remove for space members            | Tag editing requires `isOwner`            |
+| Person link goes to space person route when `spaceId` present | Correct `href` using `spacePersonId`      |
+| Person thumbnail uses space endpoint when `spaceId` present   | Correct thumbnail URL construction        |
+| Asset with zero people shows nothing for viewer               | No empty people section for space viewers |
+| Asset with zero people shows tag-people button for owner      | Owner sees the section even when empty    |
+
+#### E2E tests
+
+| Test                                               | What it verifies                                          |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| Space viewer sees tags on asset detail             | Read-only tags visible                                    |
+| Space viewer sees people on asset detail           | Read-only people with thumbnails visible                  |
+| Space editor sees tags on asset detail (read-only) | No edit controls                                          |
+| Non-member cannot see tags/people                  | Standard access denial                                    |
+| Person link navigates to space person page         | Click person → `/spaces/{spaceId}/people/{spacePersonId}` |
+
+### Edge Cases
+
+| Edge Case                                          | Handling                                                                                                    |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Asset with zero tags and zero people               | Viewers see nothing (no empty sections). Owner sees sections with add buttons                               |
+| Asset in multiple spaces, user has different roles | `spaceId` param scopes to the specific space — person mappings come from that space only                    |
+| Space member removed mid-session                   | Next API call fails `requireAccess` → 403. Acceptable                                                       |
+| Asset removed from space while viewing             | Same — 403 on next call                                                                                     |
+| Global person has no space person mapping          | Filtered out of response (below face threshold or not yet synced)                                           |
+| `isShared` prop interaction                        | `isShared` is for album context. Independent of `spaceId` — no conflict                                     |
+| User passes wrong `spaceId` to API                 | `getMember` check rejects with 403 before any enrichment                                                    |
+| User is member of space but asset not in it        | `checkSpaceAccessForSpace` returns empty set — people stripped, asset still viewable via other access paths |
+| Same asset cached with and without spaceId         | Cache key includes `spaceId` — separate cache entries. `invalidateAsset` clears all variants for given `id` |
+
+### Out of Scope (Follow-ups)
+
+1. **Tag editing for space editors** — requires `TagAsset` permission model changes or tag-ownership-aware UI
+2. **Face tagging / person assignment by editors** — complex person permission model
+3. **Nav bar actions for space editors** — `asset-viewer-nav-bar.svelte` gates edit/archive/favorite by `isOwner`. Space editors have `AssetUpdate` permission but the nav bar hides buttons
+4. **Description / rating / location editing for editors** — `DetailPanelDescription`, `DetailPanelRating`, `DetailPanelLocation` all gate edit controls on `isOwner`. Space editors already have server permission
+5. **Mobile app** — separate feature

--- a/docs/plans/2026-03-30-space-asset-metadata-impl.md
+++ b/docs/plans/2026-03-30-space-asset-metadata-impl.md
@@ -1,0 +1,919 @@
+# Show Tags & People to Space Members — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Space members see tags and recognized people in the asset detail view (read-only for all, owner-only editing).
+
+**Architecture:** Server enriches asset response with space person IDs when `spaceId` query param is provided. Frontend threads `spaceId` through the asset viewer stack, uses it for visibility, thumbnails, and person links.
+
+**Tech Stack:** NestJS (server), Svelte 5 (web), Kysely (DB queries), Vitest (tests), OpenAPI codegen
+
+**Design doc:** `docs/plans/2026-03-30-space-asset-metadata-design.md`
+
+---
+
+## Task 1: Add `checkSpaceAccessForSpace` to access repository
+
+**Files:**
+
+- Modify: `server/src/repositories/access.repository.ts:217-268`
+- Test: `server/src/services/asset.service.spec.ts` (tested via Task 4)
+
+**Step 1: Add the scoped space access check method**
+
+Add below the existing `checkSpaceAccess` method (after line 268). This is the same query but with an added `WHERE shared_space.id = spaceId` clause on both UNION branches:
+
+```typescript
+@GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID, DummyValue.UUID_SET] })
+@ChunkedSet({ paramIndex: 2 })
+async checkSpaceAccessForSpace(userId: string, spaceId: string, assetIds: Set<string>) {
+  if (assetIds.size === 0) {
+    return new Set<string>();
+  }
+
+  return this.db
+    .selectFrom(
+      this.db
+        .selectFrom('shared_space_asset')
+        .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+        .innerJoin('asset', (join) =>
+          join.onRef('asset.id', '=', 'shared_space_asset.assetId').on('asset.deletedAt', 'is', null),
+        )
+        .select(['asset.id', 'asset.livePhotoVideoId'])
+        .where('shared_space_member.userId', '=', userId)
+        .where('shared_space_asset.spaceId', '=', spaceId)
+        .where((eb) =>
+          eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
+        )
+        .union(
+          this.db
+            .selectFrom('shared_space_library')
+            .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+            .innerJoin('asset', (join) =>
+              join
+                .onRef('asset.libraryId', '=', 'shared_space_library.libraryId')
+                .on('asset.deletedAt', 'is', null)
+                .on('asset.isOffline', '=', false),
+            )
+            .select(['asset.id', 'asset.livePhotoVideoId'])
+            .where('shared_space_member.userId', '=', userId)
+            .where('shared_space_library.spaceId', '=', spaceId)
+            .where((eb) =>
+              eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
+            ),
+        )
+        .as('combined'),
+    )
+    .select(['combined.id', 'combined.livePhotoVideoId'])
+    .execute()
+    .then((assets) => {
+      const allowedIds = new Set<string>();
+      for (const asset of assets) {
+        if (asset.id && assetIds.has(asset.id)) {
+          allowedIds.add(asset.id);
+        }
+        if (asset.livePhotoVideoId && assetIds.has(asset.livePhotoVideoId)) {
+          allowedIds.add(asset.livePhotoVideoId);
+        }
+      }
+      return allowedIds;
+    });
+}
+```
+
+**Step 2: Add mock for `checkSpaceAccessForSpace`**
+
+In `server/test/repositories/access.repository.mock.ts`, add `checkSpaceAccessForSpace` to the `asset` block alongside the existing `checkSpaceAccess`:
+
+```typescript
+checkSpaceAccessForSpace: vitest.fn().mockResolvedValue(new Set()),
+```
+
+**Step 3: Run type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to access.repository.ts
+
+**Step 4: Commit**
+
+```
+feat: add checkSpaceAccessForSpace to access repository
+```
+
+---
+
+## Task 2: Add `findSpacePersonsByLinkedPersonIds` batch query
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts:903-913`
+
+**Step 1: Add batch method below existing `findSpacePersonByLinkedPersonId` (line 913)**
+
+```typescript
+@GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+async findSpacePersonsByLinkedPersonIds(spaceId: string, personIds: string[]) {
+  if (personIds.length === 0) {
+    return new Map<string, { id: string; isHidden: boolean }>();
+  }
+
+  const results = await this.db
+    .selectFrom('shared_space_person')
+    .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
+    .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+    .select(['shared_space_person.id', 'shared_space_person.isHidden', 'asset_face.personId'])
+    .where('shared_space_person.spaceId', '=', spaceId)
+    .where('asset_face.personId', 'in', personIds)
+    .groupBy(['shared_space_person.id', 'shared_space_person.isHidden', 'asset_face.personId'])
+    .execute();
+
+  const map = new Map<string, { id: string; isHidden: boolean }>();
+  for (const row of results) {
+    if (row.personId) {
+      map.set(row.personId, { id: row.id, isHidden: row.isHidden });
+    }
+  }
+  return map;
+}
+```
+
+**Step 2: Run type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors
+
+**Step 3: Commit**
+
+```
+feat: add batch findSpacePersonsByLinkedPersonIds query
+```
+
+---
+
+## Task 3: Add `spacePersonId` to DTO and `spaceId` query param to controller
+
+**Files:**
+
+- Modify: `server/src/dtos/person.dto.ts:124-127`
+- Modify: `server/src/controllers/asset.controller.ts:104-113`
+- Modify: `server/src/services/asset.service.ts:85` (method signature)
+
+**Step 1: Add `spacePersonId` to `PersonWithFacesResponseDto`**
+
+In `server/src/dtos/person.dto.ts` at line 126, after `faces!:`:
+
+```typescript
+export class PersonWithFacesResponseDto extends PersonResponseDto {
+  @ApiProperty({ description: 'Face detections' })
+  faces!: AssetFaceWithoutPersonResponseDto[];
+  @ApiPropertyOptional({ description: 'Space person ID (when viewed through a space)' })
+  spacePersonId?: string;
+}
+```
+
+**Step 2: Add `spaceId` query param to controller**
+
+In `server/src/controllers/asset.controller.ts`, change the `getAssetInfo` method (line 111):
+
+```typescript
+getAssetInfo(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto, @Query('spaceId') spaceId?: string): Promise<AssetResponseDto> {
+  return this.service.get(auth, id, spaceId) as Promise<AssetResponseDto>;
+}
+```
+
+Add `import { Query } from '@nestjs/common';` if not already imported.
+
+**Step 3: Update `asset.service.get()` method signature**
+
+In `server/src/services/asset.service.ts` line 85, add `spaceId` parameter:
+
+```typescript
+async get(auth: AuthDto, id: string, spaceId?: string): Promise<AssetResponseDto | SanitizedAssetResponseDto> {
+```
+
+(Don't change the body yet — that's Task 4.)
+
+**Step 4: Run type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors
+
+**Step 5: Commit**
+
+```
+feat: add spaceId query param and spacePersonId DTO field
+```
+
+---
+
+## Task 4: Implement server logic — keep people for space members
+
+**Files:**
+
+- Modify: `server/src/services/asset.service.ts:111-113`
+- Test: `server/src/services/asset.service.spec.ts:177-225`
+
+**Step 1: Write failing tests**
+
+In `server/src/services/asset.service.spec.ts`, replace the existing test "should clear people for shared space access (non-owner)" (lines 217-225) and add new tests after it. Keep the existing "should allow shared space access" test (207-215) unchanged.
+
+Replace lines 217-225 with:
+
+```typescript
+it('should keep people for space member with spaceId', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.getMember.mockResolvedValue({ role: 'viewer' } as any);
+  mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+  mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+    new Map([['person-1', { id: 'space-person-1', isHidden: false }]]),
+  );
+
+  const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+  expect(result).toHaveProperty('people');
+  expect((result as any).people.length).toBeGreaterThan(0);
+});
+
+it('should strip people for space member without spaceId', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+
+  const result = await sut.get(authStub.admin, asset.id);
+
+  expect(result).toHaveProperty('people', []);
+});
+
+it('should reject non-member spaceId', async () => {
+  const asset = AssetFactory.from().exif().build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.getMember.mockResolvedValue(void 0 as any);
+
+  await expect(sut.get(authStub.admin, asset.id, 'bad-space-id')).rejects.toThrow();
+});
+
+it('should filter hidden space persons', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.getMember.mockResolvedValue({ role: 'viewer' } as any);
+  mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+  mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+    new Map([['person-1', { id: 'sp-1', isHidden: true }]]),
+  );
+
+  const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+  expect(result).toHaveProperty('people', []);
+});
+
+it('should filter persons without space person mapping', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.getMember.mockResolvedValue({ role: 'viewer' } as any);
+  mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+  mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(new Map());
+
+  const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+  expect(result).toHaveProperty('people', []);
+});
+
+it('should still strip people for partner access', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+
+  const result = await sut.get(authStub.admin, asset.id);
+
+  expect(result).toHaveProperty('people', []);
+});
+
+it('should still strip people for album access', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+
+  const result = await sut.get(authStub.admin, asset.id);
+
+  expect(result).toHaveProperty('people', []);
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts 2>&1 | tail -30`
+Expected: New tests fail (method signature doesn't handle spaceId yet)
+
+**Step 3: Implement the server logic**
+
+In `server/src/services/asset.service.ts`, replace lines 111-113:
+
+```typescript
+if (auth.sharedLink) {
+  data.people = [];
+} else if (data.ownerId !== auth.user.id) {
+  if (spaceId) {
+    const member = await this.sharedSpaceRepository.getMember(spaceId, auth.user.id);
+    if (!member) {
+      throw new ForbiddenException('Not a member of this space');
+    }
+
+    const hasSpaceAccess = await this.accessRepository.asset.checkSpaceAccessForSpace(
+      auth.user.id,
+      spaceId,
+      new Set([id]),
+    );
+    if (hasSpaceAccess.size === 0) {
+      data.people = [];
+    } else {
+      const globalPersonIds = data.people.map((p) => p.id);
+      const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+        spaceId,
+        globalPersonIds,
+      );
+      for (const person of data.people) {
+        const spacePerson = spacePersonMap.get(person.id);
+        if (spacePerson) {
+          person.spacePersonId = spacePerson.id;
+        }
+      }
+      data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
+    }
+  } else {
+    data.people = [];
+  }
+}
+```
+
+Add `ForbiddenException` to the existing `@nestjs/common` import on line 1 of `asset.service.ts`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts 2>&1 | tail -30`
+Expected: All tests pass
+
+**Step 5: Run full server type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors
+
+**Step 6: Commit**
+
+```
+feat: keep people in asset response for space members
+```
+
+---
+
+## Task 5: Regenerate OpenAPI spec and SDK
+
+**Files:**
+
+- Modified by codegen: `open-api/`, `server/immich-openapi-specs.json`
+
+**Step 1: Build server**
+
+Run: `cd server && pnpm build 2>&1 | tail -5`
+Expected: Build succeeds
+
+**Step 2: Regenerate OpenAPI spec**
+
+Run: `cd server && pnpm sync:open-api 2>&1 | tail -5`
+
+**Step 3: Regenerate TypeScript SDK and Dart client**
+
+Run: `make open-api 2>&1 | tail -10`
+
+Note: Must regenerate both TypeScript SDK and Dart client when API signatures change (per project convention).
+
+**Step 4: Regenerate SQL query files**
+
+Run: `make sql 2>&1 | tail -10`
+
+**Step 5: Verify the SDK now includes `spaceId` parameter**
+
+Run: `grep -n 'spaceId' open-api/typescript-sdk/src/fetch-client.ts | head -5`
+Expected: `spaceId` appears in `getAssetInfo` function signature
+
+**Step 6: Commit**
+
+```
+chore: regenerate OpenAPI spec and SDK with spaceId param
+```
+
+---
+
+## Task 6: Add `Route.viewSpacePerson` to route helper
+
+**Files:**
+
+- Modify: `web/src/lib/route.ts:99-100`
+
+**Step 1: Add the route helper**
+
+After the `viewPerson` definition (line 100), add:
+
+```typescript
+viewSpacePerson: (spaceId: string, personId: string) => `/spaces/${spaceId}/people/${personId}`,
+```
+
+**Step 2: Run type check**
+
+Run: `cd web && npx tsc --noEmit 2>&1 | head -10`
+
+**Step 3: Commit**
+
+```
+feat: add viewSpacePerson route helper
+```
+
+---
+
+## Task 7: Thread `spaceId` through Timeline → AssetViewer
+
+**Files:**
+
+- Modify: `web/src/lib/components/timeline/Timeline.svelte:30-63` (Props), `~723` (TimelineAssetViewer)
+- Modify: `web/src/lib/components/timeline/TimelineAssetViewer.svelte:21-29` (Props), `~235` (AssetViewer)
+- Modify: `web/src/lib/components/asset-viewer/asset-viewer.svelte:62-76` (Props), `~596` (DetailPanel)
+
+**Step 1: Add `spaceId` to Timeline Props and forward it**
+
+In `Timeline.svelte`, add to the Props interface:
+
+```typescript
+spaceId?: string;
+```
+
+Forward it to TimelineAssetViewer (around line 723):
+
+```svelte
+<TimelineAssetViewer bind:invisible {timelineManager} {removeAction} {withStacked} {isShared} {album} {person} {spaceId} />
+```
+
+**Step 2: Add `spaceId` to TimelineAssetViewer Props and forward it**
+
+In `TimelineAssetViewer.svelte`, add to Props:
+
+```typescript
+spaceId?: string;
+```
+
+Forward to AssetViewer (around line 237):
+
+```svelte
+<AssetViewer {withStacked} cursor={assetCursor} {isShared} {album} {person} {spaceId} ... />
+```
+
+**Step 3: Add `spaceId` to AssetViewer Props and forward to DetailPanel**
+
+In `asset-viewer.svelte`, add to Props:
+
+```typescript
+spaceId?: string;
+```
+
+Forward to DetailPanel (around line 596):
+
+```svelte
+<DetailPanel {asset} currentAlbum={album} {spaceId} />
+```
+
+**Step 4: Do NOT commit yet** — proceed to Task 8 immediately to avoid a broken intermediate commit.
+
+---
+
+## Task 8: Update DetailPanel — show people for space members
+
+**Files:**
+
+- Modify: `web/src/lib/components/asset-viewer/detail-panel.svelte:53-56` (Props), `~62` (derivations), `~189` (people guard), `~234` (person link), `~244` (thumbnail)
+
+**Step 1: Add `spaceId` to Props and derive `isSpaceMember`**
+
+Update Props (line 53-56):
+
+```typescript
+interface Props {
+  asset: AssetResponseDto;
+  currentAlbum?: AlbumResponseDto | null;
+  spaceId?: string;
+}
+```
+
+Add derivation after `isOwner` (line 62):
+
+```typescript
+let isSpaceMember = $derived(!!spaceId);
+```
+
+**Step 2: Update people section visibility guard**
+
+Change line 189 from:
+
+```svelte
+{#if !authManager.isSharedLink && isOwner}
+```
+
+To:
+
+```svelte
+{#if !authManager.isSharedLink && (isOwner || isSpaceMember)}
+```
+
+**Step 3: Gate edit controls within people section to `isOwner` only**
+
+Wrap the face edit button, show/hide toggle, and "tag people" button with `{#if isOwner}` guards. These are inside the people section but should only show for owners. Find them by looking for the `mdiPencil`, `mdiEye`/`mdiEyeOff`, and `mdiPlus` icon references within the people section.
+
+**Step 4: Update person link to use space route**
+
+Change the person link (around line 234) from:
+
+```svelte
+href={Route.viewPerson(person, { previousRoute })}
+```
+
+To:
+
+```svelte
+href={spaceId && person.spacePersonId
+  ? Route.viewSpacePerson(spaceId, person.spacePersonId)
+  : Route.viewPerson(person, { previousRoute })}
+```
+
+Import `Route.viewSpacePerson` if needed (should be on the same `Route` object).
+
+**Step 5: Update person thumbnail to use space endpoint**
+
+Change the thumbnail URL (around line 244) from:
+
+```svelte
+url={getPeopleThumbnailUrl(person)}
+```
+
+To:
+
+```svelte
+url={spaceId && person.spacePersonId
+  ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, { updatedAt: person.updatedAt })
+  : getPeopleThumbnailUrl(person)}
+```
+
+Add `createUrl` to imports if not already present (from `$lib/utils`).
+
+**Step 6: Run type check**
+
+Run: `cd web && npx tsc --noEmit 2>&1 | head -20`
+
+**Step 7: Commit (includes Task 7 changes)**
+
+```
+feat: thread spaceId and show people to space members in detail panel
+```
+
+---
+
+## Task 9: Update DetailPanelTags — show tags read-only for space members
+
+**Files:**
+
+- Modify: `web/src/lib/components/asset-viewer/detail-panel-tags.svelte`
+
+**Step 1: Add `spaceId` to Props**
+
+```typescript
+interface Props {
+  asset: AssetResponseDto;
+  isOwner: boolean;
+  spaceId?: string;
+}
+
+let { asset = $bindable(), isOwner, spaceId }: Props = $props();
+let isSpaceMember = $derived(!!spaceId);
+```
+
+**Step 2: Update visibility guard**
+
+Change line 40 from:
+
+```svelte
+{#if isOwner && !authManager.isSharedLink}
+```
+
+To:
+
+```svelte
+{#if (isOwner || isSpaceMember) && !authManager.isSharedLink}
+```
+
+**Step 3: Gate edit controls**
+
+Wrap the `IconButton` (remove X, lines 54-61) with `{#if isOwner}`:
+
+```svelte
+{#if isOwner}
+  <IconButton
+    aria-label={$t('remove_tag')}
+    icon={mdiClose}
+    onclick={() => handleRemove(tag.id)}
+    size="tiny"
+    class="hover:bg-primary-400"
+    shape="round"
+  />
+{/if}
+```
+
+Wrap the `HeaderActionButton` (add tag, line 64) with `{#if isOwner}`:
+
+```svelte
+{#if isOwner}
+  <HeaderActionButton action={Tag} />
+{/if}
+```
+
+**Step 4: Update `getAssetInfo` re-fetch calls to include `spaceId`**
+
+Change line 25:
+
+```typescript
+asset = await getAssetInfo({ id: asset.id, spaceId });
+```
+
+Change line 31:
+
+```typescript
+asset = await getAssetInfo({ id: asset.id, spaceId });
+```
+
+**Step 5: Forward `spaceId` from DetailPanel**
+
+In `detail-panel.svelte`, update the DetailPanelTags usage (around line 570):
+
+```svelte
+<DetailPanelTags {asset} {isOwner} {spaceId} />
+```
+
+**Step 6: Run type check**
+
+Run: `cd web && npx tsc --noEmit 2>&1 | head -20`
+
+**Step 7: Commit**
+
+```
+feat: show tags read-only to space members
+```
+
+---
+
+## Task 10: Update AssetCacheManager and other `getAssetInfo` call sites
+
+**Files:**
+
+- Modify: `web/src/lib/managers/AssetCacheManager.svelte.ts:53-55`
+- Modify: `web/src/lib/components/spaces/space-search-results.svelte:25`
+- Modify: `web/src/lib/managers/asset-viewer-manager.svelte.ts:169-173`
+
+**Step 1: Update AssetCacheManager to accept `spaceId` (bypass cache for space context)**
+
+Change `getAsset` method (line 53). Space context always needs fresh data with person enrichment, so bypass the cache when `spaceId` is provided. This avoids cache key mismatch issues with `invalidateAsset`:
+
+```typescript
+async getAsset({ id, key, slug, spaceId }: { id: string; key?: string; slug?: string; spaceId?: string }, updateCache = true) {
+  if (spaceId) {
+    // Space context needs fresh data with person enrichment — bypass cache
+    return getAssetInfo({ id, key, slug, spaceId });
+  }
+  return this.#assetCache.getOrFetch({ id, key, slug }, updateCache);
+}
+```
+
+**Step 2: Update space-search-results.svelte**
+
+This component has no `spaceId` prop. Add it:
+
+1. Add `spaceId?: string` to the Props interface
+2. Update `getFullAsset` (line 25) to include `spaceId`:
+
+```typescript
+const getFullAsset = async (id: string): Promise<AssetResponseDto> => {
+  return getAssetInfo({ ...authManager.params, id, spaceId });
+};
+```
+
+3. Forward `spaceId` to the dynamically imported `AssetViewer` (around line 110-111)
+4. In the space page `+page.svelte`, find where `SpaceSearchResults` is used (around line 853) and pass `spaceId={space.id}`
+
+**Step 3: Update TimelineAssetViewer call sites**
+
+`TimelineAssetViewer.svelte` has two additional `getAssetInfo` calls that need `spaceId`:
+
+1. Line ~42-44: `assetCacheManager.getAsset({ ...authManager.params, id })` — add `spaceId`
+2. Line ~207: `getAssetInfo({ ...authManager.params, id: restoredAsset.id })` in the undo-delete handler — add `spaceId`
+
+**Step 4: Update asset-viewer-manager.svelte.ts**
+
+The `setAssetId` method (line 170) needs to accept and pass `spaceId`. Since the asset viewer manager is a singleton, passing `spaceId` per-call is better than storing it as state:
+
+```typescript
+async setAssetId(id: string, spaceId?: string): Promise<AssetResponseDto> {
+  const asset = await getAssetInfo({ ...authManager.params, id, spaceId });
+  this.setAsset(asset);
+  return asset;
+}
+```
+
+Update callers of `setAssetId` to pass `spaceId` when available.
+
+**Step 5: Run type check**
+
+Run: `cd web && npx tsc --noEmit 2>&1 | head -20`
+
+**Step 5: Commit**
+
+```
+feat: pass spaceId through cache manager and search results
+```
+
+---
+
+## Task 11: Wire `spaceId` from space page to Timeline
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte:877-941`
+
+**Step 1: Pass `spaceId` to Timeline**
+
+The space page already has `space.id` available. Add `spaceId={space.id}` to the Timeline component (around line 877):
+
+```svelte
+<Timeline
+  enableRouting={false}
+  bind:timelineManager
+  {options}
+  assetInteraction={currentAssetInteraction}
+  {isSelectionMode}
+  onEscape={handleEscape}
+  spaceId={space.id}
+>
+```
+
+**Step 2: Run svelte-check**
+
+Run: `cd web && pnpm check 2>&1 | tail -20`
+
+**Step 3: Commit**
+
+```
+feat: pass spaceId from space page to timeline
+```
+
+---
+
+## Task 12: Server unit tests — comprehensive coverage
+
+**Files:**
+
+- Modify: `server/src/services/asset.service.spec.ts`
+
+**Step 1: Verify all tests pass**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts 2>&1 | tail -30`
+Expected: All tests from Task 4 pass
+
+**Step 2: Add test for "space member but asset not in that space"**
+
+```typescript
+it('should strip people when asset is not in the specified space', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.getMember.mockResolvedValue({ role: 'viewer' } as any);
+  mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set());
+
+  const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+  expect(result).toHaveProperty('people', []);
+});
+```
+
+**Step 3: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts 2>&1 | tail -20`
+Expected: All pass
+
+**Step 4: Commit**
+
+```
+test: comprehensive server tests for space metadata visibility
+```
+
+---
+
+## Task 13: Frontend unit tests
+
+**Files:**
+
+- Modify: `web/src/lib/components/asset-viewer/detail-panel-tags.spec.ts` (create if needed)
+
+**Step 1: Check if test files exist**
+
+Run: `ls web/src/lib/components/asset-viewer/detail-panel*.spec.ts 2>/dev/null`
+
+**Step 2: Write tests for DetailPanelTags**
+
+Test that:
+
+- Tags section visible when `spaceId` is set (even when not owner)
+- Tags section hidden when no `spaceId` and not owner
+- Remove buttons hidden when `spaceId` is set (read-only)
+- Add tag button hidden when `spaceId` is set
+- Owner still sees edit controls even with `spaceId`
+
+**Step 3: Run frontend tests**
+
+Run: `cd web && pnpm test -- --run src/lib/components/asset-viewer/detail-panel-tags.spec.ts 2>&1 | tail -20`
+
+**Step 4: Commit**
+
+```
+test: frontend tests for space metadata visibility
+```
+
+---
+
+## Task 14: Regenerate SQL query files and final checks
+
+**Files:**
+
+- Modified by codegen: `server/src/queries/`
+
+**Step 1: Rebuild server**
+
+Run: `cd server && pnpm build 2>&1 | tail -5`
+
+**Step 2: Regenerate SQL**
+
+Run: `make sql 2>&1 | tail -10`
+
+**Step 3: Run full lint and type check**
+
+Run: `make check-server 2>&1 | tail -20`
+Then: `make check-web 2>&1 | tail -20`
+Then: `make lint-server 2>&1 | tail -20`
+Then: `make lint-web 2>&1 | tail -20`
+
+**Step 4: Run full test suites**
+
+Run: `cd server && pnpm test 2>&1 | tail -20`
+Then: `cd web && pnpm test 2>&1 | tail -20`
+
+**Step 5: Commit any codegen changes**
+
+```
+chore: regenerate SQL query files
+```
+
+---
+
+## Task 15: Format and final commit
+
+**Step 1: Format all changed files**
+
+Run: `make format-server && make format-web`
+
+**Step 2: Run final check**
+
+Run: `make check-all 2>&1 | tail -30`
+
+**Step 3: Commit any formatting changes**
+
+```
+style: format
+```

--- a/mobile/openapi/lib/api/assets_api.dart
+++ b/mobile/openapi/lib/api/assets_api.dart
@@ -601,10 +601,12 @@ class AssetsApi {
   ///
   /// * [String] id (required):
   ///
+  /// * [String] spaceId (required):
+  ///
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getAssetInfoWithHttpInfo(String id, { String? key, String? slug, }) async {
+  Future<Response> getAssetInfoWithHttpInfo(String id, String spaceId, { String? key, String? slug, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}'
       .replaceAll('{id}', id);
@@ -622,6 +624,7 @@ class AssetsApi {
     if (slug != null) {
       queryParams.addAll(_queryParams('', 'slug', slug));
     }
+      queryParams.addAll(_queryParams('', 'spaceId', spaceId));
 
     const contentTypes = <String>[];
 
@@ -645,11 +648,13 @@ class AssetsApi {
   ///
   /// * [String] id (required):
   ///
+  /// * [String] spaceId (required):
+  ///
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<AssetResponseDto?> getAssetInfo(String id, { String? key, String? slug, }) async {
-    final response = await getAssetInfoWithHttpInfo(id,  key: key, slug: slug, );
+  Future<AssetResponseDto?> getAssetInfo(String id, String spaceId, { String? key, String? slug, }) async {
+    final response = await getAssetInfoWithHttpInfo(id, spaceId,  key: key, slug: slug, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/assets_api.dart
+++ b/mobile/openapi/lib/api/assets_api.dart
@@ -601,12 +601,12 @@ class AssetsApi {
   ///
   /// * [String] id (required):
   ///
-  /// * [String] spaceId (required):
-  ///
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> getAssetInfoWithHttpInfo(String id, String spaceId, { String? key, String? slug, }) async {
+  ///
+  /// * [String] spaceId:
+  Future<Response> getAssetInfoWithHttpInfo(String id, { String? key, String? slug, String? spaceId, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}'
       .replaceAll('{id}', id);
@@ -624,7 +624,9 @@ class AssetsApi {
     if (slug != null) {
       queryParams.addAll(_queryParams('', 'slug', slug));
     }
+    if (spaceId != null) {
       queryParams.addAll(_queryParams('', 'spaceId', spaceId));
+    }
 
     const contentTypes = <String>[];
 
@@ -648,13 +650,13 @@ class AssetsApi {
   ///
   /// * [String] id (required):
   ///
-  /// * [String] spaceId (required):
-  ///
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<AssetResponseDto?> getAssetInfo(String id, String spaceId, { String? key, String? slug, }) async {
-    final response = await getAssetInfoWithHttpInfo(id, spaceId,  key: key, slug: slug, );
+  ///
+  /// * [String] spaceId:
+  Future<AssetResponseDto?> getAssetInfo(String id, { String? key, String? slug, String? spaceId, }) async {
+    final response = await getAssetInfoWithHttpInfo(id,  key: key, slug: slug, spaceId: spaceId, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/model/person_with_faces_response_dto.dart
+++ b/mobile/openapi/lib/model/person_with_faces_response_dto.dart
@@ -20,6 +20,7 @@ class PersonWithFacesResponseDto {
     this.isFavorite,
     required this.isHidden,
     required this.name,
+    this.spacePersonId,
     this.species,
     required this.thumbnailPath,
     this.type = 'person',
@@ -59,6 +60,15 @@ class PersonWithFacesResponseDto {
   /// Person name
   String name;
 
+  /// Space person ID (when viewed through a space)
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? spacePersonId;
+
   /// Pet species (e.g. dog, cat)
   String? species;
 
@@ -86,6 +96,7 @@ class PersonWithFacesResponseDto {
     other.isFavorite == isFavorite &&
     other.isHidden == isHidden &&
     other.name == name &&
+    other.spacePersonId == spacePersonId &&
     other.species == species &&
     other.thumbnailPath == thumbnailPath &&
     other.type == type &&
@@ -101,13 +112,14 @@ class PersonWithFacesResponseDto {
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
     (isHidden.hashCode) +
     (name.hashCode) +
+    (spacePersonId == null ? 0 : spacePersonId!.hashCode) +
     (species == null ? 0 : species!.hashCode) +
     (thumbnailPath.hashCode) +
     (type.hashCode) +
     (updatedAt == null ? 0 : updatedAt!.hashCode);
 
   @override
-  String toString() => 'PersonWithFacesResponseDto[birthDate=$birthDate, color=$color, faces=$faces, id=$id, isFavorite=$isFavorite, isHidden=$isHidden, name=$name, species=$species, thumbnailPath=$thumbnailPath, type=$type, updatedAt=$updatedAt]';
+  String toString() => 'PersonWithFacesResponseDto[birthDate=$birthDate, color=$color, faces=$faces, id=$id, isFavorite=$isFavorite, isHidden=$isHidden, name=$name, spacePersonId=$spacePersonId, species=$species, thumbnailPath=$thumbnailPath, type=$type, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -130,6 +142,11 @@ class PersonWithFacesResponseDto {
     }
       json[r'isHidden'] = this.isHidden;
       json[r'name'] = this.name;
+    if (this.spacePersonId != null) {
+      json[r'spacePersonId'] = this.spacePersonId;
+    } else {
+    //  json[r'spacePersonId'] = null;
+    }
     if (this.species != null) {
       json[r'species'] = this.species;
     } else {
@@ -161,6 +178,7 @@ class PersonWithFacesResponseDto {
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
         isHidden: mapValueOfType<bool>(json, r'isHidden')!,
         name: mapValueOfType<String>(json, r'name')!,
+        spacePersonId: mapValueOfType<String>(json, r'spacePersonId'),
         species: mapValueOfType<String>(json, r'species'),
         thumbnailPath: mapValueOfType<String>(json, r'thumbnailPath')!,
         type: mapValueOfType<String>(json, r'type')!,

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3524,7 +3524,7 @@
           },
           {
             "name": "spaceId",
-            "required": true,
+            "required": false,
             "in": "query",
             "schema": {
               "type": "string"

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3521,6 +3521,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "spaceId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -23288,6 +23296,10 @@
           },
           "name": {
             "description": "Person name",
+            "type": "string"
+          },
+          "spacePersonId": {
+            "description": "Space person ID (when viewed through a space)",
             "type": "string"
           },
           "species": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -533,6 +533,8 @@ export type PersonWithFacesResponseDto = {
     isHidden: boolean;
     /** Person name */
     name: string;
+    /** Space person ID (when viewed through a space) */
+    spacePersonId?: string;
     /** Pet species (e.g. dog, cat) */
     species?: string | null;
     /** Thumbnail path */
@@ -4469,17 +4471,19 @@ export function getAssetStatistics({ isFavorite, isTrashed, visibility }: {
 /**
  * Retrieve an asset
  */
-export function getAssetInfo({ id, key, slug }: {
+export function getAssetInfo({ id, key, slug, spaceId }: {
     id: string;
     key?: string;
     slug?: string;
+    spaceId: string;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: AssetResponseDto;
     }>(`/assets/${encodeURIComponent(id)}${QS.query(QS.explode({
         key,
-        slug
+        slug,
+        spaceId
     }))}`, {
         ...opts
     }));

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -4475,7 +4475,7 @@ export function getAssetInfo({ id, key, slug, spaceId }: {
     id: string;
     key?: string;
     slug?: string;
-    spaceId: string;
+    spaceId?: string;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;

--- a/server/src/controllers/asset.controller.ts
+++ b/server/src/controllers/asset.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Put, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import {
@@ -108,6 +108,7 @@ export class AssetController {
     description: 'Retrieve detailed information about a specific asset.',
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
+  @ApiQuery({ name: 'spaceId', required: false, type: String })
   getAssetInfo(
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,

--- a/server/src/controllers/asset.controller.ts
+++ b/server/src/controllers/asset.controller.ts
@@ -108,8 +108,12 @@ export class AssetController {
     description: 'Retrieve detailed information about a specific asset.',
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
-  getAssetInfo(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<AssetResponseDto> {
-    return this.service.get(auth, id) as Promise<AssetResponseDto>;
+  getAssetInfo(
+    @Auth() auth: AuthDto,
+    @Param() { id }: UUIDParamDto,
+    @Query('spaceId') spaceId?: string,
+  ): Promise<AssetResponseDto> {
+    return this.service.get(auth, id, spaceId) as Promise<AssetResponseDto>;
   }
 
   @Put('copy')

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -124,6 +124,8 @@ export class PersonResponseDto {
 export class PersonWithFacesResponseDto extends PersonResponseDto {
   @ApiProperty({ description: 'Face detections' })
   faces!: AssetFaceWithoutPersonResponseDto[];
+  @ApiPropertyOptional({ description: 'Space person ID (when viewed through a space)' })
+  spacePersonId?: string;
 }
 
 export class AssetFaceWithoutPersonResponseDto {

--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -164,6 +164,46 @@ from
       )
   ) as "combined"
 
+-- AccessRepository.asset.checkSpaceAccessForSpace
+select
+  "combined"."id",
+  "combined"."livePhotoVideoId"
+from
+  (
+    select
+      "asset"."id",
+      "asset"."livePhotoVideoId"
+    from
+      "shared_space_asset"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
+      inner join "asset" on "asset"."id" = "shared_space_asset"."assetId"
+      and "asset"."deletedAt" is null
+    where
+      "shared_space_member"."userId" = $1
+      and "shared_space_asset"."spaceId" = $2
+      and (
+        "asset"."id" in ($3)
+        or "asset"."livePhotoVideoId" in ($4)
+      )
+    union
+    select
+      "asset"."id",
+      "asset"."livePhotoVideoId"
+    from
+      "shared_space_library"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
+      inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
+      and "asset"."deletedAt" is null
+      and "asset"."isOffline" = $5
+    where
+      "shared_space_member"."userId" = $6
+      and "shared_space_library"."spaceId" = $7
+      and (
+        "asset"."id" in ($8)
+        or "asset"."livePhotoVideoId" in ($9)
+      )
+  ) as "combined"
+
 -- AccessRepository.asset.checkSpaceEditAccess
 select
   "combined"."id",

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -726,3 +726,20 @@ where
   and "asset_face"."personId" = $2
 limit
   $3
+
+-- SharedSpaceRepository.findSpacePersonsByLinkedPersonIds
+select
+  "shared_space_person"."id",
+  "shared_space_person"."isHidden",
+  "asset_face"."personId"
+from
+  "shared_space_person"
+  inner join "shared_space_person_face" on "shared_space_person_face"."personId" = "shared_space_person"."id"
+  inner join "asset_face" on "asset_face"."id" = "shared_space_person_face"."assetFaceId"
+where
+  "shared_space_person"."spaceId" = $1
+  and "asset_face"."personId" in ($2)
+group by
+  "shared_space_person"."id",
+  "shared_space_person"."isHidden",
+  "asset_face"."personId"

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -267,6 +267,62 @@ class AssetAccess {
       });
   }
 
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID, DummyValue.UUID_SET] })
+  @ChunkedSet({ paramIndex: 2 })
+  async checkSpaceAccessForSpace(userId: string, spaceId: string, assetIds: Set<string>) {
+    if (assetIds.size === 0) {
+      return new Set<string>();
+    }
+
+    return this.db
+      .selectFrom(
+        this.db
+          .selectFrom('shared_space_asset')
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+          .innerJoin('asset', (join) =>
+            join.onRef('asset.id', '=', 'shared_space_asset.assetId').on('asset.deletedAt', 'is', null),
+          )
+          .select(['asset.id', 'asset.livePhotoVideoId'])
+          .where('shared_space_member.userId', '=', userId)
+          .where('shared_space_asset.spaceId', '=', spaceId)
+          .where((eb) =>
+            eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
+          )
+          .union(
+            this.db
+              .selectFrom('shared_space_library')
+              .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+              .innerJoin('asset', (join) =>
+                join
+                  .onRef('asset.libraryId', '=', 'shared_space_library.libraryId')
+                  .on('asset.deletedAt', 'is', null)
+                  .on('asset.isOffline', '=', false),
+              )
+              .select(['asset.id', 'asset.livePhotoVideoId'])
+              .where('shared_space_member.userId', '=', userId)
+              .where('shared_space_library.spaceId', '=', spaceId)
+              .where((eb) =>
+                eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
+              ),
+          )
+          .as('combined'),
+      )
+      .select(['combined.id', 'combined.livePhotoVideoId'])
+      .execute()
+      .then((assets) => {
+        const allowedIds = new Set<string>();
+        for (const asset of assets) {
+          if (asset.id && assetIds.has(asset.id)) {
+            allowedIds.add(asset.id);
+          }
+          if (asset.livePhotoVideoId && assetIds.has(asset.livePhotoVideoId)) {
+            allowedIds.add(asset.livePhotoVideoId);
+          }
+        }
+        return allowedIds;
+      });
+  }
+
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID_SET] })
   @ChunkedSet({ paramIndex: 1 })
   async checkSpaceEditAccess(userId: string, assetIds: Set<string>) {

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -911,4 +911,29 @@ export class SharedSpaceRepository {
       .limit(1)
       .executeTakeFirst();
   }
+
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  async findSpacePersonsByLinkedPersonIds(spaceId: string, personIds: string[]) {
+    if (personIds.length === 0) {
+      return new Map<string, { id: string; isHidden: boolean }>();
+    }
+
+    const results = await this.db
+      .selectFrom('shared_space_person')
+      .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .select(['shared_space_person.id', 'shared_space_person.isHidden', 'asset_face.personId'])
+      .where('shared_space_person.spaceId', '=', spaceId)
+      .where('asset_face.personId', 'in', personIds)
+      .groupBy(['shared_space_person.id', 'shared_space_person.isHidden', 'asset_face.personId'])
+      .execute();
+
+    const map = new Map<string, { id: string; isHidden: boolean }>();
+    for (const row of results) {
+      if (row.personId) {
+        map.set(row.personId, { id: row.id, isHidden: row.isHidden });
+      }
+    }
+    return map;
+  }
 }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -319,6 +319,36 @@ describe(AssetService.name, () => {
       expect(result).toHaveProperty('people', []);
     });
 
+    it('should still strip people for shared link access', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSharedLinkAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+
+      const result = await sut.get(
+        { ...authStub.adminSharedLink, sharedLink: { ...authStub.adminSharedLink.sharedLink!, showExif: true } },
+        asset.id,
+      );
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should preserve people for owner access', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.admin.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(result).toHaveProperty('people');
+      expect((result as any).people.length).toBeGreaterThan(0);
+    });
+
     it('should strip people when asset is not in the specified space', async () => {
       const asset = AssetFactory.from()
         .exif()

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { AssetJobName, AssetStatsResponseDto } from 'src/dtos/asset.dto';
 import { AssetEditAction } from 'src/dtos/editing.dto';
@@ -214,12 +214,122 @@ describe(AssetService.name, () => {
       expect(mocks.access.asset.checkSpaceAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set([asset.id]));
     });
 
-    it('should clear people for shared space access (non-owner)', async () => {
-      const asset = AssetFactory.from().exif().build();
+    it('should keep people for space member with spaceId', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([['person-1', { id: 'space-person-1', isHidden: false }]]),
+      );
+
+      const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people');
+      expect((result as any).people.length).toBeGreaterThan(0);
+      expect((result as any).people[0].spacePersonId).toBe('space-person-1');
+    });
+
+    it('should strip people for space member without spaceId', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
 
       const result = await sut.get(authStub.admin, asset.id);
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should reject non-member spaceId', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue(void 0 as any);
+
+      await expect(sut.get(authStub.admin, asset.id, 'space-id')).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should filter hidden space persons', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([['person-1', { id: 'space-person-1', isHidden: true }]]),
+      );
+
+      const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should filter persons without space person mapping', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(new Map());
+
+      const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should still strip people for partner access', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should still strip people for album access', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should strip people when asset is not in the specified space', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set());
+
+      const result = await sut.get(authStub.admin, asset.id, 'space-id');
 
       expect(result).toHaveProperty('people', []);
     });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -82,7 +82,7 @@ export class AssetService extends BaseService {
     return this.assetRepository.getAllByDeviceId(auth.user.id, deviceId);
   }
 
-  async get(auth: AuthDto, id: string): Promise<AssetResponseDto | SanitizedAssetResponseDto> {
+  async get(auth: AuthDto, id: string, spaceId?: string): Promise<AssetResponseDto | SanitizedAssetResponseDto> {
     await this.requireAccess({ auth, permission: Permission.AssetRead, ids: [id] });
 
     const asset = await this.assetRepository.getById(id, {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import _ from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import { JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
@@ -108,8 +108,41 @@ export class AssetService extends BaseService {
       delete data.owner;
     }
 
-    if (data.ownerId !== auth.user.id || auth.sharedLink) {
+    if (auth.sharedLink) {
       data.people = [];
+    } else if (data.ownerId !== auth.user.id) {
+      if (spaceId) {
+        const member = await this.sharedSpaceRepository.getMember(spaceId, auth.user.id);
+        if (!member) {
+          throw new ForbiddenException('Not a member of this space');
+        }
+
+        const hasSpaceAccess = await this.accessRepository.asset.checkSpaceAccessForSpace(
+          auth.user.id,
+          spaceId,
+          new Set([id]),
+        );
+        if (hasSpaceAccess.size === 0 || !data.people) {
+          data.people = [];
+        } else {
+          const globalPersonIds = data.people.map((p) => p.id);
+          const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+            spaceId,
+            globalPersonIds,
+          );
+          for (const person of data.people) {
+            const spacePerson = spacePersonMap.get(person.id);
+            if (spacePerson) {
+              person.spacePersonId = spacePerson.id;
+            }
+          }
+          data.people = data.people.filter(
+            (p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden,
+          );
+        }
+      } else {
+        data.people = [];
+      }
     }
 
     return data;

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -136,9 +136,7 @@ export class AssetService extends BaseService {
               person.spacePersonId = spacePerson.id;
             }
           }
-          data.people = data.people.filter(
-            (p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden,
-          );
+          data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
         }
       } else {
         data.people = [];

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -21,6 +21,7 @@ export const newAccessRepositoryMock = (): IAccessRepositoryMock => {
       checkAlbumAccess: vitest.fn().mockResolvedValue(new Set()),
       checkPartnerAccess: vitest.fn().mockResolvedValue(new Set()),
       checkSpaceAccess: vitest.fn().mockResolvedValue(new Set()),
+      checkSpaceAccessForSpace: vitest.fn().mockResolvedValue(new Set()),
       checkSpaceEditAccess: vitest.fn().mockResolvedValue(new Set()),
       checkSharedLinkAccess: vitest.fn().mockResolvedValue(new Set()),
     },

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -241,7 +241,7 @@
       }
 
       if ($slideshowRepeat && slideshowStartAssetId) {
-        await assetViewerManager.setAssetId(slideshowStartAssetId);
+        await assetViewerManager.setAssetId(slideshowStartAssetId, spaceId);
         $restartSlideshowProgress = true;
         return;
       }
@@ -257,7 +257,7 @@
   let assetViewerHtmlElement = $state<HTMLElement>();
 
   const slideshowHistory = new SlideshowHistory((asset) => {
-    handlePromiseError(assetViewerManager.setAssetId(asset.id).then(() => ($restartSlideshowProgress = true)));
+    handlePromiseError(assetViewerManager.setAssetId(asset.id, spaceId).then(() => ($restartSlideshowProgress = true)));
   });
 
   const handleVideoStarted = () => {

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -73,6 +73,7 @@
     onClose?: (asset: AssetResponseDto) => void;
     onRemoveFromAlbum?: (assetIds: string[]) => void;
     onRandom?: () => Promise<{ id: string } | undefined>;
+    spaceId?: string;
   }
 
   let {
@@ -89,6 +90,7 @@
     onClose,
     onRemoveFromAlbum,
     onRandom,
+    spaceId,
   }: Props = $props();
 
   const {
@@ -593,7 +595,7 @@
       translate="yes"
     >
       {#if showDetailPanel}
-        <DetailPanel {asset} currentAlbum={album} />
+        <DetailPanel {asset} currentAlbum={album} {spaceId} />
       {:else if assetViewerManager.isShowEditor}
         <EditorPanel {asset} onClose={closeEditor} />
       {/if}

--- a/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
@@ -13,22 +13,24 @@
   interface Props {
     asset: AssetResponseDto;
     isOwner: boolean;
+    spaceId?: string;
   }
 
-  let { asset = $bindable(), isOwner }: Props = $props();
+  let { asset = $bindable(), isOwner, spaceId }: Props = $props();
+  let isSpaceMember = $derived(!!spaceId);
 
   let tags = $derived(asset.tags || []);
 
   const handleRemove = async (tagId: string) => {
     const ids = await removeTag({ tagIds: [tagId], assetIds: [asset.id], showNotification: false });
     if (ids) {
-      asset = await getAssetInfo({ id: asset.id });
+      asset = await getAssetInfo({ id: asset.id, spaceId });
     }
   };
 
   const onAssetsTag = async (ids: string[]) => {
     if (ids.includes(asset.id)) {
-      asset = await getAssetInfo({ id: asset.id });
+      asset = await getAssetInfo({ id: asset.id, spaceId });
     }
   };
 
@@ -37,7 +39,7 @@
 
 <OnEvents {onAssetsTag} />
 
-{#if isOwner && !authManager.isSharedLink}
+{#if (isOwner || isSpaceMember) && !authManager.isSharedLink}
   <section class="px-4 mt-4">
     <div class="flex h-10 w-full items-center justify-between text-sm">
       <Text color="muted">{$t('tags')}</Text>
@@ -51,17 +53,21 @@
           >
             {tag.value}
           </Link>
-          <IconButton
-            aria-label={$t('remove_tag')}
-            icon={mdiClose}
-            onclick={() => handleRemove(tag.id)}
-            size="tiny"
-            class="hover:bg-primary-400"
-            shape="round"
-          />
+          {#if isOwner}
+            <IconButton
+              aria-label={$t('remove_tag')}
+              icon={mdiClose}
+              onclick={() => handleRemove(tag.id)}
+              size="tiny"
+              class="hover:bg-primary-400"
+              shape="round"
+            />
+          {/if}
         </Badge>
       {/each}
-      <HeaderActionButton action={Tag} />
+      {#if isOwner}
+        <HeaderActionButton action={Tag} />
+      {/if}
     </section>
   </section>
 {/if}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -248,7 +248,9 @@
                   curve
                   shadow
                   url={spaceId && person.spacePersonId
-                    ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, { updatedAt: person.updatedAt })
+                    ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, {
+                        updatedAt: person.updatedAt,
+                      })
                     : getPeopleThumbnailUrl(person)}
                   altText={person.name}
                   title={person.name}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -14,7 +14,7 @@
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { locale } from '$lib/stores/preferences.store';
   import { preferences, user } from '$lib/stores/user.store';
-  import { getAssetMediaUrl, getPeopleThumbnailUrl } from '$lib/utils';
+  import { createUrl, getAssetMediaUrl, getPeopleThumbnailUrl } from '$lib/utils';
   import { delay, getDimensions } from '$lib/utils/asset-utils';
   import { getByteUnitString } from '$lib/utils/byte-units';
   import { handleError } from '$lib/utils/handle-error';
@@ -53,9 +53,11 @@
   interface Props {
     asset: AssetResponseDto;
     currentAlbum?: AlbumResponseDto | null;
+    spaceId?: string;
   }
 
-  let { asset, currentAlbum = null }: Props = $props();
+  let { asset, currentAlbum = null, spaceId }: Props = $props();
+  let isSpaceMember = $derived(!!spaceId);
 
   let showAssetPath = $state(false);
   let showEditFaces = $state(false);
@@ -122,7 +124,7 @@
   };
 
   const handleRefreshPeople = async () => {
-    asset = await getAssetInfo({ id: asset.id });
+    asset = await getAssetInfo({ id: asset.id, spaceId });
     showEditFaces = false;
   };
 
@@ -186,42 +188,44 @@
   <DetailPanelDescription {asset} {isOwner} />
   <DetailPanelRating {asset} {isOwner} />
 
-  {#if !authManager.isSharedLink && isOwner}
+  {#if !authManager.isSharedLink && (isOwner || isSpaceMember)}
     <section class="px-4 pt-4 text-sm">
       <div class="flex h-10 w-full items-center justify-between">
         <Text size="small" color="muted">{$t('people')}</Text>
         <div class="flex gap-2 items-center">
-          {#if people.some((person) => person.isHidden)}
+          {#if isOwner}
+            {#if people.some((person) => person.isHidden)}
+              <IconButton
+                aria-label={$t('show_hidden_people')}
+                icon={showingHiddenPeople ? mdiEyeOff : mdiEye}
+                size="medium"
+                shape="round"
+                color="secondary"
+                variant="ghost"
+                onclick={() => (showingHiddenPeople = !showingHiddenPeople)}
+              />
+            {/if}
             <IconButton
-              aria-label={$t('show_hidden_people')}
-              icon={showingHiddenPeople ? mdiEyeOff : mdiEye}
+              aria-label={$t('tag_people')}
+              icon={mdiPlus}
               size="medium"
               shape="round"
               color="secondary"
               variant="ghost"
-              onclick={() => (showingHiddenPeople = !showingHiddenPeople)}
+              onclick={() => (isFaceEditMode.value = !isFaceEditMode.value)}
             />
-          {/if}
-          <IconButton
-            aria-label={$t('tag_people')}
-            icon={mdiPlus}
-            size="medium"
-            shape="round"
-            color="secondary"
-            variant="ghost"
-            onclick={() => (isFaceEditMode.value = !isFaceEditMode.value)}
-          />
 
-          {#if people.length > 0 || unassignedFaces.length > 0}
-            <IconButton
-              aria-label={$t('edit_people')}
-              icon={mdiPencil}
-              size="medium"
-              shape="round"
-              color="secondary"
-              variant="ghost"
-              onclick={() => (showEditFaces = true)}
-            />
+            {#if people.length > 0 || unassignedFaces.length > 0}
+              <IconButton
+                aria-label={$t('edit_people')}
+                icon={mdiPencil}
+                size="medium"
+                shape="round"
+                color="secondary"
+                variant="ghost"
+                onclick={() => (showEditFaces = true)}
+              />
+            {/if}
           {/if}
         </div>
       </div>
@@ -231,7 +235,9 @@
           {#if showingHiddenPeople || !person.isHidden}
             <a
               class="w-22"
-              href={Route.viewPerson(person, { previousRoute })}
+              href={spaceId && person.spacePersonId
+                ? Route.viewSpacePerson(spaceId, person.spacePersonId)
+                : Route.viewPerson(person, { previousRoute })}
               onfocus={() => ($boundingBoxesArray = people[index].faces)}
               onblur={() => ($boundingBoxesArray = [])}
               onmouseover={() => ($boundingBoxesArray = people[index].faces)}
@@ -241,7 +247,9 @@
                 <ImageThumbnail
                   curve
                   shadow
-                  url={getPeopleThumbnailUrl(person)}
+                  url={spaceId && person.spacePersonId
+                    ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, { updatedAt: person.updatedAt })
+                    : getPeopleThumbnailUrl(person)}
                   altText={person.name}
                   title={person.name}
                   widthStyle="90px"
@@ -567,7 +575,7 @@
 
 {#if $preferences?.tags?.enabled}
   <section class="relative px-2 pb-12 dark:bg-immich-dark-bg dark:text-immich-dark-fg">
-    <DetailPanelTags {asset} {isOwner} />
+    <DetailPanelTags {asset} {isOwner} {spaceId} />
   </section>
 {/if}
 

--- a/web/src/lib/components/spaces/space-search-results.svelte
+++ b/web/src/lib/components/spaces/space-search-results.svelte
@@ -15,14 +15,15 @@
     hasMore: boolean;
     totalLoaded: number;
     onLoadMore: () => void;
+    spaceId?: string;
   }
 
-  let { results, isLoading, hasMore, totalLoaded, onLoadMore }: Props = $props();
+  let { results, isLoading, hasMore, totalLoaded, onLoadMore, spaceId }: Props = $props();
 
   let isViewerOpen = $state(false);
 
   const getFullAsset = async (id: string): Promise<AssetResponseDto> => {
-    return getAssetInfo({ ...authManager.params, id });
+    return getAssetInfo({ ...authManager.params, id, spaceId });
   };
 
   let cursor = $state<AssetCursor | undefined>();
@@ -108,7 +109,7 @@
 <Portal target="body">
   {#if isViewerOpen && cursor}
     {#await import('$lib/components/asset-viewer/asset-viewer.svelte') then { default: AssetViewer }}
-      <AssetViewer {cursor} isShared={true} onClose={() => handlePromiseError(handleClose())} />
+      <AssetViewer {cursor} isShared={true} {spaceId} onClose={() => handlePromiseError(handleClose())} />
     {/await}
   {/if}
 </Portal>

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -44,6 +44,7 @@
     album?: AlbumResponseDto;
     albumUsers?: UserResponseDto[];
     person?: PersonResponseDto;
+    spaceId?: string;
     onSelect?: (asset: TimelineAsset) => void;
     onEscape?: () => void;
     children?: Snippet;
@@ -76,6 +77,7 @@
     album,
     albumUsers = [],
     person,
+    spaceId,
     onSelect = () => {},
     onEscape = () => {},
     children,
@@ -720,7 +722,7 @@
 
 <Portal target="body">
   {#if assetViewerManager.isViewing}
-    <TimelineAssetViewer bind:invisible {timelineManager} {removeAction} {withStacked} {isShared} {album} {person} />
+    <TimelineAssetViewer bind:invisible {timelineManager} {removeAction} {withStacked} {isShared} {album} {person} {spaceId} />
   {/if}
 </Portal>
 

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -722,7 +722,16 @@
 
 <Portal target="body">
   {#if assetViewerManager.isViewing}
-    <TimelineAssetViewer bind:invisible {timelineManager} {removeAction} {withStacked} {isShared} {album} {person} {spaceId} />
+    <TimelineAssetViewer
+      bind:invisible
+      {timelineManager}
+      {removeAction}
+      {withStacked}
+      {isShared}
+      {album}
+      {person}
+      {spaceId}
+    />
   {/if}
 </Portal>
 

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -26,6 +26,7 @@
     album?: AlbumResponseDto;
     person?: PersonResponseDto;
     removeAction?: AssetAction.UNARCHIVE | AssetAction.ARCHIVE | AssetAction.SET_VISIBILITY_TIMELINE | null;
+    spaceId?: string;
   }
 
   let {
@@ -37,11 +38,12 @@
     isShared = false,
     album,
     person,
+    spaceId,
   }: Props = $props();
 
   const getAsset = (id: string) => {
     return handleErrorAsync(
-      () => assetCacheManager.getAsset({ ...authManager.params, id }),
+      () => assetCacheManager.getAsset({ ...authManager.params, id, spaceId }),
       $t('error_retrieving_asset_information'),
     );
   };
@@ -204,7 +206,7 @@
     }
 
     const restoredAsset = assets[0];
-    const asset = await getAssetInfo({ ...authManager.params, id: restoredAsset.id });
+    const asset = await getAssetInfo({ ...authManager.params, id: restoredAsset.id, spaceId });
     assetViewerManager.setAsset(asset);
     await navigate({ targetRoute: 'current', assetId: restoredAsset.id });
   };
@@ -239,6 +241,7 @@
     {isShared}
     {album}
     {person}
+    {spaceId}
     onAssetChange={(asset) => {
       timelineManager?.upsertAssets([toTimelineAsset(asset)]);
     }}

--- a/web/src/lib/managers/AssetCacheManager.svelte.ts
+++ b/web/src/lib/managers/AssetCacheManager.svelte.ts
@@ -50,7 +50,13 @@ class AssetCacheManager {
     });
   }
 
-  async getAsset({ id, key, slug }: { id: string; key?: string; slug?: string }, updateCache = true) {
+  async getAsset(
+    { id, key, slug, spaceId }: { id: string; key?: string; slug?: string; spaceId?: string },
+    updateCache = true,
+  ) {
+    if (spaceId) {
+      return getAssetInfo({ id, key, slug, spaceId });
+    }
     return this.#assetCache.getOrFetch({ id, key, slug }, updateCache);
   }
 

--- a/web/src/lib/managers/asset-viewer-manager.svelte.ts
+++ b/web/src/lib/managers/asset-viewer-manager.svelte.ts
@@ -166,8 +166,8 @@ class AssetViewerManager extends BaseEventManager<Events> {
     this.#viewState = true;
   }
 
-  async setAssetId(id: string): Promise<AssetResponseDto> {
-    const asset = await getAssetInfo({ ...authManager.params, id });
+  async setAssetId(id: string, spaceId?: string): Promise<AssetResponseDto> {
+    const asset = await getAssetInfo({ ...authManager.params, id, spaceId });
     this.setAsset(asset);
     return asset;
   }

--- a/web/src/lib/route.ts
+++ b/web/src/lib/route.ts
@@ -98,6 +98,7 @@ export const Route = {
   people: () => '/people',
   viewPerson: ({ id }: { id: string }, params?: { previousRoute?: string; action?: 'merge' }) =>
     `/people/${id}` + asQueryString(params),
+  viewSpacePerson: (spaceId: string, personId: string) => `/spaces/${spaceId}/people/${personId}`,
 
   // photos
   photos: (params?: { at?: string }) => '/photos' + asQueryString(params),

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -856,6 +856,7 @@
           hasMore={hasMoreResults}
           totalLoaded={searchResults.length}
           onLoadMore={handleLoadMore}
+          spaceId={space.id}
         />
       {/if}
 
@@ -881,6 +882,7 @@
             assetInteraction={currentAssetInteraction}
             {isSelectionMode}
             onEscape={handleEscape}
+            spaceId={space.id}
           >
             {#if viewMode === 'view'}
               <section class="px-4 pt-4">


### PR DESCRIPTION
## Summary

Closes discussion #194.

- **Server**: `GET /assets/:id` accepts optional `spaceId` query param. When provided for a space member, people data is preserved (instead of stripped) and enriched with `spacePersonId` for thumbnail/link resolution. Hidden and unmapped space persons are filtered out.
- **Frontend**: `spaceId` threaded from space page through Timeline → AssetViewer → DetailPanel → DetailPanelTags. Space members see people (with space-scoped thumbnails and links) and tags as read-only. Edit controls remain owner-only.
- Tags are read-only for all space members (editing deferred due to `TagAsset` permission model).

## Test plan

- [ ] Server unit tests: 8 new tests covering space member people visibility, partner/album unchanged, hidden filtering, non-member rejection
- [ ] Lint and type check pass
- [ ] Manual test: space viewer sees people and tags on asset detail
- [ ] Manual test: space viewer cannot edit tags or faces
- [ ] Manual test: owner retains full edit controls when viewing through space
- [ ] Manual test: person links navigate to space person page
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)