### PR TITLE
feat: server-side space context fallback for metadata visibility

### DIFF
--- a/docs/plans/2026-03-31-space-metadata-v2-design.md
+++ b/docs/plans/2026-03-31-space-metadata-v2-design.md
@@ -1,0 +1,177 @@
+# Space Metadata Visibility v2
+
+**Date:** 2026-03-31
+**Depends on:** PR #242 (merged)
+
+## Problem
+
+PR #242 made tags and people visible to space members in the detail panel, but only when viewing through the space page (where `spaceId` is passed explicitly). When the same asset is opened from:
+
+- The user's timeline (via `showInTimeline`)
+- Search results
+- Direct URL
+
+...the `spaceId` is missing, so `isSpaceMember` is false and people/tags are hidden even though the user has space access.
+
+Additionally, the space filter panel shows "No people found" when people exist but haven't been named, with no hint to the user about what to do.
+
+## Fix 1: Server-side space context fallback
+
+### Server change
+
+In `asset.service.get()`, the `else` branch (non-owner without `spaceId`) currently strips all people. Replace with a fallback that auto-resolves the space:
+
+```typescript
+} else {
+  // No spaceId — try to find a space containing this asset for this user
+  const spaceForAsset = await this.sharedSpaceRepository.findSpaceForAssetAndUser(id, auth.user.id);
+  if (spaceForAsset) {
+    const globalPersonIds = (data.people || []).map((p) => p.id);
+    const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+      spaceForAsset.spaceId,
+      globalPersonIds,
+    );
+    for (const person of data.people || []) {
+      const spacePerson = spacePersonMap.get(person.id);
+      if (spacePerson) {
+        person.spacePersonId = spacePerson.id;
+      }
+    }
+    data.people = (data.people || []).filter(
+      (p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden,
+    );
+    data.resolvedSpaceId = spaceForAsset.spaceId;
+  } else {
+    data.people = [];
+  }
+}
+```
+
+### New repository method
+
+`findSpaceForAssetAndUser(assetId, userId)` in `shared-space.repository.ts`. Returns `{ spaceId: string } | undefined`. Both UNION branches JOIN the `asset` table to filter deleted/offline assets (matching the pattern in `checkSpaceAccessForSpace`):
+
+```typescript
+async findSpaceForAssetAndUser(assetId: string, userId: string) {
+  return this.db
+    .selectFrom(
+      this.db
+        .selectFrom('shared_space_asset')
+        .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+        .innerJoin('asset', (join) =>
+          join
+            .onRef('asset.id', '=', 'shared_space_asset.assetId')
+            .on('asset.deletedAt', 'is', null),
+        )
+        .select('shared_space_asset.spaceId')
+        .where('shared_space_asset.assetId', '=', assetId)
+        .where('shared_space_member.userId', '=', userId)
+        .union(
+          this.db
+            .selectFrom('shared_space_library')
+            .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+            .innerJoin('asset', (join) =>
+              join
+                .onRef('asset.libraryId', '=', 'shared_space_library.libraryId')
+                .on('asset.id', '=', assetId)
+                .on('asset.deletedAt', 'is', null)
+                .on('asset.isOffline', '=', false),
+            )
+            .select('shared_space_library.spaceId')
+            .where('shared_space_member.userId', '=', userId),
+        )
+        .as('combined'),
+    )
+    .select('combined.spaceId')
+    .limit(1)
+    .executeTakeFirst();
+}
+```
+
+### New DTO field
+
+Add `resolvedSpaceId?: string` as `@ApiPropertyOptional` on `AssetResponseDto`. Assigned after `mapAsset()` when the server auto-resolves space context. Requires OpenAPI + SDK regeneration.
+
+### Frontend changes
+
+In `detail-panel.svelte`, replace:
+
+```typescript
+let isSpaceMember = $derived(!!spaceId);
+```
+
+With:
+
+```typescript
+let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
+let isSpaceMember = $derived(!!effectiveSpaceId);
+```
+
+Use `effectiveSpaceId` everywhere `spaceId` was used: thumbnail URLs, person links, forwarding to DetailPanelTags.
+
+In `detail-panel-tags.svelte`, same derivation:
+
+```typescript
+let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
+let isSpaceMember = $derived(!!effectiveSpaceId);
+```
+
+The `getAssetInfo` re-fetch calls (lines 27, 33) can optionally pass `effectiveSpaceId` for efficiency, but the server fallback will resolve it anyway if omitted.
+
+## Fix 2: "Name people" hint in space filter panel
+
+In `filter-panel.svelte` (around line 278-281), after the people provider returns an empty array in space context:
+
+1. Make a secondary call: `getSpacePeople({ id: spaceId, limit: 1 })` without `named`
+2. If it returns results, pass `emptyText="Name people to use this filter"` to `PeopleFilter`
+3. Only do this in space context (non-space pages keep the default "No people found")
+
+The `PeopleFilter` component already accepts an `emptyText` prop — no component changes needed.
+
+## Testing
+
+### Server unit tests
+
+| Test                                                | Expected                                                                         |
+| --------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Space member without spaceId sees people (fallback) | `findSpaceForAssetAndUser` returns space → people preserved with `spacePersonId` |
+| Space member without spaceId gets `resolvedSpaceId` | Response includes `resolvedSpaceId` matching the found space                     |
+| Non-member without spaceId gets empty people        | `findSpaceForAssetAndUser` returns undefined → `people = []`                     |
+| Partner without spaceId gets empty people           | No space found → `people = []`                                                   |
+| Owner without spaceId still sees all people         | Owner path (line ~111) unchanged, never hits fallback                            |
+| Library-linked asset resolves via fallback          | Second UNION branch finds library space                                          |
+| Hidden space person filtered in fallback            | Same filtering as explicit spaceId path                                          |
+| Explicit spaceId still works (existing tests)       | PR #242 tests unchanged                                                          |
+
+### Frontend behavior verification
+
+| Scenario                                 | Expected                                         |
+| ---------------------------------------- | ------------------------------------------------ |
+| Space member opens asset from timeline   | People and tags visible (via `resolvedSpaceId`)  |
+| Space member opens asset from search     | People and tags visible (via `resolvedSpaceId`)  |
+| Space member opens asset from space page | People and tags visible (via explicit `spaceId`) |
+| Owner opens own asset from timeline      | Full edit controls (owner path)                  |
+| Non-member opens asset                   | No people, no tags section                       |
+| Space filter with unnamed people         | Shows "Name people to use this filter"           |
+| Space filter with named people           | Shows people normally                            |
+| Non-space filter with no people          | Shows "No people found" (default)                |
+
+### Full test matrix (roles × entry points × metadata)
+
+| Role       | Entry Point | People | Tags   | Rating | Location | Description | EXIF |
+| ---------- | ----------- | ------ | ------ | ------ | -------- | ----------- | ---- |
+| Owner      | Space page  | Edit   | Edit   | Edit   | Edit     | Edit        | View |
+| Owner      | Timeline    | Edit   | Edit   | Edit   | Edit     | Edit        | View |
+| Editor     | Space page  | Read   | Read   | Read   | Read     | Read        | View |
+| Editor     | Timeline    | Read   | Read   | Read   | Read     | Read        | View |
+| Viewer     | Space page  | Read   | Read   | Read   | Read     | Read        | View |
+| Viewer     | Timeline    | Read   | Read   | Read   | Read     | Read        | View |
+| Non-member | Any         | Hidden | Hidden | -      | -        | -           | -    |
+| Partner    | Any         | Hidden | -      | Read   | Read     | Read        | View |
+
+## Out of scope
+
+1. **Photos page people filter** — needs cross-space person dedup logic
+2. **Tag editing for space editors** — `TagAsset` permission model limitation
+3. **`$preferences.tags.enabled` bypass** — space members must enable tags in settings
+4. **Nav bar actions for editors** — edit/archive/favorite buttons hidden for non-owners

--- a/docs/plans/2026-03-31-space-metadata-v2-impl.md
+++ b/docs/plans/2026-03-31-space-metadata-v2-impl.md
@@ -1,0 +1,424 @@
+# Space Metadata Visibility v2 — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Space members see people/tags when opening assets from timeline or search (not just space page), plus "name people" hint in filter panel.
+
+**Architecture:** Server auto-resolves space context via `findSpaceForAssetAndUser` when `spaceId` not provided. Frontend uses `resolvedSpaceId` from the response.
+
+**Tech Stack:** NestJS, Svelte 5, Kysely, Vitest, OpenAPI codegen
+
+**Design doc:** `docs/plans/2026-03-31-space-metadata-v2-design.md`
+
+---
+
+## Task 1: Add `findSpaceForAssetAndUser` repository method
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts` (after line 1003, end of `findSpacePersonsByLinkedPersonIds`)
+
+**Step 1: Add the method**
+
+```typescript
+@GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
+async findSpaceForAssetAndUser(assetId: string, userId: string) {
+  return this.db
+    .selectFrom(
+      this.db
+        .selectFrom('shared_space_asset')
+        .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+        .innerJoin('asset', (join) =>
+          join.onRef('asset.id', '=', 'shared_space_asset.assetId').on('asset.deletedAt', 'is', null),
+        )
+        .select('shared_space_asset.spaceId')
+        .where('shared_space_asset.assetId', '=', assetId)
+        .where('shared_space_member.userId', '=', userId)
+        .union(
+          this.db
+            .selectFrom('shared_space_library')
+            .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+            .innerJoin('asset', (join) =>
+              join
+                .onRef('asset.libraryId', '=', 'shared_space_library.libraryId')
+                .on('asset.id', '=', assetId)
+                .on('asset.deletedAt', 'is', null)
+                .on('asset.isOffline', '=', false),
+            )
+            .select('shared_space_library.spaceId')
+            .where('shared_space_member.userId', '=', userId),
+        )
+        .as('combined'),
+    )
+    .select('combined.spaceId')
+    .limit(1)
+    .executeTakeFirst();
+}
+```
+
+**Step 2: Type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -10`
+
+**Step 3: Commit**
+
+```
+feat: add findSpaceForAssetAndUser repository method
+```
+
+---
+
+## Task 2: Add `resolvedSpaceId` to DTO and implement server fallback
+
+**Files:**
+
+- Modify: `server/src/dtos/asset-response.dto.ts:56` (AssetResponseDto class)
+- Modify: `server/src/services/asset.service.ts:141-142` (else branch)
+
+**Step 1: Add DTO field**
+
+In `asset-response.dto.ts`, add to `AssetResponseDto` (after the last field, before the closing `}`):
+
+```typescript
+@ApiPropertyOptional({ description: 'Resolved space ID (when server auto-detects space context)' })
+resolvedSpaceId?: string;
+```
+
+**Step 2: Implement the fallback**
+
+In `asset.service.ts`, replace lines 141-142 (`} else { data.people = []; }`) with:
+
+```typescript
+    } else {
+      // No spaceId — try to find a space containing this asset for this user
+      const spaceForAsset = await this.sharedSpaceRepository.findSpaceForAssetAndUser(id, auth.user.id);
+      if (spaceForAsset) {
+        const globalPersonIds = (data.people || []).map((p) => p.id);
+        const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+          spaceForAsset.spaceId,
+          globalPersonIds,
+        );
+        for (const person of data.people || []) {
+          const spacePerson = spacePersonMap.get(person.id);
+          if (spacePerson) {
+            person.spacePersonId = spacePerson.id;
+          }
+        }
+        data.people = (data.people || []).filter(
+          (p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden,
+        );
+        data.resolvedSpaceId = spaceForAsset.spaceId;
+      } else {
+        data.people = [];
+      }
+    }
+```
+
+**Step 3: Type check**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -10`
+
+**Step 4: Commit**
+
+```
+feat: server-side space context fallback for asset metadata
+```
+
+---
+
+## Task 3: Write server unit tests
+
+**Files:**
+
+- Modify: `server/src/services/asset.service.spec.ts`
+
+**Step 1: Add tests** after the existing space-related tests in the `describe('get')` block.
+
+Use factory: `AssetFactory.from().exif().face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' })).build()`
+
+```typescript
+it('should keep people for space member without spaceId (fallback)', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue({ spaceId: 'space-1' });
+  mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+    new Map([['person-1', { id: 'sp-1', isHidden: false }]]),
+  );
+
+  const result = await sut.get(authStub.admin, asset.id);
+
+  expect(result).toHaveProperty('people');
+  expect((result as any).people.length).toBeGreaterThan(0);
+  expect((result as any).resolvedSpaceId).toBe('space-1');
+});
+
+it('should strip people when fallback finds no space', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
+
+  const result = await sut.get(authStub.admin, asset.id);
+
+  expect(result).toHaveProperty('people', []);
+  expect(result).not.toHaveProperty('resolvedSpaceId');
+});
+
+it('should filter hidden persons in fallback path', async () => {
+  const asset = AssetFactory.from()
+    .exif()
+    .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+    .build();
+  mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getById.mockResolvedValue(asset as any);
+  mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue({ spaceId: 'space-1' });
+  mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+    new Map([['person-1', { id: 'sp-1', isHidden: true }]]),
+  );
+
+  const result = await sut.get(authStub.admin, asset.id);
+
+  expect(result).toHaveProperty('people', []);
+});
+```
+
+**Step 2: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts 2>&1 | tail -20`
+
+**Step 3: Commit**
+
+```
+test: server tests for space context fallback
+```
+
+---
+
+## Task 4: Regenerate OpenAPI spec and SDK
+
+**Step 1: Build server**
+
+Run: `cd server && pnpm build 2>&1 | tail -5`
+
+**Step 2: Regenerate OpenAPI spec**
+
+Run: `cd server && pnpm sync:open-api 2>&1 | tail -5`
+
+**Step 3: Regenerate all clients**
+
+Run: `make open-api 2>&1 | tail -10`
+
+**Step 4: Verify resolvedSpaceId in SDK**
+
+Run: `grep -n 'resolvedSpaceId' open-api/typescript-sdk/src/fetch-client.ts | head -5`
+
+**Step 5: Commit**
+
+```
+chore: regenerate OpenAPI spec and SDK with resolvedSpaceId
+```
+
+---
+
+## Task 5: Frontend — use `effectiveSpaceId` in detail panel
+
+**Files:**
+
+- Modify: `web/src/lib/components/asset-viewer/detail-panel.svelte:60`
+- Modify: `web/src/lib/components/asset-viewer/detail-panel-tags.svelte:19-20`
+
+**Step 1: Update detail-panel.svelte**
+
+Change line 60 from:
+
+```typescript
+let isSpaceMember = $derived(!!spaceId);
+```
+
+To:
+
+```typescript
+let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
+let isSpaceMember = $derived(!!effectiveSpaceId);
+```
+
+Then replace all uses of `spaceId` in the template with `effectiveSpaceId`:
+
+- Person thumbnail URL (around line 250)
+- Person link href (around line 238)
+- DetailPanelTags prop (around line 580): `<DetailPanelTags {asset} {isOwner} spaceId={effectiveSpaceId} />`
+
+**Step 2: Update detail-panel-tags.svelte**
+
+Change line 19-20 from:
+
+```typescript
+let { asset = $bindable(), isOwner, spaceId }: Props = $props();
+let isSpaceMember = $derived(!!spaceId);
+```
+
+To:
+
+```typescript
+let { asset = $bindable(), isOwner, spaceId }: Props = $props();
+let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
+let isSpaceMember = $derived(!!effectiveSpaceId);
+```
+
+Update the `getAssetInfo` re-fetch calls (lines 27, 33) to pass `effectiveSpaceId`:
+
+```typescript
+asset = await getAssetInfo({ id: asset.id, spaceId: effectiveSpaceId });
+```
+
+**Step 3: Type check**
+
+Run: `cd web && npx tsc --noEmit 2>&1 | head -10`
+
+**Step 4: Commit**
+
+```
+feat: use resolvedSpaceId for timeline/search asset metadata
+```
+
+---
+
+## Task 6: "Name people" hint in filter panel
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte:278-282`
+- Modify: `web/src/lib/components/filter-panel/filter-panel.ts` (FilterPanelConfig type, if needed)
+
+**Step 1: Add `hasUnnamedPeople` state and secondary check**
+
+In `filter-panel.svelte`, add state:
+
+```typescript
+let hasUnnamedPeople = $state(false);
+```
+
+Change lines 278-282 from:
+
+```typescript
+$effect(() => {
+  if (config.providers.people && config.sections.includes('people')) {
+    void config.providers.people().then((result) => {
+      people = result;
+    });
+  }
+});
+```
+
+To:
+
+```typescript
+$effect(() => {
+  if (config.providers.people && config.sections.includes('people')) {
+    void config.providers.people().then((result) => {
+      people = result;
+      if (result.length === 0 && config.providers.allPeople) {
+        void config.providers.allPeople().then((all) => {
+          hasUnnamedPeople = all.length > 0;
+        });
+      }
+    });
+  }
+});
+```
+
+**Step 2: Add `allPeople` provider to FilterPanelConfig**
+
+In `filter-panel.ts`, add to the providers interface:
+
+```typescript
+allPeople?: () => Promise<PersonOption[]>;
+```
+
+**Step 3: Pass `emptyText` to PeopleFilter**
+
+Find where `PeopleFilter` is used in `filter-panel.svelte` and add:
+
+```svelte
+<PeopleFilter
+  {people}
+  ...
+  emptyText={hasUnnamedPeople ? 'Name people to use this filter' : undefined}
+/>
+```
+
+**Step 4: Wire the `allPeople` provider in the space page**
+
+In the space page (`+page.svelte`), add to `filterConfig.providers`:
+
+```typescript
+allPeople: async () => {
+  const people = await getSpacePeople({ id: space.id, limit: 1 });
+  return people.map((p) => ({ id: p.id, name: p.name, thumbnailUrl: '' }));
+},
+```
+
+**Step 5: Type check**
+
+Run: `cd web && npx tsc --noEmit 2>&1 | head -10`
+
+**Step 6: Commit**
+
+```
+feat: show "name people" hint when unnamed people exist in space filter
+```
+
+---
+
+## Task 7: Regenerate SQL query files and apply CI diff
+
+**Step 1: Build server**
+
+Run: `cd server && pnpm build 2>&1 | tail -5`
+
+**Step 2: Try local SQL regen (may need running DB)**
+
+Run: `make sql 2>&1 | tail -10`
+
+If no local DB, add the SQL manually for `findSpaceForAssetAndUser` to `server/src/queries/shared.space.repository.sql`. The query SQL will be provided by CI diff if needed.
+
+**Step 3: Commit**
+
+```
+chore: regenerate SQL query files
+```
+
+---
+
+## Task 8: Lint, format, final checks
+
+**Step 1: Format**
+
+Run: `make format-server && make format-web`
+
+**Step 2: Lint**
+
+Run: `make lint-server 2>&1 | tail -5`
+Run: `make lint-web 2>&1 | tail -5`
+
+**Step 3: Type check**
+
+Run: `cd server && npx tsc --noEmit`
+Run: `cd web && npx tsc --noEmit`
+
+**Step 4: Run server tests**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts 2>&1 | tail -20`
+
+**Step 5: Commit any changes**
+
+```
+style: format
+```

--- a/mobile/openapi/lib/model/asset_response_dto.dart
+++ b/mobile/openapi/lib/model/asset_response_dto.dart
@@ -40,6 +40,7 @@ class AssetResponseDto {
     required this.ownerId,
     this.people = const [],
     this.resized,
+    this.resolvedSpaceId,
     this.stack,
     this.tags = const [],
     required this.thumbhash,
@@ -152,6 +153,15 @@ class AssetResponseDto {
   ///
   bool? resized;
 
+  /// Resolved space ID (when server auto-detects space context)
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? resolvedSpaceId;
+
   AssetStackResponseDto? stack;
 
   List<TagResponseDto> tags;
@@ -202,6 +212,7 @@ class AssetResponseDto {
     other.ownerId == ownerId &&
     _deepEquality.equals(other.people, people) &&
     other.resized == resized &&
+    other.resolvedSpaceId == resolvedSpaceId &&
     other.stack == stack &&
     _deepEquality.equals(other.tags, tags) &&
     other.thumbhash == thumbhash &&
@@ -241,6 +252,7 @@ class AssetResponseDto {
     (ownerId.hashCode) +
     (people.hashCode) +
     (resized == null ? 0 : resized!.hashCode) +
+    (resolvedSpaceId == null ? 0 : resolvedSpaceId!.hashCode) +
     (stack == null ? 0 : stack!.hashCode) +
     (tags.hashCode) +
     (thumbhash == null ? 0 : thumbhash!.hashCode) +
@@ -251,7 +263,7 @@ class AssetResponseDto {
     (width == null ? 0 : width!.hashCode);
 
   @override
-  String toString() => 'AssetResponseDto[checksum=$checksum, createdAt=$createdAt, deviceAssetId=$deviceAssetId, deviceId=$deviceId, duplicateId=$duplicateId, duration=$duration, exifInfo=$exifInfo, fileCreatedAt=$fileCreatedAt, fileModifiedAt=$fileModifiedAt, hasMetadata=$hasMetadata, height=$height, id=$id, isArchived=$isArchived, isEdited=$isEdited, isFavorite=$isFavorite, isOffline=$isOffline, isTrashed=$isTrashed, libraryId=$libraryId, livePhotoVideoId=$livePhotoVideoId, localDateTime=$localDateTime, originalFileName=$originalFileName, originalMimeType=$originalMimeType, originalPath=$originalPath, owner=$owner, ownerId=$ownerId, people=$people, resized=$resized, stack=$stack, tags=$tags, thumbhash=$thumbhash, type=$type, unassignedFaces=$unassignedFaces, updatedAt=$updatedAt, visibility=$visibility, width=$width]';
+  String toString() => 'AssetResponseDto[checksum=$checksum, createdAt=$createdAt, deviceAssetId=$deviceAssetId, deviceId=$deviceId, duplicateId=$duplicateId, duration=$duration, exifInfo=$exifInfo, fileCreatedAt=$fileCreatedAt, fileModifiedAt=$fileModifiedAt, hasMetadata=$hasMetadata, height=$height, id=$id, isArchived=$isArchived, isEdited=$isEdited, isFavorite=$isFavorite, isOffline=$isOffline, isTrashed=$isTrashed, libraryId=$libraryId, livePhotoVideoId=$livePhotoVideoId, localDateTime=$localDateTime, originalFileName=$originalFileName, originalMimeType=$originalMimeType, originalPath=$originalPath, owner=$owner, ownerId=$ownerId, people=$people, resized=$resized, resolvedSpaceId=$resolvedSpaceId, stack=$stack, tags=$tags, thumbhash=$thumbhash, type=$type, unassignedFaces=$unassignedFaces, updatedAt=$updatedAt, visibility=$visibility, width=$width]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -314,6 +326,11 @@ class AssetResponseDto {
     } else {
     //  json[r'resized'] = null;
     }
+    if (this.resolvedSpaceId != null) {
+      json[r'resolvedSpaceId'] = this.resolvedSpaceId;
+    } else {
+    //  json[r'resolvedSpaceId'] = null;
+    }
     if (this.stack != null) {
       json[r'stack'] = this.stack;
     } else {
@@ -375,6 +392,7 @@ class AssetResponseDto {
         ownerId: mapValueOfType<String>(json, r'ownerId')!,
         people: PersonWithFacesResponseDto.listFromJson(json[r'people']),
         resized: mapValueOfType<bool>(json, r'resized'),
+        resolvedSpaceId: mapValueOfType<String>(json, r'resolvedSpaceId'),
         stack: AssetStackResponseDto.fromJson(json[r'stack']),
         tags: TagResponseDto.listFromJson(json[r'tags']),
         thumbhash: mapValueOfType<String>(json, r'thumbhash'),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -20250,6 +20250,10 @@
             ],
             "x-immich-state": "Deprecated"
           },
+          "resolvedSpaceId": {
+            "description": "Resolved space ID (when server auto-detects space context)",
+            "type": "string"
+          },
           "stack": {
             "allOf": [
               {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -620,6 +620,8 @@ export type AssetResponseDto = {
     people?: PersonWithFacesResponseDto[];
     /** Is resized */
     resized?: boolean;
+    /** Resolved space ID (when server auto-detects space context) */
+    resolvedSpaceId?: string;
     stack?: (AssetStackResponseDto) | null;
     tags?: TagResponseDto[];
     /** Thumbhash for thumbnail generation (base64) also used as the c query param for thumbnail cache busting. */

--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -138,6 +138,9 @@ export class AssetResponseDto extends SanitizedAssetResponseDto {
   resized?: boolean;
   @Property({ description: 'Is edited', history: new HistoryBuilder().added('v2.5.0').beta('v2.5.0') })
   isEdited!: boolean;
+
+  @ApiPropertyOptional({ description: 'Resolved space ID (when server auto-detects space context)' })
+  resolvedSpaceId?: string;
 }
 
 export type MapAsset = {

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -786,3 +786,34 @@ group by
   "shared_space_person"."id",
   "shared_space_person"."isHidden",
   "asset_face"."personId"
+
+-- SharedSpaceRepository.findSpaceForAssetAndUser
+select
+  "combined"."spaceId"
+from
+  (
+    select
+      "shared_space_asset"."spaceId"
+    from
+      "shared_space_asset"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
+      inner join "asset" on "asset"."id" = "shared_space_asset"."assetId"
+      and "asset"."deletedAt" is null
+    where
+      "shared_space_asset"."assetId" = $1
+      and "shared_space_member"."userId" = $2
+    union
+    select
+      "shared_space_library"."spaceId"
+    from
+      "shared_space_library"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
+      inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
+      and "asset"."id" = $3
+      and "asset"."deletedAt" is null
+      and "asset"."isOffline" = $4
+    where
+      "shared_space_member"."userId" = $5
+  ) as "combined"
+limit
+  $6

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1002,4 +1002,38 @@ export class SharedSpaceRepository {
     }
     return map;
   }
+
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
+  async findSpaceForAssetAndUser(assetId: string, userId: string) {
+    return this.db
+      .selectFrom(
+        this.db
+          .selectFrom('shared_space_asset')
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+          .innerJoin('asset', (join) =>
+            join.onRef('asset.id', '=', 'shared_space_asset.assetId').on('asset.deletedAt', 'is', null),
+          )
+          .select('shared_space_asset.spaceId')
+          .where('shared_space_asset.assetId', '=', assetId)
+          .where('shared_space_member.userId', '=', userId)
+          .union(
+            this.db
+              .selectFrom('shared_space_library')
+              .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+              .innerJoin('asset', (join) =>
+                join
+                  .onRef('asset.libraryId', '=', 'shared_space_library.libraryId')
+                  .on('asset.id', '=', assetId)
+                  .on('asset.deletedAt', 'is', null)
+                  .on('asset.isOffline', '=', false),
+              )
+              .select('shared_space_library.spaceId')
+              .where('shared_space_member.userId', '=', userId),
+          )
+          .as('combined'),
+      )
+      .select('combined.spaceId')
+      .limit(1)
+      .executeTakeFirst();
+  }
 }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -120,6 +120,7 @@ describe(AssetService.name, () => {
       const asset = AssetFactory.create();
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       await sut.get(authStub.admin, asset.id);
 
@@ -178,6 +179,7 @@ describe(AssetService.name, () => {
       const asset = AssetFactory.from().exif().build();
       mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       const result = await sut.get(authStub.admin, asset.id);
 
@@ -188,6 +190,7 @@ describe(AssetService.name, () => {
       const asset = AssetFactory.create();
       mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       await sut.get(authStub.admin, asset.id);
 
@@ -198,6 +201,7 @@ describe(AssetService.name, () => {
       const asset = AssetFactory.create();
       mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       await sut.get(authStub.admin, asset.id);
 
@@ -208,6 +212,7 @@ describe(AssetService.name, () => {
       const asset = AssetFactory.create();
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       await sut.get(authStub.admin, asset.id);
 
@@ -241,6 +246,7 @@ describe(AssetService.name, () => {
         .build();
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       const result = await sut.get(authStub.admin, asset.id);
 
@@ -300,6 +306,7 @@ describe(AssetService.name, () => {
         .build();
       mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       const result = await sut.get(authStub.admin, asset.id);
 
@@ -313,6 +320,7 @@ describe(AssetService.name, () => {
         .build();
       mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
 
       const result = await sut.get(authStub.admin, asset.id);
 
@@ -360,6 +368,57 @@ describe(AssetService.name, () => {
       mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set());
 
       const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should keep people for space member without spaceId (fallback)', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue({ spaceId: 'space-1' });
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([['person-1', { id: 'sp-1', isHidden: false }]]),
+      );
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(result).toHaveProperty('people');
+      expect((result as any).people.length).toBeGreaterThan(0);
+      expect((result as any).resolvedSpaceId).toBe('space-1');
+    });
+
+    it('should strip people when fallback finds no space', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(result).toHaveProperty('people', []);
+      expect(result).not.toHaveProperty('resolvedSpaceId');
+    });
+
+    it('should filter hidden persons in fallback path', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue({ spaceId: 'space-1' });
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([['person-1', { id: 'sp-1', isHidden: true }]]),
+      );
+
+      const result = await sut.get(authStub.admin, asset.id);
 
       expect(result).toHaveProperty('people', []);
     });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -139,7 +139,27 @@ export class AssetService extends BaseService {
           data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
         }
       } else {
-        data.people = [];
+        // No spaceId — try to find a space containing this asset for this user
+        const spaceForAsset = await this.sharedSpaceRepository.findSpaceForAssetAndUser(id, auth.user.id);
+        if (spaceForAsset) {
+          const globalPersonIds = (data.people || []).map((p) => p.id);
+          const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+            spaceForAsset.spaceId,
+            globalPersonIds,
+          );
+          for (const person of data.people || []) {
+            const spacePerson = spacePersonMap.get(person.id);
+            if (spacePerson) {
+              person.spacePersonId = spacePerson.id;
+            }
+          }
+          data.people = (data.people || []).filter(
+            (p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden,
+          );
+          data.resolvedSpaceId = spaceForAsset.spaceId;
+        } else {
+          data.people = [];
+        }
       }
     }
 

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -153,9 +153,7 @@ export class AssetService extends BaseService {
               person.spacePersonId = spacePerson.id;
             }
           }
-          data.people = (data.people || []).filter(
-            (p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden,
-          );
+          data.people = (data.people || []).filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
           data.resolvedSpaceId = spaceForAsset.spaceId;
         } else {
           data.people = [];

--- a/server/test/medium/specs/services/asset-shared-space-permissions.service.spec.ts
+++ b/server/test/medium/specs/services/asset-shared-space-permissions.service.spec.ts
@@ -10,6 +10,7 @@ import { LoggingRepository } from 'src/repositories/logging.repository';
 import { OcrRepository } from 'src/repositories/ocr.repository';
 import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
 import { UserRepository } from 'src/repositories/user.repository';
@@ -31,6 +32,7 @@ const setup = (db?: Kysely<DB>) => {
       AlbumRepository,
       AccessRepository,
       SharedLinkAssetRepository,
+      SharedSpaceRepository,
       StackRepository,
       UserRepository,
       SharedLinkRepository,

--- a/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
@@ -17,20 +17,21 @@
   }
 
   let { asset = $bindable(), isOwner, spaceId }: Props = $props();
-  let isSpaceMember = $derived(!!spaceId);
+  let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
+  let isSpaceMember = $derived(!!effectiveSpaceId);
 
   let tags = $derived(asset.tags || []);
 
   const handleRemove = async (tagId: string) => {
     const ids = await removeTag({ tagIds: [tagId], assetIds: [asset.id], showNotification: false });
     if (ids) {
-      asset = await getAssetInfo({ id: asset.id, spaceId });
+      asset = await getAssetInfo({ id: asset.id, spaceId: effectiveSpaceId });
     }
   };
 
   const onAssetsTag = async (ids: string[]) => {
     if (ids.includes(asset.id)) {
-      asset = await getAssetInfo({ id: asset.id, spaceId });
+      asset = await getAssetInfo({ id: asset.id, spaceId: effectiveSpaceId });
     }
   };
 

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -57,7 +57,8 @@
   }
 
   let { asset, currentAlbum = null, spaceId }: Props = $props();
-  let isSpaceMember = $derived(!!spaceId);
+  let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
+  let isSpaceMember = $derived(!!effectiveSpaceId);
 
   let showAssetPath = $state(false);
   let showEditFaces = $state(false);
@@ -124,7 +125,7 @@
   };
 
   const handleRefreshPeople = async () => {
-    asset = await getAssetInfo({ id: asset.id, spaceId });
+    asset = await getAssetInfo({ id: asset.id, spaceId: effectiveSpaceId });
     showEditFaces = false;
   };
 
@@ -235,8 +236,8 @@
           {#if showingHiddenPeople || !person.isHidden}
             <a
               class="w-22"
-              href={spaceId && person.spacePersonId
-                ? Route.viewSpacePerson(spaceId, person.spacePersonId)
+              href={effectiveSpaceId && person.spacePersonId
+                ? Route.viewSpacePerson(effectiveSpaceId, person.spacePersonId)
                 : Route.viewPerson(person, { previousRoute })}
               onfocus={() => ($boundingBoxesArray = people[index].faces)}
               onblur={() => ($boundingBoxesArray = [])}
@@ -247,8 +248,8 @@
                 <ImageThumbnail
                   curve
                   shadow
-                  url={spaceId && person.spacePersonId
-                    ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, {
+                  url={effectiveSpaceId && person.spacePersonId
+                    ? createUrl(`/shared-spaces/${effectiveSpaceId}/people/${person.spacePersonId}/thumbnail`, {
                         updatedAt: person.updatedAt,
                       })
                     : getPeopleThumbnailUrl(person)}
@@ -577,7 +578,7 @@
 
 {#if $preferences?.tags?.enabled}
   <section class="relative px-2 pb-12 dark:bg-immich-dark-bg dark:text-immich-dark-fg">
-    <DetailPanelTags {asset} {isOwner} {spaceId} />
+    <DetailPanelTags {asset} {isOwner} spaceId={effectiveSpaceId} />
   </section>
 {/if}
 

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -55,6 +55,7 @@
 
   // Fetched data for filter sections
   let people = $state<PersonOption[]>([]);
+  let hasUnnamedPeople = $state(false);
   let countries = $state<string[]>([]);
   let cameraMakes = $state<string[]>([]);
   let tags = $state<TagOption[]>([]);
@@ -278,6 +279,11 @@
     if (config.providers.people && config.sections.includes('people')) {
       void config.providers.people().then((result) => {
         people = result;
+        if (result.length === 0 && config.providers.allPeople) {
+          void config.providers.allPeople().then((all) => {
+            hasUnnamedPeople = all.length > 0;
+          });
+        }
       });
     }
   });
@@ -478,7 +484,12 @@
                 onMonthSelect={handleMonthSelect}
               />
             {:else if section === 'people'}
-              <PeopleFilter {people} selectedIds={filters.personIds} onSelectionChange={handlePeopleChange} />
+              <PeopleFilter
+                {people}
+                selectedIds={filters.personIds}
+                onSelectionChange={handlePeopleChange}
+                emptyText={hasUnnamedPeople ? 'Name people to use this filter' : undefined}
+              />
             {:else if section === 'location'}
               <LocationFilter
                 {countries}

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -25,6 +25,7 @@ export interface FilterPanelConfig {
   sections: FilterSection[];
   providers: {
     people?: (context?: FilterContext) => Promise<PersonOption[]>;
+    allPeople?: () => Promise<PersonOption[]>;
     locations?: (context?: FilterContext) => Promise<LocationOption[]>;
     cities?: (country: string, context?: FilterContext) => Promise<string[]>;
     cameras?: (context?: FilterContext) => Promise<CameraOption[]>;

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -183,6 +183,10 @@
             : undefined,
         }));
       },
+      allPeople: async () => {
+        const people = await getSpacePeople({ id: space.id, limit: 1 });
+        return people.map((p) => ({ id: p.id, name: p.name, thumbnailUrl: '' }));
+      },
       locations: async (context?: FilterContext) => {
         const countries = await getSearchSuggestions({
           $type: SearchSuggestionType.Country,


### PR DESCRIPTION
## Summary

Follow-up to PR #242. Fixes metadata visibility when space assets are opened from the timeline or search (not just the space page).

- **Server fallback**: When `spaceId` is not provided and the user is not the owner, the server auto-resolves space context via `findSpaceForAssetAndUser`. If the user has space access, people are preserved with `spacePersonId` enrichment and `resolvedSpaceId` is returned.
- **Frontend**: `detail-panel.svelte` and `detail-panel-tags.svelte` derive `effectiveSpaceId` from either the explicit `spaceId` prop or `asset.resolvedSpaceId`, so people/tags display correctly regardless of entry point.
- **UX hint**: Space filter panel shows "Name people to use this filter" when unnamed people exist but the named list is empty.

## Test plan

- [ ] Server unit tests: 3 new tests for fallback (people visible, no space found, hidden filtering)
- [ ] Lint and type check pass
- [ ] Manual: Log in as `c@c.com`, open a space asset from the **timeline** → tags and people visible
- [ ] Manual: Log in as `c@c.com`, open same asset from the **space page** → same behavior
- [ ] Manual: Space filter panel with unnamed people shows hint message
- [ ] Manual: Owner still has full edit controls from timeline
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)