### PR TITLE
fix: resolve space person IDs in filter suggestions cross-filtering

### DIFF
--- a/e2e/src/specs/server/api/filter-suggestions.e2e-spec.ts
+++ b/e2e/src/specs/server/api/filter-suggestions.e2e-spec.ts
@@ -410,4 +410,53 @@ describe('/search/suggestions/filters', () => {
     expect(rating4TagNames).toContain('travel');
     expect(rating4TagNames).not.toContain('nature');
   });
+
+  it('should return other filter categories when filtering by space person ID', async () => {
+    // Create a space with assets A (rated 5, tagged "nature", Paris) and B (rated 4, tagged "travel", Tokyo)
+    const space = await utils.createSpace(admin.accessToken, { name: 'Person Cross-Filter Space' });
+    await utils.addSpaceAssets(admin.accessToken, space.id, [assets[0].id, assets[1].id]);
+
+    // Create a global person linked to asset A via asset_face
+    const db = await utils.connectDatabase();
+    const personResult = await db.query(
+      `INSERT INTO "person" ("ownerId", "name", "thumbnailPath")
+       VALUES ($1, $2, '/test/thumbnail.jpg') RETURNING id`,
+      [admin.userId, 'PersonCrossFilter'],
+    );
+    const globalPersonId = personResult.rows[0].id as string;
+
+    const faceResult = await db.query(`INSERT INTO "asset_face" ("assetId", "personId") VALUES ($1, $2) RETURNING id`, [
+      assets[0].id,
+      globalPersonId,
+    ]);
+    const faceId = faceResult.rows[0].id as string;
+
+    // Create a space person + link via shared_space_person_face
+    const spacePersonResult = await db.query(
+      `INSERT INTO "shared_space_person" ("spaceId", "name", "isHidden", "faceCount", "assetCount", "representativeFaceId")
+       VALUES ($1, $2, false, 1, 1, $3) RETURNING id`,
+      [space.id, 'PersonCrossFilter', faceId],
+    );
+    const spacePersonId = spacePersonResult.rows[0].id as string;
+
+    await db.query(`INSERT INTO "shared_space_person_face" ("personId", "assetFaceId") VALUES ($1, $2)`, [
+      spacePersonId,
+      faceId,
+    ]);
+
+    // Filter by space person ID — this is what the frontend sends when a person is selected in a space
+    const { body } = await request(app)
+      .get(`/search/suggestions/filters?spaceId=${space.id}&personIds=${spacePersonId}`)
+      .set('Authorization', `Bearer ${admin.accessToken}`)
+      .expect(200);
+
+    // The space person is linked to asset A (Paris, rated 5, tagged "nature")
+    // All other filter categories should reflect asset A's metadata — NOT be empty
+    expect(body.countries.length).toBeGreaterThanOrEqual(1);
+    expect(body.ratings.length).toBeGreaterThanOrEqual(1);
+    expect(body.ratings).toContain(5);
+    expect(body.tags.length).toBeGreaterThanOrEqual(1);
+    const tagNames = body.tags.map((t: { value: string }) => t.value);
+    expect(tagNames).toContain('nature');
+  });
 });

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -736,7 +736,18 @@ export class SearchRepository {
           .$if(!!options.model, (qb) => qb.where('asset_exif.model', '=', options.model!))
           .$if(!!options.rating, (qb) => qb.where('asset_exif.rating', '=', options.rating!)),
       )
-      .$if(!!options.personIds?.length, (qb) =>
+      .$if(!!options.personIds?.length && !!options.spaceId, (qb) =>
+        qb.where((eb) =>
+          eb.exists(
+            eb
+              .selectFrom('shared_space_person_face')
+              .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+              .whereRef('asset_face.assetId', '=', 'asset.id')
+              .where('shared_space_person_face.personId', '=', anyUuid(options.personIds!)),
+          ),
+        ),
+      )
+      .$if(!!options.personIds?.length && !options.spaceId, (qb) =>
         qb.where((eb) =>
           eb.exists(
             eb


### PR DESCRIPTION
## Summary
- When a person was selected in a Space's filter panel, `buildFilteredAssetIds` matched space person IDs against `asset_face.personId` (global person IDs), finding zero assets — causing Location, Camera, Tags, and Rating filters to show "No values found"
- Now joins through `shared_space_person_face` → `asset_face` when `spaceId` is set, preserving the original `asset_face.personId` path for non-space contexts
- Added E2E test that filters by space person ID and asserts other filter categories still return values

## Test plan
- [ ] E2E: new test in `filter-suggestions.e2e-spec.ts` covers the exact bug scenario
- [ ] Manual: open a Space, select a person in People filter, verify Location/Camera/Tags/Rating still show values
- [ ] Verify Photos page filter panel still works correctly (non-space path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)