### PR TITLE
fix: always show all 5 rating stars to prevent positional mismatch

### DIFF
--- a/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
@@ -109,6 +109,24 @@ describe('Unified suggestionsProvider', () => {
     });
   });
 
+  it('should always show all 5 rating stars even when availableRatings is limited', async () => {
+    const config = createUnifiedConfig({
+      suggestionsProvider: vi.fn().mockResolvedValue({
+        ...defaultResponse,
+        ratings: [4, 5],
+      }),
+    });
+    render(FilterPanel, { props: { config, timeBuckets } });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => {
+      for (const star of [1, 2, 3, 4, 5]) {
+        expect(screen.getByTestId(`rating-star-${star}`)).toBeTruthy();
+      }
+    });
+  });
+
   it('should show all ratings when availableRatings is undefined (backward compat)', async () => {
     const config: FilterPanelConfig = {
       sections: ['rating'],

--- a/web/src/lib/components/filter-panel/rating-filter.svelte
+++ b/web/src/lib/components/filter-panel/rating-filter.svelte
@@ -18,11 +18,7 @@
     }
   }
 
-  let visibleStars = $derived(
-    availableRatings && availableRatings.length > 0
-      ? [1, 2, 3, 4, 5].filter((s) => availableRatings.includes(s) || s === selectedRating)
-      : [1, 2, 3, 4, 5],
-  );
+  const visibleStars = [1, 2, 3, 4, 5];
 </script>
 
 <div class="flex gap-1" data-testid="rating-filter">


### PR DESCRIPTION
## Summary

- **Fix:** Rating stars are now always rendered as a fixed `[1, 2, 3, 4, 5]` array instead of being dynamically filtered by `availableRatings`
- **Root cause:** When `availableRatings` excluded intermediate values (e.g. `[1, 2, 3, 5]` for a location with no 4-star photos), `visibleStars` rendered only 4 stars. Clicking the 4th star selected rating 5 instead of 4, since the gap at position 4 was invisible to the user. The `filled` logic (`star <= selectedRating`) filled all visible stars, reinforcing the illusion.
- I'll think of a better way of doing interdependent filtering with stars

## Test plan

- [x] Updated unit test to assert all 5 stars remain visible regardless of `availableRatings`
- [x] 1173 web unit tests pass
- [x] `check-web` (tsc + svelte-check) clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)