### PR TITLE
fix: add Location filter to map view filter panel

### DIFF
--- a/e2e/src/specs/web/map-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/map-filter-panel.e2e-spec.ts
@@ -39,8 +39,8 @@ test.describe('Map FilterPanel', () => {
     await expect(page.getByTestId('favorites-filter')).toBeVisible();
   });
 
-  test('should not show location filter section on map', async ({ context, page }) => {
+  test('should show location filter section on map', async ({ context, page }) => {
     await gotoMap(context, page);
-    await expect(page.getByTestId('filter-section-location')).not.toBeVisible();
+    await expect(page.getByTestId('filter-section-location')).toBeVisible();
   });
 });

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -27,7 +27,16 @@ describe('buildMapFilterConfig', () => {
 
   it('should include all expected sections', () => {
     const config = buildMapFilterConfig();
-    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
+    expect(config.sections).toEqual([
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+    ]);
   });
 
   it('should have suggestionsProvider', () => {

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -20,20 +20,14 @@ vi.mock('@immich/sdk', async (importOriginal) => {
 });
 
 describe('buildMapFilterConfig', () => {
-  it('should return config without location section', () => {
+  it('should include location in sections', () => {
     const config = buildMapFilterConfig();
-    expect(config.sections).not.toContain('location');
+    expect(config.sections).toContain('location');
   });
 
-  it('should include expected sections', () => {
+  it('should include all expected sections', () => {
     const config = buildMapFilterConfig();
-    expect(config.sections).toContain('timeline');
-    expect(config.sections).toContain('people');
-    expect(config.sections).toContain('camera');
-    expect(config.sections).toContain('tags');
-    expect(config.sections).toContain('rating');
-    expect(config.sections).toContain('media');
-    expect(config.sections).toContain('favorites');
+    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
   });
 
   it('should have suggestionsProvider', () => {
@@ -44,6 +38,11 @@ describe('buildMapFilterConfig', () => {
   it('should have cameraModels fallback provider', () => {
     const config = buildMapFilterConfig();
     expect(config.providers!.cameraModels).toBeDefined();
+  });
+
+  it('should have cities provider', () => {
+    const config = buildMapFilterConfig();
+    expect(config.providers!.cities).toBeDefined();
   });
 
   describe('suggestionsProvider', () => {
@@ -132,5 +131,27 @@ describe('buildMapFilterConfig', () => {
     await config.providers!.cameraModels!('Nikon');
 
     expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-123', make: 'Nikon' }));
+  });
+
+  it('should pass withSharedSpaces to cities provider when no spaceId', async () => {
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['Paris'] as never);
+
+    const config = buildMapFilterConfig();
+    await config.providers!.cities!('France');
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ country: 'France', withSharedSpaces: true }),
+    );
+  });
+
+  it('should pass spaceId to cities provider when spaceId given', async () => {
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['Berlin'] as never);
+
+    const config = buildMapFilterConfig('space-123');
+    await config.providers!.cities!('Germany');
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ country: 'Germany', spaceId: 'space-123' }),
+    );
   });
 });

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -7,7 +7,7 @@ import { createUrl } from '$lib/utils';
 import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
 
 export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
-  const sections = ['timeline', 'people', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
+  const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
 
   const suggestionsProvider = async (filters: FilterState) => {
     const context = buildFilterContext(filters);
@@ -49,6 +49,13 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
     sections: [...sections],
     suggestionsProvider,
     providers: {
+      cities: (country: string, context) =>
+        getSearchSuggestions({
+          $type: SearchSuggestionType.City,
+          country,
+          ...(spaceId ? { spaceId } : { withSharedSpaces: true }),
+          ...context,
+        }),
       cameraModels: (make: string, context) =>
         getSearchSuggestions({
           $type: SearchSuggestionType.CameraModel,


### PR DESCRIPTION
## Summary
- Added `location` to the map view filter panel sections, making it consistent with Photos, Spaces, and Timeline views
- Added `cities` provider to map filter config for country→city drill-down
- Updated unit tests: 5 new test cases covering location section presence and cities provider behavior

## Test plan
- [ ] Open map view → verify Location filter appears in the filter panel between People and Camera
- [ ] Select a country in Location filter → verify cities load and map markers filter correctly
- [ ] Combine People + Location filters on map → verify correct intersection results
- [ ] Verify Location filter works with spaceId (space map view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)