### PR TITLE
fix: space map cluster panel pre-selects photos

### DIFF
--- a/web/src/lib/components/shared-components/map/MapTimelinePanel.svelte
+++ b/web/src/lib/components/shared-components/map/MapTimelinePanel.svelte
@@ -92,7 +92,6 @@
       isFavorite: filters?.isFavorite ?? (spaceId ? undefined : $mapSettings.onlyFavorites || undefined),
       withPartners: spaceId ? undefined : $mapSettings.withPartners || undefined,
       spaceId,
-      timelineSpaceId: spaceId,
       assetFilter: selectedClusterIds,
       ...(filters?.personIds &&
         filters.personIds.length > 0 && {


### PR DESCRIPTION
## Summary
- Fixed photos appearing pre-selected (with checkmarks) when clicking a cluster on the map view inside a Space
- Removed `timelineSpaceId` from MapTimelinePanel's timeline options — this option is designed for the space page's "add assets" selection mode, not for browsing clusters
- The `spaceId` option alone correctly scopes the query to space content without triggering selection mode

## Root cause
`timelineSpaceId` causes `load-support.svelte.ts` to add all space assets to `timelineManager.albumAssets`, which the Timeline component treats as pre-selected — showing checkmarks and making clicks toggle selection instead of opening the asset viewer.

## Test plan
- [ ] Open a Space → navigate to map view → click a photo cluster
- [ ] Verify photos appear without checkmarks in the right panel
- [ ] Verify clicking a photo opens the asset viewer
- [ ] Verify the global map (via main nav) still works correctly
- [ ] Verify the space page "add assets" mode still shows checkmarks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)