### PR TITLE
fix: reindex face vectors before recognition to fix clustering at scale

### DIFF
--- a/docs/plans/2026-04-06-face-clustering-scale-fix-design.md
+++ b/docs/plans/2026-04-06-face-clustering-scale-fix-design.md
@@ -1,0 +1,109 @@
+# Fix Face Clustering at Scale
+
+**Date**: 2026-04-06
+**Branch**: `fix/face-clustering-parameter-limit`
+**Issue**: Faces detected but not assigned to persons at scale (~375k faces, ~13.5k persons)
+
+## Problem
+
+A user with two libraries (~177k and ~197k detected faces) reports that face clustering
+assigns persons to 67% of Library 1 faces but only 3% of Library 2 faces. The remaining
+191k faces have valid embeddings, are visible, and are marked as processed — the system
+silently treats them as clustered when they are not.
+
+The timeline shows degradation correlated with volume:
+
+| Date  | Faces created | Assigned | Rate |
+| ----- | ------------- | -------- | ---- |
+| Apr 1 | 142,841       | 5,911    | 4.1% |
+| Apr 2 | 46,556        | 55       | 0.1% |
+| Apr 3 | 8,239         | 0        | 0%   |
+| Apr 4 | 6             | 6        | 100% |
+
+Re-running facial recognition does not help. No errors in server logs.
+
+## Root Cause
+
+The vectorchord IVF index on `face_search` is only rebuilt on server startup
+(`reindexVectorsIfNeeded` in `database.service.ts`). When a large library scan adds
+hundreds of thousands of new face embeddings between restarts, the index configuration
+becomes stale:
+
+1. Server starts with ~177k faces -> index built with `lists=256`, `probes=32`
+2. Library 2 scan adds 197k faces -> total 375k, should be `lists=512`, `probes=64`
+3. New faces are assigned to centroids calculated for the old data distribution
+4. Recognition runs: vector search probes 32 partitions out of 256, but Library 2 faces
+   are scattered across wrong partitions due to stale centroids
+5. Search misses true nearest neighbors -> faces can't form core clusters -> no persons
+   created -> deferred faces can't find existing persons -> left unassigned
+6. Job returns `Success` with no logging -> silent failure
+
+This is an **upstream Immich issue** — the face recognition code has no Gallery-specific
+modifications.
+
+## Changes
+
+### 1. Reindex before recognition (primary fix)
+
+**File**: `server/src/services/person.service.ts`
+
+In `handleQueueRecognizeFaces`, add `reindexVectorsIfNeeded([VectorIndex.Face])` after
+`waitForQueueCompletion` and before `prewarm`. This ensures the index configuration
+matches the current face count before any recognition jobs run.
+
+The method is already battle-tested (called on every server startup). It checks the
+current `lists` value against `targetListCount(rowCount)` and only rebuilds if they
+differ (accounting for a 1.2x slack factor to avoid churn at boundaries). When the index
+is already correct, this is a no-op (milliseconds).
+
+### 2. Shared-space repository chunking (defensive)
+
+**File**: `server/src/repositories/shared-space.repository.ts`
+
+Add `@Chunked()` to methods that pass arrays to `WHERE IN` without size protection:
+
+- `recountPersons(personIds)` — `@Chunked()` (paramIndex 0)
+- `removeAssets(spaceId, assetIds)` — `@Chunked({ paramIndex: 1 })`
+
+Skipped methods:
+
+- `removePersonFacesByAssetIds` — runs three dependent queries per call; chunking with
+  `Promise.all` causes a race condition on intermediate recounts. Input sizes are
+  realistically small (user-selected assets).
+- `findSpacePersonsByLinkedPersonIds` — only called with 1-10 person IDs from single
+  asset face lookups. YAGNI.
+
+### 3. Diagnostic logging
+
+**File**: `server/src/services/person.service.ts`
+
+Add a debug log in `handleRecognizeFaces` when a face finishes processing without being
+assigned to a person. Currently the job returns `Success` silently — this makes the
+failure mode visible in logs.
+
+### 4. Unit test
+
+**File**: `server/src/services/person.service.spec.ts`
+
+Test that `handleQueueRecognizeFaces` calls `reindexVectorsIfNeeded([VectorIndex.Face])`
+before `prewarm`.
+
+## What does not change
+
+- Face recognition algorithm (upstream code)
+- Vector search query (`searchFaces`)
+- Clustering parameters (`minFaces`, `maxDistance`)
+- Face detection pipeline
+- API endpoints or DTOs (no OpenAPI regen)
+- Database schema (no migration)
+
+## Uncertainty
+
+The stale vector index is the most likely root cause, but I cannot be 100% certain
+without running diagnostics on the actual database. If the user's server restart
+(which triggers `reindexVectorsIfNeeded` on startup) resolves the issue, that confirms
+the theory. If not, the diagnostic logging from Change 3 will help identify the actual
+cause.
+
+Regardless, Change 1 is the right fix — the index should always be checked before
+recognition runs, not only on server startup.

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Insertable, Kysely, NotNull, sql, Updateable } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
-import { ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
+import { Chunked, ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
 import { AssetType, AssetVisibility, VectorIndex } from 'src/enum';
 import { probes } from 'src/repositories/database.repository';
 import type { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
@@ -195,6 +195,7 @@ export class SharedSpaceRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  @Chunked({ paramIndex: 1 })
   async removeAssets(spaceId: string, assetIds: string[]) {
     await this.db
       .deleteFrom('shared_space_asset')
@@ -675,6 +676,7 @@ export class SharedSpaceRepository {
   }
 
   @GenerateSql({ params: [[DummyValue.UUID]] })
+  @Chunked()
   async recountPersons(personIds: string[]) {
     if (personIds.length === 0) {
       return;

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -10,6 +10,7 @@ import {
   JobStatus,
   SourceType,
   SystemMetadataKey,
+  VectorIndex,
 } from 'src/enum';
 import { FaceSearchResult } from 'src/repositories/search.repository';
 import { PersonService } from 'src/services/person.service';
@@ -637,6 +638,28 @@ describe(PersonService.name, () => {
         lastRun: expect.any(String),
       });
       expect(mocks.person.vacuum).not.toHaveBeenCalled();
+    });
+
+    it('should reindex vectors before prewarm', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+      mocks.person.getAllFaces.mockReturnValue(makeStream([]));
+
+      await sut.handleQueueRecognizeFaces({});
+
+      expect(mocks.database.reindexVectorsIfNeeded).toHaveBeenCalledWith([VectorIndex.Face]);
+      expect(mocks.database.prewarm).toHaveBeenCalledWith(VectorIndex.Face);
+
+      // reindex should be called before prewarm
+      const reindexOrder = mocks.database.reindexVectorsIfNeeded.mock.invocationCallOrder[0];
+      const prewarmOrder = mocks.database.prewarm.mock.invocationCallOrder[0];
+      expect(reindexOrder).toBeLessThan(prewarmOrder);
     });
 
     it('should queue all assets', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -435,6 +435,8 @@ export class PersonService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    // Gallery: ensure vector index matches current face count (upstream only reindexes on startup)
+    await this.databaseRepository.reindexVectorsIfNeeded([VectorIndex.Face]);
     await this.databaseRepository.prewarm(VectorIndex.Face);
 
     const lastRun = new Date().toISOString();
@@ -538,6 +540,10 @@ export class PersonService extends BaseService {
     if (personId) {
       this.logger.debug(`Assigning face ${id} to person ${personId}`);
       await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: personId });
+    } else {
+      this.logger.debug(
+        `Face ${id} not assigned to a person (deferred=${deferred}, matches=${matches.length}, isCore=${isCore})`,
+      );
     }
 
     // Queue shared space face matching for any spaces containing this asset


### PR DESCRIPTION
## Summary

- Ensure the vectorchord face index is rebuilt before recognition runs, not only on server startup — fixes face clustering silently failing when face count grows significantly between restarts (97%+ unassigned faces)
- Add `@Chunked` to shared-space repository methods (`recountPersons`, `removeAssets`) that pass arrays to `WHERE IN` without size protection
- Add diagnostic logging when deferred faces go unassigned, making the silent failure visible in debug logs

## Test plan

- [ ] Verify server unit tests pass (`cd server && pnpm test`)
- [ ] Verify type check passes (`cd server && npx tsc --noEmit`)
- [ ] On a large instance: run Facial Recognition job and confirm faces get assigned to persons
- [ ] Check server logs show "Reindexing face_index" message when face count crosses a threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)