### PR TITLE
feat: publish OpenVINO ML image variant in releases

### DIFF
--- a/.github/workflows/gallery-release.yml
+++ b/.github/workflows/gallery-release.yml
@@ -232,6 +232,9 @@ jobs:
           - device: cuda
             platform: linux/amd64
             runner: ubuntu-latest
+          - device: openvino
+            platform: linux/amd64
+            runner: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -301,7 +304,8 @@ jobs:
             suffix: ''
           - device: cuda
             suffix: '-cuda'
-            # CUDA only builds for linux/amd64 — nvidia/cuda base image is amd64-only
+          - device: openvino
+            suffix: '-openvino'
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary
- Add `openvino` device to the `gallery-release.yml` build and merge matrices
- Publishes `ghcr.io/open-noodle/gallery-ml:release-openvino` alongside CPU and CUDA variants
- All infrastructure (Dockerfile stages, compose files, hwaccel config, docs) already supported OpenVINO — only the release workflow was missing it

Closes #273