### PR TITLE
fix: replace upstream image references in docs

### DIFF
--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -103,7 +103,7 @@ You can add this to the `immich-server` service instead of extending from `hwacc
 ```yaml
 immich-server:
   container_name: immich_server
-  image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+  image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-release}
   # Note the lack of an `extends` section
   devices:
     - /dev/dri:/dev/dri

--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -120,7 +120,7 @@ You can add this to the `immich-machine-learning` service instead of extending f
 immich-machine-learning:
   container_name: immich_machine_learning
   # Note the `-cuda` at the end
-  image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-cuda
+  image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}-cuda
   # Note the lack of an `extends` section
   deploy:
     resources:

--- a/docs/docs/guides/remote-machine-learning.md
+++ b/docs/docs/guides/remote-machine-learning.md
@@ -25,7 +25,7 @@ services:
     container_name: immich_machine_learning
     # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn] to the image tag.
     # Example tag: ${IMMICH_VERSION:-release}-cuda
-    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+    image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}
     # extends:
     #   file: hwaccel.ml.yml
     #   service: # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable


### PR DESCRIPTION
## Summary
- Replace `ghcr.io/immich-app/immich-machine-learning` → `ghcr.io/open-noodle/gallery-ml` in ML hardware acceleration and remote ML docs
- Replace `ghcr.io/immich-app/immich-server` → `ghcr.io/open-noodle/gallery-server` in hardware transcoding docs
- CLI and postgres images left as upstream (Gallery doesn't publish those)

Found while adding OpenVINO to the release workflow (#279).