### PR TITLE
fix: fetch tags in docs deploy for apply-branding

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -116,6 +116,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: ./.github/actions/apply-branding
 


### PR DESCRIPTION
## Summary
- Docs deploy was failing at `apply-branding` with exit code 128 — `git describe --tags` needs tags in the checkout
- Add `fetch-depth: 0` and `fetch-tags: true` to the checkout step

This broke when docs deploy started running apply-branding.