### PR TITLE
fix: remove fork check blocking docs deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -58,7 +58,7 @@ jobs:
             if (eventType == "push") {
               const branch = context.payload.workflow_run.head_branch;
               console.log({branch});
-              const shouldDeploy = !isFork && branch == "main";
+              const shouldDeploy = branch == "main";
               parameters = {
                 event: "branch",
                 name: "main",
@@ -95,7 +95,7 @@ jobs:
               parameters = {
                 event: "release",
                 name: context.payload.workflow_run.head_branch,
-                shouldDeploy: !isFork
+                shouldDeploy: true
               };
             }
 


### PR DESCRIPTION
## Summary
- Docs deploy has **never actually deployed** — `repository.fork` is always `true` for Gallery (it's a GitHub fork of Immich), so `shouldDeploy` was always `false`
- Remove the `isFork` guard from both push and release deploy paths
- The tag fetch fix from #281 is also needed (already merged)

The "successful" deploy runs in history were all skipped (checks pass, deploy job 0s).