### PR TITLE
feat: add Umami analytics to docs site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -66,6 +66,17 @@ const config = {
     ],
   ],
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {
+        defer: 'true',
+        src: 'https://analytics.opennoodle.de/script.js',
+        'data-website-id': 'eb4bfa32-e4dd-4227-85e2-3772d24bceab',
+      },
+    },
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({


### PR DESCRIPTION
## Summary
- Adds self-hosted Umami analytics tracking to docs.opennoodle.de
- Uses the `headTags` Docusaurus config to inject the script into all pages
- Umami instance: `analytics.opennoodle.de`

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] After deploy, check analytics.opennoodle.de dashboard shows docs.opennoodle.de traffic