### PR TITLE
feat: persist filter panel and space hero UI state in localStorage

### DIFF
--- a/docs/plans/2026-04-06-filter-localstorage-design.md
+++ b/docs/plans/2026-04-06-filter-localstorage-design.md
@@ -26,19 +26,23 @@ the exact pattern already used for visible sections in `filter-panel.svelte`.
 
 **Changes to `filter-panel.svelte`:**
 
-- Replace `let collapsed = $state(initialCollapsed)` with localStorage-aware init
-- On mount: read `gallery-filter-collapsed`. If present, use it. If absent, default to
-  `false` (expanded)
+- Remove `initialCollapsed` prop entirely — localStorage is the source of truth,
+  default is `false` (expanded)
+- Add `loadCollapsed()` helper: read `gallery-filter-collapsed` from localStorage.
+  If present, use it. If absent, return `false`
+- Replace `let collapsed = $state(initialCollapsed)` with
+  `let collapsed = $state(loadCollapsed())`
 - Add `$effect` to persist `collapsed` on change
-- Keep `initialCollapsed` prop but only as fallback when no localStorage entry exists
-  (for backwards compat and first-visit behavior)
 
 **Changes to parent pages:**
 
-- Photos page: change `initialCollapsed={true}` to `initialCollapsed={false}` (or
-  remove it) — first visit should show the filter panel so users discover it
-- Map page: no change (already defaults to expanded)
-- Spaces page: no change (already defaults to expanded)
+- Photos page: remove `initialCollapsed={true}` prop (no longer exists)
+- Map page: no change
+- Spaces page: no change
+
+**Existing tests:** The `describe('initialCollapsed prop')` block in
+`filter-panel.spec.ts` must be replaced with tests for localStorage persistence
+(read stored value, default when empty, persist on toggle).
 
 **Add `persistCollapsed` prop** (default `true`):
 
@@ -63,7 +67,11 @@ section type names)
 - Make it fully controlled: add `expanded` prop and `onToggleExpanded` callback
 - Remove internal `let expanded = $state(true)`
 - Parent (FilterPanel) owns the state and passes it down
-- Handle `isEmpty` in parent: do not expand a section with zero results
+- `isEmpty` handling: FilterSection still derives `isEmpty` from `count === 0` and
+  renders content only when `expanded && !isEmpty`. The parent passes the stored
+  `expanded` value regardless — an empty section just won't show content even if
+  `expanded` is true. This keeps the accordion header clickable so the user can still
+  toggle it (the click handler already guards `if (!isEmpty)`)
 
 **Changes to `filter-panel.svelte`:**
 
@@ -90,12 +98,21 @@ section type names)
 **Key:** `gallery-space-hero-collapsed` -> `Record<string, boolean>` (spaceId ->
 collapsed)
 
+**Extract hero persistence helpers** into a small utility (e.g.,
+`web/src/lib/utils/space-hero-storage.ts`) for testability:
+
+- `loadHeroCollapsed(spaceId: string): boolean` — read Record from localStorage,
+  return value for spaceId or `false`
+- `persistHeroCollapsed(spaceId: string, collapsed: boolean): void` — read Record,
+  update entry, write back
+
 **Changes to space page (`+page.svelte`):**
 
-- Replace `let heroCollapsed = $state(false)` with localStorage-aware init
-- On mount / space change: read the Record, look up current spaceId. If entry exists,
-  use it. If absent, default to `false` (expanded)
-- On **manual** toggle (chevron click): update Record and persist
+- Replace `let heroCollapsed = $state(false)` with
+  `let heroCollapsed = $state(loadHeroCollapsed(space.id))`
+- On space navigation (the `data.space.id !== space.id` effect): read the new space's
+  persisted value via `loadHeroCollapsed(data.space.id)` instead of resetting to `false`
+- On **manual** toggle (chevron click): update and persist via `persistHeroCollapsed`
 - **Do NOT persist auto-collapse from filter activation** — only persist user-initiated
   toggles via the chevron button
 
@@ -136,15 +153,21 @@ eviction needed.
   renders expanded
 - **`{#key space.id}` remount:** FilterPanel is destroyed/recreated on space navigation,
   correctly re-reading localStorage each time. The `$effect` write-on-mount is harmless.
-- **Empty sections:** FilterPanel must not allow expanding a section with zero results
-  (handle `isEmpty` logic in parent, not in FilterSection)
+- **Empty sections:** FilterSection keeps its `isEmpty` guard — content is only rendered
+  when `expanded && !isEmpty`. Stored `expanded` state is passed through regardless;
+  the section header remains clickable but disabled when empty (existing behavior)
+- **`hidden` prop interaction:** When `hidden={true}` (e.g., `isTimelineEmpty` on photos
+  page), `collapsed` state is still initialized from localStorage before the template
+  checks `hidden`. If the panel becomes unhidden, it correctly restores from storage
 
 ## Testing
 
 - Unit tests for `loadExpandedSections` / persist / toggle (mirror existing
   visible-sections tests)
-- Unit test for filter panel collapsed persistence (read/write/default)
-- Unit test for space hero per-space persistence (read/write/toggle/space-switch)
+- Unit test for filter panel collapsed persistence (read/write/default) — replaces
+  existing `initialCollapsed` test block
+- Unit tests for `loadHeroCollapsed` / `persistHeroCollapsed` helpers (standalone
+  utility, easy to test without mocking page data)
 - No E2E needed — localStorage behavior is well-covered by unit tests
 
 ## localStorage Keys Summary

--- a/docs/plans/2026-04-06-filter-localstorage-design.md
+++ b/docs/plans/2026-04-06-filter-localstorage-design.md
@@ -1,0 +1,162 @@
+# Persist Filter Panel & Space Hero UI State in localStorage
+
+## Goal
+
+Remember user preferences for filter panel and space hero collapsed/expanded state
+across page reloads and navigation, using inline localStorage (matching the existing
+visible-sections pattern).
+
+## What We're Persisting
+
+| What                   | Key                                 | Type                      | Default            | Scope               |
+| ---------------------- | ----------------------------------- | ------------------------- | ------------------ | ------------------- |
+| Filter panel collapsed | `gallery-filter-collapsed`          | `boolean`                 | `false` (expanded) | Global              |
+| Section accordions     | `gallery-filter-expanded-sections`  | `string[]`                | All expanded       | Global              |
+| Space hero collapsed   | `gallery-space-hero-collapsed`      | `Record<string, boolean>` | `false` (expanded) | Per-space           |
+| Visible sections       | `gallery-filter-visible-sections-*` | `string[]`                | All visible        | Per-page (existing) |
+
+## Approach
+
+Inline `localStorage.getItem`/`setItem` with `browser` guard and `try/catch`, following
+the exact pattern already used for visible sections in `filter-panel.svelte`.
+
+## 1. Filter Panel Collapsed/Expanded (Global)
+
+**Key:** `gallery-filter-collapsed` -> `boolean`
+
+**Changes to `filter-panel.svelte`:**
+
+- Replace `let collapsed = $state(initialCollapsed)` with localStorage-aware init
+- On mount: read `gallery-filter-collapsed`. If present, use it. If absent, default to
+  `false` (expanded)
+- Add `$effect` to persist `collapsed` on change
+- Keep `initialCollapsed` prop but only as fallback when no localStorage entry exists
+  (for backwards compat and first-visit behavior)
+
+**Changes to parent pages:**
+
+- Photos page: change `initialCollapsed={true}` to `initialCollapsed={false}` (or
+  remove it) — first visit should show the filter panel so users discover it
+- Map page: no change (already defaults to expanded)
+- Spaces page: no change (already defaults to expanded)
+
+**Add `persistCollapsed` prop** (default `true`):
+
+- The map page renders two FilterPanel instances (desktop + mobile overlay). The mobile
+  overlay is toggled by an external button and should always render expanded when the
+  overlay opens. Pass `persistCollapsed={false}` to the mobile instance.
+
+**Behavior:**
+
+- First visit: panel expanded (users discover the feature)
+- User collapses panel -> stored globally
+- All subsequent visits on any page: collapsed
+- User expands again -> stored, stays expanded
+
+## 2. Filter Section Accordion State (Global)
+
+**Key:** `gallery-filter-expanded-sections` -> `string[]` (JSON array of expanded
+section type names)
+
+**Changes to `filter-section.svelte`:**
+
+- Make it fully controlled: add `expanded` prop and `onToggleExpanded` callback
+- Remove internal `let expanded = $state(true)`
+- Parent (FilterPanel) owns the state and passes it down
+- Handle `isEmpty` in parent: do not expand a section with zero results
+
+**Changes to `filter-panel.svelte`:**
+
+- Add `expandedSections` state as `SvelteSet<FilterSectionType>` (mirrors
+  `visibleSections` pattern)
+- Add `loadExpandedSections()` function:
+  - Read from localStorage
+  - Validate against current `config.sections` (ignore unknown types)
+  - Default: all sections in `config.sections` (all expanded on first visit)
+- Add `$effect` to persist `expandedSections` on change
+- Add `toggleSectionExpanded(section)` function
+- Pass `expanded={expandedSections.has(section)}` and
+  `onToggleExpanded={() => toggleSectionExpanded(section)}` to each FilterSection
+
+**Behavior:**
+
+- First visit: all sections expanded (users see full content)
+- User collapses Timeline (40+ year entries) -> stored
+- Next visit: Timeline stays collapsed, everything else expanded
+- Global across all pages (photos, map, spaces)
+
+## 3. Space Hero Collapsed/Expanded (Per-Space)
+
+**Key:** `gallery-space-hero-collapsed` -> `Record<string, boolean>` (spaceId ->
+collapsed)
+
+**Changes to space page (`+page.svelte`):**
+
+- Replace `let heroCollapsed = $state(false)` with localStorage-aware init
+- On mount / space change: read the Record, look up current spaceId. If entry exists,
+  use it. If absent, default to `false` (expanded)
+- On **manual** toggle (chevron click): update Record and persist
+- **Do NOT persist auto-collapse from filter activation** — only persist user-initiated
+  toggles via the chevron button
+
+**Why separate auto-collapse from manual toggle:**
+
+The auto-collapse effect (`heroCollapsed = true` when filters activate) is a convenience
+hint, not a user preference. If persisted, it becomes a one-way ratchet: apply filter ->
+hero collapses and persists -> clear filters -> hero stays collapsed forever. Instead,
+distinguish the source:
+
+```typescript
+function toggleHeroCollapsed() {
+  heroCollapsed = !heroCollapsed;
+  persistHeroCollapsed(space.id, heroCollapsed); // only here
+}
+```
+
+The auto-collapse effect sets `heroCollapsed = true` without persisting.
+
+**Space navigation:** When switching spaces, read the new space's persisted value from
+localStorage in the navigation sync effect (not just on component mount).
+
+**Unbounded growth:** Not a concern. Users won't visit thousands of spaces, and a few
+hundred UUIDs with booleans is trivially small in localStorage's 5-10MB budget. No LRU
+eviction needed.
+
+## Edge Cases
+
+- **SSR safety:** All localStorage access guarded by `browser` check from
+  `$app/environment`
+- **Corrupted data:** `try/catch` with silent fallback to defaults (same as existing
+  pattern)
+- **Section type changes:** `loadExpandedSections` validates against current
+  `config.sections`, ignoring unknown types (graceful degradation if sections are
+  added/removed)
+- **Space deletion:** Stale entries in the hero Record are harmless dead keys
+- **Map mobile overlay:** `persistCollapsed={false}` ensures mobile FilterPanel always
+  renders expanded
+- **`{#key space.id}` remount:** FilterPanel is destroyed/recreated on space navigation,
+  correctly re-reading localStorage each time. The `$effect` write-on-mount is harmless.
+- **Empty sections:** FilterPanel must not allow expanding a section with zero results
+  (handle `isEmpty` logic in parent, not in FilterSection)
+
+## Testing
+
+- Unit tests for `loadExpandedSections` / persist / toggle (mirror existing
+  visible-sections tests)
+- Unit test for filter panel collapsed persistence (read/write/default)
+- Unit test for space hero per-space persistence (read/write/toggle/space-switch)
+- No E2E needed — localStorage behavior is well-covered by unit tests
+
+## localStorage Keys Summary
+
+All keys follow the existing `gallery-` prefix, kebab-case convention:
+
+```
+gallery-filter-collapsed              -> boolean
+gallery-filter-expanded-sections      -> string[]
+gallery-space-hero-collapsed          -> Record<string, boolean>
+gallery-filter-visible-sections       -> string[]  (existing, default)
+gallery-filter-visible-sections-photos -> string[] (existing, photos page)
+gallery-filter-visible-sections-map   -> string[]  (existing, map page)
+gallery-filter-visible-sections-spaces -> string[] (existing, spaces page)
+```

--- a/docs/plans/2026-04-06-filter-localstorage-plan.md
+++ b/docs/plans/2026-04-06-filter-localstorage-plan.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Svelte 5 (`$state`, `$effect`, `SvelteSet`), SvelteKit (`$app/environment` → `browser`), Vitest, @testing-library/svelte
 
+**Task order rationale:** Tasks are grouped to avoid intermediate broken states. The FilterSection refactor (controlled props) and accordion persistence are in one task because splitting them leaves section toggles non-functional between commits. Hero utility (Tasks 1-2) is first because it has zero dependencies.
+
 ---
 
 ### Task 1: Space Hero Storage Utility — Tests
@@ -144,78 +146,7 @@ git commit -m "feat: add space hero localStorage persistence utility"
 
 ---
 
-### Task 3: Make FilterSection Controlled
-
-**Files:**
-
-- Modify: `web/src/lib/components/filter-panel/filter-section.svelte` (entire file, 57 lines)
-
-**Step 1: Update FilterSection to accept `expanded` and `onToggleExpanded` props**
-
-Replace the Props interface and state in `filter-section.svelte`:
-
-```typescript
-// Old (lines 6-14):
-interface Props {
-  title: string;
-  testId: string;
-  children: Snippet;
-  refetching?: boolean;
-  count?: number;
-}
-
-let { title, testId, children, refetching = false, count }: Props = $props();
-let expanded = $state(true);
-
-// New:
-interface Props {
-  title: string;
-  testId: string;
-  children: Snippet;
-  refetching?: boolean;
-  count?: number;
-  expanded?: boolean;
-  onToggleExpanded?: () => void;
-}
-
-let { title, testId, children, refetching = false, count, expanded = true, onToggleExpanded }: Props = $props();
-```
-
-Update the click handler (line 24-28):
-
-```svelte
-<!-- Old: -->
-onclick={() => {
-  if (!isEmpty) {
-    expanded = !expanded;
-  }
-}}
-
-<!-- New: -->
-onclick={() => {
-  if (!isEmpty && onToggleExpanded) {
-    onToggleExpanded();
-  }
-}}
-```
-
-**Important:** When `onToggleExpanded` is not provided (backwards compat during transition), the section becomes inert — it just shows whatever `expanded` is. This is fine because FilterPanel will always provide both props.
-
-**Step 2: Run existing filter-panel tests to verify no regression**
-
-Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
-Expected: PASS — FilterSection still defaults `expanded=true` and existing tests don't click section headers
-
-**Step 3: Commit**
-
-```bash
-git add web/src/lib/components/filter-panel/filter-section.svelte
-git commit -m "refactor: make FilterSection accept controlled expanded prop"
-```
-
----
-
-### Task 4: Filter Panel Collapsed Persistence — Tests
+### Task 3: Filter Panel Collapsed Persistence — Tests
 
 **Files:**
 
@@ -302,6 +233,21 @@ describe('collapsed state persistence', () => {
     });
     expect(screen.getByTestId('discovery-panel')).toBeInTheDocument();
   });
+
+  it('should still allow in-session collapse when persistCollapsed is false', async () => {
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating'], providers: {} },
+        timeBuckets: [],
+        persistCollapsed: false,
+      },
+    });
+    await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+    expect(screen.getByTestId('collapsed-icon-strip')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-panel')).not.toBeInTheDocument();
+    // But nothing written to localStorage
+    expect(localStorage.getItem(COLLAPSED_KEY)).toBeNull();
+  });
 });
 ```
 
@@ -334,7 +280,7 @@ it('should render nothing when hidden and collapsed in localStorage', () => {
 **Step 2: Run tests — verify they fail**
 
 Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
-Expected: FAIL — `initialCollapsed` prop removed but component still has it; localStorage tests fail because component doesn't read from it yet
+Expected: FAIL — component still has `initialCollapsed` prop; localStorage tests fail because component doesn't read from it yet
 
 **Step 3: Commit**
 
@@ -345,11 +291,13 @@ git commit -m "test: add failing tests for filter panel collapsed localStorage p
 
 ---
 
-### Task 5: Filter Panel Collapsed Persistence — Implementation
+### Task 4: Filter Panel Collapsed Persistence — Implementation
 
 **Files:**
 
 - Modify: `web/src/lib/components/filter-panel/filter-panel.svelte` (lines 37-54)
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte` (line 188)
+- Modify: `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte` (line 205)
 
 **Step 1: Update FilterPanel Props and collapsed initialization**
 
@@ -377,7 +325,7 @@ interface Props {
 }
 ```
 
-Update the props destructuring (lines 46-53):
+Update the props destructuring (lines 46-54):
 
 ```typescript
 // Old:
@@ -486,13 +434,18 @@ git commit -m "feat: persist filter panel collapsed state in localStorage"
 
 ---
 
-### Task 6: Filter Section Accordion Persistence — Tests
+### Task 5: FilterSection Controlled + Accordion Persistence — Tests
+
+This task combines the FilterSection refactor and accordion persistence tests into one
+task to avoid an intermediate state where section header clicks are non-functional.
 
 **Files:**
 
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
 
 **Step 1: Add tests for expanded sections persistence**
+
+Add `import type { FilterSection } from '../filter-panel';` at the top of the test file.
 
 Add a new `describe` block at the bottom of the file:
 
@@ -522,14 +475,14 @@ describe('Section Accordion Persistence', () => {
 
   it('should default all sections to expanded on first visit', () => {
     renderPanel(['people', 'rating']);
-    // Section content should be visible (expanded)
-    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
-    expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeTruthy();
+    expect(ratingContent).toBeTruthy();
   });
 
   it('should persist collapsed section to localStorage when header is clicked', async () => {
     renderPanel(['people', 'rating']);
-    // Click the section header to collapse
     const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
     await fireEvent.click(peopleHeader);
     const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
@@ -540,17 +493,24 @@ describe('Section Accordion Persistence', () => {
   it('should restore collapsed sections from localStorage on mount', () => {
     localStorage.setItem(EXPANDED_KEY, JSON.stringify(['rating']));
     renderPanel(['people', 'rating']);
-    // People section content should be hidden (collapsed), rating visible
     const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
     const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
     expect(peopleContent).toBeNull();
     expect(ratingContent).toBeTruthy();
   });
 
+  it('should keep all sections collapsed when localStorage has empty array', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify([]));
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeNull();
+    expect(ratingContent).toBeNull();
+  });
+
   it('should ignore unknown section types in localStorage', () => {
     localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people', 'nonexistent']));
     renderPanel(['people', 'rating']);
-    // People is in the stored list so it's expanded, rating is not so it's collapsed
     const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
     expect(peopleContent).toBeTruthy();
   });
@@ -567,7 +527,6 @@ describe('Section Accordion Persistence', () => {
   it('should expand a collapsed section when header is clicked again', async () => {
     localStorage.setItem(EXPANDED_KEY, JSON.stringify(['rating']));
     renderPanel(['people', 'rating']);
-    // People is collapsed — click to expand
     const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
     await fireEvent.click(peopleHeader);
     const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
@@ -577,16 +536,10 @@ describe('Section Accordion Persistence', () => {
 });
 ```
 
-You'll also need to import `FilterSection` type at the top of the test file:
-
-```typescript
-import type { FilterSection } from '../filter-panel';
-```
-
 **Step 2: Run tests — verify they fail**
 
 Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
-Expected: FAIL — persistence tests fail because FilterPanel doesn't pass `expanded`/`onToggleExpanded` to FilterSection yet
+Expected: FAIL — FilterPanel doesn't pass `expanded`/`onToggleExpanded` to FilterSection yet, and section header clicks still use internal state
 
 **Step 3: Commit**
 
@@ -597,15 +550,72 @@ git commit -m "test: add failing tests for filter section accordion localStorage
 
 ---
 
-### Task 7: Filter Section Accordion Persistence — Implementation
+### Task 6: FilterSection Controlled + Accordion Persistence — Implementation
+
+This task does both the FilterSection refactor and the FilterPanel wiring in one step
+so there's no intermediate commit where section toggles are broken.
 
 **Files:**
 
+- Modify: `web/src/lib/components/filter-panel/filter-section.svelte` (entire file, 57 lines)
 - Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
 
-**Step 1: Add expandedSections state and persistence**
+**Step 1: Make FilterSection controlled**
 
-After `let visibleSections = $state(...)` (line 336), add:
+In `filter-section.svelte`, update the Props interface and state (lines 6-15):
+
+```typescript
+// Old:
+interface Props {
+  title: string;
+  testId: string;
+  children: Snippet;
+  refetching?: boolean;
+  count?: number;
+}
+
+let { title, testId, children, refetching = false, count }: Props = $props();
+let expanded = $state(true);
+
+// New:
+interface Props {
+  title: string;
+  testId: string;
+  children: Snippet;
+  refetching?: boolean;
+  count?: number;
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
+}
+
+let { title, testId, children, refetching = false, count, expanded = true, onToggleExpanded }: Props = $props();
+```
+
+Update the click handler (line 24-28):
+
+```svelte
+<!-- Old: -->
+onclick={() => {
+  if (!isEmpty) {
+    expanded = !expanded;
+  }
+}}
+
+<!-- New: -->
+onclick={() => {
+  if (!isEmpty && onToggleExpanded) {
+    onToggleExpanded();
+  }
+}}
+```
+
+**Note:** The `disabled={isEmpty}` attribute on the button (line 29) already prevents
+clicks on empty sections, so the `!isEmpty` check in the handler is a defense-in-depth
+guard. Both guards stay.
+
+**Step 2: Add expandedSections state and persistence to FilterPanel**
+
+In `filter-panel.svelte`, after `let visibleSections = $state(...)` (line 336), add:
 
 ```typescript
 const EXPANDED_SECTIONS_KEY = 'gallery-filter-expanded-sections';
@@ -614,12 +624,13 @@ function loadExpandedSections(configSections: FilterSectionType[]): SvelteSet<Fi
   if (browser) {
     try {
       const raw = localStorage.getItem(EXPANDED_SECTIONS_KEY);
-      if (raw) {
+      if (raw !== null) {
         const parsed = JSON.parse(raw) as string[];
         const valid = parsed.filter((s): s is FilterSectionType => configSections.includes(s as FilterSectionType));
-        if (valid.length > 0) {
-          return new SvelteSet(valid);
-        }
+        // Return the validated set even if empty — an empty array means the user
+        // explicitly collapsed all sections. Only fall through to default when
+        // there's no localStorage entry at all (raw === null).
+        return new SvelteSet(valid);
       }
     } catch {
       /* corrupted JSON — fall through to default */
@@ -641,6 +652,13 @@ function toggleSectionExpanded(section: FilterSectionType) {
 }
 ```
 
+**Key difference from `loadVisibleSections`:** This function uses `raw !== null` instead
+of `raw` + `valid.length > 0` to distinguish "no localStorage entry" (default to all
+expanded) from "empty array stored" (user collapsed everything, respect that). The
+existing `loadVisibleSections` has this same bug but it's less impactful there (hiding
+all sections shows a "Show all" link). For accordion state, silently re-expanding
+everything the user collapsed would be wrong.
+
 Add a `$effect` to persist (after the collapsed persistence `$effect`):
 
 ```typescript
@@ -655,7 +673,7 @@ $effect(() => {
 });
 ```
 
-**Step 2: Pass `expanded` and `onToggleExpanded` to each FilterSection**
+**Step 3: Pass `expanded` and `onToggleExpanded` to each FilterSection**
 
 In the template `{#each}` block (around line 559), update the `<FilterSection>` tag:
 
@@ -679,21 +697,22 @@ In the template `{#each}` block (around line 559), update the `<FilterSection>` 
 >
 ```
 
-**Step 3: Run tests — verify they pass**
+**Step 4: Run tests — verify they pass**
 
 Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
 Expected: PASS
 
-**Step 4: Commit**
+**Step 5: Commit**
 
 ```bash
-git add web/src/lib/components/filter-panel/filter-panel.svelte
+git add web/src/lib/components/filter-panel/filter-section.svelte \
+       web/src/lib/components/filter-panel/filter-panel.svelte
 git commit -m "feat: persist filter section accordion state in localStorage"
 ```
 
 ---
 
-### Task 8: Space Hero Persistence — Integration
+### Task 7: Space Hero Persistence — Integration
 
 **Files:**
 
@@ -717,6 +736,15 @@ let heroCollapsed = $state(false);
 let heroCollapsed = $state(loadHeroCollapsed(data.space.id));
 ```
 
+Add a named toggle function near `heroCollapsed` declaration:
+
+```typescript
+function toggleHeroCollapsed() {
+  heroCollapsed = !heroCollapsed;
+  persistHeroCollapsed(space.id, heroCollapsed);
+}
+```
+
 Update the space navigation sync effect (line 127):
 
 ```typescript
@@ -727,18 +755,7 @@ heroCollapsed = false;
 heroCollapsed = loadHeroCollapsed(data.space.id);
 ```
 
-Create a named toggle function and update the SpaceHero callback (around line 908-909):
-
-Add this function near `heroCollapsed` declaration:
-
-```typescript
-function toggleHeroCollapsed() {
-  heroCollapsed = !heroCollapsed;
-  persistHeroCollapsed(space.id, heroCollapsed);
-}
-```
-
-Update the SpaceHero props:
+Update the SpaceHero props (around line 908-909):
 
 ```svelte
 <!-- Old: -->
@@ -766,7 +783,7 @@ git commit -m "feat: persist space hero collapsed state per-space in localStorag
 
 ---
 
-### Task 9: Cleanup and Final Verification
+### Task 8: Cleanup and Final Verification
 
 **Files:**
 

--- a/docs/plans/2026-04-06-filter-localstorage-plan.md
+++ b/docs/plans/2026-04-06-filter-localstorage-plan.md
@@ -1,0 +1,808 @@
+# Filter & Space Hero localStorage Persistence — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Persist filter panel collapsed state (global), filter section accordion state (global), and space hero collapsed state (per-space) in localStorage so they survive page reloads.
+
+**Architecture:** Inline `localStorage.getItem`/`setItem` with `browser` guard and `try/catch`, following the existing visible-sections pattern in `filter-panel.svelte`. Space hero helpers extracted into a standalone utility for testability.
+
+**Tech Stack:** Svelte 5 (`$state`, `$effect`, `SvelteSet`), SvelteKit (`$app/environment` → `browser`), Vitest, @testing-library/svelte
+
+---
+
+### Task 1: Space Hero Storage Utility — Tests
+
+**Files:**
+
+- Create: `web/src/lib/utils/space-hero-storage.spec.ts`
+
+**Step 1: Write tests for `loadHeroCollapsed` and `persistHeroCollapsed`**
+
+```typescript
+import { loadHeroCollapsed, persistHeroCollapsed } from './space-hero-storage';
+
+const STORAGE_KEY = 'gallery-space-hero-collapsed';
+
+describe('space-hero-storage', () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  describe('loadHeroCollapsed', () => {
+    it('should return false when no localStorage entry exists', () => {
+      expect(loadHeroCollapsed('space-1')).toBe(false);
+    });
+
+    it('should return stored value for a known spaceId', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      expect(loadHeroCollapsed('space-1')).toBe(true);
+    });
+
+    it('should return false for an unknown spaceId in existing record', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      expect(loadHeroCollapsed('space-2')).toBe(false);
+    });
+
+    it('should return false when localStorage contains invalid JSON', () => {
+      localStorage.setItem(STORAGE_KEY, '{corrupted!!!');
+      expect(loadHeroCollapsed('space-1')).toBe(false);
+    });
+  });
+
+  describe('persistHeroCollapsed', () => {
+    it('should create a new record when none exists', () => {
+      persistHeroCollapsed('space-1', true);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, boolean>;
+      expect(stored['space-1']).toBe(true);
+    });
+
+    it('should update existing record without losing other entries', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      persistHeroCollapsed('space-2', true);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, boolean>;
+      expect(stored['space-1']).toBe(true);
+      expect(stored['space-2']).toBe(true);
+    });
+
+    it('should overwrite value for existing spaceId', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      persistHeroCollapsed('space-1', false);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, boolean>;
+      expect(stored['space-1']).toBe(false);
+    });
+  });
+});
+```
+
+**Step 2: Run tests — verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/utils/space-hero-storage.spec.ts`
+Expected: FAIL — module `./space-hero-storage` not found
+
+**Step 3: Commit failing test**
+
+```bash
+git add web/src/lib/utils/space-hero-storage.spec.ts
+git commit -m "test: add failing tests for space hero localStorage utility"
+```
+
+---
+
+### Task 2: Space Hero Storage Utility — Implementation
+
+**Files:**
+
+- Create: `web/src/lib/utils/space-hero-storage.ts`
+
+**Step 1: Implement the utility**
+
+```typescript
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'gallery-space-hero-collapsed';
+
+export function loadHeroCollapsed(spaceId: string): boolean {
+  if (browser) {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const record = JSON.parse(raw) as Record<string, boolean>;
+        return record[spaceId] ?? false;
+      }
+    } catch {
+      /* corrupted JSON — fall through */
+    }
+  }
+  return false;
+}
+
+export function persistHeroCollapsed(spaceId: string, collapsed: boolean): void {
+  if (browser) {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const record: Record<string, boolean> = raw ? (JSON.parse(raw) as Record<string, boolean>) : {};
+      record[spaceId] = collapsed;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }
+}
+```
+
+**Step 2: Run tests — verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/utils/space-hero-storage.spec.ts`
+Expected: PASS (7 tests)
+
+**Step 3: Commit**
+
+```bash
+git add web/src/lib/utils/space-hero-storage.ts
+git commit -m "feat: add space hero localStorage persistence utility"
+```
+
+---
+
+### Task 3: Make FilterSection Controlled
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-section.svelte` (entire file, 57 lines)
+
+**Step 1: Update FilterSection to accept `expanded` and `onToggleExpanded` props**
+
+Replace the Props interface and state in `filter-section.svelte`:
+
+```typescript
+// Old (lines 6-14):
+interface Props {
+  title: string;
+  testId: string;
+  children: Snippet;
+  refetching?: boolean;
+  count?: number;
+}
+
+let { title, testId, children, refetching = false, count }: Props = $props();
+let expanded = $state(true);
+
+// New:
+interface Props {
+  title: string;
+  testId: string;
+  children: Snippet;
+  refetching?: boolean;
+  count?: number;
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
+}
+
+let { title, testId, children, refetching = false, count, expanded = true, onToggleExpanded }: Props = $props();
+```
+
+Update the click handler (line 24-28):
+
+```svelte
+<!-- Old: -->
+onclick={() => {
+  if (!isEmpty) {
+    expanded = !expanded;
+  }
+}}
+
+<!-- New: -->
+onclick={() => {
+  if (!isEmpty && onToggleExpanded) {
+    onToggleExpanded();
+  }
+}}
+```
+
+**Important:** When `onToggleExpanded` is not provided (backwards compat during transition), the section becomes inert — it just shows whatever `expanded` is. This is fine because FilterPanel will always provide both props.
+
+**Step 2: Run existing filter-panel tests to verify no regression**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+Expected: PASS — FilterSection still defaults `expanded=true` and existing tests don't click section headers
+
+**Step 3: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-section.svelte
+git commit -m "refactor: make FilterSection accept controlled expanded prop"
+```
+
+---
+
+### Task 4: Filter Panel Collapsed Persistence — Tests
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+
+**Step 1: Replace `initialCollapsed` test block with localStorage persistence tests**
+
+Replace the `describe('initialCollapsed prop')` block (lines 120-143) with:
+
+```typescript
+describe('collapsed state persistence', () => {
+  const COLLAPSED_KEY = 'gallery-filter-collapsed';
+
+  beforeEach(() => {
+    localStorage.removeItem(COLLAPSED_KEY);
+  });
+
+  it('should start expanded when no localStorage entry exists (first visit)', () => {
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating', 'media'], providers: {} },
+        timeBuckets: [],
+      },
+    });
+    expect(screen.getByTestId('discovery-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('collapsed-icon-strip')).not.toBeInTheDocument();
+  });
+
+  it('should start collapsed when localStorage has true', () => {
+    localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating', 'media'], providers: {} },
+        timeBuckets: [],
+      },
+    });
+    expect(screen.getByTestId('collapsed-icon-strip')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-panel')).not.toBeInTheDocument();
+  });
+
+  it('should persist collapsed state to localStorage when user collapses', async () => {
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating'], providers: {} },
+        timeBuckets: [],
+      },
+    });
+    await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_KEY) ?? 'null')).toBe(true);
+  });
+
+  it('should persist expanded state to localStorage when user expands', async () => {
+    localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating'], providers: {} },
+        timeBuckets: [],
+      },
+    });
+    await fireEvent.click(screen.getByTestId('expand-panel-btn'));
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_KEY) ?? 'null')).toBe(false);
+  });
+
+  it('should not persist collapsed state when persistCollapsed is false', async () => {
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating'], providers: {} },
+        timeBuckets: [],
+        persistCollapsed: false,
+      },
+    });
+    await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+    expect(localStorage.getItem(COLLAPSED_KEY)).toBeNull();
+  });
+
+  it('should always start expanded when persistCollapsed is false regardless of localStorage', () => {
+    localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['rating'], providers: {} },
+        timeBuckets: [],
+        persistCollapsed: false,
+      },
+    });
+    expect(screen.getByTestId('discovery-panel')).toBeInTheDocument();
+  });
+});
+```
+
+Also update the `hidden` test that references `initialCollapsed` (line 218-229):
+
+```typescript
+// Old (line 218):
+it('should render nothing when hidden and initialCollapsed are both true', () => {
+  render(FilterPanel, {
+    props: {
+      config: { sections: ['rating'], providers: {} },
+      timeBuckets: [],
+      hidden: true,
+      initialCollapsed: true,
+    },
+  });
+
+// New:
+it('should render nothing when hidden and collapsed in localStorage', () => {
+  localStorage.setItem('gallery-filter-collapsed', JSON.stringify(true));
+  render(FilterPanel, {
+    props: {
+      config: { sections: ['rating'], providers: {} },
+      timeBuckets: [],
+      hidden: true,
+    },
+  });
+```
+
+**Step 2: Run tests — verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+Expected: FAIL — `initialCollapsed` prop removed but component still has it; localStorage tests fail because component doesn't read from it yet
+
+**Step 3: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+git commit -m "test: add failing tests for filter panel collapsed localStorage persistence"
+```
+
+---
+
+### Task 5: Filter Panel Collapsed Persistence — Implementation
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte` (lines 37-54)
+
+**Step 1: Update FilterPanel Props and collapsed initialization**
+
+In `filter-panel.svelte`, update the Props interface (lines 37-44):
+
+```typescript
+// Old:
+interface Props {
+  config: FilterPanelConfig;
+  timeBuckets: Array<{ timeBucket: string; count: number }>;
+  filters?: FilterState;
+  initialCollapsed?: boolean;
+  storageKey?: string;
+  hidden?: boolean;
+}
+
+// New:
+interface Props {
+  config: FilterPanelConfig;
+  timeBuckets: Array<{ timeBucket: string; count: number }>;
+  filters?: FilterState;
+  storageKey?: string;
+  hidden?: boolean;
+  persistCollapsed?: boolean;
+}
+```
+
+Update the props destructuring (lines 46-53):
+
+```typescript
+// Old:
+let {
+  config,
+  timeBuckets,
+  filters = $bindable(createFilterState()),
+  initialCollapsed = false,
+  storageKey = 'gallery-filter-visible-sections',
+  hidden = false,
+}: Props = $props();
+let collapsed = $state(initialCollapsed);
+
+// New:
+const COLLAPSED_KEY = 'gallery-filter-collapsed';
+
+let {
+  config,
+  timeBuckets,
+  filters = $bindable(createFilterState()),
+  storageKey = 'gallery-filter-visible-sections',
+  hidden = false,
+  persistCollapsed = true,
+}: Props = $props();
+
+function loadCollapsed(): boolean {
+  if (persistCollapsed && browser) {
+    try {
+      const raw = localStorage.getItem(COLLAPSED_KEY);
+      if (raw !== null) {
+        return JSON.parse(raw) as boolean;
+      }
+    } catch {
+      /* corrupted — fall through */
+    }
+  }
+  return false;
+}
+
+let collapsed = $state(loadCollapsed());
+```
+
+Add a `$effect` to persist collapsed state. Place it right after the existing `$effect` for `visibleSections` persistence (after line 360):
+
+```typescript
+$effect(() => {
+  if (persistCollapsed && browser) {
+    try {
+      localStorage.setItem(COLLAPSED_KEY, JSON.stringify(collapsed));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }
+});
+```
+
+**Step 2: Remove `initialCollapsed` from photos page**
+
+In `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`, line 188, delete:
+
+```
+      initialCollapsed={true}
+```
+
+**Step 3: Add `persistCollapsed={false}` to map mobile FilterPanel**
+
+In `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte`, the mobile FilterPanel instance (line 205):
+
+```svelte
+<!-- Old: -->
+<FilterPanel
+  bind:filters
+  config={filterConfig}
+  {timeBuckets}
+  storageKey="gallery-filter-visible-sections-map"
+/>
+
+<!-- New: -->
+<FilterPanel
+  bind:filters
+  config={filterConfig}
+  {timeBuckets}
+  storageKey="gallery-filter-visible-sections-map"
+  persistCollapsed={false}
+/>
+```
+
+**Step 4: Run tests — verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+Expected: PASS
+
+**Step 5: Run type check**
+
+Run: `cd web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
+Expected: No new errors (verifies `initialCollapsed` removal doesn't break anything)
+
+**Step 6: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.svelte \
+       web/src/routes/'(user)'/photos/'[[assetId=id]]'/+page.svelte \
+       web/src/routes/'(user)'/map/'[[photos=photos]]'/'[[assetId=id]]'/+page.svelte
+git commit -m "feat: persist filter panel collapsed state in localStorage"
+```
+
+---
+
+### Task 6: Filter Section Accordion Persistence — Tests
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+
+**Step 1: Add tests for expanded sections persistence**
+
+Add a new `describe` block at the bottom of the file:
+
+```typescript
+describe('Section Accordion Persistence', () => {
+  const EXPANDED_KEY = 'gallery-filter-expanded-sections';
+
+  beforeEach(() => {
+    localStorage.removeItem(EXPANDED_KEY);
+  });
+
+  function renderPanel(
+    sections: FilterSection[] = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'],
+  ) {
+    return render(FilterPanel, {
+      props: {
+        config: { sections: [...sections], providers: {} },
+        timeBuckets: sections.includes('timeline')
+          ? [
+              { timeBucket: '2023-06-01', count: 100 },
+              { timeBucket: '2023-08-01', count: 200 },
+            ]
+          : [],
+      },
+    });
+  }
+
+  it('should default all sections to expanded on first visit', () => {
+    renderPanel(['people', 'rating']);
+    // Section content should be visible (expanded)
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
+  });
+
+  it('should persist collapsed section to localStorage when header is clicked', async () => {
+    renderPanel(['people', 'rating']);
+    // Click the section header to collapse
+    const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
+    await fireEvent.click(peopleHeader);
+    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
+    expect(stored).not.toContain('people');
+    expect(stored).toContain('rating');
+  });
+
+  it('should restore collapsed sections from localStorage on mount', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['rating']));
+    renderPanel(['people', 'rating']);
+    // People section content should be hidden (collapsed), rating visible
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeNull();
+    expect(ratingContent).toBeTruthy();
+  });
+
+  it('should ignore unknown section types in localStorage', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people', 'nonexistent']));
+    renderPanel(['people', 'rating']);
+    // People is in the stored list so it's expanded, rating is not so it's collapsed
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    expect(peopleContent).toBeTruthy();
+  });
+
+  it('should fall back to all-expanded when localStorage has invalid JSON', () => {
+    localStorage.setItem(EXPANDED_KEY, 'not-valid-json!!!');
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeTruthy();
+    expect(ratingContent).toBeTruthy();
+  });
+
+  it('should expand a collapsed section when header is clicked again', async () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['rating']));
+    renderPanel(['people', 'rating']);
+    // People is collapsed — click to expand
+    const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
+    await fireEvent.click(peopleHeader);
+    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
+    expect(stored).toContain('people');
+    expect(stored).toContain('rating');
+  });
+});
+```
+
+You'll also need to import `FilterSection` type at the top of the test file:
+
+```typescript
+import type { FilterSection } from '../filter-panel';
+```
+
+**Step 2: Run tests — verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+Expected: FAIL — persistence tests fail because FilterPanel doesn't pass `expanded`/`onToggleExpanded` to FilterSection yet
+
+**Step 3: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+git commit -m "test: add failing tests for filter section accordion localStorage persistence"
+```
+
+---
+
+### Task 7: Filter Section Accordion Persistence — Implementation
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
+
+**Step 1: Add expandedSections state and persistence**
+
+After `let visibleSections = $state(...)` (line 336), add:
+
+```typescript
+const EXPANDED_SECTIONS_KEY = 'gallery-filter-expanded-sections';
+
+function loadExpandedSections(configSections: FilterSectionType[]): SvelteSet<FilterSectionType> {
+  if (browser) {
+    try {
+      const raw = localStorage.getItem(EXPANDED_SECTIONS_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as string[];
+        const valid = parsed.filter((s): s is FilterSectionType => configSections.includes(s as FilterSectionType));
+        if (valid.length > 0) {
+          return new SvelteSet(valid);
+        }
+      }
+    } catch {
+      /* corrupted JSON — fall through to default */
+    }
+  }
+  return new SvelteSet(configSections);
+}
+
+let expandedSections = $state(loadExpandedSections(config.sections));
+
+function toggleSectionExpanded(section: FilterSectionType) {
+  const next = new SvelteSet(expandedSections);
+  if (next.has(section)) {
+    next.delete(section);
+  } else {
+    next.add(section);
+  }
+  expandedSections = next;
+}
+```
+
+Add a `$effect` to persist (after the collapsed persistence `$effect`):
+
+```typescript
+$effect(() => {
+  if (browser) {
+    try {
+      localStorage.setItem(EXPANDED_SECTIONS_KEY, JSON.stringify([...expandedSections]));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }
+});
+```
+
+**Step 2: Pass `expanded` and `onToggleExpanded` to each FilterSection**
+
+In the template `{#each}` block (around line 559), update the `<FilterSection>` tag:
+
+```svelte
+<!-- Old: -->
+<FilterSection
+  title={sectionTitles[section]}
+  testId={section}
+  refetching={isRefetching && section !== 'timeline'}
+  count={...}
+>
+
+<!-- New: -->
+<FilterSection
+  title={sectionTitles[section]}
+  testId={section}
+  refetching={isRefetching && section !== 'timeline'}
+  count={...}
+  expanded={expandedSections.has(section)}
+  onToggleExpanded={() => toggleSectionExpanded(section)}
+>
+```
+
+**Step 3: Run tests — verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.svelte
+git commit -m "feat: persist filter section accordion state in localStorage"
+```
+
+---
+
+### Task 8: Space Hero Persistence — Integration
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Step 1: Import the utility and wire up persistence**
+
+Add import at top of script (with other imports):
+
+```typescript
+import { loadHeroCollapsed, persistHeroCollapsed } from '$lib/utils/space-hero-storage';
+```
+
+Update state declaration (line 154):
+
+```typescript
+// Old:
+let heroCollapsed = $state(false);
+
+// New:
+let heroCollapsed = $state(loadHeroCollapsed(data.space.id));
+```
+
+Update the space navigation sync effect (line 127):
+
+```typescript
+// Old:
+heroCollapsed = false;
+
+// New:
+heroCollapsed = loadHeroCollapsed(data.space.id);
+```
+
+Create a named toggle function and update the SpaceHero callback (around line 908-909):
+
+Add this function near `heroCollapsed` declaration:
+
+```typescript
+function toggleHeroCollapsed() {
+  heroCollapsed = !heroCollapsed;
+  persistHeroCollapsed(space.id, heroCollapsed);
+}
+```
+
+Update the SpaceHero props:
+
+```svelte
+<!-- Old: -->
+collapsed={heroCollapsed}
+onToggleCollapse={() => (heroCollapsed = !heroCollapsed)}
+
+<!-- New: -->
+collapsed={heroCollapsed}
+onToggleCollapse={toggleHeroCollapsed}
+```
+
+The auto-collapse `$effect` (lines 157-163) stays unchanged — it sets `heroCollapsed = true` without calling `persistHeroCollapsed`, so auto-collapse is not persisted.
+
+**Step 2: Run type check**
+
+Run: `cd web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add web/src/routes/'(user)'/spaces/'[spaceId]'/'[[photos=photos]]'/'[[assetId=id]]'/+page.svelte
+git commit -m "feat: persist space hero collapsed state per-space in localStorage"
+```
+
+---
+
+### Task 9: Cleanup and Final Verification
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.ts` (remove unused `FilterViewState`)
+
+**Step 1: Remove unused `FilterViewState` interface**
+
+In `filter-panel.ts` (lines 63-66), delete:
+
+```typescript
+// Client-only view state (not sent to server)
+export interface FilterViewState {
+  collapsed: boolean;
+}
+```
+
+This interface was never used and is now superseded by the localStorage approach.
+
+**Step 2: Run all filter-panel tests**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+Expected: PASS (all tests)
+
+**Step 3: Run full web test suite**
+
+Run: `cd web && pnpm test`
+Expected: PASS (no regressions)
+
+**Step 4: Run type check**
+
+Run: `cd web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.ts
+git commit -m "chore: remove unused FilterViewState interface"
+```

--- a/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
@@ -31,21 +31,38 @@ test.describe('Photos FilterPanel', () => {
 
   async function gotoPhotos(context: import('@playwright/test').BrowserContext, page: import('@playwright/test').Page) {
     await utils.setAuthCookies(context, admin.accessToken);
+    // Clear localStorage so each test starts from a clean state
     await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
     await page.waitForSelector('[data-testid="collapsed-icon-strip"], [data-testid="discovery-panel"]');
   }
 
-  test('should render FilterPanel collapsed by default on /photos', async ({ context, page }) => {
+  test('should render FilterPanel expanded by default on /photos', async ({ context, page }) => {
     await gotoPhotos(context, page);
 
-    await expect(page.locator('[data-testid="collapsed-icon-strip"]')).toBeVisible();
-    await expect(page.locator('[data-testid="discovery-panel"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="discovery-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="collapsed-icon-strip"]')).not.toBeVisible();
   });
 
-  test('should expand FilterPanel and show all 7 sections', async ({ context, page }) => {
+  test('should collapse FilterPanel and persist state', async ({ context, page }) => {
     await gotoPhotos(context, page);
 
-    await page.locator('[data-testid="expand-panel-btn"]').click();
+    // Panel starts expanded — collapse it
+    await page.locator('[data-testid="collapse-panel-btn"]').click();
+    await expect(page.locator('[data-testid="collapsed-icon-strip"]')).toBeVisible();
+    await expect(page.locator('[data-testid="discovery-panel"]')).not.toBeVisible();
+
+    // Reload — should still be collapsed (persisted in localStorage)
+    await page.reload();
+    await page.waitForSelector('[data-testid="collapsed-icon-strip"]');
+    await expect(page.locator('[data-testid="collapsed-icon-strip"]')).toBeVisible();
+  });
+
+  test('should show all 7 filter sections when expanded', async ({ context, page }) => {
+    await gotoPhotos(context, page);
+
+    // Panel starts expanded — all sections should be visible
     await expect(page.locator('[data-testid="discovery-panel"]')).toBeVisible();
 
     for (const section of ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media']) {
@@ -56,10 +73,7 @@ test.describe('Photos FilterPanel', () => {
   test('should filter by media type and show result count', async ({ context, page }) => {
     await gotoPhotos(context, page);
 
-    // Expand panel
-    await page.locator('[data-testid="expand-panel-btn"]').click();
-
-    // Apply image filter and wait for timeline to refetch
+    // Panel starts expanded — apply image filter and wait for timeline to refetch
     const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
     await page.locator('[data-testid="media-type-image"]').click();
     await bucketResponse;
@@ -74,8 +88,7 @@ test.describe('Photos FilterPanel', () => {
   test('should show ActiveFiltersBar and clear all filters', async ({ context, page }) => {
     await gotoPhotos(context, page);
 
-    // Expand, wait for filter suggestions to load, then set rating filter
-    await page.locator('[data-testid="expand-panel-btn"]').click();
+    // Panel starts expanded — wait for filter suggestions to load, then set rating filter
     await page.locator('[data-testid="rating-star-5"]').waitFor({ state: 'visible', timeout: 10_000 });
     const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
     await page.locator('[data-testid="rating-star-5"]').click();

--- a/e2e/src/ui/specs/timeline/utils.ts
+++ b/e2e/src/ui/specs/timeline/utils.ts
@@ -184,10 +184,16 @@ export const assetViewerUtils = {
 };
 export const pageUtils = {
   async deepLinkPhotosPage(page: Page, assetId: string) {
+    // Collapse the filter panel so the timeline grid has full width.
+    // These layout-sensitive tests were calibrated with the panel collapsed.
+    await page.addInitScript(() => localStorage.setItem('gallery-filter-collapsed', 'true'));
     await page.goto(`/photos?at=${assetId}`);
     await timelineUtils.waitForTimelineLoad(page);
   },
   async openPhotosPage(page: Page) {
+    // Collapse the filter panel so the timeline grid has full width.
+    // These layout-sensitive tests were calibrated with the panel collapsed.
+    await page.addInitScript(() => localStorage.setItem('gallery-filter-collapsed', 'true'));
     await page.goto(`/photos`);
     await timelineUtils.waitForTimelineLoad(page);
   },

--- a/web/src/lib/components/filter-panel/__tests__/cascade-fix.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/cascade-fix.spec.ts
@@ -2,6 +2,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import FilterPanel from '../filter-panel.svelte';
 
 describe('Cascade callbacks pass parent value', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('should call cities provider with the selected country', async () => {
     const citiesFn = vi.fn().mockResolvedValue(['Berlin', 'Munich']);
 

--- a/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
@@ -36,7 +36,7 @@ const timeBuckets = [
 describe('Contextual re-fetch on temporal change', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    localStorage.removeItem('gallery-filter-visible-sections');
+    localStorage.clear();
   });
 
   afterEach(() => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { FilterSection } from '../filter-panel';
 import { createFilterState } from '../filter-panel';
 import FilterPanel from '../filter-panel.svelte';
 
@@ -604,5 +605,90 @@ describe('Section Selector', () => {
     expect(screen.getByTestId('filter-section-timeline')).toBeTruthy();
     await fireEvent.click(screen.getByTestId('year-btn-2023'));
     expect(screen.getByTestId('filter-section-timeline')).toBeTruthy();
+  });
+});
+
+describe('Section Accordion Persistence', () => {
+  const EXPANDED_KEY = 'gallery-filter-expanded-sections';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function renderPanel(
+    sections: FilterSection[] = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'],
+  ) {
+    return render(FilterPanel, {
+      props: {
+        config: { sections: [...sections], providers: {} },
+        timeBuckets: sections.includes('timeline')
+          ? [
+              { timeBucket: '2023-06-01', count: 100 },
+              { timeBucket: '2023-08-01', count: 200 },
+            ]
+          : [],
+      },
+    });
+  }
+
+  it('should default all sections to expanded on first visit', () => {
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeTruthy();
+    expect(ratingContent).toBeTruthy();
+  });
+
+  it('should persist collapsed section to localStorage when header is clicked', async () => {
+    renderPanel(['people', 'rating']);
+    const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
+    await fireEvent.click(peopleHeader);
+    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
+    expect(stored).not.toContain('people');
+    expect(stored).toContain('rating');
+  });
+
+  it('should restore collapsed sections from localStorage on mount', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['rating']));
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeNull();
+    expect(ratingContent).toBeTruthy();
+  });
+
+  it('should keep all sections collapsed when localStorage has empty array', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify([]));
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeNull();
+    expect(ratingContent).toBeNull();
+  });
+
+  it('should ignore unknown section types in localStorage', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people', 'nonexistent']));
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    expect(peopleContent).toBeTruthy();
+  });
+
+  it('should fall back to all-expanded when localStorage has invalid JSON', () => {
+    localStorage.setItem(EXPANDED_KEY, 'not-valid-json!!!');
+    renderPanel(['people', 'rating']);
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    expect(peopleContent).toBeTruthy();
+    expect(ratingContent).toBeTruthy();
+  });
+
+  it('should expand a collapsed section when header is clicked again', async () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['rating']));
+    renderPanel(['people', 'rating']);
+    const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
+    await fireEvent.click(peopleHeader);
+    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
+    expect(stored).toContain('people');
+    expect(stored).toContain('rating');
   });
 });

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -4,6 +4,10 @@ import { createFilterState } from '../filter-panel';
 import FilterPanel from '../filter-panel.svelte';
 
 describe('FilterPanel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('should render configured sections only', () => {
     const { queryByTestId } = render(FilterPanel, {
       props: {
@@ -117,20 +121,14 @@ describe('FilterPanel', () => {
     expect(queryByTestId('filter-section-rating')).toBeTruthy();
   });
 
-  describe('initialCollapsed prop', () => {
-    it('should start collapsed when initialCollapsed is true', () => {
-      render(FilterPanel, {
-        props: {
-          config: { sections: ['rating', 'media'], providers: {} },
-          timeBuckets: [],
-          initialCollapsed: true,
-        },
-      });
-      expect(screen.getByTestId('collapsed-icon-strip')).toBeInTheDocument();
-      expect(screen.queryByTestId('discovery-panel')).not.toBeInTheDocument();
+  describe('collapsed state persistence', () => {
+    const COLLAPSED_KEY = 'gallery-filter-collapsed';
+
+    beforeEach(() => {
+      localStorage.clear();
     });
 
-    it('should start expanded by default (no prop)', () => {
+    it('should start expanded when no localStorage entry exists (first visit)', () => {
       render(FilterPanel, {
         props: {
           config: { sections: ['rating', 'media'], providers: {} },
@@ -139,6 +137,80 @@ describe('FilterPanel', () => {
       });
       expect(screen.getByTestId('discovery-panel')).toBeInTheDocument();
       expect(screen.queryByTestId('collapsed-icon-strip')).not.toBeInTheDocument();
+    });
+
+    it('should start collapsed when localStorage has true', () => {
+      localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+      render(FilterPanel, {
+        props: {
+          config: { sections: ['rating', 'media'], providers: {} },
+          timeBuckets: [],
+        },
+      });
+      expect(screen.getByTestId('collapsed-icon-strip')).toBeInTheDocument();
+      expect(screen.queryByTestId('discovery-panel')).not.toBeInTheDocument();
+    });
+
+    it('should persist collapsed state to localStorage when user collapses', async () => {
+      render(FilterPanel, {
+        props: {
+          config: { sections: ['rating'], providers: {} },
+          timeBuckets: [],
+        },
+      });
+      await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+      expect(JSON.parse(localStorage.getItem(COLLAPSED_KEY) ?? 'null')).toBe(true);
+    });
+
+    it('should persist expanded state to localStorage when user expands', async () => {
+      localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+      render(FilterPanel, {
+        props: {
+          config: { sections: ['rating'], providers: {} },
+          timeBuckets: [],
+        },
+      });
+      await fireEvent.click(screen.getByTestId('expand-panel-btn'));
+      expect(JSON.parse(localStorage.getItem(COLLAPSED_KEY) ?? 'null')).toBe(false);
+    });
+
+    it('should not persist collapsed state when persistCollapsed is false', async () => {
+      render(FilterPanel, {
+        props: {
+          config: { sections: ['rating'], providers: {} },
+          timeBuckets: [],
+          persistCollapsed: false,
+        },
+      });
+      await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+      expect(localStorage.getItem(COLLAPSED_KEY)).toBeNull();
+    });
+
+    it('should always start expanded when persistCollapsed is false regardless of localStorage', () => {
+      localStorage.setItem(COLLAPSED_KEY, JSON.stringify(true));
+      render(FilterPanel, {
+        props: {
+          config: { sections: ['rating'], providers: {} },
+          timeBuckets: [],
+          persistCollapsed: false,
+        },
+      });
+      expect(screen.getByTestId('discovery-panel')).toBeInTheDocument();
+    });
+
+    it('should still allow in-session collapse when persistCollapsed is false', async () => {
+      render(FilterPanel, {
+        props: {
+          config: { sections: ['rating'], providers: {} },
+          timeBuckets: [],
+          persistCollapsed: false,
+        },
+      });
+      await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+      expect(screen.getByTestId('collapsed-icon-strip')).toBeInTheDocument();
+      expect(screen.queryByTestId('discovery-panel')).not.toBeInTheDocument();
+      // But nothing written to localStorage
+      expect(localStorage.getItem(COLLAPSED_KEY)).toBeNull();
     });
   });
 
@@ -182,6 +254,10 @@ describe('FilterPanel', () => {
 });
 
 describe('hidden prop', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('should render nothing when hidden is true', () => {
     render(FilterPanel, {
       props: {
@@ -215,13 +291,13 @@ describe('hidden prop', () => {
     expect(screen.getByTestId('discovery-panel')).toBeInTheDocument();
   });
 
-  it('should render nothing when hidden and initialCollapsed are both true', () => {
+  it('should render nothing when hidden and collapsed in localStorage', () => {
+    localStorage.setItem('gallery-filter-collapsed', JSON.stringify(true));
     render(FilterPanel, {
       props: {
         config: { sections: ['rating'], providers: {} },
         timeBuckets: [],
         hidden: true,
-        initialCollapsed: true,
       },
     });
     expect(screen.queryByTestId('discovery-panel')).not.toBeInTheDocument();
@@ -252,7 +328,7 @@ describe('Section Selector', () => {
   }
 
   beforeEach(() => {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.clear();
   });
 
   // --- Rendering ---

--- a/web/src/lib/components/filter-panel/__tests__/orphaned-selections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/orphaned-selections.spec.ts
@@ -6,7 +6,7 @@ import FilterPanel from '../filter-panel.svelte';
 describe('Orphaned selections', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    localStorage.removeItem('gallery-filter-visible-sections');
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -144,7 +144,7 @@ describe('Orphaned selections', () => {
 describe('Empty section collapse', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    localStorage.removeItem('gallery-filter-visible-sections');
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -256,7 +256,7 @@ describe('Empty section collapse', () => {
 describe('Cascade child auto-clear', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    localStorage.removeItem('gallery-filter-visible-sections');
+    localStorage.clear();
   });
 
   afterEach(() => {

--- a/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
@@ -34,7 +34,7 @@ function createUnifiedConfig(overrides: Partial<FilterPanelConfig> = {}): Filter
 describe('Unified suggestionsProvider', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    localStorage.removeItem('gallery-filter-visible-sections');
+    localStorage.clear();
   });
 
   afterEach(() => {

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -38,20 +38,37 @@
     config: FilterPanelConfig;
     timeBuckets: Array<{ timeBucket: string; count: number }>;
     filters?: FilterState;
-    initialCollapsed?: boolean;
+    persistCollapsed?: boolean;
     storageKey?: string;
     hidden?: boolean;
   }
+
+  const COLLAPSED_KEY = 'gallery-filter-collapsed';
 
   let {
     config,
     timeBuckets,
     filters = $bindable(createFilterState()),
-    initialCollapsed = false,
     storageKey = 'gallery-filter-visible-sections',
     hidden = false,
+    persistCollapsed = true,
   }: Props = $props();
-  let collapsed = $state(initialCollapsed);
+
+  function loadCollapsed(): boolean {
+    if (persistCollapsed && browser) {
+      try {
+        const raw = localStorage.getItem(COLLAPSED_KEY);
+        if (raw !== null) {
+          return JSON.parse(raw) as boolean;
+        }
+      } catch {
+        /* corrupted — fall through */
+      }
+    }
+    return false;
+  }
+
+  let collapsed = $state(loadCollapsed());
 
   const providers = config.providers ?? {};
 
@@ -353,6 +370,16 @@
     if (browser) {
       try {
         localStorage.setItem(storageKey, JSON.stringify([...visibleSections]));
+      } catch {
+        /* localStorage unavailable */
+      }
+    }
+  });
+
+  $effect(() => {
+    if (persistCollapsed && browser) {
+      try {
+        localStorage.setItem(COLLAPSED_KEY, JSON.stringify(collapsed));
       } catch {
         /* localStorage unavailable */
       }

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -352,6 +352,39 @@
 
   let visibleSections = $state(loadVisibleSections(config.sections, storageKey));
 
+  const EXPANDED_SECTIONS_KEY = 'gallery-filter-expanded-sections';
+
+  function loadExpandedSections(configSections: FilterSectionType[]): SvelteSet<FilterSectionType> {
+    if (browser) {
+      try {
+        const raw = localStorage.getItem(EXPANDED_SECTIONS_KEY);
+        if (raw !== null) {
+          const parsed = JSON.parse(raw) as string[];
+          const valid = parsed.filter((s): s is FilterSectionType => configSections.includes(s as FilterSectionType));
+          // Return the validated set even if empty — an empty array means the user
+          // explicitly collapsed all sections. Only fall through to default when
+          // there's no localStorage entry at all (raw === null).
+          return new SvelteSet(valid);
+        }
+      } catch {
+        /* corrupted JSON — fall through to default */
+      }
+    }
+    return new SvelteSet(configSections);
+  }
+
+  let expandedSections = $state(loadExpandedSections(config.sections));
+
+  function toggleSectionExpanded(section: FilterSectionType) {
+    const next = new SvelteSet(expandedSections);
+    if (next.has(section)) {
+      next.delete(section);
+    } else {
+      next.add(section);
+    }
+    expandedSections = next;
+  }
+
   function toggleSection(section: FilterSectionType) {
     const next = new SvelteSet(visibleSections);
     if (next.has(section)) {
@@ -380,6 +413,16 @@
     if (persistCollapsed && browser) {
       try {
         localStorage.setItem(COLLAPSED_KEY, JSON.stringify(collapsed));
+      } catch {
+        /* localStorage unavailable */
+      }
+    }
+  });
+
+  $effect(() => {
+    if (browser) {
+      try {
+        localStorage.setItem(EXPANDED_SECTIONS_KEY, JSON.stringify([...expandedSections]));
       } catch {
         /* localStorage unavailable */
       }
@@ -587,6 +630,8 @@
             title={sectionTitles[section]}
             testId={section}
             refetching={isRefetching && section !== 'timeline'}
+            expanded={expandedSections.has(section)}
+            onToggleExpanded={() => toggleSectionExpanded(section)}
             count={filterContext
               ? section === 'people'
                 ? people.length

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -60,11 +60,6 @@ export interface FilterState {
   selectedMonth?: number;
 }
 
-// Client-only view state (not sent to server)
-export interface FilterViewState {
-  collapsed: boolean;
-}
-
 export function createFilterState(): FilterState {
   return {
     personIds: [],

--- a/web/src/lib/components/filter-panel/filter-section.svelte
+++ b/web/src/lib/components/filter-panel/filter-section.svelte
@@ -9,10 +9,11 @@
     children: Snippet;
     refetching?: boolean;
     count?: number;
+    expanded?: boolean;
+    onToggleExpanded?: () => void;
   }
 
-  let { title, testId, children, refetching = false, count }: Props = $props();
-  let expanded = $state(true);
+  let { title, testId, children, refetching = false, count, expanded = true, onToggleExpanded }: Props = $props();
 
   let isEmpty = $derived(count === 0);
 </script>
@@ -22,8 +23,8 @@
     type="button"
     class="flex w-full items-center justify-between px-4 py-3 hover:bg-subtle {isEmpty ? 'opacity-50' : ''}"
     onclick={() => {
-      if (!isEmpty) {
-        expanded = !expanded;
+      if (!isEmpty && onToggleExpanded) {
+        onToggleExpanded();
       }
     }}
     disabled={isEmpty}

--- a/web/src/lib/utils/space-hero-storage.spec.ts
+++ b/web/src/lib/utils/space-hero-storage.spec.ts
@@ -1,0 +1,58 @@
+import { loadHeroCollapsed, persistHeroCollapsed } from './space-hero-storage';
+
+const STORAGE_KEY = 'gallery-space-hero-collapsed';
+
+describe('space-hero-storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('loadHeroCollapsed', () => {
+    it('should return false when no localStorage entry exists', () => {
+      expect(loadHeroCollapsed('space-1')).toBe(false);
+    });
+
+    it('should return stored value for a known spaceId', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      expect(loadHeroCollapsed('space-1')).toBe(true);
+    });
+
+    it('should return false for an unknown spaceId in existing record', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      expect(loadHeroCollapsed('space-2')).toBe(false);
+    });
+
+    it('should return false when localStorage contains invalid JSON', () => {
+      localStorage.setItem(STORAGE_KEY, '{corrupted!!!');
+      expect(loadHeroCollapsed('space-1')).toBe(false);
+    });
+
+    it('should return false when localStorage value is non-object', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify('not-an-object'));
+      expect(loadHeroCollapsed('space-1')).toBe(false);
+    });
+  });
+
+  describe('persistHeroCollapsed', () => {
+    it('should create a new record when none exists', () => {
+      persistHeroCollapsed('space-1', true);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, boolean>;
+      expect(stored['space-1']).toBe(true);
+    });
+
+    it('should update existing record without losing other entries', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      persistHeroCollapsed('space-2', true);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, boolean>;
+      expect(stored['space-1']).toBe(true);
+      expect(stored['space-2']).toBe(true);
+    });
+
+    it('should overwrite value for existing spaceId', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ 'space-1': true }));
+      persistHeroCollapsed('space-1', false);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, boolean>;
+      expect(stored['space-1']).toBe(false);
+    });
+  });
+});

--- a/web/src/lib/utils/space-hero-storage.ts
+++ b/web/src/lib/utils/space-hero-storage.ts
@@ -1,0 +1,31 @@
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'gallery-space-hero-collapsed';
+
+export function loadHeroCollapsed(spaceId: string): boolean {
+  if (browser) {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const record = JSON.parse(raw) as Record<string, boolean>;
+        return record[spaceId] ?? false;
+      }
+    } catch {
+      /* corrupted JSON — fall through */
+    }
+  }
+  return false;
+}
+
+export function persistHeroCollapsed(spaceId: string, collapsed: boolean): void {
+  if (browser) {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const record: Record<string, boolean> = raw ? (JSON.parse(raw) as Record<string, boolean>) : {};
+      record[spaceId] = collapsed;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+    } catch {
+      /* localStorage unavailable */
+    }
+  }
+}

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -207,6 +207,7 @@
               config={filterConfig}
               {timeBuckets}
               storageKey="gallery-filter-visible-sections-map"
+              persistCollapsed={false}
             />
           </div>
         </div>

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -185,7 +185,6 @@
         timeBucket: `${m.yearMonth.year}-${String(m.yearMonth.month).padStart(2, '0')}-01T00:00:00.000Z`,
         count: m.assetsCount,
       })) ?? []}
-      initialCollapsed={true}
       storageKey="gallery-filter-visible-sections-photos"
       hidden={isTimelineEmpty}
     />

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -47,6 +47,7 @@
   import { preferences, user } from '$lib/stores/user.store';
   import { createUrl } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
+  import { loadHeroCollapsed, persistHeroCollapsed } from '$lib/utils/space-hero-storage';
   import { buildSmartSearchParams, SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
   import {
     addAssets,
@@ -124,7 +125,7 @@
       showSearchResults = false;
       searchPage = 1;
       hasMoreResults = false;
-      heroCollapsed = false;
+      heroCollapsed = loadHeroCollapsed(data.space.id);
       panelOpen = false;
       viewMode = 'view';
       repositioning = false;
@@ -151,7 +152,13 @@
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
 
-  let heroCollapsed = $state(false);
+  let heroCollapsed = $state(loadHeroCollapsed(data.space.id));
+
+  function toggleHeroCollapsed() {
+    heroCollapsed = !heroCollapsed;
+    persistHeroCollapsed(space.id, heroCollapsed);
+  }
+
   let prevFilterCount = 0;
 
   $effect(() => {
@@ -906,7 +913,7 @@
                   spaceId={space.id}
                   onShowMembers={handleShowMembers}
                   collapsed={heroCollapsed}
-                  onToggleCollapse={() => (heroCollapsed = !heroCollapsed)}
+                  onToggleCollapse={toggleHeroCollapsed}
                 />
 
                 {#if space.faceRecognitionEnabled && spacePeople.length > 0}


### PR DESCRIPTION
## Summary
- Persist filter panel collapsed/expanded state globally in localStorage — default expanded so users discover the feature, remembered once they collapse
- Persist individual filter section accordion state globally — each section's expand/collapse survives page reloads (empty array = all collapsed is respected)
- Persist space hero collapsed state per-space — only manual chevron toggles are stored, auto-collapse from filter activation is transient
- Mobile map overlay uses `persistCollapsed={false}` to always render expanded

## Test plan
- [x] 8 unit tests for `loadHeroCollapsed` / `persistHeroCollapsed` utility
- [x] 7 unit tests for filter panel collapsed persistence (first visit, localStorage read/write, `persistCollapsed={false}`)
- [x] 7 unit tests for section accordion persistence (default expanded, empty array, invalid JSON, toggle roundtrip)
- [x] Updated existing `initialCollapsed` and `hidden` tests
- [x] All 65 tests pass, type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)