### PR TITLE
docs: add classification to config file reference

### DIFF
--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -24,6 +24,10 @@ The default configuration looks like this:
       "keepLastAmount": 14
     }
   },
+  "classification": {
+    "enabled": true,
+    "categories": []
+  },
   "ffmpeg": {
     "accel": "disabled",
     "accelDecode": false,
@@ -69,6 +73,9 @@ The default configuration looks like this:
   "job": {
     "backgroundTask": {
       "concurrency": 5
+    },
+    "classification": {
+      "concurrency": 1
     },
     "faceDetection": {
       "concurrency": 2
@@ -247,6 +254,10 @@ In Administration > Settings is a button to copy the current configuration to yo
 So you can just grab it from there, paste it into a file and you're pretty much good to go.
 :::
 
+:::info Classification
+The `classification` section configures [Auto-Classification](/features/auto-classification) — automatic tagging and archiving of photos based on visual content. Categories are empty by default; see the [Auto-Classification docs](/features/auto-classification#option-2-config-file-yaml) for YAML examples and category field reference.
+:::
+
 ### Step 2 - Specify the file location
 
 In your `.env` file, set the variable `IMMICH_CONFIG_FILE` to the path of your config.
@@ -263,4 +274,4 @@ volumes:
   - ./configuration.yml:${IMMICH_CONFIG_FILE}
 ```
 
-::
+:::

--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -255,7 +255,31 @@ So you can just grab it from there, paste it into a file and you're pretty much 
 :::
 
 :::info Classification
-The `classification` section configures [Auto-Classification](/features/auto-classification) — automatic tagging and archiving of photos based on visual content. Categories are empty by default; see the [Auto-Classification docs](/features/auto-classification#option-2-config-file-yaml) for YAML examples and category field reference.
+The `classification` section configures [Auto-Classification](/features/auto-classification) — automatic tagging and archiving of photos based on visual content. Categories are empty by default. Here's an example with two categories:
+
+```json
+"classification": {
+  "enabled": true,
+  "categories": [
+    {
+      "name": "Nature",
+      "prompts": ["a landscape photo of mountains", "a photo of a forest", "a sunset over water"],
+      "similarity": 0.28,
+      "action": "tag",
+      "enabled": true
+    },
+    {
+      "name": "Screenshots",
+      "prompts": ["a screenshot of a phone screen", "a screenshot of a website"],
+      "similarity": 0.25,
+      "action": "tag_and_archive",
+      "enabled": true
+    }
+  ]
+}
+```
+
+The first category tags matching photos as `Auto/Nature`. The second tags and archives screenshots so they don't clutter your timeline. See the [Auto-Classification docs](/features/auto-classification) for the full field reference and prompt writing tips.
 :::
 
 ### Step 2 - Specify the file location


### PR DESCRIPTION
## Summary

- Added the `classification` section and `job.classification` concurrency to the default config JSON on the [Config File](https://docs.opennoodle.de/install/config-file) page
- Added an info callout linking to the [Auto-Classification docs](https://docs.opennoodle.de/features/auto-classification) for YAML examples and field reference
- Fixed a pre-existing broken `:::` admonition closing tag on the Docker Compose info block

Closes #219 (config file documentation aspect)

## Test plan

- [ ] Docs build passes in CI
- [ ] Config JSON is valid and matches server defaults in `server/src/config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)