### PR TITLE
fix: queue dedup after individual space face matches

### DIFF
--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -236,6 +236,9 @@ export class JobRepository {
       case JobName.SharedSpaceBulkAddAssets: {
         return { jobId: `bulk-add-${item.data.spaceId}-${item.data.userId}` };
       }
+      case JobName.SharedSpacePersonDedup: {
+        return { jobId: `space-dedup-${item.data.spaceId}` };
+      }
       default: {
         return null;
       }

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2409,6 +2409,23 @@ describe(SharedSpaceService.name, () => {
 
       expect(mocks.sharedSpace.createPerson).toHaveBeenCalledWith(expect.objectContaining({ type: 'person' }));
     });
+
+    it('should queue dedup pass after successful face match', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([]);
+
+      await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
+    });
   });
 
   describe('handleSharedSpaceFaceMatchAll', () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -816,6 +816,13 @@ export class SharedSpaceService extends BaseService {
     }
 
     await this.processSpaceFaceMatch(spaceId, assetId);
+
+    // Queue dedup pass (jobId deduplication prevents queue spam)
+    await this.jobRepository.queue({
+      name: JobName.SharedSpacePersonDedup,
+      data: { spaceId },
+    });
+
     return JobStatus.Success;
   }
 


### PR DESCRIPTION
## Summary

Fixes #289 — duplicate persons appearing in the People filter panel and space people page.

**Root cause:** `handleSharedSpaceFaceMatch` (triggered for each individual asset during face recognition) was not queuing a dedup pass. Only bulk operations (library sync, match-all, manual trigger) did. When library rescans or uploads process photos one-by-one, face matches that create new space persons (because the embedding is slightly beyond `maxDistance`) result in duplicates that persist indefinitely.

**Fix:**
- Queue `SharedSpacePersonDedup` after each successful `handleSharedSpaceFaceMatch`
- Add `jobId`-based deduplication (`space-dedup-{spaceId}`) in the job repository to prevent queue spam — BullMQ silently drops duplicate jobs with the same ID

**Verified:** Manually triggered dedup on the reporter's instance — all named duplicates (Pierre 3x, Aurelia 3x, Gudrin 2x) were successfully merged.

## Test plan
- [x] Unit test added: verifies dedup is queued after successful face match
- [x] All 3750 server unit tests pass
- [x] TypeScript type check passes