### PR TITLE
fix: queue dedup after manual space person merge

### DIFF
--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3674,6 +3674,27 @@ describe(SharedSpaceService.name, () => {
       });
     });
 
+    it('should queue dedup pass after successful merge', async () => {
+      const spaceId = newUuid();
+      const targetId = newUuid();
+      const sourceId = newUuid();
+      const target = factory.sharedSpacePerson({ id: targetId, spaceId });
+      const source = factory.sharedSpacePerson({ id: sourceId, spaceId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Editor }));
+      mocks.sharedSpace.getPersonById.mockResolvedValueOnce(target).mockResolvedValueOnce(source);
+      mocks.sharedSpace.reassignPersonFaces.mockResolvedValue(void 0);
+      mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.mergeSpacePeople(factory.auth(), spaceId, targetId, { ids: [sourceId] });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
+    });
+
     it('should reject merging across different types', async () => {
       const spaceId = newUuid();
       const targetId = newUuid();

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -763,6 +763,12 @@ export class SharedSpaceService extends BaseService {
 
     await this.sharedSpaceRepository.recountPersons([targetPersonId]);
 
+    // Queue dedup pass — merged person's embedding profile may now match other persons
+    await this.jobRepository.queue({
+      name: JobName.SharedSpacePersonDedup,
+      data: { spaceId },
+    });
+
     await this.sharedSpaceRepository.logActivity({
       spaceId,
       userId: auth.user.id,


### PR DESCRIPTION
## Summary

Follow-up to #291 — adds dedup trigger to the remaining ungapped code path identified during audit.

`mergeSpacePeople` (manual merge via UI) was not queuing a dedup pass. After merging, the target person's embedding profile changes, which could now be close enough to other persons to warrant automatic merging.

Same `jobId`-based deduplication (`space-dedup-{spaceId}`) prevents queue spam.

## Test plan
- [x] Unit test added: verifies dedup is queued after successful merge
- [x] All 3751 server unit tests pass