### PR TITLE
feat: add search field to Location filter

### DIFF
--- a/docs/plans/2026-04-06-location-filter-search-design.md
+++ b/docs/plans/2026-04-06-location-filter-search-design.md
@@ -1,0 +1,113 @@
+# Location Filter Search
+
+## Summary
+
+Add a "Search locations..." input to the Location filter, identical in behavior to the existing People and Tags search fields. Filters countries client-side with case-insensitive substring matching, truncates at 10 items with a "Show more" button.
+
+## Motivation
+
+In a large photo archive spanning many countries, finding a specific location by scrolling through the full country list is impractical. People and Tags filters already have search fields — Location should follow the same pattern.
+
+## Scope
+
+- **Single file change:** `web/src/lib/components/filter-panel/location-filter.svelte`
+- **Test additions:** `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+- **No server changes.** Countries are already fully loaded client-side via the filter suggestions endpoint.
+- **Out of scope:** Camera filter has the same gap but is a separate concern.
+
+## Design
+
+### Search Scope
+
+Countries only. Cities remain lazy-loaded when a country is expanded. This avoids prefetching all cities and keeps the existing hierarchical interaction model intact.
+
+### Behavior
+
+| Scenario                          | Behavior                                                                                  |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| User types in search              | Countries filtered by case-insensitive substring match, all matches shown (no truncation) |
+| Search cleared                    | Returns to truncated view (first 10 countries)                                            |
+| No search matches                 | Shows "No matching locations" message                                                     |
+| No countries at all               | Shows existing "No locations found" message (unchanged)                                   |
+| Orphaned country                  | Always visible above the list regardless of search query                                  |
+| Selected country hidden by search | Selection preserved; reappears with expanded state when search is cleared                 |
+| Countries list changes (refetch)  | Search query auto-clears, `showAll` resets                                                |
+| Section collapsed and re-expanded | Search state cleared (component is destroyed/recreated by FilterSection)                  |
+
+### Truncation
+
+- Default: first 10 countries shown, "Show N more" button reveals the rest
+- Matches Tags filter (`INITIAL_SHOW_COUNT = 10`)
+- While searching: all matching results shown, no truncation
+
+### Implementation
+
+Follows the exact pattern from `tags-filter.svelte`:
+
+**New imports:**
+
+- `Icon` from `@immich/ui`
+- `mdiMagnify` from `@mdi/js`
+
+**New state:**
+
+```typescript
+let searchQuery = $state('');
+let showAll = $state(false);
+const INITIAL_SHOW_COUNT = 10;
+```
+
+**Reset on refetch** (same pattern as Tags):
+
+```typescript
+let previousCountriesLength = 0;
+$effect(() => {
+  const currentLength = countries.length;
+  if (previousCountriesLength > 0 && currentLength !== previousCountriesLength) {
+    searchQuery = '';
+    showAll = false;
+  }
+  previousCountriesLength = currentLength;
+});
+```
+
+**Derived filtering and truncation:**
+
+```typescript
+let filteredCountries = $derived(
+  searchQuery.trim() ? countries.filter((c) => c.toLowerCase().includes(searchQuery.trim().toLowerCase())) : countries,
+);
+
+let visibleCountries = $derived(
+  searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, INITIAL_SHOW_COUNT),
+);
+
+let remainingCount = $derived(Math.max(0, filteredCountries.length - INITIAL_SHOW_COUNT));
+```
+
+**Template changes:**
+
+1. Search input with magnifying glass icon before the country list
+2. Replace `{#each countries as country}` with `{#each visibleCountries as country}`
+3. "No matching locations" message when `filteredCountries` is empty during search
+4. "Show N more" button after the country loop
+
+## Tests
+
+Eight new tests added to the existing `describe('LocationFilter')` block in `filter-sections.spec.ts`:
+
+1. Search filters country list
+2. Case-insensitive matching
+3. No truncation when searching (all matches shown)
+4. "Show N more" appears when more than 10 countries
+5. "Show N more" expands the full list
+6. "No matching locations" shown for empty search results
+7. Orphaned country remains visible during search
+8. Selected country preserved across search/clear cycle
+
+## Files Changed
+
+| File                                                                    | Change                                  |
+| ----------------------------------------------------------------------- | --------------------------------------- |
+| `web/src/lib/components/filter-panel/location-filter.svelte`            | Add search input, filtering, truncation |
+| `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts` | 8 new tests                             |

--- a/docs/plans/2026-04-06-location-filter-search-design.md
+++ b/docs/plans/2026-04-06-location-filter-search-design.md
@@ -21,18 +21,22 @@ In a large photo archive spanning many countries, finding a specific location by
 
 Countries only. Cities remain lazy-loaded when a country is expanded. This avoids prefetching all cities and keeps the existing hierarchical interaction model intact.
 
+City sub-lists are unaffected by the search query — they render based on `expandedCountry` state, not the search input. Searching "Germany" and clicking it will show all German cities (Berlin, Munich, etc.) even though they don't match the search text. If a country is expanded and the user types a search that hides it, the cities disappear with the country row. When the search is cleared, the country reappears with its cities still loaded (the `cities` array persists since `expandedCountry` hasn't changed).
+
 ### Behavior
 
-| Scenario                          | Behavior                                                                                  |
-| --------------------------------- | ----------------------------------------------------------------------------------------- |
-| User types in search              | Countries filtered by case-insensitive substring match, all matches shown (no truncation) |
-| Search cleared                    | Returns to truncated view (first 10 countries)                                            |
-| No search matches                 | Shows "No matching locations" message                                                     |
-| No countries at all               | Shows existing "No locations found" message (unchanged)                                   |
-| Orphaned country                  | Always visible above the list regardless of search query                                  |
-| Selected country hidden by search | Selection preserved; reappears with expanded state when search is cleared                 |
-| Countries list changes (refetch)  | Search query auto-clears, `showAll` resets                                                |
-| Section collapsed and re-expanded | Search state cleared (component is destroyed/recreated by FilterSection)                  |
+| Scenario                                | Behavior                                                                                  |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- |
+| User types in search                    | Countries filtered by case-insensitive substring match, all matches shown (no truncation) |
+| Search cleared                          | Returns to truncated view (first 10 countries)                                            |
+| No search matches                       | Shows "No matching locations" message                                                     |
+| No countries at all                     | Shows existing "No locations found" message (unchanged)                                   |
+| Orphaned country                        | Always visible above the list regardless of search query                                  |
+| Selected country hidden by search       | Selection preserved; reappears with cities still loaded when search is cleared            |
+| Search for country, click, expand       | Cities appear normally — search only filters country rows, not city sub-lists             |
+| Country expanded, then hidden by search | Cities disappear with country row; reappear with cities when search is cleared            |
+| Countries list changes (refetch)        | Search query auto-clears, `showAll` resets                                                |
+| Section collapsed and re-expanded       | Search state cleared (component is destroyed/recreated by FilterSection)                  |
 
 ### Truncation
 
@@ -94,7 +98,7 @@ let remainingCount = $derived(Math.max(0, filteredCountries.length - INITIAL_SHO
 
 ## Tests
 
-Eight new tests added to the existing `describe('LocationFilter')` block in `filter-sections.spec.ts`:
+Ten new tests added to the existing `describe('LocationFilter')` block in `filter-sections.spec.ts`:
 
 1. Search filters country list
 2. Case-insensitive matching
@@ -104,10 +108,12 @@ Eight new tests added to the existing `describe('LocationFilter')` block in `fil
 6. "No matching locations" shown for empty search results
 7. Orphaned country remains visible during search
 8. Selected country preserved across search/clear cycle
+9. Search for country, click it, cities load normally
+10. Country expanded then hidden by search, cities reappear when search cleared
 
 ## Files Changed
 
 | File                                                                    | Change                                  |
 | ----------------------------------------------------------------------- | --------------------------------------- |
 | `web/src/lib/components/filter-panel/location-filter.svelte`            | Add search input, filtering, truncation |
-| `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts` | 8 new tests                             |
+| `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts` | 10 new tests                            |

--- a/docs/plans/2026-04-06-location-filter-search-plan.md
+++ b/docs/plans/2026-04-06-location-filter-search-plan.md
@@ -20,7 +20,7 @@
 
 **Step 1: Add test data and 11 new tests**
 
-Inside the existing `describe('LocationFilter')` block (after line 360), add a new country list and all 10 tests. The tests use the existing `mockCityFetch` helper already defined at line 252.
+Inside the existing `describe('LocationFilter')` block, add a new country list and all 11 tests. The tests use the existing `mockCityFetch` helper.
 
 ```typescript
 // --- Search tests ---
@@ -261,7 +261,7 @@ Expected: All 11 new tests FAIL (search input not found, show-more not found, et
 
 ```bash
 git add web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
-git commit -m "test: add 10 failing tests for location filter search"
+git commit -m "test: add 11 failing tests for location filter search"
 ```
 
 ---
@@ -274,7 +274,7 @@ git commit -m "test: add 10 failing tests for location filter search"
 
 **Step 1: Add imports**
 
-At the top of the `<script>` block (after line 1), add:
+At the top of the `<script>` block, after the existing `FilterContext` import, add:
 
 ```typescript
 import { Icon } from '@immich/ui';
@@ -283,7 +283,7 @@ import { mdiMagnify } from '@mdi/js';
 
 **Step 2: Add state variables**
 
-After the `emptyText` prop destructuring (after line 22), add:
+After the `emptyText` prop destructuring, add:
 
 ```typescript
 let searchQuery = $state('');
@@ -327,7 +327,7 @@ let remainingCount = $derived(Math.max(0, filteredCountries.length - INITIAL_SHO
 
 **Step 5: Add search input markup**
 
-In the template, inside the `{:else}` block (after line 75, before the orphaned country block), add:
+In the template, inside the `{:else}` block, before the orphaned country block, add:
 
 ```svelte
     <!-- Search input -->
@@ -350,7 +350,7 @@ In the template, inside the `{:else}` block (after line 75, before the orphaned 
 
 **Step 6: Replace countries loop with visibleCountries**
 
-Change line 100 from:
+Change the countries loop from:
 
 ```svelte
     {#each countries as country (country)}
@@ -364,7 +364,7 @@ to:
 
 **Step 7: Add "No results" message**
 
-After the orphaned country block (after line 98) and before the `{#each visibleCountries}` loop, add:
+After the orphaned country block and before the `{#each visibleCountries}` loop, add:
 
 ```svelte
     <!-- Empty search results -->
@@ -377,7 +377,7 @@ After the orphaned country block (after line 98) and before the `{#each visibleC
 
 **Step 8: Add "Show more" button**
 
-After the `{/each}` that closes the countries loop (after line 155), add:
+After the `{/each}` that closes the countries loop, add:
 
 ```svelte
     <!-- Show more link -->

--- a/docs/plans/2026-04-06-location-filter-search-plan.md
+++ b/docs/plans/2026-04-06-location-filter-search-plan.md
@@ -1,0 +1,405 @@
+# Location Filter Search Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a search input to the Location filter that filters countries client-side, matching the existing People/Tags search pattern.
+
+**Architecture:** Pure frontend change. Add search state, derived filtering/truncation, and search input markup to `location-filter.svelte`. No server changes — countries are already fully loaded client-side.
+
+**Tech Stack:** Svelte 5 (runes), @immich/ui Icon component, Vitest + @testing-library/svelte
+
+**Design doc:** `docs/plans/2026-04-06-location-filter-search-design.md`
+
+---
+
+### Task 1: Write failing tests for search filtering
+
+**Files:**
+
+- Test: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+
+**Step 1: Add test data and 10 new tests**
+
+Inside the existing `describe('LocationFilter')` block (after line 360), add a new country list and all 10 tests. The tests use the existing `mockCityFetch` helper already defined at line 252.
+
+```typescript
+// --- Search tests ---
+const manyCountries = [
+  'Argentina',
+  'Australia',
+  'Brazil',
+  'Canada',
+  'China',
+  'France',
+  'Germany',
+  'India',
+  'Italy',
+  'Japan',
+  'Mexico',
+  'Spain',
+];
+
+it('should filter countries via search input', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+  await fireEvent.input(searchInput, { target: { value: 'Ger' } });
+
+  expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  expect(queryByTestId('location-country-France')).toBeNull();
+  expect(queryByTestId('location-country-Italy')).toBeNull();
+});
+
+it('should search case-insensitively', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+  await fireEvent.input(searchInput, { target: { value: 'germany' } });
+
+  expect(queryByTestId('location-country-Germany')).toBeTruthy();
+});
+
+it('should show all search results without truncation', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+  // "an" matches Argentina, Canada, France, Germany, Japan, Spain (6 results > would be truncated at 10? no, all 6 shown)
+  await fireEvent.input(searchInput, { target: { value: 'an' } });
+
+  expect(queryByTestId('location-country-Argentina')).toBeTruthy();
+  expect(queryByTestId('location-country-Canada')).toBeTruthy();
+  expect(queryByTestId('location-country-France')).toBeTruthy();
+  expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  expect(queryByTestId('location-country-Japan')).toBeTruthy();
+  expect(queryByTestId('location-country-Spain')).toBeTruthy();
+  // Non-matches hidden
+  expect(queryByTestId('location-country-Brazil')).toBeNull();
+  expect(queryByTestId('location-country-China')).toBeNull();
+});
+
+it('should show "Show N more" when list exceeds 10 countries', () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  // First 10 should be visible
+  expect(queryByTestId('location-country-Argentina')).toBeTruthy();
+  expect(queryByTestId('location-country-Japan')).toBeTruthy();
+  // 11th and 12th should be hidden
+  expect(queryByTestId('location-country-Mexico')).toBeNull();
+  expect(queryByTestId('location-country-Spain')).toBeNull();
+
+  const showMore = getByTestId('location-show-more');
+  expect(showMore.textContent).toContain('Show 2 more');
+});
+
+it('should expand list when "Show N more" is clicked', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  await fireEvent.click(getByTestId('location-show-more'));
+
+  expect(queryByTestId('location-country-Mexico')).toBeTruthy();
+  expect(queryByTestId('location-country-Spain')).toBeTruthy();
+});
+
+it('should show "No matching locations" for empty search results', async () => {
+  const { getByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+  await fireEvent.input(searchInput, { target: { value: 'zzzzz' } });
+
+  expect(getByTestId('location-no-results').textContent).toBe('No matching locations');
+});
+
+it('should keep orphaned country visible during search', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries, // Germany, Italy, France
+      selectedCountry: 'Switzerland', // Not in list = orphaned
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+  await fireEvent.input(searchInput, { target: { value: 'Italy' } });
+
+  // Orphaned country still visible
+  expect(queryByTestId('location-country-Switzerland')).toBeTruthy();
+  // Matched country visible
+  expect(queryByTestId('location-country-Italy')).toBeTruthy();
+  // Non-matched countries hidden
+  expect(queryByTestId('location-country-Germany')).toBeNull();
+});
+
+it('should preserve selected country across search/clear cycle', async () => {
+  let lastCountry: string | undefined;
+  const onSelectionChange = (country?: string) => {
+    lastCountry = country;
+  };
+
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      selectedCountry: 'Germany',
+      onCityFetch: mockCityFetch,
+      onSelectionChange,
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+
+  // Search hides Germany
+  await fireEvent.input(searchInput, { target: { value: 'Italy' } });
+  expect(queryByTestId('location-country-Germany')).toBeNull();
+
+  // Clear search — Germany reappears
+  await fireEvent.input(searchInput, { target: { value: '' } });
+  expect(queryByTestId('location-country-Germany')).toBeTruthy();
+});
+
+it('should show cities when searching for a country and clicking it', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  const searchInput = getByTestId('location-search-input');
+  await fireEvent.input(searchInput, { target: { value: 'Germany' } });
+  await fireEvent.click(getByTestId('location-country-Germany'));
+
+  await waitFor(() => {
+    expect(queryByTestId('location-city-Munich')).toBeTruthy();
+    expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+    expect(queryByTestId('location-city-Hamburg')).toBeTruthy();
+  });
+});
+
+it('should restore expanded country with cities after search is cleared', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      selectedCountry: 'Germany',
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  // Expand Germany to load cities
+  await fireEvent.click(getByTestId('location-country-Germany'));
+  await waitFor(() => {
+    expect(queryByTestId('location-city-Munich')).toBeTruthy();
+  });
+
+  // Search hides Germany (and its cities)
+  const searchInput = getByTestId('location-search-input');
+  await fireEvent.input(searchInput, { target: { value: 'Italy' } });
+  expect(queryByTestId('location-country-Germany')).toBeNull();
+  expect(queryByTestId('location-city-Munich')).toBeNull();
+
+  // Clear search — Germany and cities reappear
+  await fireEvent.input(searchInput, { target: { value: '' } });
+  expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  await waitFor(() => {
+    expect(queryByTestId('location-city-Munich')).toBeTruthy();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+
+Expected: All 10 new tests FAIL (search input not found, show-more not found, etc.)
+
+**Step 3: Commit failing tests**
+
+```bash
+git add web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+git commit -m "test: add 10 failing tests for location filter search"
+```
+
+---
+
+### Task 2: Implement search filtering in location-filter.svelte
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
+
+**Step 1: Add imports**
+
+At the top of the `<script>` block (after line 1), add:
+
+```typescript
+import { Icon } from '@immich/ui';
+import { mdiMagnify } from '@mdi/js';
+```
+
+**Step 2: Add state variables**
+
+After the `emptyText` prop destructuring (after line 22), add:
+
+```typescript
+let searchQuery = $state('');
+let showAll = $state(false);
+
+const INITIAL_SHOW_COUNT = 10;
+```
+
+**Step 3: Add search reset on countries change**
+
+After the new state variables, add:
+
+```typescript
+// Clear search when countries list changes (e.g. temporal filter refetch)
+let previousCountriesLength = 0;
+$effect(() => {
+  const currentLength = countries.length;
+  if (previousCountriesLength > 0 && currentLength !== previousCountriesLength) {
+    searchQuery = '';
+    showAll = false;
+  }
+  previousCountriesLength = currentLength;
+});
+```
+
+**Step 4: Add derived filtering and truncation**
+
+After the reset effect, add:
+
+```typescript
+let filteredCountries = $derived(
+  searchQuery.trim() ? countries.filter((c) => c.toLowerCase().includes(searchQuery.trim().toLowerCase())) : countries,
+);
+
+let visibleCountries = $derived(
+  searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, INITIAL_SHOW_COUNT),
+);
+
+let remainingCount = $derived(Math.max(0, filteredCountries.length - INITIAL_SHOW_COUNT));
+```
+
+**Step 5: Add search input markup**
+
+In the template, inside the `{:else}` block (after line 75, before the orphaned country block), add:
+
+```svelte
+    <!-- Search input -->
+    <div class="relative mb-2">
+      <div class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500">
+        <Icon icon={mdiMagnify} size="14" />
+      </div>
+      <input
+        type="text"
+        class="immich-form-input h-8 w-full rounded-lg pl-7 pr-2 text-sm"
+        placeholder="Search locations..."
+        bind:value={searchQuery}
+        oninput={() => {
+          showAll = false;
+        }}
+        data-testid="location-search-input"
+      />
+    </div>
+```
+
+**Step 6: Replace countries loop with visibleCountries**
+
+Change line 100 from:
+
+```svelte
+    {#each countries as country (country)}
+```
+
+to:
+
+```svelte
+    {#each visibleCountries as country (country)}
+```
+
+**Step 7: Add "No results" message**
+
+After the orphaned country block (after line 98) and before the `{#each visibleCountries}` loop, add:
+
+```svelte
+    <!-- Empty search results -->
+    {#if filteredCountries.length === 0 && searchQuery.trim()}
+      <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-no-results">
+        No matching locations
+      </p>
+    {/if}
+```
+
+**Step 8: Add "Show more" button**
+
+After the `{/each}` that closes the countries loop (after line 155), add:
+
+```svelte
+    <!-- Show more link -->
+    {#if !showAll && remainingCount > 0 && !searchQuery.trim()}
+      <button
+        type="button"
+        class="py-1 text-xs font-medium text-immich-primary dark:text-immich-dark-primary"
+        onclick={() => (showAll = true)}
+        data-testid="location-show-more"
+      >
+        Show {remainingCount} more
+      </button>
+    {/if}
+```
+
+**Step 9: Run tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+
+Expected: All tests PASS (existing + 10 new)
+
+**Step 10: Run type check**
+
+Run: `cd web && npx svelte-check --tsconfig ./tsconfig.json 2>&1 | tail -20`
+
+Expected: No errors in `location-filter.svelte`
+
+**Step 11: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/location-filter.svelte
+git commit -m "feat: add search field to location filter"
+```

--- a/docs/plans/2026-04-06-location-filter-search-plan.md
+++ b/docs/plans/2026-04-06-location-filter-search-plan.md
@@ -18,7 +18,7 @@
 
 - Test: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 
-**Step 1: Add test data and 10 new tests**
+**Step 1: Add test data and 11 new tests**
 
 Inside the existing `describe('LocationFilter')` block (after line 360), add a new country list and all 10 tests. The tests use the existing `mockCityFetch` helper already defined at line 252.
 
@@ -81,7 +81,7 @@ it('should show all search results without truncation', async () => {
   });
 
   const searchInput = getByTestId('location-search-input');
-  // "an" matches Argentina, Canada, France, Germany, Japan, Spain (6 results > would be truncated at 10? no, all 6 shown)
+  // "an" matches 6 countries — all shown regardless of search
   await fireEvent.input(searchInput, { target: { value: 'an' } });
 
   expect(queryByTestId('location-country-Argentina')).toBeTruthy();
@@ -167,17 +167,12 @@ it('should keep orphaned country visible during search', async () => {
 });
 
 it('should preserve selected country across search/clear cycle', async () => {
-  let lastCountry: string | undefined;
-  const onSelectionChange = (country?: string) => {
-    lastCountry = country;
-  };
-
   const { getByTestId, queryByTestId } = render(LocationFilter, {
     props: {
       countries: mockCountries,
       selectedCountry: 'Germany',
       onCityFetch: mockCityFetch,
-      onSelectionChange,
+      onSelectionChange: () => {},
     },
   });
 
@@ -210,6 +205,19 @@ it('should show cities when searching for a country and clicking it', async () =
     expect(queryByTestId('location-city-Berlin')).toBeTruthy();
     expect(queryByTestId('location-city-Hamburg')).toBeTruthy();
   });
+});
+
+it('should not show search input when no countries exist', () => {
+  const { queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: [],
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
+  });
+
+  expect(queryByTestId('location-search-input')).toBeNull();
+  expect(queryByTestId('location-empty')).toBeTruthy();
 });
 
 it('should restore expanded country with cities after search is cleared', async () => {
@@ -247,7 +255,7 @@ it('should restore expanded country with cities after search is cleared', async 
 
 Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 
-Expected: All 10 new tests FAIL (search input not found, show-more not found, etc.)
+Expected: All 11 new tests FAIL (search input not found, show-more not found, etc.)
 
 **Step 3: Commit failing tests**
 
@@ -389,7 +397,7 @@ After the `{/each}` that closes the countries loop (after line 155), add:
 
 Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 
-Expected: All tests PASS (existing + 10 new)
+Expected: All tests PASS (existing + 11 new)
 
 **Step 10: Run type check**
 

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -358,6 +358,233 @@ describe('LocationFilter', () => {
 
     expect(getByTestId('location-empty').textContent).toBe('No locations found');
   });
+
+  // --- Search tests ---
+  const manyCountries = [
+    'Argentina',
+    'Australia',
+    'Brazil',
+    'Canada',
+    'China',
+    'France',
+    'Germany',
+    'India',
+    'Italy',
+    'Japan',
+    'Mexico',
+    'Spain',
+  ];
+
+  it('should filter countries via search input', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'Ger' } });
+
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    expect(queryByTestId('location-country-France')).toBeNull();
+    expect(queryByTestId('location-country-Italy')).toBeNull();
+  });
+
+  it('should search case-insensitively', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'germany' } });
+
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  });
+
+  it('should show all search results without truncation', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    // "an" matches 6 countries — all shown regardless of search
+    await fireEvent.input(searchInput, { target: { value: 'an' } });
+
+    expect(queryByTestId('location-country-Argentina')).toBeTruthy();
+    expect(queryByTestId('location-country-Canada')).toBeTruthy();
+    expect(queryByTestId('location-country-France')).toBeTruthy();
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    expect(queryByTestId('location-country-Japan')).toBeTruthy();
+    expect(queryByTestId('location-country-Spain')).toBeTruthy();
+    // Non-matches hidden
+    expect(queryByTestId('location-country-Brazil')).toBeNull();
+    expect(queryByTestId('location-country-China')).toBeNull();
+  });
+
+  it('should show "Show N more" when list exceeds 10 countries', () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    // First 10 should be visible
+    expect(queryByTestId('location-country-Argentina')).toBeTruthy();
+    expect(queryByTestId('location-country-Japan')).toBeTruthy();
+    // 11th and 12th should be hidden
+    expect(queryByTestId('location-country-Mexico')).toBeNull();
+    expect(queryByTestId('location-country-Spain')).toBeNull();
+
+    const showMore = getByTestId('location-show-more');
+    expect(showMore.textContent).toContain('Show 2 more');
+  });
+
+  it('should expand list when "Show N more" is clicked', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-show-more'));
+
+    expect(queryByTestId('location-country-Mexico')).toBeTruthy();
+    expect(queryByTestId('location-country-Spain')).toBeTruthy();
+  });
+
+  it('should show "No matching locations" for empty search results', async () => {
+    const { getByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'zzzzz' } });
+
+    expect(getByTestId('location-no-results').textContent).toBe('No matching locations');
+  });
+
+  it('should keep orphaned country visible during search', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries, // Germany, Italy, France
+        selectedCountry: 'Switzerland', // Not in list = orphaned
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'Italy' } });
+
+    // Orphaned country still visible
+    expect(queryByTestId('location-country-Switzerland')).toBeTruthy();
+    // Matched country visible
+    expect(queryByTestId('location-country-Italy')).toBeTruthy();
+    // Non-matched countries hidden
+    expect(queryByTestId('location-country-Germany')).toBeNull();
+  });
+
+  it('should preserve selected country across search/clear cycle', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        selectedCountry: 'Germany',
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+
+    // Search hides Germany
+    await fireEvent.input(searchInput, { target: { value: 'Italy' } });
+    expect(queryByTestId('location-country-Germany')).toBeNull();
+
+    // Clear search — Germany reappears
+    await fireEvent.input(searchInput, { target: { value: '' } });
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  });
+
+  it('should show cities when searching for a country and clicking it', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'Germany' } });
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Munich')).toBeTruthy();
+      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+      expect(queryByTestId('location-city-Hamburg')).toBeTruthy();
+    });
+  });
+
+  it('should not show search input when no countries exist', () => {
+    const { queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: [],
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    expect(queryByTestId('location-search-input')).toBeNull();
+    expect(queryByTestId('location-empty')).toBeTruthy();
+  });
+
+  it('should restore expanded country with cities after search is cleared', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        selectedCountry: 'Germany',
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    // Expand Germany to load cities
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Munich')).toBeTruthy();
+    });
+
+    // Search hides Germany (and its cities)
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'Italy' } });
+    expect(queryByTestId('location-country-Germany')).toBeNull();
+    expect(queryByTestId('location-city-Munich')).toBeNull();
+
+    // Clear search — Germany and cities reappear
+    await fireEvent.input(searchInput, { target: { value: '' } });
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Munich')).toBeTruthy();
+    });
+  });
 });
 
 describe('CameraFilter', () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -417,18 +417,18 @@ describe('LocationFilter', () => {
     });
 
     const searchInput = getByTestId('location-search-input');
-    // "an" matches 6 countries — all shown regardless of search
+    // "an" matches 4 countries — all shown regardless of truncation
     await fireEvent.input(searchInput, { target: { value: 'an' } });
 
-    expect(queryByTestId('location-country-Argentina')).toBeTruthy();
     expect(queryByTestId('location-country-Canada')).toBeTruthy();
     expect(queryByTestId('location-country-France')).toBeTruthy();
     expect(queryByTestId('location-country-Germany')).toBeTruthy();
     expect(queryByTestId('location-country-Japan')).toBeTruthy();
-    expect(queryByTestId('location-country-Spain')).toBeTruthy();
     // Non-matches hidden
+    expect(queryByTestId('location-country-Argentina')).toBeNull();
     expect(queryByTestId('location-country-Brazil')).toBeNull();
     expect(queryByTestId('location-country-China')).toBeNull();
+    expect(queryByTestId('location-country-Spain')).toBeNull();
   });
 
   it('should show "Show N more" when list exceeds 10 countries', () => {
@@ -560,13 +560,12 @@ describe('LocationFilter', () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
         countries: mockCountries,
-        selectedCountry: 'Germany',
         onCityFetch: mockCityFetch,
         onSelectionChange: () => {},
       },
     });
 
-    // Expand Germany to load cities
+    // Select and expand Germany to load cities
     await fireEvent.click(getByTestId('location-country-Germany'));
     await waitFor(() => {
       expect(queryByTestId('location-city-Munich')).toBeTruthy();

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { FilterContext } from './filter-panel';
 
+  import { Icon } from '@immich/ui';
+  import { mdiMagnify } from '@mdi/js';
+
   interface Props {
     countries: string[];
     selectedCity?: string;
@@ -20,6 +23,32 @@
     onSelectionChange,
     emptyText = 'No locations found',
   }: Props = $props();
+
+  let searchQuery = $state('');
+  let showAll = $state(false);
+
+  const INITIAL_SHOW_COUNT = 10;
+
+  // Clear search when countries list changes (e.g. temporal filter refetch)
+  let previousCountriesLength = 0;
+  $effect(() => {
+    const currentLength = countries.length;
+    if (previousCountriesLength > 0 && currentLength !== previousCountriesLength) {
+      searchQuery = '';
+      showAll = false;
+    }
+    previousCountriesLength = currentLength;
+  });
+
+  let filteredCountries = $derived(
+    searchQuery.trim() ? countries.filter((c) => c.toLowerCase().includes(searchQuery.trim().toLowerCase())) : countries,
+  );
+
+  let visibleCountries = $derived(
+    searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, INITIAL_SHOW_COUNT),
+  );
+
+  let remainingCount = $derived(Math.max(0, filteredCountries.length - INITIAL_SHOW_COUNT));
 
   let expandedCountry = $state<string | undefined>(undefined);
   let cities = $state<string[]>([]);
@@ -73,6 +102,23 @@
   {#if countries.length === 0 && !orphanedCountry}
     <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-empty">{emptyText}</p>
   {:else}
+    <!-- Search input -->
+    <div class="relative mb-2">
+      <div class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500">
+        <Icon icon={mdiMagnify} size="14" />
+      </div>
+      <input
+        type="text"
+        class="immich-form-input h-8 w-full rounded-lg pl-7 pr-2 text-sm"
+        placeholder="Search locations..."
+        bind:value={searchQuery}
+        oninput={() => {
+          showAll = false;
+        }}
+        data-testid="location-search-input"
+      />
+    </div>
+
     <!-- Orphaned country (selected but no longer in suggestions) -->
     {#if orphanedCountry}
       {@const isCountrySelected = true}
@@ -97,7 +143,14 @@
       </button>
     {/if}
 
-    {#each countries as country (country)}
+    <!-- Empty search results -->
+    {#if filteredCountries.length === 0 && searchQuery.trim()}
+      <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-no-results">
+        No matching locations
+      </p>
+    {/if}
+
+    {#each visibleCountries as country (country)}
       {@const isCountrySelected = selectedCountry === country}
       <!-- Country row -->
       <button
@@ -153,5 +206,17 @@
         {/each}
       {/if}
     {/each}
+
+    <!-- Show more link -->
+    {#if !showAll && remainingCount > 0 && !searchQuery.trim()}
+      <button
+        type="button"
+        class="py-1 text-xs font-medium text-immich-primary dark:text-immich-dark-primary"
+        onclick={() => (showAll = true)}
+        data-testid="location-show-more"
+      >
+        Show {remainingCount} more
+      </button>
+    {/if}
   {/if}
 </div>

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -41,7 +41,9 @@
   });
 
   let filteredCountries = $derived(
-    searchQuery.trim() ? countries.filter((c) => c.toLowerCase().includes(searchQuery.trim().toLowerCase())) : countries,
+    searchQuery.trim()
+      ? countries.filter((c) => c.toLowerCase().includes(searchQuery.trim().toLowerCase()))
+      : countries,
   );
 
   let visibleCountries = $derived(
@@ -145,9 +147,7 @@
 
     <!-- Empty search results -->
     {#if filteredCountries.length === 0 && searchQuery.trim()}
-      <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-no-results">
-        No matching locations
-      </p>
+      <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-no-results">No matching locations</p>
     {/if}
 
     {#each visibleCountries as country (country)}


### PR DESCRIPTION
## Summary

- Adds a "Search locations..." input to the Location filter, matching the existing People and Tags search fields
- Client-side case-insensitive substring filtering on countries (cities remain lazy-loaded on expand)
- Truncation at 10 countries with "Show more" button
- Search auto-resets when suggestions are refetched

## Test plan

- [x] 11 new unit tests covering search filtering, case-insensitivity, truncation, show-more, empty results, orphaned country visibility, selected country preservation, search+city expansion, empty state, and expand+restore
- [x] All 35 tests in `filter-sections.spec.ts` pass
- [x] svelte-check clean
- [ ] Manual: verify search works on /photos and /spaces pages with Location filter expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)