### PR TITLE
feat: add relevance threshold to CLIP smart search

### DIFF
--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -1201,16 +1201,27 @@ Feel free to make a feature request if there's a model you want to use that we d
 
 ### Relevance threshold
 
-Smart search can optionally exclude results with low similarity to the search query. This prevents irrelevant photos from appearing when combining text search with metadata filters (e.g., searching "forest" filtered to a specific country that has no forest photos).
+When combining a text search with metadata filters (e.g., searching "forest" and filtering by a specific country), the results may include photos that match the filter but have little visual similarity to the search term. This happens because the search returns all photos matching the filter, ranked by similarity — even when the best match in that filtered set is poor.
 
-By default this is disabled (set to 0). To enable, set `machineLearning.clip.maxDistance` in Administration > Machine Learning > Smart Search, or in your config file.
+The **max search distance** setting adds a hard cutoff: results with a cosine distance above the threshold are excluded, regardless of how many remain. If no results pass the threshold, the search returns zero results rather than irrelevant ones.
+
+#### Configuration
+
+Set `machineLearning.clip.maxDistance` in **Administration > Machine Learning > Smart Search**, or in your config file. The value is a cosine distance (0 = identical, 2 = opposite).
 
 | Value  | Behavior                                                                |
 | ------ | ----------------------------------------------------------------------- |
 | `0`    | Disabled (default). All results returned regardless of similarity.      |
 | `0.5`  | Very strict. Only strong visual matches. May miss borderline results.   |
-| `0.75` | Recommended. Good balance of relevance and recall.                      |
+| `0.75` | Recommended starting point. Good balance of relevance and recall.       |
 | `1.0`  | Permissive. Includes weaker matches. Useful for broad/abstract queries. |
+
+#### Tuning tips
+
+- **Start at 0.75** and adjust based on your results. Lower values are stricter.
+- **Small changes can have a large effect.** CLIP embeddings tend to cluster in a narrow distance range rather than being spread evenly. This means a threshold change from, say, 0.75 to 0.80 may dramatically increase the number of results. This is normal — not a bug.
+- **Different CLIP models produce different distance distributions.** If you change your CLIP model, you may need to re-tune the threshold.
+- **Text-to-image vs. image-to-image searches** have different distance characteristics. Text queries typically produce higher distances (looser matches) than searching by a similar photo. If you use both search modes, pick a threshold that works for text queries — it will be permissive enough for image-based searches too.
 
 [huggingface-clip]: https://huggingface.co/collections/immich-app/clip-654eaefb077425890874cd07
 [huggingface-multilingual-clip]: https://huggingface.co/collections/immich-app/multilingual-clip-654eb08c2382f591eeb8c2a7

--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -1199,6 +1199,19 @@ Memory and execution time estimates were obtained without acceleration on a 7800
 Feel free to make a feature request if there's a model you want to use that we don't currently support.
 :::
 
+### Relevance threshold
+
+Smart search can optionally exclude results with low similarity to the search query. This prevents irrelevant photos from appearing when combining text search with metadata filters (e.g., searching "forest" filtered to a specific country that has no forest photos).
+
+By default this is disabled (set to 0). To enable, set `machineLearning.clip.maxDistance` in Administration > Machine Learning > Smart Search, or in your config file.
+
+| Value  | Behavior                                                                |
+| ------ | ----------------------------------------------------------------------- |
+| `0`    | Disabled (default). All results returned regardless of similarity.      |
+| `0.5`  | Very strict. Only strong visual matches. May miss borderline results.   |
+| `0.75` | Recommended. Good balance of relevance and recall.                      |
+| `1.0`  | Permissive. Includes weaker matches. Useful for broad/abstract queries. |
+
 [huggingface-clip]: https://huggingface.co/collections/immich-app/clip-654eaefb077425890874cd07
 [huggingface-multilingual-clip]: https://huggingface.co/collections/immich-app/multilingual-clip-654eb08c2382f591eeb8c2a7
 [smart-search-settings]: https://my.immich.app/admin/system-settings?isOpen=machine-learning+smart-search

--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -132,7 +132,8 @@ The default configuration looks like this:
     },
     "clip": {
       "enabled": true,
-      "modelName": "ViT-B-32__openai"
+      "modelName": "ViT-B-32__openai",
+      "maxDistance": 0
     },
     "duplicateDetection": {
       "enabled": true,

--- a/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
+++ b/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
@@ -20,7 +20,11 @@ Add a `maxDistance` field to `machineLearning.clip` in SystemConfig. This is app
 clause in `searchSmart()` to exclude results whose cosine distance exceeds the threshold.
 Configurable via the admin UI and YAML config file.
 
-## Default Value: 0.75
+## Default Value: 0 (disabled)
+
+This feature is **opt-in**. The default value of `0` means no relevance threshold is applied,
+preserving the original search behavior. Users who experience irrelevant results when combining
+text search with filters can enable it by setting a value.
 
 The `<=>` cosine distance operator ranges from 0 (identical) to 2 (opposite). Reference points:
 
@@ -29,8 +33,7 @@ The `<=>` cosine distance operator ranges from 0 (identical) to 2 (opposite). Re
 - CLIP text-to-image matching is inherently fuzzier — cross-modal distances are noisier than
   same-modal comparisons, so a looser threshold is needed
 
-  0.75 should exclude clearly irrelevant results while keeping reasonable matches. Users can tune
-  via admin settings. Set to 2.0 to effectively disable the threshold.
+Recommended starting value: **0.75**. Users can tune from there via admin settings.
 
 ## Changes
 
@@ -38,13 +41,13 @@ The `<=>` cosine distance operator ranges from 0 (identical) to 2 (opposite). Re
 
 **File:** `server/src/config.ts`
 
-Add `maxDistance: number` to the `machineLearning.clip` type and set default to `0.75`:
+Add `maxDistance: number` to the `machineLearning.clip` type and set default to `0` (disabled):
 
 ```typescript
 clip: {
   enabled: boolean;
   modelName: string;
-  maxDistance: number; // new
+  maxDistance: number; // new — 0 means disabled
 }
 ```
 
@@ -52,7 +55,7 @@ clip: {
 clip: {
   enabled: true,
   modelName: 'ViT-B-32__openai',
-  maxDistance: 0.75,  // new
+  maxDistance: 0,  // new — 0 = disabled, recommended: 0.75
 },
 ```
 
@@ -65,20 +68,21 @@ Add `maxDistance` to `CLIPConfig` class, following the `FacialRecognitionConfig.
 ```typescript
 export class CLIPConfig extends ModelConfig {
   @IsNumber()
-  @Min(0.3)
+  @Min(0)
   @Max(2)
   @Type(() => Number)
   @ApiProperty({
     type: 'number',
     format: 'double',
-    description: 'Maximum cosine distance for smart search results',
+    description: 'Maximum cosine distance for smart search results. 0 = disabled.',
   })
   maxDistance!: number;
 }
 ```
 
-Min is 0.3 (not 0.1) because CLIP text-to-image distances rarely go below ~0.4 even for
-strong matches. Setting 0.1 would return zero results for virtually any query.
+Min is 0 (disabled). Active range is roughly 0.3–2.0. Values below 0.3 would return zero
+results for most queries since CLIP text-to-image distances rarely go below ~0.4 even for
+strong matches.
 
 ### 3. Search Options Type
 
@@ -157,10 +161,10 @@ LIMIT $size + 1
 OFFSET $offset
 ```
 
-#### Optimization
+#### Skip Condition
 
-Skip the threshold clause entirely when `maxDistance >= 2.0`. Since cosine distance maxes at
-2.0, this is a no-op filter — omitting it avoids unnecessary computation.
+Skip the threshold clause entirely when `maxDistance` is `0` (disabled) or `>= 2.0` (no-op).
+This preserves original behavior and avoids unnecessary computation.
 
 #### Known Limitation
 
@@ -181,7 +185,7 @@ Add a `SettingInputField` inside the "smart-search" accordion (after the model n
   description={$t('admin.machine_learning_clip_max_distance_description')}
   bind:value={configToEdit.machineLearning.clip.maxDistance}
   step="0.05"
-  min={0.3}
+  min={0}
   max={2}
   disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
   isEdited={configToEdit.machineLearning.clip.maxDistance !== config.machineLearning.clip.maxDistance}
@@ -194,8 +198,8 @@ Add to the English locale file:
 
 - `admin.machine_learning_clip_max_distance`: "Max search distance"
 - `admin.machine_learning_clip_max_distance_description`: "Maximum cosine distance for smart
-  search results. Lower values return fewer but more relevant results. Set to 2.0 to disable.
-  Default: 0.75"
+  search results. Lower values return fewer but more relevant results. Set to 0 to disable
+  (default). Recommended: 0.75"
 
 ### 8. Generated Files
 
@@ -212,7 +216,7 @@ Add `maxDistance` to the clip section in the example config:
 "clip": {
   "enabled": true,
   "modelName": "ViT-B-32__openai",
-  "maxDistance": 0.75
+  "maxDistance": 0
 }
 ```
 
@@ -220,21 +224,20 @@ Add `maxDistance` to the clip section in the example config:
 
 Add a section explaining the relevance threshold:
 
-> **Relevance threshold:** By default, smart search excludes results with a cosine distance
-> greater than 0.75 from the search query. This prevents irrelevant photos from appearing when
-> combining text search with metadata filters (e.g., searching "forest" filtered to a specific
-> country that has no forest photos).
+> **Relevance threshold:** Smart search can optionally exclude results with low similarity to
+> the search query. This prevents irrelevant photos from appearing when combining text search
+> with metadata filters (e.g., searching "forest" filtered to a specific country that has no
+> forest photos).
 >
-> You can adjust this in Administration > Machine Learning > Smart Search, or in your config
-> file under `machineLearning.clip.maxDistance`. Lower values are stricter (fewer, more relevant
-> results). Higher values are more permissive. Set to 2.0 to disable the threshold entirely.
+> By default this is disabled (set to 0). To enable, set `machineLearning.clip.maxDistance` in
+> Administration > Machine Learning > Smart Search, or in your config file.
 >
 > Examples:
 >
+> - `0` — Disabled (default). All results returned regardless of similarity.
 > - `0.5` — Very strict. Only strong visual matches. May miss borderline-relevant results.
-> - `0.75` — Default. Good balance of relevance and recall.
+> - `0.75` — Recommended. Good balance of relevance and recall.
 > - `1.0` — Permissive. Includes weaker matches. Useful for broad or abstract queries.
-> - `2.0` — Disabled. All results returned regardless of similarity (original behavior).
 
 ### 10. Tests
 
@@ -246,7 +249,8 @@ Add a section explaining the relevance threshold:
 
 - Verify distance WHERE clause is applied for relevance ordering (Case A)
 - Verify distance WHERE clause is applied for date ordering (Case B)
-- Verify `maxDistance >= 2.0` skips the threshold clause
+- Verify `maxDistance` of `0` skips the threshold clause (disabled)
+- Verify `maxDistance >= 2.0` skips the threshold clause (no-op)
 - Verify pagination correctness: when threshold filters results, `hasNextPage` is correct
 
 ## What This Does NOT Change

--- a/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
+++ b/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
@@ -132,14 +132,15 @@ Two sub-cases based on ordering:
 #### Case A: Relevance Ordering (no `orderDirection`)
 
 Add a WHERE clause directly — no CTE needed. The threshold is applied before LIMIT so
-pagination stays correct:
+pagination stays correct. Use Kysely's `.$if()` pattern with explicit parentheses in the
+`sql` template to avoid operator precedence ambiguity between `<=>` and `<=`:
 
 ```sql
 SELECT asset.*
 FROM asset
   INNER JOIN smart_search ON asset.id = smart_search.assetId
 WHERE [all existing filters]
-  AND smart_search.embedding <=> $embedding <= $maxDistance
+  AND (smart_search.embedding <=> $embedding) <= $maxDistance
 ORDER BY smart_search.embedding <=> $embedding
 LIMIT $size + 1
 OFFSET $offset
@@ -155,7 +156,7 @@ WITH candidates AS (
   FROM asset
     INNER JOIN smart_search ON asset.id = smart_search.assetId
   WHERE [all existing filters]
-    AND smart_search.embedding <=> $embedding <= $maxDistance
+    AND (smart_search.embedding <=> $embedding) <= $maxDistance
   ORDER BY smart_search.embedding <=> $embedding
   LIMIT 500
 )

--- a/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
+++ b/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
@@ -82,7 +82,8 @@ export class CLIPConfig extends ModelConfig {
 
 Min is 0 (disabled). Active range is roughly 0.3–2.0. Values below 0.3 would return zero
 results for most queries since CLIP text-to-image distances rarely go below ~0.4 even for
-strong matches.
+strong matches. Note: image-to-image similarity (via `queryAssetId`) produces different
+distance distributions than text-to-image — users should tune separately if using both.
 
 ### 3. Search Options Type
 
@@ -123,7 +124,10 @@ const { hasNextPage, items } = await this.searchRepository.searchSmart(
 
 **File:** `server/src/repositories/search.repository.ts`
 
-Modify `searchSmart()` to apply the threshold. Two sub-cases based on ordering:
+Modify `searchSmart()` to apply the threshold. Also update the `@GenerateSql` decorator params
+to include `maxDistance: 0.75` so `make sql` generates representative SQL with the WHERE clause.
+
+Two sub-cases based on ordering:
 
 #### Case A: Relevance Ordering (no `orderDirection`)
 
@@ -198,8 +202,8 @@ Add to the English locale file:
 
 - `admin.machine_learning_clip_max_distance`: "Max search distance"
 - `admin.machine_learning_clip_max_distance_description`: "Maximum cosine distance for smart
-  search results. Lower values return fewer but more relevant results. Set to 0 to disable
-  (default). Recommended: 0.75"
+  search results. Lower values return fewer but more relevant results. Values below 0.3 will
+  likely return no results. Set to 0 to disable (default). Recommended: 0.75"
 
 ### 8. Generated Files
 
@@ -241,11 +245,19 @@ Add a section explaining the relevance threshold:
 
 ### 10. Tests
 
-**Service tests** (`server/src/services/search.service.spec.ts`):
+**Existing test updates** (`server/src/services/search.service.spec.ts`):
 
-- Verify `maxDistance` from config is passed to `searchRepository.searchSmart()`
+The `'should work'` test uses exact object matching on the `searchSmart` call args. Adding
+`maxDistance` to the options will break it. Update this test (and any others using exact
+matching instead of `expect.objectContaining`) to include `maxDistance: 0` in the expected
+options.
 
-**Repository tests** (if applicable — medium tests or unit mocks):
+**New service tests** (`server/src/services/search.service.spec.ts`):
+
+- Verify `maxDistance` from config is passed to `searchRepository.searchSmart()` (text query path)
+- Verify `maxDistance` from config is passed to `searchRepository.searchSmart()` (queryAssetId path)
+
+**Repository tests** (medium tests with real DB preferred, since mocking Kysely doesn't verify SQL):
 
 - Verify distance WHERE clause is applied for relevance ordering (Case A)
 - Verify distance WHERE clause is applied for date ordering (Case B)

--- a/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
+++ b/docs/plans/2026-04-06-smart-search-relevance-threshold-design.md
@@ -1,0 +1,258 @@
+# Smart Search Relevance Threshold
+
+**Issue:** [#290](https://github.com/open-noodle/gallery/issues/290)
+**Date:** 2026-04-06
+
+## Problem
+
+When combining CLIP smart search with metadata filters (location, camera, people, etc.),
+results include visually irrelevant photos. Searching "Forest" returns 100 great forest photos,
+but "Forest" + country="Qatar" returns 15 Qatar city photos — none are forests.
+
+The system returns ALL photos matching the metadata filter, ranked by CLIP similarity, with no
+minimum relevance cutoff. If the user has 15 Qatar photos and none contain forests, all 15 are
+returned anyway because they are the "most forest-like" Qatar photos — even if their similarity
+scores are terrible.
+
+## Solution
+
+Add a `maxDistance` field to `machineLearning.clip` in SystemConfig. This is applied as a WHERE
+clause in `searchSmart()` to exclude results whose cosine distance exceeds the threshold.
+Configurable via the admin UI and YAML config file.
+
+## Default Value: 0.75
+
+The `<=>` cosine distance operator ranges from 0 (identical) to 2 (opposite). Reference points:
+
+- `facialRecognition.maxDistance` defaults to 0.5 (face-to-face embeddings cluster tightly)
+- `duplicateDetection.maxDistance` defaults to 0.01 (near-identical images)
+- CLIP text-to-image matching is inherently fuzzier — cross-modal distances are noisier than
+  same-modal comparisons, so a looser threshold is needed
+
+  0.75 should exclude clearly irrelevant results while keeping reasonable matches. Users can tune
+  via admin settings. Set to 2.0 to effectively disable the threshold.
+
+## Changes
+
+### 1. Config Type
+
+**File:** `server/src/config.ts`
+
+Add `maxDistance: number` to the `machineLearning.clip` type and set default to `0.75`:
+
+```typescript
+clip: {
+  enabled: boolean;
+  modelName: string;
+  maxDistance: number; // new
+}
+```
+
+```typescript
+clip: {
+  enabled: true,
+  modelName: 'ViT-B-32__openai',
+  maxDistance: 0.75,  // new
+},
+```
+
+### 2. DTO Validation
+
+**File:** `server/src/dtos/model-config.dto.ts`
+
+Add `maxDistance` to `CLIPConfig` class, following the `FacialRecognitionConfig.maxDistance` pattern:
+
+```typescript
+export class CLIPConfig extends ModelConfig {
+  @IsNumber()
+  @Min(0.3)
+  @Max(2)
+  @Type(() => Number)
+  @ApiProperty({
+    type: 'number',
+    format: 'double',
+    description: 'Maximum cosine distance for smart search results',
+  })
+  maxDistance!: number;
+}
+```
+
+Min is 0.3 (not 0.1) because CLIP text-to-image distances rarely go below ~0.4 even for
+strong matches. Setting 0.1 would return zero results for virtually any query.
+
+### 3. Search Options Type
+
+**File:** `server/src/repositories/search.repository.ts`
+
+Add `maxDistance` to `SearchEmbeddingOptions`:
+
+```typescript
+export interface SearchEmbeddingOptions {
+  embedding: string;
+  userIds: string[];
+  maxDistance?: number; // new
+}
+```
+
+This flows into `SmartSearchOptions` via the existing type intersection.
+
+### 4. Search Service
+
+**File:** `server/src/services/search.service.ts`
+
+Pass `machineLearning.clip.maxDistance` into the repository call (line ~165):
+
+```typescript
+const { hasNextPage, items } = await this.searchRepository.searchSmart(
+  { page, size },
+  {
+    ...dto,
+    userIds: await userIds,
+    embedding,
+    orderDirection: dto.order,
+    maxDistance: machineLearning.clip.maxDistance,
+  },
+);
+```
+
+### 5. Search Repository
+
+**File:** `server/src/repositories/search.repository.ts`
+
+Modify `searchSmart()` to apply the threshold. Two sub-cases based on ordering:
+
+#### Case A: Relevance Ordering (no `orderDirection`)
+
+Add a WHERE clause directly — no CTE needed. The threshold is applied before LIMIT so
+pagination stays correct:
+
+```sql
+SELECT asset.*
+FROM asset
+  INNER JOIN smart_search ON asset.id = smart_search.assetId
+WHERE [all existing filters]
+  AND smart_search.embedding <=> $embedding <= $maxDistance
+ORDER BY smart_search.embedding <=> $embedding
+LIMIT $size + 1
+OFFSET $offset
+```
+
+#### Case B: Date Ordering (with `orderDirection`)
+
+Add the threshold inside the existing CTE that fetches top 500 by similarity:
+
+```sql
+WITH candidates AS (
+  SELECT asset.*
+  FROM asset
+    INNER JOIN smart_search ON asset.id = smart_search.assetId
+  WHERE [all existing filters]
+    AND smart_search.embedding <=> $embedding <= $maxDistance
+  ORDER BY smart_search.embedding <=> $embedding
+  LIMIT 500
+)
+SELECT * FROM candidates
+ORDER BY fileCreatedAt $direction NULLS LAST
+LIMIT $size + 1
+OFFSET $offset
+```
+
+#### Optimization
+
+Skip the threshold clause entirely when `maxDistance >= 2.0`. Since cosine distance maxes at
+2.0, this is a no-op filter — omitting it avoids unnecessary computation.
+
+#### Known Limitation
+
+The 500-row window in date ordering is pre-existing. The threshold makes under-filling more
+likely (if many results exceed the threshold, fewer than 500 candidates survive). This is
+acceptable because date ordering is a secondary use case and the window was already arbitrary.
+
+### 6. Admin UI
+
+**File:** `web/src/lib/components/admin-settings/MachineLearningSettings.svelte`
+
+Add a `SettingInputField` inside the "smart-search" accordion (after the model name field):
+
+```svelte
+<SettingInputField
+  inputType={SettingInputFieldType.NUMBER}
+  label={$t('admin.machine_learning_clip_max_distance')}
+  description={$t('admin.machine_learning_clip_max_distance_description')}
+  bind:value={configToEdit.machineLearning.clip.maxDistance}
+  step="0.05"
+  min={0.3}
+  max={2}
+  disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+  isEdited={configToEdit.machineLearning.clip.maxDistance !== config.machineLearning.clip.maxDistance}
+/>
+```
+
+### 7. i18n Keys
+
+Add to the English locale file:
+
+- `admin.machine_learning_clip_max_distance`: "Max search distance"
+- `admin.machine_learning_clip_max_distance_description`: "Maximum cosine distance for smart
+  search results. Lower values return fewer but more relevant results. Set to 2.0 to disable.
+  Default: 0.75"
+
+### 8. Generated Files
+
+- `make open-api` — regenerate TypeScript SDK and Dart client (CLIPConfig schema changed)
+- `make sql` — regenerate SQL query documentation
+
+### 9. Documentation
+
+**File:** `docs/docs/install/config-file.md`
+
+Add `maxDistance` to the clip section in the example config:
+
+```json
+"clip": {
+  "enabled": true,
+  "modelName": "ViT-B-32__openai",
+  "maxDistance": 0.75
+}
+```
+
+**File:** `docs/docs/features/searching.md`
+
+Add a section explaining the relevance threshold:
+
+> **Relevance threshold:** By default, smart search excludes results with a cosine distance
+> greater than 0.75 from the search query. This prevents irrelevant photos from appearing when
+> combining text search with metadata filters (e.g., searching "forest" filtered to a specific
+> country that has no forest photos).
+>
+> You can adjust this in Administration > Machine Learning > Smart Search, or in your config
+> file under `machineLearning.clip.maxDistance`. Lower values are stricter (fewer, more relevant
+> results). Higher values are more permissive. Set to 2.0 to disable the threshold entirely.
+>
+> Examples:
+>
+> - `0.5` — Very strict. Only strong visual matches. May miss borderline-relevant results.
+> - `0.75` — Default. Good balance of relevance and recall.
+> - `1.0` — Permissive. Includes weaker matches. Useful for broad or abstract queries.
+> - `2.0` — Disabled. All results returned regardless of similarity (original behavior).
+
+### 10. Tests
+
+**Service tests** (`server/src/services/search.service.spec.ts`):
+
+- Verify `maxDistance` from config is passed to `searchRepository.searchSmart()`
+
+**Repository tests** (if applicable — medium tests or unit mocks):
+
+- Verify distance WHERE clause is applied for relevance ordering (Case A)
+- Verify distance WHERE clause is applied for date ordering (Case B)
+- Verify `maxDistance >= 2.0` skips the threshold clause
+- Verify pagination correctness: when threshold filters results, `hasNextPage` is correct
+
+## What This Does NOT Change
+
+- Embedding generation or storage
+- Machine learning service
+- Search API contract (no new query parameter — server-side config only)
+- `searchFaces`, duplicate detection, or any other search method
+- Frontend search behavior (already handles variable result counts and "no results" state)

--- a/docs/plans/2026-04-06-smart-search-relevance-threshold-plan.md
+++ b/docs/plans/2026-04-06-smart-search-relevance-threshold-plan.md
@@ -1,0 +1,644 @@
+# Smart Search Relevance Threshold — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an opt-in `maxDistance` config to exclude low-relevance CLIP results when combined with metadata filters.
+
+**Architecture:** A new `maxDistance` field in `machineLearning.clip` SystemConfig. When set to a positive value, `searchSmart()` adds a `WHERE (embedding <=> query) <= maxDistance` clause before pagination. Default `0` = disabled (original behavior). Configurable via admin UI and YAML config file.
+
+**Tech Stack:** NestJS, Kysely, PostgreSQL (pgvector/VectorChord `<=>` operator), Svelte 5, Vitest
+
+**Design doc:** `docs/plans/2026-04-06-smart-search-relevance-threshold-design.md`
+
+---
+
+## Task 1: Config type + default
+
+**Files:**
+
+- Modify: `server/src/config.ts:62-65` (type) and `server/src/config.ts:270-273` (default)
+
+**Step 1: Add `maxDistance` to the clip type**
+
+In `server/src/config.ts`, find the clip type (line 62-65):
+
+```typescript
+clip: {
+  enabled: boolean;
+  modelName: string;
+}
+```
+
+Change to:
+
+```typescript
+clip: {
+  enabled: boolean;
+  modelName: string;
+  maxDistance: number;
+}
+```
+
+**Step 2: Add default value**
+
+Find the clip defaults (line 270-273):
+
+```typescript
+    clip: {
+      enabled: true,
+      modelName: 'ViT-B-32__openai',
+    },
+```
+
+Change to:
+
+```typescript
+    clip: {
+      enabled: true,
+      modelName: 'ViT-B-32__openai',
+      maxDistance: 0,
+    },
+```
+
+**Step 3: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: Type errors in `model-config.dto.ts` (CLIPConfig doesn't have maxDistance yet). That's expected — Task 2 fixes it.
+
+**Step 4: Commit**
+
+```bash
+git add server/src/config.ts
+git commit -m "feat(config): add maxDistance to machineLearning.clip (default 0 = disabled)"
+```
+
+---
+
+## Task 2: DTO validation
+
+**Files:**
+
+- Modify: `server/src/dtos/model-config.dto.ts:18`
+
+**Step 1: Add maxDistance to CLIPConfig**
+
+Find (line 18):
+
+```typescript
+export class CLIPConfig extends ModelConfig {}
+```
+
+Change to:
+
+```typescript
+export class CLIPConfig extends ModelConfig {
+  @IsNumber()
+  @Min(0)
+  @Max(2)
+  @Type(() => Number)
+  @ApiProperty({
+    type: 'number',
+    format: 'double',
+    description: 'Maximum cosine distance for smart search results. 0 = disabled.',
+  })
+  maxDistance!: number;
+}
+```
+
+You'll need to add `IsNumber`, `Min`, `Max` to the `class-validator` import and `Type` to the `class-transformer` import. Check what's already imported — `IsNumber`, `Min`, `Max` are already imported (used by other classes). `Type` is already imported. `ApiProperty` is already imported.
+
+**Step 2: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: Clean compile (no errors).
+
+**Step 3: Commit**
+
+```bash
+git add server/src/dtos/model-config.dto.ts
+git commit -m "feat(dto): add maxDistance validation to CLIPConfig"
+```
+
+---
+
+## Task 3: Search options type + repository implementation
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts:83-86` (interface)
+- Modify: `server/src/repositories/search.repository.ts:330-378` (searchSmart method + decorator)
+
+**Step 1: Add maxDistance to SearchEmbeddingOptions**
+
+Find (line 83-86):
+
+```typescript
+export interface SearchEmbeddingOptions {
+  embedding: string;
+  userIds: string[];
+}
+```
+
+Change to:
+
+```typescript
+export interface SearchEmbeddingOptions {
+  embedding: string;
+  userIds: string[];
+  maxDistance?: number;
+}
+```
+
+**Step 2: Update @GenerateSql decorator**
+
+Find the `@GenerateSql` params (line 330-343):
+
+```typescript
+  @GenerateSql({
+    params: [
+      { page: 1, size: 200 },
+      {
+        takenAfter: DummyValue.DATE,
+        embedding: DummyValue.VECTOR,
+        lensModel: DummyValue.STRING,
+        withStacked: true,
+        isFavorite: true,
+        userIds: [DummyValue.UUID],
+        spacePersonIds: [DummyValue.UUID],
+        orderDirection: 'desc',
+      },
+    ],
+  })
+```
+
+Change to:
+
+```typescript
+  @GenerateSql({
+    params: [
+      { page: 1, size: 200 },
+      {
+        takenAfter: DummyValue.DATE,
+        embedding: DummyValue.VECTOR,
+        lensModel: DummyValue.STRING,
+        withStacked: true,
+        isFavorite: true,
+        userIds: [DummyValue.UUID],
+        spacePersonIds: [DummyValue.UUID],
+        orderDirection: 'desc',
+        maxDistance: 0.75,
+      },
+    ],
+  })
+```
+
+**Step 3: Implement the threshold in searchSmart**
+
+Replace the `searchSmart` method body (line 345-378). The key changes:
+
+1. Add a helper to check if threshold is active: `options.maxDistance && options.maxDistance > 0 && options.maxDistance < 2`
+2. Use Kysely `.$if()` to conditionally add the WHERE clause with explicit parentheses
+3. Apply the same condition in both the relevance-ordering and date-ordering paths
+
+Find:
+
+```typescript
+  searchSmart(pagination: SearchPaginationOptions, options: SmartSearchOptions) {
+    if (!isValidInteger(pagination.size, { min: 1, max: 1000 })) {
+      throw new Error(`Invalid value for 'size': ${pagination.size}`);
+    }
+
+    return this.db.transaction().execute(async (trx) => {
+      await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
+
+      const baseQuery = searchAssetBuilder(trx, options)
+        .selectAll('asset')
+        .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
+        .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
+
+      if (options.orderDirection) {
+        const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;
+        const candidates = baseQuery.limit(500).as('candidates');
+        const items = await trx
+          .selectFrom(candidates)
+          .selectAll()
+          // sql.raw is safe here — orderDirection is validated to 'asc'|'desc' by the AssetOrder enum
+          .orderBy(sql`"candidates"."fileCreatedAt" ${sql.raw(orderDirection)} nulls last`)
+          .limit(pagination.size + 1)
+          .offset((pagination.page - 1) * pagination.size)
+          .execute();
+        return paginationHelper(items as MapAsset[], pagination.size);
+      }
+
+      const items = await baseQuery
+        .limit(pagination.size + 1)
+        .offset((pagination.page - 1) * pagination.size)
+        .execute();
+      return paginationHelper(items, pagination.size);
+    });
+  }
+```
+
+Replace with:
+
+```typescript
+  searchSmart(pagination: SearchPaginationOptions, options: SmartSearchOptions) {
+    if (!isValidInteger(pagination.size, { min: 1, max: 1000 })) {
+      throw new Error(`Invalid value for 'size': ${pagination.size}`);
+    }
+
+    const hasDistanceThreshold = !!options.maxDistance && options.maxDistance > 0 && options.maxDistance < 2;
+
+    return this.db.transaction().execute(async (trx) => {
+      await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
+
+      const baseQuery = searchAssetBuilder(trx, options)
+        .selectAll('asset')
+        .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
+        .$if(hasDistanceThreshold, (qb) =>
+          qb.where(sql`(smart_search.embedding <=> ${options.embedding})`, '<=', options.maxDistance!),
+        )
+        .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
+
+      if (options.orderDirection) {
+        const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;
+        const candidates = baseQuery.limit(500).as('candidates');
+        const items = await trx
+          .selectFrom(candidates)
+          .selectAll()
+          // sql.raw is safe here — orderDirection is validated to 'asc'|'desc' by the AssetOrder enum
+          .orderBy(sql`"candidates"."fileCreatedAt" ${sql.raw(orderDirection)} nulls last`)
+          .limit(pagination.size + 1)
+          .offset((pagination.page - 1) * pagination.size)
+          .execute();
+        return paginationHelper(items as MapAsset[], pagination.size);
+      }
+
+      const items = await baseQuery
+        .limit(pagination.size + 1)
+        .offset((pagination.page - 1) * pagination.size)
+        .execute();
+      return paginationHelper(items, pagination.size);
+    });
+  }
+```
+
+**Step 4: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: Clean compile.
+
+**Step 5: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts
+git commit -m "feat(search): apply maxDistance threshold in searchSmart query"
+```
+
+---
+
+## Task 4: Search service — pass config to repository
+
+**Files:**
+
+- Modify: `server/src/services/search.service.ts:163-166`
+
+**Step 1: Pass maxDistance from config**
+
+Find (line 163-166):
+
+```typescript
+const { hasNextPage, items } = await this.searchRepository.searchSmart(
+  { page, size },
+  { ...dto, userIds: await userIds, embedding, orderDirection: dto.order },
+);
+```
+
+Change to:
+
+```typescript
+const { hasNextPage, items } = await this.searchRepository.searchSmart(
+  { page, size },
+  {
+    ...dto,
+    userIds: await userIds,
+    embedding,
+    orderDirection: dto.order,
+    maxDistance: machineLearning.clip.maxDistance,
+  },
+);
+```
+
+**Step 2: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: Clean compile.
+
+**Step 3: Commit**
+
+```bash
+git add server/src/services/search.service.ts
+git commit -m "feat(search): pass clip.maxDistance config to searchSmart repository"
+```
+
+---
+
+## Task 5: Fix existing tests + add new service tests
+
+**Files:**
+
+- Modify: `server/src/services/search.service.spec.ts`
+
+**Step 1: Fix the `'should work'` test**
+
+Find (around line 607-610):
+
+```typescript
+expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+  { page: 1, size: 100 },
+  { query: 'test', embedding: '[1, 2, 3]', userIds: [authStub.user1.user.id] },
+);
+```
+
+Change to:
+
+```typescript
+expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+  { page: 1, size: 100 },
+  { query: 'test', embedding: '[1, 2, 3]', userIds: [authStub.user1.user.id], maxDistance: 0 },
+);
+```
+
+**Step 2: Add test for maxDistance passthrough (text query)**
+
+Add after the `'should pass orderDirection when order is not set'` test (around line 797):
+
+```typescript
+it('should pass maxDistance from config to repository', async () => {
+  mocks.systemMetadata.get.mockResolvedValue({
+    machineLearning: { clip: { maxDistance: 0.75 } },
+  });
+
+  await sut.searchSmart(authStub.user1, { query: 'test' });
+
+  expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ maxDistance: 0.75 }),
+  );
+});
+```
+
+**Step 3: Add test for maxDistance passthrough (queryAssetId)**
+
+Add right after:
+
+```typescript
+it('should pass maxDistance from config when using queryAssetId', async () => {
+  const assetId = newUuid();
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+  mocks.search.getEmbedding.mockResolvedValue('[4, 5, 6]');
+  mocks.systemMetadata.get.mockResolvedValue({
+    machineLearning: { clip: { maxDistance: 0.75 } },
+  });
+
+  await sut.searchSmart(authStub.user1, { queryAssetId: assetId });
+
+  expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ maxDistance: 0.75 }),
+  );
+});
+```
+
+**Step 4: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/search.service.spec.ts`
+
+Expected: All tests pass. If any other tests have exact-match assertions on `searchSmart` args that break, update them to include `maxDistance: 0`.
+
+**Step 5: Commit**
+
+```bash
+git add server/src/services/search.service.spec.ts
+git commit -m "test(search): update and add tests for maxDistance config passthrough"
+```
+
+---
+
+## Task 6: Admin UI — settings field
+
+**Files:**
+
+- Modify: `web/src/lib/components/admin-settings/MachineLearningSettings.svelte:144-146`
+
+**Step 1: Add the maxDistance input field**
+
+Find (line 144-146):
+
+```svelte
+        </SettingInputField>
+        </div>
+      </SettingAccordion>
+```
+
+(This is the closing of the model name input, the div, and the smart-search accordion.)
+
+Replace with:
+
+```svelte
+          </SettingInputField>
+
+          <SettingInputField
+            inputType={SettingInputFieldType.NUMBER}
+            label={$t('admin.machine_learning_clip_max_distance')}
+            description={$t('admin.machine_learning_clip_max_distance_description')}
+            bind:value={configToEdit.machineLearning.clip.maxDistance}
+            step="0.05"
+            min={0}
+            max={2}
+            disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+            isEdited={configToEdit.machineLearning.clip.maxDistance !== config.machineLearning.clip.maxDistance}
+          />
+        </div>
+      </SettingAccordion>
+```
+
+**Step 2: Verify web types compile**
+
+Run: `cd web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
+
+Expected: Clean or only pre-existing warnings. The new field should type-check against the generated SDK's CLIPConfig type (which won't exist yet until OpenAPI regen — this is fine, we regen in Task 9).
+
+**Step 3: Commit**
+
+```bash
+git add web/src/lib/components/admin-settings/MachineLearningSettings.svelte
+git commit -m "feat(web): add max search distance setting to smart search admin panel"
+```
+
+---
+
+## Task 7: i18n keys
+
+**Files:**
+
+- Modify: `i18n/en.json`
+
+**Step 1: Add the two new keys**
+
+Find (around line 158 — after `machine_learning_clip_model_description`):
+
+```json
+    "machine_learning_clip_model_description": "The name of a CLIP model listed <link>here</link>. Note that you must re-run the 'Smart Search' job for all images upon changing a model.",
+```
+
+Add after it:
+
+```json
+    "machine_learning_clip_max_distance": "Max search distance",
+    "machine_learning_clip_max_distance_description": "Maximum cosine distance for smart search results. Lower values return fewer but more relevant results. Values below 0.3 will likely return no results. Set to 0 to disable (default). Recommended: 0.75",
+```
+
+**Step 2: Sort i18n keys**
+
+Run: `pnpm --filter=immich-i18n format:fix`
+
+This ensures keys are sorted correctly (required by CI).
+
+**Step 3: Commit**
+
+```bash
+git add i18n/en.json
+git commit -m "feat(i18n): add max search distance label and description"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+
+- Modify: `docs/docs/install/config-file.md`
+- Modify: `docs/docs/features/searching.md`
+
+**Step 1: Update config-file.md**
+
+Find (around line 133-136):
+
+```json
+    "clip": {
+      "enabled": true,
+      "modelName": "ViT-B-32__openai"
+    },
+```
+
+Change to:
+
+```json
+    "clip": {
+      "enabled": true,
+      "modelName": "ViT-B-32__openai",
+      "maxDistance": 0
+    },
+```
+
+**Step 2: Update searching.md**
+
+Find the "Configuration" section (line 33). After the "CLIP models" subsection (which ends around line 66 with the memory/speed note), add a new subsection:
+
+```markdown
+### Relevance threshold
+
+Smart search can optionally exclude results with low similarity to the search query. This prevents irrelevant photos from appearing when combining text search with metadata filters (e.g., searching "forest" filtered to a specific country that has no forest photos).
+
+By default this is disabled (set to 0). To enable, set `machineLearning.clip.maxDistance` in Administration > Machine Learning > Smart Search, or in your config file.
+
+| Value  | Behavior                                                                |
+| ------ | ----------------------------------------------------------------------- |
+| `0`    | Disabled (default). All results returned regardless of similarity.      |
+| `0.5`  | Very strict. Only strong visual matches. May miss borderline results.   |
+| `0.75` | Recommended. Good balance of relevance and recall.                      |
+| `1.0`  | Permissive. Includes weaker matches. Useful for broad/abstract queries. |
+```
+
+**Step 3: Format docs**
+
+Run: `npx prettier --write docs/docs/install/config-file.md docs/docs/features/searching.md`
+
+**Step 4: Commit**
+
+```bash
+git add docs/docs/install/config-file.md docs/docs/features/searching.md
+git commit -m "docs: add relevance threshold to config reference and searching guide"
+```
+
+---
+
+## Task 9: Regenerate OpenAPI + SQL
+
+**Files:**
+
+- Various generated files in `open-api/`, `server/src/queries/`
+
+**Step 1: Build the server**
+
+Run: `cd server && pnpm build`
+
+This is required before regenerating specs.
+
+**Step 2: Regenerate OpenAPI specs**
+
+Run: `cd server && pnpm sync:open-api`
+
+Then: `make open-api`
+
+This regenerates both TypeScript SDK and Dart client.
+
+**Step 3: Regenerate SQL query docs**
+
+Run: `make sql`
+
+Note: This requires a running database. If no DB is available, manually apply the diff from CI later (per project memory `feedback_make_sql_no_db`).
+
+**Step 4: Run type checks**
+
+Run: `cd server && npx tsc --noEmit && cd ../web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
+
+Expected: Clean compile for both server and web.
+
+**Step 5: Commit all generated files**
+
+```bash
+git add open-api/ server/src/queries/ mobile/openapi/
+git commit -m "chore: regenerate OpenAPI specs and SQL query docs"
+```
+
+---
+
+## Task 10: Final verification
+
+**Step 1: Run server tests**
+
+Run: `cd server && pnpm test`
+
+Expected: All tests pass.
+
+**Step 2: Run web tests**
+
+Run: `cd web && pnpm test`
+
+Expected: All tests pass.
+
+**Step 3: Run type checks**
+
+Run: `make check-server && make check-web`
+
+Expected: Clean.
+
+**Step 4: Squash into PR branch and push**
+
+Create a feature branch, squash all work commits, and push for PR creation.

--- a/docs/plans/2026-04-06-smart-search-relevance-threshold-plan.md
+++ b/docs/plans/2026-04-06-smart-search-relevance-threshold-plan.md
@@ -64,7 +64,8 @@ Change to:
 
 Run: `cd server && npx tsc --noEmit 2>&1 | head -20`
 
-Expected: Type errors in `model-config.dto.ts` (CLIPConfig doesn't have maxDistance yet). That's expected — Task 2 fixes it.
+Expected: Clean compile. The `config.ts` type and defaults are self-consistent. The DTO class
+(`CLIPConfig`) is separate and doesn't cause errors here.
 
 **Step 4: Commit**
 
@@ -198,7 +199,7 @@ Change to:
 
 Replace the `searchSmart` method body (line 345-378). The key changes:
 
-1. Add a helper to check if threshold is active: `options.maxDistance && options.maxDistance > 0 && options.maxDistance < 2`
+1. Add a helper to check if threshold is active: `(options.maxDistance ?? 0) > 0 && (options.maxDistance ?? 0) < 2`
 2. Use Kysely `.$if()` to conditionally add the WHERE clause with explicit parentheses
 3. Apply the same condition in both the relevance-ordering and date-ordering paths
 
@@ -249,7 +250,7 @@ Replace with:
       throw new Error(`Invalid value for 'size': ${pagination.size}`);
     }
 
-    const hasDistanceThreshold = !!options.maxDistance && options.maxDistance > 0 && options.maxDistance < 2;
+    const hasDistanceThreshold = (options.maxDistance ?? 0) > 0 && (options.maxDistance ?? 0) < 2;
 
     return this.db.transaction().execute(async (trx) => {
       await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
@@ -258,7 +259,7 @@ Replace with:
         .selectAll('asset')
         .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
         .$if(hasDistanceThreshold, (qb) =>
-          qb.where(sql`(smart_search.embedding <=> ${options.embedding})`, '<=', options.maxDistance!),
+          qb.where(sql`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
         )
         .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
 
@@ -375,7 +376,8 @@ expect(mocks.search.searchSmart).toHaveBeenCalledWith(
 
 **Step 2: Add test for maxDistance passthrough (text query)**
 
-Add after the `'should pass orderDirection when order is not set'` test (around line 797):
+Add **before** the closing `});` of the `searchSmart` describe block (line 797). The new tests go
+inside the describe block, after the `'should not pass orderDirection when order is not set'` test:
 
 ```typescript
 it('should pass maxDistance from config to repository', async () => {
@@ -414,13 +416,25 @@ it('should pass maxDistance from config when using queryAssetId', async () => {
 });
 ```
 
-**Step 4: Run tests**
+**Step 4: Add test for disabled maxDistance (default 0)**
+
+Add right after:
+
+```typescript
+it('should pass maxDistance 0 (disabled) by default', async () => {
+  await sut.searchSmart(authStub.user1, { query: 'test' });
+
+  expect(mocks.search.searchSmart).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ maxDistance: 0 }));
+});
+```
+
+**Step 5: Run tests**
 
 Run: `cd server && pnpm test -- --run src/services/search.service.spec.ts`
 
 Expected: All tests pass. If any other tests have exact-match assertions on `searchSmart` args that break, update them to include `maxDistance: 0`.
 
-**Step 5: Commit**
+**Step 6: Commit**
 
 ```bash
 git add server/src/services/search.service.spec.ts
@@ -440,7 +454,7 @@ git commit -m "test(search): update and add tests for maxDistance config passthr
 Find (line 144-146):
 
 ```svelte
-        </SettingInputField>
+          </SettingInputField>
         </div>
       </SettingAccordion>
 ```
@@ -467,13 +481,10 @@ Replace with:
       </SettingAccordion>
 ```
 
-**Step 2: Verify web types compile**
+**Step 2: Commit**
 
-Run: `cd web && npx svelte-check --tsconfig tsconfig.json 2>&1 | tail -20`
-
-Expected: Clean or only pre-existing warnings. The new field should type-check against the generated SDK's CLIPConfig type (which won't exist yet until OpenAPI regen — this is fine, we regen in Task 9).
-
-**Step 3: Commit**
+Note: Skip svelte-check here — the web types depend on the regenerated `@immich/sdk` which
+won't have `maxDistance` until Task 9. Type checking is deferred to Task 10 (final verification).
 
 ```bash
 git add web/src/lib/components/admin-settings/MachineLearningSettings.svelte
@@ -548,7 +559,9 @@ Change to:
 
 **Step 2: Update searching.md**
 
-Find the "Configuration" section (line 33). After the "CLIP models" subsection (which ends around line 66 with the memory/speed note), add a new subsection:
+Find the end of the "CLIP models" subsection. It ends with a `:::note` block and link references
+around line 1200. Insert the new subsection **before** the link reference definitions at the bottom
+(before the `[huggingface-clip]` line, around line 1202):
 
 ```markdown
 ### Relevance threshold

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -154,6 +154,8 @@
     "machine_learning_availability_checks_interval_description": "Interval in milliseconds between availability checks",
     "machine_learning_availability_checks_timeout": "Request timeout",
     "machine_learning_availability_checks_timeout_description": "Timeout in milliseconds for availability checks",
+    "machine_learning_clip_max_distance": "Max search distance",
+    "machine_learning_clip_max_distance_description": "Maximum cosine distance for smart search results. Lower values return fewer but more relevant results. Values below 0.3 will likely return no results. Set to 0 to disable (default). Recommended: 0.75",
     "machine_learning_clip_model": "CLIP model",
     "machine_learning_clip_model_description": "The name of a CLIP model listed <link>here</link>. Note that you must re-run the 'Smart Search' job for all images upon changing a model.",
     "machine_learning_duplicate_detection": "Duplicate Detection",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -155,7 +155,7 @@
     "machine_learning_availability_checks_timeout": "Request timeout",
     "machine_learning_availability_checks_timeout_description": "Timeout in milliseconds for availability checks",
     "machine_learning_clip_max_distance": "Max search distance",
-    "machine_learning_clip_max_distance_description": "Maximum cosine distance for smart search results. Lower values return fewer but more relevant results. Values below 0.3 will likely return no results. Set to 0 to disable (default). Recommended: 0.75",
+    "machine_learning_clip_max_distance_description": "Maximum cosine distance for smart search results. Lower values return fewer but more relevant results. Small changes may have a large effect due to how CLIP embeddings cluster. Values below 0.3 will likely return no results. Set to 0 to disable (default). Recommended: 0.75",
     "machine_learning_clip_model": "CLIP model",
     "machine_learning_clip_model_description": "The name of a CLIP model listed <link>here</link>. Note that you must re-run the 'Smart Search' job for all images upon changing a model.",
     "machine_learning_duplicate_detection": "Duplicate Detection",

--- a/mobile/openapi/lib/model/clip_config.dart
+++ b/mobile/openapi/lib/model/clip_config.dart
@@ -14,11 +14,18 @@ class CLIPConfig {
   /// Returns a new [CLIPConfig] instance.
   CLIPConfig({
     required this.enabled,
+    required this.maxDistance,
     required this.modelName,
   });
 
   /// Whether the task is enabled
   bool enabled;
+
+  /// Maximum cosine distance for smart search results. 0 = disabled.
+  ///
+  /// Minimum value: 0
+  /// Maximum value: 2
+  double maxDistance;
 
   /// Name of the model to use
   String modelName;
@@ -26,20 +33,23 @@ class CLIPConfig {
   @override
   bool operator ==(Object other) => identical(this, other) || other is CLIPConfig &&
     other.enabled == enabled &&
+    other.maxDistance == maxDistance &&
     other.modelName == modelName;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (enabled.hashCode) +
+    (maxDistance.hashCode) +
     (modelName.hashCode);
 
   @override
-  String toString() => 'CLIPConfig[enabled=$enabled, modelName=$modelName]';
+  String toString() => 'CLIPConfig[enabled=$enabled, maxDistance=$maxDistance, modelName=$modelName]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'enabled'] = this.enabled;
+      json[r'maxDistance'] = this.maxDistance;
       json[r'modelName'] = this.modelName;
     return json;
   }
@@ -54,6 +64,7 @@ class CLIPConfig {
 
       return CLIPConfig(
         enabled: mapValueOfType<bool>(json, r'enabled')!,
+        maxDistance: (mapValueOfType<num>(json, r'maxDistance')!).toDouble(),
         modelName: mapValueOfType<String>(json, r'modelName')!,
       );
     }
@@ -103,6 +114,7 @@ class CLIPConfig {
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
     'enabled',
+    'maxDistance',
     'modelName',
   };
 }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -20498,6 +20498,13 @@
             "description": "Whether the task is enabled",
             "type": "boolean"
           },
+          "maxDistance": {
+            "description": "Maximum cosine distance for smart search results. 0 = disabled.",
+            "format": "double",
+            "maximum": 2,
+            "minimum": 0,
+            "type": "number"
+          },
           "modelName": {
             "description": "Name of the model to use",
             "type": "string"
@@ -20505,6 +20512,7 @@
         },
         "required": [
           "enabled",
+          "maxDistance",
           "modelName"
         ],
         "type": "object"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2842,6 +2842,8 @@ export type MachineLearningAvailabilityChecksDto = {
 export type ClipConfig = {
     /** Whether the task is enabled */
     enabled: boolean;
+    /** Maximum cosine distance for smart search results. 0 = disabled. */
+    maxDistance: number;
     /** Name of the model to use */
     modelName: string;
 };

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -62,6 +62,7 @@ export type SystemConfig = {
     clip: {
       enabled: boolean;
       modelName: string;
+      maxDistance: number;
     };
     duplicateDetection: {
       enabled: boolean;
@@ -270,6 +271,7 @@ export const defaults = Object.freeze<SystemConfig>({
     clip: {
       enabled: true,
       modelName: 'ViT-B-32__openai',
+      maxDistance: 0,
     },
     duplicateDetection: {
       enabled: true,

--- a/server/src/dtos/model-config.dto.ts
+++ b/server/src/dtos/model-config.dto.ts
@@ -15,7 +15,18 @@ export class ModelConfig extends TaskConfig {
   modelName!: string;
 }
 
-export class CLIPConfig extends ModelConfig {}
+export class CLIPConfig extends ModelConfig {
+  @IsNumber()
+  @Min(0)
+  @Max(2)
+  @Type(() => Number)
+  @ApiProperty({
+    type: 'number',
+    format: 'double',
+    description: 'Maximum cosine distance for smart search results. 0 = disabled.',
+  })
+  maxDistance!: number;
+}
 
 export class DuplicateDetectionConfig extends TaskConfig {
   @IsNumber()

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -135,17 +135,18 @@ from
       and "asset"."ownerId" = any ($5::uuid[])
       and "asset"."isFavorite" = $6
       and "asset"."deletedAt" is null
+      and (smart_search.embedding <=> $7) <= $8
     order by
-      smart_search.embedding <=> $7
+      smart_search.embedding <=> $9
     limit
-      $8
+      $10
   ) as "candidates"
 order by
   "candidates"."fileCreatedAt" desc nulls last
 limit
-  $9
+  $11
 offset
-  $10
+  $12
 commit
 
 -- SearchRepository.searchFaces

--- a/server/src/repositories/machine-learning.repository.spec.ts
+++ b/server/src/repositories/machine-learning.repository.spec.ts
@@ -24,7 +24,7 @@ vi.mock('src/services/storage.service', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-const clipConfig = { modelName: 'ViT-B-32__openai', enabled: true };
+const clipConfig = { modelName: 'ViT-B-32__openai', enabled: true, maxDistance: 0 };
 
 describe(MachineLearningRepository.name, () => {
   let sut: MachineLearningRepository;
@@ -36,7 +36,7 @@ describe(MachineLearningRepository.name, () => {
       enabled: true,
       urls: [mlUrl],
       availabilityChecks: { enabled: false, timeout: 2000, interval: 30_000 },
-      clip: { enabled: true, modelName: 'ViT-B-32__openai' },
+      clip: { enabled: true, modelName: 'ViT-B-32__openai', maxDistance: 0 },
       duplicateDetection: { enabled: true, maxDistance: 0.01 },
       facialRecognition: { enabled: true, modelName: 'buffalo_l', minScore: 0.7, maxDistance: 0.5, minFaces: 1 },
       ocr: {

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -349,6 +349,7 @@ export class SearchRepository {
       throw new Error(`Invalid value for 'size': ${pagination.size}`);
     }
 
+    // Skip threshold when disabled (0) or at max cosine distance (2) since it would filter nothing
     const hasDistanceThreshold = (options.maxDistance ?? 0) > 0 && (options.maxDistance ?? 0) < 2;
 
     return this.db.transaction().execute(async (trx) => {

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -83,6 +83,7 @@ export interface SearchExifOptions {
 export interface SearchEmbeddingOptions {
   embedding: string;
   userIds: string[];
+  maxDistance?: number;
 }
 
 export interface SearchOcrOptions {
@@ -339,6 +340,7 @@ export class SearchRepository {
         userIds: [DummyValue.UUID],
         spacePersonIds: [DummyValue.UUID],
         orderDirection: 'desc',
+        maxDistance: 0.75,
       },
     ],
   })
@@ -347,12 +349,17 @@ export class SearchRepository {
       throw new Error(`Invalid value for 'size': ${pagination.size}`);
     }
 
+    const hasDistanceThreshold = (options.maxDistance ?? 0) > 0 && (options.maxDistance ?? 0) < 2;
+
     return this.db.transaction().execute(async (trx) => {
       await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
 
       const baseQuery = searchAssetBuilder(trx, options)
         .selectAll('asset')
         .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
+        .$if(hasDistanceThreshold, (qb) =>
+          qb.where(sql`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
+        )
         .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
 
       if (options.orderDirection) {

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Kysely, OrderByDirection, Selectable, ShallowDehydrateObject, sql } from 'kysely';
+import { Kysely, OrderByDirection, Selectable, ShallowDehydrateObject, sql, SqlBool } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { randomUUID } from 'node:crypto';
 import { DummyValue, GenerateSql } from 'src/decorators';
@@ -358,7 +358,7 @@ export class SearchRepository {
         .selectAll('asset')
         .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
         .$if(hasDistanceThreshold, (qb) =>
-          qb.where(sql`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
+          qb.where(sql<SqlBool>`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
         )
         .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
 

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -222,6 +222,11 @@ export interface FilterSuggestionsResult {
   hasUnnamedPeople: boolean;
 }
 
+/** Skip threshold when disabled (0), undefined, or at max cosine distance (>= 2) since it would filter nothing */
+export function isActiveDistanceThreshold(maxDistance: number | undefined): boolean {
+  return (maxDistance ?? 0) > 0 && (maxDistance ?? 0) < 2;
+}
+
 @Injectable()
 export class SearchRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
@@ -349,8 +354,7 @@ export class SearchRepository {
       throw new Error(`Invalid value for 'size': ${pagination.size}`);
     }
 
-    // Skip threshold when disabled (0) or at max cosine distance (2) since it would filter nothing
-    const hasDistanceThreshold = (options.maxDistance ?? 0) > 0 && (options.maxDistance ?? 0) < 2;
+    const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);
 
     return this.db.transaction().execute(async (trx) => {
       await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1360,7 +1360,7 @@ describe(isActiveDistanceThreshold.name, () => {
     expect(isActiveDistanceThreshold(0.5)).toBe(true);
   });
 
-  it('should return true for 1.0 (permissive threshold)', () => {
-    expect(isActiveDistanceThreshold(1.0)).toBe(true);
+  it('should return true for 1 (permissive threshold)', () => {
+    expect(isActiveDistanceThreshold(1)).toBe(true);
   });
 });

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { mapAsset } from 'src/dtos/asset-response.dto';
 import { SearchSuggestionType } from 'src/dtos/search.dto';
 import { AssetOrder, AssetType, AssetVisibility } from 'src/enum';
+import { isActiveDistanceThreshold } from 'src/repositories/search.repository';
 import { SearchService } from 'src/services/search.service';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
@@ -833,6 +834,32 @@ describe(SearchService.name, () => {
         expect.objectContaining({ maxDistance: 0 }),
       );
     });
+
+    it('should pass maxDistance 2 from config to repository', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { clip: { maxDistance: 2 } },
+      });
+
+      await sut.searchSmart(authStub.user1, { query: 'test' });
+
+      expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ maxDistance: 2 }),
+      );
+    });
+
+    it('should pass maxDistance with orderDirection when both are set', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { clip: { maxDistance: 0.75 } },
+      });
+
+      await sut.searchSmart(authStub.user1, { query: 'test', order: AssetOrder.Desc });
+
+      expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ maxDistance: 0.75, orderDirection: AssetOrder.Desc }),
+      );
+    });
   });
 
   describe('searchMetadata', () => {
@@ -1293,5 +1320,47 @@ describe(SearchService.name, () => {
         expect.objectContaining({ userIds: [authStub.user1.user.id, partnerId] }),
       );
     });
+  });
+});
+
+describe(isActiveDistanceThreshold.name, () => {
+  it('should return false for undefined', () => {
+    expect(isActiveDistanceThreshold(void 0 as any)).toBe(false);
+  });
+
+  it('should return false for 0 (disabled)', () => {
+    expect(isActiveDistanceThreshold(0)).toBe(false);
+  });
+
+  it('should return false for negative values', () => {
+    expect(isActiveDistanceThreshold(-1)).toBe(false);
+  });
+
+  it('should return false for 2 (max cosine distance, no-op)', () => {
+    expect(isActiveDistanceThreshold(2)).toBe(false);
+  });
+
+  it('should return false for values above 2', () => {
+    expect(isActiveDistanceThreshold(5)).toBe(false);
+  });
+
+  it('should return true for 0.75 (typical threshold)', () => {
+    expect(isActiveDistanceThreshold(0.75)).toBe(true);
+  });
+
+  it('should return true for 0.001 (very small positive)', () => {
+    expect(isActiveDistanceThreshold(0.001)).toBe(true);
+  });
+
+  it('should return true for 1.99 (just under boundary)', () => {
+    expect(isActiveDistanceThreshold(1.99)).toBe(true);
+  });
+
+  it('should return true for 0.5 (strict threshold)', () => {
+    expect(isActiveDistanceThreshold(0.5)).toBe(true);
+  });
+
+  it('should return true for 1.0 (permissive threshold)', () => {
+    expect(isActiveDistanceThreshold(1.0)).toBe(true);
   });
 });

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -606,7 +606,7 @@ describe(SearchService.name, () => {
       );
       expect(mocks.search.searchSmart).toHaveBeenCalledWith(
         { page: 1, size: 100 },
-        { query: 'test', embedding: '[1, 2, 3]', userIds: [authStub.user1.user.id] },
+        { query: 'test', embedding: '[1, 2, 3]', userIds: [authStub.user1.user.id], maxDistance: 0 },
       );
     });
 
@@ -793,6 +793,44 @@ describe(SearchService.name, () => {
       expect(mocks.search.searchSmart).toHaveBeenCalledWith(
         { page: 1, size: 100 },
         expect.objectContaining({ orderDirection: undefined }),
+      );
+    });
+
+    it('should pass maxDistance from config to repository', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { clip: { maxDistance: 0.75 } },
+      });
+
+      await sut.searchSmart(authStub.user1, { query: 'test' });
+
+      expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ maxDistance: 0.75 }),
+      );
+    });
+
+    it('should pass maxDistance from config when using queryAssetId', async () => {
+      const assetId = newUuid();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.search.getEmbedding.mockResolvedValue('[4, 5, 6]');
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { clip: { maxDistance: 0.75 } },
+      });
+
+      await sut.searchSmart(authStub.user1, { queryAssetId: assetId });
+
+      expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ maxDistance: 0.75 }),
+      );
+    });
+
+    it('should pass maxDistance 0 (disabled) by default', async () => {
+      await sut.searchSmart(authStub.user1, { query: 'test' });
+
+      expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ maxDistance: 0 }),
       );
     });
   });

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -162,7 +162,13 @@ export class SearchService extends BaseService {
     const size = dto.size || 100;
     const { hasNextPage, items } = await this.searchRepository.searchSmart(
       { page, size },
-      { ...dto, userIds: await userIds, embedding, orderDirection: dto.order, maxDistance: machineLearning.clip.maxDistance },
+      {
+        ...dto,
+        userIds: await userIds,
+        embedding,
+        orderDirection: dto.order,
+        maxDistance: machineLearning.clip.maxDistance,
+      },
     );
 
     return this.mapResponse(items, hasNextPage ? (page + 1).toString() : null, { auth });

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -162,7 +162,7 @@ export class SearchService extends BaseService {
     const size = dto.size || 100;
     const { hasNextPage, items } = await this.searchRepository.searchSmart(
       { page, size },
-      { ...dto, userIds: await userIds, embedding, orderDirection: dto.order },
+      { ...dto, userIds: await userIds, embedding, orderDirection: dto.order, maxDistance: machineLearning.clip.maxDistance },
     );
 
     return this.mapResponse(items, hasNextPage ? (page + 1).toString() : null, { auth });

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -95,6 +95,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     clip: {
       enabled: true,
       modelName: 'ViT-B-32__openai',
+      maxDistance: 0,
     },
     duplicateDetection: {
       enabled: true,

--- a/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
+++ b/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
@@ -142,6 +142,18 @@
               </p>
             {/snippet}
           </SettingInputField>
+
+          <SettingInputField
+            inputType={SettingInputFieldType.NUMBER}
+            label={$t('admin.machine_learning_clip_max_distance')}
+            description={$t('admin.machine_learning_clip_max_distance_description')}
+            bind:value={configToEdit.machineLearning.clip.maxDistance}
+            step="0.05"
+            min={0}
+            max={2}
+            disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}
+            isEdited={configToEdit.machineLearning.clip.maxDistance !== config.machineLearning.clip.maxDistance}
+          />
         </div>
       </SettingAccordion>
 


### PR DESCRIPTION
## Summary

- Adds `machineLearning.clip.maxDistance` config to filter low-relevance CLIP search results
- Opt-in (default `0` = disabled), configurable via admin UI and YAML config file
- When set, adds a `WHERE (embedding <=> query) <= maxDistance` clause to `searchSmart()`, excluding results with cosine distance above the threshold
- Fixes issue where combining text search with metadata filters (e.g., "Forest" + country="Qatar") returned irrelevant photos

Closes #290

## Changes

- **Config**: `maxDistance: number` in `machineLearning.clip` (default 0)
- **DTO**: Validation on `CLIPConfig` (min 0, max 2)
- **Repository**: `.$if(hasDistanceThreshold)` WHERE clause in `searchSmart()`
- **Service**: Pass `clip.maxDistance` from config to repository
- **Admin UI**: Number input in Smart Search settings accordion
- **Docs**: Config file reference + searching guide with threshold value table
- **Tests**: 3 new service tests + updated existing assertions

## Test plan

- [x] Server unit tests pass (384 tests)
- [x] Server type check clean (`tsc --noEmit`)
- [x] Web type check clean (`svelte-check`)
- [x] OpenAPI + SQL regenerated
- [ ] CI passes
- [ ] Manual test: search "Forest" with location filter, verify irrelevant results excluded when maxDistance set to 0.75

🤖 Generated with [Claude Code](https://claude.com/claude-code)