### PR TITLE
fix: clean up orphaned space persons after face recognition reset

### DIFF
--- a/docs/plans/2026-04-07-space-person-orphan-cleanup-design.md
+++ b/docs/plans/2026-04-07-space-person-orphan-cleanup-design.md
@@ -1,0 +1,105 @@
+# Fix Space Person Orphans After Face Recognition Reset
+
+## Problem
+
+Resetting face recognition (`force=true`) deletes all `asset_face` rows, which cascade-deletes
+all `shared_space_person_face` junction rows (`ON DELETE CASCADE` on `assetFaceId`) and sets
+`shared_space_person.representativeFaceId` to NULL (`ON DELETE SET NULL`). But `shared_space_person`
+records survive as orphans — zero junction rows, NULL representative face.
+
+When face detection re-runs, new space persons are created alongside the old orphans, causing
+duplicates. The dedup job (`handleSharedSpacePersonDedup`) can't clean them up because it INNER
+JOINs on `face_search` via `representativeFaceId` — orphans with NULL are invisible.
+
+`deleteOrphanedPersons(spaceId)` already exists in `SharedSpaceRepository` but is only called from
+the asset-removal flow.
+
+## Approach
+
+Two-pronged fix: proactive cleanup during face reset + safety net in the dedup job.
+
+## Changes
+
+### 1. New repo method: `deleteAllOrphanedPersons()`
+
+File: `server/src/repositories/shared-space.repository.ts`
+
+Cross-space cleanup — deletes any `shared_space_person` with zero junction rows:
+
+```sql
+DELETE FROM shared_space_person
+WHERE id NOT IN (SELECT personId FROM shared_space_person_face)
+```
+
+Decorated with `@GenerateSql` for SQL query file generation.
+
+This is safe because:
+
+- `personId` in `shared_space_person_face` is a non-nullable PK column — no NULL-in-NOT-IN gotcha
+- If the junction table is empty (full reset), `NOT IN (empty set)` evaluates to TRUE for all rows,
+  correctly deleting all space persons
+- A space person with even one junction row is preserved
+
+### 2. Proactive cleanup in face reset
+
+File: `server/src/services/person.service.ts`
+
+Called in the `force` block of `handleQueueDetectFaces`, after `handlePersonCleanup()` and before
+`vacuum()` (groups cleanup operations together before the expensive reindex):
+
+```typescript
+if (force) {
+  await this.personRepository.deleteFaces({ sourceType: SourceType.MachineLearning });
+  await this.handlePersonCleanup();
+  await this.sharedSpaceRepository.deleteAllOrphanedPersons(); // NEW
+  await this.personRepository.vacuum({ reindexVectors: true });
+}
+```
+
+### 3. Safety net in dedup job
+
+File: `server/src/services/shared-space.service.ts`
+
+At the end of `handleSharedSpacePersonDedup`, after the merge loop and final log, before the return:
+
+```typescript
+await this.sharedSpaceRepository.deleteOrphanedPersons(job.spaceId);
+```
+
+Uses the existing per-space method. Catches orphans regardless of how they were created.
+
+## Assumptions
+
+- BullMQ processes jobs in FIFO order within `QueueName.FacialRecognition`, so the dedup job runs
+  after all face match jobs for that space complete. The orphan cleanup is idempotent — worst case a
+  space person is deleted and immediately recreated on the next face match.
+- No denormalized person count exists on the space table (verified — only `faceCount`/`assetCount`
+  on the space person itself, which are deleted with the orphan row).
+
+## What this does NOT do
+
+- Does not handle `handleQueueRecognizeFaces(force=true)` — that path unassigns faces
+  (`personId=null`) rather than deleting them, so junction rows survive and no orphans are created.
+  Space persons whose representative face pointed at a now-deleted global person become invisible in
+  the UI via the LEFT JOIN chain, but that is a separate concern.
+- Does not add DB-level constraints or triggers.
+- Does not change the dedup algorithm itself.
+- Does not change `getPersonsBySpaceId` (orphans are already filtered out because the LEFT JOIN
+  chain produces NULLs when `representativeFaceId` is NULL, failing the `person.thumbnailPath IS NOT
+NULL` filter).
+
+## Testing
+
+1. Unit test: `handleQueueDetectFaces` with `force=true` calls `deleteAllOrphanedPersons`
+2. Unit test: `handleQueueDetectFaces` without `force` does NOT call `deleteAllOrphanedPersons`
+3. Unit test: `handleSharedSpacePersonDedup` calls `deleteOrphanedPersons(spaceId)` after merge
+   loop — including when zero merges happen
+4. Regenerate SQL query files (`make sql`)
+
+## Files changed
+
+1. `server/src/repositories/shared-space.repository.ts` — new `deleteAllOrphanedPersons()`
+2. `server/src/services/person.service.ts` — call in force block
+3. `server/src/services/shared-space.service.ts` — call at end of dedup
+4. `server/src/services/person.service.spec.ts` — new unit tests
+5. `server/src/services/shared-space.service.spec.ts` — new unit test

--- a/docs/plans/2026-04-07-space-person-orphan-cleanup.md
+++ b/docs/plans/2026-04-07-space-person-orphan-cleanup.md
@@ -1,0 +1,249 @@
+# Space Person Orphan Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Clean up orphaned space persons after face recognition reset and as a safety net in the dedup job.
+
+**Architecture:** Add `deleteAllOrphanedPersons()` repo method (cross-space), call it proactively from the face detection reset path, and call `deleteOrphanedPersons(spaceId)` at the end of every dedup job run.
+
+**Tech Stack:** NestJS, Kysely, Vitest
+
+---
+
+### Task 1: Add `deleteAllOrphanedPersons()` to SharedSpaceRepository
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts` (near existing `deleteOrphanedPersons` at line 668)
+
+**Step 1: Add the method**
+
+Add directly after the existing `deleteOrphanedPersons` method (line 675):
+
+```typescript
+@GenerateSql({})
+async deleteAllOrphanedPersons() {
+  await this.db
+    .deleteFrom('shared_space_person')
+    .where('id', 'not in', this.db.selectFrom('shared_space_person_face').select('personId'))
+    .execute();
+}
+```
+
+**Step 2: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors related to `deleteAllOrphanedPersons`
+
+**Step 3: Commit**
+
+```
+fix: add deleteAllOrphanedPersons repo method for cross-space orphan cleanup
+```
+
+---
+
+### Task 2: Call `deleteAllOrphanedPersons` from face detection reset
+
+**Files:**
+
+- Modify: `server/src/services/person.service.ts:277-281` (the `force` block in `handleQueueDetectFaces`)
+
+**Step 1: Add the cleanup call**
+
+Change the force block from:
+
+```typescript
+if (force) {
+  await this.personRepository.deleteFaces({ sourceType: SourceType.MachineLearning });
+  await this.handlePersonCleanup();
+  await this.personRepository.vacuum({ reindexVectors: true });
+}
+```
+
+To:
+
+```typescript
+if (force) {
+  await this.personRepository.deleteFaces({ sourceType: SourceType.MachineLearning });
+  await this.handlePersonCleanup();
+  await this.sharedSpaceRepository.deleteAllOrphanedPersons();
+  await this.personRepository.vacuum({ reindexVectors: true });
+}
+```
+
+**Step 2: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```
+fix: clean up orphaned space persons during face detection reset
+```
+
+---
+
+### Task 3: Add unit tests for face detection reset orphan cleanup
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts` (in the `handleQueueDetectFaces` describe block, around line 527)
+
+**Step 1: Add assertion to the existing force=true test**
+
+In the test `'should queue all assets'` (line 504), after the existing assertions at line 515, add:
+
+```typescript
+expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalled();
+```
+
+**Step 2: Add assertion to the second force=true test**
+
+In the test `'should delete existing people and faces if forced'` (line 549), after the existing assertions around line 569, add:
+
+```typescript
+expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalled();
+```
+
+**Step 3: Add assertion to the force=undefined test**
+
+In the test `'should refresh all assets'` (line 529), after the existing `not.toHaveBeenCalled` assertions around line 538, add:
+
+```typescript
+expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
+```
+
+**Step 4: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/person.service.spec.ts`
+Expected: All tests pass
+
+**Step 5: Commit**
+
+```
+test: verify orphan cleanup during face detection reset
+```
+
+---
+
+### Task 4: Add `deleteOrphanedPersons` call to dedup job
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.ts:1011-1014` (end of `handleSharedSpacePersonDedup`)
+
+**Step 1: Add orphan cleanup before the return**
+
+Change from:
+
+```typescript
+this.logger.log(
+  `Dedup finished for space ${job.spaceId}: ${totalMerges} total merges across ${pass} pass${pass === 1 ? '' : 'es'}`,
+);
+return JobStatus.Success;
+```
+
+To:
+
+```typescript
+// Clean up orphaned persons (no faces linked) as safety net
+await this.sharedSpaceRepository.deleteOrphanedPersons(job.spaceId);
+
+this.logger.log(
+  `Dedup finished for space ${job.spaceId}: ${totalMerges} total merges across ${pass} pass${pass === 1 ? '' : 'es'}`,
+);
+return JobStatus.Success;
+```
+
+**Step 2: Verify types compile**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```
+fix: clean up orphaned space persons at end of dedup job
+```
+
+---
+
+### Task 5: Add unit tests for dedup orphan cleanup
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.spec.ts` (in the `handleSharedSpacePersonDedup` describe block, before the closing `});` at line 4925)
+
+**Step 1: Add test for orphan cleanup after zero merges**
+
+Add before line 4925:
+
+```typescript
+it('should clean up orphaned persons even with no merges', async () => {
+  const spaceId = newUuid();
+  mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+  mocks.sharedSpace.getSpacePersonsWithEmbeddings.mockResolvedValue([]);
+  mocks.sharedSpace.deleteOrphanedPersons.mockResolvedValue(void 0 as any);
+
+  const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
+});
+```
+
+**Step 2: Add assertion to an existing merge test**
+
+In the test `'should merge two people of the same type when embedding match found'` (line 4610), add the mock setup in the test body and an assertion at the end:
+
+After `mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);` (line 4638), add:
+
+```typescript
+mocks.sharedSpace.deleteOrphanedPersons.mockResolvedValue(void 0 as any);
+```
+
+After `expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([personA]);` (around line 4644), add:
+
+```typescript
+expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
+```
+
+**Step 3: Run tests**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```
+test: verify orphan cleanup in dedup job
+```
+
+---
+
+### Task 6: Regenerate SQL query files and final verification
+
+**Step 1: Rebuild server and regenerate SQL**
+
+This requires the dev DB to be running. If it is:
+
+Run: `cd server && pnpm build && make -C .. sql`
+
+If the DB is not running, apply the SQL diff manually by adding the query for `deleteAllOrphanedPersons` to `server/src/queries/shared.space.repository.sql`.
+
+**Step 2: Run full test suite**
+
+Run: `cd server && pnpm test -- --run`
+Expected: All tests pass
+
+**Step 3: Run type checks**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit SQL query files**
+
+```
+chore: regenerate SQL query files
+```

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -511,6 +511,16 @@ where
       "shared_space_person_face"
   )
 
+-- SharedSpaceRepository.deleteAllOrphanedPersons
+delete from "shared_space_person"
+where
+  "id" not in (
+    select
+      "personId"
+    from
+      "shared_space_person_face"
+  )
+
 -- SharedSpaceRepository.recountPersons
 update "shared_space_person"
 set

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -674,6 +674,14 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [] })
+  async deleteAllOrphanedPersons() {
+    await this.db
+      .deleteFrom('shared_space_person')
+      .where('id', 'not in', this.db.selectFrom('shared_space_person_face').select('personId'))
+      .execute();
+  }
+
   @GenerateSql({ params: [[DummyValue.UUID]] })
   async recountPersons(personIds: string[]) {
     if (personIds.length === 0) {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -507,11 +507,13 @@ describe(PersonService.name, () => {
 
       mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
       mocks.person.getAllWithoutFaces.mockResolvedValue([person]);
+      mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
 
       await sut.handleQueueDetectFaces({ force: true });
 
       expect(mocks.person.deleteFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
       expect(mocks.person.delete).toHaveBeenCalledWith([person.id]);
+      expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalled();
       expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: true });
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
@@ -535,6 +537,7 @@ describe(PersonService.name, () => {
       expect(mocks.person.delete).not.toHaveBeenCalled();
       expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
       expect(mocks.person.vacuum).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
       expect(mocks.storage.unlink).not.toHaveBeenCalled();
       expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(undefined);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
@@ -556,6 +559,7 @@ describe(PersonService.name, () => {
       mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
       mocks.person.getAllWithoutFaces.mockResolvedValue([person]);
       mocks.person.deleteFaces.mockResolvedValue();
+      mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
 
       await sut.handleQueueDetectFaces({ force: true });
 
@@ -567,6 +571,7 @@ describe(PersonService.name, () => {
         },
       ]);
       expect(mocks.person.delete).toHaveBeenCalledWith([person.id]);
+      expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
         data: { files: [person.thumbnailPath] },

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -277,6 +277,7 @@ export class PersonService extends BaseService {
     if (force) {
       await this.personRepository.deleteFaces({ sourceType: SourceType.MachineLearning });
       await this.handlePersonCleanup();
+      await this.sharedSpaceRepository.deleteAllOrphanedPersons();
       await this.personRepository.vacuum({ reindexVectors: true });
     }
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -4583,6 +4583,7 @@ describe(SharedSpaceService.name, () => {
   describe('handleSharedSpacePersonDedup', () => {
     beforeEach(() => {
       mocks.sharedSpace.recountPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteOrphanedPersons.mockResolvedValue(void 0 as any);
     });
 
     it('should skip when space does not exist', async () => {
@@ -4642,6 +4643,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.reassignPersonFacesSafe).toHaveBeenCalledWith(personB, personA);
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith(personB);
       expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([personA]);
+      expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
     });
 
     it('should succeed with no merges when space has one person (self-exclusion)', async () => {
@@ -4921,6 +4923,16 @@ describe(SharedSpaceService.name, () => {
       expect(result).toBe(JobStatus.Success);
       // Should have been called many times but eventually stopped
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalled();
+    });
+
+    it('should clean up orphaned persons even with no merges', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getSpacePersonsWithEmbeddings.mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
     });
   });
 

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1008,6 +1008,9 @@ export class SharedSpaceService extends BaseService {
       this.logger.log(`Dedup pass ${pass} complete: ${passMerges} merges`);
     }
 
+    // Clean up orphaned persons (no faces linked) as safety net
+    await this.sharedSpaceRepository.deleteOrphanedPersons(job.spaceId);
+
     this.logger.log(
       `Dedup finished for space ${job.spaceId}: ${totalMerges} total merges across ${pass} pass${pass === 1 ? '' : 'es'}`,
     );


### PR DESCRIPTION
## Summary
- Add `deleteAllOrphanedPersons()` repo method that removes space persons with zero junction rows across all spaces
- Call it proactively from the face detection reset path (`handleQueueDetectFaces` with `force=true`) so orphans are cleaned up immediately after the cascade deletes their face links
- Call `deleteOrphanedPersons(spaceId)` as a safety net at the end of every dedup job run

Fixes #289

## Context
When a user resets face recognition, all `asset_face` rows are deleted. This cascades to delete `shared_space_person_face` junction rows and sets `representativeFaceId` to NULL, but `shared_space_person` records survive as orphans. The dedup job can't see them (INNER JOIN on face_search skips NULL representative faces), so they persist indefinitely. When face detection re-runs, new space persons are created alongside the old orphans, causing duplicates.

## Test plan
- [x] Unit tests: `handleQueueDetectFaces` with `force=true` calls `deleteAllOrphanedPersons`
- [x] Unit tests: `handleQueueDetectFaces` without `force` does NOT call it
- [x] Unit tests: `handleSharedSpacePersonDedup` calls `deleteOrphanedPersons(spaceId)` after merge loop — including with zero merges
- [x] Full test suite: 3752 passed, 0 failures
- [x] SQL query files need regeneration (CI will flag this)