### PR TITLE
fix: iOS branding, Fastlane config, and CI build workflow

### DIFF
--- a/.github/actions/apply-branding/action.yml
+++ b/.github/actions/apply-branding/action.yml
@@ -16,7 +16,11 @@ runs:
       shell: bash
       run: |
         if ! command -v jq &>/dev/null; then
-          sudo apt-get update && sudo apt-get install -y jq
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install jq
+          else
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
         fi
 
     - name: Apply branding overlay

--- a/.github/actions/apply-branding/action.yml
+++ b/.github/actions/apply-branding/action.yml
@@ -12,13 +12,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install jq
+    - name: Install dependencies
       shell: bash
       run: |
-        if ! command -v jq &>/dev/null; then
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
-            brew install jq
-          else
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          brew install jq coreutils gnu-sed 2>/dev/null || true
+        else
+          if ! command -v jq &>/dev/null; then
             sudo apt-get update && sudo apt-get install -y jq
           fi
         fi
@@ -28,7 +28,11 @@ runs:
       env:
         FORK_VERSION: ${{ inputs.version }}
         BUILD_NUMBER: ${{ inputs.build_number }}
-      run: ./branding/scripts/apply-branding.sh
+      run: |
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+        fi
+        ./branding/scripts/apply-branding.sh
 
     - name: Verify branding applied
       shell: bash

--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -1,6 +1,16 @@
 name: Gallery Build Mobile
 
 on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'development'
+        type: choice
+        options:
+          - development
+          - production
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -1,0 +1,261 @@
+name: Gallery Build Mobile
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'development'
+        type: string
+    secrets:
+      KEY_JKS:
+        required: true
+      ALIAS:
+        required: true
+      ANDROID_KEY_PASSWORD:
+        required: true
+      ANDROID_STORE_PASSWORD:
+        required: true
+      APP_STORE_CONNECT_API_KEY_ID:
+        required: true
+      APP_STORE_CONNECT_API_KEY_ISSUER_ID:
+        required: true
+      APP_STORE_CONNECT_API_KEY:
+        required: true
+      IOS_CERTIFICATE_P12:
+        required: true
+      IOS_CERTIFICATE_PASSWORD:
+        required: true
+      FASTLANE_TEAM_ID:
+        required: true
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/gallery-build-mobile.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/gallery-build-mobile.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-sign-android:
+    name: Build and sign Android
+    permissions:
+      contents: read
+    # Skip when PR from a fork
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    runs-on: mich
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+          token: ${{ github.token }}
+
+      - uses: ./.github/actions/apply-branding
+
+      - name: Create the Keystore
+        env:
+          KEY_JKS: ${{ secrets.KEY_JKS }}
+        working-directory: ./mobile
+        run: printf "%s" $KEY_JKS | base64 -d > android/key.jks
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Restore Gradle Cache
+        id: cache-gradle-restore
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/sdk
+            mobile/android/.gradle
+            mobile/.dart_tool
+          key: build-mobile-gradle-${{ runner.os }}-main
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: 'stable'
+          flutter-version-file: ./mobile/pubspec.yaml
+          cache: true
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        with:
+          packages: ''
+
+      - name: Get Packages
+        working-directory: ./mobile
+        run: flutter pub get
+
+      - name: Generate translation file
+        run: dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
+        working-directory: ./mobile
+
+      - name: Generate platform APIs
+        run: make pigeon
+        working-directory: ./mobile
+
+      - name: Build Android App Bundle
+        working-directory: ./mobile
+        env:
+          ALIAS: ${{ secrets.ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          if [[ $IS_MAIN == 'true' ]]; then
+            flutter build apk --release
+            flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64
+          else
+            flutter build apk --debug --split-per-abi --target-platform android-arm64
+          fi
+
+      - name: Publish Android Artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: release-apk-signed
+          path: mobile/build/app/outputs/flutter-apk/*.apk
+
+      - name: Save Gradle Cache
+        id: cache-gradle-save
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        if: github.ref == 'refs/heads/main'
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/sdk
+            mobile/android/.gradle
+            mobile/.dart_tool
+          key: ${{ steps.cache-gradle-restore.outputs.cache-primary-key }}
+
+  build-sign-ios:
+    name: Build and sign iOS
+    permissions:
+      contents: read
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: macos-15
+
+    steps:
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/apply-branding
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: 'stable'
+          flutter-version-file: ./mobile/pubspec.yaml
+          cache: true
+
+      - name: Install Flutter dependencies
+        working-directory: ./mobile
+        run: flutter pub get
+
+      - name: Generate translation files
+        run: dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
+        working-directory: ./mobile
+
+      - name: Generate platform APIs
+        run: make pigeon
+        working-directory: ./mobile
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ./mobile/ios
+
+      - name: Install CocoaPods dependencies
+        working-directory: ./mobile/ios
+        run: pod install
+
+      - name: Create API Key
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        working-directory: ./mobile/ios
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$API_KEY_CONTENT" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8
+
+      - name: Import Certificate
+        env:
+          IOS_CERTIFICATE_P12: ${{ secrets.IOS_CERTIFICATE_P12 }}
+        working-directory: ./mobile/ios
+        run: echo "$IOS_CERTIFICATE_P12" | base64 --decode > certificate.p12
+
+      - name: Create keychain and import certificate
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+        working-directory: ./mobile/ios
+        run: |
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import certificate.p12 -k build.keychain -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          security find-identity -v -p codesigning build.keychain
+
+      - name: Build and deploy to TestFlight
+        env:
+          FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_NAME: build.keychain
+          KEYCHAIN_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          ENVIRONMENT: ${{ inputs.environment || 'development' }}
+          GITHUB_REF: ${{ github.ref }}
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 6
+        working-directory: ./mobile/ios
+        run: |
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            if [[ "$ENVIRONMENT" == "development" ]]; then
+              bundle exec fastlane gha_testflight_dev
+            else
+              bundle exec fastlane gha_release_prod
+            fi
+          else
+            bundle exec fastlane gha_build_only
+          fi
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain build.keychain || true
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ios-release-ipa
+          path: mobile/ios/Runner.ipa

--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -66,7 +66,7 @@ jobs:
     # Skip when PR from a fork
     if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     environment: mobile-build
-    runs-on: mich
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -241,6 +241,7 @@ jobs:
           security find-identity -v -p codesigning build.keychain
 
       - name: Build and deploy to TestFlight
+        if: github.ref == 'refs/heads/main'
         env:
           FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
@@ -248,21 +249,17 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          ENVIRONMENT: ${{ inputs.environment || 'development' }}
-          GITHUB_REF: ${{ github.ref }}
+          ENVIRONMENT: ${{ inputs.environment || 'production' }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 6
         working-directory: ./mobile/ios
+        run: bundle exec fastlane gha_release_prod
+
+      - name: Build iOS (no upload)
+        if: github.ref != 'refs/heads/main'
+        working-directory: ./mobile
         run: |
-          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
-            if [[ "$ENVIRONMENT" == "development" ]]; then
-              bundle exec fastlane gha_testflight_dev
-            else
-              bundle exec fastlane gha_release_prod
-            fi
-          else
-            bundle exec fastlane gha_build_only
-          fi
+          flutter build ipa --no-codesign
 
       - name: Clean up keychain
         if: always()

--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -73,6 +73,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
           token: ${{ github.token }}
+          fetch-tags: true
 
       - uses: ./.github/actions/apply-branding
 
@@ -173,6 +174,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
+          fetch-tags: true
 
       - uses: ./.github/actions/apply-branding
 

--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -65,6 +65,7 @@ jobs:
       contents: read
     # Skip when PR from a fork
     if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    environment: mobile-build
     runs-on: mich
 
     steps:
@@ -163,6 +164,7 @@ jobs:
     permissions:
       contents: read
     if: ${{ !github.event.pull_request.head.repo.fork }}
+    environment: mobile-build
     runs-on: macos-15
 
     steps:

--- a/branding/config.json
+++ b/branding/config.json
@@ -29,7 +29,8 @@
     "oauth_callback": "de.opennoodle.gallery:///oauth-callback",
     "shared_group": "group.de.opennoodle.gallery.share",
     "download_dir": "DCIM/NoodleGallery",
-    "background_task_prefix": "de.opennoodle.gallery.background"
+    "background_task_prefix": "de.opennoodle.gallery.background",
+    "apple_team_id": "77MWNP37MV"
   },
 
   "docker": {

--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -19,6 +19,7 @@ BUNDLE_ID_PROFILE=$(jq -r '.mobile.bundle_id_profile' "$CONFIG")
 DEEP_LINK_SCHEME=$(jq -r '.mobile.deep_link_scheme' "$CONFIG")
 SHARED_GROUP=$(jq -r '.mobile.shared_group' "$CONFIG")
 BG_TASK_PREFIX=$(jq -r '.mobile.background_task_prefix' "$CONFIG")
+APPLE_TEAM_ID=$(jq -r '.mobile.apple_team_id' "$CONFIG")
 
 # Repository
 REPO_NAME=$(jq -r '.repository.name' "$CONFIG")
@@ -328,6 +329,11 @@ patch_ios() {
   sed -i "s/PRODUCT_NAME = \"Immich-Profile\"/PRODUCT_NAME = \"${NAME}-Profile\"/g" "$pbxproj"
   sed -i "s/PRODUCT_NAME = Immich/PRODUCT_NAME = \"${NAME}\"/g" "$pbxproj"
 
+  # project.pbxproj — development team
+  if [[ -n "${APPLE_TEAM_ID:-}" && "$APPLE_TEAM_ID" != "null" ]]; then
+    sed -i "s/DEVELOPMENT_TEAM = [A-Z0-9]*;/DEVELOPMENT_TEAM = ${APPLE_TEAM_ID};/g" "$pbxproj"
+  fi
+
   # Info.plist — bundle name
   sed -i "s|<string>immich_mobile</string>|<string>${NAME_SLUG}</string>|g" "$info_plist"
 
@@ -339,15 +345,29 @@ patch_ios() {
   sed -i "s/app\.alextran\.immich\.backgroundFetch/${BUNDLE_ID}.backgroundFetch/g" "$info_plist"
   sed -i "s/app\.alextran\.immich\.backgroundProcessing/${BUNDLE_ID}.backgroundProcessing/g" "$info_plist"
 
-  # Shared app group
+  # Shared app group — patch entitlements in all targets
   local entitlements
-  for entitlements in "$REPO_ROOT"/mobile/ios/Runner/*.entitlements; do
+  for entitlements in "$REPO_ROOT"/mobile/ios/Runner/*.entitlements \
+                      "$REPO_ROOT"/mobile/ios/ShareExtension/*.entitlements \
+                      "$REPO_ROOT"/mobile/ios/WidgetExtension/*.entitlements; do
     if [[ -f "$entitlements" ]]; then
       sed -i "s/group\.app\.immich\.share/${SHARED_GROUP}/g" "$entitlements"
     fi
   done
 
-  echo "  Patched project.pbxproj, Info.plist, and entitlements"
+  # Shared app group in project.pbxproj (CUSTOM_GROUP_ID)
+  sed -i "s/group\.app\.immich\.share/${SHARED_GROUP}/g" "$pbxproj"
+
+  # Hardcoded app group in Swift source files
+  local swift_file
+  for swift_file in "$REPO_ROOT/mobile/ios/Runner/Core/URLSessionManager.swift" \
+                    "$REPO_ROOT/mobile/ios/WidgetExtension/ImmichAPI.swift"; do
+    if [[ -f "$swift_file" ]]; then
+      sed -i "s/group\.app\.immich\.share/${SHARED_GROUP}/g" "$swift_file"
+    fi
+  done
+
+  echo "  Patched project.pbxproj, Info.plist, entitlements, and Swift sources"
 }
 
 #

--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -42,7 +42,8 @@ DOCS_URL=$(jq -r '.docs.url' "$CONFIG")
 if [[ -n "${FORK_VERSION:-}" ]]; then
   FORK_VERSION="${FORK_VERSION#v}"
 else
-  FORK_VERSION=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+  FORK_VERSION=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || { git -C "$REPO_ROOT" tag -l 'v*.*.*' --sort=-v:refname 2>/dev/null | head -1; })
+  FORK_VERSION="${FORK_VERSION#v}"
 fi
 
 echo "=== Applying branding: $NAME ==="

--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -367,7 +367,22 @@ patch_ios() {
     fi
   done
 
-  echo "  Patched project.pbxproj, Info.plist, entitlements, and Swift sources"
+  # Fastlane — Appfile
+  local appfile="$REPO_ROOT/mobile/ios/fastlane/Appfile"
+  if [[ -f "$appfile" ]]; then
+    sed -i "s/app_identifier \"app\.alextran\.immich\"/app_identifier \"${BUNDLE_ID}\"/g" "$appfile"
+    sed -i "/apple_id/d" "$appfile"
+  fi
+
+  # Fastlane — Fastfile constants
+  local fastfile="$REPO_ROOT/mobile/ios/fastlane/Fastfile"
+  if [[ -f "$fastfile" ]]; then
+    sed -i "s/TEAM_ID = \"2F67MQ8R79\"/TEAM_ID = ENV[\"FASTLANE_TEAM_ID\"] || \"${APPLE_TEAM_ID}\"/g" "$fastfile"
+    sed -i "s/CODE_SIGN_IDENTITY = \"Apple Distribution: Hau Tran (#{TEAM_ID})\"/CODE_SIGN_IDENTITY = \"Apple Distribution: David Pierre Marais (#{TEAM_ID})\"/g" "$fastfile"
+    sed -i "s/BASE_BUNDLE_ID = \"app\.alextran\.immich\"/BASE_BUNDLE_ID = \"${BUNDLE_ID}\"/g" "$fastfile"
+  fi
+
+  echo "  Patched project.pbxproj, Info.plist, entitlements, Swift sources, and Fastlane"
 }
 
 #

--- a/mobile/ios/fastlane/Appfile
+++ b/mobile/ios/fastlane/Appfile
@@ -1,6 +1,4 @@
-app_identifier "app.alextran.immich" # The bundle identifier of your app
-apple_id "alex.tran1502@gmail.com" # Your Apple email address
-
+app_identifier "de.opennoodle.gallery" # The bundle identifier of your app
 
 # For more information about the Appfile, see:
 #     https://docs.fastlane.tools/advanced/#appfile

--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -17,9 +17,9 @@ default_platform(:ios)
 
 platform :ios do
   # Constants
-  TEAM_ID = "2F67MQ8R79"
-  CODE_SIGN_IDENTITY = "Apple Distribution: Hau Tran (#{TEAM_ID})"
-  BASE_BUNDLE_ID = "app.alextran.immich"
+  TEAM_ID = ENV["FASTLANE_TEAM_ID"] || "77MWNP37MV"
+  CODE_SIGN_IDENTITY = "Apple Distribution: David Pierre Marais (#{TEAM_ID})"
+  BASE_BUNDLE_ID = "de.opennoodle.gallery"
   
   # Helper method to get App Store Connect API key
   def get_api_key


### PR DESCRIPTION
## Summary
- Add `apple_team_id` to branding config, patch DEVELOPMENT_TEAM in pbxproj
- Patch entitlements for all targets (Runner, ShareExtension, WidgetExtension)
- Patch hardcoded app group in Swift source files and Fastlane config
- Add fork-only `gallery-build-mobile.yml` workflow (avoids upstream conflicts)
- Fix apply-branding action for macOS runners (GNU tools, shallow clone)
- Non-main builds use `--no-codesign`, main builds use Fastlane + TestFlight

Supersedes #299 (cherry-picked onto post-rebase main).

## Test plan
- [x] iOS build passes on macos-15 runner
- [x] Android build passes on ubuntu-latest runner
- [ ] TestFlight upload on merge to main