### PR TITLE
fix: exclude tsbuildinfo from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@
 **/dist/
 **/coverage/
 **/build/
+**/*.tsbuildinfo
 
 design/
 docker/


### PR DESCRIPTION
## Summary
- Add `**/*.tsbuildinfo` to `.dockerignore` to prevent stale incremental TypeScript compilation cache from being copied into Docker builds
- Without this, `nest build` inside Docker skips compilation when it finds a stale `tsbuildinfo` file, resulting in missing `dist/main.js`
- This broke demo Docker builds after the TS6 upgrade

## Test plan
- [ ] Demo site deploys successfully