### PR TITLE
fix: reset auto-classification tags on stricter similarity from config file

### DIFF
--- a/docs/docs/features/auto-classification.md
+++ b/docs/docs/features/auto-classification.md
@@ -144,21 +144,23 @@ job:
 
 When you modify classification categories, Gallery handles changes automatically:
 
-| Change                              | Behavior                                                                                                                                          |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Add a category**                  | New category takes effect on next classification run. Run "Scan All Libraries" to classify existing assets.                                       |
-| **Remove a category**               | Existing `Auto/{name}` tags are cleaned up and affected archived assets are unarchived.                                                           |
-| **Rename a category**               | Old tags are cleaned up (treated as removal + addition). Run scan to re-tag with the new name.                                                    |
-| **Increase similarity (stricter)**  | Existing auto-tags are removed, archived assets are unarchived. The UI prompts to rescan so only assets matching the new threshold get re-tagged. |
-| **Decrease similarity (looser)**    | Takes effect on next classification run. Run scan to find newly-matching assets.                                                                  |
-| **Change prompts**                  | Prompt embedding cache is cleared. New prompts are encoded on next classification run.                                                            |
-| **Change action**                   | Takes effect on next classification run. Changing to `tag_and_archive` does not retroactively archive already-tagged assets — run scan to apply.  |
-| **Disable/enable a category**       | Immediate. Disabled categories are skipped during classification.                                                                                 |
-| **Disable classification globally** | All classification jobs are skipped. No assets are processed until re-enabled.                                                                    |
-| **CLIP model change**               | Embedding cache is automatically cleared. All prompts are re-encoded with the new model on next use.                                              |
+| Change                              | Behavior                                                                                                                                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Add a category**                  | New category takes effect on next classification run. Run "Scan All Libraries" to classify existing assets.                                                                                                                           |
+| **Remove a category**               | Existing `Auto/{name}` tags are cleaned up and affected archived assets are unarchived.                                                                                                                                               |
+| **Rename a category**               | Old tags are cleaned up (treated as removal + addition). Run scan to re-tag with the new name.                                                                                                                                        |
+| **Increase similarity (stricter)**  | Existing auto-tags are removed, archived assets are unarchived. The UI prompts to rescan so only assets matching the new threshold get re-tagged. For config-file admins, this cleanup runs automatically on the next server restart. |
+| **Decrease similarity (looser)**    | Takes effect on next classification run. Run scan to find newly-matching assets.                                                                                                                                                      |
+| **Change prompts**                  | Prompt embedding cache is cleared. New prompts are encoded on next classification run.                                                                                                                                                |
+| **Change action**                   | Takes effect on next classification run. Changing to `tag_and_archive` does not retroactively archive already-tagged assets — run scan to apply.                                                                                      |
+| **Disable/enable a category**       | Immediate. Disabled categories are skipped during classification.                                                                                                                                                                     |
+| **Disable classification globally** | All classification jobs are skipped. No assets are processed until re-enabled.                                                                                                                                                        |
+| **CLIP model change**               | Embedding cache is automatically cleared. All prompts are re-encoded with the new model on next use.                                                                                                                                  |
 
-:::note
-Removing a category unarchives assets that were archived by that category's `tag_and_archive` action. If you independently archived a photo that also happened to be auto-tagged, removing the category will unarchive it.
+:::warning Unarchive side effect
+Cleaning up an `Auto/{name}` tag (whether by removing the category, renaming it, or tightening its similarity) unarchives **every** asset that currently holds that tag — including photos you manually archived for unrelated reasons. Gallery cannot tell the difference between an auto-archived asset and one you archived yourself.
+
+For config-file admins, this cleanup runs automatically on the next server restart whenever the YAML changes. Watch your server startup logs (`Classification category "X" similarity increased ... clearing auto-tag assignments`) so you know when it happens.
 :::
 
 ## How It Works
@@ -214,13 +216,24 @@ Upload / Re-encode
        └─ Mark asset as classified (classifiedAt timestamp)
 ```
 
-### Config Change Handling (onConfigUpdate)
+### Config Change Handling
 
-When system configuration changes, the classification service compares old and new config:
+Two paths handle config changes, depending on how classification is managed:
 
-1. If neither classification config nor CLIP model name changed → no action (unrelated config changes like SMTP don't affect classification)
+**UI / API updates (`onConfigUpdate`)** — fired immediately when an admin saves via the UI or API:
+
+1. If neither classification config nor CLIP model name changed → no action
 2. Clear embedding cache (prompts or model may have changed)
-3. For each category name present in old config but absent in new → call `removeAutoTagAssignments` to clean up `Auto/{name}` tags and unarchive affected assets
+3. Diff old vs new categories: for each removed category or category whose similarity increased, call `removeAutoTagAssignments` to clean up `Auto/{name}` tags and unarchive affected assets
+4. Persist the new classification config as a snapshot in `system_metadata`
+
+**Config file (`onConfigInit`)** — fired on every server boot, including after a YAML edit + restart:
+
+1. Read the previous classification snapshot from `system_metadata`
+2. If a snapshot exists, run the same diff logic against the freshly-loaded config (the file is the source of truth)
+3. Persist the current classification config as the new snapshot
+
+The snapshot is the bridge between the two paths. Both paths write it after running cleanup, so the boot-time check never re-runs cleanup that was already handled by the UI path. On the very first boot after upgrading, the snapshot is missing — Gallery just stores a baseline and skips cleanup, so existing tags are preserved.
 
 ### Key Details
 

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -365,6 +365,7 @@ export enum SystemMetadataKey {
   SystemFlags = 'system-flags',
   VersionCheckState = 'version-check-state',
   License = 'license',
+  ClassificationConfigState = 'classification-config-state',
 }
 
 export enum UserMetadataKey {

--- a/server/src/services/classification.service.spec.ts
+++ b/server/src/services/classification.service.spec.ts
@@ -1,4 +1,4 @@
-import { AssetVisibility, JobName, JobStatus } from 'src/enum';
+import { AssetVisibility, JobName, JobStatus, SystemMetadataKey } from 'src/enum';
 import { ClassificationService } from 'src/services/classification.service';
 import { authStub } from 'test/fixtures/auth.stub';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
@@ -707,6 +707,126 @@ describe(ClassificationService.name, () => {
       ]);
 
       await sut.onConfigUpdate({ oldConfig, newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+    });
+
+    it('should write classification snapshot to system metadata after diff', async () => {
+      const oldConfig = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' },
+      ]);
+      const newConfig = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
+      ]);
+
+      await sut.onConfigUpdate({ oldConfig, newConfig } as any);
+
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
+        SystemMetadataKey.ClassificationConfigState,
+        newConfig.classification,
+      );
+    });
+  });
+
+  describe('onConfigInit', () => {
+    it('should store baseline snapshot and skip cleanup when no snapshot exists', async () => {
+      const newConfig = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
+      ]);
+      mocks.systemMetadata.get.mockResolvedValue(null);
+
+      await sut.onConfigInit({ newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
+        SystemMetadataKey.ClassificationConfigState,
+        newConfig.classification,
+      );
+    });
+
+    it('should clean up tags when current similarity is stricter than snapshot', async () => {
+      const newConfig = makeClassificationConfig([
+        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.6, action: 'tag' },
+      ]);
+      const snapshot = makeClassificationConfig([
+        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.3, action: 'tag' },
+      ]).classification;
+      mocks.systemMetadata.get.mockResolvedValue(snapshot as any);
+
+      await sut.onConfigInit({ newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).toHaveBeenCalledWith('Screenshots');
+      expect(mocks.classification.removeAutoTagAssignments).toHaveBeenCalledTimes(1);
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
+        SystemMetadataKey.ClassificationConfigState,
+        newConfig.classification,
+      );
+    });
+
+    it('should read snapshot, reconcile, then write snapshot in that order', async () => {
+      const newConfig = makeClassificationConfig([
+        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.6, action: 'tag' },
+      ]);
+      const snapshot = makeClassificationConfig([
+        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.3, action: 'tag' },
+      ]).classification;
+      const callOrder: string[] = [];
+      mocks.systemMetadata.get.mockImplementation(async () => {
+        callOrder.push('get');
+        return snapshot as any;
+      });
+      mocks.classification.removeAutoTagAssignments.mockImplementation(async () => {
+        callOrder.push('reconcile');
+      });
+      mocks.systemMetadata.set.mockImplementation(async () => {
+        callOrder.push('set');
+      });
+
+      await sut.onConfigInit({ newConfig } as any);
+
+      expect(callOrder).toEqual(['get', 'reconcile', 'set']);
+    });
+
+    it('should clean up tags for categories removed from config', async () => {
+      const newConfig = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' },
+      ]);
+      const snapshot = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' },
+        { name: 'Removed', prompts: ['removed'], similarity: 0.3, action: 'tag' },
+      ]).classification;
+      mocks.systemMetadata.get.mockResolvedValue(snapshot as any);
+
+      await sut.onConfigInit({ newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).toHaveBeenCalledWith('Removed');
+      expect(mocks.classification.removeAutoTagAssignments).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not clean up tags when current similarity matches snapshot', async () => {
+      const newConfig = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
+      ]);
+      const snapshot = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
+      ]).classification;
+      mocks.systemMetadata.get.mockResolvedValue(snapshot as any);
+
+      await sut.onConfigInit({ newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+    });
+
+    it('should not clean up tags when current similarity is looser than snapshot', async () => {
+      const newConfig = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.2, action: 'tag' },
+      ]);
+      const snapshot = makeClassificationConfig([
+        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
+      ]).classification;
+      mocks.systemMetadata.get.mockResolvedValue(snapshot as any);
+
+      await sut.onConfigInit({ newConfig } as any);
 
       expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
     });

--- a/server/src/services/classification.service.spec.ts
+++ b/server/src/services/classification.service.spec.ts
@@ -712,12 +712,8 @@ describe(ClassificationService.name, () => {
     });
 
     it('should write classification snapshot to system metadata after diff', async () => {
-      const oldConfig = makeClassificationConfig([
-        { name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' },
-      ]);
-      const newConfig = makeClassificationConfig([
-        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
-      ]);
+      const oldConfig = makeClassificationConfig([{ name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' }]);
+      const newConfig = makeClassificationConfig([{ name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' }]);
 
       await sut.onConfigUpdate({ oldConfig, newConfig } as any);
 
@@ -730,9 +726,7 @@ describe(ClassificationService.name, () => {
 
   describe('onConfigInit', () => {
     it('should store baseline snapshot and skip cleanup when no snapshot exists', async () => {
-      const newConfig = makeClassificationConfig([
-        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
-      ]);
+      const newConfig = makeClassificationConfig([{ name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' }]);
       mocks.systemMetadata.get.mockResolvedValue(null);
 
       await sut.onConfigInit({ newConfig } as any);
@@ -771,15 +765,17 @@ describe(ClassificationService.name, () => {
         { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.3, action: 'tag' },
       ]).classification;
       const callOrder: string[] = [];
-      mocks.systemMetadata.get.mockImplementation(async () => {
+      mocks.systemMetadata.get.mockImplementation(() => {
         callOrder.push('get');
-        return snapshot as any;
+        return Promise.resolve(snapshot as any);
       });
-      mocks.classification.removeAutoTagAssignments.mockImplementation(async () => {
+      mocks.classification.removeAutoTagAssignments.mockImplementation(() => {
         callOrder.push('reconcile');
+        return Promise.resolve();
       });
-      mocks.systemMetadata.set.mockImplementation(async () => {
+      mocks.systemMetadata.set.mockImplementation(() => {
         callOrder.push('set');
+        return Promise.resolve();
       });
 
       await sut.onConfigInit({ newConfig } as any);
@@ -788,9 +784,7 @@ describe(ClassificationService.name, () => {
     });
 
     it('should clean up tags for categories removed from config', async () => {
-      const newConfig = makeClassificationConfig([
-        { name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' },
-      ]);
+      const newConfig = makeClassificationConfig([{ name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' }]);
       const snapshot = makeClassificationConfig([
         { name: 'Cats', prompts: ['cat'], similarity: 0.3, action: 'tag' },
         { name: 'Removed', prompts: ['removed'], similarity: 0.3, action: 'tag' },
@@ -804,9 +798,7 @@ describe(ClassificationService.name, () => {
     });
 
     it('should not clean up tags when current similarity matches snapshot', async () => {
-      const newConfig = makeClassificationConfig([
-        { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
-      ]);
+      const newConfig = makeClassificationConfig([{ name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' }]);
       const snapshot = makeClassificationConfig([
         { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
       ]).classification;
@@ -818,9 +810,7 @@ describe(ClassificationService.name, () => {
     });
 
     it('should not clean up tags when current similarity is looser than snapshot', async () => {
-      const newConfig = makeClassificationConfig([
-        { name: 'Cats', prompts: ['cat'], similarity: 0.2, action: 'tag' },
-      ]);
+      const newConfig = makeClassificationConfig([{ name: 'Cats', prompts: ['cat'], similarity: 0.2, action: 'tag' }]);
       const snapshot = makeClassificationConfig([
         { name: 'Cats', prompts: ['cat'], similarity: 0.5, action: 'tag' },
       ]).classification;

--- a/server/src/services/classification.service.ts
+++ b/server/src/services/classification.service.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { SystemConfig } from 'src/config';
 import { OnEvent, OnJob } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { AssetVisibility, ImmichWorker, JobName, JobStatus, QueueName } from 'src/enum';
+import { AssetVisibility, ImmichWorker, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
 import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { JobOf } from 'src/types';
 import { upsertTags } from 'src/utils/tag';
+
+type ClassificationConfig = SystemConfig['classification'];
 
 @Injectable()
 export class ClassificationService extends BaseService {
@@ -49,6 +52,17 @@ export class ClassificationService extends BaseService {
     });
   }
 
+  @OnEvent({ name: 'ConfigInit', workers: [ImmichWorker.Microservices] })
+  async onConfigInit({ newConfig }: ArgOf<'ConfigInit'>) {
+    const snapshot = await this.systemMetadataRepository.get(SystemMetadataKey.ClassificationConfigState);
+
+    if (snapshot) {
+      await this.reconcileAutoTags(snapshot, newConfig.classification);
+    }
+
+    await this.systemMetadataRepository.set(SystemMetadataKey.ClassificationConfigState, newConfig.classification);
+  }
+
   @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.Microservices], server: true })
   async onConfigUpdate({ oldConfig, newConfig }: ArgOf<'ConfigUpdate'>) {
     const clipChanged = oldConfig.machineLearning.clip.modelName !== newConfig.machineLearning.clip.modelName;
@@ -62,18 +76,29 @@ export class ClassificationService extends BaseService {
     this.pendingEncodes.clear();
 
     if (classificationChanged) {
-      const oldByName = new Map(oldConfig.classification.categories.map((c) => [c.name, c]));
-      const newNames = new Set(newConfig.classification.categories.map((c) => c.name));
+      await this.reconcileAutoTags(oldConfig.classification, newConfig.classification);
+      await this.systemMetadataRepository.set(SystemMetadataKey.ClassificationConfigState, newConfig.classification);
+    }
+  }
 
-      for (const [name, oldCategory] of oldByName) {
-        if (newNames.has(name)) {
-          const newCategory = newConfig.classification.categories.find((c) => c.name === name);
-          if (newCategory && newCategory.similarity > oldCategory.similarity) {
-            await this.classificationRepository.removeAutoTagAssignments(name);
-          }
-        } else {
-          await this.classificationRepository.removeAutoTagAssignments(name);
-        }
+  private async reconcileAutoTags(previous: ClassificationConfig, current: ClassificationConfig) {
+    const currentByName = new Map(current.categories.map((c) => [c.name, c]));
+
+    for (const previousCategory of previous.categories) {
+      const currentCategory = currentByName.get(previousCategory.name);
+
+      if (!currentCategory) {
+        this.logger.log(`Classification category "${previousCategory.name}" removed; clearing auto-tag assignments`);
+        await this.classificationRepository.removeAutoTagAssignments(previousCategory.name);
+        continue;
+      }
+
+      if (currentCategory.similarity > previousCategory.similarity) {
+        this.logger.log(
+          `Classification category "${previousCategory.name}" similarity increased ` +
+            `(${previousCategory.similarity} → ${currentCategory.similarity}); clearing auto-tag assignments`,
+        );
+        await this.classificationRepository.removeAutoTagAssignments(previousCategory.name);
       }
     }
   }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -556,6 +556,7 @@ export type MediaLocation = { location: string };
 
 export interface SystemMetadata extends Record<SystemMetadataKey, Record<string, any>> {
   [SystemMetadataKey.AdminOnboarding]: { isOnboarded: boolean };
+  [SystemMetadataKey.ClassificationConfigState]: SystemConfig['classification'];
   [SystemMetadataKey.FacialRecognitionState]: { lastRun?: string };
   [SystemMetadataKey.License]: { licenseKey: string; activationKey: string; activatedAt: Date };
   [SystemMetadataKey.MaintenanceMode]: MaintenanceModeState;


### PR DESCRIPTION
## Summary
- Persist last-applied classification config in `system_metadata` and reconcile on every server boot, so config-file users get stale `Auto/*` tags cleared and assets unarchived when similarity increases or categories are removed
- Unify the diff logic so both `onConfigInit` (file-based) and `onConfigUpdate` (UI-based) run the same reset/rescan path and both snapshot the applied config, preventing duplicate work
- Expand unit tests to cover the config-file path (stricter similarity, category removal, no-op cases, snapshot updates)

Fixes #305

## Test plan
- [ ] Unit: `cd server && pnpm test -- --run src/services/classification.service.spec.ts`
- [ ] Manual: start server with IMMICH_CONFIG_FILE classification, run a scan, increase similarity in the file, restart → confirm previously tagged assets get Auto/* tags removed and unarchived
- [ ] Manual: confirm UI-driven update path still works