### PR TITLE
fix: people and location filter suggestions on /photos (#318)

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -14,7 +14,7 @@ import {
 import { jsonArrayFrom } from 'kysely/helpers/postgres';
 import { isEmpty, isUndefined, omitBy } from 'lodash';
 import { InjectKysely } from 'nestjs-kysely';
-import { LockableProperty, lockableProperties, Stack } from 'src/database';
+import { lockableProperties, LockableProperty, Stack } from 'src/database';
 import { Chunked, ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFileType, AssetOrder, AssetStatus, AssetType, AssetVisibility } from 'src/enum';

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -14,7 +14,7 @@ import {
 import { jsonArrayFrom } from 'kysely/helpers/postgres';
 import { isEmpty, isUndefined, omitBy } from 'lodash';
 import { InjectKysely } from 'nestjs-kysely';
-import { LockableProperty, Stack } from 'src/database';
+import { LockableProperty, lockableProperties, Stack } from 'src/database';
 import { Chunked, ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFileType, AssetOrder, AssetStatus, AssetType, AssetVisibility } from 'src/enum';
@@ -261,11 +261,12 @@ export class AssetRepository {
       return;
     }
 
+    const lockedColumns = lockableProperties.filter((property) => property in options);
     await this.db
       .updateTable('asset_exif')
       .set((eb) => ({
         ...options,
-        lockedProperties: distinctLocked(eb, Object.keys(options) as LockableProperty[]),
+        lockedProperties: distinctLocked(eb, lockedColumns),
       }))
       .where('assetId', 'in', ids)
       .execute();

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -904,7 +904,6 @@ export class SearchRepository {
       .select(['person.id', 'person.name'])
       .where('person.name', '!=', '')
       .where('person.isHidden', '=', false)
-      .where('person.thumbnailPath', '!=', '')
       .where((eb) =>
         eb.exists(
           eb

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -657,6 +657,7 @@ describe(AssetService.name, () => {
       const asset = AssetFactory.create();
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.update.mockResolvedValue(asset as any);
+      mocks.map.reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
 
       await sut.update(authStub.admin, asset.id, { latitude: 40.7128, longitude: -74.006 });
 
@@ -669,6 +670,38 @@ describe(AssetService.name, () => {
         { lockedPropertiesBehavior: 'append' },
       );
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SidecarWrite, data: { id: asset.id } });
+    });
+
+    it('should reverse-geocode and persist country/state/city when latitude and longitude are updated', async () => {
+      const asset = AssetFactory.create();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.update.mockResolvedValue(asset as any);
+      mocks.map.reverseGeocode.mockResolvedValue({ country: 'Germany', state: 'Berlin', city: 'Berlin' });
+
+      await sut.update(authStub.admin, asset.id, { latitude: 52.52, longitude: 13.405 });
+
+      expect(mocks.map.reverseGeocode).toHaveBeenCalledWith({ latitude: 52.52, longitude: 13.405 });
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetId: asset.id,
+          latitude: 52.52,
+          longitude: 13.405,
+          country: 'Germany',
+          state: 'Berlin',
+          city: 'Berlin',
+        }),
+        { lockedPropertiesBehavior: 'append' },
+      );
+    });
+
+    it('should not call reverse geocoding when latitude and longitude are not updated', async () => {
+      const asset = AssetFactory.create();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.update.mockResolvedValue(asset as any);
+
+      await sut.update(authStub.admin, asset.id, { description: 'New description' });
+
+      expect(mocks.map.reverseGeocode).not.toHaveBeenCalled();
     });
   });
 
@@ -692,6 +725,7 @@ describe(AssetService.name, () => {
     it('should not update Assets table if no relevant fields are provided', async () => {
       const auth = AuthFactory.create();
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.map.reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
 
       await sut.updateAll(auth, {
         ids: ['asset-1'],
@@ -706,6 +740,7 @@ describe(AssetService.name, () => {
 
     it('should update Assets table if visibility field is provided', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.map.reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
 
       await sut.updateAll(authStub.admin, {
         ids: ['asset-1'],
@@ -717,12 +752,19 @@ describe(AssetService.name, () => {
         rating: undefined,
       });
       expect(mocks.asset.updateAll).toHaveBeenCalled();
-      expect(mocks.asset.updateAllExif).toHaveBeenCalledWith(['asset-1'], { latitude: 0, longitude: 0 });
+      expect(mocks.asset.updateAllExif).toHaveBeenCalledWith(['asset-1'], {
+        latitude: 0,
+        longitude: 0,
+        country: null,
+        state: null,
+        city: null,
+      });
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.SidecarWrite, data: { id: 'asset-1' } }]);
     });
 
     it('should update exif table if latitude field is provided', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.map.reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
       const dateTimeOriginal = new Date().toISOString();
       await sut.updateAll(authStub.admin, {
         ids: ['asset-1'],
@@ -738,12 +780,40 @@ describe(AssetService.name, () => {
         dateTimeOriginal,
         latitude: 30,
         longitude: 50,
+        country: null,
+        state: null,
+        city: null,
       });
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.SidecarWrite, data: { id: 'asset-1' } }]);
     });
 
+    it('should reverse-geocode and persist country/state/city when bulk-updating latitude and longitude', async () => {
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1', 'asset-2']));
+      mocks.map.reverseGeocode.mockResolvedValue({ country: 'France', state: 'Île-de-France', city: 'Paris' });
+
+      await sut.updateAll(authStub.admin, {
+        ids: ['asset-1', 'asset-2'],
+        latitude: 48.8566,
+        longitude: 2.3522,
+        isFavorite: undefined,
+        duplicateId: undefined,
+        rating: undefined,
+      });
+
+      expect(mocks.map.reverseGeocode).toHaveBeenCalledTimes(1);
+      expect(mocks.map.reverseGeocode).toHaveBeenCalledWith({ latitude: 48.8566, longitude: 2.3522 });
+      expect(mocks.asset.updateAllExif).toHaveBeenCalledWith(['asset-1', 'asset-2'], {
+        latitude: 48.8566,
+        longitude: 2.3522,
+        country: 'France',
+        state: 'Île-de-France',
+        city: 'Paris',
+      });
+    });
+
     it('should update Assets table if duplicateId is provided as null', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.map.reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
 
       await sut.updateAll(authStub.admin, {
         ids: ['asset-1'],

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -231,7 +231,7 @@ export class AssetService extends BaseService {
         rating,
         description,
         dateTimeOriginal,
-        ...(geo ?? {}),
+        ...geo,
       },
       _.isUndefined,
     );
@@ -602,7 +602,7 @@ export class AssetService extends BaseService {
         latitude,
         longitude,
         rating,
-        ...(geo ?? {}),
+        ...geo,
       },
       _.isUndefined,
     );

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -216,6 +216,14 @@ export class AssetService extends BaseService {
     await this.requireAccess({ auth, permission: Permission.AssetUpdate, ids });
 
     const assetDto = _.omitBy({ isFavorite, visibility, duplicateId }, _.isUndefined);
+
+    // When latitude/longitude are updated in bulk, reverse-geocode once so country/state/city
+    // stay in sync across all selected assets. See updateExif() for the rationale.
+    let geo: { country: string | null; state: string | null; city: string | null } | undefined;
+    if (latitude !== undefined && longitude !== undefined) {
+      geo = await this.mapRepository.reverseGeocode({ latitude, longitude });
+    }
+
     const exifDto = _.omitBy(
       {
         latitude,
@@ -223,6 +231,7 @@ export class AssetService extends BaseService {
         rating,
         description,
         dateTimeOriginal,
+        ...(geo ?? {}),
       },
       _.isUndefined,
     );
@@ -576,6 +585,15 @@ export class AssetService extends BaseService {
     rating?: number | null;
   }) {
     const { id, description, dateTimeOriginal, latitude, longitude, rating } = dto;
+
+    // When latitude/longitude are updated manually, reverse-geocode them so country/state/city
+    // stay in sync. Otherwise the asset shows on the map (which only needs lat/lon) but is
+    // missing from location-based filters and search (which scope by country/city).
+    let geo: { country: string | null; state: string | null; city: string | null } | undefined;
+    if (latitude !== undefined && longitude !== undefined) {
+      geo = await this.mapRepository.reverseGeocode({ latitude, longitude });
+    }
+
     const writes = _.omitBy(
       {
         description,
@@ -584,6 +602,7 @@ export class AssetService extends BaseService {
         latitude,
         longitude,
         rating,
+        ...(geo ?? {}),
       },
       _.isUndefined,
     );

--- a/server/test/medium/specs/services/asset.service.spec.ts
+++ b/server/test/medium/specs/services/asset.service.spec.ts
@@ -9,6 +9,7 @@ import { AssetRepository } from 'src/repositories/asset.repository';
 import { EventRepository } from 'src/repositories/event.repository';
 import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
+import { MapRepository } from 'src/repositories/map.repository';
 import { OcrRepository } from 'src/repositories/ocr.repository';
 import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
@@ -36,7 +37,7 @@ const setup = (db?: Kysely<DB>) => {
       StackRepository,
       UserRepository,
     ],
-    mock: [EventRepository, LoggingRepository, JobRepository, StorageRepository, OcrRepository],
+    mock: [EventRepository, LoggingRepository, JobRepository, StorageRepository, OcrRepository, MapRepository],
   });
 };
 
@@ -337,6 +338,7 @@ describe(AssetService.name, () => {
     it('should automatically lock lockable columns', async () => {
       const { sut, ctx } = setup();
       ctx.getMock(JobRepository).queue.mockResolvedValue();
+      ctx.getMock(MapRepository).reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
       const { user } = await ctx.newUser();
       const auth = factory.auth({ user });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
@@ -425,6 +427,7 @@ describe(AssetService.name, () => {
     it('should automatically lock lockable columns', async () => {
       const { sut, ctx } = setup();
       ctx.getMock(JobRepository).queueAll.mockResolvedValue();
+      ctx.getMock(MapRepository).reverseGeocode.mockResolvedValue({ country: null, state: null, city: null });
       const { user } = await ctx.newUser();
       const auth = factory.auth({ user });
       const { asset } = await ctx.newAsset({ ownerId: user.id });

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -252,4 +252,60 @@ describe(SearchService.name, () => {
       expect(suggestions).toEqual(['Canon', null]);
     });
   });
+
+  describe('getFilterSuggestions', () => {
+    it('should return countries from the user assets', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newExif({ assetId: asset.id, country: 'Germany' });
+
+      const auth = factory.auth({ user: { id: user.id } });
+      const result = await sut.getFilterSuggestions(auth, {});
+
+      expect(result.countries).toContain('Germany');
+    });
+
+    it('should return countries when withSharedSpaces is true and the user has no shared spaces', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newExif({ assetId: asset.id, country: 'Germany' });
+
+      const auth = factory.auth({ user: { id: user.id } });
+      const result = await sut.getFilterSuggestions(auth, { withSharedSpaces: true });
+
+      expect(result.countries).toContain('Germany');
+    });
+
+    it('should return tagged people for the user', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      const auth = factory.auth({ user: { id: user.id } });
+      const result = await sut.getFilterSuggestions(auth, {});
+
+      expect(result.people.map((p) => p.name)).toContain('Alice');
+    });
+
+    it('should return people whose thumbnail has not been generated yet', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Bob', thumbnailPath: '' });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      const auth = factory.auth({ user: { id: user.id } });
+      const result = await sut.getFilterSuggestions(auth, {});
+
+      expect(result.people.map((p) => p.name)).toContain('Bob');
+    });
+  });
 });


### PR DESCRIPTION
Closes open-noodle/gallery#318.

## Summary

Two distinct bugs caused the FilterPanel on `/photos` to show empty **People** and **Location** sections even when the user had photos with both.

### People — `getFilteredPeople` excluded freshly tagged people

`server/src/repositories/search.repository.ts` required `person.thumbnailPath != ''` on the global path. New persons start with an empty thumbnail until the `PersonThumbnail` background job runs, so the filter silently dropped them — even though `/people` lists them and the FilterPanel UI already has an initials-avatar fallback (`onerror` handler in `people-filter.svelte`). Removed the filter so the source of truth matches the people page.

### Location — manual lat/lon edits skipped reverse geocoding

When a user opened the asset edit dialog and set/changed coordinates, `AssetService.update()` (and `updateAll()`) wrote `latitude`/`longitude` but never called `reverseGeocode`. The map shows pins because `getMapMarkers` only needs `latitude IS NOT NULL`, but the location filter (and search) scope by `country` / `city`, which stayed null forever. Both paths now reverse-geocode the new coordinates inline and persist `country`/`state`/`city` alongside the lat/lon write. The bulk path makes a single `reverseGeocode` call (all selected assets share the same target).

### Latent bulk-update bug

While touching `updateAllExif`, fixed a related issue: it cast `Object.keys(options) as LockableProperty[]` and stuffed every passed-in column into `lockedProperties`. As soon as the bulk path started writing `country`/`state`/`city` it would have locked them too — but they aren't lockable. Filter against the real `lockableProperties` whitelist instead.

## Test plan

- [x] New medium tests in `search.service.spec.ts` cover `getFilterSuggestions` for countries (basic + `withSharedSpaces`), tagged people, and tagged people without a thumbnail (regression for the people bug).
- [x] New unit tests in `asset.service.spec.ts` assert that `update()` and `updateAll()` call `reverseGeocode` and persist `country`/`state`/`city` on lat/lon updates, and don't call it when only metadata fields change.
- [x] Existing medium tests `should automatically lock lockable columns` for both `update` and `updateAll` keep their original expectations — country/state/city are intentionally **not** added to `lockedProperties`.
- [x] `pnpm test`, `pnpm test:medium`, `make check-server` all pass locally (3 pre-existing exif spec failures unrelated to this PR).