### PR TITLE
feat: publish version.opennoodle.de/gallery on release and wire fork at it

### DIFF
--- a/.github/workflows/gallery-release.yml
+++ b/.github/workflows/gallery-release.yml
@@ -414,3 +414,52 @@ jobs:
           fi
 
           gh release create "$VERSION" --title "$VERSION" --latest -n "$notes"
+
+  publish-version-endpoint:
+    name: Publish Version Endpoint
+    if: needs.version.outputs.skip != 'true'
+    needs: [version, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::660432264815:role/noodle-prod-gallery-release-version-upload
+          aws-region: eu-west-1
+
+      - name: Build and upload version.json
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Validate version format (keep v prefix for wire-format parity with upstream Immich)
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version tag: $VERSION"
+            exit 1
+          fi
+
+          # Fetch published_at from the GitHub Release created by the tag job.
+          # Retry briefly in case of transient GH API issues immediately after release create.
+          published_at=""
+          for attempt in 1 2 3; do
+            published_at=$(gh release view "$VERSION" --repo "$REPO" --json publishedAt --jq .publishedAt 2>/dev/null || true)
+            if [[ -n "$published_at" && "$published_at" != "null" ]]; then
+              break
+            fi
+            echo "Attempt ${attempt}: could not read publishedAt, retrying in 5s..."
+            sleep 5
+          done
+          if [[ -z "$published_at" || "$published_at" == "null" ]]; then
+            echo "::error::Could not read publishedAt for release $VERSION after 3 attempts"
+            exit 1
+          fi
+
+          printf '{"version":"%s","published_at":"%s"}' "$VERSION" "$published_at" > /tmp/gallery
+
+          aws s3 cp /tmp/gallery s3://noodle-prod-version/gallery \
+            --content-type "application/json; charset=utf-8" \
+            --cache-control "public, max-age=300"

--- a/.github/workflows/gallery-release.yml
+++ b/.github/workflows/gallery-release.yml
@@ -425,7 +425,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::660432264815:role/noodle-prod-gallery-release-version-upload
           aws-region: eu-west-1

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -361,10 +361,9 @@ export const defaults = Object.freeze<SystemConfig>({
     },
   },
   newVersionCheck: {
-    // Disabled in Gallery: the upstream default would poll version.immich.cloud,
-    // which is Immich-owned infrastructure and reports fork traffic as immich-server.
-    // Re-enable once Gallery has its own release-info endpoint.
-    enabled: false,
+    // Gallery polls its own release endpoint at version.opennoodle.de/gallery
+    // (see config.repository.ts versionCheck.url).
+    enabled: true,
   },
   nightlyTasks: {
     startTime: '00:00',

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -335,7 +335,7 @@ const getEnv = (): EnvData => {
     licensePublicKey: isProd ? productionKeys : stagingKeys,
 
     versionCheck: {
-      url: isProd ? 'https://version.opennoodle.de/gallery' : 'https://version.dev.immich.cloud/version',
+      url: 'https://version.opennoodle.de/gallery',
     },
 
     network: {

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -335,7 +335,7 @@ const getEnv = (): EnvData => {
     licensePublicKey: isProd ? productionKeys : stagingKeys,
 
     versionCheck: {
-      url: isProd ? 'https://version.immich.cloud/version' : 'https://version.dev.immich.cloud/version',
+      url: isProd ? 'https://version.opennoodle.de/gallery' : 'https://version.dev.immich.cloud/version',
     },
 
     network: {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -188,7 +188,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     extractEmbedded: false,
   },
   newVersionCheck: {
-    enabled: false,
+    enabled: true,
   },
   trash: {
     enabled: true,


### PR DESCRIPTION
## Summary
- New `publish-version-endpoint` job in `gallery-release.yml` pushes `{version, published_at}` JSON to `s3://noodle-prod-version/gallery` via GitHub OIDC after each release. Hardcoded IAM role ARN, scoped to a single object key and the release workflow's trusted `main` branch.
- Direct edit to `server/src/repositories/config.repository.ts:338` pointing the server's production version check at `https://version.opennoodle.de/gallery`. Staging/dev continues hitting `version.dev.immich.cloud`.
- Re-enables `newVersionCheck.enabled` default (flipped back to `true` in `server/src/config.ts`), now that Gallery has its own endpoint — fulfills the explicit "Re-enable once Gallery has its own release-info endpoint" note from #315.
- Spec fixture in `system-config.service.spec.ts` updated to match the new default.


## Test plan
- [ ] Merge this PR to trigger a release
- [ ] Confirm the \`publish-version-endpoint\` job runs green in the workflow
- [ ] Within ~5 minutes of job completion, \`curl https://version.opennoodle.de/gallery\` returns the new \`vX.Y.Z\` tag and matching \`published_at\`
- [ ] Confirm \`x-cache: Hit from cloudfront\` on a second request
- [ ] Next hourly cron tick on the production Gallery server logs \`Found vX.Y.Z, released at …\` (or force a restart if you want to verify immediately)