### PR TITLE
fix(branding): patch remaining hardcoded immich URLs in web frontend

### DIFF
--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -109,6 +109,29 @@ patch_web() {
     echo "  Patched server-status.svelte"
   fi
 
+  # Version announcement modal — hardcoded "latest releases" link in major/minor update popup
+  local version_modal="$REPO_ROOT/web/src/lib/modals/VersionAnnouncementModal.svelte"
+  if [[ -f "$version_modal" ]]; then
+    sed -i "s|https://github\.com/immich-app/immich/releases/latest|${REPO_URL}/releases/latest|g" "$version_modal"
+    echo "  Patched VersionAnnouncementModal.svelte"
+  fi
+
+  # Error layout — hardcoded "releases" link on the error page
+  local error_layout="$REPO_ROOT/web/src/lib/components/layouts/ErrorLayout.svelte"
+  if [[ -f "$error_layout" ]]; then
+    sed -i "s|https://github\.com/immich-app/immich/releases|${REPO_URL}/releases|g" "$error_layout"
+    echo "  Patched ErrorLayout.svelte"
+  fi
+
+  # security.txt — hardcoded SECURITY.md policy URL and "Immich instance" comments
+  local security_txt="$REPO_ROOT/web/static/.well-known/security.txt"
+  if [[ -f "$security_txt" ]]; then
+    sed -i "s|https://github\.com/immich-app/immich/blob/main/SECURITY\.md|${REPO_URL}/blob/main/SECURITY.md|g" "$security_txt"
+    sed -i "s|running an Immich instance|running a ${NAME} instance|g" "$security_txt"
+    sed -i "s|Immich-related security problems should be reported to the Immich security team|${NAME}-related security problems should be reported to the ${NAME} security team|g" "$security_txt"
+    echo "  Patched security.txt"
+  fi
+
   # OpenAPI spec
   local openapi="$REPO_ROOT/open-api/immich-openapi-specs.json"
   if [[ -f "$openapi" ]]; then

--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -71,6 +71,27 @@ fi
 
 # Check that hardcoded upstream URLs are patched in user-facing frontend
 echo "--- Checking URL replacements ---"
+
+# Files where ALL `github.com/immich-app/immich` references must be patched away
+url_check_files=(
+  "web/src/lib/components/shared-components/side-bar/server-status.svelte"
+  "web/src/lib/modals/VersionAnnouncementModal.svelte"
+  "web/src/lib/components/layouts/ErrorLayout.svelte"
+  "web/static/.well-known/security.txt"
+)
+
+for file in "${url_check_files[@]}"; do
+  filepath="$REPO_ROOT/$file"
+  if [[ -f "$filepath" ]]; then
+    if grep -q "github\.com/immich-app/immich" "$filepath"; then
+      echo "  WARN: Upstream GitHub URL still present in $file"
+      EXIT_CODE=1
+    else
+      echo "  OK: $file"
+    fi
+  fi
+done
+
 help_modal="$REPO_ROOT/web/src/lib/modals/HelpAndFeedbackModal.svelte"
 if [[ -f "$help_modal" ]]; then
   # Extract content outside BRANDING:UPSTREAM markers


### PR DESCRIPTION
## Summary

`apply-branding.sh` already rewrote the release-tag URL in `server-status.svelte` (the sidebar "New update!" button) but missed three other hardcoded `github.com/immich-app/immich` references that leak the upstream repository into deployed builds:

- `web/src/lib/modals/VersionAnnouncementModal.svelte` — `releases/latest` link in the major/minor update popup
- `web/src/lib/components/layouts/ErrorLayout.svelte` — `releases` link on the error page
- `web/static/.well-known/security.txt` — `SECURITY.md` policy URL and "Immich instance" comment lines

Also extends `verify-branding.sh` with a regression check that fails the build if any of the four user-facing frontend files still contain a `github.com/immich-app/immich` reference, so future upstream rewrites of these files can't silently regress the patches.

> Note: `security.txt` still has `Contact: mailto:security@immich.app`, which is technically the wrong contact for a Gallery instance. Left untouched here because picking the right replacement (Discord, GitHub issues, dedicated email) is a separate decision.

## Test plan

- [x] `bash branding/scripts/apply-branding.sh` reports all four files patched
- [x] `bash branding/scripts/verify-branding.sh` passes with the new URL replacement section
- [x] Negative test: reverting `VersionAnnouncementModal.svelte` causes `verify-branding.sh` to fail with the new check
- [ ] CI green