### PR TITLE
ci: add release-candidate build workflow

### DIFF
--- a/.github/workflows/gallery-rc-build.yml
+++ b/.github/workflows/gallery-rc-build.yml
@@ -1,0 +1,202 @@
+name: Release Candidate Build
+
+# Builds a release-candidate server image from an arbitrary ref under a custom tag.
+# Unlike the main Release workflow, this one:
+#   - does NOT create git tags (no VERSION, no vN, no `release`)
+#   - does NOT create a GitHub Release
+#   - does NOT publish to the version endpoint
+#   - does NOT touch ML at all — no ML build, no ML retag. Testers pin the server
+#     image via a compose override (see the workflow run summary for copy-paste YAML).
+#
+# Dispatch it from the branch you want to build (or from any branch with `ref` set to
+# the target branch/tag/SHA).
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: 'Custom image tag, e.g. fix-sidecar-write-s3-rc1. Must not be "release", "v<N>", or "v<N>.<N>.<N>".'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref (branch/tag/SHA) to build. Leave empty to use the ref this workflow was dispatched on.'
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.rc_tag }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate RC tag
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Check tag shape
+        env:
+          RC_TAG: ${{ inputs.rc_tag }}
+        run: |
+          if [[ ! "$RC_TAG" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
+            echo "::error::'$RC_TAG' is not a valid Docker tag."
+            exit 1
+          fi
+          if [[ "$RC_TAG" =~ ^(release|latest)$ ]] \
+            || [[ "$RC_TAG" =~ ^v[0-9]+$ ]] \
+            || [[ "$RC_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::'$RC_TAG' collides with a reserved/stable tag. Use something like 'fix-xyz-rc1'."
+            exit 1
+          fi
+          echo "RC tag OK: $RC_TAG"
+
+  build-server:
+    name: Build Server (${{ matrix.platform }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply branding
+        uses: ./.github/actions/apply-branding
+        with:
+          version: ${{ inputs.rc_tag }}
+
+      - name: Prepare platform pair
+        id: prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "platform-pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: server/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            DEVICE=cpu
+            BUILD_ID=${{ github.run_id }}
+            BUILD_SOURCE_REF=${{ github.ref_name }}
+            BUILD_SOURCE_COMMIT=${{ github.sha }}
+          outputs: type=image,"name=ghcr.io/open-noodle/gallery-server",push-by-digest=true,name-resolution=short,push=true
+          cache-from: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }}
+          cache-to: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }},mode=max
+
+      - name: Export digest
+        run: | # zizmor: ignore[template-injection]
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: rc-server-digests-${{ steps.prepare.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-server:
+    name: Merge Server Manifest
+    needs: [validate, build-server]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: rc-server-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ghcr.io/open-noodle/gallery-server
+          RC_TAG: ${{ inputs.rc_tag }}
+        run: |
+          sources=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create -t "${IMAGE}:${RC_TAG}" ${sources}
+
+  summary:
+    name: RC Ready
+    needs: merge-server
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Write summary
+        env:
+          RC_TAG: ${{ inputs.rc_tag }}
+        run: |
+          {
+            echo "## Release candidate ready"
+            echo
+            echo "**Tag:** \`${RC_TAG}\`"
+            echo
+            echo "Only the server image was built. ML is untouched and continues to be pulled from its usual \`release\` tag."
+            echo
+            echo "### Tester instructions"
+            echo
+            echo "In the directory containing your \`docker-compose.yml\`, create (or append to) a \`docker-compose.override.yml\` file so compose pins the server image to the RC while leaving everything else alone:"
+            echo
+            echo '```yaml'
+            echo "services:"
+            echo "  immich-server:"
+            echo "    image: ghcr.io/open-noodle/gallery-server:${RC_TAG}"
+            echo '```'
+            echo
+            echo "Then:"
+            echo
+            echo '```bash'
+            echo "docker compose pull immich-server"
+            echo "docker compose up -d"
+            echo '```'
+            echo
+            echo "To roll back, delete the override file (or the \`immich-server\` block in it) and run \`docker compose up -d\` again."
+            echo
+            echo "### Image published"
+            echo
+            echo "- \`ghcr.io/open-noodle/gallery-server:${RC_TAG}\` (linux/amd64 + linux/arm64)"
+            echo
+            echo "**No git tags, no GitHub release, no version endpoint updates, no ML changes.** To promote to a stable release, merge the corresponding PR to main."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a new workflow `gallery-rc-build.yml` that lets us publish a testable server image for any branch/tag/SHA under a caller-supplied tag, **without touching** git tags, the GitHub release, the version endpoint, or the ML image. Testers can pin just the server to the RC via a compose override while ML keeps pulling from its normal `release` stream.

## Motivation

When a fix is ready for review but we want the person who reported the bug to verify it on their instance before merging, the current Release workflow isn't suitable — it always updates `release`, `vN`, creates a git tag, creates a GitHub Release, and publishes the version endpoint. Those are all write operations we don't want for a throwaway test build.

This workflow gives us a narrower primitive: "build the server under a custom tag, do nothing else."

First use case is the sidecar-write-s3 fix in #323 — the reporter has a 50k-asset instance that's been broken for a while and wants to verify the fix end-to-end before we cut a stable release.

## What it does

- `workflow_dispatch` only — no automatic triggers
- Required input `rc_tag` — rejected if it matches `release`, `latest`, `v<N>`, or `v<N>.<N>.<N>` so we can never accidentally shadow a stable release
- Optional input `ref` — defaults to the dispatched ref; lets you build any branch/tag/SHA
- Builds the server image multi-arch (amd64 + arm64) via the same matrix-and-merge pattern the main release workflow uses
- Pushes to `ghcr.io/open-noodle/gallery-server:<rc_tag>` only — no floating tags
- Writes a GitHub Actions step summary with copy-paste tester instructions (compose override YAML + `docker compose pull/up` commands)
- **Does not** rebuild or retag ML. Testers leave ML on `release`.
- **Does not** create git tags, GitHub releases, or touch the version endpoint

## Why this is a separate PR from #323

`workflow_dispatch` workflows only become dispatchable after they land on the default branch. The sidecar fix branch can't dispatch its own workflow until this one lands. Keeping this PR small and focused on the infrastructure means it can be reviewed and merged quickly, unblocking the actual RC build for #323.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow file passes
- [x] Action SHAs match the ones pinned in `gallery-release.yml`
- [ ] After merge: dispatch with `gh workflow run gallery-rc-build.yml --ref fix/sidecar-write-s3 -f rc_tag=fix-sidecar-write-s3-rc1` and verify a server image is published at `ghcr.io/open-noodle/gallery-server:fix-sidecar-write-s3-rc1` with no other tags altered

## Follow-up

Once this merges, the workflow can be used to RC-build #323 for the reporter to test their 57k affected assets.