### PR TITLE
fix(build): sequential sdk/cli build and proper version tag matching

### DIFF
--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -42,7 +42,7 @@ DOCS_URL=$(jq -r '.docs.url' "$CONFIG")
 if [[ -n "${FORK_VERSION:-}" ]]; then
   FORK_VERSION="${FORK_VERSION#v}"
 else
-  FORK_VERSION=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || { git -C "$REPO_ROOT" tag -l 'v*.*.*' --sort=-v:refname 2>/dev/null | head -1; })
+  FORK_VERSION=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || { git -C "$REPO_ROOT" tag -l 'v*.*.*' --sort=-v:refname 2>/dev/null | head -1; })
   FORK_VERSION="${FORK_VERSION#v}"
 fi
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,7 +45,8 @@ RUN --mount=type=cache,id=pnpm-cli,target=/buildcache/pnpm-store \
   --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
   --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
   pnpm --filter @immich/sdk --filter @immich/cli --frozen-lockfile install && \
-  pnpm --filter @immich/sdk --filter @immich/cli build && \
+  pnpm --filter @immich/sdk build && \
+  pnpm --filter @immich/cli build && \
   pnpm --filter @immich/cli --prod --no-optional deploy /output/cli-pruned
 
 FROM builder AS plugins


### PR DESCRIPTION
## Summary

Two small build-stability fixes that have been biting release/RC builds intermittently:

1. **`server/Dockerfile`** — the CLI stage ran `pnpm --filter @immich/sdk --filter @immich/cli build` as a single invocation. pnpm runs filtered builds in parallel, so rolldown can start resolving `@immich/cli`'s imports before the sdk's `tsc` has written `build/index.js`, producing this error:
   > `[vite]: Rolldown failed to resolve import "@immich/sdk" from "/usr/src/app/cli/src/commands/auth.ts"`

   Split into two sequential pnpm invocations so the sdk is fully built before cli starts.

2. **`branding/scripts/apply-branding.sh`** — the `git describe --tags --abbrev=0` fallback for `FORK_VERSION` happily picks up the moving `release` / `v4` tags. That string then gets stamped into every `package.json` / `pyproject.toml`; `uv` rejects `version = "release"` and the server later crash-loops with `TypeError: Invalid Version: release` from semver. Constrain the match to `v[0-9]*.[0-9]*.[0-9]*` so only real semver tags are considered.

## Why now

The Rolldown race is hit by PR #323's RC build (see run [24214925696](https://github.com/open-noodle/gallery/actions/runs/24214925696)) — the parallel build won on the `main` release workflow 10 minutes earlier and lost on the RC build 15 minutes later. Classic race. This PR deterministically fixes it so we can dispatch the RC build for #323.

## Test plan

- [x] Diff only touches `server/Dockerfile:47-49` and `branding/scripts/apply-branding.sh:45`
- [ ] Main Release workflow runs cleanly after merge (no `release`/`vN` tag ever gets stamped into package manifests)
- [ ] RC build for #323 re-dispatched after this merges and rebases succeeds