### PR TITLE
fix(server): library_user access-grant denormalization for shared-space library backfill

### DIFF
--- a/docs/plans/2026-04-11-library-user-access-backfill-design.md
+++ b/docs/plans/2026-04-11-library-user-access-backfill-design.md
@@ -1,0 +1,411 @@
+# Library Access Backfill via `library_user` Table — Design
+
+## Problem
+
+When a user gains access to a pre-existing library via a shared-space link — either by joining a space that already has libraries linked, by having a library newly linked to a space they're already in, or by rejoining a space after previously leaving — the server fails to stream:
+
+1. The library metadata row (`LibraryV1`)
+2. The library's assets (`LibraryAssetBackfillV1`)
+
+The link row (`SharedSpaceLibraryV1`) is delivered correctly via the per-link backfill loop in `syncSharedSpaceLibrariesV1`, but the library itself and its 40k+ assets are not, leaving the client's space detail view blank for any library-backed space the user wasn't a member of at their initial sync.
+
+### Root cause
+
+- `LibrarySync.getCreatedAfter` keys off `library.createId`. Pre-existing libraries have old createIds < the user's backfill checkpoint → they're not returned → per-library asset backfill never runs for them.
+- `LibrarySync.getUpserts` keys off `library.updateId > checkpoint`. The library row's updateId is also old → not returned.
+- `LibraryAssetSync.getUpserts` keys off `asset.updateId > checkpoint`. The assets haven't changed → not returned.
+- The existing comment on `LibrarySync.getCreatedAfter` acknowledges the gap: "SharedSpaceLibrarySync's per-link backfill loop in sync.service.ts handles that case" — but looking at `syncSharedSpaceLibrariesV1`, it only streams link rows, never recursing into library metadata or asset backfill. The intended handling was never implemented.
+
+### Scenarios that fail
+
+1. **User re-added to a space after leaving** (observed live in testing). Mobile's `deleteLibrariesV1` handler swept the orphan library assets from `remote_asset_entity` when the leave-side `LibraryDeleteV1` events arrived. After re-add, server delivers nothing library-related → user's local DB stays empty.
+2. **First-time invite to a space with pre-existing libraries.** User's initial sync happened before they were a member, so their `LibraryAssetBackfillV1` checkpoint is at HEAD. New member row arrives via `SharedSpaceMemberV1`, but no library flow.
+3. **Library newly linked to a space the user is already in.** New `shared_space_library` row arrives via `SharedSpaceLibraryV1`, but the referenced library and its assets are stale on the server side.
+
+All three are the same underlying bug: there is no per-user "access was granted to library X" signal that drives the sync backfill.
+
+## Solution
+
+Introduce a new denormalization table `library_user` that mirrors the existing patterns used by `shared_space_member`, `album_user`, and `partner` — one row per (userId, libraryId) access grant, with its own `createId`.
+
+The fork already has a companion `library_audit` table (from migration `1778200000000-LibraryAuditTables.ts`) plus a `user_has_library_path()` helper and trigger fan-out logic for the **delete side** of per-user library access tracking. This design adds the symmetric **create side** that was never implemented.
+
+After the fix:
+
+- `LibrarySync.getCreatedAfter` queries `library_user` instead of `library`, returning rows keyed by the per-user access-grant createId. Each access grant is a unique row with a unique createId, so the existing per-entity backfill loop in `syncLibraryAssetsV1` / `syncLibraryAssetExifsV1` works unchanged.
+- Insert triggers on `library`, `shared_space_member`, and `shared_space_library` populate `library_user` atomically with the event that grants access. Each trigger also bumps `library.updateId` so `LibrarySync.getUpserts` delivers the library metadata row on the newly-accessing user's next sync — mirroring the existing `album_user_after_insert` and `shared_space_member_after_insert` patterns.
+- An `AFTER INSERT` trigger on `library_audit` deletes the corresponding `library_user` row whenever the existing delete trigger chain determines the user has lost all paths to the library. This keeps all the "user lost access" policy in one place (the existing trigger fan-out) and makes the create-side table a simple consumer of it.
+
+No changes to any sync service method. No new sync entity types. No mobile changes.
+
+## Schema
+
+New table `library_user`:
+
+```sql
+CREATE TABLE "library_user" (
+  "userId"    uuid NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  "libraryId" uuid NOT NULL REFERENCES "library"(id) ON DELETE CASCADE,
+  "createId"  uuid NOT NULL DEFAULT immich_uuid_v7(),
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+  PRIMARY KEY ("userId", "libraryId")
+);
+
+-- Hot-path index: LibrarySync.getCreatedAfter filters by userId then
+-- createId, so a composite leading with userId lets the planner seek
+-- directly to the user's slice and walk sorted. PK (userId, libraryId)
+-- doesn't serve this query because it's ordered on the wrong column.
+CREATE INDEX "library_user_userId_createId_idx" ON "library_user" ("userId", "createId");
+
+-- Supports the library_audit consumer trigger's join on libraryId and
+-- any future `which users have access to library X` queries.
+CREATE INDEX "library_user_libraryId_idx" ON "library_user" ("libraryId");
+```
+
+- `(userId, libraryId)` primary key prevents duplicates when the same user gains access via multiple paths.
+- `createId` (uuid_v7) is the per-user access-grant timestamp. Unique per row, monotonic, drives the backfill loop.
+- `createdAt` is informational, mirrors other per-user tables.
+- **No `updateId` or `updatedAt`** — `library_user` rows are write-once: they're inserted via the create-side triggers, deleted via the `library_audit` consumer trigger, and never UPDATEd. Adding per-user library metadata (e.g. "hide this library from my timeline") is a future feature that can add the column at that point via a simple ALTER.
+- FK cascades ensure library_user is cleaned up when users or libraries are hard-deleted.
+
+Migration file: `server/src/schema/migrations-gallery/<ts>-AddLibraryUserTable.ts`.
+
+## Triggers
+
+### Create-side (three new triggers)
+
+**1. `library_after_insert`** — when a library is created, insert the owner's library_user row.
+
+```sql
+CREATE OR REPLACE FUNCTION library_after_insert()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+  INSERT INTO library_user ("userId", "libraryId")
+  SELECT "ownerId", "id"
+  FROM inserted_rows
+  WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+  ON CONFLICT DO NOTHING;
+  RETURN NULL;
+END
+$$;
+
+CREATE TRIGGER "library_after_insert"
+AFTER INSERT ON "library"
+REFERENCING NEW TABLE AS "inserted_rows"
+FOR EACH STATEMENT
+EXECUTE FUNCTION library_after_insert();
+```
+
+No `library.updateId` bump needed here — the library was just created so its updateId is already fresh.
+
+**2. `shared_space_member_after_insert_library`** — when a user joins a space, grant access to every library currently linked to that space. Also bump the library.updateId of each affected library so `LibrarySync.getUpserts` delivers the library row on the new member's next sync (mirrors `shared_space_member_after_insert`'s `shared_space.updateId` bump).
+
+```sql
+CREATE OR REPLACE FUNCTION shared_space_member_after_insert_library()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+  -- Grant per-user library access
+  INSERT INTO library_user ("userId", "libraryId")
+  SELECT DISTINCT ir."userId", ssl."libraryId"
+  FROM inserted_rows ir
+  INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+  ON CONFLICT DO NOTHING;
+
+  -- Bump updateId on affected libraries so the upsert stream redelivers metadata
+  UPDATE library
+  SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+  WHERE "id" IN (
+    SELECT DISTINCT ssl."libraryId"
+    FROM inserted_rows ir
+    INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+  );
+  RETURN NULL;
+END
+$$;
+
+CREATE TRIGGER "shared_space_member_after_insert_library"
+AFTER INSERT ON "shared_space_member"
+REFERENCING NEW TABLE AS "inserted_rows"
+FOR EACH STATEMENT
+EXECUTE FUNCTION shared_space_member_after_insert_library();
+```
+
+The trigger name is suffixed with `_library` so it sorts alphabetically AFTER the existing `shared_space_member_after_insert` trigger — Postgres fires AFTER triggers in name order and the existing `shared_space.updateId` bump should run first for stable ordering in test assertions. Both triggers are idempotent so the order is not functionally required.
+
+**3. `shared_space_library_after_insert_user`** — when a library is linked to a space, grant access to every current member of that space and bump the library's updateId.
+
+```sql
+CREATE OR REPLACE FUNCTION shared_space_library_after_insert_user()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+  INSERT INTO library_user ("userId", "libraryId")
+  SELECT DISTINCT ssm."userId", ir."libraryId"
+  FROM inserted_rows ir
+  INNER JOIN shared_space_member ssm ON ssm."spaceId" = ir."spaceId"
+  ON CONFLICT DO NOTHING;
+
+  UPDATE library
+  SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+  WHERE "id" IN (SELECT DISTINCT "libraryId" FROM inserted_rows);
+  RETURN NULL;
+END
+$$;
+
+CREATE TRIGGER "shared_space_library_after_insert_user"
+AFTER INSERT ON "shared_space_library"
+REFERENCING NEW TABLE AS "inserted_rows"
+FOR EACH STATEMENT
+EXECUTE FUNCTION shared_space_library_after_insert_user();
+```
+
+### Delete-side (one new trigger)
+
+**4. `library_user_delete_after_audit`** — when a row is inserted into `library_audit`, delete the corresponding `library_user` row. The existing delete trigger chain (`shared_space_delete_library_audit`, `shared_space_library_delete_audit`, `shared_space_member_delete_library_audit`) already encodes the "user has lost all paths" policy via `user_has_library_path()` — we just consume its output.
+
+```sql
+CREATE OR REPLACE FUNCTION library_user_delete_after_audit()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+  -- Defensive re-check: every existing path that inserts into library_audit
+  -- has already gated on `NOT user_has_library_path(...)`, so in normal
+  -- operation this filter is a no-op. We keep it so that any future code
+  -- path that inserts into library_audit without gating correctly cannot
+  -- accidentally strip a user's access — the consumer trigger will only
+  -- delete library_user rows for (user, library) pairs that genuinely have
+  -- no valid path anymore.
+  DELETE FROM library_user lu
+  USING inserted_rows ir
+  WHERE lu."userId" = ir."userId"
+    AND lu."libraryId" = ir."libraryId"
+    AND NOT user_has_library_path(lu."libraryId", lu."userId", NULL);
+  RETURN NULL;
+END
+$$;
+
+CREATE TRIGGER "library_user_delete_after_audit"
+AFTER INSERT ON "library_audit"
+REFERENCING NEW TABLE AS "inserted_rows"
+FOR EACH STATEMENT
+EXECUTE FUNCTION library_user_delete_after_audit();
+```
+
+`user_has_library_path(libraryId, userId, excludeSpaceId=NULL)` with a null exclude returns true if the user has access via ANY path (ownership, space membership, space creator). Calling it with NULL here asks "does the user have access right now?" — and if they still do, we preserve the row.
+
+## Migration: backfill `library_user` from current state
+
+The table is populated in two passes in the same migration transaction, both using `ON CONFLICT DO NOTHING` so the migration is re-runnable:
+
+```sql
+-- Pass 1: owned libraries. Use library.createId so existing synced clients
+-- don't re-backfill libraries they already have.
+INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+SELECT "ownerId", "id", "createId", "createdAt"
+FROM library
+WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+ON CONFLICT ("userId", "libraryId") DO NOTHING;
+
+-- Pass 2: transitive access via shared_space_library. Use a FRESH createId
+-- (default immich_uuid_v7()) so users in the broken state get their missing
+-- libraries re-delivered on next sync. The ON CONFLICT DO NOTHING preserves
+-- the owned-path row if the user owns AND has transitive access to the same
+-- library, so they don't get a wasteful re-sync.
+--
+-- Soft-deleted libraries are deliberately INCLUDED here — matches the
+-- existing `accessibleLibraries` comment that soft-deleted libraries are
+-- still reachable via a linked space until they're hard-deleted.
+INSERT INTO library_user ("userId", "libraryId")
+SELECT DISTINCT ssm."userId", ssl."libraryId"
+FROM shared_space_library ssl
+INNER JOIN shared_space_member ssm ON ssl."spaceId" = ssm."spaceId"
+ON CONFLICT ("userId", "libraryId") DO NOTHING;
+```
+
+### Why owned uses old createId and transitive uses fresh
+
+- **Owned libraries**: users who own a library were guaranteed to receive it via their initial sync (`library.getCreatedAfter(afterCreateId=null)` at initial sync returns all accessible libraries with no upper bound). Their sync checkpoint is past the library's createId. Populating `library_user` with the original `library.createId` means the migrated row is _also_ past the checkpoint, so the next sync's `getCreatedAfter` correctly returns nothing for this library.
+- **Transitive libraries**: before this fix, users could never have successfully synced a library via the transitive path after their initial sync — that's the bug we're fixing. So on the day this migration runs, every user with transitive access who gained it _after_ their initial sync is in the broken state for that library. Giving those rows fresh createIds triggers a one-time re-backfill that heals their local DB.
+
+  There is a corner case: a user whose _initial_ sync happened _after_ they were added to a space with linked libraries. They received those libraries via `getCreatedAfter(null)` at initial sync and are not in the broken state. After the migration, they get a fresh `library_user.createId` and the next sync will re-stream the library assets. This is wasted bandwidth (upserts are idempotent) but bounded: one extra sync per such user per library. For Pierre's instance this is fine. For larger future deployments, we'd need either per-user checkpoint-aware backfill detection or a "initial sync timestamp" signal.
+
+### Ordering of the two passes
+
+Pass 1 runs first so that owner rows land with the old createId. Pass 2's `ON CONFLICT DO NOTHING` then skips any (userId, libraryId) pair that's already present, preserving the owner's low-cost path. Users who own AND have transitive access to the same library keep the owner-path row and avoid a re-sync.
+
+## Sync repository changes
+
+Only one method changes:
+
+```ts
+// server/src/repositories/sync.repository.ts
+export class LibrarySync extends BaseSync {
+  // BEFORE: queried `library` keyed by library.createId — misses re-adds and
+  // new invites because the library's own createId is past the user's
+  // checkpoint. AFTER: queries `library_user` keyed by the per-user access
+  // grant createId, mirroring SharedSpaceSync.getCreatedAfter and
+  // AlbumSync.getCreatedAfter.
+  //
+  // The `library.id IN accessibleLibraries(userId)` filter is preserved
+  // (via an IN subquery) so that soft-deleted owned libraries are excluded
+  // from the backfill loop — matching the existing behavior where
+  // `accessibleLibraries` drops the ownership branch when `deletedAt IS NOT
+  // NULL`, while keeping soft-deleted libraries visible via the space-link
+  // branch. Without this filter, an owner who soft-deletes a library would
+  // still see its assets re-streamed on every subsequent sync.
+  @GenerateSql({ params: [dummyCreateAfterOptions] })
+  getCreatedAfter({ nowId, userId, afterCreateId }: SyncCreatedAfterOptions) {
+    return this.db
+      .selectFrom('library_user')
+      .select(['library_user.libraryId as id', 'library_user.createId'])
+      .where('library_user.userId', '=', userId)
+      .where('library_user.libraryId', 'in', (eb) => accessibleLibraries(eb, userId))
+      .$if(!!afterCreateId, (qb) => qb.where('library_user.createId', '>=', afterCreateId!))
+      .where('library_user.createId', '<', nowId)
+      .orderBy('library_user.createId', 'asc')
+      .execute();
+  }
+
+  // getUpserts is UNCHANGED — it still filters by `library.id IN accessibleLibraries`
+  // and `library.updateId > checkpoint`. The new insert triggers bump
+  // library.updateId when a user gains access, so newly-accessible libraries
+  // flow through this stream automatically.
+  ...
+}
+```
+
+`syncLibrariesV1`, `syncLibraryAssetsV1`, and `syncLibraryAssetExifsV1` are **unchanged**. The per-library backfill loops in the latter two already call `library.getCreatedAfter` and iterate the returned rows — the new implementation returns the right set.
+
+## Mobile changes
+
+**None.** The wire protocol is unchanged: `LibraryV1`, `LibraryAssetBackfillV1`, `LibraryAssetExifBackfillV1`, and `LibraryDeleteV1` are all existing event types that the mobile dispatches correctly. The only difference is that they start arriving for access-grant scenarios they previously missed.
+
+## Schema-tools registration
+
+The fork's schema pipeline requires every trigger function and trigger to be mirrored in both TypeScript-decorator form (for `make sql` / schema diff) and a `migration_overrides` row in the migration body (for `sql-tools` to pick up during CLI migrations). The `1778200000000-LibraryAuditTables.ts` migration is the canonical example — the new migration will add roughly the same volume of boilerplate for its new symbols. Concrete work items:
+
+1. **`server/src/schema/tables/library-user.table.ts`** (new file): Kysely table definition with column decorators (`@Column`, `@Index`, `@PrimaryColumn`, `@ForeignKeyColumn`). Must match the migration's `CREATE TABLE` statement exactly.
+2. **`server/src/schema/functions.ts`**: add `registerFunction` entries for the four new trigger functions: `library_after_insert`, `shared_space_member_after_insert_library`, `shared_space_library_after_insert_user`, `library_user_delete_after_audit`. Each entry declares the body SQL that `make sql` will diff against the runtime DB.
+3. **`server/src/schema/index.ts`**: import and register the four new functions in the schema registry export so they participate in schema diffing.
+4. **Trigger declarations**: add `@TriggerFunction` entries alongside the new table's decorator block so `make sql` emits matching trigger definitions.
+5. **Migration body `migration_overrides` inserts**: for each of the four functions and their triggers, insert a `migration_overrides` row storing the canonical SQL. This is what `sql-tools` consults when running `pnpm migrations:run`. Pattern lifted from `1778200000000-LibraryAuditTables.ts` lines 139–195 (function overrides) and 153–158 (trigger overrides).
+6. **Down-migration**: drop triggers, drop functions, delete the `migration_overrides` rows, drop indexes, drop the table. Mirror the up-migration in reverse.
+
+Skipping any of these will cause `make sql` and CI schema checks to diff, which blocks PR merge. Budget ~100 lines of boilerplate beyond the design SQL.
+
+## Known limitations / edge cases
+
+### Concurrent member+link insert race
+
+If two transactions concurrently insert `shared_space_member(user=U, space=S)` and `shared_space_library(space=S, library=L)`, each trigger runs against a snapshot that doesn't see the other transaction's uncommitted row. Neither insert ends up creating `library_user(U, L)`, and U doesn't get the library on next sync.
+
+This is a pre-existing weakness of trigger-based denormalization in the fork — the existing `shared_space_member_after_insert` (bumps `shared_space.updateId`) has the same shape and the same theoretical race. In practice the hazard is low because the two operations are different API calls that are rarely issued concurrently.
+
+**Not fixed in v1.** If it becomes a real problem, options are: advisory lock on `spaceId` during both inserts; SERIALIZABLE isolation with retry; or a periodic reconciliation job that finds (user, library) pairs where access exists but `library_user` is missing. Filed as a known limitation; tests document the hazard and pin current behavior.
+
+### Library ownership transfer
+
+Libraries do not currently support ownership transfer — there is no `PATCH /library/:id` endpoint or service method that updates `library.ownerId`. If such a feature is added later, the new owner needs a `library_user` row and the old owner needs the consumer-trigger-driven cleanup (assuming they lose all paths). A trigger on `UPDATE library WHEN OLD.ownerId IS DISTINCT FROM NEW.ownerId` would be required: insert a new `library_user` row for the new owner, and insert a `library_audit` row for the old owner (which our consumer trigger would then use to delete the stale `library_user` row).
+
+**Not in scope for this design.** Flagged so that whoever adds ownership transfer later knows to add the matching trigger.
+
+### Soft-delete of an owned library
+
+The owner soft-deletes their library (sets `deletedAt`). Current behavior: `accessibleLibraries` drops the ownership branch for soft-deleted libraries, so subsequent syncs exclude them from delivery. Our design preserves this behavior via the `accessibleLibraries` filter in `getCreatedAfter` (see Sync repository changes above). The `library_user` row stays in place — we don't trigger on soft-delete because un-soft-delete would need the inverse trigger and the edge case doesn't materially affect correctness. On soft-delete the library simply stops appearing in the backfill loop's output; on un-soft-delete it starts appearing again at the stored createId, which is already past the user's checkpoint, so nothing is re-streamed (the client still has the data from before the soft-delete).
+
+### Migration re-run
+
+Both passes use `ON CONFLICT DO NOTHING` so the migration is idempotent. Running it twice is a no-op on the second run. Useful for local dev workflows and CI test fixtures that may reset and re-seed the DB.
+
+## Testing strategy
+
+### Unit / small tests (`server/src/repositories/sync.repository.spec.ts` additions or new `library-user.repository.spec.ts`)
+
+- `LibrarySync.getCreatedAfter` returns rows in `createId` order
+- Filters correctly by `afterCreateId`
+- Returns empty for a user with no library access
+- Returns owned + transitive without duplicates
+- **Excludes a soft-deleted owned library when the user has no space-linked path to it** (regression guard for the `accessibleLibraries` filter)
+- **Includes a soft-deleted library when the user is a member of a space that links it** (matches existing `accessibleLibraries` behavior for the space-link branch)
+
+### Medium tests (new file `server/test/medium/specs/sync/library-user.spec.ts`)
+
+Trigger and consumer behavior against a real DB.
+
+**Create-side triggers**:
+
+- Insert library as owner → library_user row created for owner with `createId = library.createId`
+- Insert library with `ownerId IS NULL` → no library_user row
+- Insert library with `deletedAt IS NOT NULL` → no library_user row (trigger WHERE excludes)
+- Insert shared_space_member for a space with N linked libraries → N library_user rows for the new member with fresh createIds; `library.updateId` bumped for each of the N libraries
+- Insert shared_space_member for a space with zero linked libraries → no library_user rows, no library UPDATEs
+- Insert shared_space_library for a space with M members → M library_user rows; `library.updateId` bumped on the newly-linked library
+- Insert shared_space_library into a space with zero members → no library_user rows, but the library.updateId is still bumped (consistent with the trigger body)
+
+**Delete-side consumer**:
+
+- Delete shared_space_member (user leaves space) → library_user rows removed IF no other path; owned-library rows preserved
+- Delete shared_space_library (link removed) → library_user rows removed for members who have no other path; owner's row preserved
+- Delete shared_space (whole space) → all affected (member, library) pairs with no other path get library_user removed; owner of a still-linked-elsewhere library retains access
+- Delete library (hard delete) → FK cascade removes library_user rows without involving library_audit
+- Owner leaves a space that also links their own library → library_user row stays (owner path still valid per `user_has_library_path`)
+- **Defensive consumer re-check**: manually insert a row into `library_audit` for a (user, library) pair where the user still has access via an owned path, then assert that `library_user` is NOT deleted. This documents and locks in the `NOT user_has_library_path(...)` defensive clause.
+- **Bulk cascade**: delete a shared_space containing many members × libraries → audit rows fan-out correctly, consumer trigger deletes only the pairs with no surviving path
+
+**Multi-path deduplication**:
+
+- User owns library AND is a member of a space that links it → single library_user row from the owner trigger; the member-insert trigger's `ON CONFLICT DO NOTHING` preserves the row
+- User joins space S1 linking library L, then joins space S2 also linking L → second member insert is a no-op (library_user row already exists)
+
+**Concurrency race (optional, documents known limitation)**:
+
+- Using `pg_sleep()` inside one of the transactions, force T1 (member insert) and T2 (link insert) to overlap such that neither sees the other's uncommitted row. Assert that the library_user row is missing afterwards. This test PINS the current hazard so anyone later adding locking/serialization can see what the fix addresses. Annotated as `it.skip(...)` or marked with a comment as a documentation test if it's flaky.
+
+### Integration tests (new file `server/test/medium/specs/sync/library-access-backfill.spec.ts`)
+
+End-to-end sync stream assertions for the three failing scenarios, using the medium test harness against a real DB:
+
+1. **Re-add to space**: user is member, syncs, leaves, syncs, re-added, syncs → third sync delivers `LibraryV1` + `LibraryAssetBackfillV1` events for the space's libraries
+2. **First-time invite to existing space**: new user created, initial sync (empty), user added to existing space with linked libraries, second sync → delivers library metadata + assets
+3. **Library linked to existing space**: user is already in space, syncs, library linked to space, second sync → delivers library metadata + assets
+
+### Migration backfill test (`server/test/medium/specs/sync/library-user-migration.spec.ts`)
+
+- **Owned-rows use old createId**: seed library with known createId, run migration, assert `library_user.createId = library.createId`
+- **Transitive rows use fresh createId**: seed shared_space_library + shared_space_member, run migration, assert `library_user.createId > now() - ε AND > library.createId`
+- **Owned + transitive to the same library**: seed both paths, run migration, assert only ONE row with the OLD owned createId (Pass 1 wins, Pass 2 `ON CONFLICT` preserves)
+- **Idempotent re-run**: run migration twice, assert row count is stable and createIds are unchanged between runs
+- **No duplicates**: seed the DB with arbitrary overlapping owned/transitive grants, run migration, assert `(userId, libraryId)` pairs are unique
+- **Soft-deleted owned library is skipped in Pass 1** but **included in Pass 2** if linked to a space
+
+### E2E spec (`e2e/src/specs/server/api/sync-library.e2e-spec.ts` additions)
+
+HTTP-level coverage matching the failure mode we observed empirically (server API returned `SyncCompleteV1` with nothing for a broken session). Three new `describe` blocks mirroring the three scenarios, each:
+
+1. Issues real login requests to get session tokens
+2. Makes real `POST /sync/stream` calls
+3. Asserts the expected `LibraryV1`, `LibraryAssetCreateV1` / `LibraryAssetBackfillV1` events appear in the response
+
+This is the authoritative check that the fix actually closes the bug from the client's perspective. Medium tests verify trigger and query behavior; the E2E test verifies the integration through the HTTP boundary.
+
+### Regression: existing sync-library suites must still pass
+
+- `e2e/src/specs/server/api/sync-library.e2e-spec.ts` covers `LibrariesV1`, `LibraryAssetsV1`, `LibraryAssetExifsV1`, and `SharedSpaceLibrariesV1`. All existing tests must remain green.
+- `server/test/medium/specs/sync/library-audit-triggers.spec.ts` — the change is additive at the trigger level; existing delete-side assertions should still pass.
+- `server/test/medium/specs/sync/sync-library.spec.ts`, `sync-library-asset.spec.ts`, `sync-library-asset-exif.spec.ts` — verify the rewritten `getCreatedAfter` returns the same set these tests expect, plus the new cases.
+
+## Rollback plan
+
+The migration is purely additive:
+
+- **Application code rollback only**: the new table and triggers stay in place harmlessly. The old `LibrarySync.getCreatedAfter` (keyed off `library.createId`) would work against the existing `library` table as before. The new trigger-maintained `library_user` would keep growing but be unread. `library.updateId` bumps would continue, which is mildly wasteful but consistent with how `album` and `shared_space` already behave.
+- **Migration rollback**: `down()` drops the table, triggers, and functions. The `library.updateId` bumps from the running version stay — that's a minor inflation of updateIds but sync correctness is unaffected.
+- **Concurrent old+new code**: triggers fire regardless of whether the reading code path is the old or new `LibrarySync.getCreatedAfter`. Safe to roll forward or back without coordinated restarts.
+
+## YAGNI rejections
+
+- **No `updateId` / `updatedAt` column** — `library_user` rows are write-once (inserted via triggers, deleted via audit consumer). There is no code path that UPDATEs them. Add later via ALTER if per-user library metadata becomes a feature.
+- **No `role` column** — library access is binary (you have it or you don't). Unlike `shared_space_member` which has owner/editor/viewer roles.
+- **No separate `LibraryBackfillV1` sync event type** — the existing `LibraryV1` upsert type (re-triggered by the `library.updateId` bump) delivers library metadata. No new wire protocol needed.
+- **No modification of existing delete trigger functions** — the `library_audit` insert-trigger approach lets us reuse the existing `user_has_library_path()` logic without touching the trigger bodies that implement it.
+- **No per-library completion tracking** — the per-entity backfill loop's current `(createId, complete)` checkpoint is sufficient. Each library_user row's createId is unique.
+- **No ownership-transfer trigger** — libraries don't currently support ownership transfer. Flagged in known limitations; add when the feature lands.
+- **No concurrency lock on the member+link race** — pre-existing hazard in the fork's trigger-based denormalization. Document and test-pin; fix only if it materializes.

--- a/docs/plans/2026-04-11-library-user-access-backfill-design.md
+++ b/docs/plans/2026-04-11-library-user-access-backfill-design.md
@@ -158,24 +158,30 @@ EXECUTE FUNCTION shared_space_library_after_insert_user();
 
 ### Delete-side (one new trigger)
 
-**4. `library_user_delete_after_audit`** — when a row is inserted into `library_audit`, delete the corresponding `library_user` row. The existing delete trigger chain (`shared_space_delete_library_audit`, `shared_space_library_delete_audit`, `shared_space_member_delete_library_audit`) already encodes the "user has lost all paths" policy via `user_has_library_path()` — we just consume its output.
+**4. `library_user_delete_after_audit`** — when a row is inserted into `library_audit`, delete the corresponding `library_user` row. The existing delete trigger chain (`shared_space_delete_library_audit`, `shared_space_library_delete_audit`, `shared_space_member_delete_library_audit`) already encodes the "user has lost all paths" policy via `user_has_library_path()` — we consume its output unconditionally.
 
 ```sql
 CREATE OR REPLACE FUNCTION library_user_delete_after_audit()
 RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
 BEGIN
-  -- Defensive re-check: every existing path that inserts into library_audit
-  -- has already gated on `NOT user_has_library_path(...)`, so in normal
-  -- operation this filter is a no-op. We keep it so that any future code
-  -- path that inserts into library_audit without gating correctly cannot
-  -- accidentally strip a user's access — the consumer trigger will only
-  -- delete library_user rows for (user, library) pairs that genuinely have
-  -- no valid path anymore.
+  -- Trusts the gating at library_audit insertion time: every existing path
+  -- that inserts into library_audit already gates on
+  -- `NOT user_has_library_path(..., excludeSpaceId)`, so an audit row means
+  -- "this (user, library) pair has definitively lost access". We do NOT
+  -- re-check here.
+  --
+  -- Why not defensive re-check: an earlier design attempted a defensive
+  -- `NOT user_has_library_path(..., NULL)` filter here, but it is BROKEN
+  -- during `shared_space` hard-delete. `shared_space_delete_library_audit`
+  -- is a BEFORE DELETE ROW trigger, so when it inserts into library_audit
+  -- the FK-cascade deletes of shared_space_library / shared_space_member
+  -- have NOT yet run — `user_has_library_path(lib, user, NULL)` still finds
+  -- the about-to-be-cascaded rows and returns TRUE, which would incorrectly
+  -- skip the delete and leave stale library_user rows. Trust the gate.
   DELETE FROM library_user lu
   USING inserted_rows ir
   WHERE lu."userId" = ir."userId"
-    AND lu."libraryId" = ir."libraryId"
-    AND NOT user_has_library_path(lu."libraryId", lu."userId", NULL);
+    AND lu."libraryId" = ir."libraryId";
   RETURN NULL;
 END
 $$;
@@ -187,7 +193,7 @@ FOR EACH STATEMENT
 EXECUTE FUNCTION library_user_delete_after_audit();
 ```
 
-`user_has_library_path(libraryId, userId, excludeSpaceId=NULL)` with a null exclude returns true if the user has access via ANY path (ownership, space membership, space creator). Calling it with NULL here asks "does the user have access right now?" — and if they still do, we preserve the row.
+**Trust boundary:** any future code path that inserts into `library_audit` MUST gate on `NOT user_has_library_path(libraryId, userId, excludeSpaceId)` with the correct `excludeSpaceId` for the operation being performed — otherwise it will strip access it shouldn't. This is now a documented invariant of the `library_audit` table and is exercised by the test suite (see "defensive gate is owned by the inserter" in Testing strategy below).
 
 ## Migration: backfill `library_user` from current state
 
@@ -319,33 +325,9 @@ The create-side triggers handle the space-creator case indirectly: `SharedSpaceS
 
 If a future change to `SharedSpaceService.create` breaks the "creator is always a member" invariant, our design's create-side silently fails to insert `library_user` for the creator while the delete-side still defends them. That asymmetry would manifest as a creator seeing a space's libraries go missing after a cache-reset sync (the delete path preserves them, but the create path never populated the row). Pre-existing implicit invariant, but worth noting so whoever touches space creation later knows to check.
 
-### Bulk cascade performance with `user_has_library_path`
+### Bulk cascade performance
 
-The `library_user_delete_after_audit` consumer trigger calls `user_has_library_path(libraryId, userId, NULL)` once per row in `inserted_rows`. For a bulk cascade — e.g., hard-deleting a `shared_space` that contains M members × N libraries — the existing delete-side triggers can fan out hundreds or thousands of `library_audit` rows, and our consumer trigger then evaluates the path-check function once per row. Each call does its own subqueries against `library`, `shared_space_library`, and `shared_space_member`. For small instances this is fine; for a hypothetical deployment with 1000-member spaces linking 50 libraries, the per-delete cost becomes noticeable.
-
-**Not fixed in v1.** The fix if it ever matters is to rewrite the consumer trigger's DELETE to inline the path check as a `NOT EXISTS` subquery, skipping the function call entirely:
-
-```sql
-DELETE FROM library_user lu
-USING inserted_rows ir
-WHERE lu."userId" = ir."userId"
-  AND lu."libraryId" = ir."libraryId"
-  AND NOT EXISTS (
-    SELECT 1 FROM library l WHERE l.id = lu."libraryId" AND l."ownerId" = lu."userId" AND l."deletedAt" IS NULL
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM shared_space_library ssl
-    INNER JOIN shared_space_member ssm ON ssm."spaceId" = ssl."spaceId"
-    WHERE ssl."libraryId" = lu."libraryId" AND ssm."userId" = lu."userId"
-  )
-  AND NOT EXISTS (
-    SELECT 1 FROM shared_space_library ssl
-    INNER JOIN shared_space ss ON ss."id" = ssl."spaceId"
-    WHERE ssl."libraryId" = lu."libraryId" AND ss."createdById" = lu."userId"
-  );
-```
-
-Trades readability for throughput. Keep the function-call version until it actually hurts.
+The `library_user_delete_after_audit` consumer trigger does a single unconditional `DELETE ... USING inserted_rows`, so its cost is linear in the number of audit rows delivered by the BEFORE-trigger fan-out. Each deletion is a PK lookup on `library_user (userId, libraryId)`. For a hypothetical deployment hard-deleting a 1000-member space linking 50 libraries, that's ~50k PK lookups — fast. No `user_has_library_path` calls from the consumer; all path evaluation happens once, at insertion time, inside the existing audit triggers.
 
 ## Testing strategy
 
@@ -373,16 +355,18 @@ Trigger and consumer behavior against a real DB.
 - Insert shared_space_member for a space with zero linked libraries → no library_user rows, no library UPDATEs
 - Insert shared_space_library for a space with M members → M library_user rows; `library.updateId` bumped on the newly-linked library
 - Insert shared_space_library into a space with zero members → no library_user rows, but the library.updateId is still bumped (consistent with the trigger body)
+- **`LibrarySync.getUpserts` re-delivery**: after a `shared_space_member_after_insert_library` trigger fires, assert that `LibrarySync.getUpserts({ userId: newMember, ack: { updateId: <pre-bump>, ... } })` returns the affected library. Pins the integration path that depends on the `updateId` bump — if the bump breaks (or if `getUpserts` grows a filter that excludes newly-accessible libraries), the integration tests in Task 14 might still pass by accidentally riding the `getCreatedAfter` stream, masking the regression. This test asserts the upsert stream independently.
+- **Creator-not-member asymmetry (documentation test)**: manually insert a `shared_space` row via direct SQL without creating the matching `shared_space_member` row for the creator, link a library, then attempt a sync as the creator. Assert that `library_user` does NOT contain a row for the creator, documenting the known limitation where the create-side silently fails if the "creator is always a member" invariant is ever broken. Marked with a comment referencing the Known Limitations section.
 
 **Delete-side consumer**:
 
 - Delete shared_space_member (user leaves space) → library_user rows removed IF no other path; owned-library rows preserved
 - Delete shared_space_library (link removed) → library_user rows removed for members who have no other path; owner's row preserved
-- Delete shared_space (whole space) → all affected (member, library) pairs with no other path get library_user removed; owner of a still-linked-elsewhere library retains access
+- **Delete shared_space (whole space)** → all affected (member, library) pairs with no other path get library_user removed; owner of a still-linked-elsewhere library retains access. **This test is the regression guard for the dropped "defensive re-check" clause** — under the original design that clause would incorrectly re-detect the still-alive (pre-cascade) shared_space_library/shared_space_member rows and leave stale library_user entries behind.
 - **Delete library (hard delete) via FK cascade**: directly `DELETE FROM library WHERE id = ?` → all matching `library_user` rows disappear via the `ON DELETE CASCADE` FK; assert that no `library_audit` rows are emitted (the audit chain only fires on `shared_space_*` delete paths, not on a direct `DELETE library`) and that no dangling `library_user` rows remain
-- Owner leaves a space that also links their own library → library_user row stays (owner path still valid per `user_has_library_path`)
-- **Defensive consumer re-check**: manually insert a row into `library_audit` for a (user, library) pair where the user still has access via an owned path, then assert that `library_user` is NOT deleted. This documents and locks in the `NOT user_has_library_path(...)` defensive clause.
-- **Bulk cascade**: delete a shared_space containing many members × libraries → audit rows fan-out correctly, consumer trigger deletes only the pairs with no surviving path
+- Owner leaves a space that also links their own library → library_user row stays (owner path still valid; delete audit never gets emitted because the leave-trigger's `NOT user_has_library_path(..., o.spaceId)` gate already excludes the owner)
+- **Trust-the-gate contract**: manually insert a row into `library_audit` for a (user, library) pair where the user still has access via an owned path, then assert that `library_user` IS deleted. This pins the fact that the consumer trusts the inserter's gating and does NOT re-check — and is the regression guard that future code touching `library_audit` must continue to gate on `NOT user_has_library_path(libraryId, userId, excludeSpaceId)` before inserting.
+- **Bulk cascade**: delete a shared_space containing many members × libraries → audit rows fan-out correctly, consumer trigger deletes exactly the pairs flagged by the BEFORE-trigger gate.
 
 **Multi-path deduplication**:
 
@@ -433,6 +417,7 @@ The migration is purely additive:
 - **Application code rollback only**: the new table and triggers stay in place harmlessly. The old `LibrarySync.getCreatedAfter` (keyed off `library.createId`) would work against the existing `library` table as before. The new trigger-maintained `library_user` would keep growing but be unread. `library.updateId` bumps would continue, which is mildly wasteful but consistent with how `album` and `shared_space` already behave.
 - **Migration rollback**: `down()` drops the table, triggers, and functions. The `library.updateId` bumps from the running version stay — that's a minor inflation of updateIds but sync correctness is unaffected.
 - **Concurrent old+new code**: triggers fire regardless of whether the reading code path is the old or new `LibrarySync.getCreatedAfter`. Safe to roll forward or back without coordinated restarts.
+- **Checkpoint value-space shift for in-flight clients**: the `afterCreateId` checkpoint that clients send with `getCreatedAfter` changes meaning under this migration — pre-fix it was a `library.createId` watermark, post-fix it is a `library_user.createId` watermark. A client whose checkpoint was captured mid-sync just before the deploy will carry a value into the post-fix system that does not correspond to a row in `library_user`. Because the new query uses `library_user.createId >= afterCreateId`, this is fine: the client will either match (no re-delivery needed) or exceed (re-delivers from a point already past) without producing incorrect results. The worst case is a one-time harmless re-delivery of rows the client already has — upserts are idempotent in the mobile sync handler. The implementation plan adds a dedicated regression test in `sync.repository.spec.ts` that seeds a checkpoint from the pre-fix value-space and asserts the post-fix query returns a consistent superset of the user's accessible libraries.
 
 ## YAGNI rejections
 

--- a/docs/plans/2026-04-11-library-user-access-backfill-design.md
+++ b/docs/plans/2026-04-11-library-user-access-backfill-design.md
@@ -56,11 +56,9 @@ CREATE TABLE "library_user" (
 -- directly to the user's slice and walk sorted. PK (userId, libraryId)
 -- doesn't serve this query because it's ordered on the wrong column.
 CREATE INDEX "library_user_userId_createId_idx" ON "library_user" ("userId", "createId");
-
--- Supports the library_audit consumer trigger's join on libraryId and
--- any future `which users have access to library X` queries.
-CREATE INDEX "library_user_libraryId_idx" ON "library_user" ("libraryId");
 ```
+
+The `library_user_delete_after_audit` consumer trigger joins on `(userId, libraryId)` which is served by the primary key — no extra index needed for that path. A standalone `libraryId` index was considered for "which users have access to library X" admin queries but has no concrete caller, so it's dropped per YAGNI. Easy to add later if such a query shows up.
 
 - `(userId, libraryId)` primary key prevents duplicates when the same user gains access via multiple paths.
 - `createId` (uuid_v7) is the per-user access-grant timestamp. Unique per row, monotonic, drives the backfill loop.
@@ -74,14 +72,14 @@ Migration file: `server/src/schema/migrations-gallery/<ts>-AddLibraryUserTable.t
 
 ### Create-side (three new triggers)
 
-**1. `library_after_insert`** — when a library is created, insert the owner's library_user row.
+**1. `library_after_insert`** — when a library is created, insert the owner's library_user row. The insert explicitly propagates `library.createId` and `library.createdAt` instead of letting the column defaults generate fresh values. This preserves the invariant (established in the migration's Pass 1) that **owner-path rows always share the library's own createId**, which matters because existing clients' sync checkpoints are already past `library.createId` and we don't want a new-library insert to appear "fresh" enough to retrigger an already-completed backfill on reconnection. Post-migration and post-insert the rule is the same: owner rows copy from the library row.
 
 ```sql
 CREATE OR REPLACE FUNCTION library_after_insert()
 RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
 BEGIN
-  INSERT INTO library_user ("userId", "libraryId")
-  SELECT "ownerId", "id"
+  INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+  SELECT "ownerId", "id", "createId", "createdAt"
   FROM inserted_rows
   WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
   ON CONFLICT DO NOTHING;
@@ -315,6 +313,40 @@ The owner soft-deletes their library (sets `deletedAt`). Current behavior: `acce
 
 Both passes use `ON CONFLICT DO NOTHING` so the migration is idempotent. Running it twice is a no-op on the second run. Useful for local dev workflows and CI test fixtures that may reset and re-seed the DB.
 
+### Dependence on the "creator is always a member" invariant
+
+The create-side triggers handle the space-creator case indirectly: `SharedSpaceService.create` invariantly inserts a `shared_space_member` row for the creator when a space is created, and our `shared_space_member_after_insert_library` trigger then grants library_user rows from whatever libraries are linked to that space. The `user_has_library_path()` helper that drives the delete-side also defensively includes a "creator of the space that links the library" branch, so a creator-but-not-member case won't spuriously lose access if it ever arises.
+
+If a future change to `SharedSpaceService.create` breaks the "creator is always a member" invariant, our design's create-side silently fails to insert `library_user` for the creator while the delete-side still defends them. That asymmetry would manifest as a creator seeing a space's libraries go missing after a cache-reset sync (the delete path preserves them, but the create path never populated the row). Pre-existing implicit invariant, but worth noting so whoever touches space creation later knows to check.
+
+### Bulk cascade performance with `user_has_library_path`
+
+The `library_user_delete_after_audit` consumer trigger calls `user_has_library_path(libraryId, userId, NULL)` once per row in `inserted_rows`. For a bulk cascade — e.g., hard-deleting a `shared_space` that contains M members × N libraries — the existing delete-side triggers can fan out hundreds or thousands of `library_audit` rows, and our consumer trigger then evaluates the path-check function once per row. Each call does its own subqueries against `library`, `shared_space_library`, and `shared_space_member`. For small instances this is fine; for a hypothetical deployment with 1000-member spaces linking 50 libraries, the per-delete cost becomes noticeable.
+
+**Not fixed in v1.** The fix if it ever matters is to rewrite the consumer trigger's DELETE to inline the path check as a `NOT EXISTS` subquery, skipping the function call entirely:
+
+```sql
+DELETE FROM library_user lu
+USING inserted_rows ir
+WHERE lu."userId" = ir."userId"
+  AND lu."libraryId" = ir."libraryId"
+  AND NOT EXISTS (
+    SELECT 1 FROM library l WHERE l.id = lu."libraryId" AND l."ownerId" = lu."userId" AND l."deletedAt" IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM shared_space_library ssl
+    INNER JOIN shared_space_member ssm ON ssm."spaceId" = ssl."spaceId"
+    WHERE ssl."libraryId" = lu."libraryId" AND ssm."userId" = lu."userId"
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM shared_space_library ssl
+    INNER JOIN shared_space ss ON ss."id" = ssl."spaceId"
+    WHERE ssl."libraryId" = lu."libraryId" AND ss."createdById" = lu."userId"
+  );
+```
+
+Trades readability for throughput. Keep the function-call version until it actually hurts.
+
 ## Testing strategy
 
 ### Unit / small tests (`server/src/repositories/sync.repository.spec.ts` additions or new `library-user.repository.spec.ts`)
@@ -325,6 +357,7 @@ Both passes use `ON CONFLICT DO NOTHING` so the migration is idempotent. Running
 - Returns owned + transitive without duplicates
 - **Excludes a soft-deleted owned library when the user has no space-linked path to it** (regression guard for the `accessibleLibraries` filter)
 - **Includes a soft-deleted library when the user is a member of a space that links it** (matches existing `accessibleLibraries` behavior for the space-link branch)
+- **Set equality with `accessibleLibraries`**: seed a user with a mix of owned, owned-and-soft-deleted, and space-linked libraries, then assert that the set of `libraryId`s returned by `getCreatedAfter(userId, afterCreateId=null)` is exactly the same as the set returned by querying `accessibleLibraries(userId)` directly. Regression guard against any future drift between the two sources of truth — if someone changes one without the other, this test fails loudly.
 
 ### Medium tests (new file `server/test/medium/specs/sync/library-user.spec.ts`)
 
@@ -332,9 +365,10 @@ Trigger and consumer behavior against a real DB.
 
 **Create-side triggers**:
 
-- Insert library as owner → library_user row created for owner with `createId = library.createId`
+- Insert library as owner → library_user row created for owner with `createId = library.createId` (and `createdAt = library.createdAt`) — pins the I4 invariant
 - Insert library with `ownerId IS NULL` → no library_user row
 - Insert library with `deletedAt IS NOT NULL` → no library_user row (trigger WHERE excludes)
+- **Bulk library insert** — insert 10 libraries in one statement, all with distinct owners → 10 library_user rows created with 10 distinct createIds that each match the corresponding library's own createId (pins the statement-level trigger semantics and VOLATILE uuid_v7 generation)
 - Insert shared_space_member for a space with N linked libraries → N library_user rows for the new member with fresh createIds; `library.updateId` bumped for each of the N libraries
 - Insert shared_space_member for a space with zero linked libraries → no library_user rows, no library UPDATEs
 - Insert shared_space_library for a space with M members → M library_user rows; `library.updateId` bumped on the newly-linked library
@@ -345,7 +379,7 @@ Trigger and consumer behavior against a real DB.
 - Delete shared_space_member (user leaves space) → library_user rows removed IF no other path; owned-library rows preserved
 - Delete shared_space_library (link removed) → library_user rows removed for members who have no other path; owner's row preserved
 - Delete shared_space (whole space) → all affected (member, library) pairs with no other path get library_user removed; owner of a still-linked-elsewhere library retains access
-- Delete library (hard delete) → FK cascade removes library_user rows without involving library_audit
+- **Delete library (hard delete) via FK cascade**: directly `DELETE FROM library WHERE id = ?` → all matching `library_user` rows disappear via the `ON DELETE CASCADE` FK; assert that no `library_audit` rows are emitted (the audit chain only fires on `shared_space_*` delete paths, not on a direct `DELETE library`) and that no dangling `library_user` rows remain
 - Owner leaves a space that also links their own library → library_user row stays (owner path still valid per `user_has_library_path`)
 - **Defensive consumer re-check**: manually insert a row into `library_audit` for a (user, library) pair where the user still has access via an owned path, then assert that `library_user` is NOT deleted. This documents and locks in the `NOT user_has_library_path(...)` defensive clause.
 - **Bulk cascade**: delete a shared_space containing many members × libraries → audit rows fan-out correctly, consumer trigger deletes only the pairs with no surviving path

--- a/docs/plans/2026-04-11-library-user-access-backfill-plan.md
+++ b/docs/plans/2026-04-11-library-user-access-backfill-plan.md
@@ -1,0 +1,1765 @@
+# Library Access Backfill via `library_user` Table — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `library_user` denormalization table and four triggers so the sync stream correctly delivers library metadata and assets when a user gains access to a pre-existing library via a shared-space link (rejoin, first-time invite, or new link added to an existing space).
+
+**Architecture:** New table populated via insert triggers on `library`, `shared_space_member`, and `shared_space_library`. Deletions consumed from the existing `library_audit` table via a new AFTER INSERT trigger. `LibrarySync.getCreatedAfter` queries `library_user` instead of `library`. Migration backfill preserves owner createIds and mints fresh ones for transitive access. Zero mobile changes.
+
+**Tech Stack:** Postgres 14+, Kysely, NestJS, `@immich/sql-tools` schema decorators, Vitest (small + medium tests), Playwright/Vitest E2E.
+
+**Design doc:** `docs/plans/2026-04-11-library-user-access-backfill-design.md` (READ THIS FIRST — it explains every trade-off and the full SQL bodies).
+
+**Branch:** `fix/library-access-backfill` (this worktree). Do all work on this branch, one commit per task.
+
+**Test runner shorthand:**
+
+- Server unit/small tests: `cd server && pnpm test -- --run <path>`
+- Server medium tests: `cd server && pnpm test:medium -- --run <path>`
+- Server type check: `cd server && pnpm check`
+- Schema check: `cd server && pnpm sync:open-api` NOT needed for schema-only work; the CI schema check is what validates table/trigger registration. Locally, run `cd server && pnpm check` which runs `tsc --noEmit` and validates the decorator metadata.
+
+---
+
+## Task 1: Migration file skeleton + CREATE TABLE
+
+Create the migration file with just the table + indexes. No triggers yet — those come in later tasks. This keeps the first commit small and lets us verify the basic schema additions work before layering on trigger complexity.
+
+**Files:**
+
+- Create: `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts`
+
+**Step 1: Create the migration file with up/down stubs**
+
+```ts
+import { Kysely, sql } from 'kysely';
+
+// Adds the create-side mirror of library_audit: a denormalized (userId, libraryId)
+// access-grant table with a per-user createId. Drives LibrarySync.getCreatedAfter
+// so users gain access to pre-existing libraries via shared-space links correctly
+// receive the library metadata and its asset backfill on next sync.
+//
+// See docs/plans/2026-04-11-library-user-access-backfill-design.md for the full
+// design, trade-offs, and rationale.
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    CREATE TABLE "library_user" (
+      "userId"    uuid NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      "libraryId" uuid NOT NULL REFERENCES "library"(id) ON DELETE CASCADE,
+      "createId"  uuid NOT NULL DEFAULT immich_uuid_v7(),
+      "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+      PRIMARY KEY ("userId", "libraryId")
+    );
+  `.execute(db);
+
+  // Hot-path index: LibrarySync.getCreatedAfter filters by userId then createId,
+  // so a composite leading with userId lets the planner seek directly to the
+  // user's slice and walk sorted. PK (userId, libraryId) doesn't serve this
+  // query because it's ordered on the wrong column.
+  await sql`CREATE INDEX "library_user_userId_createId_idx" ON "library_user" ("userId", "createId");`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS "library_user_userId_createId_idx";`.execute(db);
+  await sql`DROP TABLE IF EXISTS "library_user";`.execute(db);
+}
+```
+
+**Step 2: Run type check to confirm the file parses**
+
+Run: `cd server && pnpm check 2>&1 | tail -10`
+
+Expected: no TypeScript errors mentioning the new migration. (The decorator-based schema diff will still be unhappy because we haven't registered the table yet — that's Task 2.)
+
+**Step 3: Commit**
+
+```bash
+git add server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+git commit -m "feat(server): add library_user migration skeleton"
+```
+
+---
+
+## Task 2: Register `LibraryUserTable` decorator class
+
+Add the Kysely table declaration that matches the migration. This is what `make sql` / CI schema check diffs against the DB. Without it, CI fails.
+
+**Files:**
+
+- Create: `server/src/schema/tables/library-user.table.ts`
+- Modify: `server/src/schema/index.ts` (add import + register in the table list + add to the DB interface type)
+
+**Step 1: Create the table class**
+
+Pattern lifted from `server/src/schema/tables/shared-space-member.table.ts` but with only the columns we actually have (no `updateId`, no `updatedAt`, no `role`, no `showInTimeline`).
+
+```ts
+// server/src/schema/tables/library-user.table.ts
+import { Column, CreateDateColumn, ForeignKeyColumn, Generated, Table, Timestamp } from '@immich/sql-tools';
+import { CreateIdColumn } from 'src/decorators';
+import { LibraryTable } from 'src/schema/tables/library.table';
+import { UserTable } from 'src/schema/tables/user.table';
+
+@Table('library_user')
+export class LibraryUserTable {
+  @ForeignKeyColumn(() => UserTable, { onDelete: 'CASCADE', primary: true })
+  userId!: string;
+
+  @ForeignKeyColumn(() => LibraryTable, { onDelete: 'CASCADE', primary: true })
+  libraryId!: string;
+
+  @CreateIdColumn({ index: false })
+  createId!: Generated<string>;
+
+  @CreateDateColumn()
+  createdAt!: Generated<Timestamp>;
+}
+```
+
+Note: `@CreateIdColumn({ index: false })` because we use a composite `(userId, createId)` index, not a standalone `createId` index. If the decorator library insists on a standalone index, override via the migration's raw SQL (Task 1 already creates the composite explicitly).
+
+**Step 2: Register in `server/src/schema/index.ts`**
+
+Add these edits in order:
+
+1. **Import**: add `import { LibraryUserTable } from 'src/schema/tables/library-user.table';` near the other library table imports (around line 48–49).
+2. **Tables array**: add `LibraryUserTable,` to the tables array (around line 124–125, next to `LibraryTable` and `LibraryAuditTable`).
+3. **DB interface type**: add `library_user: LibraryUserTable;` to the DB interface (around line 243–244, next to `library` and `library_audit`).
+
+**Step 3: Run type check**
+
+Run: `cd server && pnpm check 2>&1 | tail -20`
+
+Expected: no TypeScript errors. The schema diff (if checked) should now show that the registered table matches the migration's `CREATE TABLE`.
+
+**Step 4: Commit**
+
+```bash
+git add server/src/schema/tables/library-user.table.ts server/src/schema/index.ts
+git commit -m "feat(server): register LibraryUserTable in schema"
+```
+
+---
+
+## Task 3: Failing test — `library_after_insert` trigger
+
+Write the first trigger test BEFORE the trigger exists. This is the TDD gate: we verify the test fails for the right reason before writing implementation SQL.
+
+**Files:**
+
+- Create: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+
+**Step 1: Create the medium test file with the first failing test**
+
+```ts
+import { LibraryRepository } from 'src/repositories/library.repository';
+import { UserRepository } from 'src/repositories/user.repository';
+import { newMediumService } from 'test/medium.factory';
+import { defaultDatabase } from 'test/test-utils';
+
+describe('library_user triggers', () => {
+  describe('library_after_insert', () => {
+    it('inserts a library_user row for the owner with library.createId', async () => {
+      const { ctx } = await newMediumService({ repos: [LibraryRepository, UserRepository] });
+      const { user } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+      const rows = await defaultDatabase
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', user.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].createId).toBe(library.createId);
+      expect(rows[0].createdAt).toEqual(library.createdAt);
+    });
+  });
+});
+```
+
+If `newMediumService` / `ctx.newLibrary` / `ctx.newUser` don't exist with those exact signatures, check `server/test/medium.factory.ts` and `server/test/medium/specs/sync/sync-library-asset.spec.ts` for the actual API. Adjust imports accordingly — this is a pattern-match task.
+
+**Step 2: Run the test to verify it fails**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -15`
+
+Expected: the test FAILS with `expected 1 to equal 0` or similar (the library_user table is empty because no trigger populates it yet). If it fails with "relation library_user does not exist", something is wrong with Task 1/2 — stop and fix before proceeding.
+
+**Step 3: Commit the failing test**
+
+```bash
+git add server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "test(server): failing test for library_after_insert trigger"
+```
+
+---
+
+## Task 4: Implement `library_after_insert` trigger
+
+Add the trigger function + trigger to the migration. Run the test and watch it go green.
+
+**Files:**
+
+- Modify: `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts` (add function + trigger + migration_overrides)
+- Modify: `server/src/schema/functions.ts` (register the function)
+- Modify: `server/src/schema/tables/library-user.table.ts` (attach the trigger decorator)
+
+**Step 1: Add the function to `server/src/schema/functions.ts`**
+
+Add near the bottom, alongside the other library-related trigger functions (after `user_has_library_path`, around line 420):
+
+```ts
+export const library_after_insert = registerFunction({
+  name: 'library_after_insert',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+      SELECT "ownerId", "id", "createId", "createdAt"
+      FROM inserted_rows
+      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+      ON CONFLICT DO NOTHING;
+      RETURN NULL;
+    END`,
+});
+```
+
+**Step 2: Attach the trigger decorator to `LibraryUserTable`**
+
+Wait — this is wrong. The trigger fires on INSERT to `library`, not `library_user`. Decorators go on the OBSERVED table. Attach it to `LibraryTable` instead, but that's an upstream file we shouldn't touch lightly.
+
+Alternative: don't use a decorator. Write the trigger directly in the migration's `up()` function AND register it via `migration_overrides`. This is what `1778200000000-LibraryAuditTables.ts` does for triggers on shared_space / shared_space_library / shared_space_member. Follow that pattern.
+
+Replace Step 2 with: no decorator change needed. Add to the migration directly in Step 3.
+
+**Step 3: Add the CREATE FUNCTION + CREATE TRIGGER + migration_overrides to the migration's `up()`**
+
+Append to `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts` up() body (after the CREATE INDEX):
+
+```ts
+// --- Create-side triggers ---
+
+await sql`
+  CREATE OR REPLACE FUNCTION library_after_insert()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+      SELECT "ownerId", "id", "createId", "createdAt"
+      FROM inserted_rows
+      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+      ON CONFLICT DO NOTHING;
+      RETURN NULL;
+    END
+  $$;
+`.execute(db);
+
+await sql`
+  CREATE OR REPLACE TRIGGER "library_after_insert"
+  AFTER INSERT ON "library"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION library_after_insert();
+`.execute(db);
+
+// migration_overrides entries so sql-tools picks up the function and trigger
+// during `pnpm migrations:run`. Pattern lifted from 1778200000000-LibraryAuditTables.ts.
+await sql`
+  INSERT INTO "migration_overrides" ("name", "value") VALUES (
+    'function_library_after_insert',
+    '{"type":"function","name":"library_after_insert","sql":"CREATE OR REPLACE FUNCTION library_after_insert()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO library_user (\\"userId\\", \\"libraryId\\", \\"createId\\", \\"createdAt\\")\\n      SELECT \\"ownerId\\", \\"id\\", \\"createId\\", \\"createdAt\\"\\n      FROM inserted_rows\\n      WHERE \\"ownerId\\" IS NOT NULL AND \\"deletedAt\\" IS NULL\\n      ON CONFLICT DO NOTHING;\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb
+  );
+`.execute(db);
+
+await sql`
+  INSERT INTO "migration_overrides" ("name", "value") VALUES (
+    'trigger_library_after_insert',
+    '{"type":"trigger","name":"library_after_insert","sql":"CREATE OR REPLACE TRIGGER \\"library_after_insert\\"\\n  AFTER INSERT ON \\"library\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION library_after_insert();"}'::jsonb
+  );
+`.execute(db);
+```
+
+Mirror in `down()`:
+
+```ts
+await sql`DROP TRIGGER IF EXISTS "library_after_insert" ON "library";`.execute(db);
+await sql`DROP FUNCTION IF EXISTS library_after_insert();`.execute(db);
+await sql`DELETE FROM "migration_overrides" WHERE "name" IN ('function_library_after_insert', 'trigger_library_after_insert');`.execute(
+  db,
+);
+```
+
+**Step 4: Register the trigger function in `server/src/schema/functions.ts`**
+
+This is the decorator-side half of the trigger definition so `pnpm check` / CI schema diff recognizes it. Add near the bottom:
+
+```ts
+export const library_after_insert = registerFunction({
+  name: 'library_after_insert',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+      SELECT "ownerId", "id", "createId", "createdAt"
+      FROM inserted_rows
+      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+      ON CONFLICT DO NOTHING;
+      RETURN NULL;
+    END`,
+});
+```
+
+**Step 5: Attach the trigger to `LibraryTable`**
+
+Open `server/src/schema/tables/library.table.ts`. Add an `@AfterInsertTrigger` decorator on the class:
+
+```ts
+import { library_after_insert } from 'src/schema/functions';
+// ... other imports ...
+
+@Table('library')
+// ... existing decorators ...
+@AfterInsertTrigger({
+  name: 'library_after_insert',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: library_after_insert,
+})
+export class LibraryTable {
+  // ... columns ...
+}
+```
+
+Import `AfterInsertTrigger` from `@immich/sql-tools` if it isn't already.
+
+**Step 6: Reset the test DB and re-run the trigger test**
+
+The test DB needs to pick up the new migration. Depending on how `newMediumService` handles migrations (usually via testcontainers with a fresh DB per test), this may be automatic. If it's not, run:
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -15
+```
+
+Expected: the test now **PASSES**. If it still fails, double-check the trigger SQL — `inserted_rows` must be referenced from the trigger body exactly as written, and `REFERENCING NEW TABLE AS "inserted_rows"` must be in the CREATE TRIGGER clause.
+
+**Step 7: Run `pnpm check` to verify schema registration is consistent**
+
+Run: `cd server && pnpm check 2>&1 | tail -10`
+
+Expected: no TypeScript errors. If the schema diff tool complains about a mismatch between the registered function body and the migration SQL, copy the exact body from the migration into `registerFunction`'s `body` field (they must match character-for-character after whitespace normalization).
+
+**Step 8: Commit**
+
+```bash
+git add server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts \
+        server/src/schema/functions.ts \
+        server/src/schema/tables/library.table.ts \
+        server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "feat(server): library_after_insert trigger populates library_user for owners"
+```
+
+---
+
+## Task 5: Additional `library_after_insert` edge-case tests
+
+Pin the full semantics of the trigger with boundary cases. All tests should PASS on the first run since the trigger already exists.
+
+**Files:**
+
+- Modify: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+
+**Step 1: Add the edge-case tests**
+
+Inside the `describe('library_after_insert', ...)` block, add:
+
+```ts
+it('does not insert a library_user row when ownerId is NULL', async () => {
+  const { ctx } = await newMediumService({ repos: [LibraryRepository] });
+  // Insert a library with no owner (adjust the factory call to match reality;
+  // may need to bypass the service layer and insert directly if the service
+  // enforces ownerId NOT NULL).
+  const row = await defaultDatabase
+    .insertInto('library')
+    .values({ name: 'orphan', ownerId: null })
+    .returning(['id'])
+    .executeTakeFirstOrThrow();
+
+  const rows = await defaultDatabase.selectFrom('library_user').selectAll().where('libraryId', '=', row.id).execute();
+
+  expect(rows).toHaveLength(0);
+});
+
+it('does not insert a library_user row when deletedAt is set at insert time', async () => {
+  const { ctx } = await newMediumService({ repos: [LibraryRepository, UserRepository] });
+  const { user } = await ctx.newUser();
+  const row = await defaultDatabase
+    .insertInto('library')
+    .values({ name: 'already-deleted', ownerId: user.id, deletedAt: new Date() })
+    .returning(['id'])
+    .executeTakeFirstOrThrow();
+
+  const rows = await defaultDatabase.selectFrom('library_user').selectAll().where('libraryId', '=', row.id).execute();
+
+  expect(rows).toHaveLength(0);
+});
+
+it('inserts one library_user row per library when multiple libraries are created in one statement', async () => {
+  const { ctx } = await newMediumService({ repos: [UserRepository] });
+  const { user } = await ctx.newUser();
+
+  // Bulk insert 5 libraries in a single statement via the kysely query builder
+  const libraries = await defaultDatabase
+    .insertInto('library')
+    .values([
+      { name: 'bulk-1', ownerId: user.id },
+      { name: 'bulk-2', ownerId: user.id },
+      { name: 'bulk-3', ownerId: user.id },
+      { name: 'bulk-4', ownerId: user.id },
+      { name: 'bulk-5', ownerId: user.id },
+    ])
+    .returning(['id', 'createId', 'createdAt'])
+    .execute();
+
+  expect(libraries).toHaveLength(5);
+
+  const rows = await defaultDatabase.selectFrom('library_user').selectAll().where('userId', '=', user.id).execute();
+
+  expect(rows).toHaveLength(5);
+  // Each library_user row's createId must match its library's createId exactly.
+  const byLibraryId = new Map(rows.map((r) => [r.libraryId, r]));
+  for (const lib of libraries) {
+    const userRow = byLibraryId.get(lib.id);
+    expect(userRow).toBeDefined();
+    expect(userRow!.createId).toBe(lib.createId);
+  }
+  // All 5 createIds must be distinct (verifies immich_uuid_v7 VOLATILE
+  // per-row evaluation in both library row inserts and trigger copies)
+  const uniqueCreateIds = new Set(rows.map((r) => r.createId));
+  expect(uniqueCreateIds.size).toBe(5);
+});
+```
+
+**Step 2: Run all library_after_insert tests**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -15`
+
+Expected: 4 tests pass (1 from Task 3 + 3 new).
+
+**Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "test(server): pin library_after_insert edge cases (null owner, soft-delete, bulk insert)"
+```
+
+---
+
+## Task 6: Failing test — `shared_space_member_after_insert_library` trigger
+
+**Files:**
+
+- Modify: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+
+**Step 1: Add the failing test inside a new describe block**
+
+```ts
+describe('shared_space_member_after_insert_library', () => {
+  it('grants library_user for every library linked to the space the new member joined', async () => {
+    const { ctx } = await newMediumService({
+      repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
+    });
+    const { user: owner } = await ctx.newUser();
+    const { user: newMember } = await ctx.newUser();
+
+    // Space owned by `owner`
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    // Three libraries, all owned by `owner`, all linked to the space
+    const libraryA = (await ctx.newLibrary({ ownerId: owner.id })).library;
+    const libraryB = (await ctx.newLibrary({ ownerId: owner.id })).library;
+    const libraryC = (await ctx.newLibrary({ ownerId: owner.id })).library;
+    await ctx.linkLibraryToSpace(space.id, libraryA.id);
+    await ctx.linkLibraryToSpace(space.id, libraryB.id);
+    await ctx.linkLibraryToSpace(space.id, libraryC.id);
+
+    // Capture library.updateId BEFORE the trigger bumps them
+    const beforeUpdateIds = await defaultDatabase
+      .selectFrom('library')
+      .select(['id', 'updateId'])
+      .where('id', 'in', [libraryA.id, libraryB.id, libraryC.id])
+      .execute();
+
+    // Add newMember to the space → trigger fires
+    await ctx.addSharedSpaceMember(space.id, newMember.id);
+
+    // Each library should have a library_user row for newMember
+    const rows = await defaultDatabase
+      .selectFrom('library_user')
+      .select(['libraryId', 'createId'])
+      .where('userId', '=', newMember.id)
+      .execute();
+
+    expect(rows.map((r) => r.libraryId).sort()).toEqual([libraryA.id, libraryB.id, libraryC.id].sort());
+
+    // The createIds should all be distinct and freshly-minted (not equal to library.createId)
+    const uniqueCreateIds = new Set(rows.map((r) => r.createId));
+    expect(uniqueCreateIds.size).toBe(3);
+
+    // library.updateId should be bumped for all three libraries
+    const afterUpdateIds = await defaultDatabase
+      .selectFrom('library')
+      .select(['id', 'updateId'])
+      .where('id', 'in', [libraryA.id, libraryB.id, libraryC.id])
+      .execute();
+    const beforeById = new Map(beforeUpdateIds.map((r) => [r.id, r.updateId]));
+    for (const after of afterUpdateIds) {
+      expect(after.updateId).not.toBe(beforeById.get(after.id));
+    }
+  });
+});
+```
+
+Factory helpers like `ctx.linkLibraryToSpace` and `ctx.addSharedSpaceMember` probably already exist — check `server/test/medium/specs/sync/sync-shared-space-library.spec.ts` or similar for the names. If they don't exist, add them to `test/medium.factory.ts` as part of this task.
+
+**Step 2: Run the test, expect FAIL**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "shared_space_member_after_insert_library" 2>&1 | tail -15`
+
+Expected: the assertion `expect(rows.map(...)).toEqual(...)` fails because no rows are in library_user (no trigger yet). If it fails with a setup error (unknown factory method), fix the setup before proceeding.
+
+**Step 3: Commit the failing test**
+
+```bash
+git add server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "test(server): failing test for shared_space_member_after_insert_library trigger"
+```
+
+---
+
+## Task 7: Implement `shared_space_member_after_insert_library` trigger
+
+**Files:**
+
+- Modify: `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts`
+- Modify: `server/src/schema/functions.ts`
+- Modify: `server/src/schema/tables/shared-space-member.table.ts` (attach the new trigger)
+
+**Step 1: Add function + trigger to the migration up() (after the library_after_insert block)**
+
+```ts
+await sql`
+  CREATE OR REPLACE FUNCTION shared_space_member_after_insert_library()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ir."userId", ssl."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (
+        SELECT DISTINCT ssl."libraryId"
+        FROM inserted_rows ir
+        INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      );
+      RETURN NULL;
+    END
+  $$;
+`.execute(db);
+
+await sql`
+  CREATE OR REPLACE TRIGGER "shared_space_member_after_insert_library"
+  AFTER INSERT ON "shared_space_member"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION shared_space_member_after_insert_library();
+`.execute(db);
+```
+
+Plus the corresponding `migration_overrides` entries for the function and trigger (same pattern as Task 4 — encode the SQL as a JSON-escaped string). And mirror the drops in `down()`.
+
+**Step 2: Register the function in `server/src/schema/functions.ts`**
+
+```ts
+export const shared_space_member_after_insert_library = registerFunction({
+  name: 'shared_space_member_after_insert_library',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ir."userId", ssl."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (
+        SELECT DISTINCT ssl."libraryId"
+        FROM inserted_rows ir
+        INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      );
+      RETURN NULL;
+    END`,
+});
+```
+
+**Step 3: Attach the trigger decorator to `SharedSpaceMemberTable`**
+
+In `server/src/schema/tables/shared-space-member.table.ts`, add a new `@AfterInsertTrigger` decorator (sibling of the existing `shared_space_member_after_insert`):
+
+```ts
+import {
+  shared_space_member_after_insert,
+  shared_space_member_after_insert_library, // new
+  // ... existing imports
+} from 'src/schema/functions';
+
+@Table('shared_space_member')
+// ... existing decorators ...
+@AfterInsertTrigger({
+  name: 'shared_space_member_after_insert',
+  // ... existing ...
+})
+// New: populate library_user + bump library.updateId for every library linked
+// to the space the new member joined. See docs/plans/2026-04-11-library-user-access-backfill-design.md.
+@AfterInsertTrigger({
+  name: 'shared_space_member_after_insert_library',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: shared_space_member_after_insert_library,
+})
+// ... rest ...
+export class SharedSpaceMemberTable {
+  /* ... */
+}
+```
+
+**Step 4: Run the test**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "shared_space_member_after_insert_library" 2>&1 | tail -15`
+
+Expected: the test PASSES.
+
+**Step 5: Run `pnpm check`**
+
+Run: `cd server && pnpm check 2>&1 | tail -10`
+
+Expected: no errors.
+
+**Step 6: Commit**
+
+```bash
+git add server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts \
+        server/src/schema/functions.ts \
+        server/src/schema/tables/shared-space-member.table.ts \
+        server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "feat(server): shared_space_member_after_insert_library trigger"
+```
+
+---
+
+## Task 8: Additional `shared_space_member_after_insert_library` edge-case tests
+
+**Files:**
+
+- Modify: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+
+**Step 1: Add these tests inside the describe block**
+
+```ts
+it('is a no-op when the space has zero linked libraries', async () => {
+  const { ctx } = await newMediumService({ repos: [UserRepository, SharedSpaceRepository] });
+  const { user: owner } = await ctx.newUser();
+  const { user: newMember } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  // No libraries linked.
+
+  await ctx.addSharedSpaceMember(space.id, newMember.id);
+
+  const rows = await defaultDatabase
+    .selectFrom('library_user')
+    .selectAll()
+    .where('userId', '=', newMember.id)
+    .execute();
+  expect(rows).toHaveLength(0);
+});
+
+it('ON CONFLICT DO NOTHING preserves an existing owner library_user row', async () => {
+  const { ctx } = await newMediumService({
+    repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
+  });
+  const { user } = await ctx.newUser();
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+  // Owner already has a library_user row from library_after_insert,
+  // with createId = library.createId
+  const ownerRowBefore = await defaultDatabase
+    .selectFrom('library_user')
+    .select(['createId'])
+    .where('userId', '=', user.id)
+    .where('libraryId', '=', library.id)
+    .executeTakeFirstOrThrow();
+  expect(ownerRowBefore.createId).toBe(library.createId);
+
+  // User joins a space that also links their own library
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.linkLibraryToSpace(space.id, library.id);
+  // Owner was auto-added as member on newSharedSpace; re-adding them would
+  // be a duplicate. Use a fresh user instead.
+  const { user: peer } = await ctx.newUser();
+  await ctx.addSharedSpaceMember(space.id, peer.id);
+
+  // Owner's row is unchanged (still has library.createId)
+  const ownerRowAfter = await defaultDatabase
+    .selectFrom('library_user')
+    .select(['createId'])
+    .where('userId', '=', user.id)
+    .where('libraryId', '=', library.id)
+    .executeTakeFirstOrThrow();
+  expect(ownerRowAfter.createId).toBe(library.createId);
+});
+```
+
+**Step 2: Run tests**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -15`
+
+Expected: all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "test(server): pin shared_space_member trigger edge cases"
+```
+
+---
+
+## Task 9: Failing test + implementation — `shared_space_library_after_insert_user` trigger
+
+Bundled task because the pattern mirrors Task 6+7.
+
+**Files:**
+
+- Modify: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+- Modify: `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts`
+- Modify: `server/src/schema/functions.ts`
+- Modify: `server/src/schema/tables/shared-space-library.table.ts`
+
+**Step 1: Add the failing test**
+
+```ts
+describe('shared_space_library_after_insert_user', () => {
+  it('grants library_user for every member of the space when a library is linked', async () => {
+    const { ctx } = await newMediumService({
+      repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
+    });
+    const { user: owner } = await ctx.newUser();
+    const { user: memberA } = await ctx.newUser();
+    const { user: memberB } = await ctx.newUser();
+
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.addSharedSpaceMember(space.id, memberA.id);
+    await ctx.addSharedSpaceMember(space.id, memberB.id);
+
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+
+    // Capture library.updateId before the trigger bumps it
+    const before = await defaultDatabase
+      .selectFrom('library')
+      .select(['updateId'])
+      .where('id', '=', library.id)
+      .executeTakeFirstOrThrow();
+
+    await ctx.linkLibraryToSpace(space.id, library.id);
+
+    // memberA and memberB should get library_user rows
+    const rows = await defaultDatabase
+      .selectFrom('library_user')
+      .select(['userId'])
+      .where('libraryId', '=', library.id)
+      .execute();
+
+    const userIds = rows.map((r) => r.userId).sort();
+    // owner was already in library_user via library_after_insert + is also
+    // a space member, but ON CONFLICT preserves their existing row
+    expect(userIds).toContain(owner.id);
+    expect(userIds).toContain(memberA.id);
+    expect(userIds).toContain(memberB.id);
+
+    // library.updateId was bumped
+    const after = await defaultDatabase
+      .selectFrom('library')
+      .select(['updateId'])
+      .where('id', '=', library.id)
+      .executeTakeFirstOrThrow();
+    expect(after.updateId).not.toBe(before.updateId);
+  });
+
+  it('bumps library.updateId even when the space has zero members (covers empty-members edge)', async () => {
+    // Hypothetical scenario since newSharedSpace always adds the creator as
+    // a member, this might be impossible via the service layer. If so, use
+    // direct SQL to bypass the creator-as-member invariant for the test.
+    // (skipped if the factory doesn't expose a way)
+  });
+});
+```
+
+**Step 2: Run → expect fail on the first test**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "shared_space_library_after_insert_user" 2>&1 | tail -15`
+
+Expected: FAIL (memberA/memberB rows missing).
+
+**Step 3: Add function + trigger + migration_overrides in the migration**
+
+```ts
+await sql`
+  CREATE OR REPLACE FUNCTION shared_space_library_after_insert_user()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ssm."userId", ir."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_member ssm ON ssm."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (SELECT DISTINCT "libraryId" FROM inserted_rows);
+      RETURN NULL;
+    END
+  $$;
+`.execute(db);
+
+await sql`
+  CREATE OR REPLACE TRIGGER "shared_space_library_after_insert_user"
+  AFTER INSERT ON "shared_space_library"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION shared_space_library_after_insert_user();
+`.execute(db);
+```
+
+Plus matching `migration_overrides` entries. Mirror drops in `down()`.
+
+**Step 4: Register in `functions.ts`** (same body as Step 3).
+
+**Step 5: Attach decorator on `SharedSpaceLibraryTable`**
+
+In `server/src/schema/tables/shared-space-library.table.ts`, add `@AfterInsertTrigger` with `function: shared_space_library_after_insert_user`.
+
+**Step 6: Run test → expect PASS**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "shared_space_library_after_insert_user" 2>&1 | tail -15`
+
+Expected: PASS.
+
+**Step 7: Run full trigger spec + check**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -20`
+Run: `cd server && pnpm check 2>&1 | tail -10`
+
+Expected: all tests pass, no type errors.
+
+**Step 8: Commit**
+
+```bash
+git add server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts \
+        server/src/schema/functions.ts \
+        server/src/schema/tables/shared-space-library.table.ts \
+        server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "feat(server): shared_space_library_after_insert_user trigger"
+```
+
+---
+
+## Task 10: Failing tests + implementation — `library_user_delete_after_audit` consumer trigger
+
+This trigger is the delete-side counterpart. Bundled: failing tests, implementation, additional tests, commit.
+
+**Files:**
+
+- Modify: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+- Modify: `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts`
+- Modify: `server/src/schema/functions.ts`
+- Modify: `server/src/schema/tables/library-audit.table.ts`
+
+**Step 1: Write the failing tests inside a new describe block**
+
+```ts
+describe('library_user_delete_after_audit', () => {
+  it('removes library_user when a member leaves a space and has no other path', async () => {
+    const { ctx } = await newMediumService({
+      /* relevant repos */
+    });
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, viewer.id);
+
+    // Viewer has library access via the space path
+    const before = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', viewer.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(before).toHaveLength(1);
+
+    // Viewer leaves
+    await ctx.removeSharedSpaceMember(space.id, viewer.id);
+
+    const after = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', viewer.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(after).toHaveLength(0);
+  });
+
+  it('preserves library_user for the owner even when they leave a space that linked the library', async () => {
+    const { ctx } = await newMediumService({
+      /* ... */
+    });
+    const { user: owner } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    // Owner is auto-added as a member on space creation; leaving...
+    // Actually the space creator can't leave their own space via the normal
+    // service call — the creator is the owner of the space. Use a slightly
+    // different setup: peer owner creates space and links a library they
+    // also own, a different user (our "owner") is a space member AND owns
+    // another library that's ALSO linked to the same space. Then the "owner"
+    // leaves.
+    // (exact setup depends on factory; adapt as needed)
+  });
+
+  it('defensive re-check: does NOT delete library_user when user_has_library_path is still true', async () => {
+    // Setup: user owns library, and separately has library_audit row inserted
+    // manually (bypassing the normal delete trigger chain). Since owner path
+    // is still valid, user_has_library_path returns true → consumer trigger
+    // must NOT delete library_user.
+    const { ctx } = await newMediumService({
+      /* ... */
+    });
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    // Confirm the owner row exists
+    const before = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(before).toHaveLength(1);
+
+    // Manually insert into library_audit (bypassing gated triggers)
+    await defaultDatabase.insertInto('library_audit').values({ libraryId: library.id, userId: user.id }).execute();
+
+    // Defensive clause must have protected the row
+    const after = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(after).toHaveLength(1);
+  });
+
+  it('hard-deleting a library removes library_user rows via FK cascade (no library_audit involvement)', async () => {
+    const { ctx } = await newMediumService({
+      /* ... */
+    });
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    // library_user exists via library_after_insert
+    const before = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(before).toHaveLength(1);
+
+    // Capture library_audit state before delete
+    const auditBefore = await defaultDatabase
+      .selectFrom('library_audit')
+      .selectAll()
+      .where('libraryId', '=', library.id)
+      .execute();
+
+    await defaultDatabase.deleteFrom('library').where('id', '=', library.id).execute();
+
+    // library_user is gone via FK cascade
+    const after = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(after).toHaveLength(0);
+
+    // library_audit has NO new rows (hard-delete bypasses the audit chain)
+    const auditAfter = await defaultDatabase
+      .selectFrom('library_audit')
+      .selectAll()
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(auditAfter).toHaveLength(auditBefore.length);
+  });
+});
+```
+
+**Step 2: Run → expect fail**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "library_user_delete_after_audit" 2>&1 | tail -20`
+
+Expected: the first three tests fail (the fourth — FK cascade — would actually pass right now because FK cascade is already declared on the table). The first test might fail because the existing delete chain inserts into library_audit but nothing deletes from library_user.
+
+**Step 3: Add function + trigger + overrides in migration**
+
+```ts
+await sql`
+  CREATE OR REPLACE FUNCTION library_user_delete_after_audit()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      DELETE FROM library_user lu
+      USING inserted_rows ir
+      WHERE lu."userId" = ir."userId"
+        AND lu."libraryId" = ir."libraryId"
+        AND NOT user_has_library_path(lu."libraryId", lu."userId", NULL);
+      RETURN NULL;
+    END
+  $$;
+`.execute(db);
+
+await sql`
+  CREATE OR REPLACE TRIGGER "library_user_delete_after_audit"
+  AFTER INSERT ON "library_audit"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION library_user_delete_after_audit();
+`.execute(db);
+```
+
+Plus `migration_overrides` + `down()` drops.
+
+**Step 4: Register in `functions.ts`**
+
+```ts
+export const library_user_delete_after_audit = registerFunction({
+  name: 'library_user_delete_after_audit',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      DELETE FROM library_user lu
+      USING inserted_rows ir
+      WHERE lu."userId" = ir."userId"
+        AND lu."libraryId" = ir."libraryId"
+        AND NOT user_has_library_path(lu."libraryId", lu."userId", NULL);
+      RETURN NULL;
+    END`,
+});
+```
+
+**Step 5: Attach the decorator to `LibraryAuditTable`**
+
+```ts
+// server/src/schema/tables/library-audit.table.ts
+import { AfterInsertTrigger } from '@immich/sql-tools';
+import { library_user_delete_after_audit } from 'src/schema/functions';
+
+@Table('library_audit')
+// ... existing decorators ...
+@AfterInsertTrigger({
+  name: 'library_user_delete_after_audit',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: library_user_delete_after_audit,
+})
+export class LibraryAuditTable {
+  /* ... */
+}
+```
+
+**Step 6: Run all tests in the spec**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -25`
+
+Expected: every test passes.
+
+**Step 7: Run `pnpm check`**
+
+Run: `cd server && pnpm check 2>&1 | tail -10`
+
+**Step 8: Commit**
+
+```bash
+git add server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts \
+        server/src/schema/functions.ts \
+        server/src/schema/tables/library-audit.table.ts \
+        server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "feat(server): library_user_delete_after_audit consumer trigger + defensive re-check"
+```
+
+---
+
+## Task 11: Failing tests + implementation — migration backfill
+
+Write the migration backfill passes and the tests that verify their correctness. Done as one task because the backfill is a single transaction in the migration file and the tests are tightly coupled.
+
+**Files:**
+
+- Create: `server/test/medium/specs/sync/library-user-migration.spec.ts`
+- Modify: `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts`
+
+**Step 1: Write the failing tests**
+
+Migration tests are tricky because by the time the test suite runs, the migration has already been applied. The test needs to seed pre-migration state, then explicitly invoke the backfill SQL, then assert.
+
+```ts
+import { sql } from 'kysely';
+import { defaultDatabase } from 'test/test-utils';
+
+describe('library_user migration backfill', () => {
+  // These tests manipulate library_user directly, so clean up after each.
+  afterEach(async () => {
+    await defaultDatabase.deleteFrom('library_user').execute();
+  });
+
+  it('owner rows use library.createId (Pass 1)', async () => {
+    // Seed: create user + library via direct SQL, leave the library_after_insert
+    // trigger to populate library_user at insert time. Delete the triggered row
+    // and re-run the backfill INSERT manually — verify the Pass 1 SQL produces
+    // the same row.
+    //
+    // Simpler alternative: disable the trigger temporarily for this test, insert
+    // the library, then run the backfill. Or: just assert that the row created
+    // by the trigger has createId = library.createId (which the trigger test
+    // already covers). This test is more about the migration SQL as a string.
+    //
+    // Actual test: run Pass 1 SQL in isolation against a small seeded state.
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    // Clear what the trigger inserted
+    await defaultDatabase.deleteFrom('library_user').execute();
+
+    // Run Pass 1 SQL
+    await sql`
+      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+      SELECT "ownerId", "id", "createId", "createdAt"
+      FROM library
+      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+      ON CONFLICT ("userId", "libraryId") DO NOTHING;
+    `.execute(defaultDatabase);
+
+    const row = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .executeTakeFirstOrThrow();
+    expect(row.createId).toBe(library.createId);
+    expect(row.createdAt).toEqual(library.createdAt);
+  });
+
+  it('transitive rows use fresh createId (Pass 2)', async () => {
+    // Setup a user who has transitive access, simulate a stale state by
+    // clearing library_user, then run Pass 2 and verify createId is fresh.
+    // (details elided — same pattern)
+  });
+
+  it('Pass 2 preserves owner rows via ON CONFLICT DO NOTHING', async () => {
+    // User owns library AND is in a space that links it. Run Pass 1 then
+    // Pass 2. Assert only ONE row and its createId equals library.createId.
+  });
+
+  it('is idempotent: re-running both passes is a no-op', async () => {
+    // Run Pass 1 + Pass 2. Capture state. Run them again. Assert state
+    // unchanged.
+  });
+
+  it('includes soft-deleted libraries in Pass 2 when linked to a space (mirrors accessibleLibraries)', async () => {
+    // ...
+  });
+
+  it('skips soft-deleted libraries in Pass 1 (owned path)', async () => {
+    // ...
+  });
+});
+```
+
+**Step 2: Run → expect fail** (because the backfill SQL doesn't exist in the migration yet and the tests reference it as an isolated block).
+
+Actually wait — the tests above run the backfill SQL inline, not via the migration. So they test the SQL string itself. The failing-state here is that without the TRIGGER being disabled, Pass 1 + Pass 2 would try to populate rows already populated by triggers. The `ON CONFLICT DO NOTHING` handles that. So the tests actually should pass as soon as the SQL is correct — they test the SQL, not the migration's execution order.
+
+Modify the TDD flow: write the test, run it, it may pass already if the triggers + inline SQL work together. Then add the backfill SQL to the migration file so it runs for real during migration execution.
+
+**Step 3: Add Pass 1 + Pass 2 to the migration `up()` (after the triggers are created so any seed data gets backfilled correctly)**
+
+```ts
+// --- Backfill pass 1: owned libraries inherit library.createId so existing
+// synced clients don't re-backfill libraries they already have.
+await sql`
+  INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+  SELECT "ownerId", "id", "createId", "createdAt"
+  FROM library
+  WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+  ON CONFLICT ("userId", "libraryId") DO NOTHING;
+`.execute(db);
+
+// --- Backfill pass 2: transitive access via shared_space_library with fresh
+// createIds so users in the broken state get their missing libraries
+// re-delivered on next sync. Soft-deleted libraries deliberately included —
+// matches accessibleLibraries's space-link branch behavior.
+await sql`
+  INSERT INTO library_user ("userId", "libraryId")
+  SELECT DISTINCT ssm."userId", ssl."libraryId"
+  FROM shared_space_library ssl
+  INNER JOIN shared_space_member ssm ON ssl."spaceId" = ssm."spaceId"
+  ON CONFLICT ("userId", "libraryId") DO NOTHING;
+`.execute(db);
+```
+
+**Step 4: Run all migration tests + all trigger tests to make sure nothing regressed**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-migration.spec.ts 2>&1 | tail -20`
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -20`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts \
+        server/test/medium/specs/sync/library-user-migration.spec.ts
+git commit -m "feat(server): migration backfill populates library_user from existing state"
+```
+
+---
+
+## Task 12: Failing unit tests for `LibrarySync.getCreatedAfter`
+
+Before rewriting the query, write the new expected behavior as unit tests. This pins the set-equality invariant and soft-delete behavior.
+
+**Files:**
+
+- Modify: `server/src/repositories/sync.repository.spec.ts` (or create a new focused spec file)
+
+**Step 1: Add the failing tests**
+
+```ts
+describe('LibrarySync.getCreatedAfter', () => {
+  it('returns libraries the user owns', async () => {
+    // Setup via repo
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    // (trigger populates library_user automatically)
+
+    const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: user.id, afterCreateId: undefined });
+    expect(rows.map((r) => r.id)).toContain(library.id);
+  });
+
+  it('returns libraries the user accesses via shared_space_library', async () => {
+    /* similar */
+  });
+
+  it('returns empty for a user with no library access', async () => {
+    /* similar */
+  });
+
+  it('filters by afterCreateId', async () => {
+    /* two libraries, check that only the one >= afterCreateId is returned */
+  });
+
+  it('orders by createId ascending', async () => {
+    /* seed 3 libraries with known createIds, assert order */
+  });
+
+  it('excludes a soft-deleted owned library when the user has no space-linked path', async () => {
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    // Soft-delete
+    await defaultDatabase.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+
+    const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: user.id, afterCreateId: undefined });
+    expect(rows.find((r) => r.id === library.id)).toBeUndefined();
+  });
+
+  it('includes a soft-deleted library when the user has a space-linked path to it', async () => {
+    /* owner, stranger, space, linked library, soft-delete via owner,
+       assert stranger still sees it */
+  });
+
+  it('set equality with accessibleLibraries', async () => {
+    // Seed a user with a mix of owned, owned+soft-deleted, owned+space-linked,
+    // and transitive libraries. Query both getCreatedAfter(afterCreateId=null)
+    // and accessibleLibraries. Assert the set of libraryIds matches.
+    const { user } = await ctx.newUser();
+    const { library: owned } = await ctx.newLibrary({ ownerId: user.id });
+    const { library: softDeleted } = await ctx.newLibrary({ ownerId: user.id });
+    await defaultDatabase
+      .updateTable('library')
+      .set({ deletedAt: new Date() })
+      .where('id', '=', softDeleted.id)
+      .execute();
+
+    const { user: peer } = await ctx.newUser();
+    const { library: transitive } = await ctx.newLibrary({ ownerId: peer.id });
+    const { space } = await ctx.newSharedSpace({ createdById: peer.id });
+    await ctx.linkLibraryToSpace(space.id, transitive.id);
+    await ctx.addSharedSpaceMember(space.id, user.id);
+
+    const getCreatedAfterIds = new Set(
+      (await sut.getCreatedAfter({ nowId: dummyNowId, userId: user.id, afterCreateId: undefined })).map((r) => r.id),
+    );
+    const accessibleIds = new Set(
+      (
+        await defaultDatabase
+          .selectFrom('library')
+          .select('id')
+          .where('library.id', 'in', (eb) => accessibleLibraries(eb, user.id))
+          .execute()
+      ).map((r) => r.id),
+    );
+
+    expect(getCreatedAfterIds).toEqual(accessibleIds);
+    expect(getCreatedAfterIds.has(owned.id)).toBe(true);
+    expect(getCreatedAfterIds.has(softDeleted.id)).toBe(false); // excluded via accessibleLibraries
+    expect(getCreatedAfterIds.has(transitive.id)).toBe(true);
+  });
+});
+```
+
+**Step 2: Run → expect fail**
+
+Run: `cd server && pnpm test:medium -- --run src/repositories/sync.repository.spec.ts -t "LibrarySync.getCreatedAfter" 2>&1 | tail -20`
+
+Expected: tests fail. The OLD query reads from `library` table and uses `library.createId`. For some seeded states the set will match, for others it won't. Specifically, the "set equality with accessibleLibraries" test should fail because the old query's filtering logic differs.
+
+If some tests unexpectedly PASS, that's fine — they're pinning existing behavior that the new implementation must preserve. Note which ones passed so you know the new implementation must still make them pass.
+
+**Step 3: Commit failing tests**
+
+```bash
+git add server/src/repositories/sync.repository.spec.ts
+git commit -m "test(server): failing tests for LibrarySync.getCreatedAfter rewrite"
+```
+
+---
+
+## Task 13: Rewrite `LibrarySync.getCreatedAfter`
+
+**Files:**
+
+- Modify: `server/src/repositories/sync.repository.ts` (the `LibrarySync.getCreatedAfter` method, around line 1117)
+
+**Step 1: Replace the method body**
+
+Current:
+
+```ts
+@GenerateSql({ params: [dummyCreateAfterOptions] })
+getCreatedAfter({ nowId, userId, afterCreateId }: SyncCreatedAfterOptions) {
+  return this.db
+    .selectFrom('library')
+    .select(['library.id', 'library.createId'])
+    .where('library.id', 'in', (eb) => accessibleLibraries(eb, userId))
+    .$if(!!afterCreateId, (qb) => qb.where('library.createId', '>=', afterCreateId!))
+    .where('library.createId', '<', nowId)
+    .orderBy('library.createId', 'asc')
+    .execute();
+}
+```
+
+New:
+
+```ts
+// BEFORE: queried `library` keyed by library.createId — missed re-adds and
+// new invites because the library's own createId is past the user's checkpoint.
+// AFTER: queries `library_user` keyed by the per-user access grant createId,
+// mirroring SharedSpaceSync.getCreatedAfter and AlbumSync.getCreatedAfter.
+//
+// The `library.id IN accessibleLibraries(userId)` filter is preserved so that
+// soft-deleted owned libraries are excluded from the backfill loop — matching
+// the existing behavior where `accessibleLibraries` drops the ownership branch
+// when `deletedAt IS NOT NULL`, while keeping soft-deleted libraries visible
+// via the space-link branch. See
+// docs/plans/2026-04-11-library-user-access-backfill-design.md.
+@GenerateSql({ params: [dummyCreateAfterOptions] })
+getCreatedAfter({ nowId, userId, afterCreateId }: SyncCreatedAfterOptions) {
+  return this.db
+    .selectFrom('library_user')
+    .select(['library_user.libraryId as id', 'library_user.createId'])
+    .where('library_user.userId', '=', userId)
+    .where('library_user.libraryId', 'in', (eb) => accessibleLibraries(eb, userId))
+    .$if(!!afterCreateId, (qb) => qb.where('library_user.createId', '>=', afterCreateId!))
+    .where('library_user.createId', '<', nowId)
+    .orderBy('library_user.createId', 'asc')
+    .execute();
+}
+```
+
+**Step 2: Run the getCreatedAfter tests**
+
+Run: `cd server && pnpm test:medium -- --run src/repositories/sync.repository.spec.ts -t "LibrarySync.getCreatedAfter" 2>&1 | tail -20`
+
+Expected: all tests pass.
+
+**Step 3: Run the full sync-library test suites to check for regressions**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/sync/sync-library.spec.ts 2>&1 | tail -20
+cd server && pnpm test:medium -- --run test/medium/specs/sync/sync-library-asset.spec.ts 2>&1 | tail -20
+cd server && pnpm test:medium -- --run test/medium/specs/sync/sync-library-asset-exif.spec.ts 2>&1 | tail -20
+cd server && pnpm test:medium -- --run test/medium/specs/sync/library-audit-triggers.spec.ts 2>&1 | tail -20
+```
+
+Expected: all green.
+
+**Step 4: Regenerate SQL query docs**
+
+Run: `cd server && pnpm sql` (if available — this regenerates `server/src/queries/*.sql`)
+
+Expected: a diff in `server/src/queries/sync.repository.sql` reflecting the new `getCreatedAfter` query. Commit the regenerated SQL alongside the code.
+
+**Step 5: Commit**
+
+```bash
+git add server/src/repositories/sync.repository.ts server/src/queries/sync.repository.sql
+git commit -m "fix(server): LibrarySync.getCreatedAfter queries library_user for per-user access grants"
+```
+
+---
+
+## Task 14: Integration tests for the three failing scenarios
+
+End-to-end sync stream assertions exercising the full stack: migration + triggers + rewritten query + existing `syncLibrariesV1` / `syncLibraryAssetsV1` service methods.
+
+**Files:**
+
+- Create: `server/test/medium/specs/sync/library-access-backfill.spec.ts`
+
+**Step 1: Create the spec with the three scenarios**
+
+```ts
+import { SyncEntityType, SyncRequestType } from 'src/enum';
+import { newSyncAuthUser, newSyncTest } from 'test/medium.factory';
+
+describe('library access backfill — sync stream integration', () => {
+  // Scenario 1: User re-added to a space after leaving
+  it('re-delivers library metadata + assets after a user leaves and rejoins a space', async () => {
+    const { ctx } = await newSyncTest();
+    const auth = await newSyncAuthUser();
+    const { user: owner } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, auth.user.id);
+
+    // First sync — should deliver library + asset
+    const initial = await ctx.syncStream(auth, [SyncRequestType.LibrariesV1, SyncRequestType.LibraryAssetsV1]);
+    expect(initial.filter((e) => e.type === SyncEntityType.LibraryV1).length).toBeGreaterThanOrEqual(1);
+    // The asset may come via upsert or backfill — accept either
+    const assetsInitial = initial.filter(
+      (e) => e.type === SyncEntityType.LibraryAssetCreateV1 || e.type === SyncEntityType.LibraryAssetBackfillV1,
+    );
+    expect(assetsInitial.length).toBeGreaterThanOrEqual(1);
+
+    await ctx.syncAckAll(auth, initial);
+
+    // Leave the space
+    await ctx.removeSharedSpaceMember(space.id, auth.user.id);
+
+    // Sync the delete events so checkpoint advances past them
+    const leaveSync = await ctx.syncStream(auth, [SyncRequestType.LibrariesV1, SyncRequestType.LibraryAssetsV1]);
+    expect(leaveSync.some((e) => e.type === SyncEntityType.LibraryDeleteV1)).toBe(true);
+    await ctx.syncAckAll(auth, leaveSync);
+
+    // Re-add
+    await ctx.addSharedSpaceMember(space.id, auth.user.id);
+
+    // Third sync — THE TEST: library + asset should be re-delivered
+    const rejoinSync = await ctx.syncStream(auth, [SyncRequestType.LibrariesV1, SyncRequestType.LibraryAssetsV1]);
+    expect(rejoinSync.some((e) => e.type === SyncEntityType.LibraryV1)).toBe(true);
+    const assetsRejoin = rejoinSync.filter(
+      (e) => e.type === SyncEntityType.LibraryAssetCreateV1 || e.type === SyncEntityType.LibraryAssetBackfillV1,
+    );
+    expect(assetsRejoin.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Scenario 2: First-time invite to a space with pre-existing libraries
+  it('delivers library metadata + assets on first sync of a user added to an existing space with linked libraries', async () => {
+    const { ctx } = await newSyncTest();
+    const { user: owner } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+
+    // NEW user, auth for them
+    const auth = await newSyncAuthUser();
+    // Add them to the existing space
+    await ctx.addSharedSpaceMember(space.id, auth.user.id);
+
+    // First sync — must deliver library + asset
+    const response = await ctx.syncStream(auth, [SyncRequestType.LibrariesV1, SyncRequestType.LibraryAssetsV1]);
+    expect(response.some((e) => e.type === SyncEntityType.LibraryV1)).toBe(true);
+    const assetEvents = response.filter(
+      (e) => e.type === SyncEntityType.LibraryAssetCreateV1 || e.type === SyncEntityType.LibraryAssetBackfillV1,
+    );
+    expect(assetEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Scenario 3: Library newly linked to a space the user is already in
+  it('delivers library metadata + assets when a library is newly linked to a space the user is already in', async () => {
+    const { ctx } = await newSyncTest();
+    const auth = await newSyncAuthUser();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.addSharedSpaceMember(space.id, auth.user.id);
+
+    // User completes an initial sync with nothing library-related
+    const initial = await ctx.syncStream(auth, [SyncRequestType.LibrariesV1, SyncRequestType.LibraryAssetsV1]);
+    await ctx.syncAckAll(auth, initial);
+
+    // NOW link a library to the space
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+
+    // Next sync — library + asset delivered
+    const response = await ctx.syncStream(auth, [SyncRequestType.LibrariesV1, SyncRequestType.LibraryAssetsV1]);
+    expect(response.some((e) => e.type === SyncEntityType.LibraryV1)).toBe(true);
+    const assetEvents = response.filter(
+      (e) => e.type === SyncEntityType.LibraryAssetCreateV1 || e.type === SyncEntityType.LibraryAssetBackfillV1,
+    );
+    expect(assetEvents.length).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+Verify the factory/harness method names against an existing spec like `sync-library-asset.spec.ts` — the exact names may differ.
+
+**Step 2: Run the spec**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-access-backfill.spec.ts 2>&1 | tail -30`
+
+Expected: all 3 scenarios pass. If any fail, the fix is incomplete — stop and diagnose before proceeding.
+
+**Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/sync/library-access-backfill.spec.ts
+git commit -m "test(server): integration tests for library access backfill across the three scenarios"
+```
+
+---
+
+## Task 15: E2E spec additions at the HTTP boundary
+
+End-to-end via the real `/sync/stream` HTTP endpoint with login + session token. This is the test that matches the failure mode we observed live (server returning `SyncCompleteV1` with nothing for a broken session).
+
+**Files:**
+
+- Modify: `e2e/src/specs/server/api/sync-library.e2e-spec.ts`
+
+**Step 1: Add a new `describe` block for the three scenarios**
+
+Use the existing test file's helpers and login patterns. Add this block alongside existing scenarios (search for `describe('SharedSpaceLibrariesV1'` to find a good insertion point):
+
+```ts
+describe('library access backfill (PR #XXX)', () => {
+  beforeAll(async () => {
+    // same setup as other blocks in this file
+  });
+
+  it('re-delivers libraries after a user leaves and rejoins a space', async () => {
+    // 1. admin: create library + asset + space + link
+    // 2. admin: add member (our test user)
+    // 3. member: login, sync, ack
+    // 4. admin: remove member
+    // 5. member: sync, ack (drains the LibraryDeleteV1 events)
+    // 6. admin: re-add member
+    // 7. member: sync → assert LibraryV1 + LibraryAssetCreateV1 present
+  });
+
+  it('delivers libraries on first sync of a member added to an existing space', async () => {
+    // 1. admin: existing setup
+    // 2. admin: create a new user, add to space
+    // 3. new user: first sync → assert libraries present
+  });
+
+  it('delivers libraries when a library is newly linked to a space the user is already in', async () => {
+    // 1. admin: create space, add member
+    // 2. member: initial sync (empty), ack
+    // 3. admin: create library, link to space
+    // 4. member: sync → assert libraries present
+  });
+});
+```
+
+Copy the detailed request/response patterns from the existing tests in the same file — they use `utils.syncStream`, `utils.syncAckAll`, etc.
+
+**Step 2: Run the E2E spec**
+
+Run: `cd e2e && pnpm test 2>&1 | tail -30`
+
+Note: this requires the E2E test stack to be running (`make e2e` from repo root sets this up). The E2E tests are slower than medium tests and may require a running server.
+
+Expected: the three new test cases pass. All existing `sync-library.e2e-spec.ts` cases continue to pass.
+
+**Step 3: Commit**
+
+```bash
+git add e2e/src/specs/server/api/sync-library.e2e-spec.ts
+git commit -m "test(e2e): HTTP-level coverage for library access backfill scenarios"
+```
+
+---
+
+## Task 16: Regression sweep and final verification
+
+Run the entire test suites that touch library / shared-space / sync to make sure nothing else broke.
+
+**Files:** None — this task is verification only.
+
+**Step 1: Run all server unit tests**
+
+Run: `cd server && pnpm test 2>&1 | tail -20`
+
+Expected: all green. If any regress, the fix is broken — diagnose.
+
+**Step 2: Run all server medium sync tests**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/ 2>&1 | tail -30`
+
+Expected: all green.
+
+**Step 3: Run the full type check**
+
+Run: `cd server && pnpm check 2>&1 | tail -10`
+
+Expected: clean.
+
+**Step 4: Run the lint**
+
+Skip per `feedback_lint_sequential.md` memory — CI handles lint.
+
+**Step 5: If anything failed, commit fixes as separate tasks above. If all green, this is the final commit.**
+
+No commit needed for this task unless you're fixing something. If the regression sweep is clean, move on to Task 17.
+
+---
+
+## Task 17: Push the branch and open a draft PR
+
+**Files:** None — branch operations only.
+
+**Step 1: Push the branch**
+
+```bash
+git push origin fix/library-access-backfill
+```
+
+**Step 2: Open a draft PR**
+
+```bash
+gh pr create --draft --title "fix(server): library_user access-grant denormalization for shared-space library backfill" --body "$(cat <<'EOF'
+## Summary
+
+Fixes the "user rejoined space, library never syncs" bug and two related scenarios (first-time invite to existing space, new link to existing space).
+
+## Design
+
+Full design doc at `docs/plans/2026-04-11-library-user-access-backfill-design.md`.
+
+Summary: new `library_user (userId, libraryId, createId, createdAt)` denormalization table populated by insert triggers on `library`, `shared_space_member`, and `shared_space_library`. Delete-side consumed from the existing `library_audit` chain via a new `AFTER INSERT ON library_audit` trigger. `LibrarySync.getCreatedAfter` rewritten to query `library_user` with `accessibleLibraries` filter preserved for soft-delete correctness.
+
+## Test plan
+
+- [ ] New medium tests: `library-user-triggers.spec.ts`, `library-user-migration.spec.ts`, `library-access-backfill.spec.ts`
+- [ ] New unit tests in `sync.repository.spec.ts` for `LibrarySync.getCreatedAfter`
+- [ ] New E2E cases in `sync-library.e2e-spec.ts`
+- [ ] Existing `sync-library*.spec.ts`, `library-audit-triggers.spec.ts`, and `sync-library.e2e-spec.ts` continue to pass
+- [ ] Deploy to `pierre.opennoodle.de` via RC build and manually verify: viewer re-added to Google Takeout space sees photos on next sync without app restart
+
+## Rollback
+
+Additive: new table + triggers + one query change. Rollback options:
+
+- Code-only: revert the `getCreatedAfter` rewrite; table/triggers stay dormant.
+- Full: run the migration's `down()` to drop table + triggers + migration_overrides rows.
+
+See design doc "Rollback plan" section.
+EOF
+)"
+```
+
+**Step 3: No commit — PR is opened against the branch head.**
+
+---
+
+## Summary of files touched
+
+**New files:**
+
+- `server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts`
+- `server/src/schema/tables/library-user.table.ts`
+- `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+- `server/test/medium/specs/sync/library-user-migration.spec.ts`
+- `server/test/medium/specs/sync/library-access-backfill.spec.ts`
+
+**Modified files:**
+
+- `server/src/schema/index.ts` (table registration)
+- `server/src/schema/functions.ts` (four new trigger functions)
+- `server/src/schema/tables/library.table.ts` (attach `library_after_insert` trigger decorator)
+- `server/src/schema/tables/shared-space-member.table.ts` (attach `shared_space_member_after_insert_library` trigger decorator)
+- `server/src/schema/tables/shared-space-library.table.ts` (attach `shared_space_library_after_insert_user` trigger decorator)
+- `server/src/schema/tables/library-audit.table.ts` (attach `library_user_delete_after_audit` trigger decorator)
+- `server/src/repositories/sync.repository.ts` (rewrite `LibrarySync.getCreatedAfter`)
+- `server/src/queries/sync.repository.sql` (regenerated by `pnpm sql`)
+- `server/src/repositories/sync.repository.spec.ts` (or a new focused file)
+- `e2e/src/specs/server/api/sync-library.e2e-spec.ts` (new E2E cases)
+
+**Not touched:**
+
+- Any mobile code
+- Any service-layer code (`syncLibrariesV1`, `syncLibraryAssetsV1`, etc.)
+- Any wire-protocol / sync entity types
+- Any existing delete-side trigger bodies
+
+---
+
+## Execution notes
+
+- **Keep commits small and atomic** — one task = one commit. If a task's tests don't fully pass, don't commit; fix first.
+- **Run `pnpm check` after every trigger addition** — the `registerFunction` body and the migration SQL must match character-for-character after whitespace normalization, and `pnpm check` catches divergence early.
+- **Medium tests need a real Postgres** — make sure your local stack has the test DB available (`make dev` or the test container setup). If `newMediumService` blows up on startup, that's a stack/env issue, not a code issue.
+- **Schema tool boilerplate is fiddly** — the `migration_overrides` JSON-encoded SQL strings must escape quotes and newlines exactly as shown. Copy-paste from `1778200000000-LibraryAuditTables.ts` as a template.
+- **If the `sql-tools` decorator library doesn't support exactly the decorator form shown** for `@CreateIdColumn({ index: false })`, fall back to the raw migration index and just use `@CreateIdColumn()` in the table definition. The plan adapts — don't get stuck on that detail.
+- **Don't merge to main until the full E2E + regression sweep is green** and the fix is manually verified on `pierre.opennoodle.de` via an RC build.

--- a/docs/plans/2026-04-11-library-user-access-backfill-plan.md
+++ b/docs/plans/2026-04-11-library-user-access-backfill-plan.md
@@ -747,6 +747,118 @@ git commit -m "test(server): pin shared_space_member trigger edge cases"
 
 ---
 
+## Task 8.5: Pin the library metadata re-delivery path via `LibrarySync.getUpserts`
+
+The new member-insert trigger bumps `library.updateId` so that `LibrarySync.getUpserts` re-emits the library metadata (`LibraryV1`) to the newly-accessing member on their next sync. This is the wire-level path that delivers the library row itself — the `getCreatedAfter` change only drives the per-library asset backfill loop, not the library metadata upsert.
+
+Without a dedicated test for this path, the integration tests in Task 14 could pass accidentally by riding the `createAfter` stream even if the upsert flow were broken or accidentally filtered. This task pins the upsert path independently.
+
+**Files:**
+
+- Modify: `server/test/medium/specs/sync/library-user-triggers.spec.ts`
+
+**Step 1: Add the test inside the `shared_space_member_after_insert_library` describe block**
+
+```ts
+it('LibrarySync.getUpserts re-delivers the library to the new member after the updateId bump', async () => {
+  const { ctx, sut } = await newMediumService({
+    repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
+    sut: SyncRepository, // or however the sync repo is exposed in the harness
+  });
+  const { user: owner } = await ctx.newUser();
+  const { user: newMember } = await ctx.newUser();
+  const { library } = await ctx.newLibrary({ ownerId: owner.id });
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.linkLibraryToSpace(space.id, library.id);
+
+  // Capture the library.updateId before the trigger fires.
+  const preBump = await defaultDatabase
+    .selectFrom('library')
+    .select(['updateId'])
+    .where('id', '=', library.id)
+    .executeTakeFirstOrThrow();
+
+  // newMember joins → trigger bumps library.updateId.
+  await ctx.addSharedSpaceMember(space.id, newMember.id);
+
+  // `getUpserts` with an ack at the PRE-bump updateId must return the library.
+  const dummyNowId = '99999999-9999-9999-9999-999999999999';
+  const upserts = await sut.library.getUpserts({
+    nowId: dummyNowId,
+    userId: newMember.id,
+    ack: { updateId: preBump.updateId, updatedAt: new Date(0) },
+  });
+  expect(upserts.map((r) => r.id)).toContain(library.id);
+});
+```
+
+**Before writing this test, grep for an existing `LibrarySync.getUpserts` call** in `server/src/repositories/sync.repository.spec.ts` or any `test/medium/specs/sync/sync-library*.spec.ts` file, and copy the exact call shape (instantiation, `ack` object structure, return type). The sync repo's upserts API uses `SyncAckOptions` / `SyncUpsertOptions` internally; match those types rather than guessing. The skeleton above is approximate — the imports, the `sut` shape, and the `ack` fields MUST be aligned with an existing working test before this one can run.
+
+**Step 2: Run the test**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "getUpserts re-delivers" 2>&1 | tail -15`
+
+Expected: PASS. If it fails, either the `updateId` bump isn't landing (check the trigger body) or `getUpserts` has a filter the design didn't account for (diagnose before proceeding — this is the whole reason the test exists).
+
+**Step 3: Add a creator-not-member documentation test (known limitation guard)**
+
+Inside the same describe block:
+
+```ts
+// Documentation test: pins the known asymmetry flagged in the design's
+// "Dependence on the creator-is-always-a-member invariant" section. If the
+// invariant ever breaks, the create-side triggers won't populate library_user
+// for a space creator who is not a member. The delete-side defensively
+// includes a creator-path branch in user_has_library_path, so they'd still
+// be protected from wrongful removal — the asymmetry manifests as "creator
+// silently missing from library_user after a cache-reset sync".
+it('(known limitation) does not populate library_user for a space creator who is not a member', async () => {
+  const { ctx } = await newMediumService({
+    repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
+  });
+  const { user: creator } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { library } = await ctx.newLibrary({ ownerId: member.id });
+
+  // Bypass the service layer to create a shared_space WITHOUT the matching
+  // shared_space_member row for the creator.
+  const space = await defaultDatabase
+    .insertInto('shared_space')
+    .values({ name: 'orphan-creator', createdById: creator.id })
+    .returning(['id'])
+    .executeTakeFirstOrThrow();
+
+  await ctx.linkLibraryToSpace(space.id, library.id);
+
+  // The library-link insert trigger's SELECT is:
+  //   FROM inserted_rows ir INNER JOIN shared_space_member ssm ON ssm.spaceId = ir.spaceId
+  // which produces ZERO rows because no shared_space_member exists for the
+  // creator. No library_user for `creator` gets inserted.
+  const rows = await defaultDatabase
+    .selectFrom('library_user')
+    .selectAll()
+    .where('userId', '=', creator.id)
+    .where('libraryId', '=', library.id)
+    .execute();
+  expect(rows).toHaveLength(0);
+});
+```
+
+**Step 4: Run the full trigger spec**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts 2>&1 | tail -20`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add server/test/medium/specs/sync/library-user-triggers.spec.ts
+git commit -m "test(server): pin library metadata re-delivery + creator-not-member asymmetry"
+```
+
+---
+
 ## Task 9: Failing test + implementation — `shared_space_library_after_insert_user` trigger
 
 Bundled task because the pattern mirrors Task 6+7.
@@ -905,7 +1017,7 @@ This trigger is the delete-side counterpart. Bundled: failing tests, implementat
 describe('library_user_delete_after_audit', () => {
   it('removes library_user when a member leaves a space and has no other path', async () => {
     const { ctx } = await newMediumService({
-      /* relevant repos */
+      repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
     });
     const { user: owner } = await ctx.newUser();
     const { user: viewer } = await ctx.newUser();
@@ -935,31 +1047,113 @@ describe('library_user_delete_after_audit', () => {
     expect(after).toHaveLength(0);
   });
 
-  it('preserves library_user for the owner even when they leave a space that linked the library', async () => {
+  it('preserves library_user for the owner when another member leaves a space linking their library', async () => {
+    // This test pins TWO properties together:
+    //   1. The audit chain's gate correctly skips the owner. When peer leaves,
+    //      `shared_space_member_delete_library_audit` only emits audit rows for
+    //      userIds present in the `old` NEW TABLE (i.e., peer). The owner's
+    //      owned-path is never even evaluated — they are not in `inserted_rows`
+    //      for the consumer trigger, so the PK join `lu.userId = ir.userId`
+    //      skips them structurally. This is the "inserter-side gating" half.
+    //   2. The consumer's DELETE doesn't accidentally touch rows outside of
+    //      inserted_rows — pins that the join is a strict scoping, not a
+    //      side-effect on the full library.
+    // Together these guarantee the consumer only deletes rows the audit chain
+    // explicitly told it to delete.
     const { ctx } = await newMediumService({
-      /* ... */
+      repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
     });
     const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
     const { library } = await ctx.newLibrary({ ownerId: owner.id });
     const { space } = await ctx.newSharedSpace({ createdById: owner.id });
     await ctx.linkLibraryToSpace(space.id, library.id);
-    // Owner is auto-added as a member on space creation; leaving...
-    // Actually the space creator can't leave their own space via the normal
-    // service call — the creator is the owner of the space. Use a slightly
-    // different setup: peer owner creates space and links a library they
-    // also own, a different user (our "owner") is a space member AND owns
-    // another library that's ALSO linked to the same space. Then the "owner"
-    // leaves.
-    // (exact setup depends on factory; adapt as needed)
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    // Sanity: both have library_user rows.
+    expect(
+      await defaultDatabase.selectFrom('library_user').selectAll().where('libraryId', '=', library.id).execute(),
+    ).toHaveLength(2);
+
+    // Peer leaves
+    await ctx.removeSharedSpaceMember(space.id, peer.id);
+
+    // Owner's row survives
+    const ownerRow = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', owner.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(ownerRow).toHaveLength(1);
+    // Peer's row gone
+    const peerRow = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', peer.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(peerRow).toHaveLength(0);
   });
 
-  it('defensive re-check: does NOT delete library_user when user_has_library_path is still true', async () => {
-    // Setup: user owns library, and separately has library_audit row inserted
-    // manually (bypassing the normal delete trigger chain). Since owner path
-    // is still valid, user_has_library_path returns true → consumer trigger
-    // must NOT delete library_user.
+  it('removes library_user for all affected members when a shared_space is hard-deleted (cascade path)', async () => {
+    // REGRESSION GUARD for the dropped defensive clause. Under the original
+    // design, the `NOT user_has_library_path(..., NULL)` filter would run
+    // during the BEFORE DELETE trigger of shared_space, BEFORE the FK cascade
+    // removed shared_space_library / shared_space_member — so it would see
+    // the still-alive path and incorrectly preserve library_user rows.
     const { ctx } = await newMediumService({
-      /* ... */
+      repos: [LibraryRepository, UserRepository, SharedSpaceRepository],
+    });
+    const { user: owner } = await ctx.newUser();
+    const { user: viewerA } = await ctx.newUser();
+    const { user: viewerB } = await ctx.newUser();
+    // Non-owner creates the space so we can freely delete it without cascading
+    // through the owner's user row. The library is owned by `owner` (separate
+    // user) so owner's library_user row is NOT tied to the space.
+    const { user: spaceCreator } = await ctx.newUser();
+    const { library: lib1 } = await ctx.newLibrary({ ownerId: owner.id });
+    const { library: lib2 } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: spaceCreator.id });
+    await ctx.linkLibraryToSpace(space.id, lib1.id);
+    await ctx.linkLibraryToSpace(space.id, lib2.id);
+    await ctx.addSharedSpaceMember(space.id, viewerA.id);
+    await ctx.addSharedSpaceMember(space.id, viewerB.id);
+
+    // Sanity: each viewer has rows for both libraries (2 libs × 2 viewers = 4
+    // rows plus spaceCreator's 2 = 6 non-owner rows plus owner's 2 owned
+    // rows = 8 total).
+    expect(
+      await defaultDatabase
+        .selectFrom('library_user')
+        .selectAll()
+        .where('libraryId', 'in', [lib1.id, lib2.id])
+        .execute(),
+    ).toHaveLength(8);
+
+    // Hard-delete the whole space. BEFORE-trigger fan-out inserts into
+    // library_audit for every (viewer|spaceCreator, library) pair that loses
+    // its only path. Owner's two rows are NOT touched (owned path remains).
+    await defaultDatabase.deleteFrom('shared_space').where('id', '=', space.id).execute();
+
+    // Only owner's two rows remain.
+    const remaining = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('libraryId', 'in', [lib1.id, lib2.id])
+      .execute();
+    expect(remaining).toHaveLength(2);
+    expect(remaining.every((r) => r.userId === owner.id)).toBe(true);
+  });
+
+  it('trusts the inserter gate: a manual library_audit insert deletes library_user unconditionally', async () => {
+    // The consumer trigger does NOT re-check user_has_library_path. This test
+    // pins that contract: any code path inserting into library_audit MUST
+    // gate beforehand, because the consumer will delete whatever it's told.
+    // Regression guard in the opposite direction from the cascade test —
+    // together they ensure the consumer is neither over- nor under-deleting.
+    const { ctx } = await newMediumService({
+      repos: [LibraryRepository, UserRepository],
     });
     const { user } = await ctx.newUser();
     const { library } = await ctx.newLibrary({ ownerId: user.id });
@@ -973,22 +1167,22 @@ describe('library_user_delete_after_audit', () => {
       .execute();
     expect(before).toHaveLength(1);
 
-    // Manually insert into library_audit (bypassing gated triggers)
+    // Manually insert into library_audit (bypassing the normal gating path)
     await defaultDatabase.insertInto('library_audit').values({ libraryId: library.id, userId: user.id }).execute();
 
-    // Defensive clause must have protected the row
+    // Row IS deleted — consumer trusts the inserter's gate.
     const after = await defaultDatabase
       .selectFrom('library_user')
       .selectAll()
       .where('userId', '=', user.id)
       .where('libraryId', '=', library.id)
       .execute();
-    expect(after).toHaveLength(1);
+    expect(after).toHaveLength(0);
   });
 
   it('hard-deleting a library removes library_user rows via FK cascade (no library_audit involvement)', async () => {
     const { ctx } = await newMediumService({
-      /* ... */
+      repos: [LibraryRepository, UserRepository],
     });
     const { user } = await ctx.newUser();
     const { library } = await ctx.newLibrary({ ownerId: user.id });
@@ -1033,9 +1227,11 @@ describe('library_user_delete_after_audit', () => {
 
 Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/library-user-triggers.spec.ts -t "library_user_delete_after_audit" 2>&1 | tail -20`
 
-Expected: the first three tests fail (the fourth — FK cascade — would actually pass right now because FK cascade is already declared on the table). The first test might fail because the existing delete chain inserts into library_audit but nothing deletes from library_user.
+Expected: the `member leaves`, `owner preserved`, `shared_space cascade`, and `trusts the inserter gate` tests fail. The FK cascade test passes (FK cascade is already declared in Task 1). If `shared_space cascade` happens to pass against a defensive-clause design, that indicates the test setup isn't exercising the BEFORE-trigger window correctly — diagnose before proceeding.
 
 **Step 3: Add function + trigger + overrides in migration**
+
+The function body does NOT re-check `user_has_library_path`. It trusts the gating that every inserter into `library_audit` is required to perform (see design doc "Trust boundary"). Re-checking would be broken during `shared_space` hard-delete because the BEFORE-trigger window runs before FK cascades, and the function would find the still-alive (ssl, ssm) rows and incorrectly preserve library_user.
 
 ```ts
 await sql`
@@ -1047,8 +1243,7 @@ await sql`
       DELETE FROM library_user lu
       USING inserted_rows ir
       WHERE lu."userId" = ir."userId"
-        AND lu."libraryId" = ir."libraryId"
-        AND NOT user_has_library_path(lu."libraryId", lu."userId", NULL);
+        AND lu."libraryId" = ir."libraryId";
       RETURN NULL;
     END
   $$;
@@ -1077,8 +1272,7 @@ export const library_user_delete_after_audit = registerFunction({
       DELETE FROM library_user lu
       USING inserted_rows ir
       WHERE lu."userId" = ir."userId"
-        AND lu."libraryId" = ir."libraryId"
-        AND NOT user_has_library_path(lu."libraryId", lu."userId", NULL);
+        AND lu."libraryId" = ir."libraryId";
       RETURN NULL;
     END`,
 });
@@ -1143,38 +1337,48 @@ Migration tests are tricky because by the time the test suite runs, the migratio
 import { sql } from 'kysely';
 import { defaultDatabase } from 'test/test-utils';
 
+// Helper: run the migration's Pass 1 + Pass 2 backfill SQL as a single block.
+// Centralizing this keeps the tests focused on the expected state, not on
+// the exact SQL, and makes it easy to re-run the backfill mid-test.
+const runBackfill = async () => {
+  await sql`
+    INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+    SELECT "ownerId", "id", "createId", "createdAt"
+    FROM library
+    WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+    ON CONFLICT ("userId", "libraryId") DO NOTHING;
+  `.execute(defaultDatabase);
+
+  await sql`
+    INSERT INTO library_user ("userId", "libraryId")
+    SELECT DISTINCT ssm."userId", ssl."libraryId"
+    FROM shared_space_library ssl
+    INNER JOIN shared_space_member ssm ON ssl."spaceId" = ssm."spaceId"
+    ON CONFLICT ("userId", "libraryId") DO NOTHING;
+  `.execute(defaultDatabase);
+};
+
 describe('library_user migration backfill', () => {
-  // These tests manipulate library_user directly, so clean up after each.
+  // NOTE: the migration runs triggers + backfill in a single transaction. On
+  // a fresh DB (CI testcontainer) the library table is empty when Pass 1
+  // runs. On upgrade from a prior version, the triggers are created first,
+  // then Pass 1/2 scoop up every pre-existing row. These tests simulate the
+  // upgrade path by clearing library_user (which the triggers just populated)
+  // before running the backfill, so the state at the start of runBackfill()
+  // mirrors the post-create-tables-but-pre-backfill moment of a real upgrade.
+
   afterEach(async () => {
     await defaultDatabase.deleteFrom('library_user').execute();
   });
 
   it('owner rows use library.createId (Pass 1)', async () => {
-    // Seed: create user + library via direct SQL, leave the library_after_insert
-    // trigger to populate library_user at insert time. Delete the triggered row
-    // and re-run the backfill INSERT manually — verify the Pass 1 SQL produces
-    // the same row.
-    //
-    // Simpler alternative: disable the trigger temporarily for this test, insert
-    // the library, then run the backfill. Or: just assert that the row created
-    // by the trigger has createId = library.createId (which the trigger test
-    // already covers). This test is more about the migration SQL as a string.
-    //
-    // Actual test: run Pass 1 SQL in isolation against a small seeded state.
     const { user } = await ctx.newUser();
     const { library } = await ctx.newLibrary({ ownerId: user.id });
 
-    // Clear what the trigger inserted
+    // Simulate upgrade state: library exists, library_user empty.
     await defaultDatabase.deleteFrom('library_user').execute();
 
-    // Run Pass 1 SQL
-    await sql`
-      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
-      SELECT "ownerId", "id", "createId", "createdAt"
-      FROM library
-      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
-      ON CONFLICT ("userId", "libraryId") DO NOTHING;
-    `.execute(defaultDatabase);
+    await runBackfill();
 
     const row = await defaultDatabase
       .selectFrom('library_user')
@@ -1185,28 +1389,146 @@ describe('library_user migration backfill', () => {
     expect(row.createdAt).toEqual(library.createdAt);
   });
 
-  it('transitive rows use fresh createId (Pass 2)', async () => {
-    // Setup a user who has transitive access, simulate a stale state by
-    // clearing library_user, then run Pass 2 and verify createId is fresh.
-    // (details elided — same pattern)
+  it('transitive rows use a fresh createId (Pass 2)', async () => {
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    // Clear what the triggers populated → simulate upgrade state.
+    await defaultDatabase.deleteFrom('library_user').execute();
+
+    // Capture a pre-backfill uuid_v7 marker. Use raw SQL to avoid any
+    // Kysely-version dependency on selectNoFrom / eb.fn shape.
+    const markerResult = await sql<{
+      id: string;
+    }>`SELECT immich_uuid_v7() AS id`.execute(defaultDatabase);
+    const backfillStart = markerResult.rows[0].id;
+
+    await runBackfill();
+
+    // Peer gets a row with a createId MINTED AFTER backfillStart — i.e.,
+    // strictly greater than the pre-backfill marker AND strictly greater
+    // than library.createId. Pass 2 does not propagate library.createId.
+    const peerRow = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', peer.id)
+      .where('libraryId', '=', library.id)
+      .executeTakeFirstOrThrow();
+    expect(peerRow.createId > backfillStart).toBe(true);
+    expect(peerRow.createId > library.createId).toBe(true);
   });
 
   it('Pass 2 preserves owner rows via ON CONFLICT DO NOTHING', async () => {
-    // User owns library AND is in a space that links it. Run Pass 1 then
-    // Pass 2. Assert only ONE row and its createId equals library.createId.
+    // User owns the library AND is a member of a space that also links it.
+    // Pass 1 inserts with old createId, Pass 2 would insert with fresh, but
+    // ON CONFLICT preserves Pass 1's row.
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    // Owner is auto-added as member when they create the space.
+
+    await defaultDatabase.deleteFrom('library_user').execute();
+
+    await runBackfill();
+
+    const rows = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].createId).toBe(library.createId);
+    expect(rows[0].createdAt).toEqual(library.createdAt);
   });
 
   it('is idempotent: re-running both passes is a no-op', async () => {
-    // Run Pass 1 + Pass 2. Capture state. Run them again. Assert state
-    // unchanged.
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    await defaultDatabase.deleteFrom('library_user').execute();
+
+    await runBackfill();
+    const firstSnapshot = await defaultDatabase
+      .selectFrom('library_user')
+      .select(['userId', 'libraryId', 'createId', 'createdAt'])
+      .orderBy('userId')
+      .orderBy('libraryId')
+      .execute();
+
+    // Re-run the backfill. ON CONFLICT DO NOTHING should make this a no-op.
+    await runBackfill();
+    const secondSnapshot = await defaultDatabase
+      .selectFrom('library_user')
+      .select(['userId', 'libraryId', 'createId', 'createdAt'])
+      .orderBy('userId')
+      .orderBy('libraryId')
+      .execute();
+
+    expect(secondSnapshot).toEqual(firstSnapshot);
   });
 
-  it('includes soft-deleted libraries in Pass 2 when linked to a space (mirrors accessibleLibraries)', async () => {
-    // ...
+  it('includes soft-deleted libraries in Pass 2 when linked to a space', async () => {
+    // Matches accessibleLibraries behavior for the space-link branch: a
+    // soft-deleted library is still reachable for members via the
+    // shared_space_library path until it is hard-deleted.
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    // Soft-delete the library
+    await defaultDatabase.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+
+    await defaultDatabase.deleteFrom('library_user').execute();
+
+    await runBackfill();
+
+    // peer still gets a row (Pass 2, no deletedAt filter)
+    const peerRow = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', peer.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(peerRow).toHaveLength(1);
+    // owner does NOT (Pass 1 filters out deletedAt IS NOT NULL)
+    const ownerRow = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', owner.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(ownerRow).toHaveLength(0);
   });
 
-  it('skips soft-deleted libraries in Pass 1 (owned path)', async () => {
-    // ...
+  it('skips soft-deleted owned libraries in Pass 1 when there is no space path', async () => {
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    await defaultDatabase.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+    await defaultDatabase.deleteFrom('library_user').execute();
+
+    await runBackfill();
+
+    const rows = await defaultDatabase
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(rows).toHaveLength(0);
   });
 });
 ```
@@ -1272,30 +1594,67 @@ Before rewriting the query, write the new expected behavior as unit tests. This 
 
 ```ts
 describe('LibrarySync.getCreatedAfter', () => {
+  const dummyNowId = '99999999-9999-9999-9999-999999999999';
+
   it('returns libraries the user owns', async () => {
-    // Setup via repo
     const { user } = await ctx.newUser();
     const { library } = await ctx.newLibrary({ ownerId: user.id });
-    // (trigger populates library_user automatically)
 
     const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: user.id, afterCreateId: undefined });
     expect(rows.map((r) => r.id)).toContain(library.id);
   });
 
   it('returns libraries the user accesses via shared_space_library', async () => {
-    /* similar */
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: peer.id, afterCreateId: undefined });
+    expect(rows.map((r) => r.id)).toContain(library.id);
   });
 
   it('returns empty for a user with no library access', async () => {
-    /* similar */
+    const { user } = await ctx.newUser();
+    const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: user.id, afterCreateId: undefined });
+    expect(rows).toHaveLength(0);
   });
 
   it('filters by afterCreateId', async () => {
-    /* two libraries, check that only the one >= afterCreateId is returned */
+    const { user } = await ctx.newUser();
+    const { library: first } = await ctx.newLibrary({ ownerId: user.id });
+    const { library: second } = await ctx.newLibrary({ ownerId: user.id });
+
+    // Checkpoint strictly between the two createIds: use `second.createId`
+    // as the lower bound, so only `second` (which has createId >= itself)
+    // comes back.
+    const rows = await sut.getCreatedAfter({
+      nowId: dummyNowId,
+      userId: user.id,
+      afterCreateId: second.createId,
+    });
+    const ids = rows.map((r) => r.id);
+    expect(ids).toContain(second.id);
+    expect(ids).not.toContain(first.id);
   });
 
   it('orders by createId ascending', async () => {
-    /* seed 3 libraries with known createIds, assert order */
+    const { user } = await ctx.newUser();
+    const { library: a } = await ctx.newLibrary({ ownerId: user.id });
+    const { library: b } = await ctx.newLibrary({ ownerId: user.id });
+    const { library: c } = await ctx.newLibrary({ ownerId: user.id });
+
+    const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: user.id, afterCreateId: undefined });
+    const libIds = rows.map((r) => r.id);
+    // Natural insertion order matches uuid_v7 monotonicity.
+    expect(libIds.indexOf(a.id)).toBeLessThan(libIds.indexOf(b.id));
+    expect(libIds.indexOf(b.id)).toBeLessThan(libIds.indexOf(c.id));
+    // And the createIds returned should be non-decreasing.
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i].createId >= rows[i - 1].createId).toBe(true);
+    }
   });
 
   it('excludes a soft-deleted owned library when the user has no space-linked path', async () => {
@@ -1309,8 +1668,63 @@ describe('LibrarySync.getCreatedAfter', () => {
   });
 
   it('includes a soft-deleted library when the user has a space-linked path to it', async () => {
-    /* owner, stranger, space, linked library, soft-delete via owner,
-       assert stranger still sees it */
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    // Soft-delete from the owner side; the space link stays valid.
+    await defaultDatabase.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+
+    const rows = await sut.getCreatedAfter({ nowId: dummyNowId, userId: peer.id, afterCreateId: undefined });
+    expect(rows.map((r) => r.id)).toContain(library.id);
+  });
+
+  // Regression guard for the deploy-time checkpoint value-space shift. Before
+  // this fix, `afterCreateId` was a `library.createId` watermark; after, it's
+  // a `library_user.createId` watermark. Carry a pre-fix-value-space checkpoint
+  // over the boundary and assert the query still returns a consistent
+  // superset of the user's accessible libraries (idempotent re-delivery is OK,
+  // wrong-answers are not).
+  it('handles a pre-fix-value-space afterCreateId checkpoint without returning a wrong set', async () => {
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.linkLibraryToSpace(space.id, library.id);
+    await ctx.addSharedSpaceMember(space.id, peer.id);
+
+    // Pre-fix clients stored `library.createId` as their checkpoint.
+    const preFixCheckpoint = library.createId;
+
+    // Post-fix query using that same value — peer's library_user.createId was
+    // minted AFTER library.createId, so the peer row satisfies >= the
+    // checkpoint and is (correctly) re-delivered.
+    const rows = await sut.getCreatedAfter({
+      nowId: dummyNowId,
+      userId: peer.id,
+      afterCreateId: preFixCheckpoint,
+    });
+    const ids = new Set(rows.map((r) => r.id));
+    // Every accessible library for peer is present.
+    const accessible = new Set(
+      (
+        await defaultDatabase
+          .selectFrom('library')
+          .select('id')
+          .where('library.id', 'in', (eb) => accessibleLibraries(eb, peer.id))
+          .execute()
+      ).map((r) => r.id),
+    );
+    for (const id of accessible) {
+      expect(ids.has(id)).toBe(true);
+    }
+    // No libraries the user shouldn't have access to.
+    for (const id of ids) {
+      expect(accessible.has(id)).toBe(true);
+    }
   });
 
   it('set equality with accessibleLibraries', async () => {

--- a/mobile/lib/pages/library/spaces/space_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_detail.page.dart
@@ -237,7 +237,7 @@ class _SpaceDetailPageState extends ConsumerState<SpaceDetailPage> {
         await context.maybePop();
         return;
       }
-      _loadData();
+      await _loadData();
     });
   }
 

--- a/mobile/lib/pages/library/spaces/space_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_detail.page.dart
@@ -228,7 +228,17 @@ class _SpaceDetailPageState extends ConsumerState<SpaceDetailPage> {
   }
 
   void _navigateToMembers() {
-    context.pushRoute(SpaceMembersRoute(spaceId: widget.spaceId)).then((_) => _loadData());
+    context.pushRoute<String>(SpaceMembersRoute(spaceId: widget.spaceId)).then((result) async {
+      if (!mounted) return;
+      if (result == 'left') {
+        // The user just left this space from the members page. Re-fetching
+        // the space metadata would 403, so just pop ourselves back to the
+        // spaces list.
+        await context.maybePop();
+        return;
+      }
+      _loadData();
+    });
   }
 
   @override

--- a/mobile/lib/pages/library/spaces/space_members.page.dart
+++ b/mobile/lib/pages/library/spaces/space_members.page.dart
@@ -47,10 +47,19 @@ class SpaceMembersPage extends HookConsumerWidget {
       if (confirmed == true) {
         try {
           await ref.read(sharedSpaceApiRepositoryProvider).removeMember(spaceId, member.userId);
-          ref.invalidate(sharedSpaceMembersProvider(spaceId));
+          // Only refetch the member list if we removed SOMEONE ELSE. When the
+          // current user just left, hitting GET /shared-spaces/{id}/members
+          // triggers a 403 "Not a member of this space" because the backend
+          // permission check correctly rejects us. The spaces list is always
+          // safe to refresh.
+          if (!isLeaving) {
+            ref.invalidate(sharedSpaceMembersProvider(spaceId));
+          }
           ref.invalidate(sharedSpacesProvider);
           if (isLeaving && context.mounted) {
-            await context.maybePop();
+            // Signal to SpaceDetailPage that we just left, so it can pop
+            // itself without trying to re-fetch this (now inaccessible) space.
+            await context.maybePop<String>('left');
           } else if (context.mounted) {
             ImmichToast.show(context: context, msg: '${member.name} removed', toastType: ToastType.success);
           }

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -1618,18 +1618,19 @@ order by
 
 -- SyncRepository.library.getCreatedAfter
 select
-  "library"."id",
-  "library"."createId"
+  "library_user"."libraryId" as "id",
+  "library_user"."createId"
 from
-  "library"
+  "library_user"
 where
-  "library"."id" in (
+  "library_user"."userId" = $1
+  and "library_user"."libraryId" in (
     select
       "library"."id"
     from
       "library"
     where
-      "library"."ownerId" = $1
+      "library"."ownerId" = $2
       and "library"."deletedAt" is null
     union
     select
@@ -1643,20 +1644,20 @@ where
         from
           "shared_space"
         where
-          "shared_space"."createdById" = $2
+          "shared_space"."createdById" = $3
         union
         select
           "shared_space_member"."spaceId" as "id"
         from
           "shared_space_member"
         where
-          "shared_space_member"."userId" = $3
+          "shared_space_member"."userId" = $4
       )
   )
-  and "library"."createId" >= $4
-  and "library"."createId" < $5
+  and "library_user"."createId" >= $5
+  and "library_user"."createId" < $6
 order by
-  "library"."createId" asc
+  "library_user"."createId" asc
 
 -- SyncRepository.library.getDeletes
 select

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1105,23 +1105,34 @@ const LIBRARY_SYNC_COLUMNS = [
 ] as const;
 
 export class LibrarySync extends BaseSync {
-  // Returns libraries accessible to the user, ordered by library.createId. Unlike
-  // SharedSpaceSync.getCreatedAfter — which enumerates membership rows because
-  // each user gets a fresh per-membership createId — libraries do not have a
-  // per-user join table. The createId is a property of the library row itself,
-  // shared across all users with access. A user added to a pre-existing space
-  // that links an old library will not pick up that library here (the createId
-  // is past their backfill checkpoint); SharedSpaceLibrarySync's per-link
-  // backfill loop in sync.service.ts handles that case.
+  // Queries library_user (a (userId, libraryId) denormalization populated by
+  // the library_after_insert / shared_space_member_after_insert_library /
+  // shared_space_library_after_insert_user triggers) keyed by the per-user
+  // access-grant createId. This mirrors SharedSpaceSync.getCreatedAfter and
+  // AlbumSync.getCreatedAfter — each row represents "user U gained access to
+  // library L at time createId", so a user rejoining a space or being added
+  // to a pre-existing space gets fresh createIds > their checkpoint and the
+  // per-library asset backfill loop correctly re-iterates the library.
+  //
+  // The `library_user.libraryId IN accessibleLibraries(userId)` filter is
+  // preserved so that soft-deleted owned libraries are excluded — matching
+  // the existing behavior where `accessibleLibraries` drops the ownership
+  // branch when `deletedAt IS NOT NULL`, while keeping soft-deleted libraries
+  // visible via the space-link branch. Without this filter, an owner who
+  // soft-deletes a library would still see its assets re-streamed on every
+  // sync.
+  //
+  // See docs/plans/2026-04-11-library-user-access-backfill-design.md.
   @GenerateSql({ params: [dummyCreateAfterOptions] })
   getCreatedAfter({ nowId, userId, afterCreateId }: SyncCreatedAfterOptions) {
     return this.db
-      .selectFrom('library')
-      .select(['library.id', 'library.createId'])
-      .where('library.id', 'in', (eb) => accessibleLibraries(eb, userId))
-      .$if(!!afterCreateId, (qb) => qb.where('library.createId', '>=', afterCreateId!))
-      .where('library.createId', '<', nowId)
-      .orderBy('library.createId', 'asc')
+      .selectFrom('library_user')
+      .select(['library_user.libraryId as id', 'library_user.createId'])
+      .where('library_user.userId', '=', userId)
+      .where('library_user.libraryId', 'in', (eb) => accessibleLibraries(eb, userId))
+      .$if(!!afterCreateId, (qb) => qb.where('library_user.createId', '>=', afterCreateId!))
+      .where('library_user.createId', '<', nowId)
+      .orderBy('library_user.createId', 'asc')
       .execute();
   }
 

--- a/server/src/schema/functions.ts
+++ b/server/src/schema/functions.ts
@@ -559,3 +559,24 @@ export const shared_space_member_after_insert_library = registerFunction({
       RETURN NULL;
     END`,
 });
+
+// When a library is linked to a space, grant library_user for every current
+// member of that space and bump library.updateId so the metadata re-emits.
+export const shared_space_library_after_insert_user = registerFunction({
+  name: 'shared_space_library_after_insert_user',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ssm."userId", ir."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_member ssm ON ssm."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (SELECT DISTINCT "libraryId" FROM inserted_rows);
+      RETURN NULL;
+    END`,
+});

--- a/server/src/schema/functions.ts
+++ b/server/src/schema/functions.ts
@@ -506,3 +506,30 @@ export const asset_library_delete_audit = registerFunction({
       RETURN NULL;
     END`,
 });
+
+// --- gallery-fork: library_user create-side trigger functions ---
+//
+// See docs/plans/2026-04-11-library-user-access-backfill-design.md for the
+// full design. Summary: library_user is a (userId, libraryId) access-grant
+// denormalization; three insert triggers populate it, and one consumer
+// trigger (below) drains it when library_audit rows are emitted.
+
+// Populate library_user for the library owner when a library is created.
+// Explicitly propagates library.createId and library.createdAt rather than
+// letting the defaults generate fresh values — owner rows must share the
+// library's own createId so existing clients' sync checkpoints (which are
+// already past library.createId) don't retrigger a completed backfill.
+export const library_after_insert = registerFunction({
+  name: 'library_after_insert',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+      SELECT "ownerId", "id", "createId", "createdAt"
+      FROM inserted_rows
+      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+      ON CONFLICT DO NOTHING;
+      RETURN NULL;
+    END`,
+});

--- a/server/src/schema/functions.ts
+++ b/server/src/schema/functions.ts
@@ -533,3 +533,29 @@ export const library_after_insert = registerFunction({
       RETURN NULL;
     END`,
 });
+
+// When a user joins a space, grant access to every library currently linked
+// to that space. Also bump library.updateId so LibrarySync.getUpserts
+// re-delivers the library metadata row on the new member's next sync.
+export const shared_space_member_after_insert_library = registerFunction({
+  name: 'shared_space_member_after_insert_library',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ir."userId", ssl."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (
+        SELECT DISTINCT ssl."libraryId"
+        FROM inserted_rows ir
+        INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      );
+      RETURN NULL;
+    END`,
+});

--- a/server/src/schema/functions.ts
+++ b/server/src/schema/functions.ts
@@ -580,3 +580,32 @@ export const shared_space_library_after_insert_user = registerFunction({
       RETURN NULL;
     END`,
 });
+
+// Consume library_audit inserts by deleting the corresponding library_user
+// rows UNCONDITIONALLY. Trusts the gating at insertion time — every path
+// that inserts into library_audit already checks
+// `NOT user_has_library_path(..., excludeSpaceId)`, so audit rows represent
+// "this (user, library) pair has definitively lost access".
+//
+// IMPORTANT: any future path inserting into library_audit MUST gate
+// beforehand. See design doc "Trust boundary" and the
+// library_user_delete_after_audit test in library-user-triggers.spec.ts.
+//
+// Why we don't re-check here: `user_has_library_path(lib, user, NULL)`
+// during a shared_space hard-delete returns TRUE because the BEFORE DELETE
+// trigger fires BEFORE FK cascades remove shared_space_library /
+// shared_space_member — the still-alive path would spuriously preserve
+// rows that should have been cleaned up.
+export const library_user_delete_after_audit = registerFunction({
+  name: 'library_user_delete_after_audit',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      DELETE FROM library_user lu
+      USING inserted_rows ir
+      WHERE lu."userId" = ir."userId"
+        AND lu."libraryId" = ir."libraryId";
+      RETURN NULL;
+    END`,
+});

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -46,6 +46,7 @@ import { FaceSearchTable } from 'src/schema/tables/face-search.table';
 import { GeodataPlacesTable } from 'src/schema/tables/geodata-places.table';
 import { LibraryAssetAuditTable } from 'src/schema/tables/library-asset-audit.table';
 import { LibraryAuditTable } from 'src/schema/tables/library-audit.table';
+import { LibraryUserTable } from 'src/schema/tables/library-user.table';
 import { LibraryTable } from 'src/schema/tables/library.table';
 import { MemoryAssetAuditTable } from 'src/schema/tables/memory-asset-audit.table';
 import { MemoryAssetTable } from 'src/schema/tables/memory-asset.table';
@@ -123,6 +124,7 @@ export class ImmichDatabase {
     GeodataPlacesTable,
     LibraryTable,
     LibraryAuditTable,
+    LibraryUserTable,
     LibraryAssetAuditTable,
     MemoryTable,
     MemoryAuditTable,
@@ -242,6 +244,7 @@ export interface DB {
 
   library: LibraryTable;
   library_audit: LibraryAuditTable;
+  library_user: LibraryUserTable;
   library_asset_audit: LibraryAssetAuditTable;
 
   memory: MemoryTable;

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -165,6 +165,30 @@ export async function up(db: Kysely<any>): Promise<void> {
   await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_library_user_delete_after_audit', '{"type":"trigger","name":"library_user_delete_after_audit","sql":"CREATE OR REPLACE TRIGGER \\"library_user_delete_after_audit\\"\\n  AFTER INSERT ON \\"library_audit\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION library_user_delete_after_audit();"}'::jsonb);`.execute(
     db,
   );
+
+  // --- Backfill from current state ---
+  //
+  // Pass 1: owned libraries inherit library.createId/createdAt so existing
+  // synced clients don't re-backfill libraries they already have.
+  await sql`
+    INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+    SELECT "ownerId", "id", "createId", "createdAt"
+    FROM library
+    WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+    ON CONFLICT ("userId", "libraryId") DO NOTHING;
+  `.execute(db);
+
+  // Pass 2: transitive access via shared_space_library with fresh createIds
+  // so users in the broken state get their missing libraries re-delivered on
+  // next sync. Soft-deleted libraries are deliberately INCLUDED here —
+  // matches accessibleLibraries' space-link branch behavior.
+  await sql`
+    INSERT INTO library_user ("userId", "libraryId")
+    SELECT DISTINCT ssm."userId", ssl."libraryId"
+    FROM shared_space_library ssl
+    INNER JOIN shared_space_member ssm ON ssl."spaceId" = ssm."spaceId"
+    ON CONFLICT ("userId", "libraryId") DO NOTHING;
+  `.execute(db);
 }
 
 export async function down(db: Kysely<any>): Promise<void> {

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -1,0 +1,32 @@
+import { Kysely, sql } from 'kysely';
+
+// Adds the create-side mirror of library_audit: a denormalized (userId, libraryId)
+// access-grant table with a per-user createId. Drives LibrarySync.getCreatedAfter
+// so users who gain access to pre-existing libraries via shared-space links
+// correctly receive the library metadata and its asset backfill on next sync.
+//
+// See docs/plans/2026-04-11-library-user-access-backfill-design.md for the full
+// design, trade-offs, and rationale.
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    CREATE TABLE "library_user" (
+      "userId"    uuid NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+      "libraryId" uuid NOT NULL REFERENCES "library"(id) ON DELETE CASCADE,
+      "createId"  uuid NOT NULL DEFAULT immich_uuid_v7(),
+      "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+      CONSTRAINT "library_user_pkey" PRIMARY KEY ("userId", "libraryId")
+    );
+  `.execute(db);
+
+  // Hot-path index: LibrarySync.getCreatedAfter filters by userId then createId,
+  // so a composite leading with userId lets the planner seek directly to the
+  // user's slice and walk sorted. PK (userId, libraryId) doesn't serve this
+  // query because it's ordered on the wrong column.
+  await sql`CREATE INDEX "library_user_userId_createId_idx" ON "library_user" ("userId", "createId");`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS "library_user_userId_createId_idx";`.execute(db);
+  await sql`DROP TABLE IF EXISTS "library_user";`.execute(db);
+}

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -60,13 +60,55 @@ export async function up(db: Kysely<any>): Promise<void> {
   await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_library_after_insert', '{"type":"trigger","name":"library_after_insert","sql":"CREATE OR REPLACE TRIGGER \\"library_after_insert\\"\\n  AFTER INSERT ON \\"library\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION library_after_insert();"}'::jsonb);`.execute(
     db,
   );
+
+  // shared_space_member_after_insert_library: when a user joins a space,
+  // grant library_user for every library linked to that space and bump
+  // library.updateId so the library metadata row re-emits on next sync.
+  await sql`CREATE OR REPLACE FUNCTION shared_space_member_after_insert_library()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ir."userId", ssl."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (
+        SELECT DISTINCT ssl."libraryId"
+        FROM inserted_rows ir
+        INNER JOIN shared_space_library ssl ON ssl."spaceId" = ir."spaceId"
+      );
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "shared_space_member_after_insert_library"
+  AFTER INSERT ON "shared_space_member"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION shared_space_member_after_insert_library();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_shared_space_member_after_insert_library', '{"type":"function","name":"shared_space_member_after_insert_library","sql":"CREATE OR REPLACE FUNCTION shared_space_member_after_insert_library()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO library_user (\\"userId\\", \\"libraryId\\")\\n      SELECT DISTINCT ir.\\"userId\\", ssl.\\"libraryId\\"\\n      FROM inserted_rows ir\\n      INNER JOIN shared_space_library ssl ON ssl.\\"spaceId\\" = ir.\\"spaceId\\"\\n      ON CONFLICT DO NOTHING;\\n\\n      UPDATE library\\n      SET \\"updatedAt\\" = clock_timestamp(), \\"updateId\\" = immich_uuid_v7(clock_timestamp())\\n      WHERE \\"id\\" IN (\\n        SELECT DISTINCT ssl.\\"libraryId\\"\\n        FROM inserted_rows ir\\n        INNER JOIN shared_space_library ssl ON ssl.\\"spaceId\\" = ir.\\"spaceId\\"\\n      );\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb);`.execute(
+    db,
+  );
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_shared_space_member_after_insert_library', '{"type":"trigger","name":"shared_space_member_after_insert_library","sql":"CREATE OR REPLACE TRIGGER \\"shared_space_member_after_insert_library\\"\\n  AFTER INSERT ON \\"shared_space_member\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION shared_space_member_after_insert_library();"}'::jsonb);`.execute(
+    db,
+  );
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
   await sql`DELETE FROM "migration_overrides" WHERE "name" IN (
     'function_library_after_insert',
-    'trigger_library_after_insert'
+    'trigger_library_after_insert',
+    'function_shared_space_member_after_insert_library',
+    'trigger_shared_space_member_after_insert_library'
   )`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "shared_space_member_after_insert_library" ON "shared_space_member";`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS shared_space_member_after_insert_library();`.execute(db);
   await sql`DROP TRIGGER IF EXISTS "library_after_insert" ON "library";`.execute(db);
   await sql`DROP FUNCTION IF EXISTS library_after_insert();`.execute(db);
   await sql`DROP INDEX IF EXISTS "library_user_userId_createId_idx";`.execute(db);

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -98,6 +98,39 @@ export async function up(db: Kysely<any>): Promise<void> {
   await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_shared_space_member_after_insert_library', '{"type":"trigger","name":"shared_space_member_after_insert_library","sql":"CREATE OR REPLACE TRIGGER \\"shared_space_member_after_insert_library\\"\\n  AFTER INSERT ON \\"shared_space_member\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION shared_space_member_after_insert_library();"}'::jsonb);`.execute(
     db,
   );
+
+  // shared_space_library_after_insert_user: on library link, grant library_user
+  // for every current member and bump library.updateId.
+  await sql`CREATE OR REPLACE FUNCTION shared_space_library_after_insert_user()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId")
+      SELECT DISTINCT ssm."userId", ir."libraryId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_member ssm ON ssm."spaceId" = ir."spaceId"
+      ON CONFLICT DO NOTHING;
+
+      UPDATE library
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (SELECT DISTINCT "libraryId" FROM inserted_rows);
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "shared_space_library_after_insert_user"
+  AFTER INSERT ON "shared_space_library"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION shared_space_library_after_insert_user();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_shared_space_library_after_insert_user', '{"type":"function","name":"shared_space_library_after_insert_user","sql":"CREATE OR REPLACE FUNCTION shared_space_library_after_insert_user()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO library_user (\\"userId\\", \\"libraryId\\")\\n      SELECT DISTINCT ssm.\\"userId\\", ir.\\"libraryId\\"\\n      FROM inserted_rows ir\\n      INNER JOIN shared_space_member ssm ON ssm.\\"spaceId\\" = ir.\\"spaceId\\"\\n      ON CONFLICT DO NOTHING;\\n\\n      UPDATE library\\n      SET \\"updatedAt\\" = clock_timestamp(), \\"updateId\\" = immich_uuid_v7(clock_timestamp())\\n      WHERE \\"id\\" IN (SELECT DISTINCT \\"libraryId\\" FROM inserted_rows);\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb);`.execute(
+    db,
+  );
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_shared_space_library_after_insert_user', '{"type":"trigger","name":"shared_space_library_after_insert_user","sql":"CREATE OR REPLACE TRIGGER \\"shared_space_library_after_insert_user\\"\\n  AFTER INSERT ON \\"shared_space_library\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION shared_space_library_after_insert_user();"}'::jsonb);`.execute(
+    db,
+  );
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
@@ -105,8 +138,12 @@ export async function down(db: Kysely<any>): Promise<void> {
     'function_library_after_insert',
     'trigger_library_after_insert',
     'function_shared_space_member_after_insert_library',
-    'trigger_shared_space_member_after_insert_library'
+    'trigger_shared_space_member_after_insert_library',
+    'function_shared_space_library_after_insert_user',
+    'trigger_shared_space_library_after_insert_user'
   )`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "shared_space_library_after_insert_user" ON "shared_space_library";`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS shared_space_library_after_insert_user();`.execute(db);
   await sql`DROP TRIGGER IF EXISTS "shared_space_member_after_insert_library" ON "shared_space_member";`.execute(db);
   await sql`DROP FUNCTION IF EXISTS shared_space_member_after_insert_library();`.execute(db);
   await sql`DROP TRIGGER IF EXISTS "library_after_insert" ON "library";`.execute(db);

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -24,9 +24,51 @@ export async function up(db: Kysely<any>): Promise<void> {
   // user's slice and walk sorted. PK (userId, libraryId) doesn't serve this
   // query because it's ordered on the wrong column.
   await sql`CREATE INDEX "library_user_userId_createId_idx" ON "library_user" ("userId", "createId");`.execute(db);
+
+  // --- Create-side triggers ---
+
+  // library_after_insert: populate library_user for the library owner at
+  // library creation. Explicitly propagates library.createId/createdAt rather
+  // than letting the defaults mint fresh values, so existing clients' sync
+  // checkpoints (already past library.createId) don't retrigger a completed
+  // backfill for freshly-created owned libraries.
+  await sql`CREATE OR REPLACE FUNCTION library_after_insert()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+      SELECT "ownerId", "id", "createId", "createdAt"
+      FROM inserted_rows
+      WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+      ON CONFLICT DO NOTHING;
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "library_after_insert"
+  AFTER INSERT ON "library"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION library_after_insert();`.execute(db);
+
+  // migration_overrides entries so sql-tools' schema diff recognizes these
+  // objects. Pattern lifted from 1778200000000-LibraryAuditTables.ts.
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_library_after_insert', '{"type":"function","name":"library_after_insert","sql":"CREATE OR REPLACE FUNCTION library_after_insert()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO library_user (\\"userId\\", \\"libraryId\\", \\"createId\\", \\"createdAt\\")\\n      SELECT \\"ownerId\\", \\"id\\", \\"createId\\", \\"createdAt\\"\\n      FROM inserted_rows\\n      WHERE \\"ownerId\\" IS NOT NULL AND \\"deletedAt\\" IS NULL\\n      ON CONFLICT DO NOTHING;\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb);`.execute(
+    db,
+  );
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_library_after_insert', '{"type":"trigger","name":"library_after_insert","sql":"CREATE OR REPLACE TRIGGER \\"library_after_insert\\"\\n  AFTER INSERT ON \\"library\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION library_after_insert();"}'::jsonb);`.execute(
+    db,
+  );
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DELETE FROM "migration_overrides" WHERE "name" IN (
+    'function_library_after_insert',
+    'trigger_library_after_insert'
+  )`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "library_after_insert" ON "library";`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS library_after_insert();`.execute(db);
   await sql`DROP INDEX IF EXISTS "library_user_userId_createId_idx";`.execute(db);
   await sql`DROP TABLE IF EXISTS "library_user";`.execute(db);
 }

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -11,8 +11,8 @@ import { Kysely, sql } from 'kysely';
 export async function up(db: Kysely<any>): Promise<void> {
   await sql`
     CREATE TABLE "library_user" (
-      "userId"    uuid NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
-      "libraryId" uuid NOT NULL REFERENCES "library"(id) ON DELETE CASCADE,
+      "userId"    uuid NOT NULL REFERENCES "user"(id) ON UPDATE CASCADE ON DELETE CASCADE,
+      "libraryId" uuid NOT NULL REFERENCES "library"(id) ON UPDATE CASCADE ON DELETE CASCADE,
       "createId"  uuid NOT NULL DEFAULT immich_uuid_v7(),
       "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
       CONSTRAINT "library_user_pkey" PRIMARY KEY ("userId", "libraryId")

--- a/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
+++ b/server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts
@@ -131,6 +131,40 @@ export async function up(db: Kysely<any>): Promise<void> {
   await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_shared_space_library_after_insert_user', '{"type":"trigger","name":"shared_space_library_after_insert_user","sql":"CREATE OR REPLACE TRIGGER \\"shared_space_library_after_insert_user\\"\\n  AFTER INSERT ON \\"shared_space_library\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION shared_space_library_after_insert_user();"}'::jsonb);`.execute(
     db,
   );
+
+  // --- Delete-side consumer ---
+  //
+  // library_user_delete_after_audit: when library_audit rows land, delete the
+  // corresponding library_user rows UNCONDITIONALLY. Trusts the gating at
+  // insertion time (every inserter gates on NOT user_has_library_path(...,
+  // excludeSpaceId)). Re-checking here with NULL would be BROKEN during
+  // shared_space hard-delete because the BEFORE DELETE trigger fires before
+  // FK cascades run. See design doc.
+  await sql`CREATE OR REPLACE FUNCTION library_user_delete_after_audit()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      DELETE FROM library_user lu
+      USING inserted_rows ir
+      WHERE lu."userId" = ir."userId"
+        AND lu."libraryId" = ir."libraryId";
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "library_user_delete_after_audit"
+  AFTER INSERT ON "library_audit"
+  REFERENCING NEW TABLE AS "inserted_rows"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION library_user_delete_after_audit();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_library_user_delete_after_audit', '{"type":"function","name":"library_user_delete_after_audit","sql":"CREATE OR REPLACE FUNCTION library_user_delete_after_audit()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      DELETE FROM library_user lu\\n      USING inserted_rows ir\\n      WHERE lu.\\"userId\\" = ir.\\"userId\\"\\n        AND lu.\\"libraryId\\" = ir.\\"libraryId\\";\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb);`.execute(
+    db,
+  );
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_library_user_delete_after_audit', '{"type":"trigger","name":"library_user_delete_after_audit","sql":"CREATE OR REPLACE TRIGGER \\"library_user_delete_after_audit\\"\\n  AFTER INSERT ON \\"library_audit\\"\\n  REFERENCING NEW TABLE AS \\"inserted_rows\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION library_user_delete_after_audit();"}'::jsonb);`.execute(
+    db,
+  );
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
@@ -140,8 +174,12 @@ export async function down(db: Kysely<any>): Promise<void> {
     'function_shared_space_member_after_insert_library',
     'trigger_shared_space_member_after_insert_library',
     'function_shared_space_library_after_insert_user',
-    'trigger_shared_space_library_after_insert_user'
+    'trigger_shared_space_library_after_insert_user',
+    'function_library_user_delete_after_audit',
+    'trigger_library_user_delete_after_audit'
   )`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "library_user_delete_after_audit" ON "library_audit";`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS library_user_delete_after_audit();`.execute(db);
   await sql`DROP TRIGGER IF EXISTS "shared_space_library_after_insert_user" ON "shared_space_library";`.execute(db);
   await sql`DROP FUNCTION IF EXISTS shared_space_library_after_insert_user();`.execute(db);
   await sql`DROP TRIGGER IF EXISTS "shared_space_member_after_insert_library" ON "shared_space_member";`.execute(db);

--- a/server/src/schema/tables/library-audit.table.ts
+++ b/server/src/schema/tables/library-audit.table.ts
@@ -1,7 +1,16 @@
-import { Column, CreateDateColumn, Generated, Table, Timestamp } from '@immich/sql-tools';
+import { AfterInsertTrigger, Column, CreateDateColumn, Generated, Table, Timestamp } from '@immich/sql-tools';
 import { PrimaryGeneratedUuidV7Column } from 'src/decorators';
+import { library_user_delete_after_audit } from 'src/schema/functions';
 
 @Table('library_audit')
+// When audit rows land, drop the corresponding library_user rows. See
+// docs/plans/2026-04-11-library-user-access-backfill-design.md.
+@AfterInsertTrigger({
+  name: 'library_user_delete_after_audit',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: library_user_delete_after_audit,
+})
 export class LibraryAuditTable {
   @PrimaryGeneratedUuidV7Column()
   id!: Generated<string>;

--- a/server/src/schema/tables/library-user.table.ts
+++ b/server/src/schema/tables/library-user.table.ts
@@ -1,0 +1,43 @@
+import { CreateDateColumn, ForeignKeyColumn, Generated, Index, Table, Timestamp } from '@immich/sql-tools';
+import { CreateIdColumn } from 'src/decorators';
+import { LibraryTable } from 'src/schema/tables/library.table';
+import { UserTable } from 'src/schema/tables/user.table';
+
+// Denormalized (userId, libraryId) access-grant table with a per-user createId.
+// Drives LibrarySync.getCreatedAfter so users who gain access to pre-existing
+// libraries via shared-space links correctly receive library metadata and
+// asset backfill on next sync.
+//
+// See docs/plans/2026-04-11-library-user-access-backfill-design.md for the
+// full design, triggers, and migration backfill strategy.
+@Table({ name: 'library_user' })
+// Hot-path index: LibrarySync.getCreatedAfter filters by userId then createId,
+// so a composite leading with userId lets the planner seek directly to the
+// user's slice and walk sorted. PK (userId, libraryId) doesn't serve this
+// query because it's ordered on the wrong column.
+@Index({ name: 'library_user_userId_createId_idx', columns: ['userId', 'createId'] })
+export class LibraryUserTable {
+  @ForeignKeyColumn(() => UserTable, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: false,
+    primary: true,
+  })
+  userId!: string;
+
+  @ForeignKeyColumn(() => LibraryTable, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: false,
+    primary: true,
+  })
+  libraryId!: string;
+
+  // No standalone index — the composite (userId, createId) above is what the
+  // query planner uses.
+  @CreateIdColumn()
+  createId!: Generated<string>;
+
+  @CreateDateColumn()
+  createdAt!: Generated<Timestamp>;
+}

--- a/server/src/schema/tables/library-user.table.ts
+++ b/server/src/schema/tables/library-user.table.ts
@@ -22,6 +22,9 @@ export class LibraryUserTable {
     onUpdate: 'CASCADE',
     nullable: false,
     primary: true,
+    // The composite (userId, createId) index above already serves the
+    // userId-leading hot-path query — no need for a standalone index.
+    index: false,
   })
   userId!: string;
 
@@ -30,6 +33,9 @@ export class LibraryUserTable {
     onUpdate: 'CASCADE',
     nullable: false,
     primary: true,
+    // No query uses libraryId as the leading column on this table; the
+    // consumer trigger and migration backfill all join through PK.
+    index: false,
   })
   libraryId!: string;
 

--- a/server/src/schema/tables/library.table.ts
+++ b/server/src/schema/tables/library.table.ts
@@ -1,4 +1,5 @@
 import {
+  AfterInsertTrigger,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -10,10 +11,19 @@ import {
   UpdateDateColumn,
 } from '@immich/sql-tools';
 import { CreateIdColumn, UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
+import { library_after_insert } from 'src/schema/functions';
 import { UserTable } from 'src/schema/tables/user.table';
 
 @Table('library')
 @UpdatedAtTrigger('library_updatedAt')
+// Populate library_user for the owner on library creation. See
+// docs/plans/2026-04-11-library-user-access-backfill-design.md.
+@AfterInsertTrigger({
+  name: 'library_after_insert',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: library_after_insert,
+})
 export class LibraryTable {
   @PrimaryGeneratedColumn()
   id!: Generated<string>;

--- a/server/src/schema/tables/shared-space-library.table.ts
+++ b/server/src/schema/tables/shared-space-library.table.ts
@@ -1,5 +1,6 @@
 import {
   AfterDeleteTrigger,
+  AfterInsertTrigger,
   CreateDateColumn,
   ForeignKeyColumn,
   Generated,
@@ -8,13 +9,23 @@ import {
   UpdateDateColumn,
 } from '@immich/sql-tools';
 import { CreateIdColumn, UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
-import { shared_space_library_delete_audit } from 'src/schema/functions';
+import { shared_space_library_after_insert_user, shared_space_library_delete_audit } from 'src/schema/functions';
 import { LibraryTable } from 'src/schema/tables/library.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 import { UserTable } from 'src/schema/tables/user.table';
 
 @Table('shared_space_library')
 @UpdatedAtTrigger('shared_space_library_updatedAt')
+// Populates library_user for every member of the space when a library is
+// linked, and bumps library.updateId so the metadata row re-emits via
+// LibrarySync.getUpserts. See
+// docs/plans/2026-04-11-library-user-access-backfill-design.md.
+@AfterInsertTrigger({
+  name: 'shared_space_library_after_insert_user',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: shared_space_library_after_insert_user,
+})
 // Fan-out trigger: on unlinking (direct or via cascade from library/shared_space
 // deletion) emits rows to library_audit (per user who loses access) and
 // shared_space_library_audit (the join-row delete). The function body is the

--- a/server/src/schema/tables/shared-space-member.table.ts
+++ b/server/src/schema/tables/shared-space-member.table.ts
@@ -13,6 +13,7 @@ import { CreateIdColumn, UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators
 import { SharedSpaceRole } from 'src/enum';
 import {
   shared_space_member_after_insert,
+  shared_space_member_after_insert_library,
   shared_space_member_delete_audit,
   shared_space_member_delete_library_audit,
 } from 'src/schema/functions';
@@ -28,6 +29,16 @@ import { UserTable } from 'src/schema/tables/user.table';
   scope: 'statement',
   referencingNewTableAs: 'inserted_rows',
   function: shared_space_member_after_insert,
+})
+// Populates library_user + bumps library.updateId for every library linked
+// to the space the new member joined. Name-suffixed with `_library` so it
+// sorts after shared_space_member_after_insert in alphabetical trigger order.
+// See docs/plans/2026-04-11-library-user-access-backfill-design.md.
+@AfterInsertTrigger({
+  name: 'shared_space_member_after_insert_library',
+  scope: 'statement',
+  referencingNewTableAs: 'inserted_rows',
+  function: shared_space_member_after_insert_library,
 })
 // Always fires (no `when` clause). The function body distinguishes direct removal
 // from cascade by checking whether the parent shared_space row still exists.

--- a/server/test/medium/specs/sync/library-access-backfill.spec.ts
+++ b/server/test/medium/specs/sync/library-access-backfill.spec.ts
@@ -1,0 +1,114 @@
+import { Kysely } from 'kysely';
+import { SharedSpaceRole, SyncEntityType, SyncRequestType } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+// Integration tests for the three library-access backfill scenarios the
+// library_user denormalization fixes:
+//
+//   1. A user re-added to a space after leaving (covered in
+//      library-sync-end-to-end.spec.ts — asset+exif re-emit).
+//   2. A new user added to a pre-existing space that already has libraries
+//      linked (covered below).
+//   3. A library newly linked to a space the user is already in (covered
+//      below).
+//
+// These exercise the full server stack: triggers + rewritten getCreatedAfter
+// + existing syncLibrariesV1 / syncLibraryAssetsV1 / syncLibraryAssetExifsV1.
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const ctx = new SyncTestContext(defaultDatabase);
+  return { ctx, db: defaultDatabase };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+const ALL_LIBRARY_TYPES = [
+  SyncRequestType.LibrariesV1,
+  SyncRequestType.LibraryAssetsV1,
+  SyncRequestType.LibraryAssetExifsV1,
+  SyncRequestType.SharedSpaceLibrariesV1,
+];
+
+describe('library access backfill — sync stream integration', () => {
+  it('delivers library metadata + assets on first sync of a user added to an existing space with linked libraries', async () => {
+    const { ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id, name: 'Pre-existing library' });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestMake' });
+
+    // Space with the library already linked, BEFORE the new user exists.
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id, name: 'Existing S' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+    // Now create the new user and add them to the pre-existing space.
+    const { auth: authNew } = await ctx.newSyncAuthUser();
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: authNew.user.id, role: SharedSpaceRole.Editor });
+
+    // First sync — trigger-populated library_user with a fresh createId
+    // drives the per-library asset backfill, and the updateId bump drives
+    // the library metadata upsert stream.
+    const response = await ctx.syncStream(authNew, ALL_LIBRARY_TYPES);
+
+    const libraryEvents = response.filter((r: { type: string }) => r.type === SyncEntityType.LibraryV1);
+    expect(libraryEvents.map((e: { data: { id: string } }) => e.data.id)).toContain(library.id);
+
+    const assetEvents = response.filter(
+      (r: { type: string }) =>
+        r.type === SyncEntityType.LibraryAssetCreateV1 || r.type === SyncEntityType.LibraryAssetBackfillV1,
+    );
+    expect(assetEvents.map((e: { data: { id: string } }) => e.data.id)).toContain(asset.id);
+
+    const exifEvents = response.filter(
+      (r: { type: string }) =>
+        r.type === SyncEntityType.LibraryAssetExifCreateV1 || r.type === SyncEntityType.LibraryAssetExifBackfillV1,
+    );
+    expect(exifEvents.map((e: { data: { assetId: string } }) => e.data.assetId)).toContain(asset.id);
+  });
+
+  it('delivers library metadata + assets when a library is newly linked to a space the user is already in', async () => {
+    const { ctx } = setup();
+    const { auth: authB } = await ctx.newSyncAuthUser();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id, name: 'Initially empty S' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: authB.user.id, role: SharedSpaceRole.Editor });
+
+    // Initial sync — nothing library-related for B.
+    const initial = await ctx.syncStream(authB, ALL_LIBRARY_TYPES);
+    const initialLibraryEvents = initial.filter((r: { type: string }) => r.type === SyncEntityType.LibraryV1);
+    expect(initialLibraryEvents).toHaveLength(0);
+    await ctx.syncAckAll(authB, initial);
+
+    // Now link a new library + asset + exif to the space.
+    const { library } = await ctx.newLibrary({ ownerId: owner.id, name: 'Late-linked library' });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestMake' });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+
+    // Second sync — library + asset + exif must all flow to B.
+    const response = await ctx.syncStream(authB, ALL_LIBRARY_TYPES);
+
+    const libraryEvents = response.filter((r: { type: string }) => r.type === SyncEntityType.LibraryV1);
+    expect(libraryEvents.map((e: { data: { id: string } }) => e.data.id)).toContain(library.id);
+
+    const assetEvents = response.filter(
+      (r: { type: string }) =>
+        r.type === SyncEntityType.LibraryAssetCreateV1 || r.type === SyncEntityType.LibraryAssetBackfillV1,
+    );
+    expect(assetEvents.map((e: { data: { id: string } }) => e.data.id)).toContain(asset.id);
+
+    const exifEvents = response.filter(
+      (r: { type: string }) =>
+        r.type === SyncEntityType.LibraryAssetExifCreateV1 || r.type === SyncEntityType.LibraryAssetExifBackfillV1,
+    );
+    expect(exifEvents.map((e: { data: { assetId: string } }) => e.data.assetId)).toContain(asset.id);
+  });
+});

--- a/server/test/medium/specs/sync/library-sync-created-after.spec.ts
+++ b/server/test/medium/specs/sync/library-sync-created-after.spec.ts
@@ -1,6 +1,5 @@
 import { Kysely } from 'kysely';
-import { accessibleLibraries } from 'src/repositories/sync.repository';
-import { SyncRepository } from 'src/repositories/sync.repository';
+import { accessibleLibraries, SyncRepository } from 'src/repositories/sync.repository';
 import { DB } from 'src/schema';
 import { SyncTestContext } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
@@ -100,18 +99,18 @@ describe('LibrarySync.getCreatedAfter', () => {
     await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: transitive.id });
     await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id });
 
-    const getCreatedAfterIds = new Set(
-      (await sut.getCreatedAfter({ nowId: NOW_ID, userId: user.id, afterCreateId: undefined })).map((r) => r.id),
-    );
-    const accessibleIds = new Set(
-      (
-        await db
-          .selectFrom('library')
-          .select('id')
-          .where('library.id', 'in', (eb) => accessibleLibraries(eb, user.id))
-          .execute()
-      ).map((r) => r.id),
-    );
+    const getCreatedAfterRows = await sut.getCreatedAfter({
+      nowId: NOW_ID,
+      userId: user.id,
+      afterCreateId: undefined,
+    });
+    const getCreatedAfterIds = new Set(getCreatedAfterRows.map((r) => r.id));
+    const accessibleRows = await db
+      .selectFrom('library')
+      .select('id')
+      .where('library.id', 'in', (eb) => accessibleLibraries(eb, user.id))
+      .execute();
+    const accessibleIds = new Set(accessibleRows.map((r) => r.id));
 
     expect(getCreatedAfterIds).toEqual(accessibleIds);
     expect(getCreatedAfterIds.has(owned.id)).toBe(true);
@@ -144,15 +143,12 @@ describe('LibrarySync.getCreatedAfter', () => {
     const returnedIds = new Set(rows.map((r) => r.id));
 
     // Every accessible library for peer appears in the result.
-    const accessible = new Set(
-      (
-        await db
-          .selectFrom('library')
-          .select('id')
-          .where('library.id', 'in', (eb) => accessibleLibraries(eb, peer.id))
-          .execute()
-      ).map((r) => r.id),
-    );
+    const accessibleRows = await db
+      .selectFrom('library')
+      .select('id')
+      .where('library.id', 'in', (eb) => accessibleLibraries(eb, peer.id))
+      .execute();
+    const accessible = new Set(accessibleRows.map((r) => r.id));
     for (const id of accessible) {
       expect(returnedIds.has(id)).toBe(true);
     }

--- a/server/test/medium/specs/sync/library-sync-created-after.spec.ts
+++ b/server/test/medium/specs/sync/library-sync-created-after.spec.ts
@@ -1,0 +1,164 @@
+import { Kysely } from 'kysely';
+import { accessibleLibraries } from 'src/repositories/sync.repository';
+import { SyncRepository } from 'src/repositories/sync.repository';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+// Unit tests for LibrarySync.getCreatedAfter. These tests PIN the expected
+// behavior of the post-fix query. The current (pre-rewrite) implementation
+// reads from `library` and keys off `library.createId`; the new
+// implementation (plan Task 13) reads from `library_user` and keys off
+// `library_user.createId`. The set-equality and value-space-shift tests are
+// regression guards that must pass against the rewrite.
+
+let defaultDatabase: Kysely<DB>;
+
+// A uuid_v7 value effectively at infinity — used as `nowId` so the query's
+// `createId < nowId` clause never filters anything out.
+const NOW_ID = 'ffffffff-ffff-7fff-bfff-ffffffffffff';
+
+const setup = () => {
+  const ctx = new SyncTestContext(defaultDatabase);
+  return { ctx, db: defaultDatabase, sut: ctx.get(SyncRepository).library };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('LibrarySync.getCreatedAfter', () => {
+  it('returns libraries the user owns', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    const rows = await sut.getCreatedAfter({ nowId: NOW_ID, userId: user.id, afterCreateId: undefined });
+    expect(rows.map((r) => r.id)).toContain(library.id);
+  });
+
+  it('returns libraries the user accesses via shared_space_library', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+    const rows = await sut.getCreatedAfter({ nowId: NOW_ID, userId: peer.id, afterCreateId: undefined });
+    expect(rows.map((r) => r.id)).toContain(library.id);
+  });
+
+  it('returns empty for a user with no library access', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const rows = await sut.getCreatedAfter({ nowId: NOW_ID, userId: user.id, afterCreateId: undefined });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('excludes a soft-deleted owned library when the user has no space-linked path', async () => {
+    const { ctx, db, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    await db.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+
+    const rows = await sut.getCreatedAfter({ nowId: NOW_ID, userId: user.id, afterCreateId: undefined });
+    expect(rows.find((r) => r.id === library.id)).toBeUndefined();
+  });
+
+  it('includes a soft-deleted library when the user has a space-linked path to it', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+    await db.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+
+    const rows = await sut.getCreatedAfter({ nowId: NOW_ID, userId: peer.id, afterCreateId: undefined });
+    expect(rows.map((r) => r.id)).toContain(library.id);
+  });
+
+  it('set equality with accessibleLibraries', async () => {
+    // Seed a user with a mix of owned, owned-but-soft-deleted, and
+    // transitive libraries. getCreatedAfter(afterCreateId=null) must return
+    // exactly the same set as accessibleLibraries(userId).
+    const { ctx, db, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { library: owned } = await ctx.newLibrary({ ownerId: user.id });
+
+    const { library: softDeleted } = await ctx.newLibrary({ ownerId: user.id });
+    await db.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', softDeleted.id).execute();
+
+    const { user: peer } = await ctx.newUser();
+    const { library: transitive } = await ctx.newLibrary({ ownerId: peer.id });
+    const { space } = await ctx.newSharedSpace({ createdById: peer.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: transitive.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id });
+
+    const getCreatedAfterIds = new Set(
+      (await sut.getCreatedAfter({ nowId: NOW_ID, userId: user.id, afterCreateId: undefined })).map((r) => r.id),
+    );
+    const accessibleIds = new Set(
+      (
+        await db
+          .selectFrom('library')
+          .select('id')
+          .where('library.id', 'in', (eb) => accessibleLibraries(eb, user.id))
+          .execute()
+      ).map((r) => r.id),
+    );
+
+    expect(getCreatedAfterIds).toEqual(accessibleIds);
+    expect(getCreatedAfterIds.has(owned.id)).toBe(true);
+    expect(getCreatedAfterIds.has(softDeleted.id)).toBe(false);
+    expect(getCreatedAfterIds.has(transitive.id)).toBe(true);
+  });
+
+  // Regression guard for the deploy-time checkpoint value-space shift. Before
+  // the fix, `afterCreateId` was a `library.createId` watermark; after, it's
+  // a `library_user.createId` watermark. Carry a pre-fix-value-space
+  // checkpoint over the boundary and assert the query returns a consistent
+  // superset of the user's accessible libraries.
+  it('handles a pre-fix-value-space afterCreateId checkpoint without returning a wrong set', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+    // Pre-fix clients stored `library.createId` as their checkpoint.
+    const preFixCheckpoint = library.createId;
+
+    const rows = await sut.getCreatedAfter({
+      nowId: NOW_ID,
+      userId: peer.id,
+      afterCreateId: preFixCheckpoint,
+    });
+    const returnedIds = new Set(rows.map((r) => r.id));
+
+    // Every accessible library for peer appears in the result.
+    const accessible = new Set(
+      (
+        await db
+          .selectFrom('library')
+          .select('id')
+          .where('library.id', 'in', (eb) => accessibleLibraries(eb, peer.id))
+          .execute()
+      ).map((r) => r.id),
+    );
+    for (const id of accessible) {
+      expect(returnedIds.has(id)).toBe(true);
+    }
+    // No libraries the user shouldn't have access to.
+    for (const id of returnedIds) {
+      expect(accessible.has(id)).toBe(true);
+    }
+  });
+});

--- a/server/test/medium/specs/sync/library-sync-end-to-end.spec.ts
+++ b/server/test/medium/specs/sync/library-sync-end-to-end.spec.ts
@@ -122,9 +122,7 @@ describe('library sync end-to-end access control', () => {
 
     // Library metadata rows re-emit via the updateId bump.
     const reAddedLibraryEvents = afterReadd.filter((r: { type: string }) => r.type === SyncEntityType.LibraryV1);
-    const reAddedLibraryIds = reAddedLibraryEvents
-      .map((e: { data: { id: string } }) => e.data.id)
-      .toSorted();
+    const reAddedLibraryIds = reAddedLibraryEvents.map((e: { data: { id: string } }) => e.data.id).toSorted();
     expect(reAddedLibraryIds).toEqual([l1.id, l2.id].toSorted());
 
     // Join rows re-emit via SharedSpaceLibraryBackfillV1 — the membership

--- a/server/test/medium/specs/sync/library-sync-end-to-end.spec.ts
+++ b/server/test/medium/specs/sync/library-sync-end-to-end.spec.ts
@@ -110,31 +110,24 @@ describe('library sync end-to-end access control', () => {
     await ctx.syncAckAll(authB, afterRemoval);
 
     // Step 3: Re-add B to S. After the library_user fix, re-membership
-    // triggers the create-side library_user trigger which:
-    //   1. INSERTs a (B, L) row for each linked library with a fresh createId,
-    //      so the per-library asset backfill loop will re-iterate (landing
-    //      after the LibrarySync.getCreatedAfter rewrite — see plan Task 13).
-    //   2. Bumps library.updateId so LibrarySync.getUpserts re-emits the
+    // fires the create-side triggers which:
+    //   1. INSERT (B, L) rows for each linked library with fresh createIds,
+    //      so LibrarySync.getCreatedAfter returns them and the per-library
+    //      asset backfill loop re-iterates.
+    //   2. Bump library.updateId so LibrarySync.getUpserts re-emits the
     //      library metadata row on B's next sync.
-    //
-    // This test asserts the Library metadata re-emit half of the fix. The
-    // asset + exif re-emit half lands with the getCreatedAfter rewrite;
-    // assertions below currently expect 0 for asset/exif and will be flipped
-    // to `>= 1` in the same commit that rewrites getCreatedAfter.
     await ctx.newSharedSpaceMember({ spaceId: space.id, userId: authB.user.id, role: SharedSpaceRole.Editor });
 
     const afterReadd = await ctx.syncStream(authB, ALL_LIBRARY_TYPES);
 
-    // Library rows DO reappear now — the shared_space_member_after_insert_library
-    // trigger bumped library.updateId for every linked library, and
-    // LibrarySync.getUpserts picks that up.
+    // Library metadata rows re-emit via the updateId bump.
     const reAddedLibraryEvents = afterReadd.filter((r: { type: string }) => r.type === SyncEntityType.LibraryV1);
     const reAddedLibraryIds = reAddedLibraryEvents
       .map((e: { data: { id: string } }) => e.data.id)
       .toSorted();
     expect(reAddedLibraryIds).toEqual([l1.id, l2.id].toSorted());
 
-    // Join rows DO reappear via SharedSpaceLibraryBackfillV1 — the membership
+    // Join rows re-emit via SharedSpaceLibraryBackfillV1 — the membership
     // createId is fresh, so the backfill loop re-iterates the space.
     const reAddedLinkEvents = afterReadd.filter(
       (r: { type: string }) =>
@@ -145,19 +138,19 @@ describe('library sync end-to-end access control', () => {
       .toSorted();
     expect(reAddedLinkLibraryIds).toEqual([l1.id, l2.id].toSorted());
 
-    // Asset content does NOT reappear YET — LibrarySync.getCreatedAfter still
-    // keys off library.createId. This flips in plan Task 13.
+    // Asset content re-emits via the per-library backfill loop driven by
+    // fresh library_user.createIds.
     const reAddedAssetEvents = afterReadd.filter(
       (r: { type: string }) =>
         r.type === SyncEntityType.LibraryAssetCreateV1 || r.type === SyncEntityType.LibraryAssetBackfillV1,
     );
-    expect(reAddedAssetEvents).toHaveLength(0);
+    expect(reAddedAssetEvents.length).toBeGreaterThan(0);
 
-    // Exif content does NOT reappear YET — same reason.
+    // Exif content re-emits too.
     const reAddedExifEvents = afterReadd.filter(
       (r: { type: string }) =>
         r.type === SyncEntityType.LibraryAssetExifCreateV1 || r.type === SyncEntityType.LibraryAssetExifBackfillV1,
     );
-    expect(reAddedExifEvents).toHaveLength(0);
+    expect(reAddedExifEvents.length).toBeGreaterThan(0);
   });
 });

--- a/server/test/medium/specs/sync/library-sync-end-to-end.spec.ts
+++ b/server/test/medium/specs/sync/library-sync-end-to-end.spec.ts
@@ -109,44 +109,30 @@ describe('library sync end-to-end access control', () => {
 
     await ctx.syncAckAll(authB, afterRemoval);
 
-    // Step 3: Re-add B to S — document the Known Limitation behavior.
+    // Step 3: Re-add B to S. After the library_user fix, re-membership
+    // triggers the create-side library_user trigger which:
+    //   1. INSERTs a (B, L) row for each linked library with a fresh createId,
+    //      so the per-library asset backfill loop will re-iterate (landing
+    //      after the LibrarySync.getCreatedAfter rewrite — see plan Task 13).
+    //   2. Bumps library.updateId so LibrarySync.getUpserts re-emits the
+    //      library metadata row on B's next sync.
     //
-    // After re-membership, the four library streams behave asymmetrically:
-    //
-    // 1. SharedSpaceLibrary join rows DO re-emit. The dispatch enumerates
-    //    spaces via SharedSpaceSync.getCreatedAfter, which reads from
-    //    shared_space_member.createId. Re-adding B inserts a new
-    //    shared_space_member row with a fresh createId past B's backfill
-    //    checkpoint, so the per-space backfill loop fires and streams the
-    //    shared_space_library rows for the space again. B's mobile client
-    //    re-receives the join rows.
-    //
-    // 2. Library, LibraryAsset, and LibraryAssetExif rows do NOT re-emit.
-    //    These streams are gated by `library.createId` (per-library backfill
-    //    marker) or by `entity.updateId > ack`. The library row's createId
-    //    and updateId are unchanged since B's first sync, so:
-    //      - LibrarySync.getUpserts: WHERE updateId > ack → 0 events
-    //      - LibraryAssetSync per-library backfill: skips (createId past marker)
-    //      - LibraryAssetSync.getUpserts: WHERE updateId > ack → 0 events
-    //      - LibraryAssetExifSync: same as above
-    //
-    // The result for B's mobile client: the join rows reappear, but the
-    // library content does NOT. The mobile UI shows "library exists" with no
-    // photos. The user must trigger a sync reset or reinstall to recover the
-    // library content.
-    //
-    // This mirrors the existing AlbumSync limitation: a user added to a
-    // pre-existing album does not get a backfill of historical assets either.
-    // Solving it requires per-(user, library) backfill markers — out of scope
-    // for this PR. See design doc lines 376-378 and plan Task 27 "Accepted
-    // limitation".
+    // This test asserts the Library metadata re-emit half of the fix. The
+    // asset + exif re-emit half lands with the getCreatedAfter rewrite;
+    // assertions below currently expect 0 for asset/exif and will be flipped
+    // to `>= 1` in the same commit that rewrites getCreatedAfter.
     await ctx.newSharedSpaceMember({ spaceId: space.id, userId: authB.user.id, role: SharedSpaceRole.Editor });
 
     const afterReadd = await ctx.syncStream(authB, ALL_LIBRARY_TYPES);
 
-    // Library rows do NOT reappear — updateId is past B's ack.
+    // Library rows DO reappear now — the shared_space_member_after_insert_library
+    // trigger bumped library.updateId for every linked library, and
+    // LibrarySync.getUpserts picks that up.
     const reAddedLibraryEvents = afterReadd.filter((r: { type: string }) => r.type === SyncEntityType.LibraryV1);
-    expect(reAddedLibraryEvents).toHaveLength(0);
+    const reAddedLibraryIds = reAddedLibraryEvents
+      .map((e: { data: { id: string } }) => e.data.id)
+      .toSorted();
+    expect(reAddedLibraryIds).toEqual([l1.id, l2.id].toSorted());
 
     // Join rows DO reappear via SharedSpaceLibraryBackfillV1 — the membership
     // createId is fresh, so the backfill loop re-iterates the space.
@@ -159,14 +145,15 @@ describe('library sync end-to-end access control', () => {
       .toSorted();
     expect(reAddedLinkLibraryIds).toEqual([l1.id, l2.id].toSorted());
 
-    // Asset content does NOT reappear — this is the Known Limitation in action.
+    // Asset content does NOT reappear YET — LibrarySync.getCreatedAfter still
+    // keys off library.createId. This flips in plan Task 13.
     const reAddedAssetEvents = afterReadd.filter(
       (r: { type: string }) =>
         r.type === SyncEntityType.LibraryAssetCreateV1 || r.type === SyncEntityType.LibraryAssetBackfillV1,
     );
     expect(reAddedAssetEvents).toHaveLength(0);
 
-    // Exif content does NOT reappear either.
+    // Exif content does NOT reappear YET — same reason.
     const reAddedExifEvents = afterReadd.filter(
       (r: { type: string }) =>
         r.type === SyncEntityType.LibraryAssetExifCreateV1 || r.type === SyncEntityType.LibraryAssetExifBackfillV1,

--- a/server/test/medium/specs/sync/library-user-migration.spec.ts
+++ b/server/test/medium/specs/sync/library-user-migration.spec.ts
@@ -50,11 +50,7 @@ describe('library_user migration backfill', () => {
 
     // Simulate upgrade state: library exists, library_user empty for this
     // (user, library) pair.
-    await db
-      .deleteFrom('library_user')
-      .where('userId', '=', user.id)
-      .where('libraryId', '=', library.id)
-      .execute();
+    await db.deleteFrom('library_user').where('userId', '=', user.id).where('libraryId', '=', library.id).execute();
 
     await runBackfill(db);
 

--- a/server/test/medium/specs/sync/library-user-migration.spec.ts
+++ b/server/test/medium/specs/sync/library-user-migration.spec.ts
@@ -1,0 +1,215 @@
+import { Kysely, sql } from 'kysely';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+// Tests for the library_user migration backfill SQL. The SQL body below is a
+// verbatim copy of Pass 1 + Pass 2 in
+// server/src/schema/migrations-gallery/1778300000000-AddLibraryUserTable.ts —
+// keep the two in sync if you change either.
+//
+// These tests simulate the upgrade scenario: triggers + factory-inserted rows
+// populate library_user at test setup time, we DELETE the table to mimic the
+// post-create-tables-but-pre-backfill moment of a real upgrade, then re-run
+// the backfill SQL and assert the resulting state.
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const ctx = new SyncTestContext(defaultDatabase);
+  return { ctx, db: defaultDatabase };
+};
+
+const runBackfill = async (db: Kysely<DB>) => {
+  await sql`
+    INSERT INTO library_user ("userId", "libraryId", "createId", "createdAt")
+    SELECT "ownerId", "id", "createId", "createdAt"
+    FROM library
+    WHERE "ownerId" IS NOT NULL AND "deletedAt" IS NULL
+    ON CONFLICT ("userId", "libraryId") DO NOTHING;
+  `.execute(db);
+
+  await sql`
+    INSERT INTO library_user ("userId", "libraryId")
+    SELECT DISTINCT ssm."userId", ssl."libraryId"
+    FROM shared_space_library ssl
+    INNER JOIN shared_space_member ssm ON ssl."spaceId" = ssm."spaceId"
+    ON CONFLICT ("userId", "libraryId") DO NOTHING;
+  `.execute(db);
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('library_user migration backfill', () => {
+  it('owner rows use library.createId and createdAt (Pass 1)', async () => {
+    const { ctx, db } = setup();
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    // Simulate upgrade state: library exists, library_user empty for this
+    // (user, library) pair.
+    await db
+      .deleteFrom('library_user')
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+
+    await runBackfill(db);
+
+    const row = await db
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .executeTakeFirstOrThrow();
+    expect(row.createId).toBe(library.createId);
+    expect(row.createdAt).toEqual(library.createdAt);
+  });
+
+  it('transitive rows use a fresh createId (Pass 2)', async () => {
+    const { ctx, db } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+    // Clear what the triggers populated to simulate upgrade state.
+    await db.deleteFrom('library_user').where('libraryId', '=', library.id).execute();
+
+    // Capture a pre-backfill uuid_v7 marker via raw SQL so the Kysely API
+    // shape doesn't matter.
+    const marker = await sql<{ id: string }>`SELECT immich_uuid_v7() AS id`.execute(db);
+    const backfillStart = marker.rows[0].id;
+
+    await runBackfill(db);
+
+    const peerRow = await db
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', peer.id)
+      .where('libraryId', '=', library.id)
+      .executeTakeFirstOrThrow();
+    // Fresh createId, strictly greater than the pre-backfill marker AND the
+    // library's original createId. Pass 2 does not propagate library.createId.
+    expect(peerRow.createId > backfillStart).toBe(true);
+    expect(peerRow.createId > library.createId).toBe(true);
+  });
+
+  it('Pass 2 preserves owner rows via ON CONFLICT DO NOTHING', async () => {
+    // Owner owns the library AND is a member of a space that also links it.
+    // Pass 1 inserts owner's row with library.createId, Pass 2 would attempt
+    // a fresh createId, but ON CONFLICT preserves Pass 1.
+    const { ctx, db } = setup();
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id });
+
+    await db.deleteFrom('library_user').where('libraryId', '=', library.id).execute();
+
+    await runBackfill(db);
+
+    const rows = await db
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].createId).toBe(library.createId);
+    expect(rows[0].createdAt).toEqual(library.createdAt);
+  });
+
+  it('is idempotent: re-running both passes is a no-op', async () => {
+    const { ctx, db } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+    await db.deleteFrom('library_user').where('libraryId', '=', library.id).execute();
+
+    await runBackfill(db);
+    const firstSnapshot = await db
+      .selectFrom('library_user')
+      .select(['userId', 'libraryId', 'createId', 'createdAt'])
+      .where('libraryId', '=', library.id)
+      .orderBy('userId')
+      .orderBy('libraryId')
+      .execute();
+
+    await runBackfill(db);
+    const secondSnapshot = await db
+      .selectFrom('library_user')
+      .select(['userId', 'libraryId', 'createId', 'createdAt'])
+      .where('libraryId', '=', library.id)
+      .orderBy('userId')
+      .orderBy('libraryId')
+      .execute();
+
+    expect(secondSnapshot).toEqual(firstSnapshot);
+  });
+
+  it('includes soft-deleted libraries in Pass 2 when linked to a space', async () => {
+    // Matches accessibleLibraries behavior for the space-link branch: a
+    // soft-deleted library is still reachable for members via the
+    // shared_space_library path until hard-deleted.
+    const { ctx, db } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: peer } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+    // Soft-delete the library.
+    await db.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+
+    await db.deleteFrom('library_user').where('libraryId', '=', library.id).execute();
+
+    await runBackfill(db);
+
+    // peer still gets a row (Pass 2, no deletedAt filter).
+    const peerRow = await db
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', peer.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(peerRow).toHaveLength(1);
+    // owner does NOT (Pass 1 excludes deletedAt IS NOT NULL).
+    const ownerRow = await db
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', owner.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(ownerRow).toHaveLength(0);
+  });
+
+  it('skips soft-deleted owned libraries in Pass 1 when there is no space path', async () => {
+    const { ctx, db } = setup();
+    const { user } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+    await db.updateTable('library').set({ deletedAt: new Date() }).where('id', '=', library.id).execute();
+    await db.deleteFrom('library_user').where('libraryId', '=', library.id).execute();
+
+    await runBackfill(db);
+
+    const rows = await db
+      .selectFrom('library_user')
+      .selectAll()
+      .where('userId', '=', user.id)
+      .where('libraryId', '=', library.id)
+      .execute();
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -319,4 +319,196 @@ describe('library_user triggers', () => {
       expect(rows).toHaveLength(0);
     });
   });
+
+  describe('library_user_delete_after_audit', () => {
+    it('removes library_user when a member leaves a space and has no other path', async () => {
+      const { ctx, db } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+
+      // Sanity: viewer has the library_user row.
+      const before = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', viewer.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(before).toHaveLength(1);
+
+      // Viewer leaves (delete the shared_space_member row).
+      await db
+        .deleteFrom('shared_space_member')
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', viewer.id)
+        .execute();
+
+      const after = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', viewer.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(after).toHaveLength(0);
+    });
+
+    it('preserves library_user for the owner when another member leaves a space linking their library', async () => {
+      // Pins two properties together:
+      //   1. The audit chain's gate skips the owner when peer leaves. The
+      //      consumer trigger's DELETE ... USING inserted_rows only touches
+      //      userIds present in the `new` NEW TABLE — owner is not there.
+      //   2. The DELETE scope is strict — no side-effect on other rows.
+      const { ctx, db } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: peer } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+      // Sanity: both have rows.
+      expect(
+        await db.selectFrom('library_user').selectAll().where('libraryId', '=', library.id).execute(),
+      ).toHaveLength(2);
+
+      // Peer leaves.
+      await db
+        .deleteFrom('shared_space_member')
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', peer.id)
+        .execute();
+
+      // Owner's row survives.
+      const ownerRows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', owner.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(ownerRows).toHaveLength(1);
+      // Peer's row is gone.
+      const peerRows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', peer.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(peerRows).toHaveLength(0);
+    });
+
+    it('removes library_user for all affected members when a shared_space is hard-deleted (cascade path)', async () => {
+      // REGRESSION GUARD for the dropped defensive clause. Under the original
+      // design, the `NOT user_has_library_path(..., NULL)` filter would run
+      // inside the BEFORE DELETE trigger of shared_space, BEFORE the FK
+      // cascade removed shared_space_library / shared_space_member rows — so
+      // it would see the still-alive path and incorrectly preserve library_user
+      // rows for members who should have lost access.
+      const { ctx, db } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewerA } = await ctx.newUser();
+      const { user: viewerB } = await ctx.newUser();
+      const { user: spaceCreator } = await ctx.newUser();
+      const { library: lib1 } = await ctx.newLibrary({ ownerId: owner.id });
+      const { library: lib2 } = await ctx.newLibrary({ ownerId: owner.id });
+      const { space } = await ctx.newSharedSpace({ createdById: spaceCreator.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: lib1.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: lib2.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewerA.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewerB.id });
+      // spaceCreator is NOT auto-added as member by newSharedSpace, so the
+      // user_has_library_path "creator-of-a-linked-space" branch covers them.
+
+      // Sanity snapshot: owner's 2 rows + viewerA's 2 + viewerB's 2 = 6.
+      // spaceCreator has no library_user row because the trigger only runs
+      // for member-insert, not creator-insert.
+      const beforeRows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('libraryId', 'in', [lib1.id, lib2.id])
+        .execute();
+      expect(beforeRows).toHaveLength(6);
+
+      // Hard-delete the whole space. BEFORE-trigger fan-out inserts into
+      // library_audit for every (viewerA|B, library) pair that loses its
+      // only path, and for spaceCreator (via the creator branch) — though
+      // spaceCreator has no library_user row, so nothing changes for them.
+      // Owner's rows are NOT touched (owned path remains).
+      await db.deleteFrom('shared_space').where('id', '=', space.id).execute();
+
+      // Only owner's two rows remain.
+      const remaining = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('libraryId', 'in', [lib1.id, lib2.id])
+        .execute();
+      expect(remaining).toHaveLength(2);
+      expect(remaining.every((r) => r.userId === owner.id)).toBe(true);
+    });
+
+    it('trusts the inserter gate: a manual library_audit insert deletes library_user unconditionally', async () => {
+      // The consumer does NOT re-check user_has_library_path. Any code path
+      // inserting into library_audit MUST gate beforehand — the consumer
+      // deletes whatever it's told to.
+      const { ctx, db } = setup();
+      const { user } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+      const before = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', user.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(before).toHaveLength(1);
+
+      // Manually insert into library_audit, bypassing the gating path.
+      await db.insertInto('library_audit').values({ libraryId: library.id, userId: user.id }).execute();
+
+      const after = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', user.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(after).toHaveLength(0);
+    });
+
+    it('hard-deleting a library removes library_user rows via FK cascade (no library_audit involvement)', async () => {
+      const { ctx, db } = setup();
+      const { user } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+      const before = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(before).toHaveLength(1);
+
+      const auditBefore = await db
+        .selectFrom('library_audit')
+        .selectAll()
+        .where('libraryId', '=', library.id)
+        .execute();
+
+      await db.deleteFrom('library').where('id', '=', library.id).execute();
+
+      const after = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(after).toHaveLength(0);
+
+      const auditAfter = await db
+        .selectFrom('library_audit')
+        .selectAll()
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(auditAfter).toHaveLength(auditBefore.length);
+    });
+  });
 });

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -240,6 +240,49 @@ describe('library_user triggers', () => {
       expect(rows.map((r) => r.id)).toContain(library.id);
     });
 
+  });
+
+  describe('shared_space_library_after_insert_user', () => {
+    it('grants library_user for every member of the space when a library is linked', async () => {
+      const { ctx, db } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: memberA } = await ctx.newUser();
+      const { user: memberB } = await ctx.newUser();
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberA.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberB.id });
+
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+
+      const before = await db
+        .selectFrom('library')
+        .select(['updateId'])
+        .where('id', '=', library.id)
+        .executeTakeFirstOrThrow();
+
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+      // memberA and memberB should both get library_user rows.
+      const rows = await db
+        .selectFrom('library_user')
+        .select(['userId'])
+        .where('libraryId', '=', library.id)
+        .execute();
+      const userIds = rows.map((r) => r.userId);
+      expect(userIds).toContain(owner.id); // from library_after_insert
+      expect(userIds).toContain(memberA.id);
+      expect(userIds).toContain(memberB.id);
+
+      // library.updateId was bumped.
+      const after = await db
+        .selectFrom('library')
+        .select(['updateId'])
+        .where('id', '=', library.id)
+        .executeTakeFirstOrThrow();
+      expect(after.updateId).not.toBe(before.updateId);
+    });
+
     // Documentation test: pins the "creator is always a member" asymmetry
     // flagged in the design's Known Limitations section. If the invariant
     // breaks (e.g., a future refactor of SharedSpaceService.create), the

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
+import { SyncEntityType } from 'src/enum';
 import { SyncRepository } from 'src/repositories/sync.repository';
 import { DB } from 'src/schema';
-import { SyncEntityType } from 'src/enum';
 import { SyncTestContext } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
@@ -51,11 +51,7 @@ describe('library_user triggers', () => {
         .returning(['id'])
         .executeTakeFirstOrThrow();
 
-      const rows = await db
-        .selectFrom('library_user')
-        .selectAll()
-        .where('libraryId', '=', library.id)
-        .execute();
+      const rows = await db.selectFrom('library_user').selectAll().where('libraryId', '=', library.id).execute();
       expect(rows).toHaveLength(0);
     });
 
@@ -239,7 +235,6 @@ describe('library_user triggers', () => {
       }
       expect(rows.map((r) => r.id)).toContain(library.id);
     });
-
   });
 
   describe('shared_space_library_after_insert_user', () => {
@@ -264,11 +259,7 @@ describe('library_user triggers', () => {
       await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
 
       // memberA and memberB should both get library_user rows.
-      const rows = await db
-        .selectFrom('library_user')
-        .select(['userId'])
-        .where('libraryId', '=', library.id)
-        .execute();
+      const rows = await db.selectFrom('library_user').select(['userId']).where('libraryId', '=', library.id).execute();
       const userIds = rows.map((r) => r.userId);
       expect(userIds).toContain(owner.id); // from library_after_insert
       expect(userIds).toContain(memberA.id);
@@ -481,11 +472,7 @@ describe('library_user triggers', () => {
       const { user } = await ctx.newUser();
       const { library } = await ctx.newLibrary({ ownerId: user.id });
 
-      const before = await db
-        .selectFrom('library_user')
-        .selectAll()
-        .where('libraryId', '=', library.id)
-        .execute();
+      const before = await db.selectFrom('library_user').selectAll().where('libraryId', '=', library.id).execute();
       expect(before).toHaveLength(1);
 
       const auditBefore = await db
@@ -496,18 +483,10 @@ describe('library_user triggers', () => {
 
       await db.deleteFrom('library').where('id', '=', library.id).execute();
 
-      const after = await db
-        .selectFrom('library_user')
-        .selectAll()
-        .where('libraryId', '=', library.id)
-        .execute();
+      const after = await db.selectFrom('library_user').selectAll().where('libraryId', '=', library.id).execute();
       expect(after).toHaveLength(0);
 
-      const auditAfter = await db
-        .selectFrom('library_audit')
-        .selectAll()
-        .where('libraryId', '=', library.id)
-        .execute();
+      const auditAfter = await db.selectFrom('library_audit').selectAll().where('libraryId', '=', library.id).execute();
       expect(auditAfter).toHaveLength(auditBefore.length);
     });
   });

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -99,4 +99,55 @@ describe('library_user triggers', () => {
       expect(uniqueCreateIds.size).toBe(5);
     });
   });
+
+  describe('shared_space_member_after_insert_library', () => {
+    it('grants library_user for every library linked to the space the new member joined', async () => {
+      const { ctx, db } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: newMember } = await ctx.newUser();
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+      // Three libraries, all owned by owner, all linked to the space.
+      const { library: libraryA } = await ctx.newLibrary({ ownerId: owner.id });
+      const { library: libraryB } = await ctx.newLibrary({ ownerId: owner.id });
+      const { library: libraryC } = await ctx.newLibrary({ ownerId: owner.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: libraryA.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: libraryB.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: libraryC.id });
+
+      // Capture library.updateId BEFORE the trigger bumps them.
+      const beforeUpdateIds = await db
+        .selectFrom('library')
+        .select(['id', 'updateId'])
+        .where('id', 'in', [libraryA.id, libraryB.id, libraryC.id])
+        .execute();
+
+      // Add newMember — trigger fires.
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: newMember.id });
+
+      // Each library should have a library_user row for newMember.
+      const rows = await db
+        .selectFrom('library_user')
+        .select(['libraryId', 'createId'])
+        .where('userId', '=', newMember.id)
+        .execute();
+      expect(rows.map((r) => r.libraryId).toSorted()).toEqual([libraryA.id, libraryB.id, libraryC.id].toSorted());
+
+      // CreateIds should be freshly-minted (distinct).
+      const uniqueCreateIds = new Set(rows.map((r) => r.createId));
+      expect(uniqueCreateIds.size).toBe(3);
+
+      // library.updateId bumped for all three libraries.
+      const afterUpdateIds = await db
+        .selectFrom('library')
+        .select(['id', 'updateId'])
+        .where('id', 'in', [libraryA.id, libraryB.id, libraryC.id])
+        .execute();
+      const beforeById = new Map(beforeUpdateIds.map((r) => [r.id, r.updateId]));
+      for (const after of afterUpdateIds) {
+        expect(after.updateId).not.toBe(beforeById.get(after.id));
+      }
+    });
+  });
 });

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -149,5 +149,58 @@ describe('library_user triggers', () => {
         expect(after.updateId).not.toBe(beforeById.get(after.id));
       }
     });
+
+    it('is a no-op when the space has zero linked libraries', async () => {
+      const { ctx, db } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: newMember } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: newMember.id });
+
+      const rows = await db.selectFrom('library_user').selectAll().where('userId', '=', newMember.id).execute();
+      expect(rows).toHaveLength(0);
+    });
+
+    it('ON CONFLICT DO NOTHING preserves an existing owner library_user row', async () => {
+      const { ctx, db } = setup();
+      const { user } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+      // Owner already has a row from library_after_insert with library.createId.
+      const ownerRowBefore = await db
+        .selectFrom('library_user')
+        .select(['createId'])
+        .where('userId', '=', user.id)
+        .where('libraryId', '=', library.id)
+        .executeTakeFirstOrThrow();
+      expect(ownerRowBefore.createId).toBe(library.createId);
+
+      // Link the library to a space and add a new member. The trigger's
+      // INSERT...ON CONFLICT won't touch the owner's existing row, but it
+      // will grant access to peer.
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+      const { user: peer } = await ctx.newUser();
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id });
+
+      // Owner's row is unchanged.
+      const ownerRowAfter = await db
+        .selectFrom('library_user')
+        .select(['createId'])
+        .where('userId', '=', user.id)
+        .where('libraryId', '=', library.id)
+        .executeTakeFirstOrThrow();
+      expect(ownerRowAfter.createId).toBe(library.createId);
+
+      // Peer got a row with a fresh createId.
+      const peerRow = await db
+        .selectFrom('library_user')
+        .select(['createId'])
+        .where('userId', '=', peer.id)
+        .where('libraryId', '=', library.id)
+        .executeTakeFirstOrThrow();
+      expect(peerRow.createId).not.toBe(library.createId);
+    });
   });
 });

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -1,0 +1,36 @@
+import { Kysely } from 'kysely';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const ctx = new SyncTestContext(defaultDatabase);
+  return { ctx, db: defaultDatabase };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('library_user triggers', () => {
+  describe('library_after_insert', () => {
+    it('inserts a library_user row for the owner with library.createId', async () => {
+      const { ctx, db } = setup();
+      const { user } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+      const rows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', user.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].createId).toBe(library.createId);
+      expect(rows[0].createdAt).toEqual(library.createdAt);
+    });
+  });
+});

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -32,5 +32,71 @@ describe('library_user triggers', () => {
       expect(rows[0].createId).toBe(library.createId);
       expect(rows[0].createdAt).toEqual(library.createdAt);
     });
+
+    it('does not insert a library_user row when deletedAt is set at insert time', async () => {
+      const { ctx, db } = setup();
+      const { user } = await ctx.newUser();
+      // Direct insert so we can set deletedAt at creation time.
+      const library = await db
+        .insertInto('library')
+        .values({
+          name: 'already-deleted',
+          ownerId: user.id,
+          importPaths: ['/import'],
+          exclusionPatterns: [],
+          deletedAt: new Date(),
+        })
+        .returning(['id'])
+        .executeTakeFirstOrThrow();
+
+      const rows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(rows).toHaveLength(0);
+    });
+
+    it('inserts one library_user row per library when multiple libraries are created in one statement', async () => {
+      const { ctx, db } = setup();
+      const { user } = await ctx.newUser();
+
+      const libraries = await db
+        .insertInto('library')
+        .values([
+          { name: 'bulk-1', ownerId: user.id, importPaths: ['/import'], exclusionPatterns: [] },
+          { name: 'bulk-2', ownerId: user.id, importPaths: ['/import'], exclusionPatterns: [] },
+          { name: 'bulk-3', ownerId: user.id, importPaths: ['/import'], exclusionPatterns: [] },
+          { name: 'bulk-4', ownerId: user.id, importPaths: ['/import'], exclusionPatterns: [] },
+          { name: 'bulk-5', ownerId: user.id, importPaths: ['/import'], exclusionPatterns: [] },
+        ])
+        .returning(['id', 'createId', 'createdAt'])
+        .execute();
+      expect(libraries).toHaveLength(5);
+
+      const rows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', user.id)
+        .where(
+          'libraryId',
+          'in',
+          libraries.map((l) => l.id),
+        )
+        .execute();
+      expect(rows).toHaveLength(5);
+
+      // Each library_user row's createId must match its library's createId.
+      const byLibraryId = new Map(rows.map((r) => [r.libraryId, r]));
+      for (const lib of libraries) {
+        const userRow = byLibraryId.get(lib.id);
+        expect(userRow).toBeDefined();
+        expect(userRow!.createId).toBe(lib.createId);
+      }
+      // All 5 createIds are distinct (pins VOLATILE immich_uuid_v7 per-row
+      // evaluation for both the library INSERT and the trigger's copy).
+      const uniqueCreateIds = new Set(rows.map((r) => r.createId));
+      expect(uniqueCreateIds.size).toBe(5);
+    });
   });
 });

--- a/server/test/medium/specs/sync/library-user-triggers.spec.ts
+++ b/server/test/medium/specs/sync/library-user-triggers.spec.ts
@@ -1,5 +1,7 @@
 import { Kysely } from 'kysely';
+import { SyncRepository } from 'src/repositories/sync.repository';
 import { DB } from 'src/schema';
+import { SyncEntityType } from 'src/enum';
 import { SyncTestContext } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
@@ -201,6 +203,77 @@ describe('library_user triggers', () => {
         .where('libraryId', '=', library.id)
         .executeTakeFirstOrThrow();
       expect(peerRow.createId).not.toBe(library.createId);
+    });
+
+    it('LibrarySync.getUpserts re-delivers the library to the new member after the updateId bump', async () => {
+      const { ctx, db } = setup();
+      const syncRepo = ctx.get(SyncRepository);
+      const { user: owner } = await ctx.newUser();
+      const { user: newMember } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+      // Snapshot library.updateId before the trigger bumps it.
+      const preBump = await db
+        .selectFrom('library')
+        .select(['updateId'])
+        .where('id', '=', library.id)
+        .executeTakeFirstOrThrow();
+
+      // newMember joins → shared_space_member_after_insert_library fires
+      // and bumps library.updateId.
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: newMember.id });
+
+      // A dummyNowId past any possible uuid_v7, and ack at the pre-bump
+      // updateId. The new updateId is > ack, so the upsert stream should
+      // include this library.
+      const upsertStream = syncRepo.library.getUpserts({
+        nowId: 'ffffffff-ffff-7fff-bfff-ffffffffffff',
+        userId: newMember.id,
+        ack: { type: SyncEntityType.LibraryV1, updateId: preBump.updateId },
+      });
+      const rows: { id: string }[] = [];
+      for await (const row of upsertStream) {
+        rows.push(row);
+      }
+      expect(rows.map((r) => r.id)).toContain(library.id);
+    });
+
+    // Documentation test: pins the "creator is always a member" asymmetry
+    // flagged in the design's Known Limitations section. If the invariant
+    // breaks (e.g., a future refactor of SharedSpaceService.create), the
+    // create-side trigger will silently fail to populate library_user for
+    // a creator-but-not-member, while the delete-side defensively preserves
+    // them. This test documents that state so whoever touches space creation
+    // knows the consequence.
+    it('(known limitation) does not populate library_user for a space creator who is not a member', async () => {
+      const { ctx, db } = setup();
+      const { user: creator } = await ctx.newUser();
+      const { user: libOwner } = await ctx.newUser();
+      const { library } = await ctx.newLibrary({ ownerId: libOwner.id });
+
+      // Direct insert of a shared_space WITHOUT a shared_space_member row
+      // for the creator.
+      const space = await db
+        .insertInto('shared_space')
+        .values({ name: 'orphan-creator', createdById: creator.id })
+        .returning(['id'])
+        .executeTakeFirstOrThrow();
+
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+      // shared_space_library_after_insert_user (Task 9) joins on
+      // shared_space_member; there's no row for creator, so no library_user
+      // is created for them. library_after_insert already populated libOwner,
+      // but NOT the creator.
+      const rows = await db
+        .selectFrom('library_user')
+        .selectAll()
+        .where('userId', '=', creator.id)
+        .where('libraryId', '=', library.id)
+        .execute();
+      expect(rows).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the **\"user rejoined space, library never syncs\"** bug and two related scenarios that share the same root cause: when a user gains access to a pre-existing library via a shared-space link, the server fails to stream the library metadata and assets on the next sync.

The three scenarios:

1. **Re-add to a space after leaving** — observed live in testing during PR #313
2. **First-time invite to a space with pre-existing libraries** — initial sync happened before space membership
3. **Library newly linked to a space the user is already in** — sync checkpoint already past the library's createId

All three are the same underlying bug: there is no per-user "access was granted to library X" signal that drives the sync backfill. The fix introduces a `library_user (userId, libraryId, createId, createdAt)` denormalization table — the symmetric create-side counterpart to the existing fork-only `library_audit` delete-side infrastructure.

## Design

Full design + plan documents committed to the branch:

- `docs/plans/2026-04-11-library-user-access-backfill-design.md`
- `docs/plans/2026-04-11-library-user-access-backfill-plan.md`

Summary:

- **New table** `library_user` populated by three insert triggers on `library`, `shared_space_member`, and `shared_space_library`
- **One consumer trigger** on `library_audit` drains rows when access is lost — trusts the insertion-time gating in the existing audit chain (re-checking would be broken during `shared_space` hard-delete because the BEFORE trigger fires before FK cascades)
- **Migration backfill** in two passes: owned libraries inherit `library.createId` (no re-sync for already-synced clients), transitive access uses fresh createIds (heals broken state for users in the bug's footprint)
- **`LibrarySync.getCreatedAfter` rewritten** to query `library_user` keyed by per-user access-grant createId, mirroring `SharedSpaceSync.getCreatedAfter` and `AlbumSync.getCreatedAfter`. The existing `accessibleLibraries` filter is preserved so soft-deleted owned libraries are still correctly excluded.
- **Zero mobile changes.** The wire protocol is unchanged; existing event types (`LibraryV1`, `LibraryAssetBackfillV1`, etc.) start arriving for the previously-broken scenarios.

## Test plan

- [x] Medium tests:
  - `library-user-triggers.spec.ts` — 13 trigger tests covering all four triggers, edge cases (null owner, soft-delete, bulk insert, ON CONFLICT, zero-member space, zero-library space), `LibrarySync.getUpserts` re-delivery, creator-not-member documentation test
  - `library-user-migration.spec.ts` — 6 migration backfill tests (owner createId preservation, transitive fresh createId, ON CONFLICT preservation, idempotency, soft-delete behavior in both passes)
  - `library-sync-created-after.spec.ts` — 7 unit tests for the rewritten query (set-equality with `accessibleLibraries`, soft-delete behavior, checkpoint value-space shift regression guard)
  - `library-access-backfill.spec.ts` — integration tests for scenarios 2 and 3
  - `library-sync-end-to-end.spec.ts` — updated to assert post-fix behavior for scenario 1 (rejoin)
- [x] All 580 medium tests pass
- [x] All 3809 unit tests pass
- [x] \`tsc --noEmit\` clean
- [ ] Deploy to \`pierre.opennoodle.de\` via RC build and manually verify: viewer re-added to a Google Takeout space sees photos on next sync without app restart

## Critical design fix vs. initial draft

The original design had a defensive \`NOT user_has_library_path(..., NULL)\` re-check in the consumer trigger. Code review caught that this is **broken** during \`shared_space\` hard-delete: the BEFORE DELETE trigger fires before FK cascades remove \`shared_space_library\` / \`shared_space_member\` rows, so the re-check would see the still-alive path and incorrectly preserve \`library_user\` rows for users who lost access. The fix trusts the gating at insertion time (every existing audit-chain insert path already gates on \`NOT user_has_library_path(..., excludeSpaceId)\`).

The cascade case is now explicitly tested (\`library_user_delete_after_audit > removes library_user for all affected members when a shared_space is hard-deleted\`) — that test would fail under the original design.

## Rollback

Purely additive migration:

- **Code-only rollback**: revert the \`LibrarySync.getCreatedAfter\` rewrite; new triggers + table stay in place dormant
- **Full rollback**: \`down()\` drops triggers, functions, table, indexes, and the \`migration_overrides\` rows

See design doc \"Rollback plan\" section for the in-flight checkpoint value-space shift behavior.