### PR TITLE
docs: document shared-space sync in duplicate resolution

### DIFF
--- a/docs/docs/features/duplicates-utility.md
+++ b/docs/docs/features/duplicates-utility.md
@@ -17,15 +17,16 @@ When using "Deduplicate All" or viewing suggestions, Immich automatically presel
 
 When resolving duplicates, metadata from trashed assets is automatically synchronized to the kept assets. The following metadata is synchronized:
 
-| Name        | Description                                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Album       | The kept assets will be added to _every_ album that the other assets in the group belong to.                                    |
-| Favorite    | If any of the assets in the group have been added to favorites, every kept asset will also be added to favorites.               |
-| Rating      | If one or more assets in the duplicate group have a rating, the highest rating is selected and synchronized to the kept assets. |
-| Description | Descriptions from each asset are combined together and synchronized to all the kept assets.                                     |
-| Visibility  | The most restrictive visibility is applied to the kept assets.                                                                  |
-| Location    | Latitude and longitude are copied if all assets with geolocation data in the group share the same coordinates.                  |
-| Tag         | Tags from all assets in the group are merged and applied to every kept asset.                                                   |
+| Name         | Description                                                                                                                                                                                                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Album        | The kept assets will be added to _every_ album that the other assets in the group belong to.                                                                                                                                                                                   |
+| Shared Space | The kept assets will be added to every [Shared Space](./shared-spaces.md) the trashed duplicates belonged to, provided you have Owner or Editor role. Face recognition re-runs on the keeper inside each space so any people it captures flow into the space's people sidebar. |
+| Favorite     | If any of the assets in the group have been added to favorites, every kept asset will also be added to favorites.                                                                                                                                                              |
+| Rating       | If one or more assets in the duplicate group have a rating, the highest rating is selected and synchronized to the kept assets.                                                                                                                                                |
+| Description  | Descriptions from each asset are combined together and synchronized to all the kept assets.                                                                                                                                                                                    |
+| Visibility   | The most restrictive visibility is applied to the kept assets.                                                                                                                                                                                                                 |
+| Location     | Latitude and longitude are copied if all assets with geolocation data in the group share the same coordinates.                                                                                                                                                                 |
+| Tag          | Tags from all assets in the group are merged and applied to every kept asset.                                                                                                                                                                                                  |
 
 ### Re-upload prevention
 


### PR DESCRIPTION
## Summary
- Add a **Shared Space** row to the metadata sync table in `duplicates-utility.md`, linking to the shared-spaces feature page
- Calls out the Owner/Editor permission check and the face-recognition re-run that queues face-match jobs on the keeper

The sync table previously listed every field that carries over from trashed duplicates to keepers _except_ shared-space membership, which is actually mirrored the same way albums are (PR #317).

## Test plan
- [ ] `pnpm --dir docs build` renders the page without broken links
- [ ] Relative link `./shared-spaces.md` resolves to the shared-spaces feature doc