### PR TITLE
fix(ci): drive mobile build from release workflow so stores get the right version

### DIFF
--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -11,6 +11,11 @@ on:
         options:
           - development
           - production
+      version:
+        description: 'Fork version to stamp and deploy (e.g. v4.48.5). Leave empty for a smoke build with no store upload.'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -21,6 +21,11 @@ on:
         required: true
         default: 'development'
         type: string
+      version:
+        description: 'Fork version to stamp (e.g. v4.48.5). When set, the build is stamped with this version and deployed to the stores; when empty, the job runs as a smoke build only.'
+        required: false
+        type: string
+        default: ''
     secrets:
       KEY_JKS:
         required: true
@@ -76,9 +81,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
           token: ${{ github.token }}
+          fetch-depth: 0
           fetch-tags: true
 
       - uses: ./.github/actions/apply-branding
+        with:
+          version: ${{ inputs.version }}
 
       - name: Create the Keystore
         env:
@@ -132,7 +140,11 @@ jobs:
         working-directory: ./mobile
         run: |
           version_name=$(awk -F'[ +]' '/^version:/ {print $2}' pubspec.yaml)
-          version_code=$(( 1000 + GITHUB_RUN_NUMBER ))
+          # Monotonic, trigger-independent version code: commit count on the
+          # current ref. Must not depend on GITHUB_RUN_NUMBER because this
+          # workflow is invoked from multiple callers (push, workflow_call
+          # from Release Gallery) whose run numbers aren't comparable.
+          version_code=$(git -C .. rev-list --count HEAD)
           echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
           echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
           echo "Building $version_name ($version_code)"
@@ -157,7 +169,7 @@ jobs:
           path: mobile/build/app/outputs/bundle/release/app-release.aab
 
       - name: Setup Ruby
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: inputs.version != ''
         uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
         with:
           ruby-version: '3.3'
@@ -165,14 +177,14 @@ jobs:
           working-directory: ./mobile/android/gallery-release
 
       - name: Write Play Store service account key
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: inputs.version != ''
         working-directory: ./mobile/android/gallery-release
         env:
           PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
         run: printf '%s' "$PLAY_STORE_JSON_KEY" > fastlane/play-store-key.json
 
       - name: Upload to Play Store internal track
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: inputs.version != ''
         working-directory: ./mobile/android/gallery-release
         run: bundle exec fastlane android internal
 
@@ -214,6 +226,8 @@ jobs:
           fetch-tags: true
 
       - uses: ./.github/actions/apply-branding
+        with:
+          version: ${{ inputs.version }}
 
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -276,7 +290,7 @@ jobs:
           security find-identity -v -p codesigning build.keychain
 
       - name: Build and deploy to TestFlight
-        if: github.ref == 'refs/heads/main'
+        if: inputs.version != ''
         env:
           FASTLANE_TEAM_ID: ${{ secrets.FASTLANE_TEAM_ID }}
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
@@ -291,7 +305,7 @@ jobs:
         run: bundle exec fastlane gha_release_prod
 
       - name: Build iOS (no upload)
-        if: github.ref != 'refs/heads/main'
+        if: inputs.version == ''
         working-directory: ./mobile
         run: |
           flutter build ipa --no-codesign

--- a/.github/workflows/gallery-release.yml
+++ b/.github/workflows/gallery-release.yml
@@ -377,10 +377,22 @@ jobs:
           sources=$(printf "${IMAGE}@sha256:%s " *)
           docker buildx imagetools create ${tags} ${sources}
 
+  build-mobile:
+    name: Build Mobile
+    if: needs.version.outputs.skip != 'true'
+    needs: version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/gallery-build-mobile.yml
+    with:
+      environment: production
+      version: ${{ needs.version.outputs.version }}
+    secrets: inherit
+
   tag:
     name: Create Git Tag
     if: needs.version.outputs.skip != 'true'
-    needs: [version, merge-server, merge-ml]
+    needs: [version, merge-server, merge-ml, build-mobile]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Mobile builds triggered on push-to-main ran **before** the Release Gallery workflow created the next tag. `apply-branding` fell back to `git describe --tags --abbrev=0`, which returned the **previous** tag — so TestFlight uploaded `Gallery 4.48.4 (250)` the instant `v4.48.5` was cut on the same commit.
- `Release Gallery` now calls `gallery-build-mobile` via `workflow_call` and passes the computed version, the same way server/ml already pass `version` to `apply-branding`. `tag` job blocks on the mobile build.
- The `push: main` trigger on `gallery-build-mobile` still fires on mobile PRs merging to main, but gates deploy steps (TestFlight, Play Store internal) on `inputs.version != ''`, so it runs as a smoke build only. `Build iOS (no upload)` fills that role for iOS.
- Android `version_code` switched from `1000 + GITHUB_RUN_NUMBER` to `git rev-list --count HEAD`. Run numbers aren't comparable across triggers (in `workflow_call`, `github.run_number` is the caller's run number), so a monotonic trigger-independent source is needed to avoid Play Store rejections. Commit count on main grows by 1 per merge and is currently ~10 000, comfortably above anything previously uploaded.
- Android checkout gains `fetch-depth: 0` so `git rev-list --count` actually works; iOS checkout still just uses `fetch-tags: true`.

## Root cause trace

From the failed run on PR #337 (`171c09e`):

```
Build and sign iOS  Run ./.github/actions/apply-branding  FORK_VERSION:
Build and sign iOS  Run ./.github/actions/apply-branding  === Applying branding: Noodle Gallery ===
Build and sign iOS  Run ./.github/actions/apply-branding    Patched mobile/pubspec.yaml (4.48.4+1)
```

`FORK_VERSION` was empty → `branding/scripts/apply-branding.sh` fell back to the last tag (`v4.48.4`). Fastlane read `4.48.4` from `mobile/pubspec.yaml` and uploaded that.

## Test plan

- [ ] Merge a mobile-only change to main and confirm the mobile workflow runs a smoke build (no TestFlight/Play Store upload, no version bump).
- [ ] Manually dispatch `Release Gallery`. Confirm the `build-mobile` job runs with the new version, `apply-branding` logs `Patched mobile/pubspec.yaml (<new_version>+1)`, Fastlane uploads that version to TestFlight, Fastlane uploads the same version with a commit-count-based code to the Play Store internal track, and the `tag` job only runs after `build-mobile` succeeds.
- [ ] Verify Play Store internal track shows version_code ≈ 10 000+ (monotonic, above any prior uploads).