### PR TITLE
fix(ci): avoid concurrency deadlock when mobile workflow is called from release

### DIFF
--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -65,7 +65,10 @@ on:
       - '.github/workflows/gallery-build-mobile.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix — when called via workflow_call from Release Gallery,
+  # ${{ github.workflow }} resolves to the caller's name and the group
+  # string collides with the parent run, deadlocking the reusable call.
+  group: gallery-build-mobile-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## Summary

The mobile workflow's concurrency group resolves identically to the Release Gallery workflow's group when invoked as a reusable workflow, causing GitHub to cancel the call as a self-reference and fail the release.

- Both workflows used \`group: \${{ github.workflow }}-\${{ github.ref }}\`.
- Inside a reusable workflow called via \`uses:\`, \`github.workflow\` resolves to the **caller's** name.
- So both computed \`Release Gallery-refs/heads/main\` and deadlocked.

Fix: give this workflow a literal prefix so its concurrency group is always distinct from any caller's group, regardless of how it's invoked.

This was first exposed by [run 24358093391](https://github.com/open-noodle/gallery/actions/runs/24358093391) — 11 success + 2 skipped + no mobile jobs visible, error \`Canceling since a deadlock was detected for concurrency group: 'Release Gallery-refs/heads/main' between a top level workflow and 'Build Mobile'\`.

The bug is pre-existing — it became reachable when #338 (yesterday) made Release Gallery the canonical path for invoking the mobile build.

## Test plan

- [ ] Merge and re-trigger Release Gallery; confirm the \`Build Mobile\` reusable workflow call runs to completion and the \`tag\` job creates the release with the APK attached.
- [ ] Standalone push/PR/dispatch of \`gallery-build-mobile.yml\` still deduplicates concurrent runs on the same ref.