### PR TITLE
chore(ci): temporarily disable Play Store internal upload while in review

### DIFF
--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -198,30 +198,34 @@ jobs:
           path: mobile/build/app/outputs/flutter-apk/gallery-${{ inputs.version }}.apk
           if-no-files-found: error
 
-      - name: Setup Ruby
-        if: inputs.version != ''
-        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
-        with:
-          ruby-version: '3.3'
-          bundler-cache: true
-          working-directory: ./mobile/android/gallery-release
-
-      - name: Write Play Store service account key
-        if: inputs.version != ''
-        working-directory: ./mobile/android/gallery-release
-        env:
-          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
-        run: printf '%s' "$PLAY_STORE_JSON_KEY" > fastlane/play-store-key.json
-
-      - name: Upload to Play Store internal track
-        if: inputs.version != ''
-        working-directory: ./mobile/android/gallery-release
-        run: bundle exec fastlane android internal
-
-      - name: Remove Play Store service account key
-        if: always()
-        working-directory: ./mobile/android/gallery-release
-        run: rm -f fastlane/play-store-key.json
+      # Play Store upload temporarily disabled while the app is in review —
+      # new internal-track builds can't be pushed until Google finishes review.
+      # The AAB artifact is still produced above and the APK is attached to the
+      # GitHub Release, so sideload users remain unblocked.
+      # - name: Setup Ruby
+      #   if: inputs.version != ''
+      #   uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
+      #   with:
+      #     ruby-version: '3.3'
+      #     bundler-cache: true
+      #     working-directory: ./mobile/android/gallery-release
+      #
+      # - name: Write Play Store service account key
+      #   if: inputs.version != ''
+      #   working-directory: ./mobile/android/gallery-release
+      #   env:
+      #     PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
+      #   run: printf '%s' "$PLAY_STORE_JSON_KEY" > fastlane/play-store-key.json
+      #
+      # - name: Upload to Play Store internal track
+      #   if: inputs.version != ''
+      #   working-directory: ./mobile/android/gallery-release
+      #   run: bundle exec fastlane android internal
+      #
+      # - name: Remove Play Store service account key
+      #   if: always()
+      #   working-directory: ./mobile/android/gallery-release
+      #   run: rm -f fastlane/play-store-key.json
 
       - name: Save Gradle Cache
         id: cache-gradle-save


### PR DESCRIPTION
## Summary

Gallery is currently in review on the Play Store; new internal-track uploads are rejected until Google finishes the review. That makes the fastlane \`android internal\` step in the mobile workflow fail every release, which cascades up and blocks the \`tag\` job from cutting the GitHub Release.

Comment out the four Play Store publish steps in \`gallery-build-mobile.yml\`:

- Setup Ruby (for the Android fastlane bundle)
- Write Play Store service account key
- Upload to Play Store internal track
- Remove Play Store service account key

Everything else stays:

- AAB is still built and uploaded as an artifact.
- APK is still built and uploaded as the \`gallery-apk\` artifact.
- The release workflow still attaches the APK to the GitHub Release.
- iOS / TestFlight path is untouched.

Re-enable the four steps by removing the comments once the Play Store review clears.

## Test plan

- [ ] Merge and re-trigger Release Gallery on main; confirm \`Build and sign Android\` runs to completion (no fastlane step), the \`tag\` job runs, and \`gallery-v<version>.apk\` appears on the new GitHub Release.