### PR TITLE
fix: stamp release sourceRef + finer smart-search threshold step

### DIFF
--- a/.github/workflows/gallery-release.yml
+++ b/.github/workflows/gallery-release.yml
@@ -195,7 +195,7 @@ jobs:
           build-args: |
             DEVICE=cpu
             BUILD_ID=${{ github.run_id }}
-            BUILD_SOURCE_REF=${{ github.ref_name }}
+            BUILD_SOURCE_REF=${{ needs.version.outputs.version }}
             BUILD_SOURCE_COMMIT=${{ github.sha }}
           outputs: type=image,"name=ghcr.io/open-noodle/gallery-server",push-by-digest=true,name-resolution=short,push=true
           cache-from: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }}

--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -1218,7 +1218,7 @@ Set `machineLearning.clip.maxDistance` in **Administration > Machine Learning > 
 
 #### Tuning tips
 
-- **Start at 0.75** and adjust based on your results. Lower values are stricter.
+- **Start at 0.75** and adjust based on your results. Lower values are stricter. If searches return nothing at 0.75, raise the threshold in small steps until relevant photos reappear — some libraries and CLIP models produce higher distances than others.
 - **Small changes can have a large effect.** CLIP embeddings tend to cluster in a narrow distance range rather than being spread evenly. This means a threshold change from, say, 0.75 to 0.80 may dramatically increase the number of results. This is normal — not a bug.
 - **Different CLIP models produce different distance distributions.** If you change your CLIP model, you may need to re-tune the threshold.
 - **Text-to-image vs. image-to-image searches** have different distance characteristics. Text queries typically produce higher distances (looser matches) than searching by a similar photo. If you use both search modes, pick a threshold that works for text queries — it will be permissive enough for image-based searches too.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -155,7 +155,7 @@
     "machine_learning_availability_checks_timeout": "Request timeout",
     "machine_learning_availability_checks_timeout_description": "Timeout in milliseconds for availability checks",
     "machine_learning_clip_max_distance": "Max search distance",
-    "machine_learning_clip_max_distance_description": "Maximum cosine distance for smart search results. Lower values return fewer but more relevant results. Small changes may have a large effect due to how CLIP embeddings cluster. Values below 0.3 will likely return no results. Set to 0 to disable (default). Recommended: 0.75",
+    "machine_learning_clip_max_distance_description": "Maximum cosine distance for smart search results. Lower values return fewer but more relevant results. The ideal value depends on your library and CLIP model — 0.75 is a reasonable starting point, but if searches return nothing, raise the threshold in small steps until relevant photos reappear. Set to 0 to disable (default).",
     "machine_learning_clip_model": "CLIP model",
     "machine_learning_clip_model_description": "The name of a CLIP model listed <link>here</link>. Note that you must re-run the 'Smart Search' job for all images upon changing a model.",
     "machine_learning_duplicate_detection": "Duplicate Detection",

--- a/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
+++ b/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
@@ -148,7 +148,7 @@
             label={$t('admin.machine_learning_clip_max_distance')}
             description={$t('admin.machine_learning_clip_max_distance_description')}
             bind:value={configToEdit.machineLearning.clip.maxDistance}
-            step="0.05"
+            step="0.01"
             min={0}
             max={2}
             disabled={disabled || !configToEdit.machineLearning.enabled || !configToEdit.machineLearning.clip.enabled}


### PR DESCRIPTION
## Summary

Two small fixes that surfaced from a user report after switching from Immich to Gallery on the v4.49.0 release image:

- **`fix(ci): stamp release image sourceRef with version tag instead of main`** — `gallery-release.yml` was passing `BUILD_SOURCE_REF=${{ github.ref_name }}`, which is `main` whenever the release workflow is dispatched from `main`. That baked into the image as `IMMICH_SOURCE_REF=main`, which `ServerAboutModal.svelte:22` treats as a development build and shows the *"You're using a development version; we strongly recommend using a release version!"* warning on every release. Pass the computed version tag (`needs.version.outputs.version`) instead so the About modal links to the actual tagged commit and the warning stays where it belongs (true main builds).
- **`fix(web): allow finer smart-search threshold steps and soften default guidance`** — the admin "max search distance" input had `step="0.05"`, which made the browser reject any value not on a 0.05 grid (e.g. `0.77`) with a *"please enter a valid value"* popup. Drop the step to `0.01`. Also add a sentence to the admin description and the docs tuning tip telling users to raise the threshold in small steps if 0.75 returns nothing — some libraries and CLIP models produce higher distances than the recommended starting point.

The recommended value (0.75) and the rest of the docs table are unchanged.

## Test plan

- [ ] Dispatch a release build and verify the About modal no longer shows the development-version banner and that the Source link resolves to `vX.Y.Z@<sha>`
- [ ] In Admin > Machine Learning > Smart Search, type `0.77` into Max search distance and confirm the field accepts it on save
- [ ] Verify the docs page (`docs/docs/features/searching.md`) renders the updated tuning tip