### PR TITLE
fix(web): prevent filter panel header from bleeding through mobile sidebar

### DIFF
--- a/web/src/lib/components/sidebar/sidebar.svelte
+++ b/web/src/lib/components/sidebar/sidebar.svelte
@@ -35,7 +35,7 @@
   id="sidebar"
   aria-label={ariaLabel}
   tabindex="-1"
-  class="immich-scrollbar relative z-1 w-0 sidebar:w-64 overflow-y-auto overflow-x-hidden pt-8 transition-all duration-200 bg-light"
+  class="immich-scrollbar relative z-10 w-0 sidebar:w-64 overflow-y-auto overflow-x-hidden pt-8 transition-all duration-200 bg-light"
   class:shadow-2xl={isExpanded}
   class:dark:border-e-immich-dark-gray={isExpanded}
   class:border-r={isExpanded}


### PR DESCRIPTION
## Summary

- On narrow viewports the filter panel's sticky **Filters** header was painting through the sidebar overlay between *Photos* and *Explore* (see screenshot on original report).
- Root cause: the filter panel sticky header uses `z-5` while `sidebar.svelte` used `z-1`. Both live inside `user-page-layout.svelte`'s `relative z-0` grid, so the sticky header won the stacking race when the mobile sidebar slid in as an overlay.
- Fix: bump `sidebar.svelte` from `z-1` → `z-10`. Desktop layout is unaffected because above the `sidebar:` breakpoint the nav occupies its own grid column and doesn't overlap the main content.

## Test plan

- [ ] Open `/photos` on a narrow viewport, open the sidebar via the hamburger — Filters header no longer shows through
- [ ] Same check on `/spaces/:id` and `/map` where the filter panel also lives
- [ ] Desktop `(>= sidebar breakpoint)` renders unchanged