### PR TITLE
docs: add contributing section and refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Upstream Immich references are rewritten to Gallery at build time by `branding/a
 
 ## Releases & Deploys
 
-- **Release workflow** (`.github/workflows/release.yml`): builds `gallery-server`, `gallery-ml`, and `gallery-ml:*-cuda` on every merge to `main`, computes the next semver from commit prefixes / PR labels (`feat:` → minor, `BREAKING CHANGE` → major, anything else → patch, `changelog:skip` → no release), and pushes to `ghcr.io/open-noodle/*`.
+- **Release workflow** (`.github/workflows/gallery-release.yml`): manual-only (`workflow_dispatch`) — a maintainer triggers it from the Actions tab or via `gh workflow run gallery-release.yml`. It builds `gallery-server`, `gallery-ml`, and `gallery-ml:*-cuda` in parallel, computes the next semver from commit prefixes / PR labels since the last tag (`feat:` → minor, `BREAKING CHANGE` → major, anything else → patch, `changelog:skip` → no release), and pushes to `ghcr.io/open-noodle/*`.
 - **Deploy targets**: `demo.opennoodle.de` (demo), `pierre.opennoodle.de` (personal), `opennoodle.de` (marketing Astro site), `test.opennoodle.de` (marketing staging), `docs.opennoodle.de` (Docusaurus). Each has a corresponding skill in `.claude/skills/` (see `/deploy-gallery-*` slash commands).
 - **RC builds**: `rc-personal` skill ships a tagged server image to the personal instance via a compose override — remember to remove the override after merge or release deploys will ship stale RC images.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Immich is a self-hosted photo and video management solution. It's a monorepo managed with **pnpm workspaces** containing:
+Gallery is a community fork of [Immich](https://github.com/immich-app/immich), a self-hosted photo and video management solution. The fork is currently based on **Immich v2.7.5** and regularly rebased onto upstream. Source package names are still `immich` / `immich-web` so the rebase path stays clean — only branding, Docker image names, and fork-only code diverge.
+
+Fork-specific features layered on top of upstream include: shared spaces, smart search & filters, user groups, S3-compatible storage, auto-classification, video duplicate detection, pet detection, Google Photos import, image editing & video trimming, and structured JSON logging. See `README.md` for the full list and docs links.
+
+It's a monorepo managed with **pnpm workspaces** containing:
 
 - **server/** — NestJS 11 backend (TypeScript) — package name: `immich`
 - **web/** — SvelteKit frontend with Svelte 5 (TypeScript) — package name: `immich-web`
 - **mobile/** — Flutter/Dart app with Riverpod state management
-- **machine-learning/** — Python FastAPI service (CLIP, facial recognition, OCR via ONNX Runtime)
+- **machine-learning/** — Python FastAPI service (CLIP, facial recognition, OCR, YOLO pet detection via ONNX Runtime)
 - **cli/** — Node.js CLI (`@immich/cli`)
 - **open-api/** — OpenAPI spec and generated SDKs (`@immich/sdk`)
 - **e2e/** — End-to-end tests (Playwright + Vitest)
+- **docs/** — Docusaurus site deployed to `docs.opennoodle.de`
+- **branding/** — Fork branding assets and the `apply-branding` script that rewrites upstream Immich references before Docker builds
+- **deployment/** — Demo, personal, and marketing deploy configs and scripts
 
 ## Common Commands
 
@@ -52,6 +59,12 @@ pnpm test -- --run src/lib/components/MyComponent.spec.ts  # Single test file
 cd e2e
 pnpm test                                    # API tests (vitest)
 pnpm test:web                                # Playwright web tests
+
+# Run Playwright against an already-running `make dev` stack on :2283
+make e2e-web-dev                             # web suite
+make e2e-web-dev-ui                          # web suite with Playwright UI
+make e2e-api-dev                             # API tests
+make e2e-integration-dev                     # integration suite
 ```
 
 ### Linting & Formatting
@@ -124,6 +137,7 @@ This merge is needed because:
 - **Middleware**: Auth guards, error interceptors, file upload handling in `src/middleware/`
 - **Database**: PostgreSQL with extensions (pgvectors/vectorchord for embeddings, cube, earthdistance, pg_trgm)
 - **Testing**: Vitest with `newTestService()` factory in `test/utils.ts` for auto-mocking dependencies. Medium tests use real DB via testcontainers
+- **Fork-only services**: `shared-space.service.ts`, `classification.service.ts`, `pet-detection.service.ts`, and extensions to `duplicate.service.ts` (video dedup) live alongside upstream services. S3 support is wired through `storage.service.ts` / `storage.repository.ts` with both disk and S3 backends active simultaneously.
 
 ### Web (SvelteKit)
 
@@ -168,4 +182,20 @@ When server API endpoints change:
 2. Regenerate specs: `pnpm sync:open-api`
 3. Regenerate clients: `make open-api` (generates both TypeScript SDK and Dart client)
 
-The TypeScript SDK uses `oazapfts` for generation. The Dart client uses OpenAPI Generator with custom mustache templates and patches.
+The TypeScript SDK uses `oazapfts` for generation. The Dart client uses OpenAPI Generator with custom mustache templates and patches (Java required — see `feedback_openapi_dart_generation`).
+
+## Fork Branding
+
+Upstream Immich references are rewritten to Gallery at build time by `branding/apply-branding.sh`. This runs automatically inside the Dockerfiles before `nest build` / the web build, so local `pnpm dev` and `make dev` keep upstream names in source. **Do not commit branded output**: edit the original Immich references and let the script rewrite them during Docker builds. Skipping `apply-branding` before a Docker build will leak upstream names into deployed artifacts.
+
+## Releases & Deploys
+
+- **Release workflow** (`.github/workflows/release.yml`): builds `gallery-server`, `gallery-ml`, and `gallery-ml:*-cuda` on every merge to `main`, computes the next semver from commit prefixes / PR labels (`feat:` → minor, `BREAKING CHANGE` → major, anything else → patch, `changelog:skip` → no release), and pushes to `ghcr.io/open-noodle/*`.
+- **Deploy targets**: `demo.opennoodle.de` (demo), `pierre.opennoodle.de` (personal), `opennoodle.de` (marketing Astro site), `test.opennoodle.de` (marketing staging), `docs.opennoodle.de` (Docusaurus). Each has a corresponding skill in `.claude/skills/` (see `/deploy-gallery-*` slash commands).
+- **RC builds**: `rc-personal` skill ships a tagged server image to the personal instance via a compose override — remember to remove the override after merge or release deploys will ship stale RC images.
+
+## Contributing & Docs
+
+- `CONTRIBUTING.md` and the README's Contributing section cover the dev-environment setup (`cp docker/example.env docker/.env`, `pnpm install`, `make dev`).
+- User-facing docs live in `docs/docs/` and are deployed to `docs.opennoodle.de`. Run prettier on any markdown under `docs/` or `docs/plans/` before committing — CI Docs Build is strict.
+- Guides for switching to / from Gallery live under `docs/docs/guides/` — the switch-back-to-immich script is at `scripts/revert-to-immich/`.

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Pre-built Docker images are published to GitHub Container Registry (GHCR) under 
 
 ### Publishing
 
-Images are automatically built and published on every push to `main` via the **Release** GitHub Actions workflow (`.github/workflows/release.yml`).
+Images are built and published by the **Release Gallery** GitHub Actions workflow (`.github/workflows/gallery-release.yml`). The workflow is **manually triggered** via `workflow_dispatch` — it does not run automatically on merges to `main`.
 
 **How it works:**
 
-1. Every merged PR triggers an automatic build (unless the PR has the `changelog:skip` label)
-2. The version is computed from the latest git tag using semantic versioning:
+1. A maintainer triggers the workflow from the Actions tab (or via `gh workflow run`), optionally passing an explicit version.
+2. If no version is passed, the next semver is computed from commits since the latest tag:
    - `changelog:skip` PR label → **no release** (skips build, tag, and push entirely)
    - `feat:` commit or `changelog:feat` PR label → **minor** bump (e.g. `v4.2.6` → `v4.3.0`)
    - `BREAKING CHANGE` in commit body → **major** bump (e.g. `v4.3.0` → `v5.0.0`)
@@ -249,13 +249,13 @@ Images are automatically built and published on every push to `main` via the **R
 5. Git tags are created after successful builds
 6. Images are pushed to GHCR using the built-in `GITHUB_TOKEN` — no extra secrets needed
 
-**To manually publish a specific version:**
+**To publish a specific version:**
 
 ```bash
-gh workflow run release.yml --ref main -f version=v4.2.6
+gh workflow run gallery-release.yml --ref main -f version=v4.2.6
 ```
 
-Or use the GitHub Actions UI: Actions > Release > Run workflow > enter version > Run.
+Or use the GitHub Actions UI: Actions > Release Gallery > Run workflow > enter version (or leave blank for auto-bump) > Run.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -256,3 +256,76 @@ gh workflow run release.yml --ref main -f version=v4.2.6
 ```
 
 Or use the GitHub Actions UI: Actions > Release > Run workflow > enter version > Run.
+
+## Contributing
+
+Gallery is a community fork and contributions are welcome — bug fixes, features, docs, translations. Come say hi on [Discord](https://discord.gg/cxBfbuxyG4) if you want to chat about an idea before diving in.
+
+### Setting Up a Dev Environment
+
+The repo is a `pnpm` workspace monorepo — server (NestJS), web (SvelteKit), mobile (Flutter), machine-learning (Python), and a few supporting packages. The dev stack runs in Docker Compose with live reload for the server and web.
+
+**Prerequisites:** Docker, Docker Compose, Node.js 22+, and [pnpm](https://pnpm.io/installation).
+
+1. **Fork and clone the repo**
+
+   ```bash
+   git clone https://github.com/<your-username>/gallery.git
+   cd gallery
+   ```
+
+2. **Copy the example env file**
+
+   ```bash
+   cp docker/example.env docker/.env
+   ```
+
+   The defaults work out of the box for local development. Adjust `UPLOAD_LOCATION` and `DB_DATA_LOCATION` if you want to store data somewhere other than the repo directory.
+
+3. **Install dependencies**
+
+   ```bash
+   pnpm install
+   ```
+
+   This installs deps for every workspace package (server, web, cli, sdk, e2e).
+
+4. **Start the dev stack**
+
+   ```bash
+   make dev
+   ```
+
+   This brings up Postgres, Redis, the ML service, the server (with hot reload), and the web UI on http://localhost:2283. The first run downloads ML models and builds containers, so give it a few minutes.
+
+### Running Tests and Checks Before You Push
+
+```bash
+# Server
+cd server && pnpm test          # unit tests
+cd server && pnpm check         # TypeScript type check
+
+# Web
+cd web && pnpm test             # unit tests
+cd web && pnpm check            # svelte-check + tsc
+
+# All modules from the repo root
+make check-all                  # type checks everywhere
+make format-all                 # prettier --write
+```
+
+CI runs lint, type checks, unit tests, and e2e tests on every PR. If you're touching server controllers or repositories, regenerate the OpenAPI clients and SQL query files:
+
+```bash
+make open-api                   # regenerates TS SDK + Dart client
+make sql                        # regenerates SQL query docs (needs DB running)
+```
+
+### Opening a Pull Request
+
+- Branch off `main` and keep PRs focused on one change.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for your commit messages (`feat:`, `fix:`, `docs:`, `chore:`, etc.) — the release workflow uses them to compute version bumps.
+- Include a short description of what changed and why, plus screenshots or screen recordings for UI work.
+- Make sure CI is green before requesting review.
+
+See [CLAUDE.md](CLAUDE.md) for a deeper tour of the codebase architecture and common commands.


### PR DESCRIPTION
## Summary

- Adds a Contributing section at the bottom of the README walking through dev setup (`cp docker/example.env docker/.env`, `pnpm install`, `make dev`), test/check commands, OpenAPI/SQL regen, and PR conventions.
- Refreshes `CLAUDE.md` to reflect the current fork state: Gallery as a community fork of Immich v2.7.5, fork-only services and directories (`docs/`, `branding/`, `deployment/`), `e2e-*-dev` make targets, branding script notes, and deploy targets.
- Corrects the release workflow description in both files — the workflow is manual (`workflow_dispatch` on `gallery-release.yml`), not automatic on merges to `main`.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Contributing steps work for a fresh checkout (`cp`, `pnpm install`, `make dev`)