### PR TITLE
docs: bump example.env IMMICH_VERSION to v4

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -9,8 +9,8 @@ DB_DATA_LOCATION=./postgres
 # To set a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # TZ=Etc/UTC
 
-# The Immich version to use. You can pin this to a specific version like "v3.0.1"
-IMMICH_VERSION=v3
+# The Gallery version to use. You can pin this to a specific version like "v4.50.0"
+IMMICH_VERSION=v4
 
 # Connection secret for postgres. You should change it to a random password
 # Please use only the characters `A-Za-z0-9`, without special characters or spaces


### PR DESCRIPTION
## Summary
- docker/example.env still pinned `IMMICH_VERSION=v3` and referenced `"v3.0.1"` as the pinnable-version example, but current Gallery releases are `v4.x.x` (latest tag `v4.50.0`).
- The quick-start docs page (`docs.opennoodle.de/overview/quick-start`) renders `docker/example.env` verbatim via `raw-loader`, so users following the guide were told to pin to v3.

## Test plan
- [ ] Verify rendered quick-start page shows `IMMICH_VERSION=v4` after docs deploy.