### PR TITLE
docs: replace stale upstream Immich links with Gallery equivalents

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -1,4 +1,4 @@
-# You can find documentation for all the supported env variables at https://docs.immich.app/install/environment-variables
+# You can find documentation for all the supported env variables at https://docs.opennoodle.de/install/environment-variables
 
 # The location where your uploaded files are stored
 UPLOAD_LOCATION=./library

--- a/docs/docs/developer/directories.md
+++ b/docs/docs/developer/directories.md
@@ -4,18 +4,18 @@ title: Directories
 
 # Repository Folder Structure
 
-Our [GitHub Repository](https://github.com/immich-app/immich) is a [monorepo](https://en.wikipedia.org/wiki/Monorepo) and includes the following folders:
+Our [GitHub Repository](https://github.com/open-noodle/gallery) is a [monorepo](https://en.wikipedia.org/wiki/Monorepo) and includes the following folders:
 
-| Folder              | Description                                                          |
-| :------------------ | :------------------------------------------------------------------- |
-| `.github/`          | Github templates and action workflows                                |
-| `.vscode/`          | VSCode debug launch profiles                                         |
-| `cli/`              | Source code for the work-in-progress CLI rewrite                     |
-| `docker/`           | Docker compose resources for dev, test, production                   |
-| `design/`           | Screenshots and logos for the README                                 |
-| `docs/`             | Source code for the [https://immich.app](https://immich.app) website |
-| `machine-learning/` | Source code for the `immich-machine-learning` docker image           |
-| `misc/release/`     | Scripts for version bumps and draft releases                         |
-| `mobile/`           | Source code for the mobile app, both Android and iOS                 |
-| `server/`           | Source code for the `immich-server` docker image                     |
-| `web/`              | Source code for the `web`                                            |
+| Folder              | Description                                                                          |
+| :------------------ | :----------------------------------------------------------------------------------- |
+| `.github/`          | Github templates and action workflows                                                |
+| `.vscode/`          | VSCode debug launch profiles                                                         |
+| `cli/`              | Source code for the work-in-progress CLI rewrite                                     |
+| `docker/`           | Docker compose resources for dev, test, production                                   |
+| `design/`           | Screenshots and logos for the README                                                 |
+| `docs/`             | Source code for the [https://docs.opennoodle.de](https://docs.opennoodle.de) website |
+| `machine-learning/` | Source code for the `gallery-ml` docker image                                        |
+| `misc/release/`     | Scripts for version bumps and draft releases                                         |
+| `mobile/`           | Source code for the mobile app, both Android and iOS                                 |
+| `server/`           | Source code for the `gallery-server` docker image                                    |
+| `web/`              | Source code for the `web`                                                            |

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -64,13 +64,13 @@ If you only want to do web development connected to an existing, remote backend,
 4. Start the web development server
 
 ```bash
-IMMICH_SERVER_URL=https://demo.immich.app/ pnpm run dev
+IMMICH_SERVER_URL=https://demo.opennoodle.de/ pnpm run dev
 ```
 
 If you're using PowerShell on Windows you may need to set the env var separately like so:
 
 ```powershell
-$env:IMMICH_SERVER_URL = "https://demo.immich.app/"
+$env:IMMICH_SERVER_URL = "https://demo.opennoodle.de/"
 pnpm run dev
 ```
 
@@ -106,7 +106,7 @@ To add a new translation text, enter the key-value pair in the `i18n/en.json` in
 make translation
 ```
 
-The mobile app asks you what backend to connect to. You can utilize the demo backend (https://demo.immich.app/) if you don't need to change server code or upload photos. Alternatively, you can run the server yourself per the instructions above.
+The mobile app asks you what backend to connect to. You can utilize the demo backend (https://demo.opennoodle.de/) if you don't need to change server code or upload photos. Alternatively, you can run the server yourself per the instructions above.
 
 ## IDE setup
 

--- a/docs/docs/install/script.md
+++ b/docs/docs/install/script.md
@@ -19,7 +19,7 @@ The install script only supports Linux operating systems and requires Docker to 
 In the shell, from a directory of your choice, run the following command:
 
 ```bash
-curl -o- https://raw.githubusercontent.com/immich-app/immich/main/install.sh | bash
+curl -o- https://raw.githubusercontent.com/open-noodle/gallery/main/install.sh | bash
 ```
 
 The script will perform the following actions:

--- a/docs/docs/install/unraid.md
+++ b/docs/docs/install/unraid.md
@@ -110,7 +110,7 @@ alt="Go to Docker Tab and visit the address listed next to gallery-web"
 
 <details >
     <summary>Using the FolderView plugin for organizing your Docker containers? Click me! Otherwise you're complete!</summary>
-    <p>If you are using the FolderView plugin go the Docker tab and select "<b>New Folder</b>".<br />Label it <i>"Gallery"</i> and use this URL as the logo: https://raw.githubusercontent.com/immich-app/immich/main/design/immich-logo.png<br/>Then simply select all the Gallery related containers before clicking "<b>Submit</b>"</p>
+    <p>If you are using the FolderView plugin go the Docker tab and select "<b>New Folder</b>".<br />Label it <i>"Gallery"</i> and use this URL as the logo: https://raw.githubusercontent.com/open-noodle/gallery/main/branding/assets/logo-mark.svg<br/>Then simply select all the Gallery related containers before clicking "<b>Submit</b>"</p>
     <img
         src={require('./img/unraid07.webp').default}
         width="80%"

--- a/docs/docs/install/upgrading.md
+++ b/docs/docs/install/upgrading.md
@@ -23,8 +23,8 @@ docker image prune
 ```
 
 [watchtower]: https://containrrr.dev/watchtower/
-[breaking]: https://github.com/immich-app/immich/discussions?discussions_q=label%3Achangelog%3Abreaking-change+sort%3Adate_created
-[releases]: https://github.com/immich-app/immich/releases
+[breaking]: https://github.com/open-noodle/gallery/releases?q=label%3Abreaking&expanded=true
+[releases]: https://github.com/open-noodle/gallery/releases
 
 ## Versioning Policy
 
@@ -103,7 +103,7 @@ After making these changes, you can start Gallery as normal. Gallery will make s
 After switching to VectorChord, you should not downgrade Gallery below 1.133.0.
 :::
 
-Please don’t hesitate to contact us on [GitHub](https://github.com/immich-app/immich/discussions) or [Discord](https://discord.gg/cxBfbuxyG4) if you encounter migration issues.
+Please don’t hesitate to contact us on [GitHub](https://github.com/open-noodle/gallery/discussions) or [Discord](https://discord.gg/cxBfbuxyG4) if you encounter migration issues.
 
 ### VectorChord FAQ
 


### PR DESCRIPTION
## Summary
Audit of `docs/docs/**` (which is shipped verbatim to docs.opennoodle.de — the branding script only rewrites `docusaurus.config.js` and static logo assets, not markdown source) turned up six places where upstream Immich URLs were still linked and would mislead users.

- **install/script.md** — curl installer URL pointed at `raw.githubusercontent.com/immich-app/immich/main/install.sh`. That script installs upstream Immich, not Gallery. Repointed to `open-noodle/gallery`.
- **docker/example.env** — top-of-file env-var docs link → `docs.opennoodle.de/install/environment-variables`.
- **developer/setup.md** — contributor dev-server `IMMICH_SERVER_URL=` and the mobile-app demo-backend line both pointed to `demo.immich.app`. Swapped to `demo.opennoodle.de`.
- **developer/directories.md** — "Our GitHub Repository" link, docs-site link, and the `immich-machine-learning` / `immich-server` image-name column all repointed to Gallery.
- **install/upgrading.md** — `[breaking]` and `[releases]` ref links + the "contact us on GitHub" link at the end of the VectorChord section repointed to `open-noodle/gallery`. Postgres image references (`ghcr.io/immich-app/postgres:*`) left alone — those are the real images users consume.
- **install/unraid.md** — FolderView plugin logo URL switched to the Gallery `logo-mark.svg`.

Left alone on purpose:
- `my.immich.app/...` redirector links (11 occurrences across features/admin docs) — functional via the `.well-known/immich` endpoint Gallery still serves.
- `container_name: immich_*` in compose snippets — matches the shipped `docker-compose.yml`.
- `ghcr.io/immich-app/immich-cli` in command-line-interface.md — the fork doesn't rebuild the CLI image.
- FAQ / storage-template upstream cross-links — legitimate "based on Immich" context.

## Test plan
- [ ] After docs deploy, spot-check each edited page on docs.opennoodle.de and click the fixed links.