### PR TITLE
feat(server): tag outgoing user-agent with environment

### DIFF
--- a/server/src/utils/fetch.spec.ts
+++ b/server/src/utils/fetch.spec.ts
@@ -1,18 +1,47 @@
 import { serverVersion } from 'src/constants';
+import { ImmichEnvironment } from 'src/enum';
 import { configureUserAgent } from 'src/utils/fetch';
 
 describe('fetch', () => {
-  it('should set the default user-agent header', async () => {
-    const spy = vi.fn().mockResolvedValue(new Response());
-    const original = globalThis.fetch;
-    globalThis.fetch = spy;
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnv: string | undefined;
 
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = process.env.IMMICH_ENV;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.env.IMMICH_ENV = originalEnv;
+  });
+
+  const getUserAgent = async () => {
+    const spy = vi.fn().mockResolvedValue(new Response());
+    globalThis.fetch = spy;
     configureUserAgent();
     await globalThis.fetch('http://test.local');
-
     const headers: Headers = spy.mock.calls[0][1].headers;
-    expect(headers.get('User-Agent')).toBe(`gallery-server/${serverVersion}`);
+    return headers.get('User-Agent');
+  };
 
-    globalThis.fetch = original;
+  it('should label production with (prod)', async () => {
+    process.env.IMMICH_ENV = ImmichEnvironment.Production;
+    expect(await getUserAgent()).toBe(`gallery-server/${serverVersion} (prod)`);
+  });
+
+  it('should label development with (dev)', async () => {
+    process.env.IMMICH_ENV = ImmichEnvironment.Development;
+    expect(await getUserAgent()).toBe(`gallery-server/${serverVersion} (dev)`);
+  });
+
+  it('should label testing with (testing)', async () => {
+    process.env.IMMICH_ENV = ImmichEnvironment.Testing;
+    expect(await getUserAgent()).toBe(`gallery-server/${serverVersion} (testing)`);
+  });
+
+  it('should default to (prod) when IMMICH_ENV is unset', async () => {
+    delete process.env.IMMICH_ENV;
+    expect(await getUserAgent()).toBe(`gallery-server/${serverVersion} (prod)`);
   });
 });

--- a/server/src/utils/fetch.ts
+++ b/server/src/utils/fetch.ts
@@ -1,11 +1,21 @@
 import { serverVersion } from 'src/constants';
+import { ImmichEnvironment } from 'src/enum';
+
+const environmentLabel: Record<ImmichEnvironment, string> = {
+  [ImmichEnvironment.Development]: 'dev',
+  [ImmichEnvironment.Testing]: 'testing',
+  [ImmichEnvironment.Production]: 'prod',
+};
 
 export function configureUserAgent() {
+  const env = (process.env.IMMICH_ENV as ImmichEnvironment) || ImmichEnvironment.Production;
+  const label = environmentLabel[env] ?? environmentLabel[ImmichEnvironment.Production];
+  const userAgent = `gallery-server/${serverVersion} (${label})`;
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (input, init) => {
     const headers = new Headers(init?.headers);
     if (!headers.has('User-Agent')) {
-      headers.set('User-Agent', `gallery-server/${serverVersion}`);
+      headers.set('User-Agent', userAgent);
     }
     return originalFetch(input, { ...init, headers });
   };


### PR DESCRIPTION
## Summary

- Outgoing HTTP requests now tag their User-Agent with the environment so `version.opennoodle.de/gallery` analytics can tell real users apart from local `make dev` and CI e2e instances.
- `gallery-server/${version} (prod)` for production, `(dev)` for `IMMICH_ENV=development`, `(testing)` for `IMMICH_ENV=testing`. Unset/unknown defaults to `(prod)`.
- Implementation in `server/src/utils/fetch.ts` (the existing global fetch interceptor) with updated spec coverage for all three values plus the unset fallback.

## Test plan

- [ ] Unit tests pass — `pnpm --filter immich test -- --run src/utils/fetch.spec.ts`
- [ ] `tsc --noEmit` clean on server
- [ ] Hit a `make dev` stack and confirm the version-check outbound request shows `(dev)` in the UA
- [ ] After merge, confirm e2e runs show `(testing)` at the endpoint