### PR TITLE
fix(web): cmdk palette people thumbnails + scope hint

### DIFF
--- a/docs/plans/2026-04-17-cmdk-followups-design.md
+++ b/docs/plans/2026-04-17-cmdk-followups-design.md
@@ -1,0 +1,183 @@
+# Design: cmdk palette follow-ups (v1.2.1)
+
+Two small, post-merge polish fixes to the command palette shipped in PR #365
+(`feat/cmdk-prefix-scoping`): broken face thumbnails, and poor discoverability
+of the `@ # / >` scope prefixes.
+
+## Issue 1 — face thumbnails render as empty circles
+
+### Symptom
+
+Under the `@` scope (and anywhere the palette lists people — search
+results, recents, preview pane) every person row's avatar circle is a flat
+grey placeholder. The preview pane's big round thumbnail is also empty,
+though the 4-asset strip below the name _does_ render correctly.
+
+### Root cause
+
+`PersonResponseDto` in the generated SDK has a `thumbnailPath` field but
+**no `faceAssetId`**. Both `person-row.svelte` and `person-preview.svelte`
+type their prop as:
+
+```ts
+PersonResponseDto & { numberOfAssets?: number; faceAssetId?: string }
+```
+
+and build the thumbnail URL with:
+
+```ts
+item.faceAssetId ? getAssetMediaUrl({ id: item.faceAssetId, size: ... }) : ''
+```
+
+The intersection type made TS accept the property, but nothing upstream
+populates it — so the ternary always falls through to `''` and the
+placeholder `<div>` renders instead. The manager's `activate('person')`
+path saves `thumbnailAssetId: p.faceAssetId` into recents, which also
+resolves to `undefined` for the same reason.
+
+### Fix
+
+Switch every person thumbnail site to `getPeopleThumbnailUrl(person)`
+(`web/src/lib/utils.ts:248`), which hits `/api/people/:id/thumbnail` — the
+dedicated face-crop endpoint used everywhere else in the app
+(`manage-people-visibility.svelte`, `PeoplePickerModal`, merge modal,
+person-side-panel, the person page itself). It only needs `person.id`.
+
+Concretely:
+
+1. **`web/src/lib/components/global-search/rows/person-row.svelte`**
+   - Drop `faceAssetId?: string` from the prop intersection.
+   - Replace the `getAssetMediaUrl` call with `getPeopleThumbnailUrl(item)`.
+   - Add an `onerror` fallback for the case where the server 404s
+     (person whose thumbnail hasn't been generated yet — fresh ML
+     pipeline, or deleted person referenced in stale recents). Concrete
+     wiring with Svelte 5 runes:
+     ```svelte
+     let failed = $state(false);
+     // reset when the person changes
+     $effect(() => { void item.id; failed = false; });
+     ```
+     Then in the template:
+     ```svelte
+     {#if !failed}
+       <img src={thumbUrl} ... onerror={() => (failed = true)} />
+     {:else}
+       <div class="h-10 w-10 rounded-full bg-subtle/40" aria-hidden="true"></div>
+     {/if}
+     ```
+
+2. **`web/src/lib/components/global-search/previews/person-preview.svelte`**
+   - Same change as `person-row`. Use the same `let failed = $state(false)`
+     + `onerror` pattern. `size: AssetMediaSize.Preview` is no longer
+     relevant — `getPeopleThumbnailUrl` returns a single-size face crop,
+     which is what the design already assumed.
+
+3. **`web/src/lib/managers/global-search-manager.svelte.ts`**
+   - `activate('person')` (line ~990): drop `thumbnailAssetId: p.faceAssetId`
+     from the recent entry payload.
+   - `activeItemFromRecent` person branch (line ~852): drop
+     `faceAssetId: entry.thumbnailAssetId` from the synthesised data
+     object. The preview component only needs `id` + `name`.
+
+4. **`web/src/lib/stores/cmdk-recent.ts`**
+   - Remove `thumbnailAssetId?: string` from the `person` variant of
+     `RecentEntry`. **Backward compatibility**: stored entries written by
+     the old code still carry `thumbnailAssetId`; the JSON read path
+     (`rawRead` → `JSON.parse` → cast to `RecentEntry[]`) does no
+     narrowing, so legacy entries deserialise fine and the new code
+     simply ignores the extra field. No migration needed.
+
+5. **`web/src/lib/components/global-search/rows/recent-row.svelte`**
+   - Stop passing `faceAssetId: entry.thumbnailAssetId` in the
+     synthesised `PersonRow` props. After step 1, `PersonRow` derives the
+     thumbnail URL itself via `getPeopleThumbnailUrl(item)` from
+     `item.id` — so recent-row only needs to forward `id` (=
+     `entry.personId`) and `name` (= `entry.label`).
+
+6. **Tests to update**
+   - `person-row.spec.ts`: remove `faceAssetId` from fixtures; assert that
+     an `<img>` with a URL matching `/api/people/.*/thumbnail` is rendered.
+     Replace the existing "renders a placeholder div when faceAssetId is
+     missing" case with a new "swaps to placeholder on image error" case
+     that renders the row, dispatches an `error` event on the `<img>`, and
+     asserts the placeholder `<div>` is now in the DOM.
+   - `person-preview.spec.ts`: same fixture cleanup, same URL assertion.
+   - `cmdk-recent.spec.ts`: drop the `thumbnailAssetId` field from sample
+     entries.
+   - `global-search-manager.svelte.spec.ts`: lines 818, 2565, 2568 assert
+     on `faceAssetId` directly — rewrite assertions to check `id` +
+     `name` instead.
+   - `recent-row.spec.ts`: no behavioural change expected; confirm the
+     render still passes.
+
+### Edge cases
+
+- **Recents persisted before this change**: covered by step 4 — stored
+  `thumbnailAssetId` field is harmless clutter on read; new writes won't
+  include it.
+- **Deleted person**: `getPeopleThumbnailUrl` returns a URL that 404s.
+  Handle via the `failed` state + `onerror` pattern in step 1 → swap to
+  the placeholder `<div>` (same UX shape as today, just triggered on
+  network failure rather than missing field).
+- **No `updatedAt` on recents**: `getPeopleThumbnailUrl(person, updatedAt)`
+  cache-busts via `updatedAt ?? person.updatedAt`. Recent entries don't
+  carry either, so the URL gets `updatedAt=undefined` → `createUrl` drops
+  the param. Acceptable: recents are short-lived snapshots, and a thumbnail
+  refresh on the live People page already busts the cache there. No need
+  to extend the recent payload.
+- **Shared-space people**: Spaces have their own `space_person` records.
+  The current cmdk palette queries global people only (via smart search
+  and search suggestions), so this fix does not need to disambiguate.
+
+## Issue 2 — `@ # / >` prefixes are not discoverable
+
+### Symptom
+
+Users don't realise the prefixes exist. The only UI surface is a small
+footer chip (`cmdk_scope_hint_footer`) and the `?` shortcut modal — both
+require the user to look past the search input.
+
+### Fix
+
+Update the `cmdk_placeholder` i18n value from `"Search Gallery"` to:
+
+```
+Search Gallery — try @ for people, # tags, / albums, > pages
+```
+
+This is the most prominent surface on a fresh palette open, and a full
+decomposition of each prefix → entity mapping is more educational than
+a terse `@ # / >` chip. The footer chip stays as secondary reinforcement.
+
+### Translation
+
+`en.json` only; other locales inherit via fallback until re-translated.
+Standard i18n flow.
+
+### Trade-off
+
+The placeholder is 62 chars and _will_ visually truncate on small
+viewports (e.g. iPhone SE 360px renders ~30 chars). In LTR locales this
+clips the tail (`/ albums, > pages`) — the high-value `try @ for people, #
+tags` segment stays visible. In RTL locales the clip flips and may swallow
+the prefix hint. Accepted: same string for all locales, no mobile-specific
+fork. If RTL feedback comes in, we can revisit with a shorter string for
+those locales.
+
+## Out of scope
+
+- First-run tooltip / callout animation for scope prefixes. Premature.
+- Hover tooltips on the footer chip expanding each glyph. The placeholder
+  already carries the full mapping; doubling up adds noise.
+- Reworking `cmdk_helper` (the "Start typing — photos, people, places,
+  tags." line). That string only renders when recents **and** quick links
+  are both empty, which almost never happens in practice.
+
+## Delivery shape
+
+- Single branch: `fix/cmdk-people-thumbnails` (housing both commits).
+- Two commits, in order:
+  1. `fix(web): cmdk palette person thumbnails`
+  2. `feat(web): cmdk placeholder hints scope prefixes`
+- One PR, standard CI (`pnpm --filter=immich-web test` + lint + tsc).
+- No server / SDK / DB changes. No OpenAPI regen.

--- a/docs/plans/2026-04-17-cmdk-followups-design.md
+++ b/docs/plans/2026-04-17-cmdk-followups-design.md
@@ -68,9 +68,9 @@ Concretely:
 
 2. **`web/src/lib/components/global-search/previews/person-preview.svelte`**
    - Same change as `person-row`. Use the same `let failed = $state(false)`
-     + `onerror` pattern. `size: AssetMediaSize.Preview` is no longer
-     relevant — `getPeopleThumbnailUrl` returns a single-size face crop,
-     which is what the design already assumed.
+     - `onerror` pattern. `size: AssetMediaSize.Preview` is no longer
+       relevant — `getPeopleThumbnailUrl` returns a single-size face crop,
+       which is what the design already assumed.
 
 3. **`web/src/lib/managers/global-search-manager.svelte.ts`**
    - `activate('person')` (line ~990): drop `thumbnailAssetId: p.faceAssetId`

--- a/docs/plans/2026-04-17-cmdk-followups-plan.md
+++ b/docs/plans/2026-04-17-cmdk-followups-plan.md
@@ -1,0 +1,733 @@
+# cmdk Palette Follow-ups Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix blank face thumbnails in the command palette and surface the
+`@ # / >` scope prefixes in the search input placeholder.
+
+**Architecture:** Replace dead `faceAssetId` plumbing with the existing
+`getPeopleThumbnailUrl()` helper (hits `/api/people/:id/thumbnail`).
+Update the `cmdk_placeholder` i18n string. Pure web-only changes — no
+server, SDK, or DB touches.
+
+**Tech Stack:** SvelteKit, Svelte 5 runes, Vitest + @testing-library/svelte
+with happy-dom, generated `@immich/sdk`. All work in
+`web/src/lib/components/global-search/`,
+`web/src/lib/managers/global-search-manager.svelte.ts`,
+`web/src/lib/stores/cmdk-recent.ts`, and `i18n/en.json`.
+
+**Working directory for all tasks:** `web/` (`cd web` once, stay there).
+Use `pnpm test -- --run <file>` to scope test runs.
+
+**Design reference:** `docs/plans/2026-04-17-cmdk-followups-design.md`
+
+---
+
+## Task 1: Update person-row test (RED + GREEN)
+
+**Files:**
+- Modify: `web/src/lib/components/global-search/__tests__/person-row.spec.ts`
+
+**Step 1: Replace the test file**
+
+Open the file. Rewrite the test cases so they (a) drop `faceAssetId` from
+fixtures, (b) assert the rendered thumbnail URL points to
+`/api/people/.*/thumbnail`, and (c) replace the "placeholder when
+faceAssetId is missing" case with an `onerror` swap test.
+
+Replace the entire `describe('person-row', () => { ... })` block with:
+
+```ts
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import PersonRow from '../rows/person-row.svelte';
+
+describe('person-row', () => {
+  it('renders the person name and asset count', () => {
+    render(PersonRow, {
+      props: {
+        item: { id: 'p1', name: 'Alice', numberOfAssets: 42 } as never,
+      },
+    });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText(/42 photos/)).toBeInTheDocument();
+  });
+
+  it('falls back to "Unnamed person" label when name is empty', () => {
+    render(PersonRow, {
+      props: { item: { id: 'p1', name: '' } as never },
+    });
+    expect(screen.getByText(/cmdk_unnamed_person|Unnamed/)).toBeInTheDocument();
+  });
+
+  it('renders the people thumbnail endpoint url', () => {
+    const { container } = render(PersonRow, {
+      props: { item: { id: 'p1', name: 'Alice' } as never },
+    });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toMatch(/\/api\/people\/p1\/thumbnail/);
+  });
+
+  it('swaps to placeholder div when the thumbnail image fails to load', async () => {
+    const { container } = render(PersonRow, {
+      props: { item: { id: 'p1', name: 'Alice' } as never },
+    });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    await fireEvent.error(img!);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('does NOT set role="option"', () => {
+    const { container } = render(PersonRow, {
+      props: { item: { id: 'p1', name: 'X' } as never },
+    });
+    expect(container.querySelector('[role="option"]')).toBeNull();
+  });
+});
+```
+
+**Step 2: Run the new tests — they should FAIL**
+
+```bash
+cd web
+pnpm test -- --run src/lib/components/global-search/__tests__/person-row.spec.ts
+```
+
+Expected: the "renders the people thumbnail endpoint url" and "swaps to
+placeholder div" cases FAIL because the component still uses
+`getAssetMediaUrl({ id: faceAssetId })` and the URL never matches
+`/api/people/.*/thumbnail`.
+
+**Step 3: Implement person-row.svelte**
+
+Open `web/src/lib/components/global-search/rows/person-row.svelte`.
+Replace the entire file with:
+
+```svelte
+<script lang="ts">
+  import { getPeopleThumbnailUrl } from '$lib/utils';
+  import { type PersonResponseDto } from '@immich/sdk';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    item: PersonResponseDto & { numberOfAssets?: number };
+  }
+  let { item }: Props = $props();
+
+  const thumbUrl = $derived(getPeopleThumbnailUrl(item));
+  let failed = $state(false);
+  // Reset the failure flag whenever the row swaps to a different person — the
+  // component instance is re-used by bits-ui as the user scrolls the list.
+  $effect(() => {
+    void item.id;
+    failed = false;
+  });
+</script>
+
+<div
+  class="flex h-[52px] items-center gap-3 rounded-lg px-3 py-2 transition-colors duration-[80ms] ease-out group-data-[selected]:bg-primary/10"
+>
+  {#if !failed}
+    <img
+      src={thumbUrl}
+      alt=""
+      class="h-10 w-10 rounded-full object-cover"
+      loading="lazy"
+      onerror={() => (failed = true)}
+    />
+  {:else}
+    <div class="h-10 w-10 rounded-full bg-subtle/40" aria-hidden="true"></div>
+  {/if}
+  <div class="min-w-0 flex-1">
+    <div class="truncate text-sm font-medium">{item.name || $t('cmdk_unnamed_person')}</div>
+    {#if item.numberOfAssets !== undefined}
+      <div class="text-xs text-gray-500 dark:text-gray-400">{item.numberOfAssets} photos</div>
+    {/if}
+  </div>
+</div>
+```
+
+**Step 4: Run tests — they should PASS**
+
+```bash
+pnpm test -- --run src/lib/components/global-search/__tests__/person-row.spec.ts
+```
+
+Expected: all 5 tests PASS.
+
+**Step 5: Do NOT commit yet** — Tasks 3-4 introduce coupled type changes;
+commit happens after Task 4 once the tree is consistent again.
+
+---
+
+## Task 2: Update person-preview test + component (RED + GREEN)
+
+**Files:**
+- Modify: `web/src/lib/components/global-search/__tests__/person-preview.spec.ts`
+- Modify: `web/src/lib/components/global-search/previews/person-preview.svelte`
+
+**Step 1: Update the test file**
+
+Replace the entire `describe('person-preview', () => { ... })` block with:
+
+```ts
+import { searchAssets } from '@immich/sdk';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PersonPreview from '../previews/person-preview.svelte';
+
+vi.mock('@immich/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk');
+  return { ...actual, searchAssets: vi.fn() };
+});
+
+describe('person-preview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.mocked(searchAssets).mockResolvedValue({ assets: { items: [], nextPage: null } } as never);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the person name and count', () => {
+    render(PersonPreview, {
+      props: {
+        person: { id: 'p1', name: 'Alice', numberOfAssets: 42 } as never,
+      },
+    });
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText(/42 photos/)).toBeInTheDocument();
+  });
+
+  it('defers searchAssets by 300ms after mount', async () => {
+    render(PersonPreview, { props: { person: { id: 'p1', name: 'Alice' } as never } });
+    await vi.advanceTimersByTimeAsync(200);
+    expect(searchAssets).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(150);
+    expect(searchAssets).toHaveBeenCalledOnce();
+  });
+
+  it('renders the people thumbnail endpoint url', () => {
+    const { container } = render(PersonPreview, {
+      props: { person: { id: 'p1', name: 'Alice' } as never },
+    });
+    const img = container.querySelector('[data-cmdk-preview-person] img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toMatch(/\/api\/people\/p1\/thumbnail/);
+  });
+
+  it('swaps to placeholder when the thumbnail image fails to load', async () => {
+    const { container } = render(PersonPreview, {
+      props: { person: { id: 'p1', name: 'Alice' } as never },
+    });
+    const img = container.querySelector('[data-cmdk-preview-person] > img');
+    expect(img).not.toBeNull();
+    await fireEvent.error(img!);
+    // After error: the avatar img is gone, only the placeholder div remains as
+    // the first child of the preview wrapper.
+    expect(container.querySelector('[data-cmdk-preview-person] > img')).toBeNull();
+    expect(container.querySelector('[data-cmdk-preview-person] > div[aria-hidden="true"]')).not.toBeNull();
+  });
+});
+```
+
+Note: the second img-existence selector uses `> img` (direct child) so it
+only matches the avatar, not the 4-asset strip below the name.
+
+**Step 2: Run tests — they should FAIL**
+
+```bash
+pnpm test -- --run src/lib/components/global-search/__tests__/person-preview.spec.ts
+```
+
+Expected: the "renders the people thumbnail endpoint url" and "swaps to
+placeholder" cases FAIL.
+
+**Step 3: Implement person-preview.svelte**
+
+Open `web/src/lib/components/global-search/previews/person-preview.svelte`.
+Replace the entire file with:
+
+```svelte
+<script lang="ts">
+  import { getAssetMediaUrl, getPeopleThumbnailUrl } from '$lib/utils';
+  import { AssetMediaSize, searchAssets, type AssetResponseDto, type PersonResponseDto } from '@immich/sdk';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    person: PersonResponseDto & { numberOfAssets?: number };
+  }
+  let { person }: Props = $props();
+
+  let photos = $state<AssetResponseDto[]>([]);
+  let loaded = $state(false);
+  let generation = 0;
+
+  const thumbUrl = $derived(getPeopleThumbnailUrl(person));
+  let failed = $state(false);
+  // Reset failure when the person changes (preview is re-used as the user
+  // arrows through the People section).
+  $effect(() => {
+    void person.id;
+    failed = false;
+  });
+
+  $effect(() => {
+    const gen = ++generation;
+    const id = person.id;
+    photos = [];
+    loaded = false;
+    const dwell = setTimeout(() => {
+      // Wrap the async work in an IIFE so setTimeout's callback is synchronous.
+      // ESLint's `no-misused-promises` flags async setTimeout callbacks because
+      // setTimeout doesn't await the returned promise.
+      void (async () => {
+        const ctrl = new AbortController();
+        try {
+          const response = await searchAssets(
+            { metadataSearchDto: { personIds: [id], size: 4 } },
+            { signal: ctrl.signal },
+          );
+          if (gen !== generation) {
+            return;
+          }
+          photos = response.assets.items;
+        } catch {
+          // ignore — preview is best-effort
+        } finally {
+          if (gen === generation) {
+            loaded = true;
+          }
+        }
+      })();
+    }, 300);
+    return () => clearTimeout(dwell);
+  });
+</script>
+
+<div data-cmdk-preview-person class="flex flex-col items-center gap-3 p-5">
+  {#if !failed}
+    <img
+      src={thumbUrl}
+      alt={person.name ?? ''}
+      class="h-[120px] w-[120px] rounded-full object-cover"
+      onerror={() => (failed = true)}
+    />
+  {:else}
+    <div class="h-[120px] w-[120px] rounded-full bg-subtle/40" aria-hidden="true"></div>
+  {/if}
+  <div class="text-center">
+    <div class="text-lg font-semibold">{person.name || $t('cmdk_unnamed_person')}</div>
+    {#if person.numberOfAssets !== undefined}
+      <div class="text-xs font-normal text-gray-500 dark:text-gray-400">{person.numberOfAssets} photos</div>
+    {/if}
+  </div>
+  {#if loaded && photos.length > 0}
+    <div class="mt-2 flex gap-2">
+      {#each photos as photo (photo.id)}
+        <img
+          src={getAssetMediaUrl({ id: photo.id, size: AssetMediaSize.Thumbnail })}
+          alt=""
+          class="h-12 w-12 rounded-md object-cover"
+        />
+      {/each}
+    </div>
+  {/if}
+</div>
+```
+
+**Step 4: Run tests — they should PASS**
+
+```bash
+pnpm test -- --run src/lib/components/global-search/__tests__/person-preview.spec.ts
+```
+
+Expected: all 4 tests PASS.
+
+**Step 5: Do NOT commit yet** — same reason as Task 1.
+
+---
+
+## Task 3: Drop `thumbnailAssetId` from `RecentEntry.person`
+
+**Files:**
+- Modify: `web/src/lib/stores/cmdk-recent.ts`
+
+**Step 1: Edit the type declaration**
+
+In `web/src/lib/stores/cmdk-recent.ts`, find the union member at line 16:
+
+```ts
+| { kind: 'person'; id: string; personId: string; label: string; thumbnailAssetId?: string; lastUsed: number }
+```
+
+Replace with:
+
+```ts
+| { kind: 'person'; id: string; personId: string; label: string; lastUsed: number }
+```
+
+**Step 2: Run cmdk-recent tests — should still PASS**
+
+```bash
+pnpm test -- --run src/lib/stores/cmdk-recent.spec.ts
+```
+
+Expected: all tests PASS. Existing tests don't reference `thumbnailAssetId`
+on person entries, so this is a pure type narrowing.
+
+**Step 3: Do NOT commit yet** — manager + recent-row still set the now-removed
+field and won't typecheck. Fixed in next task.
+
+---
+
+## Task 4: Drop `faceAssetId` plumbing in manager + recent-row
+
+**Files:**
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
+- Modify: `web/src/lib/components/global-search/rows/recent-row.svelte`
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Step 1: Update manager — `activate('person')`**
+
+In `web/src/lib/managers/global-search-manager.svelte.ts` around line 990,
+find:
+
+```ts
+case 'person': {
+  const p = item as { id: string; name?: string; faceAssetId?: string };
+  addEntry({
+    kind: 'person',
+    id: `person:${p.id}`,
+    personId: p.id,
+    label: p.name ?? '',
+    thumbnailAssetId: p.faceAssetId,
+    lastUsed: now,
+  });
+  void goto(Route.viewPerson({ id: p.id }));
+  break;
+}
+```
+
+Replace with:
+
+```ts
+case 'person': {
+  const p = item as { id: string; name?: string };
+  addEntry({
+    kind: 'person',
+    id: `person:${p.id}`,
+    personId: p.id,
+    label: p.name ?? '',
+    lastUsed: now,
+  });
+  void goto(Route.viewPerson({ id: p.id }));
+  break;
+}
+```
+
+**Step 2: Update manager — `activeItemFromRecent` person branch**
+
+In the same file around line 852, find:
+
+```ts
+case 'person': {
+  return {
+    kind: 'person',
+    data: {
+      id: entry.personId,
+      name: entry.label,
+      faceAssetId: entry.thumbnailAssetId,
+    } as unknown,
+  };
+}
+```
+
+Replace with:
+
+```ts
+case 'person': {
+  return {
+    kind: 'person',
+    data: {
+      id: entry.personId,
+      name: entry.label,
+    } as unknown,
+  };
+}
+```
+
+**Step 3: Update recent-row.svelte**
+
+In `web/src/lib/components/global-search/rows/recent-row.svelte` line 28,
+find:
+
+```svelte
+<PersonRow item={{ id: entry.personId, name: entry.label, faceAssetId: entry.thumbnailAssetId } as never} />
+```
+
+Replace with:
+
+```svelte
+<PersonRow item={{ id: entry.personId, name: entry.label } as never} />
+```
+
+**Step 4: Update manager spec — line 818**
+
+In `web/src/lib/managers/global-search-manager.svelte.spec.ts` line 818-822,
+find:
+
+```ts
+m.activate('person', { id: 'p1', name: 'Alice', faceAssetId: 'face1' });
+expect(goto).toHaveBeenCalledWith('/people/p1');
+const entries = getEntries();
+expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice', thumbnailAssetId: 'face1' });
+```
+
+Replace with:
+
+```ts
+m.activate('person', { id: 'p1', name: 'Alice' });
+expect(goto).toHaveBeenCalledWith('/people/p1');
+const entries = getEntries();
+expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice' });
+```
+
+**Step 5: Update manager spec — `synthesizes a person ActiveItem` case (~line 2549)**
+
+Find the test that adds a person recent and asserts `faceAssetId`. The
+fixture passes `thumbnailAssetId: 'face-1'` to `addEntry` and asserts
+`data.faceAssetId === 'face-1'`. Update both:
+
+- In the `addEntry({ kind: 'person', ...` call, **remove** the
+  `thumbnailAssetId: 'face-1',` line.
+- Replace the assertion block:
+
+  ```ts
+  if (active?.kind === 'person') {
+    const data = active.data as { id: string; name: string; faceAssetId: string };
+    expect(data.id).toBe('p1');
+    expect(data.name).toBe('Alice');
+    expect(data.faceAssetId).toBe('face-1');
+  }
+  ```
+
+  with:
+
+  ```ts
+  if (active?.kind === 'person') {
+    const data = active.data as { id: string; name: string };
+    expect(data.id).toBe('p1');
+    expect(data.name).toBe('Alice');
+  }
+  ```
+
+**Step 6: Run the full web unit test suite**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: all tests PASS. If any spec fails because it referenced
+`faceAssetId` or `thumbnailAssetId` on person entries that this plan
+missed, fix the spec the same way (remove the field from fixtures, drop
+the assertion).
+
+**Step 7: Run svelte-check + tsc**
+
+```bash
+cd ..
+make check-web
+```
+
+Expected: zero errors. The dropped `thumbnailAssetId` field on the
+`person` recent variant is exhaustive — if anything still references it,
+TypeScript will fail and point at the file.
+
+If `make check-web` fails, address each error and re-run before continuing.
+
+---
+
+## Task 5: Commit fix
+
+**Step 1: Stage and commit**
+
+```bash
+cd ..
+git add \
+  web/src/lib/components/global-search/rows/person-row.svelte \
+  web/src/lib/components/global-search/rows/recent-row.svelte \
+  web/src/lib/components/global-search/previews/person-preview.svelte \
+  web/src/lib/components/global-search/__tests__/person-row.spec.ts \
+  web/src/lib/components/global-search/__tests__/person-preview.spec.ts \
+  web/src/lib/managers/global-search-manager.svelte.ts \
+  web/src/lib/managers/global-search-manager.svelte.spec.ts \
+  web/src/lib/stores/cmdk-recent.ts
+git status --short
+```
+
+Confirm only the files above are staged (no unrelated diffs).
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(web): cmdk palette person thumbnails
+
+PersonResponseDto has no faceAssetId field — the existing intersection
+type silently let the property be undefined and the thumbnail ternary
+always fell through to the placeholder div. Switch person row + preview
+to getPeopleThumbnailUrl(person), which hits the dedicated face-crop
+endpoint used elsewhere in the app, and add an onerror fallback for the
+404 case (deleted person, thumbnail not yet generated).
+
+Drops the dead faceAssetId / thumbnailAssetId plumbing from the recent
+store, the manager's activate/activeItemFromRecent paths, and the
+recent-row component. Backward-compatible with stale localStorage
+entries: the JSON read path does no narrowing, and the new code
+silently ignores the extra property.
+EOF
+)"
+```
+
+---
+
+## Task 6: Update placeholder hint + commit
+
+**Files:**
+- Modify: `i18n/en.json`
+
+**Step 1: Edit the placeholder string**
+
+In `i18n/en.json` line 839, find:
+
+```json
+"cmdk_placeholder": "Search Gallery",
+```
+
+Replace with:
+
+```json
+"cmdk_placeholder": "Search Gallery — try @ for people, # tags, / albums, > pages",
+```
+
+**Step 2: Run i18n format/sort**
+
+The repo enforces sorted keys via a dedicated script (per memory
+`feedback_i18n_key_sorting`):
+
+```bash
+pnpm --filter=immich-i18n format:fix
+```
+
+Expected: clean exit, no diff (the key already exists in place).
+
+**Step 3: Run web unit tests + svelte-check**
+
+```bash
+cd web
+pnpm test -- --run
+cd ..
+make check-web
+```
+
+Expected: all tests PASS, zero check errors.
+
+**Step 4: Commit**
+
+```bash
+git add i18n/en.json
+git status --short
+```
+
+Confirm only `i18n/en.json` is staged.
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(web): cmdk placeholder advertises @ # / > scope prefixes
+
+The footer chip and the keyboard-shortcut modal already document the
+prefixes, but the search input — the most prominent affordance on a
+fresh palette open — said only "Search Gallery". Inline the prefix →
+entity mapping so users discover @ for people, # for tags, / for
+albums/spaces, and > for pages without having to look elsewhere.
+
+Long string (62 chars); on narrow viewports it clips left-to-right so
+the head ("try @ for people, # tags") stays visible.
+EOF
+)"
+```
+
+---
+
+## Task 7: Push + open PR
+
+**Step 1: Push branch**
+
+```bash
+git push -u origin fix/cmdk-people-thumbnails
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create --title "fix(web): cmdk palette people thumbnails + scope hint" --body "$(cat <<'EOF'
+## Summary
+
+Two post-merge polish fixes for the cmdk palette (PR #365):
+
+- **Fix blank face thumbnails.** `PersonResponseDto` has no `faceAssetId`
+  field — the intersection type silently allowed undefined and the
+  thumbnail ternary always fell through to the placeholder div. Switch
+  to `getPeopleThumbnailUrl(person)` (the dedicated `/api/people/:id/thumbnail`
+  endpoint used elsewhere in the app). `<img onerror>` falls back to the
+  placeholder for 404s.
+- **Discoverability for `@ # / >` scope prefixes.** Inline the prefix →
+  entity mapping into `cmdk_placeholder` so the search input itself
+  documents what the prefixes do.
+
+Design doc: `docs/plans/2026-04-17-cmdk-followups-design.md`
+
+## Test plan
+
+- [ ] CI green
+- [ ] Open palette (Ctrl+K), type `@`: rows render face thumbnails (cropped
+      circles), not blank placeholders. Highlighted row's preview pane shows
+      the same face in the big circle on the right.
+- [ ] Type `@alice` (or any name): same — thumbnails resolve.
+- [ ] Open palette fresh: placeholder reads
+      `Search Gallery — try @ for people, # tags, / albums, > pages`.
+- [ ] Trigger an `onerror` (e.g. delete a person and re-open recents that
+      still reference it): row falls back to the grey placeholder
+      circle without breaking layout.
+- [ ] On `pierre.opennoodle.de` (real photo library): browse a few
+      arrowed-through people in the People section to confirm the row
+      thumbnail and the preview pane both update correctly per person.
+EOF
+)"
+```
+
+Expected: PR URL printed. Save the URL — that's what gets reported back
+to the user.
+
+---
+
+## Notes for the implementer
+
+- **Order matters.** Tasks 1-4 leave the tree in an uncompiled state
+  intentionally. Don't try to commit between them.
+- **No server / SDK / OpenAPI / migration changes.** If you find yourself
+  reaching for `make sql` or `make open-api`, you're off-plan.
+- **Don't run tests in parallel** (per memory `feedback_no_parallel_tests`).
+  One `pnpm test -- --run <file>` at a time, then the full suite at the end.
+- **`make check-web` is the gate**, not lint. Lint runs in CI; tsc/svelte-check
+  is what catches the type fallout from the recent-store change.
+- **Memory references that informed this plan:**
+  `feedback_format_docs.md` (prettier on docs/plans),
+  `feedback_i18n_key_sorting.md` (use `pnpm --filter=immich-i18n format:fix`),
+  `feedback_always_use_prs.md`,
+  `feedback_lint_sequential.md` (lint last),
+  `feedback_no_parallel_tests.md`.

--- a/docs/plans/2026-04-17-cmdk-followups-plan.md
+++ b/docs/plans/2026-04-17-cmdk-followups-plan.md
@@ -26,6 +26,7 @@ Use `pnpm test -- --run <file>` to scope test runs.
 ## Task 1: Update person-row test (RED + GREEN)
 
 **Files:**
+
 - Modify: `web/src/lib/components/global-search/__tests__/person-row.spec.ts`
 
 **Step 1: Replace the test file**
@@ -166,6 +167,7 @@ commit happens after Task 4 once the tree is consistent again.
 ## Task 2: Update person-preview test + component (RED + GREEN)
 
 **Files:**
+
 - Modify: `web/src/lib/components/global-search/__tests__/person-preview.spec.ts`
 - Modify: `web/src/lib/components/global-search/previews/person-preview.svelte`
 
@@ -356,6 +358,7 @@ Expected: all 4 tests PASS.
 ## Task 3: Drop `thumbnailAssetId` from `RecentEntry.person`
 
 **Files:**
+
 - Modify: `web/src/lib/stores/cmdk-recent.ts`
 
 **Step 1: Edit the type declaration**
@@ -389,6 +392,7 @@ field and won't typecheck. Fixed in next task.
 ## Task 4: Drop `faceAssetId` plumbing in manager + recent-row
 
 **Files:**
+
 - Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
 - Modify: `web/src/lib/components/global-search/rows/recent-row.svelte`
 - Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
@@ -598,6 +602,7 @@ EOF
 ## Task 6: Update placeholder hint + commit
 
 **Files:**
+
 - Modify: `i18n/en.json`
 
 **Step 1: Edit the placeholder string**

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -836,7 +836,7 @@
   "cmdk_open": "Open",
   "cmdk_people_heading": "People",
   "cmdk_photos_heading": "Photos",
-  "cmdk_placeholder": "Search Gallery",
+  "cmdk_placeholder": "Search Gallery — try @ for people, # tags, / albums, > pages",
   "cmdk_places_heading": "Places",
   "cmdk_preview_item_count": "{count, plural, one {# item} other {# items}}",
   "cmdk_preview_member_count": "{count, plural, one {# member} other {# members}}",

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Shared hoisted user mock — navigation provider and render-time recent filter both
 // read `get(user)` / `$user`. Must appear above the component import so Vitest hoists
@@ -129,6 +129,15 @@ describe('global-search root', () => {
     mockUser.current = { id: 'test-user', isAdmin: false };
     mockFlags.valueOrUndefined = { search: true, map: true, trash: true };
     user = userEvent.setup({ pointerEventsCheck: 0 });
+  });
+
+  // Drain bits-ui's body-scroll-lock deferred cleanup (setTimeout with 24ms
+  // delay in bits-ui/dist/internal/body-scroll-lock.svelte.js) before happy-dom
+  // tears down the document. Without this, the cleanup fires after teardown
+  // and throws `ReferenceError: document is not defined` as an unhandled error,
+  // which Vitest surfaces as a whole-file failure even though every test passed.
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
   });
 
   it('renders dialog containing the palette', () => {

--- a/web/src/lib/components/global-search/__tests__/person-preview.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/person-preview.spec.ts
@@ -1,5 +1,5 @@
 import { searchAssets } from '@immich/sdk';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PersonPreview from '../previews/person-preview.svelte';
 
@@ -21,7 +21,7 @@ describe('person-preview', () => {
   it('renders the person name and count', () => {
     render(PersonPreview, {
       props: {
-        person: { id: 'p1', name: 'Alice', faceAssetId: 'face1', numberOfAssets: 42 } as never,
+        person: { id: 'p1', name: 'Alice', numberOfAssets: 42 } as never,
       },
     });
     expect(screen.getByText('Alice')).toBeInTheDocument();
@@ -29,17 +29,30 @@ describe('person-preview', () => {
   });
 
   it('defers searchAssets by 300ms after mount', async () => {
-    render(PersonPreview, { props: { person: { id: 'p1', name: 'Alice', faceAssetId: 'f' } as never } });
+    render(PersonPreview, { props: { person: { id: 'p1', name: 'Alice' } as never } });
     await vi.advanceTimersByTimeAsync(200);
     expect(searchAssets).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(150);
     expect(searchAssets).toHaveBeenCalledOnce();
   });
 
-  it('falls back to placeholder when faceAssetId is missing', () => {
+  it('renders the people thumbnail endpoint url', () => {
     const { container } = render(PersonPreview, {
-      props: { person: { id: 'p1', name: 'NoFace' } as never },
+      props: { person: { id: 'p1', name: 'Alice' } as never },
     });
-    expect(container.querySelector('img')).toBeNull();
+    const img = container.querySelector('[data-cmdk-preview-person] > img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toMatch(/\/api\/people\/p1\/thumbnail/);
+  });
+
+  it('swaps to placeholder when the thumbnail image fails to load', async () => {
+    const { container } = render(PersonPreview, {
+      props: { person: { id: 'p1', name: 'Alice' } as never },
+    });
+    const img = container.querySelector('[data-cmdk-preview-person] > img');
+    expect(img).not.toBeNull();
+    await fireEvent.error(img!);
+    expect(container.querySelector('[data-cmdk-preview-person] > img')).toBeNull();
+    expect(container.querySelector('[data-cmdk-preview-person] > div[aria-hidden="true"]')).not.toBeNull();
   });
 });

--- a/web/src/lib/components/global-search/__tests__/person-row.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/person-row.spec.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import PersonRow from '../rows/person-row.svelte';
 
@@ -6,7 +6,7 @@ describe('person-row', () => {
   it('renders the person name and asset count', () => {
     render(PersonRow, {
       props: {
-        item: { id: 'p1', name: 'Alice', faceAssetId: 'face1', numberOfAssets: 42 } as never,
+        item: { id: 'p1', name: 'Alice', numberOfAssets: 42 } as never,
       },
     });
     expect(screen.getByText('Alice')).toBeInTheDocument();
@@ -15,22 +15,34 @@ describe('person-row', () => {
 
   it('falls back to "Unnamed person" label when name is empty', () => {
     render(PersonRow, {
-      props: { item: { id: 'p1', name: '', faceAssetId: 'face1' } as never },
+      props: { item: { id: 'p1', name: '' } as never },
     });
     expect(screen.getByText(/cmdk_unnamed_person|Unnamed/)).toBeInTheDocument();
   });
 
-  it('renders a placeholder div when faceAssetId is missing', () => {
+  it('renders the people thumbnail endpoint url', () => {
     const { container } = render(PersonRow, {
-      props: { item: { id: 'p1', name: 'NoFace' } as never },
+      props: { item: { id: 'p1', name: 'Alice' } as never },
     });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toMatch(/\/api\/people\/p1\/thumbnail/);
+  });
+
+  it('swaps to placeholder div when the thumbnail image fails to load', async () => {
+    const { container } = render(PersonRow, {
+      props: { item: { id: 'p1', name: 'Alice' } as never },
+    });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    await fireEvent.error(img!);
     expect(container.querySelector('img')).toBeNull();
     expect(container.querySelector('[aria-hidden="true"]')).not.toBeNull();
   });
 
   it('does NOT set role="option"', () => {
     const { container } = render(PersonRow, {
-      props: { item: { id: 'p1', name: 'X', faceAssetId: 'f' } as never },
+      props: { item: { id: 'p1', name: 'X' } as never },
     });
     expect(container.querySelector('[role="option"]')).toBeNull();
   });

--- a/web/src/lib/components/global-search/previews/person-preview.svelte
+++ b/web/src/lib/components/global-search/previews/person-preview.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { getAssetMediaUrl } from '$lib/utils';
+  import { getAssetMediaUrl, getPeopleThumbnailUrl } from '$lib/utils';
   import { AssetMediaSize, searchAssets, type AssetResponseDto, type PersonResponseDto } from '@immich/sdk';
   import { t } from 'svelte-i18n';
 
   interface Props {
-    person: PersonResponseDto & { numberOfAssets?: number; faceAssetId?: string };
+    person: PersonResponseDto & { numberOfAssets?: number };
   }
   let { person }: Props = $props();
 
@@ -12,9 +12,14 @@
   let loaded = $state(false);
   let generation = 0;
 
-  const thumbUrl = $derived(
-    person.faceAssetId ? getAssetMediaUrl({ id: person.faceAssetId, size: AssetMediaSize.Preview }) : '',
-  );
+  const thumbUrl = $derived(getPeopleThumbnailUrl(person));
+  let failed = $state(false);
+  // Reset failure when the person changes (preview is re-used as the user
+  // arrows through the People section).
+  $effect(() => {
+    void person.id;
+    failed = false;
+  });
 
   $effect(() => {
     const gen = ++generation;
@@ -50,8 +55,13 @@
 </script>
 
 <div data-cmdk-preview-person class="flex flex-col items-center gap-3 p-5">
-  {#if thumbUrl}
-    <img src={thumbUrl} alt={person.name ?? ''} class="h-[120px] w-[120px] rounded-full object-cover" />
+  {#if !failed}
+    <img
+      src={thumbUrl}
+      alt={person.name ?? ''}
+      class="h-[120px] w-[120px] rounded-full object-cover"
+      onerror={() => (failed = true)}
+    />
   {:else}
     <div class="h-[120px] w-[120px] rounded-full bg-subtle/40" aria-hidden="true"></div>
   {/if}

--- a/web/src/lib/components/global-search/rows/person-row.svelte
+++ b/web/src/lib/components/global-search/rows/person-row.svelte
@@ -1,23 +1,34 @@
 <script lang="ts">
-  import { getAssetMediaUrl } from '$lib/utils';
-  import { AssetMediaSize, type PersonResponseDto } from '@immich/sdk';
+  import { getPeopleThumbnailUrl } from '$lib/utils';
+  import { type PersonResponseDto } from '@immich/sdk';
   import { t } from 'svelte-i18n';
 
   interface Props {
-    item: PersonResponseDto & { numberOfAssets?: number; faceAssetId?: string };
+    item: PersonResponseDto & { numberOfAssets?: number };
   }
   let { item }: Props = $props();
 
-  const thumbUrl = $derived(
-    item.faceAssetId ? getAssetMediaUrl({ id: item.faceAssetId, size: AssetMediaSize.Thumbnail }) : '',
-  );
+  const thumbUrl = $derived(getPeopleThumbnailUrl(item));
+  let failed = $state(false);
+  // Reset the failure flag whenever the row swaps to a different person — the
+  // component instance is re-used by bits-ui as the user scrolls the list.
+  $effect(() => {
+    void item.id;
+    failed = false;
+  });
 </script>
 
 <div
   class="flex h-[52px] items-center gap-3 rounded-lg px-3 py-2 transition-colors duration-[80ms] ease-out group-data-[selected]:bg-primary/10"
 >
-  {#if thumbUrl}
-    <img src={thumbUrl} alt="" class="h-10 w-10 rounded-full object-cover" loading="lazy" />
+  {#if !failed}
+    <img
+      src={thumbUrl}
+      alt=""
+      class="h-10 w-10 rounded-full object-cover"
+      loading="lazy"
+      onerror={() => (failed = true)}
+    />
   {:else}
     <div class="h-10 w-10 rounded-full bg-subtle/40" aria-hidden="true"></div>
   {/if}

--- a/web/src/lib/components/global-search/rows/recent-row.svelte
+++ b/web/src/lib/components/global-search/rows/recent-row.svelte
@@ -25,7 +25,7 @@
 {:else if entry.kind === 'photo'}
   <PhotoRow item={{ id: entry.assetId, originalFileName: entry.label } as never} />
 {:else if entry.kind === 'person'}
-  <PersonRow item={{ id: entry.personId, name: entry.label, faceAssetId: entry.thumbnailAssetId } as never} />
+  <PersonRow item={{ id: entry.personId, name: entry.label } as never} />
 {:else if entry.kind === 'place'}
   <PlaceRow item={{ name: entry.label, latitude: entry.latitude, longitude: entry.longitude } as never} />
 {:else if entry.kind === 'tag'}

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -815,10 +815,10 @@ describe('activate()', () => {
   it('activate("person", item) navigates to /people/:id and records recent entry', () => {
     const m = new GlobalSearchManager();
     m.open();
-    m.activate('person', { id: 'p1', name: 'Alice', faceAssetId: 'face1' });
+    m.activate('person', { id: 'p1', name: 'Alice' });
     expect(goto).toHaveBeenCalledWith('/people/p1');
     const entries = getEntries();
-    expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice', thumbnailAssetId: 'face1' });
+    expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice' });
   });
 
   it('activate("place", item) navigates to /map with hash and records recent entry', () => {
@@ -2553,7 +2553,6 @@ describe('getActiveItem recent-entry preview lookup (cold open)', () => {
       id: 'person:p1',
       personId: 'p1',
       label: 'Alice',
-      thumbnailAssetId: 'face-1',
       lastUsed: 1,
     });
     const m = new GlobalSearchManager();
@@ -2562,10 +2561,9 @@ describe('getActiveItem recent-entry preview lookup (cold open)', () => {
     const active = m.getActiveItem();
     expect(active?.kind).toBe('person');
     if (active?.kind === 'person') {
-      const data = active.data as { id: string; name: string; faceAssetId: string };
+      const data = active.data as { id: string; name: string };
       expect(data.id).toBe('p1');
       expect(data.name).toBe('Alice');
-      expect(data.faceAssetId).toBe('face-1');
     }
   });
 

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -855,7 +855,6 @@ export class GlobalSearchManager {
           data: {
             id: entry.personId,
             name: entry.label,
-            faceAssetId: entry.thumbnailAssetId,
           } as unknown,
         };
       }
@@ -988,13 +987,12 @@ export class GlobalSearchManager {
         break;
       }
       case 'person': {
-        const p = item as { id: string; name?: string; faceAssetId?: string };
+        const p = item as { id: string; name?: string };
         addEntry({
           kind: 'person',
           id: `person:${p.id}`,
           personId: p.id,
           label: p.name ?? '',
-          thumbnailAssetId: p.faceAssetId,
           lastUsed: now,
         });
         void goto(Route.viewPerson({ id: p.id }));

--- a/web/src/lib/stores/cmdk-recent.ts
+++ b/web/src/lib/stores/cmdk-recent.ts
@@ -13,7 +13,7 @@ const MAX_ENTRIES = 20;
 export type RecentEntry =
   | { kind: 'query'; id: string; text: string; mode: SearchMode; lastUsed: number }
   | { kind: 'photo'; id: string; assetId: string; label: string; lastUsed: number }
-  | { kind: 'person'; id: string; personId: string; label: string; thumbnailAssetId?: string; lastUsed: number }
+  | { kind: 'person'; id: string; personId: string; label: string; lastUsed: number }
   | { kind: 'place'; id: string; latitude: number; longitude: number; label: string; lastUsed: number }
   | { kind: 'tag'; id: string; tagId: string; label: string; lastUsed: number }
   | {


### PR DESCRIPTION
## Summary

Two post-merge polish fixes for the cmdk palette (PR #365):

- **Fix blank face thumbnails.** `PersonResponseDto` has no `faceAssetId` field — the intersection type silently allowed undefined and the thumbnail ternary always fell through to the placeholder div. Switch to `getPeopleThumbnailUrl(person)` (the dedicated `/api/people/:id/thumbnail` endpoint used elsewhere in the app). `<img onerror>` falls back to the placeholder for 404s.
- **Discoverability for `@ # / >` scope prefixes.** Inline the prefix → entity mapping into `cmdk_placeholder` so the search input itself documents what the prefixes do.

Design doc: `docs/plans/2026-04-17-cmdk-followups-design.md`

## Test plan

- [ ] CI green
- [ ] Open palette (Ctrl+K), type `@`: rows render face thumbnails (cropped circles), not blank placeholders. Highlighted row's preview pane shows the same face in the big circle on the right.
- [ ] Type `@alice` (or any name): same — thumbnails resolve.
- [ ] Open palette fresh: placeholder reads `Search Gallery — try @ for people, # tags, / albums, > pages`.
- [ ] Trigger an `onerror` (e.g. delete a person and re-open recents that still reference it): row falls back to the grey placeholder circle without breaking layout.
- [ ] On `pierre.opennoodle.de` (real photo library): browse a few arrowed-through people in the People section to confirm the row thumbnail and the preview pane both update correctly per person.