### PR TITLE
fix(branding): use bash ANSI-C quoting for tab indent, drop grep -P

### DIFF
--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -429,8 +429,10 @@ patch_ios() {
   # The CFBundleURLSchemes <string>immich</string> entry sits at 4-tab indent inside
   # CFBundleURLTypes; CFBundleName (also <string>${NAME_SLUG}</string>) is at 1-tab indent,
   # so we anchor the idempotency check to the 4-tab prefix to avoid a false-positive when
-  # NAME_SLUG happens to equal DEEP_LINK_SCHEME.
-  if ! grep -qP "^\t\t\t\t<string>${DEEP_LINK_SCHEME}</string>" "$info_plist"; then
+  # NAME_SLUG happens to equal DEEP_LINK_SCHEME. Use $'\t' ANSI-C quoting for literal
+  # tabs — BSD grep (macOS) lacks -P.
+  local indent=$'\t\t\t\t'
+  if ! grep -q "^${indent}<string>${DEEP_LINK_SCHEME}</string>" "$info_plist"; then
     sed -i $'/\t\t\t\t<string>immich<\\/string>/a\\\n\t\t\t\t<string>'"${DEEP_LINK_SCHEME}"$'<\\/string>' "$info_plist"
   fi
 

--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -166,10 +166,12 @@ info_plist="$REPO_ROOT/mobile/ios/Runner/Info.plist"
 if [[ -f "$info_plist" ]]; then
   # CFBundleURLSchemes entries sit at 4-tab indent; anchor to that to avoid matching
   # CFBundleName (<string>${NAME_SLUG}</string>) at 1-tab indent.
-  if ! grep -qP "^\t\t\t\t<string>immich</string>" "$info_plist"; then
+  # Use $'\t' ANSI-C quoting for literal tabs — BSD grep (macOS) lacks -P.
+  indent=$'\t\t\t\t'
+  if ! grep -q "^${indent}<string>immich</string>" "$info_plist"; then
     echo "  FAIL: Info.plist missing <string>immich</string> in CFBundleURLSchemes (legacy scheme must remain)"
     EXIT_CODE=1
-  elif ! grep -qP "^\t\t\t\t<string>${DEEP_LINK_SCHEME}</string>" "$info_plist"; then
+  elif ! grep -q "^${indent}<string>${DEEP_LINK_SCHEME}</string>" "$info_plist"; then
     echo "  FAIL: Info.plist missing <string>${DEEP_LINK_SCHEME}</string> in CFBundleURLSchemes"
     EXIT_CODE=1
   else


### PR DESCRIPTION
## Summary

- Replace `grep -qP "^\t\t\t\t..."` with `indent=$'\t\t\t\t'; grep -q "^${indent}..."` in `verify-branding.sh` and `apply-branding.sh`.

## Why

`grep -P` (Perl-compatible regex) is GNU-only. macOS ships BSD grep, which rejects `-P` with `grep: invalid option -- P`. PR #361 introduced these checks to verify both `immich://` and `noodle-gallery://` URL schemes are present in `Info.plist`'s `CFBundleURLSchemes`. The Android branch of the mobile build runs on `ubuntu-latest` (GNU grep) so it passed, but today's first iOS build since #361 hit the macOS runner and exploded in `verify-branding.sh`:

```
grep: invalid option -- P
FAIL: Info.plist missing <string>immich</string> in CFBundleURLSchemes (legacy scheme must remain)
```

`$'\t'` ANSI-C quoting emits literal tab bytes before the string is passed to grep, so a plain (POSIX-BRE) `grep -q "^<tab><tab><tab><tab><string>..."` matches on both BSD and GNU grep — no Perl regex needed for this use.

Run that failed: https://github.com/open-noodle/gallery/actions/runs/24582084007

## Test plan

- [x] `$'\t\t\t\t'` expansion matches real `Info.plist` locally (`grep -q "^${indent}<string>immich</string>" mobile/ios/Runner/Info.plist` returns 0)
- [ ] Green CI on this PR (`Zizmor`, `.github Files Formatting`, `ShellCheck`)
- [ ] After merge: re-trigger Release Mobile P1 and confirm the iOS branding step passes