### PR TITLE
fix(mobile): clarify iOS photo library purpose strings

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -147,9 +147,9 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>We need to access the microphone to let you take beautiful video using this app</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>We need to manage backup your photos album</string>
+	<string>Noodle Gallery needs access to your photo library to save photos and videos to your device. For example, when you download an asset from your Gallery server, it is added to your device's Photos app.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>We need to manage backup your photos album</string>
+	<string>Noodle Gallery needs access to your photo library to back up your photos and videos to your Gallery server. For example, selected albums are uploaded in the background so your memories are preserved and viewable across your devices.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -133,23 +133,23 @@
 		<string>_CC1AD845._googlecast._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>Noodle Gallery needs access to your camera so you can capture photos and videos directly from the app. For example, you can take a new photo and have it uploaded to your Gallery server alongside your existing library.</string>
+	<string>Noodle Gallery uses the camera so you can capture photos and videos in the app. For example, a photo you take is uploaded to your own self-hosted Gallery server and is not sent to any third party.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Noodle Gallery uses Face ID to protect your private content. For example, Face ID is required to unlock the locked folder where you have hidden sensitive photos and videos.</string>
+	<string>Noodle Gallery uses Face ID to unlock your private content. For example, Face ID is checked locally on your device to open the locked folder and is never sent off-device.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Noodle Gallery needs local network access to communicate with your self-hosted Gallery server on your home network. For example, this allows the app to connect to your server by its local IP address and cast photos to a TV on the same network.</string>
+	<string>Noodle Gallery uses the local network to reach your self-hosted Gallery server. For example, your device connects directly to the server's local IP to sync photos and cast to a TV; no data is sent to third-party servers.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Noodle Gallery uses your location in the background to detect which Wi-Fi network you are connected to, so that automatic backups only run on networks you trust. For example, you can configure the app to upload your photos only when connected to your home Wi-Fi and pause uploads on cellular or public networks.</string>
+	<string>Noodle Gallery uses your location in the background only to read the current Wi-Fi network name, so backups run only on networks you trust. For example, uploads continue on your home Wi-Fi and pause elsewhere. Your location is used on-device and never uploaded.</string>
 	<key>NSLocationUsageDescription</key>
-	<string>Noodle Gallery uses your location to detect which Wi-Fi network you are connected to, so that automatic backups only run on networks you trust. For example, you can configure the app to upload your photos only when connected to your home Wi-Fi.</string>
+	<string>Noodle Gallery uses your location only to read the current Wi-Fi network name, so backups run only on networks you trust. For example, uploads continue on your home Wi-Fi. Your location is used on-device and never uploaded.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Noodle Gallery uses your location to detect which Wi-Fi network you are connected to, so that automatic backups only run on networks you trust. For example, you can configure the app to upload your photos only when connected to your home Wi-Fi.</string>
+	<string>Noodle Gallery uses your location only to read the current Wi-Fi network name, so backups run only on networks you trust. For example, uploads continue on your home Wi-Fi. Your location is used on-device and never uploaded.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Noodle Gallery needs access to your microphone so that videos you record with the in-app camera include audio. For example, when you capture a video from within the app, the microphone records sound alongside the footage before it is uploaded to your Gallery server.</string>
+	<string>Noodle Gallery uses the microphone to record audio when you capture video in the app. For example, the resulting video is uploaded to your own self-hosted Gallery server and is not sent to any third party.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Noodle Gallery needs access to your photo library to save photos and videos to your device. For example, when you download an asset from your Gallery server, it is added to your device's Photos app.</string>
+	<string>Noodle Gallery saves photos and videos to your photo library. For example, when you download an asset from your Gallery server, it is added to the Photos app and stays on your device.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Noodle Gallery needs access to your photo library to back up your photos and videos to your Gallery server. For example, selected albums are uploaded in the background so your memories are preserved and viewable across your devices.</string>
+	<string>Noodle Gallery reads your photo library to back up selected photos and videos. For example, chosen albums are uploaded to your own self-hosted Gallery server and are not sent to any third party.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -133,19 +133,19 @@
 		<string>_CC1AD845._googlecast._tcp</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>We need to access the camera to let you take beautiful video using this app</string>
+	<string>Noodle Gallery needs access to your camera so you can capture photos and videos directly from the app. For example, you can take a new photo and have it uploaded to your Gallery server alongside your existing library.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>We need to use FaceID to allow access to your locked folder</string>
+	<string>Noodle Gallery uses Face ID to protect your private content. For example, Face ID is required to unlock the locked folder where you have hidden sensitive photos and videos.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>We need local network permission to connect to the local server using IP address and allow the casting feature to work</string>
+	<string>Noodle Gallery needs local network access to communicate with your self-hosted Gallery server on your home network. For example, this allows the app to connect to your server by its local IP address and cast photos to a TV on the same network.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>We require this permission to access the local WiFi name for background upload mechanism</string>
+	<string>Noodle Gallery uses your location in the background to detect which Wi-Fi network you are connected to, so that automatic backups only run on networks you trust. For example, you can configure the app to upload your photos only when connected to your home Wi-Fi and pause uploads on cellular or public networks.</string>
 	<key>NSLocationUsageDescription</key>
-	<string>We require this permission to access the local WiFi name</string>
+	<string>Noodle Gallery uses your location to detect which Wi-Fi network you are connected to, so that automatic backups only run on networks you trust. For example, you can configure the app to upload your photos only when connected to your home Wi-Fi.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>We require this permission to access the local WiFi name</string>
+	<string>Noodle Gallery uses your location to detect which Wi-Fi network you are connected to, so that automatic backups only run on networks you trust. For example, you can configure the app to upload your photos only when connected to your home Wi-Fi.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>We need to access the microphone to let you take beautiful video using this app</string>
+	<string>Noodle Gallery needs access to your microphone so that videos you record with the in-app camera include audio. For example, when you capture a video from within the app, the microphone records sound alongside the footage before it is uploaded to your Gallery server.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Noodle Gallery needs access to your photo library to save photos and videos to your device. For example, when you download an asset from your Gallery server, it is added to your device's Photos app.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
## Summary
- Apple rejected v4.51.0 under guideline 5.1.1(ii) because the iOS photo library purpose string did not sufficiently describe the app's use of the data.
- Rewrote both `NSPhotoLibraryUsageDescription` and `NSPhotoLibraryAddUsageDescription` in `mobile/ios/Runner/Info.plist` to explain the use and include a concrete example, matching App Store review guidance.

## Test plan
- [ ] Build iOS app and verify the updated strings appear in the photo library permission prompt
- [ ] Resubmit to App Store Connect