### PR TITLE
docs(plans): cmdk palette v1.4 design — context-aware commands + inline confirm

### DIFF
--- a/docs/plans/2026-04-19-cmdk-v1.4-design.md
+++ b/docs/plans/2026-04-19-cmdk-v1.4-design.md
@@ -1,0 +1,795 @@
+# Design: cmdk palette v1.4 — Context-aware commands + inline confirm
+
+Sixth installment of the command palette. v1.3.0 (#374) shipped 7
+stateless global verbs. v1.3.1 (#379) added 8 admin queue verbs. Both
+are route-agnostic — they fire identically whether the user hits
+Ctrl+K on `/photos`, `/albums/abc`, or `/settings`.
+
+v1.4 introduces **context-aware commands** — verbs that only surface
+on specific pages and operate on the entity the user is looking at.
+Lead surfaces: album detail (`/albums/[albumId=id]/…`) and space
+detail (`/spaces/[spaceId]/…`). The v1.3 design doc deferred two
+pieces of infra here: a `CommandContext` primitive with stale-context
+handling, and an inline-confirm UX for destructive verbs. They ship
+together because `Delete this album` is the forcing function for the
+confirm UX and vice-versa.
+
+## Non-goals (v1.4)
+
+- **Selection verbs** (Add selected to album / Favorite / Archive) —
+  deferred to v1.5 per the v1.3 design. Requires `selectedAssetIds`
+  plumbing and a separate "palette opened from selection toolbar"
+  trigger.
+- **Multi-step palette state** (asset picker inside the palette for
+  "Add photos to this album") — deferred to v1.5.
+- **Settings toggles** (map-tile theme, `showInTimeline`,
+  auto-classification) — still deferred (originally slated for
+  v1.3.2). These need a fetch-merge-put helper for user prefs and
+  system config that v1.4 doesn't build.
+- **Typed-confirm destructive UX** (GitHub-style "type the name to
+  confirm"). Inline two-step Enter is sufficient for single-user
+  destructive verbs.
+- **Confirmation for `cmd:signout` / `cmd:clear_recents`**. Neither is
+  data-destructive. Matches v1.3 precedent.
+- **Route-aware predicates beyond album/space pages**. Tag detail,
+  person detail, folder pages, map, asset viewer — not in scope.
+  Infra ships capable of handling them later.
+- **"Add photos to this album / space"** verbs — deferred to v1.5.
+- **`cmd:space_rename`** — the space page renames inline via
+  `updateSpace` with no existing modal. Adding a dedicated modal is
+  scope creep for v1.4; defer to a follow-up slice.
+- **`cmd:space_copy_invite`** — Gallery does not expose a shareable
+  invite link for spaces; members are added by email/username via
+  `SpaceAddMemberModal`. No verb to write here.
+- **Frecency ranking / per-command keybindings / onboarding callout** —
+  still deferred per v1.3 non-goals.
+- **Live context updates mid-palette without keystroke / navigation.**
+  If another window renames the current album while the palette sits
+  idle on a matching page (rare edge), commands keep the stale
+  in-memory context until the next keystroke or reopen. Accepted.
+- **Dynamic command labels** ("Delete 'Summer 2024'"). All v1.4 labels
+  are static ("Delete this album") to avoid per-context fuzzy-search
+  corpus invalidation.
+
+## Command inventory (v1.4)
+
+10 new `CommandItem`s across two route contexts. Every handler calls a
+primitive that already exists in the codebase — verified against
+`web/src/lib/services/album.service.ts`, the `@immich/sdk` generated
+client, and the modals under `web/src/lib/modals/`. No new modals or
+services.
+
+### Album context — route matches `/(user)/albums/[albumId=id]/…`
+
+| id                   | Label                   | When available    | Handler                                                                                                                                                          | Destructive |
+| -------------------- | ----------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `cmd:album_rename`   | Rename this album       | Owner only        | `modalManager.show(AlbumEditModal, { album })`                                                                                                                   | —           |
+| `cmd:album_share`    | Share this album        | Owner only        | `modalManager.show(AlbumOptionsModal, { album })` (contains invite / link / role sub-UI)                                                                         | —           |
+| `cmd:album_download` | Download this album     | Any viewer        | `handleDownloadAlbum(album)`                                                                                                                                     | —           |
+| `cmd:album_leave`    | Leave this shared album | Member, non-owner | `try { await removeUserFromAlbum({ id: album.id, userId: ctx.userId }); goto('/albums'); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }` | ✓           |
+| `cmd:album_delete`   | Delete this album       | Owner only        | `const ok = await handleDeleteAlbum(album, { prompt: false }); if (ok) goto('/albums');` (`handleDeleteAlbum` already wraps its own error toast)                 | ✓           |
+
+`handleDeleteAlbum` already renders its own confirm dialog; passing
+`prompt: false` suppresses it so the palette's inline confirm is the
+single source of truth. Consistent with the doc's "palette is
+terminal" goal — no modal chaining.
+
+### Space context — route matches `/(user)/spaces/[spaceId]/…`
+
+| id                         | Label                           | When available    | Handler                                                                                                                                                   | Destructive |
+| -------------------------- | ------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `cmd:space_manage_members` | Manage space members            | Owner only        | `modalManager.show(SpaceMembersModal, { spaceId, members, isOwner: true, spaceColor })`                                                                   | —           |
+| `cmd:space_add_member`     | Add a member to this space      | Owner only        | `modalManager.show(SpaceAddMemberModal, { spaceId })`                                                                                                     | —           |
+| `cmd:space_bulk_add`       | Add all my photos to this space | Owner or editor   | `await bulkAddAssets({ id: space.id })` + `toastManager.primary($t('bulk_add_queued'))`; on failure `handleError(err, $t('errors.something_went_wrong'))` | ✓           |
+| `cmd:space_leave`          | Leave this space                | Member, non-owner | `try { await removeMember({ id, userId: ctx.userId }); goto('/spaces'); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }`           | ✓           |
+| `cmd:space_delete`         | Delete this space               | Owner only        | `try { await removeSpace({ id: space.id }); goto('/spaces'); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }`                      | ✓           |
+
+`removeSpace` and `removeMember` are SDK methods at `fetch-client.ts`
+L6709 and L6887. `bulkAddAssets` is at L6793 (job endpoint from PR
+#150). None need new wrappers in `web/src/lib/services/`. The space
+page currently wraps `removeSpace` and `bulkAddAssets` in inline
+`showDialog` prompts (see `+page.svelte` L452-460 and L478-489); the
+palette's inline confirm replaces those prompts for the palette call
+path — the page's own "Delete space" and "Add all my photos" buttons
+keep their existing dialogs.
+
+`cmd:space_bulk_add` is marked destructive even though it's semantically
+additive (reversible via `removeAssets`). Reasoning: queuing a
+background job that touches N thousand assets deserves a second-Enter
+checkpoint — matches the space page's own dialog, and a one-Enter
+tap of "Add all" would be out-of-character for the palette's ethos
+("every action is deliberate").
+
+Sub-route scoping: `/spaces/[spaceId]/people`,
+`/spaces/[spaceId]/[[photos=photos]]/…`, and the future people-child
+routes all count as "in space context". Availability predicates match
+on `ctx.routeId?.startsWith('/(user)/spaces/[spaceId]')`. SvelteKit's
+`page.route.id` includes the `(group)` literal, parens and all — verify
+at implementation with a one-line `console.log` on boot, then pin via
+a unit test matching the exact string.
+
+5 destructive verbs (album_leave, album_delete, space_bulk_add,
+space_leave, space_delete) exercise the inline-confirm UX across both
+surfaces. The three that call destructive-in-the-data-model SDKs
+(`removeMember` / `removeSpace` / `removeUserFromAlbum`) wrap their
+awaits in try/catch + `handleError` so rejection produces a toast —
+silent failure on a destructive verb would be the worst outcome.
+`handleDeleteAlbum` already wraps its own error toast.
+
+## Architecture
+
+### New module: `command-context-manager.svelte.ts`
+
+A tiny manager holding a reactive snapshot of "what entity is the
+current page about" plus helper flags computed at registration time
+by the page that has the DTO.
+
+```ts
+// web/src/lib/managers/command-context-manager.svelte.ts
+
+import { page } from '$app/state';
+import { user } from '$lib/stores/user.store';
+import { get } from 'svelte/store';
+
+export interface AlbumContext {
+  id: string;
+  albumName: string;
+  ownerId: string;
+  /** True when the current user owns the album. Computed at registration time. */
+  isOwner: boolean;
+  /** True when the current user appears in albumUsers (shared-with). */
+  isMember: boolean;
+}
+
+export interface SpaceContext {
+  id: string;
+  name: string;
+  ownerId: string;
+  /** True when the current user owns the space. Computed at registration time. */
+  isOwner: boolean;
+  /** True when the current user's role is owner or editor. Used for bulk-add gating. */
+  canWrite: boolean;
+  /** True when the current user appears in members (needed for space_leave). */
+  isMember: boolean;
+}
+
+export interface CommandContext {
+  routeId: string | null;
+  params: Record<string, string>;
+  album: AlbumContext | null;
+  space: SpaceContext | null;
+  userId: string | null;
+  isAdmin: boolean;
+}
+
+class CommandContextManager {
+  private _album: AlbumContext | null = $state(null);
+  private _space: SpaceContext | null = $state(null);
+
+  setAlbum(album: AlbumContext | null) {
+    this._album = album;
+  }
+  setSpace(space: SpaceContext | null) {
+    this._space = space;
+  }
+
+  /** Snapshot read at provider-run time. Pure; no side effects. */
+  getContext(): CommandContext {
+    const u = get(user);
+    return {
+      routeId: page.route.id,
+      params: { ...page.params },
+      album: this._album,
+      space: this._space,
+      userId: u?.id ?? null,
+      isAdmin: u?.isAdmin ?? false,
+    };
+  }
+}
+
+export const commandContextManager = new CommandContextManager();
+
+/**
+ * Page-side convenience. Call inside a component's script block. Registers a
+ * reactive context that clears on unmount and re-syncs when `albumDto` changes.
+ * Centralises the isOwner / isMember flag computation so each page can't drift.
+ */
+export function registerAlbumContext(albumDto: () => AlbumResponseDto) {
+  $effect(() => {
+    const currentUserId = get(user)?.id ?? null;
+    const album = albumDto();
+    commandContextManager.setAlbum({
+      id: album.id,
+      albumName: album.albumName,
+      ownerId: album.ownerId,
+      isOwner: currentUserId === album.ownerId,
+      isMember: album.albumUsers?.some((u) => u.user.id === currentUserId) ?? false,
+    });
+    return () => commandContextManager.setAlbum(null);
+  });
+}
+
+/** Sibling helper for space pages. Same cleanup + flag-computation discipline. */
+export function registerSpaceContext(spaceDto: () => SharedSpaceResponseDto) {
+  $effect(() => {
+    const currentUserId = get(user)?.id ?? null;
+    const space = spaceDto();
+    const self = space.members?.find((m) => m.userId === currentUserId) ?? null;
+    commandContextManager.setSpace({
+      id: space.id,
+      name: space.name,
+      ownerId: space.createdById,
+      isOwner: currentUserId === space.createdById,
+      canWrite: self?.role === SharedSpaceRole.Owner || self?.role === SharedSpaceRole.Editor,
+      isMember: self !== null,
+    });
+    return () => commandContextManager.setSpace(null);
+  });
+}
+```
+
+The helper pattern scales: v1.6 adds `registerTagContext`,
+`registerPersonContext`, etc. Each sibling function encapsulates its
+flag semantics so a future page can't mis-implement `isOwner`.
+
+Notes on reactivity:
+
+- `_album` / `_space` are `$state` fields so their writes are tracked.
+  `getContext()` is called **imperatively** from
+  `filterNavAndCommands`, not from a `$derived` or template, so reads
+  here are not reactively subscribed — they're just read-through
+  accesses that happen on every provider run. That's exactly what we
+  want (provider runs on every keystroke and every palette open, which
+  covers every UX moment where the list visibly updates).
+- `page` from `$app/state` is a reactive object elsewhere in the app
+  but read imperatively here. Same semantics as `_album`/`_space`:
+  snapshot-at-call.
+- No UI tree reads `commandContextManager.album` reactively in v1.4.
+  If v1.5 wants that (e.g. a preview pane keyed on context), this
+  manager is where to add `$derived` getters, not where to speculate
+  today.
+
+### Page-side registration hooks
+
+Two `$effect` hooks. Each runs after the page's loader populates
+`data`, computes the helper flags, and clears on unmount (or before
+re-run when `data` reloads after a rename/add-member).
+
+With the helpers exported from `command-context-manager.svelte`, each
+page is a single line.
+
+**`web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte`:**
+
+```ts
+import { registerAlbumContext } from '$lib/managers/command-context-manager.svelte';
+
+registerAlbumContext(() => data.album);
+```
+
+**`web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`:**
+
+```ts
+import { registerSpaceContext } from '$lib/managers/command-context-manager.svelte';
+
+registerSpaceContext(() => data.sharedSpace);
+```
+
+The thunk (`() => data.album`) is what re-runs the `$effect` when
+`data` changes — Svelte 5 tracks the runes read inside the effect
+body. Passing the DTO directly would make the effect fire only on
+initial mount.
+
+`SharedSpaceResponseDto.members` is optional in the DTO type
+(`members?: SharedSpaceMemberResponseDto[]`). If the space page's
+loader omits the `members` field for any reason, `canWrite`
+collapses to false — commands that require it hide. Safe default.
+Grep the actual loader at implementation time to confirm `members` is
+always populated for the detail page (the existing
+`SpaceMembersModal` consumes it, so it must be).
+
+Cleanup runs on component unmount AND between `$effect` re-runs. The
+tiny `album: null` window between cleanup and re-registration is
+acceptable because palette-close-on-navigate fires first (see below)
+and the user is not typing in a palette that isn't open.
+
+`data.album.albumUsers` is the confirmed field name (see
+`AlbumResponseDto` — `albumUsers?: AlbumUserResponseDto[]`). Each entry
+has `{ user: UserResponseDto, role: AlbumUserRole }`. Confirm at impl.
+
+### Close palette on navigation — wire in the root layout
+
+**Moved from the palette component to `+layout.svelte`.** The palette
+is mounted conditionally inside a Modal; `afterNavigate` must be
+registered during component initialisation, but the palette component
+unmounts between opens, so a registration there is torn down
+immediately on close. The root layout persists across navigation and
+is the correct lifetime.
+
+```svelte
+<!-- web/src/routes/+layout.svelte -->
+<script lang="ts">
+  import { afterNavigate } from '$app/navigation';
+  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+
+  afterNavigate(() => {
+    if (globalSearchManager.isOpen) {
+      globalSearchManager.close();
+    }
+  });
+</script>
+```
+
+The manager's close sequence (`cancelConfirm()` + clear controllers) is
+idempotent; calling on an already-closed palette is a no-op. Palette
+rows that navigate synchronously (existing behavior, e.g. nav rows
+calling `close()` then `goto()`) still close the palette first, then
+`afterNavigate` fires, sees `isOpen === false`, does nothing.
+
+If the root `+layout.svelte` is used by non-authenticated routes
+(`/auth/*`), wrap the import in a try/catch or gate on `page.route.id`
+pattern so a pre-auth navigation doesn't attempt to poke an
+unmounted singleton. The manager is a module-level singleton that
+exists regardless of auth state, so the simpler path — always
+register — is fine.
+
+### Extended `CommandItem` type
+
+```ts
+// web/src/lib/managers/command-items.ts
+
+import type { CommandContext } from '$lib/managers/command-context-manager.svelte';
+
+export interface CommandItem {
+  id: `cmd:${string}`;
+  labelKey: string;
+  descriptionKey: string;
+  icon: string;
+  /** Now receives the context. All 15 existing v1.3/v1.3.1 handlers are zero-arg and remain
+   *  valid under the widened signature — TS accepts call sites that pass fewer declared args. */
+  handler: (ctx: CommandContext) => void | Promise<unknown>;
+  adminOnly?: boolean;
+  featureFlag?: keyof ServerFeaturesDto;
+
+  // v1.4 new:
+  /** Sync predicate gating appearance. Omit for always-available commands.
+   *  Must be pure over `ctx`. Throwing excludes the command (defensive). */
+  isAvailable?: (ctx: CommandContext) => boolean;
+  /** Requires inline two-step Enter confirmation. First Enter flips the row to a
+   *  red "Press Enter again" state for 3 s; second Enter fires; Esc / query change /
+   *  selection change / timeout cancels. */
+  destructive?: boolean;
+}
+```
+
+Zero migration for existing handlers — they simply ignore the new
+first parameter. A drift-guard unit test pins this (see Testing).
+
+### Provider filter update
+
+`filterNavAndCommands` in `global-search-manager.svelte.ts` adds one
+predicate branch, pulling context once per run:
+
+```ts
+const ctx = commandContextManager.getContext();
+
+const eligibleCmd: CommandItem[] = [];
+for (const item of COMMAND_ITEMS) {
+  if (item.adminOnly && !isAdmin) continue;
+  if (item.featureFlag && !flags?.[item.featureFlag]) continue;
+  if (item.isAvailable) {
+    try {
+      if (!item.isAvailable(ctx)) continue;
+    } catch (error) {
+      console.error('[cmdk] isAvailable threw', { id: item.id, error });
+      continue;
+    }
+  }
+  eligibleCmd.push(item);
+}
+```
+
+One `getContext()` call per provider run (sync, no I/O). `console.error`
+matches the manager's existing logging style (see L1187 for the
+handler-failed log path).
+
+### Inline-confirm state machine
+
+Three new fields on the manager (beside `commandInFlight` which stays
+unchanged):
+
+```ts
+/** Id of the command currently awaiting second-Enter confirmation. Null otherwise. */
+pendingConfirmId: string | null = $state(null);
+/** Timeout handle for the 3 s auto-cancel. */
+private confirmTimer: ReturnType<typeof setTimeout> | null = null;
+```
+
+Helpers:
+
+```ts
+private startConfirm(cmdId: string) {
+  this.pendingConfirmId = cmdId;
+  if (this.confirmTimer !== null) clearTimeout(this.confirmTimer);
+  this.confirmTimer = setTimeout(() => {
+    // Guard against a stale timer firing after a new confirm was started:
+    // only clear if we're still confirming the id we armed this timer for.
+    if (this.pendingConfirmId === cmdId) {
+      this.pendingConfirmId = null;
+    }
+    this.confirmTimer = null;
+  }, 3000);
+}
+
+cancelConfirm() {
+  if (this.confirmTimer !== null) {
+    clearTimeout(this.confirmTimer);
+    this.confirmTimer = null;
+  }
+  this.pendingConfirmId = null;
+}
+```
+
+`cancelConfirm` is public so `global-search.svelte` can call it from
+its Escape handler.
+
+`activate('command')` gets a destructive branch at the top:
+
+```ts
+case 'command': {
+  const cmd = item as CommandItem;
+
+  if (cmd.destructive) {
+    if (this.pendingConfirmId === cmd.id) {
+      // Second Enter on the same destructive command — clear pending and fire.
+      this.cancelConfirm();
+      // fall through to fire path
+    } else {
+      // First Enter (or a different destructive command replacing the pending one).
+      this.startConfirm(cmd.id);
+      return; // do NOT close, do NOT fire
+    }
+  } else if (this.pendingConfirmId !== null) {
+    // User picked a non-destructive verb while a destructive one was pending.
+    // Cancel the pending; fire the picked one. (Mouse-click or arrow-then-Enter path.)
+    this.cancelConfirm();
+  }
+
+  if (this.commandInFlight.has(cmd.id)) return;
+  this.commandInFlight.add(cmd.id);
+  this.close();
+  queueMicrotask(() => {
+    const ctx = commandContextManager.getContext();
+    void Promise.resolve()
+      .then(() => cmd.handler(ctx))
+      .catch((error) => console.error('[cmdk] command handler failed', { id: cmd.id, error }))
+      .finally(() => this.commandInFlight.delete(cmd.id));
+  });
+  return;
+}
+```
+
+Five cancel triggers wired outside `activate`:
+
+1. **Query change.** `setQuery(q)` (existing method) cancels when
+   `pendingConfirmId !== null`. Typing anything clears the red row.
+2. **Selection change.** `setActiveItem(value)` — if the new value
+   differs from `pendingConfirmId`, cancel. Arrowing away reverts
+   the red row.
+3. **Escape.** `onKeyDown` in `global-search.svelte` gets a new
+   first-pass branch: if `manager.pendingConfirmId !== null`, call
+   `manager.cancelConfirm()`, `e.preventDefault()`, and **return** —
+   so the palette stays open and the red row reverts. Second Escape
+   (pending cleared) falls through to existing `clearOrClose()`.
+4. **`close()`.** Calls `this.cancelConfirm()` as its first line, so
+   reopening never inherits a stale confirm state.
+5. **`afterNavigate`.** Closes the palette (from the root layout);
+   `close()` clears pending via (4).
+
+Auto-cancel via the 3s timeout is the sixth trigger, self-wired in
+`startConfirm`.
+
+**Mouse click path.** Clicking a row fires the same `activate('command')`
+as Enter. So:
+
+- Click destructive row → pending; row turns red; palette stays open.
+- Click same destructive row again within 3s → fires.
+- Click a different row (destructive or not) → cancels pending and
+  activates the new one per the logic above.
+
+The red-pending affordance is keyboard-first (Enter-mediated), but the
+mouse path is consistent. Mouse users who click once and don't
+follow through get the same 3s auto-cancel.
+
+**3s boundary race.** If the timer callback fires at the exact moment
+of a second-Enter:
+
+- If the timer callback runs first: `pendingConfirmId` becomes null,
+  then the Enter handler takes the first-Enter path — it sets
+  pending again. User mashing Enter sees the red row re-appear with
+  no action on that press. Harmless; next Enter fires. Documented.
+- If the Enter handler runs first: it reads `pendingConfirmId === cmd.id`,
+  cancels, fires. The timer callback runs next; its guard
+  `if (pendingConfirmId === cmdId)` is false now (null) — no-op. Also
+  harmless.
+
+### `CommandRow` rendering — pending state
+
+`CommandRow.svelte` adds one optional prop:
+
+```ts
+interface Props {
+  // ... existing ...
+  pending?: boolean;
+}
+```
+
+When `pending`:
+
+- Applies `@immich/ui`'s danger accent (background + border). Token
+  name to verify at implementation (grep existing destructive buttons
+  for the canonical class — likely `bg-danger/10` or the
+  `variant="danger"` equivalent).
+- Replaces the description text with the fixed i18n string
+  `cmdk_cmd_confirm_hint` → "Press Enter again to confirm · Esc to cancel".
+- Keeps the same icon + label. Intent is conveyed by the red
+  background + hint, not a glyph swap — reduces visual noise during
+  rapid Enter/Esc cycles.
+
+`GlobalSearchCommandsSection` reads `manager.pendingConfirmId` and
+passes `pending={item.id === manager.pendingConfirmId}` to each
+`CommandRow`. Since `pendingConfirmId` is a `$state` field, the
+derived per-row prop updates reactively without extra plumbing.
+
+### Caching
+
+`getNavigationSearchStrings()` / `getCommandSearchStrings()` build
+fuzzy-search corpora memoized on i18n locale. Context-aware commands
+don't invalidate the cache — labels are static per command and don't
+depend on the current context. `isAvailable` runs separately from
+corpus lookup, so filtering is context-sensitive while scoring stays
+cached.
+
+## Error handling
+
+| Failure mode                                                             | Behavior                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isAvailable` predicate throws                                           | Caught in provider loop. Command excluded. `console.error` logs id + error.                                                                                                                                                                                            |
+| Handler throws or rejects                                                | Existing v1.3 path: `.catch` logs, `.finally` cleans up `commandInFlight`. No user bubble.                                                                                                                                                                             |
+| `removeSpace` / `removeMember` / `handleDeleteAlbum` fails after confirm | Handler swallows + logs + toast via existing `handleError` where available, or relies on the route navigation. `goto('/spaces')` / `goto('/albums')` fires only on the success path.                                                                                   |
+| User confirms a destructive verb but context went null between Enters    | `data.album` / `data.sharedSpace` is stable across the 3s window unless the user navigates. On navigation the palette closes via `afterNavigate`, which clears pending. Invariant holds.                                                                               |
+| Palette closes mid-confirm (backdrop click, Ctrl+K, etc.)                | `close()` calls `cancelConfirm()` first. Reopen: pending is clean.                                                                                                                                                                                                     |
+| User clicks a destructive row (mouse) once                               | Pending state; row turns red; palette stays open. Second click within 3s fires. Clicking a different row cancels pending and activates the new row.                                                                                                                    |
+| User holds Enter down on a destructive row (key repeat)                  | First fire: pending set. Every subsequent repeat satisfies `pendingConfirmId === cmd.id` → cancels + fires once (`commandInFlight` guard holds). Third repeat sees pending null → sets it again. No double-fire.                                                       |
+| Two different destructive rows: Enter A, then arrow to B, Enter B        | Arrow-to-B cancels A via selection-change trigger (A's red state reverts). First Enter on B sets B's pending. Second Enter on B fires B. A never fires.                                                                                                                |
+| 3 s timeout fires exactly as user presses second Enter                   | Race documented above. Either order yields an acceptable result: action fires or user sees the red row re-appear for another confirm.                                                                                                                                  |
+| Browser tab goes to background mid-confirm (timers throttled)            | Timer may fire >3s late; pending persists until it does. User returning to foreground still sees the red row. Accepted.                                                                                                                                                |
+| `afterNavigate` fires while palette is opening (racy initial render)     | `isOpen` guard skips close. Palette open-animation completes normally.                                                                                                                                                                                                 |
+| Context predicate references fields DTO hasn't loaded yet                | Page `$effect` runs after `data` is populated (SvelteKit load completes before render). No half-populated context.                                                                                                                                                     |
+| Context-aware command activated without matching context (dev-dispatch)  | Predicate prevents visibility; handlers must still guard: `if (!ctx.album) return;` as belt-and-braces. Covered by a unit test.                                                                                                                                        |
+| Another tab logs out mid-palette                                         | `user` store reflects logout; next `getContext()` returns `userId: null`. Owner-check predicates return false. Commands disappear on the next keystroke / reopen.                                                                                                      |
+| `user` store changes while page context is already registered            | `isOwner` / `canWrite` / `isMember` were computed at effect run; they're now stale until `data.album` reloads. Accepted — logout triggers an auth redirect that unmounts the page within a tick, so the stale window is closed before the user can act on it.          |
+| `afterNavigate` fires on a same-URL `replaceState`                       | Palette closes even though the user didn't navigate. Accepted — palette row activations don't use `replaceState`, so this only affects upstream callers; one-line grep at implementation to confirm no `(user)/*` route uses `replaceState` in a non-navigation sense. |
+
+## Testing
+
+### Unit — vitest + @testing-library/svelte
+
+**New spec: `web/src/lib/managers/command-context-manager.spec.ts`**
+
+- `setAlbum` / `setSpace` round-trip — `getContext()` reflects set values
+- `getContext().params` is a snapshot (mutation doesn't affect later reads)
+- `userId` / `isAdmin` derive from the mocked `user` store
+- Null default state for album + space
+- Sequential set-then-null clears back to null
+
+**New spec / extension: `web/src/lib/components/global-search/__tests__/command-row.spec.ts`**
+
+- `pending` prop true renders the confirm-hint text + danger class
+- `pending` prop false renders the normal description
+- `pending` flip false→true→false swaps cleanly (no leaked danger class)
+
+**Extensions to `global-search-manager.svelte.spec.ts`:**
+
+- `filterNavAndCommands` filters out commands whose `isAvailable` returns false
+- `filterNavAndCommands` swallows a throwing `isAvailable` and logs
+- **Drift guard:** `activate('command')` on an existing v1.3 stateless
+  command (e.g. `cmd:theme`) still fires while an album context is
+  registered. Pins "widened handler signature doesn't break v1.3"
+- Destructive command — first Enter: palette stays open, handler NOT
+  called, `pendingConfirmId === cmd.id`
+- Destructive command — second Enter within 3s: palette closes,
+  handler called with context, `pendingConfirmId === null`
+- Activate destructive A, then destructive B — pending flips to B, only B fires on confirm
+- Activate destructive A, then non-destructive C — pending cleared, C fires, A never fires
+- **Mouse-click path:** `activate('command', destructiveItem)` twice
+  in a row (no Enter) mirrors the double-Enter behavior
+- **Rapid mouse double-click (~50 ms apart):** two synchronous
+  `activate` calls — first sets pending, second sees `pendingConfirmId === cmd.id`
+  and fires exactly once. No extra fire on repeat.
+- **Held-Enter race:** fire `activate` three times synchronously on a
+  destructive — handler invoked at most once (`commandInFlight` guard)
+- `setQuery('anything')` while pending cancels confirm
+- `setActiveItem('other-row')` while pending cancels confirm
+- `setActiveItem(pendingId)` keeps confirm alive (arrowing back)
+- `close()` while pending clears confirm; reopen → pending null
+- 3s timeout with fake timers clears pending; subsequent Enter takes
+  first-Enter path
+- Handler receives `CommandContext` with live `album` / `space` +
+  route id (set via mocked `commandContextManager`)
+- **`afterNavigate` close:** unit-test the root-layout wire by calling
+  the exposed hook directly: palette open → invoke hook → palette
+  closed (spy on `globalSearchManager.close`)
+
+**Extensions to `command-items.spec.ts`:**
+
+- Every `cmd:album_*` item's `isAvailable` returns false when `ctx.album === null`
+- `cmd:album_rename` / `cmd:album_share` / `cmd:album_delete` return false when `ctx.album.isOwner === false`
+- `cmd:album_leave` returns false when `ctx.album.isOwner === true` (owners don't leave) AND returns false when `ctx.album.isMember === false` (non-members don't leave)
+- `cmd:album_download` available whenever `ctx.album !== null`
+- Same polarity tests for space verbs, using `isOwner` / `canWrite` / `isMember`
+- Explicit: `cmd:space_bulk_add` hides when `ctx.space.canWrite === false` (viewer role)
+- Explicit: `cmd:space_bulk_add` has `destructive: true` set (drift guard)
+- `data.album.albumUsers === undefined` → `isMember` false → `cmd:album_leave` hides
+- Every destructive command (`cmd:album_leave`, `cmd:album_delete`, `cmd:space_leave`, `cmd:space_delete`) has `destructive: true`
+- No non-destructive command has `destructive: true` (drift guard)
+
+### E2E — Playwright, `e2e/src/web/specs/cmdk-context.e2e.ts`
+
+Seven cases. Uses real-server fixtures for album / space ownership;
+no mock-based tests here per `feedback_e2e_mock_filterpanel`.
+
+1. **Album context appearance**: navigate to `/albums/<owned>`, open
+   palette with `>`, assert `cmd:album_rename` / `_delete` / `_share` /
+   `_download` rows render.
+2. **Context hidden off-route**: navigate to `/photos`, open palette
+   with `>`, assert none of `cmd:album_*` or `cmd:space_*` render.
+3. **Ownership gating**: navigate to an album shared by another user,
+   open palette with `>`, assert `cmd:album_leave` renders but
+   `cmd:album_delete` / `_rename` / `_share` do not.
+4. **Destructive happy path**: navigate to an owned album, open palette,
+   type `>delete`, Enter — palette still open, row red with confirm
+   hint. Enter again — album deleted, redirect to `/albums`, album
+   no longer in list.
+5. **Destructive Esc cancels**: same setup, first Enter, then Esc —
+   palette stays open, row reverts. Second Esc closes palette. Album
+   still exists.
+6. **Arrow-away cancels pending**: first Enter on the destructive row
+   → Arrow Down to next row → assert previous row reverted (no
+   danger class). Press Enter on the now-focused non-destructive row
+   → assert that row's handler fires (not the destructive one).
+7. **Close-on-navigate**: open palette on `/photos`, type nothing,
+   click a nav row (or use the Upload command) so the route changes,
+   assert the palette `<Modal>` is absent from the DOM afterward.
+   Dedicated test so a regression in the `afterNavigate` wire fails
+   loudly instead of masquerading as an unrelated redirect-after-delete
+   failure.
+
+Held-Enter destructive test and 3s timeout: unit-level only. E2E
+holding a key across a real 3-second window is brittle and the unit
+test with fake timers covers the contract without clock-mocking
+Playwright.
+
+## i18n
+
+New keys in `en.json`:
+
+- `cmdk_cmd_confirm_hint` — "Press Enter again to confirm · Esc to cancel"
+- `cmdk_cmd_album_rename_label` — "Rename this album"
+- `cmdk_cmd_album_rename_description` — "Change the album's name or description"
+- `cmdk_cmd_album_share_label` — "Share this album"
+- `cmdk_cmd_album_share_description` — "Invite people or manage access"
+- `cmdk_cmd_album_download_label` — "Download this album"
+- `cmdk_cmd_album_download_description` — "Download all album assets as a zip"
+- `cmdk_cmd_album_leave_label` — "Leave this shared album"
+- `cmdk_cmd_album_leave_description` — "Remove yourself from this album"
+- `cmdk_cmd_album_delete_label` — "Delete this album"
+- `cmdk_cmd_album_delete_description` — "Permanently remove this album"
+- `cmdk_cmd_space_manage_members_label` — "Manage space members"
+- `cmdk_cmd_space_manage_members_description` — "Add, remove, or change member permissions"
+- `cmdk_cmd_space_add_member_label` — "Add a member to this space"
+- `cmdk_cmd_space_add_member_description` — "Invite someone to join this space"
+- `cmdk_cmd_space_bulk_add_label` — "Add all my photos to this space"
+- `cmdk_cmd_space_bulk_add_description` — "Queue a background job to add all your assets"
+- `cmdk_cmd_space_leave_label` — "Leave this space"
+- `cmdk_cmd_space_leave_description` — "Remove yourself from this space"
+- `cmdk_cmd_space_delete_label` — "Delete this space"
+- `cmdk_cmd_space_delete_description` — "Permanently remove this space"
+- `bulk_add_queued` — "Adding all your photos to this space — this may take a while"
+
+Sort via `pnpm --filter=immich-i18n format:fix` per
+`feedback_i18n_key_sorting`.
+
+## Alternatives considered
+
+- **Sync availability via route string matching only (no DTO data).**
+  Simpler, but loses ownership gating — every album verb would show
+  even on albums the user doesn't own. Rejected: palette invariant
+  "every visible row is a valid action" matters more than avoiding a
+  `$effect` per page.
+- **Palette fetches entity on open (`await getAlbum(id)`).** Fresh
+  data, zero page hooks. Rejected: duplicates data already loaded on
+  the page; adds a round-trip to every palette open on album/space
+  routes.
+- **Snapshot-at-open context.** Frozen when palette opens. With
+  close-on-navigate wired, live-reactive gives the same visible
+  behavior with less surface — rejected the frozen variant.
+- **Typed-confirm** (GitHub-style). Rejected: friction mismatched
+  with palette ethos; single-user destructive verbs don't warrant.
+- **Fall through to existing modals** (`AlbumDeleteModal` etc.).
+  Rejected: every destructive verb leaves the palette; the palette
+  stops being terminal.
+- **Per-page command registries** (each page exports verbs, registers
+  on mount). More Svelte-idiomatic, but splits the canonical command
+  list — breaks future keybind registry, shortcut docs, v1.5 filter.
+  Rejected.
+- **Availability via handler route-guard** (always render, no-op if
+  ctx wrong). Rejected: violates the palette invariant.
+- **`afterNavigate` in the palette component.** Rejected per review:
+  the palette unmounts between opens, so a registration there is torn
+  down immediately on close. Root layout is the correct lifetime.
+- **`cmd:space_rename` via new `SpaceEditModal`.** Rejected: no
+  existing modal; building one is scope creep. Defer.
+- **`cmd:space_copy_invite`.** Rejected: Gallery doesn't have share-by-link
+  for spaces; members are added by email/username.
+- **Dynamic command labels.** Rejected: per-context corpus rebuild
+  complexity not worth the visual win in v1.4.
+- **Wider v1.4 scope** (+ tag / person / folder). Rejected: two
+  surfaces is enough to validate the `CommandContext` abstraction.
+
+## Future sub-versions
+
+### v1.5 — Selection verbs + multi-step palette
+
+Per v1.3 design intent. `CommandContext` extends with
+`selectedAssetIds: string[]`. Palette opens from the selection toolbar
+with selection pre-loaded. Verbs gated on non-empty selection: Add
+selected to album… / Favorite / Archive / Delete selected (reuses
+v1.4's inline confirm). "Add to album…" introduces multi-step palette
+state (secondary picker view).
+
+### v1.4.1 — Space rename + more space verbs
+
+Once `SpaceEditModal` exists (or the inline rename flow is extracted),
+add `cmd:space_rename`. Also add `cmd:space_toggle_pets`,
+`cmd:space_toggle_face_recognition`, `cmd:space_set_cover_from_current`
+(context-aware verbs using the existing toggles on the space page).
+
+### v1.6 — More page contexts
+
+Same infra, new `$effect` hooks: tag detail, person detail, folder,
+map, asset viewer. Examples: "Merge with other person", "Download
+face crops", "Filter by current map bounds", "Copy asset link".
+
+### Settings toggles (originally v1.3.2)
+
+Still open from the v1.3 roadmap. Unrelated to v1.4; ships whenever
+the fetch-merge-put helper shows up.
+
+## Delivery shape
+
+- **Branch:** `feat/cmdk-v1.4-context`
+- **Commits** (each passes tsc + vitest in isolation):
+  1. `feat(web): add CommandContextManager + extend CommandItem` —
+     new manager, `isAvailable` / `destructive` fields on `CommandItem`,
+     widened handler signature. No new command items yet; no UI
+     changes.
+  2. `feat(web): close cmdk palette on navigation` — wires
+     `afterNavigate` in the root layout. Unit-tests the hook.
+  3. `feat(web): cmdk inline-confirm UX for destructive commands` —
+     adds `pendingConfirmId` state machine to manager, cancel
+     triggers, Escape intercept in palette, `pending` prop on
+     `CommandRow` + danger styling + confirm-hint i18n key.
+  4. `feat(web): cmdk album-context commands` — adds `registerAlbumContext`
+     helper, wires it on the album page, adds 5 `cmd:album_*` items
+     (2 destructive) + i18n keys.
+  5. `feat(web): cmdk space-context commands` — adds `registerSpaceContext`
+     helper, wires it on the space page, adds 5 `cmd:space_*` items
+     (3 destructive including `bulk_add`) + i18n keys.
+  6. `test(e2e): cmdk context commands and destructive confirm` —
+     Playwright spec, 7 cases.
+
+- **One PR** titled `feat(web): cmdk palette v1.4 — context-aware commands + inline confirm`.
+- **No server / SDK / DB changes.** All endpoints already exist
+  (`removeSpace`, `removeMember`, `bulkAddAssets`, `removeUserFromAlbum`,
+  `deleteAlbum`).
+- Standard CI (lint + tsc + vitest + Playwright).

--- a/docs/plans/2026-04-19-cmdk-v1.4-design.md
+++ b/docs/plans/2026-04-19-cmdk-v1.4-design.md
@@ -61,13 +61,13 @@ services.
 
 ### Album context — route matches `/(user)/albums/[albumId=id]/…`
 
-| id                   | Label                   | When available    | Handler                                                                                                                                                          | Destructive |
-| -------------------- | ----------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `cmd:album_rename`   | Rename this album       | Owner only        | `modalManager.show(AlbumEditModal, { album })`                                                                                                                   | —           |
-| `cmd:album_share`    | Share this album        | Owner only        | `modalManager.show(AlbumOptionsModal, { album })` (contains invite / link / role sub-UI)                                                                         | —           |
-| `cmd:album_download` | Download this album     | Any viewer        | `handleDownloadAlbum(album)`                                                                                                                                     | —           |
-| `cmd:album_leave`    | Leave this shared album | Member, non-owner | `try { await removeUserFromAlbum({ id: album.id, userId: ctx.userId }); goto('/albums'); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }` | ✓           |
-| `cmd:album_delete`   | Delete this album       | Owner only        | `const ok = await handleDeleteAlbum(album, { prompt: false }); if (ok) goto('/albums');` (`handleDeleteAlbum` already wraps its own error toast)                 | ✓           |
+| id                   | Label                   | When available    | Handler                                                                                                                                                               | Destructive |
+| -------------------- | ----------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `cmd:album_rename`   | Rename this album       | Owner only        | `modalManager.show(AlbumEditModal, { album })`                                                                                                                        | —           |
+| `cmd:album_share`    | Share this album        | Owner only        | `modalManager.show(AlbumOptionsModal, { album })` (contains invite / link / role sub-UI)                                                                              | —           |
+| `cmd:album_download` | Download this album     | Any viewer        | `handleDownloadAlbum(album)`                                                                                                                                          | —           |
+| `cmd:album_leave`    | Leave this shared album | Member, non-owner | `try { await removeUserFromAlbum({ id: album.id, userId: ctx.userId }); goto(Route.albums()); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }` | ✓           |
+| `cmd:album_delete`   | Delete this album       | Owner only        | `const ok = await handleDeleteAlbum(album, { prompt: false }); if (ok) goto(Route.albums());` (`handleDeleteAlbum` already wraps its own error toast)                 | ✓           |
 
 `handleDeleteAlbum` already renders its own confirm dialog; passing
 `prompt: false` suppresses it so the palette's inline confirm is the
@@ -76,13 +76,13 @@ terminal" goal — no modal chaining.
 
 ### Space context — route matches `/(user)/spaces/[spaceId]/…`
 
-| id                         | Label                           | When available    | Handler                                                                                                                                                   | Destructive |
-| -------------------------- | ------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `cmd:space_manage_members` | Manage space members            | Owner only        | `modalManager.show(SpaceMembersModal, { spaceId, members, isOwner: true, spaceColor })`                                                                   | —           |
-| `cmd:space_add_member`     | Add a member to this space      | Owner only        | `modalManager.show(SpaceAddMemberModal, { spaceId })`                                                                                                     | —           |
-| `cmd:space_bulk_add`       | Add all my photos to this space | Owner or editor   | `await bulkAddAssets({ id: space.id })` + `toastManager.primary($t('bulk_add_queued'))`; on failure `handleError(err, $t('errors.something_went_wrong'))` | ✓           |
-| `cmd:space_leave`          | Leave this space                | Member, non-owner | `try { await removeMember({ id, userId: ctx.userId }); goto('/spaces'); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }`           | ✓           |
-| `cmd:space_delete`         | Delete this space               | Owner only        | `try { await removeSpace({ id: space.id }); goto('/spaces'); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }`                      | ✓           |
+| id                         | Label                           | When available    | Handler                                                                                                                                                        | Destructive |
+| -------------------------- | ------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `cmd:space_manage_members` | Manage space members            | Owner only        | `modalManager.show(SpaceMembersModal, { spaceId, members, isOwner: true, spaceColor })`                                                                        | —           |
+| `cmd:space_add_member`     | Add a member to this space      | Owner only        | `modalManager.show(SpaceAddMemberModal, { spaceId })`                                                                                                          | —           |
+| `cmd:space_bulk_add`       | Add all my photos to this space | Owner or editor   | `await bulkAddAssets({ id: space.id })` + `toastManager.primary($t('bulk_add_queued'))`; on failure `handleError(err, $t('errors.something_went_wrong'))`      | ✓           |
+| `cmd:space_leave`          | Leave this space                | Member, non-owner | `try { await removeMember({ id: space.id, userId: ctx.userId }); goto(Route.spaces()); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }` | ✓           |
+| `cmd:space_delete`         | Delete this space               | Owner only        | `try { await removeSpace({ id: space.id }); goto(Route.spaces()); } catch (err) { handleError(err, $t('errors.something_went_wrong')); }`                      | ✓           |
 
 `removeSpace` and `removeMember` are SDK methods at `fetch-client.ts`
 L6709 and L6887. `bulkAddAssets` is at L6793 (job endpoint from PR
@@ -115,6 +115,22 @@ surfaces. The three that call destructive-in-the-data-model SDKs
 awaits in try/catch + `handleError` so rejection produces a toast —
 silent failure on a destructive verb would be the worst outcome.
 `handleDeleteAlbum` already wraps its own error toast.
+
+**On `handleRemoveUserFromAlbum` vs raw `removeUserFromAlbum`:** the
+existing helper at `album.service.ts:196-215` always shows its own
+`modalManager.showDialog` confirm (`confirmText: $t('remove_user')`)
+and cannot be called with `prompt: false` (unlike `handleDeleteAlbum`).
+Calling it from the palette would double-confirm. The raw SDK call +
+manual `handleError` is the minimum-diff alternative. The helper also
+emits `eventManager.emit('AlbumUserDelete', ...)` which we intentionally
+drop — the `goto(Route.albums())` that follows triggers a fresh page
+load that supersedes the event. Palette is terminal; the albums page
+reloads from scratch on arrival.
+
+**Redirect helpers:** every handler uses `Route.albums()` /
+`Route.spaces()` / `Route.viewAlbum({ id })` rather than raw strings.
+Drift-safe if the route literals change; consistent with existing call
+sites (see `album.service.ts:141` and sidebar routing).
 
 ## Architecture
 
@@ -282,10 +298,13 @@ initial mount.
 `SharedSpaceResponseDto.members` is optional in the DTO type
 (`members?: SharedSpaceMemberResponseDto[]`). If the space page's
 loader omits the `members` field for any reason, `canWrite`
-collapses to false — commands that require it hide. Safe default.
-Grep the actual loader at implementation time to confirm `members` is
-always populated for the detail page (the existing
-`SpaceMembersModal` consumes it, so it must be).
+collapses to false — commands that require it hide. Safe default,
+pinned by a unit test that feeds `registerSpaceContext` a DTO with
+`members: undefined` and asserts `canWrite === false` + `isMember
+=== false`. The existing `SpaceMembersModal` consumes `members` at
+`modals/SpaceMembersModal.svelte:26`, so the loader must populate
+it — the test is a belt-and-braces drift guard against a future
+loader refactor silently dropping the field.
 
 Cleanup runs on component unmount AND between `$effect` re-runs. The
 tiny `album: null` window between cleanup and re-registration is
@@ -305,17 +324,27 @@ unmounts between opens, so a registration there is torn down
 immediately on close. The root layout persists across navigation and
 is the correct lifetime.
 
+The callback is an exported named function so it can be unit-tested
+directly without mocking `$app/navigation`:
+
+```ts
+// web/src/lib/managers/close-palette-on-navigate.ts
+import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+
+export function closePaletteOnNavigate() {
+  if (globalSearchManager.isOpen) {
+    globalSearchManager.close();
+  }
+}
+```
+
 ```svelte
 <!-- web/src/routes/+layout.svelte -->
 <script lang="ts">
   import { afterNavigate } from '$app/navigation';
-  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+  import { closePaletteOnNavigate } from '$lib/managers/close-palette-on-navigate';
 
-  afterNavigate(() => {
-    if (globalSearchManager.isOpen) {
-      globalSearchManager.close();
-    }
-  });
+  afterNavigate(closePaletteOnNavigate);
 </script>
 ```
 
@@ -388,9 +417,12 @@ for (const item of COMMAND_ITEMS) {
 }
 ```
 
-One `getContext()` call per provider run (sync, no I/O). `console.error`
-matches the manager's existing logging style (see L1187 for the
-handler-failed log path).
+`filterNavAndCommands` is invoked from both `runNavigationProvider`
+and `runCommandsProvider`, so `getContext()` runs **twice per
+keystroke** — not once. Each call is sync and allocates a small
+object (~6 fields); the cost is negligible, noted here for accuracy.
+`console.error` matches the manager's existing logging style (see
+L1187 for the handler-failed log path).
 
 ### Inline-confirm state machine
 
@@ -551,24 +583,25 @@ cached.
 
 ## Error handling
 
-| Failure mode                                                             | Behavior                                                                                                                                                                                                                                                               |
-| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `isAvailable` predicate throws                                           | Caught in provider loop. Command excluded. `console.error` logs id + error.                                                                                                                                                                                            |
-| Handler throws or rejects                                                | Existing v1.3 path: `.catch` logs, `.finally` cleans up `commandInFlight`. No user bubble.                                                                                                                                                                             |
-| `removeSpace` / `removeMember` / `handleDeleteAlbum` fails after confirm | Handler swallows + logs + toast via existing `handleError` where available, or relies on the route navigation. `goto('/spaces')` / `goto('/albums')` fires only on the success path.                                                                                   |
-| User confirms a destructive verb but context went null between Enters    | `data.album` / `data.sharedSpace` is stable across the 3s window unless the user navigates. On navigation the palette closes via `afterNavigate`, which clears pending. Invariant holds.                                                                               |
-| Palette closes mid-confirm (backdrop click, Ctrl+K, etc.)                | `close()` calls `cancelConfirm()` first. Reopen: pending is clean.                                                                                                                                                                                                     |
-| User clicks a destructive row (mouse) once                               | Pending state; row turns red; palette stays open. Second click within 3s fires. Clicking a different row cancels pending and activates the new row.                                                                                                                    |
-| User holds Enter down on a destructive row (key repeat)                  | First fire: pending set. Every subsequent repeat satisfies `pendingConfirmId === cmd.id` → cancels + fires once (`commandInFlight` guard holds). Third repeat sees pending null → sets it again. No double-fire.                                                       |
-| Two different destructive rows: Enter A, then arrow to B, Enter B        | Arrow-to-B cancels A via selection-change trigger (A's red state reverts). First Enter on B sets B's pending. Second Enter on B fires B. A never fires.                                                                                                                |
-| 3 s timeout fires exactly as user presses second Enter                   | Race documented above. Either order yields an acceptable result: action fires or user sees the red row re-appear for another confirm.                                                                                                                                  |
-| Browser tab goes to background mid-confirm (timers throttled)            | Timer may fire >3s late; pending persists until it does. User returning to foreground still sees the red row. Accepted.                                                                                                                                                |
-| `afterNavigate` fires while palette is opening (racy initial render)     | `isOpen` guard skips close. Palette open-animation completes normally.                                                                                                                                                                                                 |
-| Context predicate references fields DTO hasn't loaded yet                | Page `$effect` runs after `data` is populated (SvelteKit load completes before render). No half-populated context.                                                                                                                                                     |
-| Context-aware command activated without matching context (dev-dispatch)  | Predicate prevents visibility; handlers must still guard: `if (!ctx.album) return;` as belt-and-braces. Covered by a unit test.                                                                                                                                        |
-| Another tab logs out mid-palette                                         | `user` store reflects logout; next `getContext()` returns `userId: null`. Owner-check predicates return false. Commands disappear on the next keystroke / reopen.                                                                                                      |
-| `user` store changes while page context is already registered            | `isOwner` / `canWrite` / `isMember` were computed at effect run; they're now stale until `data.album` reloads. Accepted — logout triggers an auth redirect that unmounts the page within a tick, so the stale window is closed before the user can act on it.          |
-| `afterNavigate` fires on a same-URL `replaceState`                       | Palette closes even though the user didn't navigate. Accepted — palette row activations don't use `replaceState`, so this only affects upstream callers; one-line grep at implementation to confirm no `(user)/*` route uses `replaceState` in a non-navigation sense. |
+| Failure mode                                                             | Behavior                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isAvailable` predicate throws                                           | Caught in provider loop. Command excluded. `console.error` logs id + error.                                                                                                                                                                                                                                                                                                         |
+| Handler throws or rejects                                                | Existing v1.3 path: `.catch` logs, `.finally` cleans up `commandInFlight`. No user bubble.                                                                                                                                                                                                                                                                                          |
+| `removeSpace` / `removeMember` / `handleDeleteAlbum` fails after confirm | Handler swallows + logs + toast via existing `handleError` where available, or relies on the route navigation. `goto('/spaces')` / `goto('/albums')` fires only on the success path.                                                                                                                                                                                                |
+| User confirms a destructive verb but context went null between Enters    | `data.album` / `data.sharedSpace` is stable across the 3s window unless the user navigates. On navigation the palette closes via `afterNavigate`, which clears pending. Invariant holds.                                                                                                                                                                                            |
+| Palette closes mid-confirm (backdrop click, Ctrl+K, etc.)                | `close()` calls `cancelConfirm()` first. Reopen: pending is clean.                                                                                                                                                                                                                                                                                                                  |
+| User clicks a destructive row (mouse) once                               | Pending state; row turns red; palette stays open. Second click within 3s fires. Clicking a different row cancels pending and activates the new row.                                                                                                                                                                                                                                 |
+| User holds Enter down on a destructive row (key repeat)                  | First fire: pending set. Every subsequent repeat satisfies `pendingConfirmId === cmd.id` → cancels + fires once (`commandInFlight` guard holds). Third repeat sees pending null → sets it again. No double-fire.                                                                                                                                                                    |
+| Two different destructive rows: Enter A, then arrow to B, Enter B        | Arrow-to-B cancels A via selection-change trigger (A's red state reverts). First Enter on B sets B's pending. Second Enter on B fires B. A never fires.                                                                                                                                                                                                                             |
+| 3 s timeout fires exactly as user presses second Enter                   | Race documented above. Either order yields an acceptable result: action fires or user sees the red row re-appear for another confirm.                                                                                                                                                                                                                                               |
+| Browser tab goes to background mid-confirm (timers throttled)            | Timer may fire >3s late; pending persists until it does. User returning to foreground still sees the red row. Accepted.                                                                                                                                                                                                                                                             |
+| `afterNavigate` fires while palette is opening (racy initial render)     | `isOpen` guard skips close. Palette open-animation completes normally.                                                                                                                                                                                                                                                                                                              |
+| Context predicate references fields DTO hasn't loaded yet                | Page `$effect` runs after `data` is populated (SvelteKit load completes before render). No half-populated context.                                                                                                                                                                                                                                                                  |
+| Context-aware command activated without matching context (dev-dispatch)  | Predicate prevents visibility; handlers must still guard: `if (!ctx.album) return;` as belt-and-braces. Covered by a unit test.                                                                                                                                                                                                                                                     |
+| Another tab logs out mid-palette                                         | `user` store reflects logout; next `getContext()` returns `userId: null`. Owner-check predicates return false. Commands disappear on the next keystroke / reopen.                                                                                                                                                                                                                   |
+| `user` store changes while page context is already registered            | `isOwner` / `canWrite` / `isMember` were computed at effect run; they're now stale until `data.album` reloads. Accepted — logout triggers an auth redirect that unmounts the page within a tick, so the stale window is closed before the user can act on it.                                                                                                                       |
+| `afterNavigate` fires on a same-URL `replaceState`                       | Palette closes even though the user didn't navigate. Accepted — palette row activations don't use `replaceState`, so this only affects upstream callers; one-line grep at implementation to confirm no `(user)/*` route uses `replaceState` in a non-navigation sense.                                                                                                              |
+| Destructive A pending, user picks an entity row (photo / person / etc.)  | `activate('photo' / 'person' / ...)` doesn't hit the command switch branch, so `cancelConfirm()` isn't called there — but the switch's trailing `this.close()` (existing line ~1193) does fire, and `close()` calls `cancelConfirm()` as its first line. Pending clears as the palette unmounts. Tested: activate destructive A, then activate a photo row, assert pending cleared. |
 
 ## Testing
 
@@ -581,6 +614,29 @@ cached.
 - `userId` / `isAdmin` derive from the mocked `user` store
 - Null default state for album + space
 - Sequential set-then-null clears back to null
+- **`registerAlbumContext` cleanup:** render a Svelte test component
+  that calls `registerAlbumContext(() => mockAlbum)`, unmount, assert
+  `commandContextManager.getContext().album === null`. Pins the
+  cleanup return — a future Svelte cleanup-semantics change that breaks
+  this would leak context between routes.
+- **`registerSpaceContext` cleanup:** same shape.
+- **`registerSpaceContext` with undefined `members`:** feed a DTO with
+  `members: undefined`, assert the resulting space context has
+  `canWrite === false` + `isMember === false`. Defensive drift guard
+  if a future loader refactor drops the field.
+- **`registerSpaceContext` role matrix:** DTOs with the current user
+  as owner / editor / viewer each produce the expected `isOwner` /
+  `canWrite` combinations.
+
+**New spec: `web/src/lib/managers/close-palette-on-navigate.spec.ts`**
+
+- `closePaletteOnNavigate()` calls `globalSearchManager.close` when
+  `isOpen === true`
+- `closePaletteOnNavigate()` no-ops when `isOpen === false`
+- `closePaletteOnNavigate()` fired on a same-URL `replaceState`
+  regression case (mock `navigating` transitions): behaves the same
+  — always calls close if open. Documents that replaceState does
+  close the palette; sets the test as the drift guard.
 
 **New spec / extension: `web/src/lib/components/global-search/__tests__/command-row.spec.ts`**
 
@@ -616,11 +672,18 @@ cached.
   first-Enter path
 - Handler receives `CommandContext` with live `album` / `space` +
   route id (set via mocked `commandContextManager`)
-- **`afterNavigate` close:** unit-test the root-layout wire by calling
-  the exposed hook directly: palette open → invoke hook → palette
-  closed (spy on `globalSearchManager.close`)
+- **`afterNavigate` close:** covered by the new
+  `close-palette-on-navigate.spec.ts` — see above.
+- **Entity-row activation clears pending:** arrange destructive
+  pending, then `activate('photo', ...)` — assert `pendingConfirmId`
+  is null after (via `close()`'s `cancelConfirm`).
+- **Toast-on-rejection drift guard:** for each destructive command
+  whose handler calls an SDK that rejects (mock), assert
+  `handleError` is called exactly once with the `errors.something_went_wrong`
+  key. Pins the error-handling contract — if a future edit drops the
+  try/catch wrapper, the test fails.
 
-**Extensions to `command-items.spec.ts`:**
+**Extensions to `command-items.spec.ts` — availability polarity:**
 
 - Every `cmd:album_*` item's `isAvailable` returns false when `ctx.album === null`
 - `cmd:album_rename` / `cmd:album_share` / `cmd:album_delete` return false when `ctx.album.isOwner === false`
@@ -630,12 +693,37 @@ cached.
 - Explicit: `cmd:space_bulk_add` hides when `ctx.space.canWrite === false` (viewer role)
 - Explicit: `cmd:space_bulk_add` has `destructive: true` set (drift guard)
 - `data.album.albumUsers === undefined` → `isMember` false → `cmd:album_leave` hides
-- Every destructive command (`cmd:album_leave`, `cmd:album_delete`, `cmd:space_leave`, `cmd:space_delete`) has `destructive: true`
+- Every destructive command (`cmd:album_leave`, `cmd:album_delete`, `cmd:space_bulk_add`, `cmd:space_leave`, `cmd:space_delete`) has `destructive: true`
 - No non-destructive command has `destructive: true` (drift guard)
+
+**Extensions to `command-items.spec.ts` — handler wiring (one per handler):**
+
+Each context-aware handler is invoked with a mocked SDK + mocked
+`goto` / `modalManager` / `toastManager` + a synthesised `CommandContext`,
+then the test asserts the right primitive was called with the right
+args. Rejection cases assert `handleError` was called. This is the
+coverage that proves verbs actually _do_ what their names claim — the
+polarity tests above don't cover invocation.
+
+- **`cmd:album_rename.handler(ctx)`** → `modalManager.show` called with `AlbumEditModal` and `{ album: ctx.album }` (mapped to the original DTO).
+- **`cmd:album_share.handler(ctx)`** → `modalManager.show` called with `AlbumOptionsModal`.
+- **`cmd:album_download.handler(ctx)`** → `handleDownloadAlbum` called with the album DTO.
+- **`cmd:album_leave.handler(ctx)`** → `removeUserFromAlbum({ id: album.id, userId: ctx.userId })` called; then `goto(Route.albums())`. SDK rejection → `handleError` fires, `goto` NOT called.
+- **`cmd:album_delete.handler(ctx)`** → `handleDeleteAlbum(album, { prompt: false })` called. On success → `goto(Route.albums())`. On falsy return (dialog internal failure) → no goto.
+- **`cmd:space_manage_members.handler(ctx)`** → `modalManager.show` called with `SpaceMembersModal` and the right props shape.
+- **`cmd:space_add_member.handler(ctx)`** → `modalManager.show` called with `SpaceAddMemberModal`.
+- **`cmd:space_bulk_add.handler(ctx)`** → `bulkAddAssets({ id: space.id })` called; then `toastManager.primary` with the `bulk_add_queued` i18n key. SDK rejection → `handleError` fires, toast NOT called.
+- **`cmd:space_leave.handler(ctx)`** → `removeMember({ id: space.id, userId: ctx.userId })` called; then `goto(Route.spaces())`. SDK rejection → `handleError` fires, `goto` NOT called.
+- **`cmd:space_delete.handler(ctx)`** → `removeSpace({ id: space.id })` called; then `goto(Route.spaces())`. SDK rejection → `handleError` fires, `goto` NOT called.
+- **Route-helper drift guard:** grep-style assertion that no
+  `cmd:album_*` or `cmd:space_*` handler source contains the string
+  literals `'/albums'` / `'/spaces'` — any such literal should be
+  `Route.albums()` / `Route.spaces()`. Prevents silent drift if the
+  route literals change.
 
 ### E2E — Playwright, `e2e/src/web/specs/cmdk-context.e2e.ts`
 
-Seven cases. Uses real-server fixtures for album / space ownership;
+Eight cases. Uses real-server fixtures for album / space ownership;
 no mock-based tests here per `feedback_e2e_mock_filterpanel`.
 
 1. **Album context appearance**: navigate to `/albums/<owned>`, open
@@ -648,8 +736,10 @@ no mock-based tests here per `feedback_e2e_mock_filterpanel`.
    `cmd:album_delete` / `_rename` / `_share` do not.
 4. **Destructive happy path**: navigate to an owned album, open palette,
    type `>delete`, Enter — palette still open, row red with confirm
-   hint. Enter again — album deleted, redirect to `/albums`, album
-   no longer in list.
+   hint. Enter again — album deleted, redirect to `/albums`. Use
+   `expect.poll` or a locator with auto-retry to assert the deleted
+   album's name disappears from the list (the albums page re-fetches
+   after the redirect; avoid asserting against a pre-cached render).
 5. **Destructive Esc cancels**: same setup, first Enter, then Esc —
    palette stays open, row reverts. Second Esc closes palette. Album
    still exists.
@@ -663,6 +753,11 @@ no mock-based tests here per `feedback_e2e_mock_filterpanel`.
    Dedicated test so a regression in the `afterNavigate` wire fails
    loudly instead of masquerading as an unrelated redirect-after-delete
    failure.
+8. **Sub-route context**: navigate to `/spaces/<owned>/people`, open
+   palette with `>`, assert space verbs (`cmd:space_delete`,
+   `cmd:space_manage_members`, etc.) render — pins the
+   `startsWith('/(user)/spaces/[spaceId]')` predicate against a
+   sub-route, not just the top-level detail page.
 
 Held-Enter destructive test and 3s timeout: unit-level only. E2E
 holding a key across a real 3-second window is brittle and the unit
@@ -786,7 +881,7 @@ the fetch-merge-put helper shows up.
      helper, wires it on the space page, adds 5 `cmd:space_*` items
      (3 destructive including `bulk_add`) + i18n keys.
   6. `test(e2e): cmdk context commands and destructive confirm` —
-     Playwright spec, 7 cases.
+     Playwright spec, 8 cases.
 
 - **One PR** titled `feat(web): cmdk palette v1.4 — context-aware commands + inline confirm`.
 - **No server / SDK / DB changes.** All endpoints already exist

--- a/docs/plans/2026-04-19-cmdk-v1.4-plan.md
+++ b/docs/plans/2026-04-19-cmdk-v1.4-plan.md
@@ -1,0 +1,1482 @@
+# cmdk Palette v1.4 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship context-aware commands (route-gated verbs for album and space detail pages) + inline two-step Enter confirm UX for destructive commands, per the design at `docs/plans/2026-04-19-cmdk-v1.4-design.md`.
+
+**Architecture:** New `CommandContextManager` holds a reactive snapshot of the current route entity (album or space). Pages register their DTO via helpers (`registerAlbumContext`, `registerSpaceContext`); the palette filters `COMMAND_ITEMS` through an `isAvailable(ctx)` predicate on every provider run. Destructive commands gain a `destructive: true` flag that routes activation through a `pendingConfirmId` state machine with 3 s timeout + 5 cancel triggers. `afterNavigate` in the root layout closes the palette on route change.
+
+**Tech Stack:** SvelteKit 2, Svelte 5 runes, Vitest + @testing-library/svelte (happy-dom), generated `@immich/sdk`, Playwright. All work in `web/`.
+
+**Design reference:** `docs/plans/2026-04-19-cmdk-v1.4-design.md` — read before starting. Every task below assumes familiarity with the design's architecture and inventory sections. Handler column in the design is the source of truth for SDK call shapes.
+
+**Working directory:** `web/` for everything except E2E (final commit). Use `pnpm test -- --run <spec-file>` to scope unit-test runs.
+
+**Execution discipline:**
+
+- TDD: failing test → minimal impl → green → commit.
+- Never run `make sql` (`feedback_make_sql_no_db`).
+- Never run lint locally; CI handles it (`feedback_lint_sequential`). Do run `pnpm check` (svelte-check + tsc) before each commit.
+- i18n keys: after adding any, run `pnpm --filter=immich-i18n format:fix` per `feedback_i18n_key_sorting`.
+- Commits per the design's "Delivery shape" section — six commits total, grouping the tasks below.
+- No amending: on test failure, fix + re-commit.
+
+---
+
+## Commit 1 — CommandContextManager + extended CommandItem
+
+_Tasks 1–7. No new command items or UI at the end of this commit; only infra._
+
+---
+
+### Task 1: Scaffold `CommandContextManager` — types and manager class
+
+**Files:**
+
+- Create: `web/src/lib/managers/command-context-manager.svelte.ts`
+- Create: `web/src/lib/managers/command-context-manager.spec.ts`
+
+**Step 1: Write the failing test**
+
+`command-context-manager.spec.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { commandContextManager } from '$lib/managers/command-context-manager.svelte';
+
+describe('CommandContextManager', () => {
+  beforeEach(() => {
+    commandContextManager.setAlbum(null);
+    commandContextManager.setSpace(null);
+  });
+
+  it('returns null album and space by default', () => {
+    const ctx = commandContextManager.getContext();
+    expect(ctx.album).toBeNull();
+    expect(ctx.space).toBeNull();
+  });
+
+  it('round-trips setAlbum / setSpace', () => {
+    commandContextManager.setAlbum({
+      id: 'a1',
+      albumName: 'Test',
+      ownerId: 'u1',
+      isOwner: true,
+      isMember: false,
+    });
+    expect(commandContextManager.getContext().album?.id).toBe('a1');
+  });
+
+  it('params is a snapshot — mutation does not leak into next read', () => {
+    const ctx1 = commandContextManager.getContext();
+    (ctx1.params as Record<string, string>).foo = 'bar';
+    const ctx2 = commandContextManager.getContext();
+    expect(ctx2.params.foo).toBeUndefined();
+  });
+});
+```
+
+**Step 2: Run, verify fails**
+
+```
+cd web && pnpm test -- --run src/lib/managers/command-context-manager.spec.ts
+```
+
+Expected: module not found.
+
+**Step 3: Implement**
+
+Create `command-context-manager.svelte.ts` with the `AlbumContext`, `SpaceContext`, `CommandContext` types and the `CommandContextManager` class exactly as specified in the design's "New module" section. Export `commandContextManager` singleton. Do NOT yet add `registerAlbumContext` / `registerSpaceContext` — those come in tasks 4 and 5.
+
+You'll need to mock `$app/state` and the `user` store in the spec if they blow up on import. Pattern:
+
+```ts
+vi.mock('$app/state', () => ({ page: { route: { id: null }, params: {} } }));
+vi.mock('$lib/stores/user.store', () => ({
+  user: {
+    subscribe: (fn: (v: null) => void) => {
+      fn(null);
+      return () => {};
+    },
+  },
+}));
+```
+
+**Step 4: Run, verify green**
+
+Same command; all three tests pass.
+
+**Step 5: `pnpm check`, then commit**
+
+```bash
+git add src/lib/managers/command-context-manager.{svelte.ts,spec.ts}
+git commit -m "feat(web): scaffold CommandContextManager"
+```
+
+---
+
+### Task 2: Extend `CommandItem` type with `isAvailable` + `destructive`
+
+**Files:**
+
+- Modify: `web/src/lib/managers/command-items.ts`
+
+**Step 1: Write the failing test** (extend `command-items.spec.ts`)
+
+```ts
+it('COMMAND_ITEMS type allows isAvailable and destructive', () => {
+  const shape: CommandItem = {
+    id: 'cmd:test',
+    labelKey: 'x',
+    descriptionKey: 'y',
+    icon: 'z',
+    handler: (ctx) => void ctx.album,
+    isAvailable: (ctx) => ctx.album !== null,
+    destructive: true,
+  };
+  expect(shape.destructive).toBe(true);
+});
+```
+
+Import `CommandItem` and `CommandContext` at the top.
+
+**Step 2: Run, verify fails** (type error — `isAvailable` / `destructive` not allowed).
+
+**Step 3: Implement**
+
+In `command-items.ts`:
+
+1. Import `type { CommandContext } from '$lib/managers/command-context-manager.svelte'`.
+2. Widen `handler` signature from `() => void | Promise<unknown>` to `(ctx: CommandContext) => void | Promise<unknown>`.
+3. Add `isAvailable?: (ctx: CommandContext) => boolean` and `destructive?: boolean` fields.
+
+Do NOT modify the existing 15 command items. Their `() => handler()` definitions remain valid under the widened signature (TS accepts fewer-args).
+
+**Step 4: Run all existing `command-items.spec.ts` tests** — they must still pass, pinning the zero-migration property:
+
+```
+pnpm test -- --run src/lib/managers/command-items.spec.ts
+```
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/command-items.{ts,spec.ts}
+git commit -m "feat(web): extend CommandItem with isAvailable + destructive"
+```
+
+---
+
+### Task 3: Wire `isAvailable` into `filterNavAndCommands`
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` (around L414-499)
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Step 1: Write the failing test**
+
+Add to the manager spec:
+
+```ts
+describe('filterNavAndCommands — isAvailable gating', () => {
+  it('excludes commands whose isAvailable returns false', async () => {
+    // Stash a fake command via spy or module-level mock; simplest is to use
+    // a real existing command and spy on a predicate. Pattern: inject a
+    // mock COMMAND_ITEMS via vi.mock at the top of the spec file, including
+    // one item with isAvailable = () => false, assert it's not in the
+    // provider output under scope 'nav'.
+  });
+
+  it('includes commands whose isAvailable returns true', async () => {
+    /* inverse */
+  });
+
+  it('swallows a throwing isAvailable and logs', async () => {
+    // Mock item with isAvailable = () => { throw new Error('boom'); }
+    // Spy on console.error, assert command excluded, assert logged once.
+  });
+});
+```
+
+Use the module-mock pattern already used elsewhere in this spec file; look at how `vi.mock` is used for `COMMAND_ITEMS` in existing destructive-behavior tests. If no such mock exists, factor it in via a local `vi.mock('$lib/managers/command-items', ...)` at the top of the new `describe` block.
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+In `filterNavAndCommands`, just after the `featureFlag` check in the command loop (around L440-449), add:
+
+```ts
+if (item.isAvailable) {
+  try {
+    if (!item.isAvailable(ctx)) continue;
+  } catch (error) {
+    console.error('[cmdk] isAvailable threw', { id: item.id, error });
+    continue;
+  }
+}
+```
+
+Pull `ctx` from `commandContextManager.getContext()` at the top of the function (before the eligibility loops).
+
+**Step 4: Run, verify green**
+
+Run the single spec file, then the whole web test suite to catch regressions:
+
+```
+pnpm test -- --run src/lib/managers/global-search-manager.svelte.spec.ts
+pnpm test
+```
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/global-search-manager.svelte.ts src/lib/managers/global-search-manager.svelte.spec.ts
+git commit -m "feat(web): invoke CommandItem.isAvailable in filterNavAndCommands"
+```
+
+---
+
+### Task 4: `registerAlbumContext` helper + cleanup + undefined-members tests
+
+**Files:**
+
+- Modify: `web/src/lib/managers/command-context-manager.svelte.ts`
+- Modify: `web/src/lib/managers/command-context-manager.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { render } from '@testing-library/svelte';
+import { mount, unmount } from 'svelte';
+// or use a minimal test-harness component pattern per existing specs
+
+it('registerAlbumContext sets album on mount, clears on unmount', () => {
+  const mockAlbum = { id: 'a1', albumName: 'Test', ownerId: 'u-owner', albumUsers: [] };
+  // Render a test component that invokes registerAlbumContext(() => mockAlbum)
+  // Assert commandContextManager.getContext().album.id === 'a1'
+  // Unmount, assert .album === null
+});
+
+it('registerAlbumContext computes isOwner by comparing to current user', () => {
+  // Arrange user store mock to return { id: 'u-owner', isAdmin: false }
+  // Register album with ownerId 'u-owner', assert isOwner=true
+  // Register album with ownerId 'u-other', assert isOwner=false
+});
+
+it('registerAlbumContext treats undefined albumUsers as isMember=false', () => {
+  // mockAlbum.albumUsers = undefined
+  // assert context.album.isMember === false
+});
+
+it('registerAlbumContext sets isMember=true when current user is in albumUsers', () => {
+  // mockAlbum.albumUsers = [{ user: { id: 'u-current' }, role: 'editor' }]
+  // assert isMember===true
+});
+```
+
+For the test-component pattern, look at how other Svelte 5 component specs render a thin wrapper. Create `web/src/lib/managers/__tests__/register-album-context-harness.svelte` if needed.
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+Add `registerAlbumContext` in `command-context-manager.svelte.ts` exactly per the design's "New module" code block. Import types from `@immich/sdk`:
+
+```ts
+import type { AlbumResponseDto } from '@immich/sdk';
+```
+
+The function body uses `$effect` + `get(user)` + `setAlbum(...)` with an `isOwner` / `isMember` computation and a cleanup returning `setAlbum(null)`.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/command-context-manager.{svelte.ts,spec.ts} src/lib/managers/__tests__/register-album-context-harness.svelte
+git commit -m "feat(web): registerAlbumContext helper"
+```
+
+---
+
+### Task 5: `registerSpaceContext` helper + role-matrix tests
+
+**Files:**
+
+- Modify: `web/src/lib/managers/command-context-manager.svelte.ts`
+- Modify: `web/src/lib/managers/command-context-manager.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it('registerSpaceContext sets isOwner when current user is createdById', () => {
+  /* ... */
+});
+it('registerSpaceContext canWrite=true for owner, editor; false for viewer', () => {
+  // three subcases using SharedSpaceRole.Owner / Editor / Viewer
+});
+it('registerSpaceContext treats undefined members as isMember=false + canWrite=false', () => {
+  /* ... */
+});
+it('registerSpaceContext isMember=true when user appears in members', () => {
+  /* ... */
+});
+it('registerSpaceContext cleanup clears space on unmount', () => {
+  /* ... */
+});
+```
+
+Import `SharedSpaceRole` from `@immich/sdk`.
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+`registerSpaceContext` exactly per the design. Uses `SharedSpaceRole.Owner` / `.Editor` enum comparison on `self?.role`.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/command-context-manager.{svelte.ts,spec.ts}
+git commit -m "feat(web): registerSpaceContext helper"
+```
+
+---
+
+### Task 6: Context-aware command handler receives fresh context at activate time
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` — the `activate('command')` branch around L1177-1191
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it('activate("command") passes CommandContext to handler', async () => {
+  commandContextManager.setAlbum({ id: 'a1', albumName: 'X', ownerId: 'u', isOwner: true, isMember: false });
+  const handler = vi.fn();
+  const cmd: CommandItem = { id: 'cmd:ctx_probe', labelKey: 'x', descriptionKey: 'y', icon: 'z', handler };
+  manager.activate('command', cmd);
+  await vi.waitFor(() => expect(handler).toHaveBeenCalled());
+  expect(handler).toHaveBeenCalledWith(expect.objectContaining({ album: expect.objectContaining({ id: 'a1' }) }));
+});
+
+it('drift guard: activate("command") still fires cmd:theme while album context is registered', async () => {
+  // Import cmd:theme from COMMAND_ITEMS, spy on themeManager.toggleTheme, fire, assert called.
+});
+```
+
+**Step 2: Run, verify fails** (handler currently invoked with no args).
+
+**Step 3: Implement**
+
+In the `case 'command':` branch, change:
+
+```ts
+.then(() => cmd.handler())
+```
+
+to:
+
+```ts
+const ctx = commandContextManager.getContext();
+...
+.then(() => cmd.handler(ctx))
+```
+
+Snapshot `ctx` BEFORE the `queueMicrotask` (reading it inside the microtask is also fine — palette close doesn't mutate `commandContextManager`, but pre-snapshot is defensive). Place the `getContext()` call right before the `queueMicrotask` line so the snapshot is tied to activation time.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/global-search-manager.svelte.{ts,spec.ts}
+git commit -m "feat(web): pass CommandContext to command handlers at activate time"
+```
+
+---
+
+### Task 7: Baseline smoke commit (combine commit message for Commit 1)
+
+This is a no-code task: verify the cumulative state of commits 1.1–1.6 is clean. Run:
+
+```
+cd web && pnpm check && pnpm test
+```
+
+If anything regressed, fix + commit (do NOT amend). Otherwise, move on.
+
+Commit 1 of the design's delivery plan is now represented by commits from tasks 1, 2, 3, 4, 5, 6. No squash needed — the granular commits are acceptable per Gallery's merge style (the PR reviewer decides final squashing).
+
+---
+
+## Commit 2 — Close palette on navigation
+
+_Tasks 8–9._
+
+---
+
+### Task 8: `closePaletteOnNavigate` helper + spec
+
+**Files:**
+
+- Create: `web/src/lib/managers/close-palette-on-navigate.ts`
+- Create: `web/src/lib/managers/close-palette-on-navigate.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/managers/global-search-manager.svelte', () => ({
+  globalSearchManager: {
+    isOpen: false,
+    close: vi.fn(),
+  },
+}));
+
+import { closePaletteOnNavigate } from './close-palette-on-navigate';
+import { globalSearchManager } from './global-search-manager.svelte';
+
+describe('closePaletteOnNavigate', () => {
+  beforeEach(() => {
+    vi.mocked(globalSearchManager.close).mockReset();
+    globalSearchManager.isOpen = false;
+  });
+
+  it('no-ops when palette is closed', () => {
+    closePaletteOnNavigate();
+    expect(globalSearchManager.close).not.toHaveBeenCalled();
+  });
+
+  it('calls close when palette is open', () => {
+    globalSearchManager.isOpen = true;
+    closePaletteOnNavigate();
+    expect(globalSearchManager.close).toHaveBeenCalledOnce();
+  });
+
+  it('calls close on same-URL replaceState regression case', () => {
+    // Fired unconditionally by afterNavigate on replaceState — we still close.
+    globalSearchManager.isOpen = true;
+    closePaletteOnNavigate();
+    closePaletteOnNavigate();
+    expect(globalSearchManager.close).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+```ts
+// web/src/lib/managers/close-palette-on-navigate.ts
+import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+
+export function closePaletteOnNavigate() {
+  if (globalSearchManager.isOpen) {
+    globalSearchManager.close();
+  }
+}
+```
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/close-palette-on-navigate.{ts,spec.ts}
+git commit -m "feat(web): closePaletteOnNavigate helper"
+```
+
+---
+
+### Task 9: Wire `afterNavigate` in root `+layout.svelte`
+
+**Files:**
+
+- Modify: `web/src/routes/+layout.svelte`
+
+**Step 1: Write the failing test**
+
+E2E-only — a unit test here would require mocking SvelteKit's internal `afterNavigate`, which is brittle. The E2E case 7 (Task 30) covers it. Skip to impl.
+
+**Step 2: N/A**
+
+**Step 3: Implement**
+
+Add to `+layout.svelte`'s `<script>` block:
+
+```ts
+import { afterNavigate } from '$app/navigation';
+import { closePaletteOnNavigate } from '$lib/managers/close-palette-on-navigate';
+
+afterNavigate(closePaletteOnNavigate);
+```
+
+Place the import near other `$app/...` imports. Place the `afterNavigate` call at the end of the script block or alongside other lifecycle hooks.
+
+**Step 4: Manual smoke test**
+
+Start `make dev`, open palette, trigger a navigation (e.g. click a sidebar link), verify palette closes.
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/routes/+layout.svelte
+git commit -m "feat(web): close cmdk palette on navigation"
+```
+
+---
+
+## Commit 3 — Inline-confirm UX for destructive commands
+
+_Tasks 10–15._
+
+---
+
+### Task 10: Add `pendingConfirmId` state + `startConfirm` / `cancelConfirm` helpers
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+describe('pending-confirm state', () => {
+  it('startConfirm sets pendingConfirmId', () => {
+    manager.startConfirm('cmd:test'); // will need to be exposed or tested via activate; keep private if possible
+    expect(manager.pendingConfirmId).toBe('cmd:test');
+  });
+
+  it('cancelConfirm clears pendingConfirmId and timer', () => {
+    manager.startConfirm('cmd:test');
+    manager.cancelConfirm();
+    expect(manager.pendingConfirmId).toBeNull();
+  });
+
+  it('3s timeout auto-clears pending', async () => {
+    vi.useFakeTimers();
+    manager.startConfirm('cmd:test');
+    vi.advanceTimersByTime(3000);
+    expect(manager.pendingConfirmId).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('stale-timer guard: new confirm during window does not clear new id', async () => {
+    vi.useFakeTimers();
+    manager.startConfirm('cmd:a');
+    vi.advanceTimersByTime(1000);
+    manager.startConfirm('cmd:b');
+    vi.advanceTimersByTime(2000); // 3s from start of cmd:a — but cmd:b armed its own timer
+    expect(manager.pendingConfirmId).toBe('cmd:b');
+    vi.advanceTimersByTime(1000); // 3s from start of cmd:b
+    expect(manager.pendingConfirmId).toBeNull();
+    vi.useRealTimers();
+  });
+});
+```
+
+Note: if `startConfirm` is private, expose it for tests via a test-only accessor or invoke through `activate('command', destructiveItem)`. Prefer the latter once Task 11 lands; for this task test them directly by temporarily making them public or using `(manager as any).startConfirm` in the spec.
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+Add to the manager class:
+
+```ts
+pendingConfirmId: string | null = $state(null);
+private confirmTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Expose as public so activate() and the palette's keydown can call them.
+startConfirm(cmdId: string) {
+  this.pendingConfirmId = cmdId;
+  if (this.confirmTimer !== null) clearTimeout(this.confirmTimer);
+  this.confirmTimer = setTimeout(() => {
+    if (this.pendingConfirmId === cmdId) {
+      this.pendingConfirmId = null;
+    }
+    this.confirmTimer = null;
+  }, 3000);
+}
+
+cancelConfirm() {
+  if (this.confirmTimer !== null) {
+    clearTimeout(this.confirmTimer);
+    this.confirmTimer = null;
+  }
+  this.pendingConfirmId = null;
+}
+```
+
+Then wire `this.cancelConfirm()` as the first line of the existing `close()` method so palette close clears state.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/global-search-manager.svelte.{ts,spec.ts}
+git commit -m "feat(web): inline-confirm state machine for destructive commands"
+```
+
+---
+
+### Task 11: Update `activate('command')` destructive branching
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` (activate command branch, ~L1177)
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+describe('activate("command") — destructive', () => {
+  const destructiveCmd: CommandItem = {
+    id: 'cmd:destruct',
+    labelKey: 'x',
+    descriptionKey: 'y',
+    icon: 'z',
+    destructive: true,
+    handler: vi.fn(),
+  };
+
+  it('first Enter on destructive: palette stays open, handler not called, pending set', () => {
+    manager.open();
+    manager.activate('command', destructiveCmd);
+    expect(manager.isOpen).toBe(true);
+    expect(destructiveCmd.handler).not.toHaveBeenCalled();
+    expect(manager.pendingConfirmId).toBe('cmd:destruct');
+  });
+
+  it('second Enter within 3s: palette closes, handler called, pending cleared', async () => {
+    manager.open();
+    manager.activate('command', destructiveCmd);
+    manager.activate('command', destructiveCmd);
+    await vi.waitFor(() => expect(destructiveCmd.handler).toHaveBeenCalledOnce());
+    expect(manager.isOpen).toBe(false);
+    expect(manager.pendingConfirmId).toBeNull();
+  });
+
+  it('destructive A then destructive B: pending flips, only B fires on confirm', async () => {
+    /* ... */
+  });
+  it('destructive A then non-destructive C: pending cleared, C fires, A never', async () => {
+    /* ... */
+  });
+  it('held-Enter guard: three sync activates on destructive → handler called at most once', async () => {
+    /* ... */
+  });
+  it('rapid mouse double-click: two sync activates fire exactly once', async () => {
+    /* ... */
+  });
+});
+```
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+Replace the `case 'command':` body with the code from the design's "activate('command') gets a destructive branch at the top" code block. Snapshot `ctx` before `queueMicrotask`.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/global-search-manager.svelte.{ts,spec.ts}
+git commit -m "feat(web): destructive-command two-step Enter in activate"
+```
+
+---
+
+### Task 12: Wire cancel triggers — query change + selection change
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` — `setQuery` and `setActiveItem`
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it('setQuery("anything") while pending cancels confirm', () => {
+  manager.activate('command', destructiveCmd);
+  expect(manager.pendingConfirmId).not.toBeNull();
+  manager.setQuery('x');
+  expect(manager.pendingConfirmId).toBeNull();
+});
+
+it('setActiveItem(otherId) while pending cancels confirm', () => {
+  /* ... */
+});
+it('setActiveItem(pendingId) keeps confirm alive', () => {
+  /* ... */
+});
+```
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+In `setQuery`: if `this.pendingConfirmId !== null`, call `this.cancelConfirm()` as the first line.
+
+In `setActiveItem(value: string | null)`: if `this.pendingConfirmId !== null && value !== this.pendingConfirmId`, call `this.cancelConfirm()` before doing the normal state update.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/global-search-manager.svelte.{ts,spec.ts}
+git commit -m "feat(web): cancel pending confirm on query or selection change"
+```
+
+---
+
+### Task 13: Escape intercept in `global-search.svelte`
+
+**Files:**
+
+- Modify: `web/src/lib/components/global-search/global-search.svelte` (the `onKeyDown` handler at L209+)
+- Modify: `web/src/lib/components/global-search/__tests__/global-search.spec.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it('Escape while pending cancels confirm but does not close palette', async () => {
+  const { container } = render(GlobalSearch, { ... });
+  await openPalette();
+  // type '>delete' or similar to focus a destructive command; fire Enter to arm pending
+  manager.activate('command', destructiveCmd);
+  const input = container.querySelector('input[role="combobox"]');
+  await fireEvent.keyDown(input!, { key: 'Escape' });
+  expect(manager.pendingConfirmId).toBeNull();
+  expect(manager.isOpen).toBe(true);
+});
+
+it('Escape with no pending closes palette as before', async () => { /* ... */ });
+```
+
+**Step 2: Run, verify fails**
+
+**Step 3: Implement**
+
+In `onKeyDown` (global-search.svelte L209), insert a new first branch BEFORE the existing `'?'` branch:
+
+```ts
+if (e.key === 'Escape' && manager.pendingConfirmId !== null) {
+  manager.cancelConfirm();
+  e.preventDefault();
+  return;
+}
+```
+
+Leave the existing Escape branch untouched — it now fires only when no pending.
+
+**Step 4: Run, verify green**
+
+**Step 5: `pnpm check`, commit**
+
+```bash
+git add src/lib/components/global-search/global-search.svelte src/lib/components/global-search/__tests__/global-search.spec.ts
+git commit -m "feat(web): intercept Escape to cancel pending confirm"
+```
+
+---
+
+### Task 14: `CommandRow` pending prop + danger styling + confirm-hint i18n
+
+**Files:**
+
+- Modify: `web/src/lib/components/global-search/rows/command-row.svelte`
+- Modify: `web/src/lib/components/global-search/__tests__/command-row.spec.ts`
+- Modify: `web/src/lib/i18n/locales/en.json`
+
+**Step 1: Add i18n key**
+
+In `en.json`:
+
+```json
+"cmdk_cmd_confirm_hint": "Press Enter again to confirm · Esc to cancel",
+```
+
+Then: `cd web && pnpm --filter=immich-i18n format:fix` to re-sort.
+
+**Step 2: Write the failing test**
+
+```ts
+it('pending=true renders the confirm hint text', () => {
+  render(CommandRow, { props: { item: mockDestructiveCmd, pending: true, ... } });
+  expect(screen.getByText(/Press Enter again/)).toBeInTheDocument();
+});
+
+it('pending=true applies the danger class', () => { /* ... */ });
+it('pending=false renders the normal description', () => { /* ... */ });
+it('pending flip false→true→false swaps cleanly', async () => { /* ... */ });
+```
+
+**Step 3: Run, verify fails**
+
+**Step 4: Implement**
+
+Look at how existing destructive buttons in the Gallery web codebase apply danger styling — grep for `bg-danger` or `variant="danger"` in `.svelte` files. Pick the canonical token (likely a Tailwind class like `bg-danger/10` or a `@immich/ui` variant prop). Apply it to the row's outer container when `pending` is true.
+
+Add `pending?: boolean` to the row's `Props` interface. When `pending`, replace the description slot with `$t('cmdk_cmd_confirm_hint')`. Keep icon + label unchanged.
+
+**Step 5: Run, verify green**
+
+**Step 6: `pnpm check`, commit**
+
+```bash
+git add src/lib/components/global-search/rows/command-row.svelte src/lib/components/global-search/__tests__/command-row.spec.ts src/lib/i18n/locales/en.json
+git commit -m "feat(web): CommandRow pending state + confirm hint i18n"
+```
+
+---
+
+### Task 15: Wire `pending` prop in `GlobalSearchCommandsSection`
+
+**Files:**
+
+- Modify: `web/src/lib/components/global-search/global-search-commands-section.svelte`
+
+**Step 1: No new test** — the row test covers rendering; the manager spec covers state transitions. Integration is exercised by E2E later.
+
+**Step 2: Implement**
+
+In the section component's row loop, add to the `CommandRow` invocation:
+
+```svelte
+<CommandRow
+  {item}
+  pending={item.id === manager.pendingConfirmId}
+  ...
+/>
+```
+
+**Step 3: `pnpm check`, commit**
+
+```bash
+git add src/lib/components/global-search/global-search-commands-section.svelte
+git commit -m "feat(web): pass pending prop to CommandRow based on manager state"
+```
+
+---
+
+## Commit 4 — Album-context commands
+
+_Tasks 16–23. All live on the album detail page; each command item has its own task with availability + handler-wiring tests._
+
+---
+
+### Task 16: Wire `registerAlbumContext` on the album page
+
+**Files:**
+
+- Modify: `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Step 1: No new unit test** — the helper is tested in Task 4; this is an integration. E2E case 1 covers it.
+
+**Step 2: Implement**
+
+Add to the page's `<script>` block:
+
+```ts
+import { registerAlbumContext } from '$lib/managers/command-context-manager.svelte';
+
+registerAlbumContext(() => data.album);
+```
+
+Place with other imports / top-of-script setup. The thunk captures `data.album` reactively — do not pass `data.album` directly.
+
+**Step 3: Manual smoke test**
+
+Start `make dev`, navigate to an album, open devtools console, poke `commandContextManager.getContext().album` — should be populated.
+
+**Step 4: `pnpm check`, commit**
+
+```bash
+git add src/routes/...+page.svelte
+git commit -m "feat(web): register album context on album detail page"
+```
+
+---
+
+### Task 17: `cmd:album_rename` — availability + handler + i18n
+
+**Files:**
+
+- Modify: `web/src/lib/managers/command-items.ts`
+- Modify: `web/src/lib/managers/command-items.spec.ts`
+- Modify: `web/src/lib/i18n/locales/en.json`
+
+**Step 1: Add i18n keys**
+
+```json
+"cmdk_cmd_album_rename_label": "Rename this album",
+"cmdk_cmd_album_rename_description": "Change the album's name or description",
+```
+
+Then `pnpm --filter=immich-i18n format:fix`.
+
+**Step 2: Write the failing test**
+
+```ts
+import type { CommandContext } from '$lib/managers/command-context-manager.svelte';
+
+const album = { id: 'a1', albumName: 'X', ownerId: 'u-owner', isOwner: true, isMember: false };
+const ctxOwner: CommandContext = {
+  routeId: '/(user)/albums/[albumId=id]',
+  params: { albumId: 'a1' },
+  album,
+  space: null,
+  userId: 'u-owner',
+  isAdmin: false,
+};
+const ctxNonOwner = { ...ctxOwner, album: { ...album, isOwner: false }, userId: 'u-other' };
+const ctxNoAlbum = { ...ctxOwner, album: null };
+
+it('cmd:album_rename hides when album is null', () => {
+  const cmd = COMMAND_ITEMS.find((c) => c.id === 'cmd:album_rename')!;
+  expect(cmd.isAvailable!(ctxNoAlbum)).toBe(false);
+});
+
+it('cmd:album_rename hides for non-owners', () => {
+  const cmd = COMMAND_ITEMS.find((c) => c.id === 'cmd:album_rename')!;
+  expect(cmd.isAvailable!(ctxNonOwner)).toBe(false);
+});
+
+it('cmd:album_rename shows for owner', () => {
+  const cmd = COMMAND_ITEMS.find((c) => c.id === 'cmd:album_rename')!;
+  expect(cmd.isAvailable!(ctxOwner)).toBe(true);
+});
+
+it('cmd:album_rename handler opens AlbumEditModal', async () => {
+  vi.mock('@immich/ui', async () => ({ ...(await vi.importActual('@immich/ui')), modalManager: { show: vi.fn() } }));
+  const cmd = COMMAND_ITEMS.find((c) => c.id === 'cmd:album_rename')!;
+  await cmd.handler(ctxOwner);
+  expect(modalManager.show).toHaveBeenCalledWith(AlbumEditModal, expect.objectContaining({ album: expect.anything() }));
+});
+```
+
+To make the handler test work, the handler needs access to the _original_ `AlbumResponseDto`, not just the context struct. See Task 17 note below.
+
+**Step 3: Run, verify fails**
+
+**Step 4: Implement**
+
+**Context-only is not enough for handler args.** `modalManager.show(AlbumEditModal, { album })` expects the full `AlbumResponseDto`, but `CommandContext.album` is our minimal `AlbumContext` struct. Two options:
+
+1. **Extend `AlbumContext` to carry the original DTO** as an opaque `raw: AlbumResponseDto` field. Cheap; the thunk in `registerAlbumContext` already has the DTO.
+2. **Handler re-fetches** via `getAlbumInfo({ id })` on activation. Adds a round-trip; rejected in the design alternatives list.
+
+Go with option 1. Edit `AlbumContext` in `command-context-manager.svelte.ts`:
+
+```ts
+export interface AlbumContext {
+  id: string;
+  albumName: string;
+  ownerId: string;
+  isOwner: boolean;
+  isMember: boolean;
+  /** Original DTO passed through for handlers that open modals / call SDKs needing the full object. */
+  raw: AlbumResponseDto;
+}
+```
+
+Update `registerAlbumContext` to set `raw: album` when calling `setAlbum`. Same for `SpaceContext` + `registerSpaceContext` — add `raw: SharedSpaceResponseDto`.
+
+Re-run existing tests; they may need fixture adjustments to include `raw`.
+
+Then add the `cmd:album_rename` entry to `COMMAND_ITEMS`:
+
+```ts
+{
+  id: 'cmd:album_rename',
+  labelKey: 'cmdk_cmd_album_rename_label',
+  descriptionKey: 'cmdk_cmd_album_rename_description',
+  icon: mdiPencilOutline, // grep for the canonical album-edit icon
+  isAvailable: (ctx) => ctx.album !== null && ctx.album.isOwner,
+  handler: (ctx) => {
+    if (!ctx.album) return;
+    return modalManager.show(AlbumEditModal, { album: ctx.album.raw });
+  },
+},
+```
+
+Imports: `mdiPencilOutline` from `@mdi/js`, `AlbumEditModal` from `$lib/modals/AlbumEditModal.svelte`.
+
+**Step 5: Run, verify green**
+
+**Step 6: `pnpm check`, commit**
+
+```bash
+git add src/lib/managers/command-items.{ts,spec.ts} src/lib/managers/command-context-manager.{svelte.ts,spec.ts} src/lib/i18n/locales/en.json
+git commit -m "feat(web): cmd:album_rename command"
+```
+
+---
+
+### Task 18: `cmd:album_share` — availability + handler + i18n
+
+**Files:** same shape as Task 17.
+
+**Step 1: i18n**
+
+```json
+"cmdk_cmd_album_share_label": "Share this album",
+"cmdk_cmd_album_share_description": "Invite people or manage access",
+```
+
+**Step 2–5:** Same pattern. Availability: owner-only. Handler: `modalManager.show(AlbumOptionsModal, { album: ctx.album.raw })`. Icon: grep for the share icon on albums (`mdiShareVariantOutline` or similar).
+
+Commit: `feat(web): cmd:album_share command`.
+
+---
+
+### Task 19: `cmd:album_download` — availability + handler + i18n
+
+**Step 1: i18n**
+
+```json
+"cmdk_cmd_album_download_label": "Download this album",
+"cmdk_cmd_album_download_description": "Download all album assets as a zip",
+```
+
+**Step 2–5:** Availability: `ctx.album !== null` (any viewer). Handler: `handleDownloadAlbum(ctx.album.raw)`. Icon: `mdiDownloadOutline`.
+
+Import `handleDownloadAlbum` from `$lib/services/album.service`.
+
+Commit: `feat(web): cmd:album_download command`.
+
+---
+
+### Task 20: `cmd:album_leave` — availability + handler + destructive + i18n
+
+**Step 1: i18n**
+
+```json
+"cmdk_cmd_album_leave_label": "Leave this shared album",
+"cmdk_cmd_album_leave_description": "Remove yourself from this album",
+```
+
+**Step 2: Test matrix**
+
+```ts
+it('cmd:album_leave hides for owners', () => {
+  /* ctx.album.isOwner=true → false */
+});
+it('cmd:album_leave hides for non-members', () => {
+  /* ctx.album.isMember=false, isOwner=false → false */
+});
+it('cmd:album_leave shows for non-owner member', () => {
+  /* both flags set right → true */
+});
+it('cmd:album_leave has destructive:true', () => {
+  /* drift guard */
+});
+it('cmd:album_leave handler calls removeUserFromAlbum then goto(Route.albums())', async () => {
+  vi.mock('@immich/sdk', async () => ({
+    ...(await vi.importActual('@immich/sdk')),
+    removeUserFromAlbum: vi.fn().mockResolvedValue(undefined),
+  }));
+  vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+  await cmd.handler(ctxLeaveableAlbum);
+  expect(removeUserFromAlbum).toHaveBeenCalledWith({ id: 'a1', userId: 'u-me' });
+  expect(goto).toHaveBeenCalledWith(Route.albums());
+});
+it('cmd:album_leave handler calls handleError on rejection + does NOT goto', async () => {
+  /* ... */
+});
+```
+
+**Step 3: Impl**
+
+```ts
+{
+  id: 'cmd:album_leave',
+  labelKey: 'cmdk_cmd_album_leave_label',
+  descriptionKey: 'cmdk_cmd_album_leave_description',
+  icon: mdiExitRun,
+  destructive: true,
+  isAvailable: (ctx) => ctx.album !== null && !ctx.album.isOwner && ctx.album.isMember,
+  handler: async (ctx) => {
+    if (!ctx.album || !ctx.userId) return;
+    try {
+      await removeUserFromAlbum({ id: ctx.album.id, userId: ctx.userId });
+      await goto(Route.albums());
+    } catch (err) {
+      const $t = get(t);
+      handleError(err, $t('errors.something_went_wrong'));
+    }
+  },
+},
+```
+
+Imports: `removeUserFromAlbum` from `@immich/sdk`, `goto` from `$app/navigation`, `Route` from the route-helpers module (grep for existing `import { Route } from ...` in album.service.ts), `handleError` from `$lib/utils/handle-error`, `mdiExitRun` from `@mdi/js`.
+
+**Step 4-5:** Run, green, commit. `feat(web): cmd:album_leave destructive command`.
+
+---
+
+### Task 21: `cmd:album_delete` — availability + handler + destructive + i18n
+
+**Step 1: i18n**
+
+```json
+"cmdk_cmd_album_delete_label": "Delete this album",
+"cmdk_cmd_album_delete_description": "Permanently remove this album",
+```
+
+**Step 2: Test**
+
+```ts
+it('cmd:album_delete hides for non-owners', () => {
+  /* ... */
+});
+it('cmd:album_delete shows for owner', () => {
+  /* ... */
+});
+it('cmd:album_delete has destructive:true', () => {
+  /* ... */
+});
+it('cmd:album_delete handler calls handleDeleteAlbum({prompt:false}) + goto on success', async () => {
+  vi.mock('$lib/services/album.service', async () => ({
+    ...(await vi.importActual('$lib/services/album.service')),
+    handleDeleteAlbum: vi.fn().mockResolvedValue(true),
+  }));
+  vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+  await cmd.handler(ctxOwner);
+  expect(handleDeleteAlbum).toHaveBeenCalledWith(ctxOwner.album!.raw, { prompt: false });
+  expect(goto).toHaveBeenCalledWith(Route.albums());
+});
+it('cmd:album_delete handler does NOT goto when handleDeleteAlbum returns falsy', async () => {
+  vi.mocked(handleDeleteAlbum).mockResolvedValue(false);
+  await cmd.handler(ctxOwner);
+  expect(goto).not.toHaveBeenCalled();
+});
+```
+
+**Step 3: Impl**
+
+```ts
+{
+  id: 'cmd:album_delete',
+  labelKey: 'cmdk_cmd_album_delete_label',
+  descriptionKey: 'cmdk_cmd_album_delete_description',
+  icon: mdiDeleteOutline,
+  destructive: true,
+  isAvailable: (ctx) => ctx.album !== null && ctx.album.isOwner,
+  handler: async (ctx) => {
+    if (!ctx.album) return;
+    const ok = await handleDeleteAlbum(ctx.album.raw, { prompt: false });
+    if (ok) await goto(Route.albums());
+  },
+},
+```
+
+Imports: `handleDeleteAlbum` from `$lib/services/album.service`, `mdiDeleteOutline` from `@mdi/js`.
+
+**Step 4-5:** green, commit. `feat(web): cmd:album_delete destructive command`.
+
+---
+
+### Task 22: Drift guard — Route-helper grep test
+
+**Files:**
+
+- Modify: `web/src/lib/managers/command-items.spec.ts`
+
+**Step 1: Write the test**
+
+```ts
+it('no cmd:album_* or cmd:space_* handler source uses raw /albums or /spaces strings', async () => {
+  const src = await fs.readFile('src/lib/managers/command-items.ts', 'utf-8');
+  // split on lines, find the cmd:album_/cmd:space_ blocks, fail if any contains a goto with a quoted literal
+  const lines = src.split('\n');
+  for (const line of lines) {
+    if (line.includes("goto('/albums')") || line.includes("goto('/spaces')")) {
+      throw new Error(`Found raw path in: ${line}`);
+    }
+  }
+});
+```
+
+Use `fs.readFile` from `node:fs/promises` (already used in other spec files; grep for existing pattern).
+
+**Step 2-5:** green (should pass because tasks 20-21 already use Route helpers), commit. `test(web): route-helper drift guard for command-items`.
+
+---
+
+### Task 23: Destructive drift guard across album verbs
+
+Add one more sweeping test in `command-items.spec.ts`:
+
+```ts
+it('all cmd:album_* and cmd:space_* destructive commands have destructive:true', () => {
+  const destructiveIds = ['cmd:album_leave', 'cmd:album_delete'];
+  for (const id of destructiveIds) {
+    const cmd = COMMAND_ITEMS.find((c) => c.id === id)!;
+    expect(cmd.destructive).toBe(true);
+  }
+});
+
+it('no cmd:album_* non-destructive command is marked destructive', () => {
+  const nonDestructiveIds = ['cmd:album_rename', 'cmd:album_share', 'cmd:album_download'];
+  for (const id of nonDestructiveIds) {
+    const cmd = COMMAND_ITEMS.find((c) => c.id === id)!;
+    expect(cmd.destructive).toBeFalsy();
+  }
+});
+```
+
+Commit: `test(web): destructive-flag drift guards for album commands`.
+
+---
+
+## Commit 5 — Space-context commands
+
+_Tasks 24–29. Same shape as Commit 4._
+
+---
+
+### Task 24: Wire `registerSpaceContext` on the space page
+
+**Files:** `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+Add:
+
+```ts
+import { registerSpaceContext } from '$lib/managers/command-context-manager.svelte';
+
+registerSpaceContext(() => data.sharedSpace);
+```
+
+Verify `data.sharedSpace` is the actual field name — grep the page's `data = $props()` destructure. If it's different (e.g. `data.space`), adjust. Commit: `feat(web): register space context on space detail page`.
+
+---
+
+### Task 25: `cmd:space_manage_members` — owner-only, opens SpaceMembersModal
+
+i18n:
+
+```json
+"cmdk_cmd_space_manage_members_label": "Manage space members",
+"cmdk_cmd_space_manage_members_description": "Add, remove, or change member permissions",
+```
+
+Handler:
+
+```ts
+handler: (ctx) => {
+  if (!ctx.space) return;
+  return modalManager.show(SpaceMembersModal, {
+    spaceId: ctx.space.id,
+    members: ctx.space.raw.members ?? [],
+    isOwner: true,
+    spaceColor: ctx.space.raw.color ?? 'primary',
+  });
+},
+isAvailable: (ctx) => ctx.space !== null && ctx.space.isOwner,
+```
+
+Icon: `mdiAccountGroupOutline`. Test shape mirrors Task 17. Commit.
+
+---
+
+### Task 26: `cmd:space_add_member` — owner-only, opens SpaceAddMemberModal
+
+i18n:
+
+```json
+"cmdk_cmd_space_add_member_label": "Add a member to this space",
+"cmdk_cmd_space_add_member_description": "Invite someone to join this space",
+```
+
+Handler: `modalManager.show(SpaceAddMemberModal, { spaceId: ctx.space.id })`. Icon: `mdiAccountPlus`. Commit.
+
+---
+
+### Task 27: `cmd:space_bulk_add` — destructive, bulkAddAssets + toast
+
+i18n:
+
+```json
+"cmdk_cmd_space_bulk_add_label": "Add all my photos to this space",
+"cmdk_cmd_space_bulk_add_description": "Queue a background job to add all your assets",
+"bulk_add_queued": "Adding all your photos to this space — this may take a while",
+```
+
+Availability: `ctx.space !== null && ctx.space.canWrite`. Destructive: true.
+
+Handler:
+
+```ts
+handler: async (ctx) => {
+  if (!ctx.space) return;
+  const $t = get(t);
+  try {
+    await bulkAddAssets({ id: ctx.space.id });
+    toastManager.primary($t('bulk_add_queued'));
+  } catch (err) {
+    handleError(err, $t('errors.something_went_wrong'));
+  }
+},
+```
+
+Icon: `mdiImageMultipleOutline`. Tests per the design's handler-wiring section. Commit.
+
+---
+
+### Task 28: `cmd:space_leave` — destructive, removeMember + goto
+
+i18n:
+
+```json
+"cmdk_cmd_space_leave_label": "Leave this space",
+"cmdk_cmd_space_leave_description": "Remove yourself from this space",
+```
+
+Availability: `ctx.space !== null && !ctx.space.isOwner && ctx.space.isMember`. Destructive.
+
+Handler mirrors `cmd:album_leave` but calls `removeMember({ id: ctx.space.id, userId: ctx.userId })` + `goto(Route.spaces())`. Icon: `mdiExitRun` (same as album_leave — intentional consistency).
+
+Commit.
+
+---
+
+### Task 29: `cmd:space_delete` — destructive, removeSpace + goto
+
+i18n:
+
+```json
+"cmdk_cmd_space_delete_label": "Delete this space",
+"cmdk_cmd_space_delete_description": "Permanently remove this space",
+```
+
+Availability: owner-only. Destructive.
+
+Handler:
+
+```ts
+handler: async (ctx) => {
+  if (!ctx.space) return;
+  const $t = get(t);
+  try {
+    await removeSpace({ id: ctx.space.id });
+    await goto(Route.spaces());
+  } catch (err) {
+    handleError(err, $t('errors.something_went_wrong'));
+  }
+},
+```
+
+Icon: `mdiDeleteOutline`. Tests per handler-wiring template. Commit.
+
+---
+
+### Task 29b: Destructive drift guard across space verbs
+
+Extend the drift-guard test from Task 23 to include `cmd:space_leave`, `cmd:space_delete`, `cmd:space_bulk_add` in the destructive list; `cmd:space_manage_members`, `cmd:space_add_member` in the non-destructive list. Commit.
+
+---
+
+## Commit 6 — E2E Playwright coverage
+
+_Task 30 — one spec file, 8 cases._
+
+---
+
+### Task 30: `cmdk-context.e2e.ts` — 8 cases
+
+**Files:**
+
+- Create: `e2e/src/web/specs/cmdk-context.e2e.ts`
+
+**Step 1: Fixtures**
+
+The E2E suite has existing helpers for creating users, albums, and spaces with specific ownership. Grep `e2e/src/web/specs/` for existing cmdk tests (`cmdk-commands.e2e.ts`) and space tests to see the fixture patterns. Needs:
+
+- Two users: `owner@e2e.local`, `member@e2e.local`
+- An album owned by `owner`, shared with `member`
+- A space owned by `owner`, with `member` as editor
+
+**Step 2: Case 1 — Album context appearance**
+
+Per the design's E2E section, case 1: navigate as `owner` to their owned album, press Ctrl+K, type `>`, assert the four `cmd:album_*` rows are visible via `data-value` attribute on `[data-command-item]` selectors.
+
+**Step 3: Case 2 — Context hidden off-route**
+
+Navigate to `/photos`, `>`, assert zero album/space cmd rows.
+
+**Step 4: Case 3 — Ownership gating**
+
+As `member` visiting the album shared by `owner`: `>`, assert `cmd:album_leave` visible, `cmd:album_delete` / `_rename` / `_share` NOT visible.
+
+**Step 5: Case 4 — Destructive happy path**
+
+As `owner` on the album: `>delete`, Enter. Assert palette modal is still open and the focused row has the danger class (`.bg-danger\\/10` or whatever class Task 14 landed). Enter again. Assert redirect to `/albums`. Use `expect.poll` to wait for the deleted album's name to vanish from the list — don't assert against a pre-cached render.
+
+**Step 6: Case 5 — Destructive Esc cancels**
+
+Same setup, first Enter, Escape. Palette still open, row reverts to normal class. Escape again, palette closes. Album still exists.
+
+**Step 7: Case 6 — Arrow-away cancels**
+
+First Enter on destructive row, Arrow Down, verify the previous row has normal class now. Press Enter, verify a non-destructive handler fires (e.g. `cmd:album_download` starts a download — assert a download event or toast, not the actual file).
+
+**Step 8: Case 7 — Close-on-navigate**
+
+On `/photos`, open palette, click a nav row that navigates (e.g. `go to albums`). Assert `.svelte-modal` or `[role="dialog"]` no longer in DOM.
+
+**Step 9: Case 8 — Sub-route context**
+
+Navigate as `owner` to `/spaces/<id>/people`, `>`, assert `cmd:space_delete` and `cmd:space_manage_members` visible. Pins the `startsWith` predicate.
+
+**Step 10: Run E2E locally**
+
+```
+make e2e-web-dev
+```
+
+Only run the new spec file via Playwright's `--grep` flag or similar.
+
+**Step 11: Commit**
+
+```bash
+git add e2e/src/web/specs/cmdk-context.e2e.ts
+git commit -m "test(e2e): cmdk context commands and destructive confirm"
+```
+
+---
+
+## Post-implementation — PR prep
+
+After Task 30:
+
+1. Run full web test suite + check: `cd web && pnpm check && pnpm test`
+2. Run full E2E (via `make e2e`) as a sanity check; `cmdk-context.e2e.ts` plus the existing `cmdk-commands.e2e.ts` should all pass.
+3. Push branch: `git push -u origin feat/cmdk-v1.4-context`
+4. Open PR titled `feat(web): cmdk palette v1.4 — context-aware commands + inline confirm`. Reference design doc and this plan.
+
+---
+
+## Notes on drift / risk
+
+- **Icon names**: `@mdi/js` has dozens of plausible icons per concept. The names above (`mdiPencilOutline`, `mdiExitRun`, etc.) are best guesses; verify against what existing Gallery UI uses for the equivalent action and swap if a different one is the house style.
+- **Modal prop shapes**: `AlbumEditModal`, `AlbumOptionsModal`, `SpaceMembersModal`, `SpaceAddMemberModal` props were verified at design time but may drift. Before each relevant task, grep the modal's `let { ... } = $props()` line and adjust the handler's call args.
+- **`ctx.userId` can be null** in tests where `user` store is not set. Every handler that uses it should early-return when null (pattern already in Task 20 impl).
+- **`data.sharedSpace` field name**: Task 24 notes to grep the page for the actual field name. If the space route's `+page.ts` calls it `data.space`, update the `registerSpaceContext(() => data.space)` call accordingly.
+- **`Route` import**: there's one canonical `Route` helper module in `web/src/lib/` — grep existing callers (e.g. `album.service.ts:141`) for the exact import path.
+- **Held-Enter test reliability**: the destructive state machine has multiple cancel triggers. Unit tests should use `vi.useFakeTimers()` for any assertion about the 3 s timeout; rely on real timers only for the debounce tests already in the manager spec.


### PR DESCRIPTION
## Summary
- Design doc for cmdk palette v1.4, the sixth increment
- Adds `CommandContextManager` for route-aware verbs (album + space detail pages)
- Inline two-step Enter confirm UX for destructive commands
- 10 new verbs (5 album + 5 space), 5 destructive
- Reusability helpers (`registerAlbumContext`, `registerSpaceContext`) so v1.6 adds new page contexts with a one-liner

## Test plan
- [ ] No code changes in this PR — docs-only
- [ ] Follow-up PR (`feat/cmdk-v1.4-context`) will implement per the delivery-shape section