### PR TITLE
fix(server): filter null thumbhashes from spaces recent assets

### DIFF
--- a/e2e/src/specs/server/api/jobs.e2e-spec.ts
+++ b/e2e/src/specs/server/api/jobs.e2e-spec.ts
@@ -64,6 +64,12 @@ describe('/jobs', () => {
         force: false,
       });
 
+      // Wait for the pause to actually take effect before uploading. Otherwise a
+      // race between Pause propagation and the upload's metadata-job enqueue can
+      // land the job in `waiting` (instead of `paused`), which never drains —
+      // causing the subsequent waitForQueueFinish to time out on slow CI.
+      await utils.waitForQueuePaused(admin.accessToken, 'metadataExtraction');
+
       const { id } = await utils.createAsset(admin.accessToken, {
         assetData: { bytes: await readFile(path), filename: basename(path) },
       });

--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -176,6 +176,8 @@ describe('/shared-spaces', () => {
       });
       const imageAsset = await utils.createAsset(user3.accessToken);
       await utils.addSpaceAssets(user3.accessToken, space.id, [videoAsset.id, imageAsset.id]);
+      // recent assets are filtered to those with a thumbhash; wait for thumbnail generation
+      await utils.waitForQueueFinish(admin.accessToken, 'thumbnailGeneration');
 
       const { body } = await request(app)
         .get(`/shared-spaces/${space.id}`)

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -797,6 +797,24 @@ export const utils = {
     });
   },
 
+  waitForQueuePaused: (accessToken: string, queue: keyof QueuesResponseLegacyDto, ms?: number) => {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise<void>(async (resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timed out waiting for queue to pause')), ms || 10_000);
+
+      while (true) {
+        const queues = await getQueuesLegacy({ headers: asBearerAuth(accessToken) });
+        if (queues[queue].queueStatus.isPaused) {
+          break;
+        }
+        await setAsyncTimeout(200);
+      }
+
+      clearTimeout(timeout);
+      resolve();
+    });
+  },
+
   cliLogin: async (accessToken: string) => {
     const key = await utils.createApiKey(accessToken, [Permission.All]);
     await immichCli(['login', app, `${key.secret}`]);

--- a/server/src/dtos/shared-space.dto.ts
+++ b/server/src/dtos/shared-space.dto.ts
@@ -187,7 +187,7 @@ export class SharedSpaceResponseDto {
   recentAssetIds?: string[];
 
   @ApiPropertyOptional({ description: 'Thumbhashes for recent assets (parallel array)', type: [String] })
-  recentAssetThumbhashes?: (string | null)[];
+  recentAssetThumbhashes?: string[];
 
   @ApiPropertyOptional({ description: 'Space members (summary)', type: [SharedSpaceMemberResponseDto] })
   members?: SharedSpaceMemberResponseDto[];

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -199,6 +199,7 @@ from
       and "asset"."deletedAt" is null
       and "asset"."isOffline" = $2
       and "asset"."type" = $3
+      and "asset"."thumbhash" is not null
     union
     select
       "asset"."id",
@@ -212,6 +213,7 @@ from
       and "asset"."deletedAt" is null
       and "asset"."isOffline" = $5
       and "asset"."type" = $6
+      and "asset"."thumbhash" is not null
   ) as "combined"
 order by
   "combined"."fileCreatedAt" desc

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -308,6 +308,7 @@ export class SharedSpaceRepository {
           .where('asset.deletedAt', 'is', null)
           .where('asset.isOffline', '=', false)
           .where('asset.type', '=', AssetType.Image)
+          .where('asset.thumbhash', 'is not', null)
           .union(
             this.db
               .selectFrom('shared_space_library')
@@ -316,7 +317,8 @@ export class SharedSpaceRepository {
               .where('shared_space_library.spaceId', '=', spaceId)
               .where('asset.deletedAt', 'is', null)
               .where('asset.isOffline', '=', false)
-              .where('asset.type', '=', AssetType.Image),
+              .where('asset.type', '=', AssetType.Image)
+              .where('asset.thumbhash', 'is not', null),
           )
           .as('combined'),
       )

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -257,6 +257,27 @@ describe(SharedSpaceService.name, () => {
       expect(result[0].recentAssetThumbhashes).toEqual(['YWJjMTIz', 'ZGVmNDU2']);
     });
 
+    it('should drop both id and thumbhash when thumbhash is null (parallel-array contract)', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace();
+      const recentAssets = [
+        { id: newUuid(), thumbhash: Buffer.from('abc123') },
+        { id: newUuid(), thumbhash: null },
+        { id: newUuid(), thumbhash: Buffer.from('def456') },
+      ];
+
+      mocks.sharedSpace.getAllByUserId.mockResolvedValue([space]);
+      mocks.sharedSpace.getMembers.mockResolvedValue([]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(5);
+      mocks.sharedSpace.getRecentAssets.mockResolvedValue(recentAssets);
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ lastViewedAt: null }));
+
+      const result = await sut.getAll(auth);
+
+      expect(result[0].recentAssetIds).toEqual([recentAssets[0].id, recentAssets[2].id]);
+      expect(result[0].recentAssetThumbhashes).toEqual(['YWJjMTIz', 'ZGVmNDU2']);
+    });
+
     it('should return empty arrays for spaces with no assets', async () => {
       const auth = factory.auth();
       const space = factory.sharedSpace();
@@ -570,6 +591,28 @@ describe(SharedSpaceService.name, () => {
 
       expect(result.recentAssetIds).toEqual([recentAssets[0].id, recentAssets[1].id, recentAssets[2].id]);
       expect(result.recentAssetThumbhashes).toEqual(['dGh1bWIx', 'dGh1bWIy', 'dGh1bWIz']);
+    });
+
+    it('should drop both id and thumbhash when thumbhash is null (parallel-array contract)', async () => {
+      const auth = factory.auth();
+      const space = factory.sharedSpace();
+      const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+      const recentAssets = [
+        { id: newUuid(), thumbhash: Buffer.from('thumb1') },
+        { id: newUuid(), thumbhash: null },
+        { id: newUuid(), thumbhash: Buffer.from('thumb3') },
+      ];
+
+      mocks.sharedSpace.getMember.mockResolvedValue(member);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getMembers.mockResolvedValue([member]);
+      mocks.sharedSpace.getAssetCount.mockResolvedValue(10);
+      mocks.sharedSpace.getRecentAssets.mockResolvedValue(recentAssets);
+
+      const result = await sut.get(auth, space.id);
+
+      expect(result.recentAssetIds).toEqual([recentAssets[0].id, recentAssets[2].id]);
+      expect(result.recentAssetThumbhashes).toEqual(['dGh1bWIx', 'dGh1bWIz']);
     });
 
     it('should include lastActivityAt in response', async () => {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -555,7 +555,7 @@ describe(SharedSpaceService.name, () => {
       const member = makeMemberResult({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
       const recentAssets = [
         { id: newUuid(), thumbhash: Buffer.from('thumb1') },
-        { id: newUuid(), thumbhash: null },
+        { id: newUuid(), thumbhash: Buffer.from('thumb2') },
         { id: newUuid(), thumbhash: Buffer.from('thumb3') },
       ];
 
@@ -569,7 +569,7 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.get(auth, space.id);
 
       expect(result.recentAssetIds).toEqual([recentAssets[0].id, recentAssets[1].id, recentAssets[2].id]);
-      expect(result.recentAssetThumbhashes).toEqual(['dGh1bWIx', null, 'dGh1bWIz']);
+      expect(result.recentAssetThumbhashes).toEqual(['dGh1bWIx', 'dGh1bWIy', 'dGh1bWIz']);
     });
 
     it('should include lastActivityAt in response', async () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -116,9 +116,9 @@ export class SharedSpaceService extends BaseService {
         memberCount: members.length,
         assetCount,
         recentAssetIds: recentAssets.map((a) => a.id),
-        recentAssetThumbhashes: recentAssets.map((a) =>
-          a.thumbhash ? Buffer.from(a.thumbhash).toString('base64') : null,
-        ),
+        recentAssetThumbhashes: recentAssets
+          .map((a) => (a.thumbhash ? Buffer.from(a.thumbhash).toString('base64') : null))
+          .filter((h): h is string => h !== null),
         members: members.map((m) => this.mapMember(m)),
         newAssetCount,
         lastContributor,
@@ -182,9 +182,9 @@ export class SharedSpaceService extends BaseService {
       memberCount: members.length,
       assetCount,
       recentAssetIds: recentAssets.map((a) => a.id),
-      recentAssetThumbhashes: recentAssets.map((a) =>
-        a.thumbhash ? Buffer.from(a.thumbhash).toString('base64') : null,
-      ),
+      recentAssetThumbhashes: recentAssets
+        .map((a) => (a.thumbhash ? Buffer.from(a.thumbhash).toString('base64') : null))
+        .filter((h): h is string => h !== null),
       members: members.map((m) => this.mapMember(m)),
       newAssetCount,
       lastViewedAt: membership.lastViewedAt ? (membership.lastViewedAt as unknown as Date).toISOString() : null,

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -111,14 +111,21 @@ export class SharedSpaceService extends BaseService {
         }
       }
 
+      const recentAssetIds: string[] = [];
+      const recentAssetThumbhashes: string[] = [];
+      for (const asset of recentAssets) {
+        if (asset.thumbhash) {
+          recentAssetIds.push(asset.id);
+          recentAssetThumbhashes.push(Buffer.from(asset.thumbhash).toString('base64'));
+        }
+      }
+
       results.push({
         ...this.mapSpace(space),
         memberCount: members.length,
         assetCount,
-        recentAssetIds: recentAssets.map((a) => a.id),
-        recentAssetThumbhashes: recentAssets
-          .map((a) => (a.thumbhash ? Buffer.from(a.thumbhash).toString('base64') : null))
-          .filter((h): h is string => h !== null),
+        recentAssetIds,
+        recentAssetThumbhashes,
         members: members.map((m) => this.mapMember(m)),
         newAssetCount,
         lastContributor,
@@ -176,15 +183,22 @@ export class SharedSpaceService extends BaseService {
       }
     }
 
+    const recentAssetIds: string[] = [];
+    const recentAssetThumbhashes: string[] = [];
+    for (const asset of recentAssets) {
+      if (asset.thumbhash) {
+        recentAssetIds.push(asset.id);
+        recentAssetThumbhashes.push(Buffer.from(asset.thumbhash).toString('base64'));
+      }
+    }
+
     return {
       ...this.mapSpace(space),
       thumbnailAssetId,
       memberCount: members.length,
       assetCount,
-      recentAssetIds: recentAssets.map((a) => a.id),
-      recentAssetThumbhashes: recentAssets
-        .map((a) => (a.thumbhash ? Buffer.from(a.thumbhash).toString('base64') : null))
-        .filter((h): h is string => h !== null),
+      recentAssetIds,
+      recentAssetThumbhashes,
       members: members.map((m) => this.mapMember(m)),
       newAssetCount,
       lastViewedAt: membership.lastViewedAt ? (membership.lastViewedAt as unknown as Date).toISOString() : null,

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -538,9 +538,9 @@ describe(SharedSpaceRepository.name, () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
-      const { asset: asset1 } = await ctx.newAsset({ ownerId: user.id });
-      const { asset: asset2 } = await ctx.newAsset({ ownerId: user.id });
-      const { asset: asset3 } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: asset1 } = await ctx.newAsset({ ownerId: user.id, thumbhash: Buffer.from('thumb1') });
+      const { asset: asset2 } = await ctx.newAsset({ ownerId: user.id, thumbhash: Buffer.from('thumb2') });
+      const { asset: asset3 } = await ctx.newAsset({ ownerId: user.id, thumbhash: Buffer.from('thumb3') });
 
       // Add assets with slight delay to ensure ordering
       await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset1.id });
@@ -554,6 +554,22 @@ describe(SharedSpaceRepository.name, () => {
       expect(result[0].id).toBe(asset3.id);
       expect(result[1].id).toBe(asset2.id);
       expect(result[0]).toHaveProperty('thumbhash');
+    });
+
+    it('should exclude assets without a thumbhash', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const { asset: withThumb } = await ctx.newAsset({ ownerId: user.id, thumbhash: Buffer.from('thumb1') });
+      const { asset: withoutThumb } = await ctx.newAsset({ ownerId: user.id, thumbhash: null });
+
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: withoutThumb.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: withThumb.id });
+
+      const result = await sut.getRecentAssets(space.id, 4);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(withThumb.id);
     });
   });
 


### PR DESCRIPTION
## Summary

- Filters out assets with null `thumbhash` at the DB query level in `getRecentAssets` (both direct-upload and library-linked branches)
- Tightens `recentAssetThumbhashes` DTO type from `(string | null)[]` to `string[]` and adds a defensive `.filter()` in the service
- Updates the SQL query docs file and the one unit test that expected `null` in the array

## Root cause

Assets not yet processed by the thumbnail job have a null `thumbhash` in the DB. The server was including them in the `recentAssetThumbhashes` response array. The generated Dart model (auto-generated, `cast<String>()`) threw:

```
type 'Null' is not a subtype of type 'String' in type cast
```

…crashing the entire Spaces view on load.

## Test plan

- [ ] All server unit tests pass (`pnpm test` in `server/`)
- [ ] TypeScript check passes (`make check-server`)
- [ ] Deploy to personal instance and verify Spaces view loads on iOS