### PR TITLE
fix(server): skip S3 relative paths in storage migration jobs (#383)

### DIFF
--- a/.github/workflows/storage-migration-tests.yml
+++ b/.github/workflows/storage-migration-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: ./e2e
@@ -68,6 +68,21 @@ jobs:
 
       - name: 'Phase: migrate-to-s3'
         run: pnpm tsx src/storage-migration.ts migrate-to-s3
+
+      - name: 'Phase: template-s3-bulk-skipped'
+        run: pnpm tsx src/storage-migration.ts template-s3-bulk-skipped
+
+      - name: 'Phase: template-s3-upload-skipped'
+        run: pnpm tsx src/storage-migration.ts template-s3-upload-skipped
+
+      - name: 'Phase: template-s3-live-photo-skipped'
+        run: pnpm tsx src/storage-migration.ts template-s3-live-photo-skipped
+
+      - name: 'Phase: template-s3-sidecar-skipped'
+        run: pnpm tsx src/storage-migration.ts template-s3-sidecar-skipped
+
+      - name: 'Phase: template-s3-queue-migration-skipped'
+        run: pnpm tsx src/storage-migration.ts template-s3-queue-migration-skipped
 
       - name: 'Phase: no-files'
         run: pnpm tsx src/storage-migration.ts no-files
@@ -130,6 +145,18 @@ jobs:
 
       - name: 'Phase: rollback'
         run: pnpm tsx src/storage-migration.ts rollback
+
+      # ---------------------------------------------------------------
+      # Phase group 7: backend=disk — template-disk-baseline regression guard
+      # Runs last; no further phases after this.
+      # ---------------------------------------------------------------
+      - name: Restart server (backend=disk, post-rollback)
+        run: |
+          IMMICH_STORAGE_BACKEND=disk \
+          docker compose up -d --no-deps --force-recreate --wait --wait-timeout 120 immich-server
+
+      - name: 'Phase: template-disk-baseline'
+        run: pnpm tsx src/storage-migration.ts template-disk-baseline
 
       # ---------------------------------------------------------------
       # Cleanup and logs

--- a/docs/plans/2026-04-19-storage-template-s3-compat-design.md
+++ b/docs/plans/2026-04-19-storage-template-s3-compat-design.md
@@ -12,16 +12,16 @@ Issue [#383](https://github.com/open-noodle/gallery/issues/383) reported ENOENT 
 
 Already on `fix/s3-storage-move` (+81/−10):
 
-| Location                          | Change                                                                                                 |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `storage.core.ts:136`             | `isImmichPath` returns `false` for relative paths (fixes CWD-based `resolve()` false positive)         |
-| `storage.core.ts:189`             | `moveFile` returns early for relative `oldPath` before `ensureFolders`, `move_history`, or any fs call |
-| `storage-template.service.ts:229` | `moveAsset` skips relative paths + external assets + android-motion paths                              |
-| `storage-template.service.ts:154` | `handleMigrationSingle` skips S3 assets before live-photo fan-out                                      |
-| `storage-template.service.ts:213` | `handleMigration` bulk job guards `removeEmptyDirs(libraryFolder)` with a `checkFileExists` pre-check  |
-| `media.service.ts:204`            | `handleAssetMigration` returns `JobStatus.Skipped` for relative `originalPath`                         |
-| `person.service.ts:595`           | `handlePersonMigration` returns `JobStatus.Skipped` for relative or empty `thumbnailPath`              |
-| `asset-job.repository.ts`         | `getForMigrationJob` now selects `originalPath` (required for the new guard)                           |
+| Location                          | Change                                                                                                                                                                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `storage.core.ts:136`             | `isImmichPath` returns `false` for relative paths (fixes CWD-based `resolve()` false positive)                                                                                                                                        |
+| `storage.core.ts:189`             | `moveFile` returns early for relative `oldPath` before `ensureFolders`, `move_history`, or any fs call                                                                                                                                |
+| `storage-template.service.ts:229` | `moveAsset` skips relative paths + external assets + android-motion paths                                                                                                                                                             |
+| `storage-template.service.ts:154` | `handleMigrationSingle` skips S3 still assets before the live-photo fan-out (still-is-S3 case). Mixed-backend cases (still disk / motion S3) are handled by the inner `moveAsset` guard composing correctly; see test addition below. |
+| `storage-template.service.ts:213` | `handleMigration` bulk job guards `removeEmptyDirs(libraryFolder)` with a `checkFileExists` pre-check                                                                                                                                 |
+| `media.service.ts:204`            | `handleAssetMigration` returns `JobStatus.Skipped` for relative `originalPath`                                                                                                                                                        |
+| `person.service.ts:595`           | `handlePersonMigration` returns `JobStatus.Skipped` for relative or empty `thumbnailPath`                                                                                                                                             |
+| `asset-job.repository.ts`         | `getForMigrationJob` now selects `originalPath` (required for the new guard)                                                                                                                                                          |
 
 All guards are covered by unit tests in the same diff.
 
@@ -86,6 +86,35 @@ Add negative assertions that prove `moveAsset` short-circuits before entering `m
 ```ts
 expect(mocks.move.create).not.toHaveBeenCalled();
 expect(mocks.storage.stat).not.toHaveBeenCalled();
+```
+
+**`storage-template.service.spec.ts` — add mixed-backend live-photo test (new).**
+
+Close the one untested composition: still asset absolute (disk), motion video relative (S3). The still should be migrated; the motion's own `moveAsset` guard should skip it. Asserts the inner guard does the work when the outer `handleMigrationSingle` guard doesn't catch the mixed case:
+
+```ts
+it('should migrate a disk still and skip an S3 motion video', async () => {
+  const motion = AssetFactory.from({
+    type: AssetType.Video,
+    originalPath: 'upload/user/ab/cd/motion.mp4', // relative — on S3
+  })
+    .exif()
+    .build();
+  const still = AssetFactory.from({
+    livePhotoVideoId: motion.id,
+    originalPath: '/data/upload/user/ab/cd/still.jpg', // absolute — on disk
+  })
+    .exif()
+    .build();
+
+  mocks.user.get.mockResolvedValue(userStub.user1);
+  mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(still));
+  mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(motion));
+
+  await expect(sut.handleMigrationSingle({ id: still.id })).resolves.toBe(JobStatus.Success);
+  expect(mocks.storage.rename).toHaveBeenCalledWith(still.originalPath, expect.any(String));
+  expect(mocks.storage.rename).toHaveBeenCalledTimes(1); // motion skipped
+});
 ```
 
 **`media.service.spec.ts:285` — update `handleQueueMigration` tests for the new guard.**
@@ -197,12 +226,14 @@ Each phase follows the pattern:
 
 - Regression guard that the template feature still works end-to-end on disk.
 - Reuses the post-rollback disk restart added below.
-- Set `storageLabel='admin'` on the admin user via `PUT /users/me` or direct DB update so the library path component is predictable (`admin` has no storageLabel by default; path would otherwise contain the user UUID).
+- **Upload path format for reference:** uploads land at `<mediaLocation>/upload/<userUuid>/<uuid0..2>/<uuid2..4>/<uuid>.<ext>` (see `AssetMediaService.getUploadFolder` → `StorageCore.getNestedFolder(StorageFolder.Upload, user.id, file.uuid)`). The path uses `userId` (UUID), NOT `storageLabel`. Only the _library_ path (template destination) uses `storageLabel`.
+- Set `storageLabel='admin'` on the admin user via `PUT /users/me` or direct DB update so the _library_ path component is predictable — without this, the library path contains the admin UUID (unstable across runs).
+- Before migration: capture pre-state via `captureState()` so pre-migration paths are known for delta assertions; capture `preMoveHistoryCount = countMoveHistory()`.
 - Enable template with `{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}`, trigger bulk migration, wait.
-- Assert admin asset `originalPath` matches `/usr/src/app/upload/library/admin/YYYY/YYYY-MM-DD/…`.
-- Assert old `upload/admin/…` paths no longer exist on disk, new paths exist.
-- Assert sidecar followed to `newPath.xmp`.
-- `countMoveHistory() === 0` after success (assets are now at their template-derived destinations; `cleanMoveHistory` ran at job start).
+- Assert admin asset new `originalPath` matches `/usr/src/app/upload/library/admin/YYYY/YYYY-MM-DD/…` (library folder + storageLabel + template).
+- Assert each captured pre-migration upload path no longer exists on disk, and the corresponding new path does exist. Do not hardcode `upload/admin/…` — pre-state paths contain the user UUID.
+- Assert sidecar followed to `${newPath}.xmp`.
+- Assert `countMoveHistory()` equals `preMoveHistoryCount` (each successful move deletes its own row via `moveRepository.delete` at `storage.core.ts:262`; count should return to baseline even if prior phases left legitimate rows).
 - No teardown needed — last phase.
 
 ### 4. Workflow wiring
@@ -242,6 +273,7 @@ Raise `timeout-minutes` from 30 → 45.
 
 - **`template-mixed-disk-then-s3`** and **`template-s3-rollback-preserves-templated-paths`** — backend-swap phases excluded per the scope decision. They test downstream S3-migration behavior not directly affected by this fix. Candidate for a follow-up spec.
 - **Stale `move_history` cleanup.** Pre-existing: failed pre-fix bulk runs left `move_history` rows with relative `oldPath` that now masquerade as "incomplete move" and block legitimate future migrations. Separate design if pursued; workaround today is `DELETE FROM move_history WHERE "oldPath" NOT LIKE '/%'`.
+- **`AssetService.copySidecar` on S3 targets** (`asset.service.ts:345`). Adjacent concern surfaced during the code-path audit: `storageRepository.copyFile(src, '${targetAsset.originalPath}.xmp')` will create a file relative to CWD if `targetAsset.originalPath` is a relative S3 key. Different trigger path (asset duplication/stack creation, not storage template). Not addressed here; flagged for a follow-up audit.
 - **Helper extraction into `storage-harness.ts`** (Approaches 2/3 from brainstorming).
 - **Per-PR workflow trigger.** Retains existing nightly + `workflow_dispatch`.
 - **API endpoint for manually triggering single-asset template migration.** Not needed; `AssetMetadataExtracted` is the trigger in production, and uploads exercise it.
@@ -287,17 +319,20 @@ FileMigrationQueueAll (format change, S3)
 
 ## Testing strategy and coverage matrix
 
-| Path                                               | Unit (now)   | Unit (new) | E2E (new)                |
-| -------------------------------------------------- | ------------ | ---------- | ------------------------ |
-| Bulk template migration S3 skip                    | ✓            | —          | ✓                        |
-| Single template migration S3 skip                  | ✓            | —          | ✓                        |
-| Live-photo fan-out S3 skip                         | ✓ (indirect) | —          | ✓                        |
-| Sidecar file S3 skip                               | —            | —          | ✓                        |
-| Asset file migration format-change S3 skip         | ✓            | —          | ✓                        |
-| Person file migration S3 skip                      | ✓            | —          | — (nightly cost skipped) |
-| `moveFile` direct guard                            | indirect     | ✓          | —                        |
-| `handleQueueMigration` `checkFileExists` pre-check | —            | ✓          | ✓                        |
-| Template feature still works on disk (regression)  | ✓            | —          | ✓                        |
+| Path                                                         | Unit (now)   | Unit (new) | E2E (new)                |
+| ------------------------------------------------------------ | ------------ | ---------- | ------------------------ |
+| Bulk template migration S3 skip                              | ✓            | —          | ✓                        |
+| Single template migration S3 skip                            | ✓            | —          | ✓                        |
+| Live-photo fan-out S3 skip (both on S3)                      | ✓ (indirect) | —          | ✓                        |
+| Live-photo mixed-backend (still disk / motion S3)            | —            | ✓ (new)    | —                        |
+| Sidecar file S3 skip                                         | —            | —          | ✓                        |
+| Asset file migration format-change S3 skip                   | ✓            | —          | ✓                        |
+| Person file migration S3 skip                                | ✓            | —          | — (nightly cost skipped) |
+| `moveFile` direct guard                                      | indirect     | ✓          | —                        |
+| `handleQueueMigration` `checkFileExists` pre-check           | —            | ✓          | ✓                        |
+| Template feature still works on disk (regression)            | ✓            | —          | ✓                        |
+| Template rendering error recovery (`getTemplatePath` throws) | ✓ (:540)     | —          | —                        |
+| `moveFile` EXDEV cross-filesystem copy fallback              | ✓ (:723)     | —          | —                        |
 
 ## Risk & cost
 
@@ -322,8 +357,17 @@ Applied from code-reviewer subagent feedback on the draft:
 
 - `docker compose logs --since` takes a relative duration or ISO timestamp, NOT raw epoch seconds — helper rewritten.
 - Existing `handleQueueMigration` unit test at `media.service.spec.ts:286` will break with the new pre-check — update it, plus add a negative test where `checkFileExists` returns `false`.
-- `template-disk-baseline` path component is the user UUID by default (no `storageLabel` on admin); phase sets `storageLabel='admin'` explicitly for predictable assertions.
-- `countMoveHistory` assertions use pre/post delta instead of `=== 0` (prior phases may leave legitimate rows that `cleanMoveHistory` doesn't purge).
+- `template-disk-baseline` path component is the user UUID by default (no `storageLabel` on admin); phase sets `storageLabel='admin'` explicitly for predictable _library_ assertions. Upload paths remain `upload/<userUuid>/…` regardless of `storageLabel` — documented inline in the phase.
+- `countMoveHistory` assertions use pre/post delta instead of `=== 0` (prior phases may leave legitimate rows that `cleanMoveHistory` doesn't purge). Applied to `template-disk-baseline` too.
 - `template-s3-queue-migration-skipped` expectation explicitly documented: DB path stays on pre-flip extension — intended skip behavior, not a latent bug.
 - Dropped `template-s3-config-change-logs-clean` — cannot catch any bug in this fix's scope.
 - Crash-resilience: every phase starts with an invariant-reset step rather than relying solely on `finally`.
+
+Applied from post-commit review pass:
+
+- Path assertion in `template-disk-baseline` originally read "Assert old `upload/admin/…` paths no longer exist on disk" — fixed. Upload paths use `userId` (UUID), not `storageLabel`. Corrected to "capture pre-migration paths, assert those specific strings no longer exist."
+- Added unit test for mixed-backend live photo (still disk / motion S3) — closes the only untested composition in the guard graph. The outer `handleMigrationSingle` guard handles the still-S3/motion-disk case; the new test covers the reverse.
+- Added `AssetService.copySidecar` (asset.service.ts:345) as a flagged follow-up in "Out of scope" — adjacent S3-relative-path concern surfaced during the code-path audit, different trigger path (asset duplication), not storage-template.
+- Added existing-coverage rows to the matrix (template-render error recovery, EXDEV fallback) for completeness.
+- Verified `QueueName.StorageTemplateMigration = 'storageTemplateMigration'` and `QueueName.Migration = 'migration'` — design's `triggerQueueCommand` strings match the enum exactly.
+- Verified `AssetMediaService.getUploadFolder` produces `upload/<userId>/<uuid0..2>/<uuid2..4>/<uuid>.<ext>` — documented inline.

--- a/docs/plans/2026-04-19-storage-template-s3-compat-design.md
+++ b/docs/plans/2026-04-19-storage-template-s3-compat-design.md
@@ -1,0 +1,329 @@
+# Storage Template S3 Compatibility — Design
+
+## Overview
+
+Issue [#383](https://github.com/open-noodle/gallery/issues/383) reported ENOENT errors on S3 deployments when the storage-template migration job tried to `fs.rename` an S3 relative key (`upload/uuid/4e/e6/file.jpg`) onto an absolute disk path. The `fix/s3-storage-move` branch adds `isAbsolute()` skip guards at five call sites to prevent this. This design captures:
+
+1. One remaining production-code gap of the same bug class, surfaced during review (`MediaService.handleQueueMigration` unguarded `removeEmptyDirs`).
+2. Unit-test hardening for the existing skip paths (direct `moveFile` guard test, tightened bulk-S3 assertions).
+3. Six new E2E phases covering the storage-template × S3 intersection. The existing harness (`e2e/src/storage-migration.ts`) has zero coverage of this area — the original bug would not have been caught by any test in the repo.
+
+## Context: what the branch already ships
+
+Already on `fix/s3-storage-move` (+81/−10):
+
+| Location                          | Change                                                                                                 |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `storage.core.ts:136`             | `isImmichPath` returns `false` for relative paths (fixes CWD-based `resolve()` false positive)         |
+| `storage.core.ts:189`             | `moveFile` returns early for relative `oldPath` before `ensureFolders`, `move_history`, or any fs call |
+| `storage-template.service.ts:229` | `moveAsset` skips relative paths + external assets + android-motion paths                              |
+| `storage-template.service.ts:154` | `handleMigrationSingle` skips S3 assets before live-photo fan-out                                      |
+| `storage-template.service.ts:213` | `handleMigration` bulk job guards `removeEmptyDirs(libraryFolder)` with a `checkFileExists` pre-check  |
+| `media.service.ts:204`            | `handleAssetMigration` returns `JobStatus.Skipped` for relative `originalPath`                         |
+| `person.service.ts:595`           | `handlePersonMigration` returns `JobStatus.Skipped` for relative or empty `thumbnailPath`              |
+| `asset-job.repository.ts`         | `getForMigrationJob` now selects `originalPath` (required for the new guard)                           |
+
+All guards are covered by unit tests in the same diff.
+
+## In scope for this design
+
+### 1. Production code: `handleQueueMigration` guard
+
+Same bug class as #383, different job handler. `MediaService.handleQueueMigration` (`media.service.ts:162`) currently runs:
+
+```ts
+if (active === 1 && waiting === 0) {
+  await this.storageCore.removeEmptyDirs(StorageFolder.Thumbnails);
+  await this.storageCore.removeEmptyDirs(StorageFolder.EncodedVideo);
+}
+```
+
+`StorageRepository.removeEmptyDirs` calls `fs.lstat(directory)` (`storage.repository.ts:164`) which throws `ENOENT` if the directory doesn't exist. On a pure-S3 deployment that has never written thumbnails or encoded videos locally, `/data/thumbs` and `/data/encoded-video` may not exist, failing the `FileMigrationQueueAll` job on its first run.
+
+**Fix:** inline the same `checkFileExists` pre-check already used at `storage-template.service.ts:213`, switching the call site from the `storageCore` wrapper to the repository directly (consistent with that precedent):
+
+```ts
+if (active === 1 && waiting === 0) {
+  for (const folder of [StorageFolder.Thumbnails, StorageFolder.EncodedVideo]) {
+    const path = StorageCore.getBaseFolder(folder);
+    if (await this.storageRepository.checkFileExists(path)) {
+      await this.storageRepository.removeEmptyDirs(path);
+    }
+  }
+}
+```
+
+This inlining makes the `StorageCore.removeEmptyDirs(folder)` wrapper unused (`media.service.ts:165-166` was its only caller). Delete the wrapper in the same change.
+
+### 2. Unit test hardening
+
+**`storage.core.spec.ts` — add `moveFile` describe block with direct guard test.**
+
+Current spec only exercises static helpers. Add an instance-level test that constructs a `StorageCore` with mocked repositories and calls `moveFile` with a relative `oldPath`. Assert the guard fires before any side-effect:
+
+```ts
+describe('moveFile', () => {
+  it('should skip when oldPath is relative (S3 key)', async () => {
+    // StorageCore.create(...) with mocks
+    await core.moveFile({
+      entityId: 'asset-1',
+      pathType: AssetPathType.Original,
+      oldPath: 'upload/user/ab/cd/file.jpg',
+      newPath: '/data/library/user/2021/file.jpg',
+    });
+    expect(mocks.storage.mkdirSync).not.toHaveBeenCalled();
+    expect(mocks.move.getByEntity).not.toHaveBeenCalled();
+    expect(mocks.move.create).not.toHaveBeenCalled();
+    expect(mocks.storage.rename).not.toHaveBeenCalled();
+  });
+});
+```
+
+**`storage-template.service.spec.ts:650` — tighten bulk-S3-skip assertions.**
+
+Add negative assertions that prove `moveAsset` short-circuits before entering `moveFile`:
+
+```ts
+expect(mocks.move.create).not.toHaveBeenCalled();
+expect(mocks.storage.stat).not.toHaveBeenCalled();
+```
+
+**`media.service.spec.ts:285` — update `handleQueueMigration` tests for the new guard.**
+
+The existing "removes empty dirs" test asserts `removeEmptyDirs` was called twice. With the new `checkFileExists` pre-check, that mock now needs to return `true` before the two calls fire. Add a new negative test where `checkFileExists` returns `false` and `removeEmptyDirs` is never called. Without these updates, the production-code fix fails its own unit suite.
+
+### 3. E2E phases (six)
+
+All new phases extend `e2e/src/storage-migration.ts` via its existing `phase` multiplexer. No new files, no helper extraction. Dropped from the initial outline: `template-s3-config-change-logs-clean` (template-disabled config edits can't trigger the bug class — the `!enabled` check at `handleMigrationSingle:145` short-circuits before any `isAbsolute` logic, so the phase would catch nothing).
+
+#### Shared helpers to add to `storage-migration.ts`
+
+```ts
+export async function setStorageTemplate(token: string, opts: { enabled?: boolean; template?: string }): Promise<void> {
+  // GET full config, mutate storageTemplate subtree, PUT (endpoint replaces whole config)
+}
+
+export async function triggerQueueCommand(token: string, queueName: string): Promise<void> {
+  // PUT /jobs/:name { command: 'start' } — one wrapper used by two phases
+}
+
+export async function countMoveHistory(assetId?: string): Promise<number> {
+  const q = assetId
+    ? 'SELECT COUNT(*)::int c FROM move_history WHERE "entityId" = $1'
+    : 'SELECT COUNT(*)::int c FROM move_history';
+  const rows = await queryDb<{ c: number }>(q, assetId ? [assetId] : []);
+  return rows[0].c;
+}
+
+export function captureContainerLogsSince(service: string, sinceMs: number): string {
+  // docker compose `--since` accepts ISO-8601 or relative durations (e.g. "42s"),
+  // NOT raw epoch seconds. Compute elapsed-seconds as a relative duration.
+  // MyConsoleLogger defaults to non-JSON output; substring matches work in JSON mode too
+  // (the warning message appears verbatim in the `message` field).
+  const elapsedSec = Math.max(1, Math.ceil((Date.now() - sinceMs) / 1000));
+  return execSync(`${COMPOSE} logs --since ${elapsedSec}s --no-color ${service}`, {
+    cwd: E2E_DIR,
+    timeout: 30_000,
+    encoding: 'utf8',
+  });
+}
+
+export function assertNoMoveEnoent(logs: string, phaseTag: string): void {
+  const bad = logs.split('\n').filter((l) => l.includes('Unable to complete move') || /ENOENT.*rename/.test(l));
+  assert.equal(bad.length, 0, `[${phaseTag}] unexpected ENOENT/move warnings:\n${bad.join('\n')}`);
+}
+```
+
+`assertNoMoveEnoent` is a secondary signal. Structural invariants (paths unchanged, MinIO keys intact, `move_history` count stable) are the primary signal.
+
+#### Phase specifications
+
+Each phase follows the pattern:
+
+1. **Invariant reset** — `setStorageTemplate(token, { enabled: false })` as the first action. Guards against prior-phase crash-before-teardown (e.g., SIGKILL or throw-in-finally).
+2. Capture start time (`Date.now()`).
+3. Capture `preMoveHistoryCount = countMoveHistory()` (baseline for delta assertions).
+4. Precondition assertions (state matches phase's documented precondition).
+5. Setup (config change, uploads).
+6. Trigger (job or config event).
+7. `waitForProcessing(token)`.
+8. Structural assertions — compare `countMoveHistory()` against `preMoveHistoryCount` rather than asserting `=== 0` (prior phases may have left legitimate rows; `cleanMoveHistory` only removes orphans of deleted assets).
+9. Log-scrape via `assertNoMoveEnoent(logs, phaseTag)`.
+10. Teardown in `finally` (restore default config). Not load-bearing — invariant reset at step 1 is the actual safety net.
+
+**`template-s3-bulk-skipped`** _(backend=s3, runs after `migrate-to-s3`)_
+
+- Capture `captureState()` as pre-state (all paths relative).
+- `setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MM}}/{{filename}}' })`.
+- `triggerQueueCommand(token, 'storageTemplateMigration')` → wait.
+- Assert every asset's `originalPath` unchanged, MinIO keys unchanged, `countMoveHistory()` equals the baseline captured in step 3.
+- `assertNoMoveEnoent`.
+- Teardown: `setStorageTemplate(token, { enabled: false })`.
+
+**`template-s3-upload-skipped`** _(backend=s3)_
+
+- `setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MMMM}}/{{filename}}' })`.
+- Upload a fresh PNG → capture `newAssetId` → `waitForProcessing` (drains metadata extraction + single-migration job).
+- Assert DB `originalPath` starts with `upload/{userId}/…`, MinIO object exists there, `countMoveHistory(newAssetId) === 0`, no ENOENT warnings.
+- Teardown: disable template.
+
+**`template-s3-live-photo-skipped`** _(backend=s3)_
+
+- Upload a motion MP4 → capture `motionId`.
+- Upload a PNG with `livePhotoVideoId: motionId` form field (extend the existing `uploadAsset` helper to accept arbitrary form fields; the field is already valid per `asset-media.dto.ts:75`).
+- Enable template, wait for processing.
+- Both `originalPath`s begin with `upload/…`; both `countMoveHistory(id) === 0`; no ENOENT.
+- Teardown: disable template.
+
+**`template-s3-sidecar-skipped`** _(backend=s3, reuses the sidecar asset from `setup`)_
+
+- Query `asset_file` row where `assetId = sidecarAssetId AND type = 'sidecar'` — capture path.
+- Enable template with a different preset.
+- Trigger bulk migration, wait.
+- Assert sidecar path unchanged, asset `originalPath` unchanged, `countMoveHistory(sidecarAssetId) === 0`, no ENOENT.
+- Teardown: disable template.
+
+**`template-s3-queue-migration-skipped`** _(backend=s3)_
+
+- GET system config; capture current `image.thumbnail.format`.
+- Flip to the other value (webp↔jpeg); PUT config.
+- `triggerQueueCommand(token, 'migration')` → wait.
+- Assert `asset_file.path` rows for `type='thumbnail'` unchanged (still point at the PRE-flip extension, e.g., `thumbs/…/*_thumbnail.webp` even though config now advertises jpeg). This is intended: `handleAssetMigration` skips S3 assets, so the DB path stays on the old extension and the thumbnail would be rewritten only on the next regeneration. Not a bug under this fix.
+- Assert `person.thumbnailPath` unchanged.
+- `assertNoMoveEnoent` — **this is the primary catch for the `handleQueueMigration` `removeEmptyDirs` ENOENT**. Without the production-code fix above, this phase fails.
+- Teardown: restore original thumbnail format.
+
+**`template-disk-baseline`** _(backend=disk, runs LAST, standalone)_
+
+- Regression guard that the template feature still works end-to-end on disk.
+- Reuses the post-rollback disk restart added below.
+- Set `storageLabel='admin'` on the admin user via `PUT /users/me` or direct DB update so the library path component is predictable (`admin` has no storageLabel by default; path would otherwise contain the user UUID).
+- Enable template with `{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}`, trigger bulk migration, wait.
+- Assert admin asset `originalPath` matches `/usr/src/app/upload/library/admin/YYYY/YYYY-MM-DD/…`.
+- Assert old `upload/admin/…` paths no longer exist on disk, new paths exist.
+- Assert sidecar followed to `newPath.xmp`.
+- `countMoveHistory() === 0` after success (assets are now at their template-derived destinations; `cleanMoveHistory` ran at job start).
+- No teardown needed — last phase.
+
+### 4. Workflow wiring
+
+`.github/workflows/storage-migration-tests.yml`:
+
+**Phase group 2 (backend=s3) — insert after `migrate-to-s3` and before `no-files`:**
+
+```yaml
+- name: 'Phase: template-s3-bulk-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-bulk-skipped
+- name: 'Phase: template-s3-upload-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-upload-skipped
+- name: 'Phase: template-s3-live-photo-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-live-photo-skipped
+- name: 'Phase: template-s3-sidecar-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-sidecar-skipped
+- name: 'Phase: template-s3-queue-migration-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-queue-migration-skipped
+```
+
+**New trailing group — after `rollback`, restart server on disk, run disk baseline:**
+
+```yaml
+- name: Restart server (backend=disk, post-rollback)
+  run: |
+    IMMICH_STORAGE_BACKEND=disk \
+    docker compose up -d --no-deps --force-recreate --wait --wait-timeout 120 immich-server
+
+- name: 'Phase: template-disk-baseline'
+  run: pnpm tsx src/storage-migration.ts template-disk-baseline
+```
+
+Raise `timeout-minutes` from 30 → 45.
+
+## Out of scope
+
+- **`template-mixed-disk-then-s3`** and **`template-s3-rollback-preserves-templated-paths`** — backend-swap phases excluded per the scope decision. They test downstream S3-migration behavior not directly affected by this fix. Candidate for a follow-up spec.
+- **Stale `move_history` cleanup.** Pre-existing: failed pre-fix bulk runs left `move_history` rows with relative `oldPath` that now masquerade as "incomplete move" and block legitimate future migrations. Separate design if pursued; workaround today is `DELETE FROM move_history WHERE "oldPath" NOT LIKE '/%'`.
+- **Helper extraction into `storage-harness.ts`** (Approaches 2/3 from brainstorming).
+- **Per-PR workflow trigger.** Retains existing nightly + `workflow_dispatch`.
+- **API endpoint for manually triggering single-asset template migration.** Not needed; `AssetMetadataExtracted` is the trigger in production, and uploads exercise it.
+
+## Data flow
+
+```
+User changes template config
+  → ConfigUpdate event
+  → Template recompiles in-memory
+  → No file ops until the next AssetMetadataExtracted or manual bulk trigger
+
+Upload asset (S3 backend)
+  → POST /assets (object lands in MinIO under upload/{uuid}/…)
+  → MetadataExtraction job
+  → AssetMetadataExtracted event
+  → StorageTemplateMigrationSingle queued
+  → handleMigrationSingle:
+    ├─ template disabled         → Skipped
+    ├─ originalPath relative      → Skipped  [SHIP]
+    └─ else → moveAsset → moveFile (redundant relative guard) [SHIP]
+
+Admin triggers bulk migration (S3)
+  → StorageTemplateMigration job
+  → handleMigration:
+    ├─ cleanMoveHistory (orphaned rows only)
+    ├─ stream assets → moveAsset [relative → return] [SHIP]
+    └─ removeEmptyDirs(libraryFolder) with pre-check [SHIP]
+
+FileMigrationQueueAll (format change, S3)
+  → handleQueueMigration:
+    ├─ if idle: removeEmptyDirs(Thumbnails/EncodedVideo) [THIS DESIGN adds pre-check]
+    ├─ stream assets → queue AssetFileMigration [relative → Skipped] [SHIP]
+    └─ stream persons → queue PersonFileMigration [relative/empty → Skipped] [SHIP]
+```
+
+## Error handling
+
+- Phase scripts use `try { … } finally { teardown(); }` so a failed assertion still restores template state.
+- `waitForProcessing` is the existing 60s-timeout helper; no new polling logic.
+- `assertNoMoveEnoent` is advisory — failures on log scrape alone would be a weak signal, so structural assertions are primary. Log-scrape catches silent regressions where a move happens but fails post-hoc.
+- Phases that mutate global config (storage template, thumbnail format) restore the prior value in `finally` — subsequent phases inherit a known-clean state.
+
+## Testing strategy and coverage matrix
+
+| Path                                               | Unit (now)   | Unit (new) | E2E (new)                |
+| -------------------------------------------------- | ------------ | ---------- | ------------------------ |
+| Bulk template migration S3 skip                    | ✓            | —          | ✓                        |
+| Single template migration S3 skip                  | ✓            | —          | ✓                        |
+| Live-photo fan-out S3 skip                         | ✓ (indirect) | —          | ✓                        |
+| Sidecar file S3 skip                               | —            | —          | ✓                        |
+| Asset file migration format-change S3 skip         | ✓            | —          | ✓                        |
+| Person file migration S3 skip                      | ✓            | —          | — (nightly cost skipped) |
+| `moveFile` direct guard                            | indirect     | ✓          | —                        |
+| `handleQueueMigration` `checkFileExists` pre-check | —            | ✓          | ✓                        |
+| Template feature still works on disk (regression)  | ✓            | —          | ✓                        |
+
+## Risk & cost
+
+- **CI time:** +10–15 min to the nightly workflow (6 phases × ~1.5–2 min each, plus one extra disk restart). Well under the bumped 45-min `timeout-minutes`.
+- **File size:** `storage-migration.ts` grows from ~1525 to ~1850 lines. Below the 2000-line threshold where splitting becomes compelling.
+- **Log-scraping flakiness:** mitigated by using structural assertions as primary signal. `docker compose logs --since` takes a relative duration (`42s`), not epoch seconds — helper implementation reflects this.
+- **Production-code change:** a single `checkFileExists` pre-check plus deletion of a now-unused `StorageCore.removeEmptyDirs` wrapper. Same pattern as the already-reviewed precedent in `handleMigration`. Low risk.
+- **Helper additions:** `setStorageTemplate`, `triggerQueueCommand`, `countMoveHistory`, `captureContainerLogsSince`, `assertNoMoveEnoent`. All thin wrappers over existing primitives.
+- **Crash resilience:** every S3 phase starts by resetting `storageTemplate.enabled = false` before any other action — protects against prior-phase crash-before-teardown bleeding state into the next phase.
+
+## Self-review checkpoints
+
+Verified before drafting:
+
+- `livePhotoVideoId` is a valid form field (`asset-media.dto.ts:75`).
+- `PUT /jobs/:name` with `{ command: 'start' }` is the queue trigger (`job.controller.ts:45`).
+- `removeEmptyDirs` + `checkFileExists` both exist in `StorageRepository` (`storage.repository.ts:137, 162`).
+- Phase ordering: `template-disk-baseline` runs last on its own disk restart, avoiding interaction with other phases.
+- `StorageCore.removeEmptyDirs` wrapper has only one caller (`media.service.ts:165-166`). Safe to delete after inlining.
+
+Applied from code-reviewer subagent feedback on the draft:
+
+- `docker compose logs --since` takes a relative duration or ISO timestamp, NOT raw epoch seconds — helper rewritten.
+- Existing `handleQueueMigration` unit test at `media.service.spec.ts:286` will break with the new pre-check — update it, plus add a negative test where `checkFileExists` returns `false`.
+- `template-disk-baseline` path component is the user UUID by default (no `storageLabel` on admin); phase sets `storageLabel='admin'` explicitly for predictable assertions.
+- `countMoveHistory` assertions use pre/post delta instead of `=== 0` (prior phases may leave legitimate rows that `cleanMoveHistory` doesn't purge).
+- `template-s3-queue-migration-skipped` expectation explicitly documented: DB path stays on pre-flip extension — intended skip behavior, not a latent bug.
+- Dropped `template-s3-config-change-logs-clean` — cannot catch any bug in this fix's scope.
+- Crash-resilience: every phase starts with an invariant-reset step rather than relying solely on `finally`.

--- a/docs/plans/2026-04-19-storage-template-s3-compat-plan.md
+++ b/docs/plans/2026-04-19-storage-template-s3-compat-plan.md
@@ -272,6 +272,16 @@ checkFileExists before removeEmptyDirs. Wrapper StorageCore.removeEmptyDirs
 deleted (single caller inlined)."
 ```
 
+**Step 7: Full-suite sanity check after the deletion**
+
+Removing the `StorageCore.removeEmptyDirs` wrapper could break any test that referenced it. Grep already confirmed no callers, but run the full server suite once to catch any latent reference:
+
+```bash
+cd server && pnpm test -- --run
+```
+
+Expected: all tests pass. If anything fails unexpectedly, inspect the failure before proceeding to E2E work.
+
 ---
 
 ## Task 5: Shared E2E helpers
@@ -807,8 +817,16 @@ async function phaseTemplateDiskBaseline(): Promise<void> {
 
   // Set a predictable storageLabel on admin so library paths are stable.
   // Note: upload paths use userId (UUID), NOT storageLabel — only library paths use it.
+  //
+  // `PUT /users/me` does NOT accept storageLabel (UserUpdateMeDto omits it).
+  // Use the admin endpoint `PUT /admin/users/:id` (UserAdminUpdateDto accepts storageLabel).
+  // Admin users can update themselves via this endpoint.
+  //
+  // This write is idempotent — if a prior run on the same DB already set
+  // storageLabel='admin', the re-update is a no-op from the asset path's
+  // perspective. No teardown needed (last phase in the workflow).
   const me = await api('GET', '/users/me', { token });
-  await api('PUT', '/users/me', { body: { storageLabel: 'admin', name: me.name, email: me.email }, token });
+  await api('PUT', `/admin/users/${me.id}`, { body: { storageLabel: 'admin' }, token });
 
   const preCount = await countMoveHistory();
   const preState = await captureState();

--- a/docs/plans/2026-04-19-storage-template-s3-compat-plan.md
+++ b/docs/plans/2026-04-19-storage-template-s3-compat-plan.md
@@ -1,0 +1,997 @@
+# Storage Template S3 Compatibility Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close one remaining production-code gap from issue #383 (`MediaService.handleQueueMigration` unguarded `removeEmptyDirs`), harden unit tests for the existing skip guards, and add six nightly E2E phases that lock in the storage-template × S3 interaction.
+
+**Architecture:** Three independent slices. Slice A patches the server (one `checkFileExists` pre-check + delete unused helper + unit test hardening); every server change is TDD. Slice B adds shared helpers to `e2e/src/storage-migration.ts` without new files. Slice C adds one phase per task, each self-contained, each registered in the existing phase dispatcher. Slice D wires the workflow YAML.
+
+**Tech Stack:** NestJS 11, Vitest, Kysely, Docker Compose (MinIO), tsx, Playwright (unused here). Prettier+ESLint. All server tests go through `newTestService(Service)` in `server/test/utils.ts` — `{sut, mocks}` pairs with automocked repositories.
+
+**Reference:** design doc at `docs/plans/2026-04-19-storage-template-s3-compat-design.md` (commits `0a865a712`, `3e17c10da`).
+
+---
+
+## Task 1: Direct `moveFile` relative-path guard test
+
+**Files:**
+
+- Modify: `server/src/cores/storage.core.spec.ts` (currently only tests static helpers)
+- Reference: `server/test/utils.ts:285` (`getMocks()`)
+
+**Step 1: Add the test**
+
+Append a new `describe('moveFile', …)` block at the end of the outer `describe('StorageCore', …)`. This block instantiates a real `StorageCore` via the singleton factory, with the `getMocks()` pool, and asserts the guard short-circuits before any side-effect.
+
+```ts
+import { StorageCore } from 'src/cores/storage.core';
+import { AssetFileType, AssetPathType, ImageFormat, StorageFolder } from 'src/enum';
+// ... existing imports
+
+// at bottom of the outer describe('StorageCore', () => { ... })
+
+describe('moveFile', () => {
+  let core: StorageCore;
+  let mocks: ReturnType<typeof getMocks>;
+
+  beforeEach(() => {
+    StorageCore.reset();
+    StorageCore.setMediaLocation('/data');
+    mocks = getMocks();
+    core = StorageCore.create(
+      mocks.asset as any,
+      mocks.config as any,
+      mocks.crypto as any,
+      mocks.move as any,
+      mocks.person as any,
+      mocks.storage as any,
+      mocks.systemMetadata as any,
+      mocks.logger as any,
+    );
+  });
+
+  it('should skip when oldPath is a relative S3 key', async () => {
+    await core.moveFile({
+      entityId: 'asset-1',
+      pathType: AssetPathType.Original,
+      oldPath: 'upload/user/ab/cd/file.jpg',
+      newPath: '/data/library/user/2021/file.jpg',
+    });
+    expect(mocks.storage.mkdirSync).not.toHaveBeenCalled();
+    expect(mocks.move.getByEntity).not.toHaveBeenCalled();
+    expect(mocks.move.create).not.toHaveBeenCalled();
+    expect(mocks.storage.rename).not.toHaveBeenCalled();
+  });
+});
+```
+
+Add `import { getMocks } from 'test/utils';` at the top of the file.
+
+**Step 2: Run — expect PASS on first run**
+
+The production guard at `storage.core.ts:189` already exists. This test locks in that behavior.
+
+```bash
+cd server && pnpm test -- --run src/cores/storage.core.spec.ts
+```
+
+Expected: all existing tests pass; new `should skip when oldPath is a relative S3 key` passes.
+
+**Step 3: Commit**
+
+```bash
+git add server/src/cores/storage.core.spec.ts
+git commit -m "test(storage-core): add direct moveFile guard test for relative S3 keys"
+```
+
+---
+
+## Task 2: Tighten bulk-S3 assertions in storage-template spec
+
+**Files:**
+
+- Modify: `server/src/services/storage-template.service.spec.ts` around line 650
+
+**Step 1: Add two negative assertions to the existing `should skip S3 assets with relative paths during bulk migration` test**
+
+Find the test at line ~650 and append:
+
+```ts
+expect(mocks.move.create).not.toHaveBeenCalled();
+expect(mocks.storage.stat).not.toHaveBeenCalled();
+```
+
+**Step 2: Run — expect PASS**
+
+```bash
+cd server && pnpm test -- --run src/services/storage-template.service.spec.ts
+```
+
+Expected: all tests still pass. The new assertions prove `moveAsset` short-circuits at `storage-template.service.ts:229` before entering `moveFile` (where `move.create` and `storage.stat` would fire).
+
+**Step 3: Commit**
+
+```bash
+git add server/src/services/storage-template.service.spec.ts
+git commit -m "test(storage-template): tighten bulk-S3-skip to assert no moveFile side effects"
+```
+
+---
+
+## Task 3: Mixed-backend live-photo unit test
+
+**Files:**
+
+- Modify: `server/src/services/storage-template.service.spec.ts` (add inside the existing `describe('handleMigrationSingle', …)` block)
+
+**Step 1: Add the test**
+
+Place near the existing "should skip S3 assets with relative paths" test (line ~113). Uses the same `AssetFactory`/`getForStorageTemplate` helpers already imported in this file.
+
+```ts
+it('should migrate a disk still photo and skip its S3 motion video', async () => {
+  const motion = AssetFactory.from({
+    type: AssetType.Video,
+    originalPath: 'upload/user/ab/cd/motion.mp4', // relative — on S3
+    fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+  })
+    .exif()
+    .build();
+  const still = AssetFactory.from({
+    livePhotoVideoId: motion.id,
+    originalPath: '/data/upload/user/ab/cd/still.jpg', // absolute — on disk
+    fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+  })
+    .exif()
+    .build();
+
+  mocks.user.get.mockResolvedValue(userStub.user1);
+  mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(still));
+  mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(motion));
+  mocks.move.create.mockResolvedValue({
+    id: 'move-1',
+    entityId: still.id,
+    pathType: AssetPathType.Original,
+    oldPath: still.originalPath,
+    newPath: `/data/library/${still.ownerId}/2022/2022-06-19/${still.originalFileName}`,
+  });
+
+  await expect(sut.handleMigrationSingle({ id: still.id })).resolves.toBe(JobStatus.Success);
+  expect(mocks.storage.rename).toHaveBeenCalledTimes(1); // only the still
+  expect(mocks.storage.rename).toHaveBeenCalledWith(still.originalPath, expect.any(String));
+});
+```
+
+**Step 2: Run — expect PASS**
+
+```bash
+cd server && pnpm test -- --run src/services/storage-template.service.spec.ts
+```
+
+Expected: new test passes. Proves the composition of guards (`handleMigrationSingle` outer guard fires on still-S3 case; inner `moveAsset` guard fires on motion-S3 case when still is disk).
+
+**Step 3: Commit**
+
+```bash
+git add server/src/services/storage-template.service.spec.ts
+git commit -m "test(storage-template): cover mixed-backend live photo (still disk, motion S3)"
+```
+
+---
+
+## Task 4: Production fix — guard `handleQueueMigration` removeEmptyDirs
+
+This is the only real TDD task — red-first.
+
+**Files:**
+
+- Modify: `server/src/services/media.service.ts:162-167`
+- Modify: `server/src/services/media.service.spec.ts` (around line 285)
+- Modify: `server/src/cores/storage.core.ts` (delete `removeEmptyDirs` wrapper at lines 305-307)
+
+**Step 1: Write failing negative test**
+
+In `media.service.spec.ts`, find the `describe('handleQueueMigration', …)` block at line 285. Before the existing "removes empty dirs" test, add:
+
+```ts
+it('should skip removeEmptyDirs when storage folders do not exist (pure-S3 deployment)', async () => {
+  mocks.job.getJobCounts.mockResolvedValue({ active: 1, waiting: 0 } as any);
+  mocks.storage.checkFileExists.mockResolvedValue(false); // /data/thumbs, /data/encoded-video absent
+  mocks.assetJob.streamForMigrationJob.mockReturnValue(makeStream([]));
+  mocks.person.getAll.mockReturnValue(makeStream([]));
+
+  await expect(sut.handleQueueMigration()).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(2);
+  expect(mocks.storage.removeEmptyDirs).not.toHaveBeenCalled();
+});
+```
+
+Also update the existing test that asserts `removeEmptyDirs` called twice — add a `checkFileExists` mock returning `true` so both calls fire. Find the test that reads `expect(mocks.storage.removeEmptyDirs).toHaveBeenCalledTimes(2)` near line 296 and add at its top:
+
+```ts
+mocks.storage.checkFileExists.mockResolvedValue(true);
+```
+
+**Step 2: Run — expect both the new test AND the existing test to FAIL**
+
+```bash
+cd server && pnpm test -- --run src/services/media.service.spec.ts -t "handleQueueMigration"
+```
+
+Expected: new "should skip removeEmptyDirs" test fails with `expected not to have been called, was called 2 times`. Existing positive test still passes (because `checkFileExists` isn't a gate yet). If the positive test fails unexpectedly, something else is wrong — investigate before proceeding.
+
+**Step 3: Apply production fix**
+
+Edit `server/src/services/media.service.ts` around line 164. Replace:
+
+```ts
+if (active === 1 && waiting === 0) {
+  await this.storageCore.removeEmptyDirs(StorageFolder.Thumbnails);
+  await this.storageCore.removeEmptyDirs(StorageFolder.EncodedVideo);
+}
+```
+
+with:
+
+```ts
+if (active === 1 && waiting === 0) {
+  for (const folder of [StorageFolder.Thumbnails, StorageFolder.EncodedVideo]) {
+    const path = StorageCore.getBaseFolder(folder);
+    if (await this.storageRepository.checkFileExists(path)) {
+      await this.storageRepository.removeEmptyDirs(path);
+    }
+  }
+}
+```
+
+If `StorageCore` is not already imported in this file, add `import { StorageCore } from 'src/cores/storage.core';` (grep confirms it's already imported via `ImagePathOptions, StorageCore, ThumbnailPathEntity`).
+
+**Step 4: Delete the now-unused wrapper**
+
+In `server/src/cores/storage.core.ts`, delete lines 305-307 (the `removeEmptyDirs(folder: StorageFolder)` method). It has no other callers (verified).
+
+**Step 5: Run all three — expect PASS**
+
+```bash
+cd server && pnpm test -- --run src/services/media.service.spec.ts src/cores/storage.core.spec.ts
+```
+
+Expected: all tests pass. If `storage.core.spec.ts` has a test touching the deleted wrapper, update or remove it (grep before running: no such test exists).
+
+**Step 6: Commit**
+
+```bash
+git add server/src/services/media.service.ts server/src/services/media.service.spec.ts server/src/cores/storage.core.ts
+git commit -m "fix(server): guard handleQueueMigration removeEmptyDirs against missing S3-mode dirs
+
+Pure-S3 deployments that never wrote thumbnails or encoded videos to disk
+would hit ENOENT on fs.lstat when FileMigrationQueueAll kicks off the first
+batch. Same bug class as #383; matches the handleMigration precedent of
+checkFileExists before removeEmptyDirs. Wrapper StorageCore.removeEmptyDirs
+deleted (single caller inlined)."
+```
+
+---
+
+## Task 5: Shared E2E helpers
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts` (add helpers near the other exports; no new file)
+
+**Step 1: Add helpers**
+
+Below the existing `waitForMigration` helper (around line 307), add:
+
+```ts
+export async function setStorageTemplate(token: string, opts: { enabled?: boolean; template?: string }): Promise<void> {
+  const config = await api('GET', '/system-config', { token });
+  if (opts.enabled !== undefined) {
+    config.storageTemplate.enabled = opts.enabled;
+  }
+  if (opts.template !== undefined) {
+    config.storageTemplate.template = opts.template;
+  }
+  await api('PUT', '/system-config', { body: config, token });
+}
+
+export async function triggerQueueCommand(token: string, queueName: string): Promise<void> {
+  await api('PUT', `/jobs/${queueName}`, { body: { command: 'start' }, token });
+}
+
+export async function countMoveHistory(assetId?: string): Promise<number> {
+  const rows = assetId
+    ? await queryDb<{ c: string }>('SELECT COUNT(*)::text c FROM move_history WHERE "entityId" = $1', [assetId])
+    : await queryDb<{ c: string }>('SELECT COUNT(*)::text c FROM move_history');
+  return Number(rows[0].c);
+}
+
+export function captureContainerLogsSince(service: string, sinceMs: number): string {
+  // docker compose --since accepts ISO-8601 OR a relative duration (e.g. "42s").
+  // Bare epoch seconds are NOT accepted — compute elapsed seconds.
+  // Substring matches work regardless of JSON vs plaintext logger mode;
+  // the warning text appears verbatim in either.
+  const elapsedSec = Math.max(1, Math.ceil((Date.now() - sinceMs) / 1000));
+  return execSync(`${COMPOSE} logs --since ${elapsedSec}s --no-color ${service}`, {
+    cwd: E2E_DIR,
+    timeout: 30_000,
+    encoding: 'utf8',
+  });
+}
+
+export function assertNoMoveEnoent(logs: string, phaseTag: string): void {
+  const bad = logs.split('\n').filter((l) => l.includes('Unable to complete move') || /ENOENT.*rename/.test(l));
+  assert.equal(bad.length, 0, `[${phaseTag}] unexpected ENOENT/move warnings:\n${bad.join('\n')}`);
+}
+```
+
+Also extend the existing `uploadAsset` helper (line 133-164) to accept arbitrary extra form fields. Change its signature and body:
+
+```ts
+export async function uploadAsset(
+  token: string,
+  filename: string,
+  data: Buffer,
+  sidecar?: Buffer,
+  extraFields?: Record<string, string>,
+): Promise<{ id: string; status: number }> {
+  const form = new FormData();
+  form.append('assetData', new Blob([new Uint8Array(data)]), filename);
+  form.append('deviceAssetId', `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  form.append('deviceId', 'e2e-storage-migration');
+  form.append('fileCreatedAt', new Date().toISOString());
+  form.append('fileModifiedAt', new Date().toISOString());
+
+  if (sidecar) {
+    form.append('sidecarData', new Blob([new Uint8Array(sidecar)]), `${filename}.xmp`);
+  }
+  if (extraFields) {
+    for (const [k, v] of Object.entries(extraFields)) {
+      form.append(k, v);
+    }
+  }
+
+  const url = `${BASE_URL}/assets`;
+  const res = await fetch(url, { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: form });
+  const body = await res.json();
+  if (!res.ok) {
+    throw new Error(`Upload asset failed: ${res.status} ${JSON.stringify(body)}`);
+  }
+  return { id: body.id, status: res.status };
+}
+```
+
+**Step 2: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+Expected: no type errors.
+
+**Step 3: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): add storage-template helpers (setStorageTemplate, triggerQueueCommand, countMoveHistory, log scrape)"
+```
+
+---
+
+## Task 6: Phase `template-s3-bulk-skipped`
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts` (add phase function + dispatcher case)
+
+**Step 1: Add the phase function**
+
+Append after `phaseSidecarVerify` (around line 1450), before the `main` function:
+
+```ts
+// ---------------------------------------------------------------------------
+// Phase: Template bulk migration skips S3 assets (regression for #383)
+// Precondition: S3 backend, assets already on S3
+// ---------------------------------------------------------------------------
+async function phaseTemplateS3BulkSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-bulk-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false }); // invariant reset
+  const startMs = Date.now();
+  const preCount = await countMoveHistory();
+  const preState = await captureState();
+
+  // Precondition: every asset has a relative S3 path
+  for (const a of preState.assets) {
+    assert.ok(!a.originalPath.startsWith('/'), `Precondition failed: asset ${a.id} path is absolute`);
+  }
+
+  try {
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MM}}/{{filename}}' });
+    await triggerQueueCommand(token, 'storageTemplateMigration');
+    await waitForProcessing(token);
+
+    const postState = await captureState();
+
+    // Every asset path unchanged
+    for (const pre of preState.assets) {
+      const post = postState.assets.find((a) => a.id === pre.id);
+      assert.ok(post, `Asset ${pre.id} disappeared`);
+      assert.equal(post.originalPath, pre.originalPath, `Path changed for asset ${pre.id}`);
+    }
+
+    // MinIO keys still exist
+    minioSetupAlias();
+    for (const a of postState.assets) {
+      assert.ok(minioFileExists(a.originalPath), `MinIO key missing: ${a.originalPath}`);
+    }
+
+    // No new move_history rows
+    const postCount = await countMoveHistory();
+    assert.equal(postCount, preCount, `move_history grew from ${preCount} to ${postCount}`);
+
+    // Log-scrape (secondary)
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-bulk-skipped');
+
+    console.log('  Bulk template migration skipped S3 assets cleanly.');
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-bulk-skipped complete ===');
+}
+```
+
+**Step 2: Register in dispatcher**
+
+In `main()` at the bottom of the file, add inside the `switch (phase)` block:
+
+```ts
+case 'template-s3-bulk-skipped': {
+  await phaseTemplateS3BulkSkipped();
+  break;
+}
+```
+
+Also update the `default` error message listing valid phases.
+
+**Step 3: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): phase template-s3-bulk-skipped — regression for #383"
+```
+
+---
+
+## Task 7: Phase `template-s3-upload-skipped`
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts`
+
+**Step 1: Add phase function**
+
+Append after `phaseTemplateS3BulkSkipped`:
+
+```ts
+async function phaseTemplateS3UploadSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-upload-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  try {
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MMMM}}/{{filename}}' });
+
+    const png = createPng();
+    const { id: newAssetId } = await uploadAsset(token, 'template-upload-skip.png', png);
+    await waitForProcessing(token);
+
+    const rows = await queryDb<{ originalPath: string }>('SELECT "originalPath" FROM asset WHERE id = $1', [
+      newAssetId,
+    ]);
+    assert.ok(rows[0], `Asset ${newAssetId} not found`);
+    const { originalPath } = rows[0];
+
+    assert.ok(!originalPath.startsWith('/'), `Expected relative path, got ${originalPath}`);
+    assert.ok(originalPath.startsWith('upload/'), `Expected upload/ prefix, got ${originalPath}`);
+
+    minioSetupAlias();
+    assert.ok(minioFileExists(originalPath), `MinIO key missing: ${originalPath}`);
+
+    const count = await countMoveHistory(newAssetId);
+    assert.equal(count, 0, `Expected 0 move_history rows for new asset, got ${count}`);
+
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-upload-skipped');
+
+    console.log(`  New S3 upload ${newAssetId} stayed at ${originalPath}.`);
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-upload-skipped complete ===');
+}
+```
+
+**Step 2: Register in dispatcher**
+
+Add a `case 'template-s3-upload-skipped'` branch in `main`.
+
+**Step 3: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): phase template-s3-upload-skipped — single-asset AssetMetadataExtracted path"
+```
+
+---
+
+## Task 8: Phase `template-s3-live-photo-skipped`
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts`
+
+**Step 1: Add phase function**
+
+```ts
+async function phaseTemplateS3LivePhotoSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-live-photo-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  try {
+    // Upload motion video first; then still with livePhotoVideoId linking to motion.
+    // A valid video payload is required for a ffprobe-driven asset flow, but in e2e
+    // the upload path only stores the bytes — metadata extraction handles the rest
+    // and tolerates minimal MP4 headers. A 1x1 PNG stands in fine for the still.
+    const motionBytes = Buffer.from([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, 0x69, 0x73, 0x6f,
+      0x6d, 0x69, 0x73, 0x6f, 0x32, 0x61, 0x76, 0x63, 0x31, 0x6d, 0x70, 0x34, 0x31,
+    ]);
+    const { id: motionId } = await uploadAsset(token, 'lp-motion.mp4', motionBytes);
+    const { id: stillId } = await uploadAsset(token, 'lp-still.png', createPng(), undefined, {
+      livePhotoVideoId: motionId,
+    });
+
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MM}}/{{filename}}' });
+    await waitForProcessing(token);
+
+    const rows = await queryDb<{ id: string; originalPath: string }>(
+      'SELECT id, "originalPath" FROM asset WHERE id = ANY($1)',
+      [[motionId, stillId]],
+    );
+    assert.equal(rows.length, 2, `Expected 2 assets, got ${rows.length}`);
+    for (const r of rows) {
+      assert.ok(!r.originalPath.startsWith('/'), `Expected relative path for ${r.id}, got ${r.originalPath}`);
+      assert.ok(r.originalPath.startsWith('upload/'), `Expected upload/ prefix for ${r.id}`);
+    }
+
+    for (const id of [motionId, stillId]) {
+      const c = await countMoveHistory(id);
+      assert.equal(c, 0, `Asset ${id} has ${c} move_history rows, expected 0`);
+    }
+
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-live-photo-skipped');
+
+    console.log(`  Live photo pair (still=${stillId}, motion=${motionId}) skipped template migration.`);
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-live-photo-skipped complete ===');
+}
+```
+
+**Step 2: Register in dispatcher**
+
+Add `case 'template-s3-live-photo-skipped'`.
+
+**Step 3: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): phase template-s3-live-photo-skipped — live photo fan-out skip"
+```
+
+---
+
+## Task 9: Phase `template-s3-sidecar-skipped`
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts`
+
+**Step 1: Add phase function**
+
+```ts
+async function phaseTemplateS3SidecarSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-sidecar-skipped ===');
+  const token = await loginAdmin();
+  const saved = loadState();
+  assert.ok(saved.sidecarAssetId, 'No sidecarAssetId — run `setup` and `migrate-to-s3` first');
+  const sidecarAssetId: string = saved.sidecarAssetId;
+
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+  const preCount = await countMoveHistory(sidecarAssetId);
+
+  const preRows = await queryDb<{ id: string; path: string }>(
+    `SELECT af.id, af.path FROM asset_file af WHERE af."assetId" = $1 AND af.type = 'sidecar'`,
+    [sidecarAssetId],
+  );
+  assert.equal(preRows.length, 1, `Expected 1 sidecar row, got ${preRows.length}`);
+  const preSidecarPath = preRows[0].path;
+
+  const preAssetRows = await queryDb<{ originalPath: string }>('SELECT "originalPath" FROM asset WHERE id = $1', [
+    sidecarAssetId,
+  ]);
+  const preOriginalPath = preAssetRows[0].originalPath;
+
+  try {
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MMMM}}/{{filename}}' });
+    await triggerQueueCommand(token, 'storageTemplateMigration');
+    await waitForProcessing(token);
+
+    const postRows = await queryDb<{ path: string }>(`SELECT path FROM asset_file WHERE id = $1`, [preRows[0].id]);
+    assert.equal(postRows[0].path, preSidecarPath, `Sidecar path changed`);
+
+    const postAssetRows = await queryDb<{ originalPath: string }>('SELECT "originalPath" FROM asset WHERE id = $1', [
+      sidecarAssetId,
+    ]);
+    assert.equal(postAssetRows[0].originalPath, preOriginalPath, `Original path changed`);
+
+    const postCount = await countMoveHistory(sidecarAssetId);
+    assert.equal(postCount, preCount, `move_history grew for ${sidecarAssetId}: ${preCount} → ${postCount}`);
+
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-sidecar-skipped');
+
+    console.log(`  Sidecar asset ${sidecarAssetId} and its .xmp row both unchanged.`);
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-sidecar-skipped complete ===');
+}
+```
+
+**Step 2: Register in dispatcher**
+
+Add `case 'template-s3-sidecar-skipped'`.
+
+**Step 3: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): phase template-s3-sidecar-skipped — sidecar asset_file row stable"
+```
+
+---
+
+## Task 10: Phase `template-s3-queue-migration-skipped`
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts`
+
+**Step 1: Add phase function**
+
+```ts
+async function phaseTemplateS3QueueMigrationSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-queue-migration-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  const config = await api('GET', '/system-config', { token });
+  const originalFormat: string = config.image.thumbnail.format;
+  const flippedFormat = originalFormat === 'webp' ? 'jpeg' : 'webp';
+
+  const preThumbs = await queryDb<{ id: string; path: string }>(
+    `SELECT id, path FROM asset_file WHERE type = 'thumbnail'`,
+  );
+  const prePersons = await queryDb<{ id: string; thumbnailPath: string }>(
+    `SELECT id, "thumbnailPath" FROM person WHERE "thumbnailPath" != ''`,
+  );
+
+  try {
+    // Flip thumbnail format
+    const flipped = {
+      ...config,
+      image: { ...config.image, thumbnail: { ...config.image.thumbnail, format: flippedFormat } },
+    };
+    await api('PUT', '/system-config', { body: flipped, token });
+
+    // Trigger FileMigrationQueueAll (fans out AssetFileMigration + PersonFileMigration)
+    await triggerQueueCommand(token, 'migration');
+    await waitForProcessing(token);
+
+    // Thumbnails unchanged (still point at pre-flip extension — intended skip behavior)
+    const postThumbs = await queryDb<{ id: string; path: string }>(
+      `SELECT id, path FROM asset_file WHERE type = 'thumbnail'`,
+    );
+    assert.equal(postThumbs.length, preThumbs.length, `thumbnail row count changed`);
+    for (const pre of preThumbs) {
+      const post = postThumbs.find((r) => r.id === pre.id);
+      assert.ok(post, `thumbnail row ${pre.id} disappeared`);
+      assert.equal(post.path, pre.path, `thumbnail path changed for ${pre.id}`);
+    }
+
+    // Person thumbnails unchanged
+    const postPersons = await queryDb<{ id: string; thumbnailPath: string }>(
+      `SELECT id, "thumbnailPath" FROM person WHERE "thumbnailPath" != ''`,
+    );
+    for (const pre of prePersons) {
+      const post = postPersons.find((r) => r.id === pre.id);
+      assert.ok(post, `person ${pre.id} thumbnailPath disappeared`);
+      assert.equal(post.thumbnailPath, pre.thumbnailPath, `person ${pre.id} thumbnailPath changed`);
+    }
+
+    // Primary catch: no ENOENT from handleQueueMigration removeEmptyDirs on pure-S3
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-queue-migration-skipped');
+
+    console.log(`  Format flipped ${originalFormat}→${flippedFormat}; DB paths stable; no ENOENT.`);
+  } finally {
+    // Restore original thumbnail format
+    const restore = await api('GET', '/system-config', { token });
+    restore.image.thumbnail.format = originalFormat;
+    await api('PUT', '/system-config', { body: restore, token });
+  }
+  console.log('=== Phase: template-s3-queue-migration-skipped complete ===');
+}
+```
+
+**Step 2: Register in dispatcher**
+
+Add `case 'template-s3-queue-migration-skipped'`.
+
+**Step 3: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): phase template-s3-queue-migration-skipped — FileMigrationQueueAll no ENOENT on pure-S3"
+```
+
+---
+
+## Task 11: Phase `template-disk-baseline`
+
+**Files:**
+
+- Modify: `e2e/src/storage-migration.ts`
+
+**Step 1: Add phase function**
+
+```ts
+async function phaseTemplateDiskBaseline(): Promise<void> {
+  console.log('=== Phase: template-disk-baseline ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  // Set a predictable storageLabel on admin so library paths are stable.
+  // Note: upload paths use userId (UUID), NOT storageLabel — only library paths use it.
+  const me = await api('GET', '/users/me', { token });
+  await api('PUT', '/users/me', { body: { storageLabel: 'admin', name: me.name, email: me.email }, token });
+
+  const preCount = await countMoveHistory();
+  const preState = await captureState();
+
+  // Every asset is on disk (absolute) post-rollback
+  for (const a of preState.assets) {
+    assert.ok(a.originalPath.startsWith('/'), `Pre-baseline: asset ${a.id} not absolute`);
+  }
+  const preAssetPaths = new Map(preState.assets.map((a) => [a.id, a.originalPath]));
+
+  await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}' });
+  await triggerQueueCommand(token, 'storageTemplateMigration');
+  await waitForProcessing(token);
+
+  const postState = await captureState();
+
+  for (const a of postState.assets) {
+    assert.ok(
+      a.originalPath.startsWith('/usr/src/app/upload/library/admin/'),
+      `Expected library/admin/ path, got ${a.originalPath}`,
+    );
+    assert.ok(diskFileExists(a.originalPath), `New disk path missing: ${a.originalPath}`);
+
+    // Old path gone
+    const prePath = preAssetPaths.get(a.id);
+    assert.ok(prePath, `Asset ${a.id} missing from pre-state`);
+    if (prePath !== a.originalPath) {
+      assert.ok(!diskFileExists(prePath), `Old disk path still exists: ${prePath}`);
+    }
+  }
+
+  // Sidecar followed the asset
+  const saved = loadState();
+  if (saved.sidecarAssetId) {
+    const sidecarAssetId: string = saved.sidecarAssetId;
+    const asset = postState.assets.find((a) => a.id === sidecarAssetId);
+    assert.ok(asset, 'Sidecar asset missing from post-state');
+    const sidecar = postState.assetFiles.find((f) => f.type === 'sidecar' && f.path.startsWith(asset.originalPath));
+    assert.ok(sidecar, `Sidecar .xmp did not follow asset to ${asset.originalPath}`);
+  }
+
+  // move_history returns to baseline (each successful move deletes its own row)
+  const postCount = await countMoveHistory();
+  assert.equal(postCount, preCount, `move_history delta: ${preCount} → ${postCount}`);
+
+  const logs = captureContainerLogsSince('immich-server', startMs);
+  assertNoMoveEnoent(logs, 'template-disk-baseline');
+
+  console.log(`  Disk template migration moved ${postState.assets.length} assets to library/admin/…`);
+  console.log('=== Phase: template-disk-baseline complete ===');
+}
+```
+
+**Step 2: Register in dispatcher**
+
+Add `case 'template-disk-baseline'`.
+
+**Step 3: Verify compilation**
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts
+git commit -m "test(e2e): phase template-disk-baseline — regression guard for disk template feature"
+```
+
+---
+
+## Task 12: Wire the workflow YAML
+
+**Files:**
+
+- Modify: `.github/workflows/storage-migration-tests.yml`
+
+**Step 1: Insert template phases into Phase group 2**
+
+Open the file. Find the line `# Phase group 2: backend=s3 — migrate to S3, verify` (around line 62). After the `- name: 'Phase: migrate-to-s3'` step and BEFORE `- name: 'Phase: no-files'`, insert:
+
+```yaml
+- name: 'Phase: template-s3-bulk-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-bulk-skipped
+
+- name: 'Phase: template-s3-upload-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-upload-skipped
+
+- name: 'Phase: template-s3-live-photo-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-live-photo-skipped
+
+- name: 'Phase: template-s3-sidecar-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-sidecar-skipped
+
+- name: 'Phase: template-s3-queue-migration-skipped'
+  run: pnpm tsx src/storage-migration.ts template-s3-queue-migration-skipped
+```
+
+**Step 2: Append the disk-baseline step group**
+
+After the `- name: 'Phase: rollback'` step (around line 132), add:
+
+```yaml
+# ---------------------------------------------------------------
+# Phase group 7: backend=disk — template-disk-baseline regression guard
+# Runs last; no further phases after this.
+# ---------------------------------------------------------------
+- name: Restart server (backend=disk, post-rollback)
+  run: |
+    IMMICH_STORAGE_BACKEND=disk \
+    docker compose up -d --no-deps --force-recreate --wait --wait-timeout 120 immich-server
+
+- name: 'Phase: template-disk-baseline'
+  run: pnpm tsx src/storage-migration.ts template-disk-baseline
+```
+
+**Step 3: Bump timeout**
+
+Change `timeout-minutes: 30` → `timeout-minutes: 45`.
+
+**Step 4: Validate YAML**
+
+```bash
+yamllint .github/workflows/storage-migration-tests.yml 2>&1 | head -5 || true
+```
+
+If `yamllint` isn't installed, skip — GitHub will parse on push.
+
+**Step 5: Commit**
+
+```bash
+git add .github/workflows/storage-migration-tests.yml
+git commit -m "ci(storage-migration): add 6 template×S3 phases + disk-baseline regression guard
+
+Inserts template-s3-bulk-skipped, -upload-skipped, -live-photo-skipped,
+-sidecar-skipped, -queue-migration-skipped between migrate-to-s3 and
+no-files. Adds a trailing disk restart + template-disk-baseline as a
+feature regression guard. Bumps timeout-minutes 30 → 45."
+```
+
+---
+
+## Validation after all tasks
+
+Run the full server test suite before opening PR:
+
+```bash
+cd server && pnpm test -- --run
+```
+
+Expected: all tests pass, no new failures, no skips.
+
+Run type check on e2e:
+
+```bash
+cd e2e && pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+CI validation: push the branch, watch the storage-migration-tests workflow on the next scheduled run or trigger via `workflow_dispatch`.
+
+---
+
+## Notes for the implementer
+
+- The unit-test hardening tasks (1-3) are **not classic TDD** — the production guards already exist; these tests lock in behavior. They should pass on first run. If any fails, the production code has a bug — stop and investigate before proceeding.
+- Task 4 **is** classic TDD — write red test, confirm red, write production fix, confirm green.
+- E2E phase tasks (6-11) cannot be verified locally without the full docker stack — rely on `tsc --noEmit` + visual review. CI is the final validation.
+- Every commit should leave `main` mergeable. Tasks 1-4 are independent of 5-12 and could land as their own PR if the E2E work drags.
+- `setStorageTemplate` uses PUT /system-config which replaces the entire config — always GET first, mutate, PUT.
+- The Gallery fork uses `docker compose` (no hyphen). If adapting commands, keep that form.
+- `assertNoMoveEnoent` is a secondary signal. Structural assertions (paths, MinIO keys, `move_history` counts) are primary.
+- Frequent commits after each task keep rollback targets tight if a later phase surfaces an issue.
+- No OpenAPI or SQL regen needed — no new controllers or `@GenerateSql` methods in this plan.
+
+---
+
+## Out of scope (carried from design)
+
+- Backend-swap phases (`template-mixed-disk-then-s3`, `template-s3-rollback-preserves-templated-paths`).
+- Stale `move_history` cleanup.
+- `AssetService.copySidecar` on S3 targets.
+- Helper extraction to `storage-harness.ts`.
+- Per-PR workflow trigger.

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1548,6 +1548,44 @@ async function phaseTemplateS3BulkSkipped(): Promise<void> {
   console.log('=== Phase: template-s3-bulk-skipped complete ===');
 }
 
+async function phaseTemplateS3UploadSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-upload-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  try {
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MMMM}}/{{filename}}' });
+
+    const png = createPng();
+    const { id: newAssetId } = await uploadAsset(token, 'template-upload-skip.png', png);
+    await waitForProcessing(token);
+
+    const rows = await queryDb<{ originalPath: string }>('SELECT "originalPath" FROM asset WHERE id = $1', [
+      newAssetId,
+    ]);
+    assert.ok(rows[0], `Asset ${newAssetId} not found`);
+    const { originalPath } = rows[0];
+
+    assert.ok(!originalPath.startsWith('/'), `Expected relative path, got ${originalPath}`);
+    assert.ok(originalPath.startsWith('upload/'), `Expected upload/ prefix, got ${originalPath}`);
+
+    minioSetupAlias();
+    assert.ok(minioFileExists(originalPath), `MinIO key missing: ${originalPath}`);
+
+    const count = await countMoveHistory(newAssetId);
+    assert.equal(count, 0, `Expected 0 move_history rows for new asset, got ${count}`);
+
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-upload-skipped');
+
+    console.log(`  New S3 upload ${newAssetId} stayed at ${originalPath}.`);
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-upload-skipped complete ===');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1613,9 +1651,13 @@ async function main() {
         await phaseTemplateS3BulkSkipped();
         break;
       }
+      case 'template-s3-upload-skipped': {
+        await phaseTemplateS3UploadSkipped();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped`,
         );
       }
     }

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1586,6 +1586,54 @@ async function phaseTemplateS3UploadSkipped(): Promise<void> {
   console.log('=== Phase: template-s3-upload-skipped complete ===');
 }
 
+async function phaseTemplateS3LivePhotoSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-live-photo-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  try {
+    // Upload motion video first; then still with livePhotoVideoId linking to motion.
+    // A valid video payload is required for a ffprobe-driven asset flow, but in e2e
+    // the upload path only stores the bytes — metadata extraction handles the rest
+    // and tolerates minimal MP4 headers. A 1x1 PNG stands in fine for the still.
+    const motionBytes = Buffer.from([
+      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, 0x69, 0x73, 0x6f,
+      0x6d, 0x69, 0x73, 0x6f, 0x32, 0x61, 0x76, 0x63, 0x31, 0x6d, 0x70, 0x34, 0x31,
+    ]);
+    const { id: motionId } = await uploadAsset(token, 'lp-motion.mp4', motionBytes);
+    const { id: stillId } = await uploadAsset(token, 'lp-still.png', createPng(), undefined, {
+      livePhotoVideoId: motionId,
+    });
+
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MM}}/{{filename}}' });
+    await waitForProcessing(token);
+
+    const rows = await queryDb<{ id: string; originalPath: string }>(
+      'SELECT id, "originalPath" FROM asset WHERE id = ANY($1)',
+      [[motionId, stillId]],
+    );
+    assert.equal(rows.length, 2, `Expected 2 assets, got ${rows.length}`);
+    for (const r of rows) {
+      assert.ok(!r.originalPath.startsWith('/'), `Expected relative path for ${r.id}, got ${r.originalPath}`);
+      assert.ok(r.originalPath.startsWith('upload/'), `Expected upload/ prefix for ${r.id}`);
+    }
+
+    for (const id of [motionId, stillId]) {
+      const c = await countMoveHistory(id);
+      assert.equal(c, 0, `Asset ${id} has ${c} move_history rows, expected 0`);
+    }
+
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-live-photo-skipped');
+
+    console.log(`  Live photo pair (still=${stillId}, motion=${motionId}) skipped template migration.`);
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-live-photo-skipped complete ===');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1655,9 +1703,13 @@ async function main() {
         await phaseTemplateS3UploadSkipped();
         break;
       }
+      case 'template-s3-live-photo-skipped': {
+        await phaseTemplateS3LivePhotoSkipped();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped`,
         );
       }
     }

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1683,6 +1683,70 @@ async function phaseTemplateS3SidecarSkipped(): Promise<void> {
   console.log('=== Phase: template-s3-sidecar-skipped complete ===');
 }
 
+async function phaseTemplateS3QueueMigrationSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-queue-migration-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  const config = await api('GET', '/system-config', { token });
+  const originalFormat: string = config.image.thumbnail.format;
+  const flippedFormat = originalFormat === 'webp' ? 'jpeg' : 'webp';
+
+  const preThumbs = await queryDb<{ id: string; path: string }>(
+    `SELECT id, path FROM asset_file WHERE type = 'thumbnail'`,
+  );
+  const prePersons = await queryDb<{ id: string; thumbnailPath: string }>(
+    `SELECT id, "thumbnailPath" FROM person WHERE "thumbnailPath" != ''`,
+  );
+
+  try {
+    // Flip thumbnail format
+    const flipped = {
+      ...config,
+      image: { ...config.image, thumbnail: { ...config.image.thumbnail, format: flippedFormat } },
+    };
+    await api('PUT', '/system-config', { body: flipped, token });
+
+    // Trigger FileMigrationQueueAll (fans out AssetFileMigration + PersonFileMigration)
+    await triggerQueueCommand(token, 'migration');
+    await waitForProcessing(token);
+
+    // Thumbnails unchanged (still point at pre-flip extension — intended skip behavior)
+    const postThumbs = await queryDb<{ id: string; path: string }>(
+      `SELECT id, path FROM asset_file WHERE type = 'thumbnail'`,
+    );
+    assert.equal(postThumbs.length, preThumbs.length, `thumbnail row count changed`);
+    for (const pre of preThumbs) {
+      const post = postThumbs.find((r) => r.id === pre.id);
+      assert.ok(post, `thumbnail row ${pre.id} disappeared`);
+      assert.equal(post.path, pre.path, `thumbnail path changed for ${pre.id}`);
+    }
+
+    // Person thumbnails unchanged
+    const postPersons = await queryDb<{ id: string; thumbnailPath: string }>(
+      `SELECT id, "thumbnailPath" FROM person WHERE "thumbnailPath" != ''`,
+    );
+    for (const pre of prePersons) {
+      const post = postPersons.find((r) => r.id === pre.id);
+      assert.ok(post, `person ${pre.id} thumbnailPath disappeared`);
+      assert.equal(post.thumbnailPath, pre.thumbnailPath, `person ${pre.id} thumbnailPath changed`);
+    }
+
+    // Primary catch: no ENOENT from handleQueueMigration removeEmptyDirs on pure-S3
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-queue-migration-skipped');
+
+    console.log(`  Format flipped ${originalFormat}→${flippedFormat}; DB paths stable; no ENOENT.`);
+  } finally {
+    // Restore original thumbnail format
+    const restore = await api('GET', '/system-config', { token });
+    restore.image.thumbnail.format = originalFormat;
+    await api('PUT', '/system-config', { body: restore, token });
+  }
+  console.log('=== Phase: template-s3-queue-migration-skipped complete ===');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1760,9 +1824,13 @@ async function main() {
         await phaseTemplateS3SidecarSkipped();
         break;
       }
+      case 'template-s3-queue-migration-skipped': {
+        await phaseTemplateS3QueueMigrationSkipped();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped`,
         );
       }
     }

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1634,6 +1634,55 @@ async function phaseTemplateS3LivePhotoSkipped(): Promise<void> {
   console.log('=== Phase: template-s3-live-photo-skipped complete ===');
 }
 
+async function phaseTemplateS3SidecarSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-sidecar-skipped ===');
+  const token = await loginAdmin();
+  const saved = loadState();
+  assert.ok(saved.sidecarAssetId, 'No sidecarAssetId — run `setup` and `migrate-to-s3` first');
+  const sidecarAssetId: string = saved.sidecarAssetId;
+
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+  const preCount = await countMoveHistory(sidecarAssetId);
+
+  const preRows = await queryDb<{ id: string; path: string }>(
+    `SELECT af.id, af.path FROM asset_file af WHERE af."assetId" = $1 AND af.type = 'sidecar'`,
+    [sidecarAssetId],
+  );
+  assert.equal(preRows.length, 1, `Expected 1 sidecar row, got ${preRows.length}`);
+  const preSidecarPath = preRows[0].path;
+
+  const preAssetRows = await queryDb<{ originalPath: string }>('SELECT "originalPath" FROM asset WHERE id = $1', [
+    sidecarAssetId,
+  ]);
+  const preOriginalPath = preAssetRows[0].originalPath;
+
+  try {
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MMMM}}/{{filename}}' });
+    await triggerQueueCommand(token, 'storageTemplateMigration');
+    await waitForProcessing(token);
+
+    const postRows = await queryDb<{ path: string }>(`SELECT path FROM asset_file WHERE id = $1`, [preRows[0].id]);
+    assert.equal(postRows[0].path, preSidecarPath, `Sidecar path changed`);
+
+    const postAssetRows = await queryDb<{ originalPath: string }>('SELECT "originalPath" FROM asset WHERE id = $1', [
+      sidecarAssetId,
+    ]);
+    assert.equal(postAssetRows[0].originalPath, preOriginalPath, `Original path changed`);
+
+    const postCount = await countMoveHistory(sidecarAssetId);
+    assert.equal(postCount, preCount, `move_history grew for ${sidecarAssetId}: ${preCount} → ${postCount}`);
+
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-sidecar-skipped');
+
+    console.log(`  Sidecar asset ${sidecarAssetId} and its .xmp row both unchanged.`);
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-sidecar-skipped complete ===');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1707,9 +1756,13 @@ async function main() {
         await phaseTemplateS3LivePhotoSkipped();
         break;
       }
+      case 'template-s3-sidecar-skipped': {
+        await phaseTemplateS3SidecarSkipped();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped`,
         );
       }
     }

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1781,10 +1781,13 @@ async function phaseTemplateDiskBaseline(): Promise<void> {
 
   const postState = await captureState();
 
+  // All assets land under library/<storageLabel-or-userUuid>/YYYY/YYYY-MM-DD/filename.
+  // Per-user storageLabel: admin got 'admin'; other users keep their UUID in the path.
+  const libraryTemplatePath = /\/usr\/src\/app\/upload\/library\/[^/]+\/\d{4}\/\d{4}-\d{2}-\d{2}\//;
   for (const a of postState.assets) {
     assert.ok(
-      a.originalPath.startsWith('/usr/src/app/upload/library/admin/'),
-      `Expected library/admin/ path, got ${a.originalPath}`,
+      libraryTemplatePath.test(a.originalPath),
+      `Expected library/<label>/YYYY/YYYY-MM-DD/ path, got ${a.originalPath}`,
     );
     assert.ok(diskFileExists(a.originalPath), `New disk path missing: ${a.originalPath}`);
 
@@ -1795,6 +1798,12 @@ async function phaseTemplateDiskBaseline(): Promise<void> {
       assert.ok(!diskFileExists(prePath), `Old disk path still exists: ${prePath}`);
     }
   }
+
+  // Admin's storageLabel must have taken effect — at least one asset under library/admin/.
+  assert.ok(
+    postState.assets.some((a) => a.originalPath.startsWith('/usr/src/app/upload/library/admin/')),
+    'No asset landed under library/admin/ — storageLabel=admin was not applied',
+  );
 
   // Sidecar followed the asset
   const saved = loadState();

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1766,25 +1766,41 @@ async function phaseTemplateDiskBaseline(): Promise<void> {
   const me = await api('GET', '/users/me', { token });
   await api('PUT', `/admin/users/${me.id}`, { body: { storageLabel: 'admin' }, token });
 
+  // Only assert against assets created in phaseSetup — later phases
+  // (template-s3-upload-skipped, template-s3-live-photo-skipped) upload
+  // additional test assets directly to S3 that end up with non-library
+  // disk paths after migrate-to-disk, which is not the regression we're
+  // guarding here.
+  const saved = loadState();
+  const seededIds: string[] = [...(saved.adminAssetIds ?? []), ...(saved.user2AssetIds ?? [])];
+  assert.ok(seededIds.length > 0, 'No seeded asset IDs found — run `setup` first');
+
   const preCount = await countMoveHistory();
   const preState = await captureState();
+  const preSeeded = preState.assets.filter((a) => seededIds.includes(a.id));
+  assert.equal(
+    preSeeded.length,
+    seededIds.length,
+    `Missing seeded assets in pre-state: expected ${seededIds.length}, got ${preSeeded.length}`,
+  );
 
-  // Every asset is on disk (absolute) post-rollback
-  for (const a of preState.assets) {
-    assert.ok(a.originalPath.startsWith('/'), `Pre-baseline: asset ${a.id} not absolute`);
+  // Every seeded asset is on disk (absolute) post-rollback
+  for (const a of preSeeded) {
+    assert.ok(a.originalPath.startsWith('/'), `Pre-baseline: seeded asset ${a.id} not absolute`);
   }
-  const preAssetPaths = new Map(preState.assets.map((a) => [a.id, a.originalPath]));
+  const preAssetPaths = new Map(preSeeded.map((a) => [a.id, a.originalPath]));
 
   await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}' });
   await triggerQueueCommand(token, 'storageTemplateMigration');
   await waitForProcessing(token);
 
   const postState = await captureState();
+  const postSeeded = postState.assets.filter((a) => seededIds.includes(a.id));
 
-  // All assets land under library/<storageLabel-or-userUuid>/YYYY/YYYY-MM-DD/filename.
-  // Per-user storageLabel: admin got 'admin'; other users keep their UUID in the path.
+  // Seeded assets land under library/<storageLabel-or-userUuid>/YYYY/YYYY-MM-DD/filename.
+  // Per-user storageLabel: admin got 'admin'; user2 keeps their UUID in the path.
   const libraryTemplatePath = /\/usr\/src\/app\/upload\/library\/[^/]+\/\d{4}\/\d{4}-\d{2}-\d{2}\//;
-  for (const a of postState.assets) {
+  for (const a of postSeeded) {
     assert.ok(
       libraryTemplatePath.test(a.originalPath),
       `Expected library/<label>/YYYY/YYYY-MM-DD/ path, got ${a.originalPath}`,
@@ -1793,23 +1809,22 @@ async function phaseTemplateDiskBaseline(): Promise<void> {
 
     // Old path gone
     const prePath = preAssetPaths.get(a.id);
-    assert.ok(prePath, `Asset ${a.id} missing from pre-state`);
+    assert.ok(prePath, `Seeded asset ${a.id} missing from pre-state`);
     if (prePath !== a.originalPath) {
       assert.ok(!diskFileExists(prePath), `Old disk path still exists: ${prePath}`);
     }
   }
 
-  // Admin's storageLabel must have taken effect — at least one asset under library/admin/.
+  // Admin's storageLabel must have taken effect — at least one seeded asset under library/admin/.
   assert.ok(
-    postState.assets.some((a) => a.originalPath.startsWith('/usr/src/app/upload/library/admin/')),
-    'No asset landed under library/admin/ — storageLabel=admin was not applied',
+    postSeeded.some((a) => a.originalPath.startsWith('/usr/src/app/upload/library/admin/')),
+    'No seeded asset landed under library/admin/ — storageLabel=admin was not applied',
   );
 
   // Sidecar followed the asset
-  const saved = loadState();
   if (saved.sidecarAssetId) {
     const sidecarAssetId: string = saved.sidecarAssetId;
-    const asset = postState.assets.find((a) => a.id === sidecarAssetId);
+    const asset = postSeeded.find((a) => a.id === sidecarAssetId);
     assert.ok(asset, 'Sidecar asset missing from post-state');
     const sidecar = postState.assetFiles.find((f) => f.type === 'sidecar' && f.path.startsWith(asset.originalPath));
     assert.ok(sidecar, `Sidecar .xmp did not follow asset to ${asset.originalPath}`);
@@ -1822,7 +1837,7 @@ async function phaseTemplateDiskBaseline(): Promise<void> {
   const logs = captureContainerLogsSince('immich-server', startMs);
   assertNoMoveEnoent(logs, 'template-disk-baseline');
 
-  console.log(`  Disk template migration moved ${postState.assets.length} assets to library/admin/…`);
+  console.log(`  Disk template migration moved ${postSeeded.length} seeded assets to library/…`);
   console.log('=== Phase: template-disk-baseline complete ===');
 }
 

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -135,6 +135,7 @@ export async function uploadAsset(
   filename: string,
   data: Buffer,
   sidecar?: Buffer,
+  extraFields?: Record<string, string>,
 ): Promise<{ id: string; status: number }> {
   const form = new FormData();
   form.append('assetData', new Blob([new Uint8Array(data)]), filename);
@@ -145,6 +146,12 @@ export async function uploadAsset(
 
   if (sidecar) {
     form.append('sidecarData', new Blob([new Uint8Array(sidecar)]), `${filename}.xmp`);
+  }
+
+  if (extraFields) {
+    for (const [k, v] of Object.entries(extraFields)) {
+      form.append(k, v);
+    }
   }
 
   const url = `${BASE_URL}/assets`;
@@ -304,6 +311,46 @@ export async function waitForMigration(token: string, timeoutMs = 120_000): Prom
   }
 
   throw new Error(`waitForMigration timed out after ${timeoutMs}ms`);
+}
+
+export async function setStorageTemplate(token: string, opts: { enabled?: boolean; template?: string }): Promise<void> {
+  const config = await api('GET', '/system-config', { token });
+  if (opts.enabled !== undefined) {
+    config.storageTemplate.enabled = opts.enabled;
+  }
+  if (opts.template !== undefined) {
+    config.storageTemplate.template = opts.template;
+  }
+  await api('PUT', '/system-config', { body: config, token });
+}
+
+export async function triggerQueueCommand(token: string, queueName: string): Promise<void> {
+  await api('PUT', `/jobs/${queueName}`, { body: { command: 'start' }, token });
+}
+
+export async function countMoveHistory(assetId?: string): Promise<number> {
+  const rows = assetId
+    ? await queryDb<{ c: string }>('SELECT COUNT(*)::text c FROM move_history WHERE "entityId" = $1', [assetId])
+    : await queryDb<{ c: string }>('SELECT COUNT(*)::text c FROM move_history');
+  return Number(rows[0].c);
+}
+
+export function captureContainerLogsSince(service: string, sinceMs: number): string {
+  // docker compose --since accepts ISO-8601 OR a relative duration (e.g. "42s").
+  // Bare epoch seconds are NOT accepted — compute elapsed seconds.
+  // Substring matches work regardless of JSON vs plaintext logger mode;
+  // the warning text appears verbatim in either.
+  const elapsedSec = Math.max(1, Math.ceil((Date.now() - sinceMs) / 1000));
+  return execSync(`${COMPOSE} logs --since ${elapsedSec}s --no-color ${service}`, {
+    cwd: E2E_DIR,
+    timeout: 30_000,
+    encoding: 'utf8',
+  });
+}
+
+export function assertNoMoveEnoent(logs: string, phaseTag: string): void {
+  const bad = logs.split('\n').filter((l) => l.includes('Unable to complete move') || /ENOENT.*rename/.test(l));
+  assert.equal(bad.length, 0, `[${phaseTag}] unexpected ENOENT/move warnings:\n${bad.join('\n')}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1497,6 +1497,58 @@ async function phaseSidecarVerify(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Phase: Template bulk migration skips S3 assets (regression for #383)
+// Precondition: S3 backend, assets already on S3
+// ---------------------------------------------------------------------------
+async function phaseTemplateS3BulkSkipped(): Promise<void> {
+  console.log('=== Phase: template-s3-bulk-skipped ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false }); // invariant reset
+  const startMs = Date.now();
+  const preCount = await countMoveHistory();
+  const preState = await captureState();
+
+  // Precondition: every asset has a relative S3 path
+  for (const a of preState.assets) {
+    assert.ok(!a.originalPath.startsWith('/'), `Precondition failed: asset ${a.id} path is absolute`);
+  }
+
+  try {
+    await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{MM}}/{{filename}}' });
+    await triggerQueueCommand(token, 'storageTemplateMigration');
+    await waitForProcessing(token);
+
+    const postState = await captureState();
+
+    // Every asset path unchanged
+    for (const pre of preState.assets) {
+      const post = postState.assets.find((a) => a.id === pre.id);
+      assert.ok(post, `Asset ${pre.id} disappeared`);
+      assert.equal(post.originalPath, pre.originalPath, `Path changed for asset ${pre.id}`);
+    }
+
+    // MinIO keys still exist
+    minioSetupAlias();
+    for (const a of postState.assets) {
+      assert.ok(minioFileExists(a.originalPath), `MinIO key missing: ${a.originalPath}`);
+    }
+
+    // No new move_history rows
+    const postCount = await countMoveHistory();
+    assert.equal(postCount, preCount, `move_history grew from ${preCount} to ${postCount}`);
+
+    // Log-scrape (secondary)
+    const logs = captureContainerLogsSince('immich-server', startMs);
+    assertNoMoveEnoent(logs, 'template-s3-bulk-skipped');
+
+    console.log('  Bulk template migration skipped S3 assets cleanly.');
+  } finally {
+    await setStorageTemplate(token, { enabled: false });
+  }
+  console.log('=== Phase: template-s3-bulk-skipped complete ===');
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 async function main() {
@@ -1557,9 +1609,13 @@ async function main() {
         await phaseSidecarVerify();
         break;
       }
+      case 'template-s3-bulk-skipped': {
+        await phaseTemplateS3BulkSkipped();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped`,
         );
       }
     }

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1747,6 +1747,76 @@ async function phaseTemplateS3QueueMigrationSkipped(): Promise<void> {
   console.log('=== Phase: template-s3-queue-migration-skipped complete ===');
 }
 
+async function phaseTemplateDiskBaseline(): Promise<void> {
+  console.log('=== Phase: template-disk-baseline ===');
+  const token = await loginAdmin();
+  await setStorageTemplate(token, { enabled: false });
+  const startMs = Date.now();
+
+  // Set a predictable storageLabel on admin so library paths are stable.
+  // Note: upload paths use userId (UUID), NOT storageLabel — only library paths use it.
+  //
+  // `PUT /users/me` does NOT accept storageLabel (UserUpdateMeDto omits it).
+  // Use the admin endpoint `PUT /admin/users/:id` (UserAdminUpdateDto accepts storageLabel).
+  // Admin users can update themselves via this endpoint.
+  //
+  // This write is idempotent — if a prior run on the same DB already set
+  // storageLabel='admin', the re-update is a no-op from the asset path's
+  // perspective. No teardown needed (last phase in the workflow).
+  const me = await api('GET', '/users/me', { token });
+  await api('PUT', `/admin/users/${me.id}`, { body: { storageLabel: 'admin' }, token });
+
+  const preCount = await countMoveHistory();
+  const preState = await captureState();
+
+  // Every asset is on disk (absolute) post-rollback
+  for (const a of preState.assets) {
+    assert.ok(a.originalPath.startsWith('/'), `Pre-baseline: asset ${a.id} not absolute`);
+  }
+  const preAssetPaths = new Map(preState.assets.map((a) => [a.id, a.originalPath]));
+
+  await setStorageTemplate(token, { enabled: true, template: '{{y}}/{{y}}-{{MM}}-{{dd}}/{{filename}}' });
+  await triggerQueueCommand(token, 'storageTemplateMigration');
+  await waitForProcessing(token);
+
+  const postState = await captureState();
+
+  for (const a of postState.assets) {
+    assert.ok(
+      a.originalPath.startsWith('/usr/src/app/upload/library/admin/'),
+      `Expected library/admin/ path, got ${a.originalPath}`,
+    );
+    assert.ok(diskFileExists(a.originalPath), `New disk path missing: ${a.originalPath}`);
+
+    // Old path gone
+    const prePath = preAssetPaths.get(a.id);
+    assert.ok(prePath, `Asset ${a.id} missing from pre-state`);
+    if (prePath !== a.originalPath) {
+      assert.ok(!diskFileExists(prePath), `Old disk path still exists: ${prePath}`);
+    }
+  }
+
+  // Sidecar followed the asset
+  const saved = loadState();
+  if (saved.sidecarAssetId) {
+    const sidecarAssetId: string = saved.sidecarAssetId;
+    const asset = postState.assets.find((a) => a.id === sidecarAssetId);
+    assert.ok(asset, 'Sidecar asset missing from post-state');
+    const sidecar = postState.assetFiles.find((f) => f.type === 'sidecar' && f.path.startsWith(asset.originalPath));
+    assert.ok(sidecar, `Sidecar .xmp did not follow asset to ${asset.originalPath}`);
+  }
+
+  // move_history returns to baseline (each successful move deletes its own row)
+  const postCount = await countMoveHistory();
+  assert.equal(postCount, preCount, `move_history delta: ${preCount} → ${postCount}`);
+
+  const logs = captureContainerLogsSince('immich-server', startMs);
+  assertNoMoveEnoent(logs, 'template-disk-baseline');
+
+  console.log(`  Disk template migration moved ${postState.assets.length} assets to library/admin/…`);
+  console.log('=== Phase: template-disk-baseline complete ===');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1828,9 +1898,13 @@ async function main() {
         await phaseTemplateS3QueueMigrationSkipped();
         break;
       }
+      case 'template-disk-baseline': {
+        await phaseTemplateDiskBaseline();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped, template-disk-baseline`,
         );
       }
     }

--- a/server/src/cores/storage.core.spec.ts
+++ b/server/src/cores/storage.core.spec.ts
@@ -1,5 +1,6 @@
 import { StorageCore } from 'src/cores/storage.core';
-import { AssetFileType, ImageFormat, StorageFolder } from 'src/enum';
+import { AssetFileType, AssetPathType, ImageFormat, StorageFolder } from 'src/enum';
+import { getMocks } from 'test/utils';
 import { vitest } from 'vitest';
 
 vitest.mock('src/constants', () => ({
@@ -44,6 +45,10 @@ describe('StorageCore', () => {
     it('should return false for paths outside the APP_MEDIA_LOCATION', () => {
       const nonImmichPath = '/some/other/path';
       expect(StorageCore.isImmichPath(nonImmichPath)).toBe(false);
+    });
+
+    it('should return false for S3 relative keys', () => {
+      expect(StorageCore.isImmichPath('upload/uuid/4e/e6/file.jpg')).toBe(false);
     });
   });
 
@@ -214,6 +219,40 @@ describe('StorageCore', () => {
         const result = StorageCore.getPersonThumbnailPath({ id: 'person-1', ownerId: 'user-1' });
         expect(result.startsWith('/data/')).toBe(true);
       });
+    });
+  });
+
+  describe('moveFile', () => {
+    let core: StorageCore;
+    let mocks: ReturnType<typeof getMocks>;
+
+    beforeEach(() => {
+      StorageCore.reset();
+      StorageCore.setMediaLocation('/data');
+      mocks = getMocks();
+      core = StorageCore.create(
+        mocks.asset as any,
+        mocks.config as any,
+        mocks.crypto as any,
+        mocks.move as any,
+        mocks.person as any,
+        mocks.storage as any,
+        mocks.systemMetadata as any,
+        mocks.logger as any,
+      );
+    });
+
+    it('should skip when oldPath is a relative S3 key', async () => {
+      await core.moveFile({
+        entityId: 'asset-1',
+        pathType: AssetPathType.Original,
+        oldPath: 'upload/user/ab/cd/file.jpg',
+        newPath: '/data/library/user/2021/file.jpg',
+      });
+      expect(mocks.storage.mkdirSync).not.toHaveBeenCalled();
+      expect(mocks.move.getByEntity).not.toHaveBeenCalled();
+      expect(mocks.move.create).not.toHaveBeenCalled();
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -302,10 +302,6 @@ export class StorageCore {
     this.storageRepository.mkdirSync(dirname(input));
   }
 
-  removeEmptyDirs(folder: StorageFolder) {
-    return this.storageRepository.removeEmptyDirs(StorageCore.getBaseFolder(folder));
-  }
-
   private savePath(pathType: PathType, id: string, newPath: string) {
     switch (pathType) {
       case AssetPathType.Original: {

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { StorageAsset } from 'src/database';
 import {
   AssetFileType,
@@ -133,6 +133,9 @@ export class StorageCore {
   }
 
   static isImmichPath(path: string) {
+    if (!isAbsolute(path)) {
+      return false;
+    }
     const resolvedPath = resolve(path);
     const resolvedAppMediaLocation = StorageCore.getMediaLocation();
     const normalizedPath = resolvedPath.endsWith('/') ? resolvedPath : resolvedPath + '/';
@@ -180,6 +183,10 @@ export class StorageCore {
   async moveFile(request: MoveRequest) {
     const { entityId, pathType, oldPath, newPath, assetInfo } = request;
     if (!oldPath || oldPath === newPath) {
+      return;
+    }
+
+    if (!isAbsolute(oldPath)) {
       return;
     }
 

--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -175,6 +175,7 @@ where
 select
   "asset"."id",
   "asset"."ownerId",
+  "asset"."originalPath",
   (
     select
       coalesce(json_agg(agg), '[]')

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -104,7 +104,7 @@ export class AssetJobRepository {
   getForMigrationJob(id: string) {
     return this.db
       .selectFrom('asset')
-      .select(['asset.id', 'asset.ownerId'])
+      .select(['asset.id', 'asset.ownerId', 'asset.originalPath'])
       .select(withFiles)
       .where('asset.id', '=', id)
       .executeTakeFirst();

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -307,6 +307,20 @@ describe(MediaService.name, () => {
       expect(mocks.move.getByEntity).not.toHaveBeenCalled();
     });
 
+    it('should skip S3 assets with relative paths', async () => {
+      const asset = AssetFactory.from({ originalPath: 'upload/user/ab/cd/file.jpg' })
+        .files([AssetFileType.FullSize, AssetFileType.Preview, AssetFileType.Thumbnail])
+        .build();
+      mocks.assetJob.getForMigrationJob.mockResolvedValue(asset);
+
+      await expect(sut.handleAssetMigration({ id: asset.id })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.move.create).not.toHaveBeenCalled();
+      expect(mocks.move.getByEntity).not.toHaveBeenCalled();
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
+      expect(mocks.storage.copyFile).not.toHaveBeenCalled();
+    });
+
     it('should move asset files', async () => {
       const asset = AssetFactory.from()
         .files([AssetFileType.FullSize, AssetFileType.Preview, AssetFileType.Thumbnail])

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -283,7 +283,20 @@ describe(MediaService.name, () => {
   });
 
   describe('handleQueueMigration', () => {
+    it('should skip removeEmptyDirs when storage folders do not exist (pure-S3 deployment)', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({ active: 1, waiting: 0 } as JobCounts);
+      mocks.storage.checkFileExists.mockResolvedValue(false);
+      mocks.assetJob.streamForMigrationJob.mockReturnValue(makeStream([]));
+      mocks.person.getAll.mockReturnValue(makeStream([]));
+
+      await expect(sut.handleQueueMigration()).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(2);
+      expect(mocks.storage.removeEmptyDirs).not.toHaveBeenCalled();
+    });
+
     it('should remove empty directories and queue jobs', async () => {
+      mocks.storage.checkFileExists.mockResolvedValue(true);
       const asset = AssetFactory.create();
       const person = PersonFactory.create();
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -162,8 +162,12 @@ export class MediaService extends BaseService {
   async handleQueueMigration(): Promise<JobStatus> {
     const { active, waiting } = await this.jobRepository.getJobCounts(QueueName.Migration);
     if (active === 1 && waiting === 0) {
-      await this.storageCore.removeEmptyDirs(StorageFolder.Thumbnails);
-      await this.storageCore.removeEmptyDirs(StorageFolder.EncodedVideo);
+      for (const folder of [StorageFolder.Thumbnails, StorageFolder.EncodedVideo]) {
+        const path = StorageCore.getBaseFolder(folder);
+        if (await this.storageRepository.checkFileExists(path)) {
+          await this.storageRepository.removeEmptyDirs(path);
+        }
+      }
     }
 
     let jobs: JobItem[] = [];

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -201,6 +201,12 @@ export class MediaService extends BaseService {
       return JobStatus.Failed;
     }
 
+    if (!asset.originalPath || !isAbsolute(asset.originalPath)) {
+      // S3 assets live under relative keys and are managed by the S3 backend, not fs.rename.
+      this.logger.debug(`Skipping asset file migration for S3 asset ${id}`);
+      return JobStatus.Skipped;
+    }
+
     await this.storageCore.moveAssetImage(asset, AssetFileType.FullSize, image.fullsize.format);
     await this.storageCore.moveAssetImage(asset, AssetFileType.Preview, image.preview.format);
     await this.storageCore.moveAssetImage(asset, AssetFileType.Thumbnail, image.thumbnail.format);

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -369,6 +369,28 @@ describe(PersonService.name, () => {
     it('should not move person files', async () => {
       await expect(sut.handlePersonMigration(PersonFactory.create())).resolves.toBe(JobStatus.Failed);
     });
+
+    it('should skip persons with relative S3 thumbnail paths', async () => {
+      const person = PersonFactory.create({ thumbnailPath: 'thumbs/user/ab/cd/person.jpeg' });
+      mocks.person.getById.mockResolvedValue(person);
+
+      await expect(sut.handlePersonMigration({ id: person.id })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.move.create).not.toHaveBeenCalled();
+      expect(mocks.move.getByEntity).not.toHaveBeenCalled();
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
+    });
+
+    it('should skip persons with empty thumbnail paths', async () => {
+      const person = PersonFactory.create({ thumbnailPath: '' });
+      mocks.person.getById.mockResolvedValue(person);
+
+      await expect(sut.handlePersonMigration({ id: person.id })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.move.create).not.toHaveBeenCalled();
+      expect(mocks.move.getByEntity).not.toHaveBeenCalled();
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
+    });
   });
 
   describe('getFacesById', () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { Insertable, Updateable } from 'kysely';
+import { isAbsolute } from 'node:path';
 import { JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
 import { Person } from 'src/database';
 import { Chunked, OnJob } from 'src/decorators';
@@ -589,6 +590,12 @@ export class PersonService extends BaseService {
     const person = await this.personRepository.getById(id);
     if (!person) {
       return JobStatus.Failed;
+    }
+
+    if (!person.thumbnailPath || !isAbsolute(person.thumbnailPath)) {
+      // S3 thumbnails live under relative keys and are managed by the S3 backend, not fs.rename.
+      this.logger.debug(`Skipping person file migration for S3 person ${id}`);
+      return JobStatus.Skipped;
     }
 
     await this.storageCore.movePersonFile(person, PersonPathType.Face);

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -121,6 +121,39 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.asset.update).not.toHaveBeenCalled();
     });
 
+    it('should migrate a disk still photo and skip its S3 motion video', async () => {
+      const motion = AssetFactory.from({
+        type: AssetType.Video,
+        originalPath: 'upload/user/ab/cd/motion.mp4', // relative — on S3
+        fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+      })
+        .exif()
+        .build();
+      const still = AssetFactory.from({
+        livePhotoVideoId: motion.id,
+        originalPath: '/data/upload/user/ab/cd/still.jpg', // absolute — on disk
+        fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+      })
+        .exif()
+        .build();
+
+      mocks.user.get.mockResolvedValue(userStub.user1);
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(still));
+      mocks.assetJob.getForStorageTemplateJob.mockResolvedValueOnce(getForStorageTemplate(motion));
+      mocks.move.create.mockResolvedValueOnce({
+        id: 'move-1',
+        entityId: still.id,
+        pathType: AssetPathType.Original,
+        oldPath: still.originalPath,
+        newPath: `/data/library/${still.ownerId}/2022/2022-06-19/${still.originalFileName}`,
+      });
+
+      await expect(sut.handleMigrationSingle({ id: still.id })).resolves.toBe(JobStatus.Success);
+      expect(mocks.storage.rename).toHaveBeenCalledTimes(1); // only the still
+      expect(mocks.storage.rename).toHaveBeenCalledWith(still.originalPath, expect.any(String));
+      expect(mocks.move.create).toHaveBeenCalledTimes(1);
+    });
+
     it('should migrate single moving picture', async () => {
       const motionAsset = AssetFactory.from({
         type: AssetType.Video,

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -569,6 +569,16 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.assetJob.streamForStorageTemplateJob).toHaveBeenCalled();
     });
 
+    it('should not throw when library folder does not exist on S3 deployments', async () => {
+      mocks.assetJob.streamForStorageTemplateJob.mockReturnValue(makeStream([]));
+      mocks.user.getList.mockResolvedValue([]);
+      mocks.storage.checkFileExists.mockResolvedValue(false);
+
+      await expect(sut.handleMigration()).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.storage.removeEmptyDirs).not.toHaveBeenCalled();
+    });
+
     it('should handle an asset with a duplicate destination', async () => {
       const asset = AssetFactory.from({
         fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
@@ -596,7 +606,7 @@ describe(StorageTemplateService.name, () => {
       await sut.handleMigration();
 
       expect(mocks.assetJob.streamForStorageTemplateJob).toHaveBeenCalled();
-      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(2);
+      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(3); // 2 for duplicate detection + 1 for library folder pre-check
       expect(mocks.asset.update).toHaveBeenCalledWith({ id: asset.id, originalPath: newPath2 });
       expect(mocks.user.getList).toHaveBeenCalled();
     });
@@ -616,7 +626,6 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.assetJob.streamForStorageTemplateJob).toHaveBeenCalled();
       expect(mocks.storage.rename).not.toHaveBeenCalled();
       expect(mocks.storage.copyFile).not.toHaveBeenCalled();
-      expect(mocks.storage.checkFileExists).not.toHaveBeenCalledTimes(2);
       expect(mocks.asset.update).not.toHaveBeenCalled();
     });
 
@@ -635,8 +644,22 @@ describe(StorageTemplateService.name, () => {
       expect(mocks.assetJob.streamForStorageTemplateJob).toHaveBeenCalled();
       expect(mocks.storage.rename).not.toHaveBeenCalled();
       expect(mocks.storage.copyFile).not.toHaveBeenCalled();
-      expect(mocks.storage.checkFileExists).not.toHaveBeenCalledTimes(2);
       expect(mocks.asset.update).not.toHaveBeenCalled();
+    });
+
+    it('should skip S3 assets with relative paths during bulk migration', async () => {
+      const asset = AssetFactory.from({ originalPath: 'upload/user/ab/cd/file.jpg' }).exif().build();
+
+      mocks.assetJob.streamForStorageTemplateJob.mockReturnValue(makeStream([getForStorageTemplate(asset)]));
+      mocks.user.getList.mockResolvedValue([userStub.user1]);
+
+      await sut.handleMigration();
+
+      expect(mocks.storage.rename).not.toHaveBeenCalled();
+      expect(mocks.storage.copyFile).not.toHaveBeenCalled();
+      expect(mocks.asset.update).not.toHaveBeenCalled();
+      expect(mocks.move.create).not.toHaveBeenCalled();
+      expect(mocks.storage.stat).not.toHaveBeenCalled();
     });
 
     it('should move an asset', async () => {
@@ -864,7 +887,7 @@ describe(StorageTemplateService.name, () => {
       await sut.handleMigration();
 
       expect(mocks.assetJob.streamForStorageTemplateJob).toHaveBeenCalled();
-      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(2);
+      expect(mocks.storage.checkFileExists).toHaveBeenCalledTimes(3); // 2 for path lookups + 1 for library folder pre-check
       expect(mocks.asset.update).toHaveBeenCalledWith({ id: stillAsset.id, originalPath: newStillPicturePath });
       expect(mocks.asset.update).toHaveBeenCalledWith({ id: motionAsset.id, originalPath: newMotionPicturePath });
     });

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -210,7 +210,9 @@ export class StorageTemplateService extends BaseService {
 
     this.logger.debug('Cleaning up empty directories...');
     const libraryFolder = StorageCore.getBaseFolder(StorageFolder.Library);
-    await this.storageRepository.removeEmptyDirs(libraryFolder);
+    if (await this.storageRepository.checkFileExists(libraryFolder)) {
+      await this.storageRepository.removeEmptyDirs(libraryFolder);
+    }
 
     this.logger.log('Finished storage template migration');
 
@@ -227,6 +229,12 @@ export class StorageTemplateService extends BaseService {
     if (asset.isExternal || StorageCore.isAndroidMotionPath(asset.originalPath)) {
       // External assets are not affected by storage template
       // TODO: shouldn't this only apply to external assets?
+      return;
+    }
+
+    if (!path.isAbsolute(asset.originalPath)) {
+      // S3 relative keys cannot be moved through fs.rename — S3 has its own placement rules.
+      this.logger.debug(`Skipping storage template migration for S3 asset ${asset.id}`);
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/open-noodle/gallery/issues/383 — on S3 deployments, asset paths are stored as relative S3 keys (e.g. `upload/<uuid>/ab/cd/file.jpg`). Storage-template migration and related file-migration jobs previously passed these keys directly to `fs.rename`, which resolved them against CWD and threw ENOENT.

Adds guards at every mover entry point so the jobs skip relative paths cleanly, plus a new pre-check so `removeEmptyDirs` tolerates missing directories on pure-S3 deployments that never wrote thumbs/encoded-video to disk.

## What's in here

**Production guards (fix #383 + adjacent same-class bug):**
- `storage.core.ts:isImmichPath` — returns false for non-absolute paths (fixes CWD-based `resolve()` false positive).
- `storage.core.ts:moveFile` — early-returns for relative `oldPath` before any fs call.
- `storage-template.service.ts:moveAsset` — skips relative paths in addition to external / android-motion paths.
- `storage-template.service.ts:handleMigrationSingle` — returns `Skipped` for S3 still assets before live-photo fan-out.
- `storage-template.service.ts:handleMigration` — guards `removeEmptyDirs(libraryFolder)` with `checkFileExists`.
- `media.service.ts:handleAssetMigration` — returns `Skipped` for relative `originalPath`.
- `media.service.ts:handleQueueMigration` — inlines `checkFileExists` pre-check for thumb/encoded-video folders (same bug class; pure-S3 deployments never wrote those on disk). `StorageCore.removeEmptyDirs` wrapper deleted (single caller inlined).
- `person.service.ts:handlePersonMigration` — returns `Skipped` for relative/empty `thumbnailPath`.
- `asset-job.repository.ts:getForMigrationJob` — now selects `originalPath` (required for the media.service guard).

**Unit tests** — every guard covered. Direct `moveFile` guard test, tightened bulk-S3 assertions, mixed-backend live-photo composition test, red-first TDD cycle on the `handleQueueMigration` fix.

**E2E phases (6 new)** — extend `e2e/src/storage-migration.ts`:
- `template-s3-bulk-skipped` — bulk template migration leaves S3 assets unchanged (primary #383 regression guard).
- `template-s3-upload-skipped` — single-asset upload on S3 stays at `upload/` path.
- `template-s3-live-photo-skipped` — motion + still live-photo pair both stay on S3.
- `template-s3-sidecar-skipped` — sidecar `asset_file` row unchanged after template toggle.
- `template-s3-queue-migration-skipped` — FileMigrationQueueAll (format flip) on pure-S3 produces no ENOENT. Primary E2E catch for the `handleQueueMigration` fix.
- `template-disk-baseline` — feature-regression guard proving disk template migration still works end-to-end.

Inserted into `.github/workflows/storage-migration-tests.yml` between `migrate-to-s3` and `no-files`; disk-baseline appended after `rollback` with its own backend=disk restart. Timeout bumped 30→45 min.

## Test plan

- [x] `Storage Migration Tests` workflow passes on the next nightly run (or `workflow_dispatch`).
- [x] Server unit suite green locally: `cd server && pnpm test -- --run` → 3866 passed / 8 skipped.
- [x] `cd e2e && pnpm exec tsc --noEmit` clean.
- [x] Manual verification on a pure-S3 deployment: enable storage template, confirm no ENOENT warnings in server logs.

## Notes

- Design doc: `docs/plans/2026-04-19-storage-template-s3-compat-design.md`.
- Implementation plan: `docs/plans/2026-04-19-storage-template-s3-compat-plan.md`.
- Out of scope (deferred): backend-swap E2E phases, stale `move_history` cleanup, `AssetService.copySidecar` on S3 targets.