### PR TITLE
fix(download): prevent S3 socket exhaustion on large archive downloads

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -40,6 +40,15 @@ const config = {
           postcssOptions.plugins.push(require('autoprefixer'));
           return postcssOptions;
         },
+        // webpackbar@6 stores extra options (name, color, reporters) in this.options which
+        // extends ProgressPlugin — webpack 5.106+ validates those options strictly and rejects
+        // the unknown fields. Strip the webpackbar plugins before webpack sees them.
+        configureWebpack(config) {
+          return {
+            mergeStrategy: { plugins: 'replace' },
+            plugins: (config.plugins ?? []).filter((p) => p?.constructor.name !== 'WebpackBarPlugin'),
+          };
+        },
       };
     },
     require.resolve('docusaurus-lunr-search'),

--- a/docs/plans/2026-04-21-s3-download-hang-design.md
+++ b/docs/plans/2026-04-21-s3-download-hang-design.md
@@ -1,0 +1,210 @@
+# S3 Download Hang Design
+
+**Date:** 2026-04-21  
+**Branch:** `s3-download-hang-design`  
+**Scope:** `download.service.ts` + `download.controller.ts`
+
+## Problem
+
+Users on S3 backends (Wasabi, MinIO, etc.) who download large selections (~150 assets) via the
+Gallery web UI experience a server hang:
+
+1. The download dialog appears but stays at 0% indefinitely.
+2. Thumbnail loading for new assets also stalls.
+3. Cancelling the download and refreshing the UI — the server stops responding entirely.
+4. No server-side errors log. Memory is not exhausted.
+
+Reported on v4.52.0 with Wasabi S3 and `serveMode: proxy`.
+
+## Root Cause
+
+`downloadArchive()` in `server/src/services/download.service.ts:88-133` loops over all N assets
+and calls `await backend.get(filePath)` for each S3 asset **upfront**, before archiver has consumed
+any of them.
+
+`backend.get()` sends a `GetObjectCommand` to S3, opening a real TCP connection and beginning the
+HTTP response body stream. `archive.append(stream, ...)` queues the stream in archiver, but
+archiver uses an internal sequential queue (`async.queue(..., 1)`) and processes entries one at a
+time. So N−1 connections sit stalled:
+
+- Their Node.js `Readable` internal buffers fill to the `highWaterMark`.
+- TCP backpressure kicks in (receive window → 0).
+- S3 holds the connection open but stops sending.
+
+With 150 assets, 150 sockets are held simultaneously.
+
+**Why thumbnails also stall (`serveMode: proxy`):** every thumbnail request calls
+`backend.get()` via `getServeStrategy()`, consuming a socket from the same AWS SDK connection
+pool. Those requests queue behind the stalled download connections and make no progress until
+a download socket frees up — which doesn't happen because archiver is draining them one-by-one.
+
+**Why the server appears dead after cancel:** there is no disconnect cleanup. When the client
+cancels, the 150 stalled connections persist until TCP keepalive timeout. During this window the
+connection pool remains exhausted for all S3-backed requests.
+
+**Why nothing logs:** no errors occur — the sockets are valid and alive, just idle with full
+receive buffers.
+
+## Fix
+
+### Part 1 — LazyS3Readable (eliminates the socket pile-up)
+
+Introduce `LazyS3Readable extends Readable` inside `download.service.ts`. Its `_read()` method
+defers `backend.get()` until archiver's internal pipeline actually calls `_read()` for the first
+time — which only happens when archiver has started processing that specific entry.
+
+Because archiver's internal queue runs at concurrency 1, `_read()` on entry N+1 is never called
+until entry N has fully drained. At any moment, exactly one S3 socket is open.
+
+**Loop change:**
+```typescript
+// Before: opens socket immediately for every asset
+const { stream } = await backend.get(filePath);
+zip.addFile(stream, filename);
+
+// After: defers socket until archiver reaches this entry
+const lazy = new LazyS3Readable(backend, filePath);
+lazies.push(lazy);
+zip.addFile(lazy, filename);
+```
+
+The S3 branch of the loop becomes synchronous — no `await backend.get()` per asset. Disk assets
+still call `await this.storageRepository.realpath(filePath)` inside the same loop; that path is
+unchanged.
+
+**`LazyS3Readable` class:**
+```typescript
+class LazyS3Readable extends Readable {
+  private source?: Readable;
+  private started = false;
+
+  constructor(
+    private readonly backend: StorageBackend,
+    private readonly key: string,
+  ) { super(); }
+
+  override _read(): void {
+    if (this.source) {
+      // Source was paused by backpressure — resume it
+      if (this.source.isPaused()) this.source.resume();
+      return;
+    }
+    if (this.started) return; // fetch already in flight
+    this.started = true;
+
+    this.backend.get(this.key)
+      .then(({ stream }) => {
+        this.source = stream;
+        stream.on('data', (chunk: Buffer) => {
+          if (!this.push(chunk)) stream.pause();
+        });
+        stream.on('end', () => this.push(null));
+        stream.on('error', (err: Error) => this.destroy(err));
+      })
+      .catch((err: Error) => this.destroy(err));
+  }
+
+  override _destroy(err: Error | null, callback: (err?: Error | null) => void): void {
+    // destroy() without error arg emits 'close' on source, not 'error',
+    // so archiver's error listener on the piped stream is not triggered.
+    this.source?.destroy();
+    callback(err);
+  }
+}
+```
+
+Backpressure notes:
+- When `this.push(chunk)` returns false (consumer is slow), `source.pause()` applies backpressure
+  to the S3 stream.
+- When the consumer calls `_read()` again (internal Node.js stream machinery, not the `'resume'`
+  event), `source.isPaused()` is true and `source.resume()` is called.
+- The `'resume'` event on a `Readable` does **not** fire as part of Node.js internal backpressure
+  resolution and must not be used for this purpose.
+
+Error handling notes:
+- `backend.get()` rejection inside the async `.then()/.catch()` chain must be caught explicitly;
+  without `.catch()`, a rejected promise inside `_read()` (which is synchronous) becomes an
+  unhandled rejection.
+- Mid-stream S3 errors are forwarded via `stream.on('error', (err) => this.destroy(err))`.
+
+### Part 2 — Disconnect cleanup (prevents post-cancel hang)
+
+Even with the lazy fix, the one currently-open S3 socket must be closed when the client disconnects.
+`archive.stream.destroy()` alone is not sufficient — archiver does not override `_destroy()` to
+propagate to its source streams (`compress-commons` has no destroy propagation).
+
+**Approach:** collect all `LazyS3Readable` instances in an array and destroy all of them in
+`abort()`. At most one has an active S3 socket (the one archiver is consuming); the rest have
+`source === undefined` so `_destroy()` is a no-op for them.
+
+```typescript
+const lazies: LazyS3Readable[] = [];
+// built in the loop above
+
+const abort = () => {
+  zip.stream.destroy();
+  for (const lazy of lazies) lazy.destroy();
+};
+```
+
+**Controller wiring:**
+```typescript
+async downloadArchive(
+  @Auth() auth: AuthDto,
+  @Body() dto: DownloadArchiveDto,
+  @Req() req: Request,
+): Promise<StreamableFile> {
+  const { stream, abort } = await this.service.downloadArchive(auth, dto);
+  req.on('close', abort);
+  return new StreamableFile(stream);
+}
+```
+
+The service return type changes locally from `ImmichReadStream` to `{ stream: Readable; abort: () => void }`.
+`ImmichReadStream` and `asStreamableFile` are untouched; the one-liner `.then(asStreamableFile)`
+in the controller is replaced by the `async/await` form above.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `server/src/services/download.service.ts` | Add `LazyS3Readable`; change S3 branch to use it; collect `lazies`; return `{ stream, abort }` |
+| `server/src/controllers/download.controller.ts` | Add `@Req() req: Request`; `async/await` form; wire `req.on('close', abort)` |
+
+**No changes to:** `S3StorageBackend`, `StorageRepository`, `StorageBackend` interface,
+`ImmichReadStream` (globally), archiver wiring, disk-asset path.
+
+## Approaches Considered and Rejected
+
+| Approach | Why rejected |
+|----------|-------------|
+| Pin `maxSockets` on the AWS SDK agent | Bounds pool size but does not fix the deadlock: N streams are still registered upfront, N−1 still stall |
+| Sequential `await`-before-append | Requires archiver per-entry completion signals; archiver does not expose these without significant additional wiring |
+| Presigned URL manifest (client-side zip) | Correct long-term architecture for very large archives but a major scope change (web app changes, new API shape, OpenAPI churn); wrong fix for a one-file bug |
+| Async semaphore (K=2 prefetch) | More complex than needed; marginal throughput gain not worth the complexity for a bug fix |
+
+## Testing
+
+### Unit tests (`server/src/services/download.service.spec.ts`)
+
+- Mock `backend.get()` to return a mock `Readable`. Verify it is **not** called during loop
+  construction — only after archiver has started draining the first entry.
+- Call `abort()` and verify `destroy()` is called on each registered `LazyS3Readable`.
+- Verify a `backend.get()` rejection inside `_read()` calls `this.destroy(err)` (no unhandled
+  rejection).
+
+### Manual smoke test (MinIO or Wasabi)
+
+- Download 150 assets. While the download is in progress, run `ss -tnp | grep <s3-port>` —
+  should show **1** `ESTABLISHED` connection, not 150.
+- Load thumbnails during the download — they should appear normally (no socket contention).
+- Cancel the download mid-way. The server should remain responsive immediately; `ss` should show
+  0 connections within a few seconds.
+- Repeat with `serveMode: redirect` to confirm no regression.
+
+## Out of Scope
+
+- `2026-04-21-s3-relative-path-audit-design.md` — a separate class of S3 bug (relative paths
+  reaching local-FS ops). No overlap with this fix.
+- `maxSockets` pin on `S3StorageBackend` — not needed; the lazy approach means at most 1 socket
+  per download is ever in use.

--- a/docs/plans/2026-04-21-s3-download-hang-design.md
+++ b/docs/plans/2026-04-21-s3-download-hang-design.md
@@ -57,6 +57,7 @@ Because archiver's internal queue runs at concurrency 1, `_read()` on entry N+1 
 until entry N has fully drained. At any moment, exactly one S3 socket is open.
 
 **Loop change:**
+
 ```typescript
 // Before: opens socket immediately for every asset
 const { stream } = await backend.get(filePath);
@@ -73,6 +74,7 @@ still call `await this.storageRepository.realpath(filePath)` inside the same loo
 unchanged.
 
 **`LazyS3Readable` class:**
+
 ```typescript
 class LazyS3Readable extends Readable {
   private source?: Readable;
@@ -81,7 +83,9 @@ class LazyS3Readable extends Readable {
   constructor(
     private readonly backend: StorageBackend,
     private readonly key: string,
-  ) { super(); }
+  ) {
+    super();
+  }
 
   override _read(): void {
     if (this.source) {
@@ -92,7 +96,8 @@ class LazyS3Readable extends Readable {
     if (this.started) return; // fetch already in flight
     this.started = true;
 
-    this.backend.get(this.key)
+    this.backend
+      .get(this.key)
       .then(({ stream }) => {
         this.source = stream;
         stream.on('data', (chunk: Buffer) => {
@@ -114,6 +119,7 @@ class LazyS3Readable extends Readable {
 ```
 
 Backpressure notes:
+
 - When `this.push(chunk)` returns false (consumer is slow), `source.pause()` applies backpressure
   to the S3 stream.
 - When the consumer calls `_read()` again (internal Node.js stream machinery, not the `'resume'`
@@ -122,6 +128,7 @@ Backpressure notes:
   resolution and must not be used for this purpose.
 
 Error handling notes:
+
 - `backend.get()` rejection inside the async `.then()/.catch()` chain must be caught explicitly;
   without `.catch()`, a rejected promise inside `_read()` (which is synchronous) becomes an
   unhandled rejection.
@@ -148,6 +155,7 @@ const abort = () => {
 ```
 
 **Controller wiring:**
+
 ```typescript
 async downloadArchive(
   @Auth() auth: AuthDto,
@@ -166,22 +174,22 @@ in the controller is replaced by the `async/await` form above.
 
 ## Files Changed
 
-| File | Change |
-|------|--------|
-| `server/src/services/download.service.ts` | Add `LazyS3Readable`; change S3 branch to use it; collect `lazies`; return `{ stream, abort }` |
-| `server/src/controllers/download.controller.ts` | Add `@Req() req: Request`; `async/await` form; wire `req.on('close', abort)` |
+| File                                            | Change                                                                                         |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `server/src/services/download.service.ts`       | Add `LazyS3Readable`; change S3 branch to use it; collect `lazies`; return `{ stream, abort }` |
+| `server/src/controllers/download.controller.ts` | Add `@Req() req: Request`; `async/await` form; wire `req.on('close', abort)`                   |
 
 **No changes to:** `S3StorageBackend`, `StorageRepository`, `StorageBackend` interface,
 `ImmichReadStream` (globally), archiver wiring, disk-asset path.
 
 ## Approaches Considered and Rejected
 
-| Approach | Why rejected |
-|----------|-------------|
-| Pin `maxSockets` on the AWS SDK agent | Bounds pool size but does not fix the deadlock: N streams are still registered upfront, N−1 still stall |
-| Sequential `await`-before-append | Requires archiver per-entry completion signals; archiver does not expose these without significant additional wiring |
+| Approach                                 | Why rejected                                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pin `maxSockets` on the AWS SDK agent    | Bounds pool size but does not fix the deadlock: N streams are still registered upfront, N−1 still stall                                                       |
+| Sequential `await`-before-append         | Requires archiver per-entry completion signals; archiver does not expose these without significant additional wiring                                          |
 | Presigned URL manifest (client-side zip) | Correct long-term architecture for very large archives but a major scope change (web app changes, new API shape, OpenAPI churn); wrong fix for a one-file bug |
-| Async semaphore (K=2 prefetch) | More complex than needed; marginal throughput gain not worth the complexity for a bug fix |
+| Async semaphore (K=2 prefetch)           | More complex than needed; marginal throughput gain not worth the complexity for a bug fix                                                                     |
 
 ## Testing
 

--- a/docs/plans/2026-04-21-s3-download-hang-plan.md
+++ b/docs/plans/2026-04-21-s3-download-hang-plan.md
@@ -29,7 +29,7 @@ and that the stream passed to `addFile` is a `Readable` (the lazy wrapper), not 
 
 **Step 1: Replace all `resolves.toEqual({ stream: ... })` with `resolves.toMatchObject`**
 
-There are 11 occurrences across the `downloadArchive` describe block (lines 48, 71, 95, 117, 139,
+There are 12 occurrences across the `downloadArchive` describe block (lines 48, 71, 95, 117, 139,
 168, 194, 216, 236, 257, 278, 298). Replace every instance.
 
 Find: `resolves.toEqual({`
@@ -86,17 +86,55 @@ implementation still calls `backend.get()` upfront). This establishes the red ba
 
 ---
 
-### Task 2: Add three new failing unit tests
+### Task 2: Update the controller spec mock
+
+The controller spec at `server/src/controllers/download.controller.spec.ts:39` mocks
+`service.downloadArchive.mockResolvedValue({ stream })`. After the fix the controller destructures
+`abort` from that result and calls `req.on('close', abort)`. With `abort === undefined`, Node.js
+EventEmitter throws `TypeError: "listener" argument must be a function`. The mock must be updated
+before the controller is changed.
+
+**Files:**
+- Modify: `server/src/controllers/download.controller.spec.ts`
+
+**Step 1: Add `abort` to the mock resolved value**
+
+Find the test at line 33–44 (`should be an authenticated route` inside `POST /download/archive`).
+Change:
+
+```typescript
+service.downloadArchive.mockResolvedValue({ stream });
+```
+
+To:
+
+```typescript
+service.downloadArchive.mockResolvedValue({ stream, abort: vitest.fn() });
+```
+
+**Step 2: Run the controller spec to confirm it still passes**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm test -- --run src/controllers/download.controller.spec.ts
+```
+
+Expected: all tests pass (the mock shape now matches the new return type even though the
+implementation hasn't changed yet).
+
+---
+
+### Task 3: Add new failing unit tests
 
 **Files:**
 - Modify: `server/src/services/download.service.spec.ts`
 
-Add the three tests below inside the `downloadArchive` describe block, after the rewritten S3 test.
+Add all tests below inside the `downloadArchive` describe block, after the rewritten S3 test.
 
-**Step 1: Add test — abort() destroys all registered lazy streams**
+**Step 1: Add test — abort() destroys all lazy streams AND the zip stream**
 
 ```typescript
-it('should destroy all lazy streams when abort() is called', async () => {
+it('should destroy all lazy streams and the zip stream when abort() is called', async () => {
   const capturedStreams: Readable[] = [];
   const archiveMock = {
     addFile: vitest.fn().mockImplementation((input: Readable | string) => {
@@ -122,17 +160,118 @@ it('should destroy all lazy streams when abort() is called', async () => {
     assetIds: [s3Asset1.id, s3Asset2.id],
   });
 
-  const destroySpies = capturedStreams.map((s) => vitest.spyOn(s, 'destroy'));
+  const lazyDestroySpies = capturedStreams.map((s) => vitest.spyOn(s, 'destroy'));
+  const zipDestroyspy = vitest.spyOn(archiveMock.stream, 'destroy');
 
   abort();
 
-  for (const spy of destroySpies) {
+  expect(zipDestroyspy).toHaveBeenCalled();
+  for (const spy of lazyDestroySpies) {
     expect(spy).toHaveBeenCalled();
   }
 });
 ```
 
-**Step 2: Add test — backend.get() rejection surfaces as stream error**
+**Step 2: Add test — abort() is safe when called before any entry is read (pre-activation)**
+
+```typescript
+it('should not throw when abort() is called before archiver has started any entry', async () => {
+  const archiveMock = {
+    addFile: vitest.fn(),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  const asset = AssetFactory.create();
+  const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+  const mockBackend = { get: vitest.fn() };
+  vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+  const { abort } = await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+  // abort() fires before _read() is ever called — no S3 socket is open, source is undefined
+  expect(() => abort()).not.toThrow();
+  // backend.get() must still not have been called
+  expect(mockBackend.get).not.toHaveBeenCalled();
+});
+```
+
+**Step 3: Add test — abort() is safe when lazies is empty (all-disk archive)**
+
+```typescript
+it('should not throw when abort() is called on an all-disk archive', async () => {
+  const archiveMock = {
+    addFile: vitest.fn(),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  // AssetFactory.create() produces absolute paths by default → disk branch
+  const asset1 = AssetFactory.create();
+  const asset2 = AssetFactory.create();
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset1.id, asset2.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+  const { abort } = await sut.downloadArchive(authStub.admin, {
+    assetIds: [asset1.id, asset2.id],
+  });
+
+  expect(() => abort()).not.toThrow();
+});
+```
+
+**Step 4: Add test — mixed disk + S3 archive routes correctly**
+
+```typescript
+it('should wrap only S3 assets in LazyS3Readable, leaving disk assets as string paths', async () => {
+  const capturedCalls: Array<[Readable | string, string]> = [];
+  const archiveMock = {
+    addFile: vitest.fn().mockImplementation((input: Readable | string, name: string) => {
+      capturedCalls.push([input, name]);
+    }),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  // Disk asset — absolute path
+  const diskAsset = AssetFactory.create({ originalPath: '/data/library/disk.jpg' });
+  // S3 asset — relative path
+  const s3AssetBase = AssetFactory.create();
+  const s3Asset = { ...s3AssetBase, originalPath: 'upload/library/s3.jpg' };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([diskAsset.id, s3Asset.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([diskAsset, s3Asset]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+  mocks.storage.realpath.mockResolvedValue('/data/library/disk.jpg');
+
+  const mockBackend = { get: vitest.fn() };
+  vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+  await sut.downloadArchive(authStub.admin, { assetIds: [diskAsset.id, s3Asset.id] });
+
+  expect(archiveMock.addFile).toHaveBeenCalledTimes(2);
+
+  // Disk asset — must receive a string path, not a Readable
+  const [diskInput] = capturedCalls[0];
+  expect(typeof diskInput).toBe('string');
+
+  // S3 asset — must receive a Readable (LazyS3Readable), not a string
+  const [s3Input] = capturedCalls[1];
+  expect(s3Input).toBeInstanceOf(Readable);
+
+  // backend.get() must not have been called upfront
+  expect(mockBackend.get).not.toHaveBeenCalled();
+});
+```
+
+**Step 5: Add test — backend.get() rejection surfaces as stream error**
 
 ```typescript
 it('should forward backend.get() rejection as a stream error on _read()', async () => {
@@ -172,7 +311,7 @@ it('should forward backend.get() rejection as a stream error on _read()', async 
 });
 ```
 
-**Step 3: Add test — mid-stream S3 error forwarded**
+**Step 6: Add test — mid-stream S3 error forwarded**
 
 ```typescript
 it('should forward a mid-stream S3 error to the lazy readable', async () => {
@@ -211,18 +350,19 @@ it('should forward a mid-stream S3 error to the lazy readable', async () => {
 });
 ```
 
-**Step 4: Run to confirm all three new tests fail**
+**Step 7: Run to confirm all new tests fail**
 
 ```bash
 cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
 pnpm test -- --run src/services/download.service.spec.ts
 ```
 
-Expected: 4 failures (the rewritten S3 test + the 3 new tests). All other tests pass.
+Expected: the rewritten S3 test + the 6 new tests fail (7 failures total). All other existing
+tests pass.
 
 ---
 
-### Task 3: Implement LazyS3Readable and update downloadArchive()
+### Task 4: Implement LazyS3Readable and update downloadArchive()
 
 **Files:**
 - Modify: `server/src/services/download.service.ts`
@@ -235,7 +375,13 @@ The file already imports from `node:path`. Add `Readable` to the existing Node i
 import { Readable } from 'node:stream';
 ```
 
-**Step 2: Add the LazyS3Readable class**
+**Step 2: Add StorageBackend to the imports**
+
+```typescript
+import { StorageBackend } from 'src/interfaces/storage-backend.interface';
+```
+
+**Step 3: Add the LazyS3Readable class**
 
 Insert this class just above the `@Injectable()` decorator (before the `DownloadService` class):
 
@@ -253,10 +399,12 @@ class LazyS3Readable extends Readable {
 
   override _read(): void {
     if (this.source) {
+      // Node.js calls _read() again when consumer drains the buffer after backpressure.
+      // Resume the source so data starts flowing again.
       if (this.source.isPaused()) this.source.resume();
       return;
     }
-    if (this.started) return;
+    if (this.started) return; // fetch already in flight — another _read() will not re-trigger it
     this.started = true;
 
     this.backend
@@ -264,32 +412,32 @@ class LazyS3Readable extends Readable {
       .then(({ stream }) => {
         this.source = stream;
         stream.on('data', (chunk: Buffer) => {
-          if (!this.push(chunk)) stream.pause();
+          if (!this.push(chunk)) stream.pause(); // apply backpressure to S3 source
         });
         stream.on('end', () => this.push(null));
         stream.on('error', (err: Error) => this.destroy(err));
       })
-      .catch((err: Error) => this.destroy(err));
+      .catch((err: Error) => this.destroy(err)); // prevent unhandled rejection
   }
 
   override _destroy(err: Error | null, callback: (err?: Error | null) => void): void {
+    // Calling destroy() without an error arg emits 'close' on source, not 'error',
+    // which avoids triggering archiver's error listener on the piped stream.
     this.source?.destroy();
     callback(err);
   }
 }
 ```
 
-**Step 3: Add StorageBackend to the imports**
+**Step 4: Declare the lazies array at the top of downloadArchive()**
 
-`StorageBackend` is the interface type used in the constructor. It is already used via
-`StorageService.resolveBackendForKey()`, but the class constructor parameter needs the type.
-Add to the existing import line at the top:
+Just after `const paths: Record<string, number> = {};` (line 94), add:
 
 ```typescript
-import { StorageBackend } from 'src/interfaces/storage-backend.interface';
+const lazies: LazyS3Readable[] = [];
 ```
 
-**Step 4: Rewrite the S3 branch of downloadArchive()**
+**Step 5: Rewrite the S3 branch of downloadArchive() and return statement**
 
 Replace the current S3 else-branch and return statement (lines 122–132):
 
@@ -331,14 +479,6 @@ With:
     return { stream: zip.stream, abort };
 ```
 
-**Step 5: Declare the lazies array at the top of downloadArchive()**
-
-Just after `const paths: Record<string, number> = {};` (line 94), add:
-
-```typescript
-const lazies: LazyS3Readable[] = [];
-```
-
 **Step 6: Update the return type of downloadArchive()**
 
 Change the method signature from:
@@ -353,10 +493,15 @@ To:
 async downloadArchive(auth: AuthDto, dto: DownloadArchiveDto): Promise<{ stream: Readable; abort: () => void }> {
 ```
 
-Remove `ImmichReadStream` from the import at the top of the file if it is no longer used anywhere
-else in this file (check — it's only used in `downloadArchive`'s return type, so remove it).
+**Step 7: Remove the ImmichReadStream import**
 
-**Step 7: Run the spec to verify all tests now pass**
+`ImmichReadStream` is now unused in this file. Remove it from the import:
+
+```typescript
+import { ImmichReadStream } from 'src/repositories/storage.repository';
+```
+
+**Step 8: Run the spec to verify all tests now pass**
 
 ```bash
 cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
@@ -365,7 +510,16 @@ pnpm test -- --run src/services/download.service.spec.ts
 
 Expected: all tests pass, 0 failures.
 
-**Step 8: Commit**
+**Step 9: Lint the service file**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm exec eslint --max-warnings 0 src/services/download.service.ts src/services/download.service.spec.ts
+```
+
+Expected: no warnings or errors. Fix any that appear before continuing.
+
+**Step 10: Commit**
 
 ```bash
 cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design
@@ -375,7 +529,7 @@ git commit -m "fix(download): lazy S3 socket opening and abort cleanup"
 
 ---
 
-### Task 4: Update the download controller
+### Task 5: Update the download controller
 
 **Files:**
 - Modify: `server/src/controllers/download.controller.ts`
@@ -418,30 +572,41 @@ With:
   }
 ```
 
-`asStreamableFile` is no longer called from this method. Check if it is still imported and used
-elsewhere in the file — if not, remove the import.
+**Step 3: Remove the asStreamableFile import**
 
-**Step 3: Run a type-check to catch any import or type errors**
+`asStreamableFile` is now unused in the controller. Remove it from the import at the top of the
+file.
+
+**Step 4: Run both controller and service specs**
 
 ```bash
 cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
-pnpm exec tsc --noEmit
+pnpm test -- --run src/controllers/download.controller.spec.ts
+pnpm test -- --run src/services/download.service.spec.ts
 ```
 
-Expected: no errors. If `Request` is not found, the express type package is `@types/express` which
-is already a devDependency of the server workspace.
+Expected: all tests pass.
 
-**Step 4: Commit**
+**Step 5: Lint the controller file**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm exec eslint --max-warnings 0 src/controllers/download.controller.ts src/controllers/download.controller.spec.ts
+```
+
+Expected: no warnings or errors.
+
+**Step 6: Commit**
 
 ```bash
 cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design
-git add server/src/controllers/download.controller.ts
+git add server/src/controllers/download.controller.ts server/src/controllers/download.controller.spec.ts
 git commit -m "fix(download): wire req.on('close', abort) to release S3 socket on disconnect"
 ```
 
 ---
 
-### Task 5: Full test run and type-check
+### Task 6: Full test run and type-check
 
 **Step 1: Run the full server test suite**
 
@@ -450,7 +615,8 @@ cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
 pnpm test
 ```
 
-Expected: all tests pass. `download.service.spec.ts` should show 0 failures.
+Expected: all tests pass. `download.service.spec.ts` and `download.controller.spec.ts` show 0
+failures.
 
 **Step 2: TypeScript type-check**
 
@@ -460,13 +626,11 @@ pnpm exec tsc --noEmit
 
 Expected: no errors.
 
-**Step 3: If any failures — diagnose before fixing**
+**Step 3: If any failures — common causes**
 
-Common issues:
-- `ImmichReadStream` import left dangling → remove it from `download.service.ts`
-- `asStreamableFile` import left dangling in controller → remove it
-- `Request` from express not found → confirm `@types/express` is in `server/package.json` devDeps
-  (it is — NestJS installs it transitively)
+- `ImmichReadStream` import still present in `download.service.ts` → remove it
+- `asStreamableFile` import still present in controller → remove it
+- `Request` from express not found → `@types/express` is a transitive NestJS dep, should be present
 
 ---
 
@@ -480,3 +644,5 @@ Run the dev stack (`make dev` from repo root) with an S3 backend configured.
 - [ ] Cancel the download mid-way. Server stays responsive; connection count drops to 0 within ~10 s
 - [ ] Repeat with 1 and 20 photos to confirm no regressions at small scale
 - [ ] Repeat with disk-only assets to confirm the disk path is unaffected
+- [ ] Repeat with `serveMode: redirect` — thumbnails should be unaffected regardless of download
+  state (presigned URLs use no server-side sockets)

--- a/docs/plans/2026-04-21-s3-download-hang-plan.md
+++ b/docs/plans/2026-04-21-s3-download-hang-plan.md
@@ -1,0 +1,482 @@
+# S3 Download Hang Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix a server hang where downloading N S3-backed assets opens N concurrent S3 sockets, exhausting the connection pool and stalling thumbnails and all subsequent S3 requests.
+
+**Architecture:** Replace upfront `await backend.get()` in `downloadArchive()` with a `LazyS3Readable` that defers the S3 GET until archiver actually starts consuming each entry. Since archiver is sequential (concurrency 1), at most one socket is ever open. A collected `lazies` array lets `abort()` destroy the one active socket on client disconnect, wired via `req.on('close')` in the controller.
+
+**Tech Stack:** Node.js `Readable` streams, archiver (zip, store mode), NestJS `@Req()`, AWS SDK v3 `GetObjectCommand` (via existing `backend.get()`), Vitest
+
+**Design doc:** `docs/plans/2026-04-21-s3-download-hang-design.md`
+
+---
+
+### Task 1: Fix existing tests — new return shape + S3 lazy behaviour
+
+The service return type changes from `ImmichReadStream` (`{ stream }`) to `{ stream, abort }`.
+All existing assertions using `resolves.toEqual({ stream: ... })` will fail because `toEqual`
+is strict about extra keys. Switch them to `toMatchObject` so `abort` being present doesn't break
+existing tests.
+
+The existing S3 test (`should stream S3 assets by resolving the backend`) currently asserts
+`backend.get()` was called during `downloadArchive()`. After the fix it won't be called until
+archiver drains the entry, so rewrite that test to assert `get()` was NOT called during construction
+and that the stream passed to `addFile` is a `Readable` (the lazy wrapper), not the raw S3 stream.
+
+**Files:**
+- Modify: `server/src/services/download.service.spec.ts`
+
+**Step 1: Replace all `resolves.toEqual({ stream: ... })` with `resolves.toMatchObject`**
+
+There are 11 occurrences across the `downloadArchive` describe block (lines 48, 71, 95, 117, 139,
+168, 194, 216, 236, 257, 278, 298). Replace every instance.
+
+Find: `resolves.toEqual({`
+Replace with: `resolves.toMatchObject({`
+
+Only replace inside the `downloadArchive` describe block. The `getDownloadInfo` tests don't return
+streams and are unaffected.
+
+**Step 2: Rewrite the S3 streaming test**
+
+Replace the test at lines 306–333 (`should stream S3 assets by resolving the backend`) with:
+
+```typescript
+it('should use a LazyS3Readable for S3 assets without calling backend.get() upfront', async () => {
+  const archiveMock = {
+    addFile: vitest.fn(),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  // Relative path → isAbsolute returns false → S3 branch
+  const asset = AssetFactory.create();
+  const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+  const mockBackend = { get: vitest.fn() };
+  vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+  await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+  // backend.get() must NOT be called during archive construction — it is lazy
+  expect(mockBackend.get).not.toHaveBeenCalled();
+
+  // addFile receives a Readable (the LazyS3Readable wrapper), not a raw S3 stream
+  expect(archiveMock.addFile).toHaveBeenCalledTimes(1);
+  const [passedStream, passedName] = archiveMock.addFile.mock.calls[0];
+  expect(passedStream).toBeInstanceOf(Readable);
+  expect(passedName).toBe(s3Asset.originalFileName);
+});
+```
+
+**Step 3: Run the full spec to see which tests now fail**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm test -- --run src/services/download.service.spec.ts
+```
+
+Expected outcome: all existing tests pass except the rewritten S3 test (which now fails because the
+implementation still calls `backend.get()` upfront). This establishes the red baseline.
+
+---
+
+### Task 2: Add three new failing unit tests
+
+**Files:**
+- Modify: `server/src/services/download.service.spec.ts`
+
+Add the three tests below inside the `downloadArchive` describe block, after the rewritten S3 test.
+
+**Step 1: Add test — abort() destroys all registered lazy streams**
+
+```typescript
+it('should destroy all lazy streams when abort() is called', async () => {
+  const capturedStreams: Readable[] = [];
+  const archiveMock = {
+    addFile: vitest.fn().mockImplementation((input: Readable | string) => {
+      if (typeof input !== 'string') capturedStreams.push(input);
+    }),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  const asset1 = AssetFactory.create();
+  const asset2 = AssetFactory.create();
+  const s3Asset1 = { ...asset1, originalPath: 'upload/library/a.jpg' };
+  const s3Asset2 = { ...asset2, originalPath: 'upload/library/b.jpg' };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset1.id, s3Asset2.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([s3Asset1, s3Asset2]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+  const mockBackend = { get: vitest.fn() };
+  vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+  const { abort } = await sut.downloadArchive(authStub.admin, {
+    assetIds: [s3Asset1.id, s3Asset2.id],
+  });
+
+  const destroySpies = capturedStreams.map((s) => vitest.spyOn(s, 'destroy'));
+
+  abort();
+
+  for (const spy of destroySpies) {
+    expect(spy).toHaveBeenCalled();
+  }
+});
+```
+
+**Step 2: Add test — backend.get() rejection surfaces as stream error**
+
+```typescript
+it('should forward backend.get() rejection as a stream error on _read()', async () => {
+  let capturedLazy: Readable | undefined;
+  const archiveMock = {
+    addFile: vitest.fn().mockImplementation((input: Readable | string) => {
+      if (typeof input !== 'string') capturedLazy = input;
+    }),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  const asset = AssetFactory.create();
+  const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+  const fetchError = new Error('S3 connection refused');
+  const mockBackend = { get: vitest.fn().mockRejectedValue(fetchError) };
+  vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+  await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+  // Register an error handler before triggering _read()
+  const errorHandler = vitest.fn();
+  capturedLazy!.on('error', errorHandler);
+
+  // Trigger _read() — this starts the fetch which will reject
+  capturedLazy!.read();
+
+  // Let the rejected promise settle
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  expect(errorHandler).toHaveBeenCalledWith(fetchError);
+});
+```
+
+**Step 3: Add test — mid-stream S3 error forwarded**
+
+```typescript
+it('should forward a mid-stream S3 error to the lazy readable', async () => {
+  let capturedLazy: Readable | undefined;
+  const archiveMock = {
+    addFile: vitest.fn().mockImplementation((input: Readable | string) => {
+      if (typeof input !== 'string') capturedLazy = input;
+    }),
+    finalize: vitest.fn(),
+    stream: new Readable(),
+  };
+
+  const asset = AssetFactory.create();
+  const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+  mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+  mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+  const s3Stream = new Readable({ read() {} });
+  const mockBackend = { get: vitest.fn().mockResolvedValue({ stream: s3Stream }) };
+  vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+  await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+  const errorHandler = vitest.fn();
+  capturedLazy!.on('error', errorHandler);
+  capturedLazy!.read(); // starts fetch
+
+  await new Promise<void>((resolve) => setImmediate(resolve)); // let .then() run
+
+  const midStreamError = new Error('S3 connection reset');
+  s3Stream.emit('error', midStreamError);
+
+  expect(errorHandler).toHaveBeenCalledWith(midStreamError);
+});
+```
+
+**Step 4: Run to confirm all three new tests fail**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm test -- --run src/services/download.service.spec.ts
+```
+
+Expected: 4 failures (the rewritten S3 test + the 3 new tests). All other tests pass.
+
+---
+
+### Task 3: Implement LazyS3Readable and update downloadArchive()
+
+**Files:**
+- Modify: `server/src/services/download.service.ts`
+
+**Step 1: Add import for Readable at the top of the file**
+
+The file already imports from `node:path`. Add `Readable` to the existing Node imports:
+
+```typescript
+import { Readable } from 'node:stream';
+```
+
+**Step 2: Add the LazyS3Readable class**
+
+Insert this class just above the `@Injectable()` decorator (before the `DownloadService` class):
+
+```typescript
+class LazyS3Readable extends Readable {
+  private source?: Readable;
+  private started = false;
+
+  constructor(
+    private readonly backend: StorageBackend,
+    private readonly key: string,
+  ) {
+    super();
+  }
+
+  override _read(): void {
+    if (this.source) {
+      if (this.source.isPaused()) this.source.resume();
+      return;
+    }
+    if (this.started) return;
+    this.started = true;
+
+    this.backend
+      .get(this.key)
+      .then(({ stream }) => {
+        this.source = stream;
+        stream.on('data', (chunk: Buffer) => {
+          if (!this.push(chunk)) stream.pause();
+        });
+        stream.on('end', () => this.push(null));
+        stream.on('error', (err: Error) => this.destroy(err));
+      })
+      .catch((err: Error) => this.destroy(err));
+  }
+
+  override _destroy(err: Error | null, callback: (err?: Error | null) => void): void {
+    this.source?.destroy();
+    callback(err);
+  }
+}
+```
+
+**Step 3: Add StorageBackend to the imports**
+
+`StorageBackend` is the interface type used in the constructor. It is already used via
+`StorageService.resolveBackendForKey()`, but the class constructor parameter needs the type.
+Add to the existing import line at the top:
+
+```typescript
+import { StorageBackend } from 'src/interfaces/storage-backend.interface';
+```
+
+**Step 4: Rewrite the S3 branch of downloadArchive()**
+
+Replace the current S3 else-branch and return statement (lines 122–132):
+
+```typescript
+      } else {
+        // S3 asset — stream from backend
+        const backend = StorageService.resolveBackendForKey(filePath);
+        const { stream } = await backend.get(filePath);
+        zip.addFile(stream, filename);
+      }
+    }
+
+    void zip.finalize();
+
+    return { stream: zip.stream };
+```
+
+With:
+
+```typescript
+      } else {
+        // S3 asset — open socket lazily when archiver starts consuming this entry.
+        // All N sockets would open concurrently if we awaited backend.get() here;
+        // archiver is sequential (concurrency 1) so only 1 socket is ever needed at once.
+        const backend = StorageService.resolveBackendForKey(filePath);
+        const lazy = new LazyS3Readable(backend, filePath);
+        lazies.push(lazy);
+        zip.addFile(lazy, filename);
+      }
+    }
+
+    void zip.finalize();
+
+    const abort = (): void => {
+      zip.stream.destroy();
+      for (const lazy of lazies) lazy.destroy();
+    };
+
+    return { stream: zip.stream, abort };
+```
+
+**Step 5: Declare the lazies array at the top of downloadArchive()**
+
+Just after `const paths: Record<string, number> = {};` (line 94), add:
+
+```typescript
+const lazies: LazyS3Readable[] = [];
+```
+
+**Step 6: Update the return type of downloadArchive()**
+
+Change the method signature from:
+
+```typescript
+async downloadArchive(auth: AuthDto, dto: DownloadArchiveDto): Promise<ImmichReadStream> {
+```
+
+To:
+
+```typescript
+async downloadArchive(auth: AuthDto, dto: DownloadArchiveDto): Promise<{ stream: Readable; abort: () => void }> {
+```
+
+Remove `ImmichReadStream` from the import at the top of the file if it is no longer used anywhere
+else in this file (check — it's only used in `downloadArchive`'s return type, so remove it).
+
+**Step 7: Run the spec to verify all tests now pass**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm test -- --run src/services/download.service.spec.ts
+```
+
+Expected: all tests pass, 0 failures.
+
+**Step 8: Commit**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design
+git add server/src/services/download.service.ts server/src/services/download.service.spec.ts
+git commit -m "fix(download): lazy S3 socket opening and abort cleanup"
+```
+
+---
+
+### Task 4: Update the download controller
+
+**Files:**
+- Modify: `server/src/controllers/download.controller.ts`
+
+**Step 1: Add `@Req()` import and `Request` type**
+
+NestJS re-exports `@Req()` from `@nestjs/common`. Add `Req` to the existing import:
+
+```typescript
+import { Body, Controller, HttpCode, HttpStatus, Post, Req, StreamableFile } from '@nestjs/common';
+```
+
+Add the Express `Request` type import below the NestJS import:
+
+```typescript
+import { Request } from 'express';
+```
+
+**Step 2: Rewrite downloadArchive() in the controller**
+
+Replace:
+
+```typescript
+  downloadArchive(@Auth() auth: AuthDto, @Body() dto: DownloadArchiveDto): Promise<StreamableFile> {
+    return this.service.downloadArchive(auth, dto).then(asStreamableFile);
+  }
+```
+
+With:
+
+```typescript
+  async downloadArchive(
+    @Auth() auth: AuthDto,
+    @Body() dto: DownloadArchiveDto,
+    @Req() req: Request,
+  ): Promise<StreamableFile> {
+    const { stream, abort } = await this.service.downloadArchive(auth, dto);
+    req.on('close', abort);
+    return new StreamableFile(stream);
+  }
+```
+
+`asStreamableFile` is no longer called from this method. Check if it is still imported and used
+elsewhere in the file — if not, remove the import.
+
+**Step 3: Run a type-check to catch any import or type errors**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors. If `Request` is not found, the express type package is `@types/express` which
+is already a devDependency of the server workspace.
+
+**Step 4: Commit**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design
+git add server/src/controllers/download.controller.ts
+git commit -m "fix(download): wire req.on('close', abort) to release S3 socket on disconnect"
+```
+
+---
+
+### Task 5: Full test run and type-check
+
+**Step 1: Run the full server test suite**
+
+```bash
+cd /home/pierre/dev/gallery/.worktrees/s3-download-hang-design/server
+pnpm test
+```
+
+Expected: all tests pass. `download.service.spec.ts` should show 0 failures.
+
+**Step 2: TypeScript type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+**Step 3: If any failures — diagnose before fixing**
+
+Common issues:
+- `ImmichReadStream` import left dangling → remove it from `download.service.ts`
+- `asStreamableFile` import left dangling in controller → remove it
+- `Request` from express not found → confirm `@types/express` is in `server/package.json` devDeps
+  (it is — NestJS installs it transitively)
+
+---
+
+### Manual smoke test checklist (against MinIO or Wasabi — not required to merge, but good to do)
+
+Run the dev stack (`make dev` from repo root) with an S3 backend configured.
+
+- [ ] Select ~150 S3-backed photos and click Download. While downloading:
+  - `ss -tnp | grep <minio-port>` shows **1** ESTABLISHED connection, not 150
+  - Thumbnails load normally during the download
+- [ ] Cancel the download mid-way. Server stays responsive; connection count drops to 0 within ~10 s
+- [ ] Repeat with 1 and 20 photos to confirm no regressions at small scale
+- [ ] Repeat with disk-only assets to confirm the disk path is unaffected

--- a/docs/plans/2026-04-21-s3-download-hang-plan.md
+++ b/docs/plans/2026-04-21-s3-download-hang-plan.md
@@ -25,6 +25,7 @@ archiver drains the entry, so rewrite that test to assert `get()` was NOT called
 and that the stream passed to `addFile` is a `Readable` (the lazy wrapper), not the raw S3 stream.
 
 **Files:**
+
 - Modify: `server/src/services/download.service.spec.ts`
 
 **Step 1: Replace all `resolves.toEqual({ stream: ... })` with `resolves.toMatchObject`**
@@ -95,6 +96,7 @@ EventEmitter throws `TypeError: "listener" argument must be a function`. The moc
 before the controller is changed.
 
 **Files:**
+
 - Modify: `server/src/controllers/download.controller.spec.ts`
 
 **Step 1: Add `abort` to the mock resolved value**
@@ -127,6 +129,7 @@ implementation hasn't changed yet).
 ### Task 3: Add new failing unit tests
 
 **Files:**
+
 - Modify: `server/src/services/download.service.spec.ts`
 
 Add all tests below inside the `downloadArchive` describe block, after the rewritten S3 test.
@@ -365,6 +368,7 @@ tests pass.
 ### Task 4: Implement LazyS3Readable and update downloadArchive()
 
 **Files:**
+
 - Modify: `server/src/services/download.service.ts`
 
 **Step 1: Add import for Readable at the top of the file**
@@ -532,6 +536,7 @@ git commit -m "fix(download): lazy S3 socket opening and abort cleanup"
 ### Task 5: Update the download controller
 
 **Files:**
+
 - Modify: `server/src/controllers/download.controller.ts`
 
 **Step 1: Add `@Req()` import and `Request` type**
@@ -645,4 +650,4 @@ Run the dev stack (`make dev` from repo root) with an S3 backend configured.
 - [ ] Repeat with 1 and 20 photos to confirm no regressions at small scale
 - [ ] Repeat with disk-only assets to confirm the disk path is unaffected
 - [ ] Repeat with `serveMode: redirect` — thumbnails should be unaffected regardless of download
-  state (presigned URLs use no server-side sockets)
+      state (presigned URLs use no server-side sockets)

--- a/docs/upstream-reports/2026-04-20-upstream-sync.md
+++ b/docs/upstream-reports/2026-04-20-upstream-sync.md
@@ -10,13 +10,13 @@
 
 ## Final CI status (commit `a54e8552e` on `rebase/upstream-post-v2.7.5`)
 
-| Workflow              | Status |
-| --------------------- | ------ |
-| Test                  | ✅ pass |
-| Static Code Analysis  | ✅ pass |
-| Storage Migration     | ✅ pass |
-| PR Label Validation   | ✅ pass |
-| Pull Request Labeler  | ✅ pass |
+| Workflow             | Status  |
+| -------------------- | ------- |
+| Test                 | ✅ pass |
+| Static Code Analysis | ✅ pass |
+| Storage Migration    | ✅ pass |
+| PR Label Validation  | ✅ pass |
+| Pull Request Labeler | ✅ pass |
 
 ## Strategy used for conflict resolution
 
@@ -64,13 +64,14 @@ For non-refactor conflicts, resolution was:
 
 Three resolution decisions during the rebase silently lost fork behavior. All three were caught later by CI iteration but should be flagged at Checkpoint 2 in future rebases:
 
-| File                                        | What was lost                                                                                                                                                  | Detected via                                       | Fix commit |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ---------- |
-| `server/src/services/auth.service.ts`       | Fork's S3 upload branch in `syncProfilePicture` — taking upstream cleanly dropped it                                                                            | Manual review during rebase fixup                  | `fee878e34` |
+| File                                                      | What was lost                                                                                                                                                                                                      | Detected via                                           | Fix commit  |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ | ----------- |
+| `server/src/services/auth.service.ts`                     | Fork's S3 upload branch in `syncProfilePicture` — taking upstream cleanly dropped it                                                                                                                               | Manual review during rebase fixup                      | `fee878e34` |
 | `web/src/lib/components/asset-viewer/detail-panel.svelte` | "Orphan-div fix" deleted the entire `<div class="px-4 py-4">` containing DetailPanelDate / originalFileName / Location. Camera + lens were re-added INSIDE people section but Date + filename + Location were lost | Web E2E test on `detail-panel-edit-date-button` testid | `60cc13c65` |
-| `web/src/lib/managers/auth-manager.svelte.ts` | `this.reset()` call before `goto(redirectUri)` in `logout()` — without it, user stays "authenticated" client-side and `/auth/login` redirects to `/photos`     | Web E2E auth Registration test (URL mismatch)      | `a54e8552e` |
+| `web/src/lib/managers/auth-manager.svelte.ts`             | `this.reset()` call before `goto(redirectUri)` in `logout()` — without it, user stays "authenticated" client-side and `/auth/login` redirects to `/photos`                                                         | Web E2E auth Registration test (URL mismatch)          | `a54e8552e` |
 
 **Side-effect of `pnpm install --no-frozen-lockfile`** during conflict resolution:
+
 - Bumped `@faker-js/faker` 10.3.0 → 10.4.0, which silently changed seeded UUIDs in UI Playwright fixtures (5 tests broke). Fixed in `f75397836`.
 
 ## Conflict Resolutions (summary by file category)
@@ -235,6 +236,7 @@ The structured 3-parallel-agent review surfaced **duplicate migration timestamps
 ### Bugs surfaced and fixed during CI iteration
 
 See "Remote CI Iteration Log" above. All have memory entries for next rebase:
+
 - `feedback_zod_dto_gotchas` — 3 zod conversion pitfalls (z.date crash, query-param arrays, enum codegen)
 - `feedback_e2e_auth_server_no_divergence` — always take upstream's auth-server.ts
 - `feedback_mocktail_stream_stub` — Dart mockail null-Stream gotcha
@@ -256,17 +258,23 @@ Performed locally before initial test-branch push:
 The push surfaced **8 categories of failures** that needed iterative fixing:
 
 ### 1. Mobile generated code stale (`mobile/lib/routing/router.gr.dart`)
+
 Newer `auto_route` adds `operator==`/`hashCode` overrides to RouteArgs. Dart Code Analysis "Verify files have not changed" caught the stale file.
+
 - **Fix**: `make build` in `mobile/` to regenerate.
 - **Commit**: `ad9492a32`
 
 ### 2. Mobile deprecation: `SemanticsService.announce` → `sendAnnouncement`
+
 Flutter 3.41 deprecated `announce` in favor of `sendAnnouncement(FlutterView, message, textDirection)`. `dart analyze --fatal-infos` failed.
+
 - **File**: `mobile/lib/presentation/widgets/filter_sheet/filter_sheet.widget.dart`
 - **Commit**: `edbe5a232`
 
 ### 3. e2e workspace drift: removed-API tests + auth-server divergence
+
 Multiple e2e issues from upstream API removals (#27818 `deviceId`, #27022 `replaceAsset`) and an out-of-date local copy of `e2e-auth-server/auth-server.ts` that lacked upstream's new `OAuthUser.ID_TOKEN_CLAIMS` enum.
+
 - **Fixes**:
   - Took upstream's `e2e-auth-server/auth-server.ts` wholesale (file has zero fork-only content — saved as `feedback_e2e_auth_server_no_divergence`)
   - Deleted `e2e/src/specs/server/api/asset-video-device.e2e-spec.ts` (tested removed `getAllByDeviceId` endpoint)
@@ -275,7 +283,9 @@ Multiple e2e issues from upstream API removals (#27818 `deviceId`, #27022 `repla
 - **Commit**: `c861fb57d`
 
 ### 4. Lost zod validation rules + `replaceAsset` test cleanup
+
 The class-validator → zod conversion silently dropped 6 validation constraints and broke 25+ e2e tests testing removed endpoints.
+
 - **Server fixes (validation gaps)**:
   - `SmartSearchDto.withSharedSpaces` — was `stringToBool` (rejects native booleans on POST body); switched to `z.boolean()`
   - `ModelConfigSchema.modelName` — added `.min(1)` (was `@IsNotEmpty`)
@@ -291,6 +301,7 @@ The class-validator → zod conversion silently dropped 6 validation constraints
 - **Commit**: `5c0a574cf` (memory: `feedback_zod_dto_gotchas`)
 
 ### 5. SvelteKit env hash mismatch — Web E2E hung indefinitely
+
 Symptom: every Web E2E test timed out at 30s with browser console showing `Cannot read properties of undefined (reading 'env')`. Server healthy, uploads worked, websocket events fired — but the page stayed on the loading spinner.
 
 Root cause: `web/svelte.config.js` had `version: { name: process.env.IMMICH_BUILD || Date.now().toString() }`. When `IMMICH_BUILD` is unset, SvelteKit's `load_config()` re-imports `svelte.config.js` with `?ts=` cache buster between Vite phases (chunks vs adapter-static prerender). The user's `Date.now()` is recomputed each time, producing different `version_hash = hash(kit.version.name)` values. Chunks bake in one hash (`globalThis.__sveltekit_<hash>.env`), the SPA-fallback `index.html` bakes in another. At runtime the chunk's lookup is undefined — anything reading `$env/dynamic/public` (e.g., `@immich/ui`'s `env.PUBLIC_IMMICH_HOSTNAME`) crashes.
@@ -299,18 +310,21 @@ Root cause: `web/svelte.config.js` had `version: { name: process.env.IMMICH_BUIL
 - **Commit**: `e0fb67f73` (memory: `feedback_sveltekit_version_name_datenow`)
 
 ### 6. Detail-panel orphan-div fix over-deleted upstream content
+
 The earlier orphan-div fix (`5ae8d47fc`) removed the entire `<div class="px-4 py-4">` containing `<DetailPanelDate />`, `originalFileName`/path/dimensions, camera, lens, and `<DetailPanelLocation />`. Camera and lens were re-added inside the people `<section>` but Date + filename + Location were lost. Web E2E test "Detail Panel > Date editor > displays inferred asset timezone" timed out at 30s on the missing `detail-panel-edit-date-button` testid.
 
 - **Fix**: restored the full upstream layout (Date → filename + path + dimensions → camera → lens → Location) inside its own `px-4 py-4` div; restored `DetailPanelDate` import; added inline `getMegapixel`/`getAssetFolderHref` helpers; added `slide` transition import.
 - **Commit**: `60cc13c65` (+ `818c9b87e` for prettier format)
 
 ### 7. Faker bumped 10.3.0 → 10.4.0 → seeded UUIDs shifted
+
 `pnpm install --no-frozen-lockfile` (run during conflict resolution) bumped `@faker-js/faker` from 10.3.0 to 10.4.0 (allowed by `^10.1.0` specifier). UI Playwright tests under `e2e/src/ui/specs/timeline/` use `faker.seed(42)` and **hardcode** specific UUIDs like `ad31e29f-2069-4574-b9a9-ad86523c92cb`. Faker 10.4.0 produces different UUIDs from the same seed — `getAsset()` returned undefined → `.id` access threw `TypeError`.
 
 - **Fix**: pinned `@faker-js/faker` to `^10.3.0` to match upstream's lockfile.
 - **Commit**: `f75397836` (memory: `feedback_faker_pin_seeded_uuids`)
 
 ### 8. authManager.logout() lost upstream's `this.reset()` call
+
 Symptom: e2e Registration test ended up on `/photos` after change-password instead of `/auth/login?autoLaunch=0` (the URL the server returns from `LOGIN_URL`).
 
 Root cause: the squashed fork commit was missing the `this.reset()` call that upstream's `authManager.logout()` makes before `goto(redirectUri)`. Without it, `#user`/`#preferences` stay populated; `/auth/login`'s page-load sees `authManager.authenticated === true` and 307s to the continue URL (`/photos`).
@@ -320,18 +334,18 @@ Root cause: the squashed fork commit was missing the `this.reset()` call that up
 
 ### CI iteration summary
 
-| Iteration | Commit      | Failure category                                | Outcome             |
-| --------- | ----------- | ----------------------------------------------- | ------------------- |
-| 1         | `2e6e88148` | Initial push                                    | Test failed (e2e)   |
-| 2         | `c861fb57d` | e2e cleanup (auth-server, deviceId)             | Static Analysis ❌  |
-| 3         | `ad9492a32` | router.gr.dart regen                            | Static Analysis ❌  |
-| 4         | `edbe5a232` | sendAnnouncement migration                      | Static Analysis ✅; Test failed (zod gaps + endpoint tests) |
-| 5         | `5c0a574cf` | zod validation + e2e cleanup                    | Test failed (Lint Web + Web E2E hung) |
-| 6         | `e0fb67f73` | svelte-config Date.now fallback                 | Web E2E partial — detail-panel test still fails |
-| 7         | `60cc13c65` | restore detail-panel details section            | Lint Web (prettier) failed |
-| 8         | `818c9b87e` | prettier format detail-panel                    | UI tests fail (faker) |
-| 9         | `f75397836` | pin faker 10.3.0                                | Web auth.e2e fails |
-| 10        | `a54e8552e` | authManager.logout reset() call                 | **ALL CI GREEN** ✅ |
+| Iteration | Commit      | Failure category                     | Outcome                                                     |
+| --------- | ----------- | ------------------------------------ | ----------------------------------------------------------- |
+| 1         | `2e6e88148` | Initial push                         | Test failed (e2e)                                           |
+| 2         | `c861fb57d` | e2e cleanup (auth-server, deviceId)  | Static Analysis ❌                                          |
+| 3         | `ad9492a32` | router.gr.dart regen                 | Static Analysis ❌                                          |
+| 4         | `edbe5a232` | sendAnnouncement migration           | Static Analysis ✅; Test failed (zod gaps + endpoint tests) |
+| 5         | `5c0a574cf` | zod validation + e2e cleanup         | Test failed (Lint Web + Web E2E hung)                       |
+| 6         | `e0fb67f73` | svelte-config Date.now fallback      | Web E2E partial — detail-panel test still fails             |
+| 7         | `60cc13c65` | restore detail-panel details section | Lint Web (prettier) failed                                  |
+| 8         | `818c9b87e` | prettier format detail-panel         | UI tests fail (faker)                                       |
+| 9         | `f75397836` | pin faker 10.3.0                     | Web auth.e2e fails                                          |
+| 10        | `a54e8552e` | authManager.logout reset() call      | **ALL CI GREEN** ✅                                         |
 
 ## Post-Rebase Verification
 

--- a/server/src/controllers/download.controller.spec.ts
+++ b/server/src/controllers/download.controller.spec.ts
@@ -37,7 +37,7 @@ describe(DownloadController.name, () => {
           this.push(null);
         },
       });
-      service.downloadArchive.mockResolvedValue({ stream, abort: vitest.fn() });
+      service.downloadArchive.mockResolvedValue({ stream, abort: vitest.fn() } as any);
       await request(ctx.getHttpServer())
         .post('/download/archive')
         .send({ assetIds: [factory.uuid()] });

--- a/server/src/controllers/download.controller.spec.ts
+++ b/server/src/controllers/download.controller.spec.ts
@@ -37,7 +37,7 @@ describe(DownloadController.name, () => {
           this.push(null);
         },
       });
-      service.downloadArchive.mockResolvedValue({ stream, abort: vitest.fn() } as any);
+      service.downloadArchive.mockResolvedValue({ stream, abort: vitest.fn() });
       await request(ctx.getHttpServer())
         .post('/download/archive')
         .send({ assetIds: [factory.uuid()] });

--- a/server/src/controllers/download.controller.spec.ts
+++ b/server/src/controllers/download.controller.spec.ts
@@ -1,10 +1,10 @@
 import { Readable } from 'node:stream';
 import { DownloadController } from 'src/controllers/download.controller';
-import { vitest } from 'vitest';
 import { DownloadService } from 'src/services/download.service';
 import request from 'supertest';
 import { factory } from 'test/small.factory';
 import { ControllerContext, controllerSetup, mockBaseService } from 'test/utils';
+import { vitest } from 'vitest';
 
 describe(DownloadController.name, () => {
   let ctx: ControllerContext;

--- a/server/src/controllers/download.controller.spec.ts
+++ b/server/src/controllers/download.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream';
 import { DownloadController } from 'src/controllers/download.controller';
+import { vitest } from 'vitest';
 import { DownloadService } from 'src/services/download.service';
 import request from 'supertest';
 import { factory } from 'test/small.factory';
@@ -36,7 +37,7 @@ describe(DownloadController.name, () => {
           this.push(null);
         },
       });
-      service.downloadArchive.mockResolvedValue({ stream });
+      service.downloadArchive.mockResolvedValue({ stream, abort: vitest.fn() });
       await request(ctx.getHttpServer())
         .post('/download/archive')
         .send({ assetIds: [factory.uuid()] });

--- a/server/src/controllers/download.controller.ts
+++ b/server/src/controllers/download.controller.ts
@@ -1,12 +1,12 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, StreamableFile } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Req, StreamableFile } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { DownloadArchiveDto, DownloadInfoDto, DownloadResponseDto } from 'src/dtos/download.dto';
 import { ApiTag, Permission } from 'src/enum';
 import { Auth, Authenticated, FileResponse } from 'src/middleware/auth.guard';
 import { DownloadService } from 'src/services/download.service';
-import { asStreamableFile } from 'src/utils/file';
 
 @ApiTags(ApiTag.Download)
 @Controller('download')
@@ -35,7 +35,13 @@ export class DownloadController {
       'Download a ZIP archive containing the specified assets. The assets must have been previously requested via the "getDownloadInfo" endpoint.',
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
-  downloadArchive(@Auth() auth: AuthDto, @Body() dto: DownloadArchiveDto): Promise<StreamableFile> {
-    return this.service.downloadArchive(auth, dto).then(asStreamableFile);
+  async downloadArchive(
+    @Auth() auth: AuthDto,
+    @Body() dto: DownloadArchiveDto,
+    @Req() req: Request,
+  ): Promise<StreamableFile> {
+    const { stream, abort } = await this.service.downloadArchive(auth, dto);
+    req.on('close', abort);
+    return new StreamableFile(stream);
   }
 }

--- a/server/src/services/download.service.spec.ts
+++ b/server/src/services/download.service.spec.ts
@@ -337,7 +337,9 @@ describe(DownloadService.name, () => {
       const capturedStreams: Readable[] = [];
       const archiveMock = {
         addFile: vitest.fn().mockImplementation((input: Readable | string) => {
-          if (typeof input !== 'string') capturedStreams.push(input);
+          if (typeof input !== 'string') {
+            capturedStreams.push(input);
+          }
         }),
         finalize: vitest.fn(),
         stream: new Readable(),
@@ -461,7 +463,9 @@ describe(DownloadService.name, () => {
       let capturedLazy: Readable | undefined;
       const archiveMock = {
         addFile: vitest.fn().mockImplementation((input: Readable | string) => {
-          if (typeof input !== 'string') capturedLazy = input;
+          if (typeof input !== 'string') {
+            capturedLazy = input;
+          }
         }),
         finalize: vitest.fn(),
         stream: new Readable(),
@@ -497,7 +501,9 @@ describe(DownloadService.name, () => {
       let capturedLazy: Readable | undefined;
       const archiveMock = {
         addFile: vitest.fn().mockImplementation((input: Readable | string) => {
-          if (typeof input !== 'string') capturedLazy = input;
+          if (typeof input !== 'string') {
+            capturedLazy = input;
+          }
         }),
         finalize: vitest.fn(),
         stream: new Readable(),

--- a/server/src/services/download.service.spec.ts
+++ b/server/src/services/download.service.spec.ts
@@ -332,6 +332,201 @@ describe(DownloadService.name, () => {
       expect(passedStream).toBeInstanceOf(Readable);
       expect(passedName).toBe(s3Asset.originalFileName);
     });
+
+    it('should destroy all lazy streams and the zip stream when abort() is called', async () => {
+      const capturedStreams: Readable[] = [];
+      const archiveMock = {
+        addFile: vitest.fn().mockImplementation((input: Readable | string) => {
+          if (typeof input !== 'string') capturedStreams.push(input);
+        }),
+        finalize: vitest.fn(),
+        stream: new Readable(),
+      };
+
+      const asset1 = AssetFactory.create();
+      const asset2 = AssetFactory.create();
+      const s3Asset1 = { ...asset1, originalPath: 'upload/library/a.jpg' };
+      const s3Asset2 = { ...asset2, originalPath: 'upload/library/b.jpg' };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset1.id, s3Asset2.id]));
+      mocks.asset.getForOriginals.mockResolvedValue([s3Asset1, s3Asset2]);
+      mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+      const mockBackend = { get: vitest.fn() };
+      vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+      const { abort } = await sut.downloadArchive(authStub.admin, {
+        assetIds: [s3Asset1.id, s3Asset2.id],
+      });
+
+      const lazyDestroySpies = capturedStreams.map((s) => vitest.spyOn(s, 'destroy'));
+      const zipDestroySpy = vitest.spyOn(archiveMock.stream, 'destroy');
+
+      abort();
+
+      expect(zipDestroySpy).toHaveBeenCalled();
+      for (const spy of lazyDestroySpies) {
+        expect(spy).toHaveBeenCalled();
+      }
+    });
+
+    it('should not throw when abort() is called before archiver has started any entry', async () => {
+      const archiveMock = {
+        addFile: vitest.fn(),
+        finalize: vitest.fn(),
+        stream: new Readable(),
+      };
+
+      const asset = AssetFactory.create();
+      const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+      mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+      mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+      const mockBackend = { get: vitest.fn() };
+      vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+      const { abort } = await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+      // abort() fires before _read() is ever called — no S3 socket is open, source is undefined
+      expect(() => abort()).not.toThrow();
+      // backend.get() must still not have been called
+      expect(mockBackend.get).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when abort() is called on an all-disk archive', async () => {
+      const archiveMock = {
+        addFile: vitest.fn(),
+        finalize: vitest.fn(),
+        stream: new Readable(),
+      };
+
+      // AssetFactory.create() produces absolute paths by default → disk branch
+      const asset1 = AssetFactory.create();
+      const asset2 = AssetFactory.create();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset1.id, asset2.id]));
+      mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
+      mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+      const { abort } = await sut.downloadArchive(authStub.admin, {
+        assetIds: [asset1.id, asset2.id],
+      });
+
+      expect(() => abort()).not.toThrow();
+    });
+
+    it('should wrap only S3 assets in LazyS3Readable, leaving disk assets as string paths', async () => {
+      const capturedCalls: Array<[Readable | string, string]> = [];
+      const archiveMock = {
+        addFile: vitest.fn().mockImplementation((input: Readable | string, name: string) => {
+          capturedCalls.push([input, name]);
+        }),
+        finalize: vitest.fn(),
+        stream: new Readable(),
+      };
+
+      // Disk asset — absolute path
+      const diskAsset = AssetFactory.create({ originalPath: '/data/library/disk.jpg' });
+      // S3 asset — relative path
+      const s3AssetBase = AssetFactory.create();
+      const s3Asset = { ...s3AssetBase, originalPath: 'upload/library/s3.jpg' };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([diskAsset.id, s3Asset.id]));
+      mocks.asset.getForOriginals.mockResolvedValue([diskAsset, s3Asset]);
+      mocks.storage.createZipStream.mockReturnValue(archiveMock);
+      mocks.storage.realpath.mockResolvedValue('/data/library/disk.jpg');
+
+      const mockBackend = { get: vitest.fn() };
+      vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+      await sut.downloadArchive(authStub.admin, { assetIds: [diskAsset.id, s3Asset.id] });
+
+      expect(archiveMock.addFile).toHaveBeenCalledTimes(2);
+
+      // Disk asset — must receive a string path, not a Readable
+      const [diskInput] = capturedCalls[0];
+      expect(typeof diskInput).toBe('string');
+
+      // S3 asset — must receive a Readable (LazyS3Readable), not a string
+      const [s3Input] = capturedCalls[1];
+      expect(s3Input).toBeInstanceOf(Readable);
+
+      // backend.get() must not have been called upfront
+      expect(mockBackend.get).not.toHaveBeenCalled();
+    });
+
+    it('should forward backend.get() rejection as a stream error on _read()', async () => {
+      let capturedLazy: Readable | undefined;
+      const archiveMock = {
+        addFile: vitest.fn().mockImplementation((input: Readable | string) => {
+          if (typeof input !== 'string') capturedLazy = input;
+        }),
+        finalize: vitest.fn(),
+        stream: new Readable(),
+      };
+
+      const asset = AssetFactory.create();
+      const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+      mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+      mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+      const fetchError = new Error('S3 connection refused');
+      const mockBackend = { get: vitest.fn().mockRejectedValue(fetchError) };
+      vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+      await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+      // Register an error handler before triggering _read()
+      const errorHandler = vitest.fn();
+      capturedLazy!.on('error', errorHandler);
+
+      // Trigger _read() — this starts the fetch which will reject
+      capturedLazy!.read();
+
+      // Let the rejected promise settle
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(errorHandler).toHaveBeenCalledWith(fetchError);
+    });
+
+    it('should forward a mid-stream S3 error to the lazy readable', async () => {
+      let capturedLazy: Readable | undefined;
+      const archiveMock = {
+        addFile: vitest.fn().mockImplementation((input: Readable | string) => {
+          if (typeof input !== 'string') capturedLazy = input;
+        }),
+        finalize: vitest.fn(),
+        stream: new Readable(),
+      };
+
+      const asset = AssetFactory.create();
+      const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
+      mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
+      mocks.storage.createZipStream.mockReturnValue(archiveMock);
+
+      const s3Stream = new Readable({ read() {} });
+      const mockBackend = { get: vitest.fn().mockResolvedValue({ stream: s3Stream }) };
+      vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
+
+      await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
+
+      const errorHandler = vitest.fn();
+      capturedLazy!.on('error', errorHandler);
+      capturedLazy!.read(); // starts fetch
+
+      await new Promise<void>((resolve) => setImmediate(resolve)); // let .then() run
+
+      const midStreamError = new Error('S3 connection reset');
+      s3Stream.emit('error', midStreamError);
+
+      expect(errorHandler).toHaveBeenCalledWith(midStreamError);
+    });
   });
 
   describe('getDownloadInfo', () => {

--- a/server/src/services/download.service.spec.ts
+++ b/server/src/services/download.service.spec.ts
@@ -45,7 +45,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id, 'unknown-asset'] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id, 'unknown-asset'] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -68,7 +68,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -92,7 +92,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -114,7 +114,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -136,7 +136,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -165,7 +165,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -191,7 +191,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset1, asset2]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset1.id, asset2.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -213,7 +213,7 @@ describe(DownloadService.name, () => {
       mocks.storage.realpath.mockResolvedValue('/path/to/realpath.jpg');
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -233,7 +233,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([editedAsset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id], edited: true })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id], edited: true })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -254,7 +254,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([assetWithoutEdit]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id], edited: true })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id], edited: true })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -275,7 +275,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([editedAsset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id], edited: true })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id], edited: true })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -295,7 +295,7 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id] })).resolves.toEqual({
+      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id] })).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 
@@ -303,33 +303,34 @@ describe(DownloadService.name, () => {
       expect(archiveMock.addFile).toHaveBeenCalledWith(asset.originalPath, asset.originalFileName);
     });
 
-    it('should stream S3 assets by resolving the backend', async () => {
+    it('should use a LazyS3Readable for S3 assets without calling backend.get() upfront', async () => {
       const archiveMock = {
         addFile: vitest.fn(),
         finalize: vitest.fn(),
         stream: new Readable(),
       };
-      const mockStream = new Readable();
 
-      // S3 asset has a relative (non-absolute) path
-      const asset = AssetFactory.create({ originalPath: 's3://bucket/key/photo.jpg' });
-      // Override originalPath to a relative (non-absolute) path so isAbsolute returns false
+      // Relative path → isAbsolute returns false → S3 branch
+      const asset = AssetFactory.create();
       const s3Asset = { ...asset, originalPath: 'upload/library/photo.jpg' };
 
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([s3Asset.id]));
       mocks.asset.getForOriginals.mockResolvedValue([s3Asset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      // Mock StorageService.resolveBackendForKey
-      const mockBackend = { get: vitest.fn().mockResolvedValue({ stream: mockStream }) };
+      const mockBackend = { get: vitest.fn() };
       vitest.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(mockBackend as any);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] })).resolves.toEqual({
-        stream: archiveMock.stream,
-      });
+      await sut.downloadArchive(authStub.admin, { assetIds: [s3Asset.id] });
 
-      expect(mockBackend.get).toHaveBeenCalledWith('upload/library/photo.jpg');
-      expect(archiveMock.addFile).toHaveBeenCalledWith(mockStream, s3Asset.originalFileName);
+      // backend.get() must NOT be called during archive construction — it is lazy
+      expect(mockBackend.get).not.toHaveBeenCalled();
+
+      // addFile receives a Readable (the LazyS3Readable wrapper), not a raw S3 stream
+      expect(archiveMock.addFile).toHaveBeenCalledTimes(1);
+      const [passedStream, passedName] = archiveMock.addFile.mock.calls[0];
+      expect(passedStream).toBeInstanceOf(Readable);
+      expect(passedName).toBe(s3Asset.originalFileName);
     });
   });
 

--- a/server/src/services/download.service.spec.ts
+++ b/server/src/services/download.service.spec.ts
@@ -45,7 +45,9 @@ describe(DownloadService.name, () => {
       mocks.asset.getForOriginals.mockResolvedValue([asset]);
       mocks.storage.createZipStream.mockReturnValue(archiveMock);
 
-      await expect(sut.downloadArchive(authStub.admin, { assetIds: [asset.id, 'unknown-asset'] })).resolves.toMatchObject({
+      await expect(
+        sut.downloadArchive(authStub.admin, { assetIds: [asset.id, 'unknown-asset'] }),
+      ).resolves.toMatchObject({
         stream: archiveMock.stream,
       });
 

--- a/server/src/services/download.service.ts
+++ b/server/src/services/download.service.ts
@@ -1,15 +1,70 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { isAbsolute, parse } from 'node:path';
+import { Readable } from 'node:stream';
 import sanitize from 'sanitize-filename';
 import { StorageCore } from 'src/cores/storage.core';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { DownloadArchiveDto, DownloadArchiveInfo, DownloadInfoDto, DownloadResponseDto } from 'src/dtos/download.dto';
 import { Permission } from 'src/enum';
-import { ImmichReadStream } from 'src/repositories/storage.repository';
+import { StorageBackend } from 'src/interfaces/storage-backend.interface';
 import { BaseService } from 'src/services/base.service';
 import { StorageService } from 'src/services/storage.service';
 import { HumanReadableSize } from 'src/utils/bytes';
 import { getPreferences } from 'src/utils/preferences';
+
+class LazyS3Readable extends Readable {
+  private source?: Readable;
+  private started = false;
+
+  constructor(
+    private readonly backend: StorageBackend,
+    private readonly key: string,
+  ) {
+    super();
+  }
+
+  override _read(): void {
+    if (this.source) {
+      // Node.js calls _read() again when consumer drains the buffer after backpressure.
+      // Resume the source so data starts flowing again.
+      if (this.source.isPaused()) {
+        this.source.resume();
+      }
+      return;
+    }
+    if (this.started) {
+      return; // fetch already in flight — another _read() will not re-trigger it
+    }
+    this.started = true;
+
+    this.backend
+      .get(this.key)
+      .then(({ stream }) => {
+        this.source = stream;
+        stream.on('data', (chunk: Buffer) => {
+          if (!this.push(chunk)) {
+            stream.pause(); // apply backpressure to S3 source
+          }
+        });
+        stream.on('end', () => this.push(null));
+        // emit('error') is synchronous; destroy(err) defers the error event when called
+        // from within another stream's event handler (Node.js re-entrancy guard), which
+        // would cause consumers to miss the error if they don't await.
+        stream.on('error', (err: Error) => {
+          this.destroy();
+          this.emit('error', err);
+        });
+      })
+      .catch((error: Error) => this.destroy(error)); // prevent unhandled rejection
+  }
+
+  override _destroy(err: Error | null, callback: (err?: Error | null) => void): void {
+    // Calling destroy() without an error arg emits 'close' on source, not 'error',
+    // which avoids triggering archiver's error listener on the piped stream.
+    this.source?.destroy();
+    callback(err);
+  }
+}
 
 @Injectable()
 export class DownloadService extends BaseService {
@@ -85,13 +140,14 @@ export class DownloadService extends BaseService {
     return { totalSize, archives };
   }
 
-  async downloadArchive(auth: AuthDto, dto: DownloadArchiveDto): Promise<ImmichReadStream> {
+  async downloadArchive(auth: AuthDto, dto: DownloadArchiveDto): Promise<{ stream: Readable; abort: () => void }> {
     await this.requireAccess({ auth, permission: Permission.AssetDownload, ids: dto.assetIds });
 
     const zip = this.storageRepository.createZipStream();
     const assets = await this.assetRepository.getForOriginals(dto.assetIds, dto.edited ?? false);
     const assetMap = new Map(assets.map((asset) => [asset.id, asset]));
     const paths: Record<string, number> = {};
+    const lazies: LazyS3Readable[] = [];
 
     for (const assetId of dto.assetIds) {
       const asset = assetMap.get(assetId);
@@ -120,15 +176,25 @@ export class DownloadService extends BaseService {
         }
         zip.addFile(filePath, filename);
       } else {
-        // S3 asset — stream from backend
+        // S3 asset — open socket lazily when archiver starts consuming this entry.
+        // All N sockets would open concurrently if we awaited backend.get() here;
+        // archiver is sequential (concurrency 1) so only 1 socket is ever needed at once.
         const backend = StorageService.resolveBackendForKey(filePath);
-        const { stream } = await backend.get(filePath);
-        zip.addFile(stream, filename);
+        const lazy = new LazyS3Readable(backend, filePath);
+        lazies.push(lazy);
+        zip.addFile(lazy, filename);
       }
     }
 
     void zip.finalize();
 
-    return { stream: zip.stream };
+    const abort = (): void => {
+      zip.stream.destroy();
+      for (const lazy of lazies) {
+        lazy.destroy();
+      }
+    };
+
+    return { stream: zip.stream, abort };
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `downloadArchive()` called `await backend.get()` for every S3 asset upfront, opening N concurrent HTTP GET connections before archiver consumed any. With 150 assets, 150 sockets were held simultaneously; archiver drains them one-by-one so N−1 sit stalled. In `serveMode: proxy`, thumbnail requests share the same connection pool and queue behind the stalled download connections.
- **Fix (Part 1):** Introduce `LazyS3Readable extends Readable` — defers `backend.get()` until archiver actually calls `_read()` for each entry. Since archiver has an internal queue with concurrency 1, at most 1 S3 socket is ever open during a download.
- **Fix (Part 2):** Expose an `abort()` function from `downloadArchive()`; controller wires `req.on('close', abort)` to destroy the archiver and the one active S3 stream when the client disconnects mid-download.

## Files changed

- `server/src/services/download.service.ts` — `LazyS3Readable` class + updated `downloadArchive()` loop and return type
- `server/src/controllers/download.controller.ts` — `@Req()` parameter + `req.on('close', abort)` wiring

## Test plan

- [ ] All 3867 server unit tests pass, 0 failures
- [ ] `tsc --noEmit` clean
- [ ] New tests cover: lazy deferred fetch, `abort()` destroys all lazies + zip stream, abort before activation, all-disk archive abort, mixed disk+S3 routing, `backend.get()` rejection forwarded as stream error, mid-stream S3 error forwarded
- [ ] Manual smoke test (MinIO/Wasabi): `ss -tnp | grep <s3-port>` shows 1 ESTABLISHED connection during a 150-asset download (not 150); thumbnails load normally; cancel releases the socket promptly

## Design doc

`docs/plans/2026-04-21-s3-download-hang-design.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)