### PR TITLE
fix(search): drop asset.id tiebreaker from searchSmart to restore vchord

### DIFF
--- a/docs/plans/2026-04-21-search-tiebreaker-design.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-design.md
@@ -88,25 +88,25 @@ Add two new `it` blocks:
 
 Run `pnpm sql` in `server/` after the code change. `server/src/queries/search.repository.sql` will update; commit the diff. CI's Schema Check catches drift between committed SQL and regenerated SQL.
 
-### Local reproducer on pierre.opennoodle.de (before shipping to users)
+### Local reproducer on a smaller personal instance (before shipping to users)
 
-Pierre's personal instance (~40k photos) is the fastest feedback loop. Before cutting a Gallery release:
+A personal dev instance (~40k photos, for example) is the fastest feedback loop. Before cutting a Gallery release:
 
-1. Build an RC via `rc-personal` skill pointing at the fix branch.
-2. Enable `GALLERY_SEARCH_TIMING=true` on pierre's instance.
-3. Run `auto_explain` (reuse the gist: https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102).
+1. Build an RC pointing at the fix branch.
+2. Enable `GALLERY_SEARCH_TIMING=true` on the instance.
+3. Run `auto_explain` via the diagnostic gist.
 4. Smoke-test 3-4 smart searches from the UI.
 5. Confirm EXPLAIN lines show `Index Scan using clip_index` and `db=` phase drops to <500ms.
 
-This catches anything unit tests miss — real planner behavior, real CPU saturation, real pagination. Only ship the release once pierre looks good.
+This catches anything unit tests miss — real planner behavior, real CPU saturation, real pagination. Only ship the release once the smaller instance looks good.
 
-Pierre's 40k vs atlasshrugged's 200k: the query shape is identical; planner behavior should match. If vchord wins on 40k, it should win on 200k — the difference is just how much slower the seq-scan fallback is at each size.
+Smaller instance (~40k) vs the reporter's 200k: the query shape is identical; planner behavior should match. If vchord wins on 40k, it should win on 200k — the difference is just how much slower the seq-scan fallback is at each size.
 
-### Real-data validation on atlasshrugged's 200k instance
+### Real-data validation on the reporter's 200k instance
 
 After Gallery release:
 
-1. atlasshrugged pulls the release.
+1. Reporter pulls the release.
 2. Re-runs the diagnostic gist (with `GALLERY_SEARCH_TIMING=true` still set).
 3. Reports new `db=` values + `auto_explain` output.
 
@@ -133,7 +133,7 @@ Proposed follow-up: add a short per-user TTL cache (30-60s) keyed by `(userId, s
 
 ### `maxDistance` config perf impact (docs-only)
 
-Default `machineLearning.clip.maxDistance = 0.5` in fork config. The reporter had it bumped to `0.95`, which expands the filter's selectivity estimate enough to push the planner further toward seq scan even with the tiebreaker fix. Re-validate on atlasshrugged's instance after the fix lands; if still seq-scanning, add a docs note in `docs/docs/features/searching.md` about the tradeoff.
+Default `machineLearning.clip.maxDistance = 0.5` in fork config. The reporter had it bumped to `0.95`, which expands the filter's selectivity estimate enough to push the planner further toward seq scan even with the tiebreaker fix. Re-validate on the reporter's instance after the fix lands; if still seq-scanning, add a docs note in `docs/docs/features/searching.md` about the tradeoff.
 
 ### Missing indexes (benefits upstream too)
 

--- a/docs/plans/2026-04-21-search-tiebreaker-design.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-design.md
@@ -25,6 +25,7 @@ In `server/src/repositories/search.repository.ts`:
   // by the frontend dedup in web/src/lib/components/search/smart-search-results.svelte.
   ```
 
+- **Extract a private helper** `#buildSearchSmartQueries(trx, options)` on `SearchRepository` that returns `{ baseQuery, candidates, applyProbes }`. `searchSmart` calls it inside the existing transaction. This refactor exists purely so the unit test can `.compile()` the queries without going through a transaction closure. See "Verification / Unit test" below for why this is necessary.
 - **Update `web/src/lib/components/search/smart-search-results.svelte:48-49` comment** to reflect that the frontend dedup is now the primary guard (not supplementary to a backend tiebreaker).
 
 ## Why this is safe
@@ -32,9 +33,10 @@ In `server/src/repositories/search.repository.ts`:
 `asset.id` is the primary key of `asset`; the join `asset.id = smart_search.assetId` guarantees each `asset.id` appears at most once per query result — so intra-page duplicates are schema-impossible regardless of the ORDER BY.
 
 Cross-page duplicates via non-deterministic OFFSET ordering are caught by the frontend dedup at `smart-search-results.svelte:50-51`:
+
 ```js
-const existingIds = new Set(searchResults.map(a => a.id));
-const deduped = assets.items.filter(a => !existingIds.has(a.id));
+const existingIds = new Set(searchResults.map((a) => a.id));
+const deduped = assets.items.filter((a) => !existingIds.has(a.id));
 ```
 
 Upstream Immich's `searchSmart` (`git show upstream/main:server/src/repositories/search.repository.ts`) has a single-key `ORDER BY embedding <=>` with no tiebreaker. The proposed change brings Gallery in line with upstream.
@@ -47,40 +49,75 @@ This risk must be called out in the PR description so future "missing results af
 
 ## Verification
 
-### Unit test (new)
+### Unit test — SQL shape regression (new file)
 
-New file `server/src/repositories/search.repository.spec.ts`. Uses Kysely's `.compile()` offline (no DB) to get the final SQL string and assert ordering shape.
+New file `server/src/repositories/search.repository.spec.ts`. Uses Kysely's `DummyDriver` (offline, no DB connection) to build a `Kysely<DB>` instance, call the extracted `#buildSearchSmartQueries` helper, and `.compile()` the result. No transaction needed — `DummyDriver` doesn't execute statements.
 
-Required assertions:
-1. `searchSmart` non-CTE path: generated SQL's `ORDER BY` contains `smart_search.embedding` and does **not** contain `"asset"."id"` as a secondary sort key.
-2. `searchSmart` CTE path (`orderDirection: 'desc'`): inner query's ORDER BY has no `asset.id`; outer query's ORDER BY retains `"candidates"."id"`.
+The test relies on the refactor noted in "Change": without extracting the private helper, the queries are trapped inside `this.db.transaction().execute(async (trx) => { ... })` and unreachable from outside. Rather than mock Kysely's transaction machinery (fragile), the refactor is the cleanest path to a testable seam.
 
-Each assertion's failure message must be explicit:
+**Required assertions (stricter than "doesn't contain `asset.id`"):**
+
+1. **Non-CTE path** (options without `orderDirection`): compiled SQL's top-level `ORDER BY` has **exactly one** expression, and that expression contains `"smart_search"."embedding"`.
+2. **CTE path** (`orderDirection: 'desc'`): inner subquery's `ORDER BY` has exactly one expression (embedding); outer `ORDER BY` contains both `"candidates"."fileCreatedAt"` and `"candidates"."id"` (unchanged).
+3. **CTE path with `orderDirection: 'asc'`**: same shape as (2).
+4. **No-maxDistance permutation** (`hasDistanceThreshold = false`): same ORDER BY shape; no `WHERE (embedding <=>) <= ...` predicate.
+
+The "exactly one expression" assertion generalizes the bug to any secondary sort key — catches not just `asset.id` re-additions but also hypothetical `asset.fileCreatedAt` / `asset.createdAt` / etc.
+
+**Each assertion's failure message must be explicit:**
+
 ```
-Do not re-add asset.id to the inner ORDER BY of searchSmart.
+Do not add any secondary ORDER BY key to the inner searchSmart query.
 See comment at server/src/repositories/search.repository.ts:359.
-Secondary ORDER BY keys force Parallel Seq Scan instead of vchord index.
+Secondary ORDER BY keys force Parallel Seq Scan on smart_search instead
+of the vchord clip_index ordered scan (~100× slowdown at 200k rows).
 ```
 
-This guards against silent regressions from merge-conflict resolves or future refactors. Brittleness to Kysely version bumps is acceptable — the failure text points at the exact intent.
+Brittleness to Kysely version bumps is acceptable — the failure text points at exact intent.
+
+### Unit test — frontend dedup regression (add to existing spec)
+
+Existing `web/src/lib/components/search/smart-search-results.spec.ts` has 14 `it` blocks but **none verify the cross-page dedup behavior** at `smart-search-results.svelte:50-51`. Since this dedup is now the primary guard (not a belt-and-braces supplement), it needs a regression test.
+
+Add two new `it` blocks:
+
+1. `"de-duplicates cross-page results on append by asset id"` — mocks `searchSmart` to return `{items: [{id: 'A'}, {id: 'B'}, {id: 'C'}]}` for page 1 and `{items: [{id: 'B'}, {id: 'D'}]}` for page 2; loads page 1, then loads page 2 with `append: true`; asserts final `searchResults` is `[A, B, C, D]` (B de-duplicated, D appended).
+2. `"does not crash when every page-2 result is a duplicate of page 1"` — page 1 returns `[A, B]`, page 2 returns `[A, B]`; assert no crash, no duplicate IDs in final state.
 
 ### Reference SQL regeneration
 
 Run `pnpm sql` in `server/` after the code change. `server/src/queries/search.repository.sql` will update; commit the diff. CI's Schema Check catches drift between committed SQL and regenerated SQL.
 
-### Real-data validation
+### Local reproducer on pierre.opennoodle.de (before shipping to users)
 
-1. Ship to `main`.
-2. Ship a Gallery release (standard `gallery-release.yml` workflow run).
-3. atlasshrugged pulls the release and re-runs the diagnostic gist (https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102) with `GALLERY_SEARCH_TIMING=true` still set.
+Pierre's personal instance (~40k photos) is the fastest feedback loop. Before cutting a Gallery release:
+
+1. Build an RC via `rc-personal` skill pointing at the fix branch.
+2. Enable `GALLERY_SEARCH_TIMING=true` on pierre's instance.
+3. Run `auto_explain` (reuse the gist: https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102).
+4. Smoke-test 3-4 smart searches from the UI.
+5. Confirm EXPLAIN lines show `Index Scan using clip_index` and `db=` phase drops to <500ms.
+
+This catches anything unit tests miss — real planner behavior, real CPU saturation, real pagination. Only ship the release once pierre looks good.
+
+Pierre's 40k vs atlasshrugged's 200k: the query shape is identical; planner behavior should match. If vchord wins on 40k, it should win on 200k — the difference is just how much slower the seq-scan fallback is at each size.
+
+### Real-data validation on atlasshrugged's 200k instance
+
+After Gallery release:
+
+1. atlasshrugged pulls the release.
+2. Re-runs the diagnostic gist (with `GALLERY_SEARCH_TIMING=true` still set).
+3. Reports new `db=` values + `auto_explain` output.
 
 **Success criteria:**
-- `db=` phase in `GALLERY_SEARCH_TIMING` log lines drops from 3-16s to <1s for cache-hit embeddings.
+
+- `db=` phase drops from 3-16s to <1s for cache-hit embeddings.
 - `auto_explain` output for `searchSmart` shows `Index Scan using clip_index` instead of `Parallel Seq Scan on smart_search`.
 
 ## Rollback
 
-Single-commit `git revert <sha>`. Frontend dedup remains in place regardless. Reverting just reintroduces the belt-and-braces behavior at the original perf cost.
+Single-commit `git revert <sha>`. Frontend dedup remains in place regardless. Reverting just reintroduces the belt-and-braces behavior at the original perf cost. Refactored helper stays — removing it is cosmetic and not worth the churn.
 
 ## Callers verified
 
@@ -102,8 +139,12 @@ Default `machineLearning.clip.maxDistance = 0.5` in fork config. The reporter ha
 
 `asset.type` has no index → `SELECT DISTINCT type FROM asset` full-scans every FilterPanel open. A composite `(ownerId, visibility, deletedAt, fileCreatedAt)` would help many of the seq-scanning queries in the burst. These also apply to upstream Immich and are candidates for an upstream PR rather than a fork-only change.
 
+### Medium-test EXPLAIN regression (future, if needed)
+
+A medium test could seed ~5k rows in `smart_search`, run `searchSmart`, and parse `EXPLAIN (FORMAT JSON)` to assert `Index Scan using clip_index` appears in the plan tree. Higher fidelity than the unit SQL-shape test — catches semantic (planner) regressions rather than syntactic ones. Deferred for now: the unit test + local-reproducer + real-data validation stack is sufficient for this fix. Revisit if we see repeat regressions in this area.
+
 ## Out of scope
 
-- No frontend behavior changes beyond the comment update.
+- No frontend behavior changes beyond the dedup test additions and comment update.
 - No changes to `searchAssetBuilder` (the `withSharedSpaces`, `maxDistance`, `orderDirection` options all remain).
 - No index additions, no `vchordrq.probes` tuning, no `maxDistance` default change.

--- a/docs/plans/2026-04-21-search-tiebreaker-design.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-design.md
@@ -1,0 +1,109 @@
+# Smart search: restore vchord index usage
+
+**Date:** 2026-04-21
+**Status:** Design approved, ready for implementation plan
+**Owner:** Pierre
+
+## Goal
+
+Close the 3-5× performance gap between Gallery smart search (5-16s on a 200k-photo instance) and upstream Immich (2-4s on the same data). Root cause proven: fork-added `asset.id` secondary `ORDER BY` prevents Postgres from using the vchord `clip_index` — 17/17 slow queries in the reporter's `auto_explain` output show `Parallel Seq Scan on smart_search` instead of `Index Scan using clip_index`.
+
+## Change
+
+In `server/src/repositories/search.repository.ts`:
+
+- **Remove line 361** — `.orderBy('asset.id')` on `baseQuery`. This is the inner ORDER BY that both branches (non-CTE at line 379, CTE at line 365) feed into. Dropping it restores vchord's ordered index scan on `smart_search`.
+- **Keep line 372** — `.orderBy('candidates.id')` on the CTE outer sort. Operates on a materialized 500-row CTE, costs microseconds, preserves determinism when multiple candidates share the same `fileCreatedAt` (common: photos taken at the same second).
+- **Replace the line-359 comment** with a load-bearing warning:
+
+  ```
+  // DO NOT add a secondary ORDER BY key on any column here.
+  // vchord's ordered index scan can only satisfy a single-key ORDER BY on
+  // `smart_search.embedding <=>`. Any additional sort key forces the planner
+  // to Parallel Seq Scan + in-memory sort (~15s on 200k rows vs ~200ms
+  // via vchord). Cross-page duplicates from identical embeddings are caught
+  // by the frontend dedup in web/src/lib/components/search/smart-search-results.svelte.
+  ```
+
+- **Update `web/src/lib/components/search/smart-search-results.svelte:48-49` comment** to reflect that the frontend dedup is now the primary guard (not supplementary to a backend tiebreaker).
+
+## Why this is safe
+
+`asset.id` is the primary key of `asset`; the join `asset.id = smart_search.assetId` guarantees each `asset.id` appears at most once per query result — so intra-page duplicates are schema-impossible regardless of the ORDER BY.
+
+Cross-page duplicates via non-deterministic OFFSET ordering are caught by the frontend dedup at `smart-search-results.svelte:50-51`:
+```js
+const existingIds = new Set(searchResults.map(a => a.id));
+const deduped = assets.items.filter(a => !existingIds.has(a.id));
+```
+
+Upstream Immich's `searchSmart` (`git show upstream/main:server/src/repositories/search.repository.ts`) has a single-key `ORDER BY embedding <=>` with no tiebreaker. The proposed change brings Gallery in line with upstream.
+
+## Honest risk
+
+For users with byte-identical duplicate image content (rare): infinite scroll may surface fewer unique results than exist. The same `asset.id` can "spend" a slot on both page 1 and page 2 (frontend dedup removes the duplicate on page 2), pushing a different asset off the viewed window. Unlike typical pagination edge cases, **this is not self-healing** — the missed asset only reappears if continued scroll randomly happens to include it on a later page.
+
+This risk must be called out in the PR description so future "missing results after infinite scroll" bug reports are searchable and resolvable without rediscovery. Rarity is consistent with upstream Immich, which ships without a tiebreaker.
+
+## Verification
+
+### Unit test (new)
+
+New file `server/src/repositories/search.repository.spec.ts`. Uses Kysely's `.compile()` offline (no DB) to get the final SQL string and assert ordering shape.
+
+Required assertions:
+1. `searchSmart` non-CTE path: generated SQL's `ORDER BY` contains `smart_search.embedding` and does **not** contain `"asset"."id"` as a secondary sort key.
+2. `searchSmart` CTE path (`orderDirection: 'desc'`): inner query's ORDER BY has no `asset.id`; outer query's ORDER BY retains `"candidates"."id"`.
+
+Each assertion's failure message must be explicit:
+```
+Do not re-add asset.id to the inner ORDER BY of searchSmart.
+See comment at server/src/repositories/search.repository.ts:359.
+Secondary ORDER BY keys force Parallel Seq Scan instead of vchord index.
+```
+
+This guards against silent regressions from merge-conflict resolves or future refactors. Brittleness to Kysely version bumps is acceptable — the failure text points at the exact intent.
+
+### Reference SQL regeneration
+
+Run `pnpm sql` in `server/` after the code change. `server/src/queries/search.repository.sql` will update; commit the diff. CI's Schema Check catches drift between committed SQL and regenerated SQL.
+
+### Real-data validation
+
+1. Ship to `main`.
+2. Ship a Gallery release (standard `gallery-release.yml` workflow run).
+3. atlasshrugged pulls the release and re-runs the diagnostic gist (https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102) with `GALLERY_SEARCH_TIMING=true` still set.
+
+**Success criteria:**
+- `db=` phase in `GALLERY_SEARCH_TIMING` log lines drops from 3-16s to <1s for cache-hit embeddings.
+- `auto_explain` output for `searchSmart` shows `Index Scan using clip_index` instead of `Parallel Seq Scan on smart_search`.
+
+## Rollback
+
+Single-commit `git revert <sha>`. Frontend dedup remains in place regardless. Reverting just reintroduces the belt-and-braces behavior at the original perf cost.
+
+## Callers verified
+
+`grep -rn 'searchRepository.searchSmart\|.searchSmart('` → only `server/src/controllers/search.controller.ts:91` calls this in production. Fork-specific features (duplicate detection, classification, video dedup) use other repository methods and are unaffected. Service spec tests at `server/src/services/search.service.spec.ts` do not assert ordering of identical-embedding ties.
+
+## Scope exclusions — documented follow-ups
+
+### Filter suggestions batch burst (future PR)
+
+`getFilterSuggestions` at `server/src/repositories/search.repository.ts:631` uses `Promise.all` to fire 6 concurrent seq-scans (countries, cameraMakes, tags, people, ratings, mediaTypes) per invocation. On the reporter's 200k instance this generates 2-3s of additional load per FilterPanel open, compounding with smart search CPU contention.
+
+Proposed follow-up: add a short per-user TTL cache (30-60s) keyed by `(userId, serialized options)`. Invalidate on asset upload/delete websocket events or time-based. Measure impact after the tiebreaker fix lands — if real-world searches drop below upstream parity, this becomes lower priority.
+
+### `maxDistance` config perf impact (docs-only)
+
+Default `machineLearning.clip.maxDistance = 0.5` in fork config. The reporter had it bumped to `0.95`, which expands the filter's selectivity estimate enough to push the planner further toward seq scan even with the tiebreaker fix. Re-validate on atlasshrugged's instance after the fix lands; if still seq-scanning, add a docs note in `docs/docs/features/searching.md` about the tradeoff.
+
+### Missing indexes (benefits upstream too)
+
+`asset.type` has no index → `SELECT DISTINCT type FROM asset` full-scans every FilterPanel open. A composite `(ownerId, visibility, deletedAt, fileCreatedAt)` would help many of the seq-scanning queries in the burst. These also apply to upstream Immich and are candidates for an upstream PR rather than a fork-only change.
+
+## Out of scope
+
+- No frontend behavior changes beyond the comment update.
+- No changes to `searchAssetBuilder` (the `withSharedSpaces`, `maxDistance`, `orderDirection` options all remain).
+- No index additions, no `vchordrq.probes` tuning, no `maxDistance` default change.

--- a/docs/plans/2026-04-21-search-tiebreaker-impl.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-impl.md
@@ -4,9 +4,11 @@
 
 **Goal:** Remove the fork-added `asset.id` secondary ORDER BY from `searchSmart` to restore Postgres's use of the vchord `clip_index` ordered scan. Expected perf gain: 3-16s → <1s on 200k-photo instances.
 
-**Architecture:** The change is intentionally small — one `.orderBy('asset.id')` call removed from `server/src/repositories/search.repository.ts`. Supporting work: (1) extract a private query-builder helper so the SQL shape is testable offline via Kysely's `DummyDriver`, (2) add a unit spec that asserts "exactly one ORDER BY expression" on the inner query to prevent any future secondary-key regression (not just the specific `asset.id` case), (3) add frontend dedup regression tests since that dedup is now the load-bearing safety net, (4) regenerate reference SQL and update the load-bearing code comment.
+**Architecture:** The change is intentionally small — one `.orderBy('asset.id')` call removed from `server/src/repositories/search.repository.ts`. Supporting work: (1) extract a private query-builder helper so the SQL shape is testable offline via Kysely's `DummyDriver`, (2) add a unit spec that asserts "exactly one ORDER BY expression" on the inner query AND verifies the primary sort key is still the embedding, (3) extract the frontend dedup into a pure utility so it can be tested in isolation (the component's current internals aren't testable — see existing `it.todo` entries at lines 149-165 of the spec), (4) regenerate reference SQL, (5) update the load-bearing code comments.
 
 **Tech Stack:** NestJS + Kysely 0.28.15 (server), SvelteKit + Svelte 5 + Vitest (web), `vchordrq` pgvector extension (DB). Design doc: `docs/plans/2026-04-21-search-tiebreaker-design.md`.
+
+**Design deviation (deliberate):** The design (lines 78-85) specifies adding two new `it` blocks directly to `web/src/lib/components/search/smart-search-results.spec.ts`. The component API doesn't support this — `handleLoadMore` is a local function and `searchResults` is internal `$state`, neither exposed on the component instance. Four `it.todo` entries at lines 149-165 of the existing spec confirm this is a known testability gap. This plan instead **extracts the dedup to a pure utility function** (`web/src/lib/utils/search-dedup.ts`) and unit-tests it directly. Same behavior coverage, cleaner seam, no component rework. Documented here so it surfaces in PR review.
 
 ---
 
@@ -15,7 +17,7 @@
 Before starting, from repo root:
 
 ```bash
-# 1. Confirm dev stack is running (needed for `make sql` in Task 4).
+# 1. Confirm dev stack is running (needed for `make sql` in Task 5).
 docker ps --filter name=immich_postgres --format '{{.Names}} {{.Status}}'
 # Expect: immich_postgres Up (healthy)
 
@@ -23,142 +25,193 @@ docker ps --filter name=immich_postgres --format '{{.Names}} {{.Status}}'
 git status
 # Expect: "nothing to commit, working tree clean"
 
-# 3. Create a feature branch.
+# 3. Verify required imports exist (fail fast if fork diverged from assumptions).
+grep -q "OrderByDirection.*SqlBool" server/src/repositories/search.repository.ts && \
+  grep -q "export enum AssetOrder" server/src/enum.ts && \
+  grep -q "isActiveDistanceThreshold" server/src/repositories/search.repository.ts && \
+  echo OK || echo "FAIL: one of OrderByDirection/SqlBool/AssetOrder/isActiveDistanceThreshold is missing; plan assumptions need updating"
+
+# 4. Verify Kysely exports DummyDriver (required for Task 3 offline SQL compilation).
+node -e "const k = require('./server/node_modules/kysely'); if (!k.DummyDriver || !k.PostgresAdapter || !k.PostgresQueryCompiler || !k.PostgresIntrospector) throw new Error('Kysely missing one of DummyDriver/PostgresAdapter/PostgresQueryCompiler/PostgresIntrospector'); console.log('Kysely OK');"
+
+# 5. Create a feature branch.
 git switch -c fix/search-tiebreaker-vchord
 ```
 
+If any pre-flight step fails, stop and update the plan before proceeding — the plan's assumptions have drifted from code reality.
+
 ---
 
-## Task 1: Add frontend dedup regression tests
+## Task 1: Extract frontend dedup to a testable utility
 
-The frontend dedup at `smart-search-results.svelte:50-51` is the sole cross-page duplicate guard after this change. It currently has zero test coverage. Add tests FIRST so we validate the safety net while the backend tiebreaker still exists — if anything in the dedup logic is subtly wrong, we want to know before removing the backend guard.
+The frontend dedup at `smart-search-results.svelte:50-51` is the sole cross-page duplicate guard after this change. It currently has zero test coverage AND the component's internal API (`handleLoadMore` is a local function, `searchResults` is internal `$state`) makes it untestable in place — the existing spec documents this via four `it.todo` entries at lines 149-165.
+
+Extract the dedup to a pure utility function so it can be unit-tested directly. Do this FIRST so the safety net is covered before the backend tiebreaker is removed.
 
 **Files:**
 
-- Modify: `web/src/lib/components/search/smart-search-results.spec.ts`
+- Create: `web/src/lib/utils/search-dedup.ts`
+- Create: `web/src/lib/utils/__tests__/search-dedup.spec.ts`
+- Modify: `web/src/lib/components/search/smart-search-results.svelte:48-52`
 
-**Step 1: Read the existing spec to match its style**
-
-```bash
-head -50 web/src/lib/components/search/smart-search-results.spec.ts
-```
-
-Note the mocking pattern — it mocks `searchSmart` from `@immich/sdk` via `vi.mock`. All new tests follow the same pattern.
-
-**Step 2: Add the first dedup test (RED)**
-
-Inside the `describe('SmartSearchResults', ...)` block, after the existing `'handles empty results'` test, add:
+**Step 1: Create the dedup utility**
 
 ```ts
-it('de-duplicates cross-page results on append by asset id', async () => {
-  const page1 = [
-    { id: 'asset-a' } as AssetResponseDto,
-    { id: 'asset-b' } as AssetResponseDto,
-    { id: 'asset-c' } as AssetResponseDto,
-  ];
-  const page2 = [
-    // asset-b repeats (identical embedding scenario)
-    { id: 'asset-b' } as AssetResponseDto,
-    { id: 'asset-d' } as AssetResponseDto,
-  ];
+// web/src/lib/utils/search-dedup.ts
+/**
+ * Append new paginated items to an existing array, de-duplicating by `id`.
+ *
+ * Used by smart-search-results.svelte to guard against the same asset.id
+ * appearing on adjacent paginated responses from searchSmart. The server
+ * does not currently apply a stable tiebreaker to identical CLIP distances
+ * (byte-identical image content), so offset pagination can yield the same
+ * asset.id on both pages 1 and 2. Dedup here prevents Svelte's keyed
+ * {#each} from crashing with each_key_duplicate.
+ *
+ * Pure function by design — both for testability and because the dedup
+ * is load-bearing (this is the only cross-page duplicate guard now).
+ */
+export function dedupeAppend<T extends { id: string }>(existing: T[], incoming: T[]): T[] {
+  const existingIds = new Set(existing.map((a) => a.id));
+  return existing.concat(incoming.filter((a) => !existingIds.has(a.id)));
+}
+```
 
-  mockedSearchSmart
-    .mockResolvedValueOnce({ assets: { items: page1, nextPage: '2' } } as never)
-    .mockResolvedValueOnce({ assets: { items: page2, nextPage: null } } as never);
+**Step 2: Write the failing / comprehensive utility tests**
 
-  const { component } = render(SmartSearchResults, {
-    props: { query: 'trees', filters: defaultFilters() },
+```ts
+// web/src/lib/utils/__tests__/search-dedup.spec.ts
+import { describe, expect, it } from 'vitest';
+import { dedupeAppend } from '$lib/utils/search-dedup';
+
+describe('dedupeAppend', () => {
+  it('appends new items and de-duplicates by id (primary cross-page scenario)', () => {
+    // Page 1 returned [a, b, c]; page 2 returned [b, d].
+    // After append + dedup, searchResults should be [a, b, c, d].
+    const result = dedupeAppend(
+      [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+      [{ id: 'b' }, { id: 'd' }],
+    );
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c', 'd']);
   });
-  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(1));
 
-  // Load page 2 via component's public loadMore method (adjust to whatever the
-  // component actually exposes — inspect smart-search-results.svelte for the
-  // trigger; may be an IntersectionObserver effect or a bindable).
-  await component.loadMore();
-  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(2));
+  it('returns existing array unchanged when every incoming item is a duplicate', () => {
+    // Byte-identical images scenario: page 2 returns the same assets as page 1.
+    const result = dedupeAppend(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ id: 'a' }, { id: 'b' }],
+    );
+    expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+    // No duplicates in output.
+    expect(new Set(result.map((r) => r.id)).size).toBe(result.length);
+  });
 
-  const finalResults = component.searchResults;
-  expect(finalResults.map((r) => r.id)).toEqual(['asset-a', 'asset-b', 'asset-c', 'asset-d']);
+  it('handles empty existing (first page)', () => {
+    const result = dedupeAppend([], [{ id: 'a' }, { id: 'b' }]);
+    expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('handles empty incoming (end of pagination)', () => {
+    const result = dedupeAppend([{ id: 'a' }], []);
+    expect(result.map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('preserves order — new items append after existing, no reordering', () => {
+    const result = dedupeAppend(
+      [{ id: 'a' }, { id: 'b' }],
+      [{ id: 'c' }, { id: 'a' }, { id: 'd' }],
+    );
+    // 'a' is dropped from incoming; 'c' and 'd' append in the order they arrived.
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
 });
 ```
 
-**Step 3: Run test to confirm it fails or passes correctly**
+**Step 3: Run utility tests — expect PASS (utility is a clean extraction, no bug to test against)**
 
 ```bash
 cd web
-pnpm test -- --run src/lib/components/search/smart-search-results.spec.ts
+pnpm test -- --run src/lib/utils/__tests__/search-dedup.spec.ts
 ```
 
-If the test framework can't reach `component.loadMore()` / `component.searchResults`, the test needs to be rewritten to drive the component through its public interface (props, user events). Inspect `smart-search-results.svelte` and adjust. **Key invariant to test: after page 1 + page 2 load, no duplicate IDs appear in the rendered list.** The test as written above is illustrative — rewrite to match how the component actually exposes pagination state.
+Expected: 5 passing. If any fail, fix before proceeding.
 
-Once adjusted: the test should PASS against current code (backend tiebreaker + frontend dedup together prevent dups). The point is to lock in the frontend behavior.
+**Step 4: Update the component to use the utility**
 
-**Step 4: Add the second dedup test**
+Edit `web/src/lib/components/search/smart-search-results.svelte`.
+
+At the top of `<script>`, add the import next to the existing `$lib/utils/space-search` import:
 
 ```ts
-it('does not render duplicate assets when every page-2 result was on page 1', async () => {
-  const page1 = [{ id: 'asset-a' } as AssetResponseDto, { id: 'asset-b' } as AssetResponseDto];
-  const page2 = [{ id: 'asset-a' } as AssetResponseDto, { id: 'asset-b' } as AssetResponseDto];
-
-  mockedSearchSmart
-    .mockResolvedValueOnce({ assets: { items: page1, nextPage: '2' } } as never)
-    .mockResolvedValueOnce({ assets: { items: page2, nextPage: null } } as never);
-
-  const { component } = render(SmartSearchResults, {
-    props: { query: 'trees', filters: defaultFilters() },
-  });
-  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(1));
-  await component.loadMore();
-  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(2));
-
-  const ids = component.searchResults.map((r) => r.id);
-  expect(new Set(ids).size).toBe(ids.length); // no duplicates
-  expect(ids).toEqual(['asset-a', 'asset-b']);
-});
+import { dedupeAppend } from '$lib/utils/search-dedup';
 ```
 
-**Step 5: Update the frontend comment**
+Then replace lines 47-55 (the `if (append) { ... } else { ... }` block). Old:
 
-Edit `web/src/lib/components/search/smart-search-results.svelte:48-49`:
-
-Old:
-
-```
-// Defend against pagination overlaps (e.g., backend tie-breaker gaps or
-// race-y page boundaries) so Svelte's keyed {#each} doesn't crash on duplicate IDs.
+```ts
+      if (append) {
+        // Defend against pagination overlaps (e.g., backend tie-breaker gaps or
+        // race-y page boundaries) so Svelte's keyed {#each} doesn't crash on duplicate IDs.
+        const existingIds = new Set(searchResults.map((a) => a.id));
+        const deduped = assets.items.filter((a) => !existingIds.has(a.id));
+        searchResults = [...searchResults, ...deduped];
+      } else {
+        searchResults = assets.items;
+      }
 ```
 
 New:
 
-```
-// Primary guard against duplicate IDs across paginated responses from searchSmart.
-// vchord's ordered scan does not guarantee a stable tiebreaker for assets with
-// identical CLIP embeddings (byte-identical image content), so offset pagination
-// can return the same asset.id on adjacent pages. Dedup here keeps Svelte's
-// keyed {#each} from crashing with each_key_duplicate.
+```ts
+      if (append) {
+        // Primary guard against duplicate IDs across paginated searchSmart
+        // responses. The server's ORDER BY is single-key (smart_search.embedding
+        // <=>) so that vchord's ordered index scan can be used; identical
+        // embeddings (byte-identical image content) can then yield the same
+        // asset.id on adjacent pages. See docs/plans/2026-04-21-search-tiebreaker-design.md.
+        searchResults = dedupeAppend(searchResults, assets.items);
+      } else {
+        searchResults = assets.items;
+      }
 ```
 
-**Step 6: Run ALL frontend specs in this file to ensure no regression**
+**Step 5: Run the component's existing spec to catch regressions**
 
 ```bash
 cd web
 pnpm test -- --run src/lib/components/search/smart-search-results.spec.ts
 ```
 
-Expected: all existing tests pass + both new tests pass.
+Expected: all existing `it` blocks still pass (dedup behavior is identical, just moved to a utility). The four `it.todo` entries remain TODOs — they're about component loadMore testability, out of scope for this PR.
+
+**Step 6: Run type check**
+
+```bash
+cd web
+pnpm check
+```
+
+Expected: no errors.
 
 **Step 7: Commit**
 
 ```bash
-git add web/src/lib/components/search/smart-search-results.spec.ts \
+git add web/src/lib/utils/search-dedup.ts \
+         web/src/lib/utils/__tests__/search-dedup.spec.ts \
          web/src/lib/components/search/smart-search-results.svelte
-git commit -m "test(web): cover cross-page dedup in smart-search-results spec
+git commit -m "refactor(web): extract smart-search dedup to a pure utility
 
-The dedup at smart-search-results.svelte:50-51 is the sole guard against
-Svelte each_key_duplicate crashes when searchSmart returns the same asset
-on adjacent pages. It previously had zero coverage — the next commit
-removes the backend tiebreaker that was the other half of the belt-and-
-braces defence, making this test the primary regression guard."
+Hoists the inline cross-page dedup from smart-search-results.svelte into
+lib/utils/search-dedup.ts so it can be unit-tested directly. The
+component's internals (handleLoadMore is a local function, searchResults
+is \$state) aren't exposed on the component instance, and four it.todo
+entries in the existing spec confirm this is a known testability gap.
+
+This matters because a subsequent commit removes the backend asset.id
+tiebreaker, promoting this dedup from a belt-and-braces supplement to
+the sole cross-page duplicate guard against Svelte each_key_duplicate
+crashes on byte-identical embeddings. The dedup behavior is unchanged;
+only its location and test coverage are."
 ```
 
 ---
@@ -169,7 +222,7 @@ Extract the query-construction logic out of the transaction closure in `searchSm
 
 **Files:**
 
-- Modify: `server/src/repositories/search.repository.ts` (searchSmart method + new private helper)
+- Modify: `server/src/repositories/search.repository.ts`
 
 **Step 1: Add the helper above `searchSmart`**
 
@@ -270,9 +323,9 @@ return this.db.transaction().execute(async (trx) => {
 });
 ```
 
-Also remove the now-unused local `const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);` declaration from the top of `searchSmart` (it moved into the helper).
+Also remove the now-unused `const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);` declaration from the top of `searchSmart` (it moved into the helper).
 
-**Step 3: Regenerate reference SQL and verify diff is empty**
+**Step 3: Regenerate reference SQL and verify ZERO diff — this is the strong regression check for the refactor**
 
 ```bash
 cd server
@@ -281,16 +334,18 @@ pnpm sync:sql
 git diff src/queries/search.repository.sql
 ```
 
-Expected: **zero diff**. The refactor changes TypeScript organization only — generated SQL must be byte-identical. If there is a diff, something about the refactor changed query shape. Investigate and fix before moving on.
+Expected: **zero diff**. The refactor changes TypeScript organization only — generated SQL must be byte-identical. If there is a diff, something about the refactor changed query shape. Fix before moving on.
 
-**Step 4: Run existing service specs to catch any regression**
+Why this is the strong check: the service spec in Step 4 uses `newTestService()` which auto-mocks the repository, so internal refactors don't flow through. The reference-SQL byte-diff is the actual proof that the extraction preserved query shape.
+
+**Step 4: Sanity: run existing service specs**
 
 ```bash
 cd server
 pnpm test -- --run src/services/search.service.spec.ts
 ```
 
-Expected: all tests pass.
+Expected: all tests pass. Sanity only — the real regression guard is the zero SQL diff from Step 3.
 
 **Step 5: Run type check**
 
@@ -362,7 +417,7 @@ const FAILURE_MESSAGE =
 const countOrderByExpressions = (compiledSql: string, anchor: string): number => {
   // Find the ORDER BY that immediately precedes the given anchor (or LIMIT/OFFSET).
   // Kysely's PostgresQueryCompiler emits a single-line compact SQL string.
-  const orderByRegex = /order by\s+(.+?)\s+(?:limit\b|offset\b|\)\s+as\b)/gi;
+  const orderByRegex = /order by\s+([\s\S]+?)\s+(?:limit\b|offset\b|\)\s+as\b)/gi;
   const matches = Array.from(compiledSql.matchAll(orderByRegex));
   const match = matches.find((m) => compiledSql.indexOf(anchor) > compiledSql.indexOf(m[0]));
   if (!match) throw new Error(`no ORDER BY before anchor "${anchor}" in: ${compiledSql}`);
@@ -381,11 +436,20 @@ describe(SearchRepository.name, () => {
   };
 
   describe('searchSmart query shape', () => {
-    it('non-CTE inner ORDER BY has exactly one expression (vchord index guard)', () => {
+    it('non-CTE inner ORDER BY: exactly one expression AND primary key is smart_search.embedding', () => {
       const { base } = buildQueries(sut, { page: 1, size: 100 }, baseOptions);
-      const { sql } = base.compile();
-      const keys = countOrderByExpressions(sql + ' limit', 'limit');
+      const innerSql = base.compile().sql;
+
+      // Count: exactly one key. Catches any secondary-sort regression.
+      const keys = countOrderByExpressions(innerSql + ' limit', 'limit');
       expect(keys, FAILURE_MESSAGE).toBe(1);
+
+      // Identity: the one key must be the embedding sort. Catches accidental
+      // replacement (e.g., someone re-orders to .orderBy('asset.fileCreatedAt')
+      // with count still == 1, but vchord still doesn't fire).
+      expect(innerSql, 'primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+        /order by\s+smart_search\.embedding\s*<=>/i,
+      );
     });
   });
 });
@@ -398,9 +462,9 @@ cd server
 pnpm test -- --run src/repositories/search.repository.spec.ts
 ```
 
-Expected: FAIL with message matching `FAILURE_MESSAGE` — the current compiled SQL still has `"asset"."id"` as the second ORDER BY expression after the refactor.
+Expected: FAIL on the `expect(keys, FAILURE_MESSAGE).toBe(1)` assertion — the current compiled SQL still has `"asset"."id"` as the second ORDER BY expression after the refactor, so `keys === 2`.
 
-If the test PASSES unexpectedly, the regex or SQL format is wrong. Fix the regex before proceeding (a common cause: Kysely emits newlines instead of spaces in some versions — adjust the regex to `[\s\S]+?`).
+If the test PASSES unexpectedly, the regex or SQL format is wrong. Fix the regex before proceeding (common cause: different whitespace in the compiled SQL — check by logging `innerSql`).
 
 **Step 3: Remove the tiebreaker from the helper**
 
@@ -421,7 +485,7 @@ To:
     // `smart_search.embedding <=>`. Any additional sort key forces the planner
     // to Parallel Seq Scan + in-memory sort (~15s on 200k rows vs ~200ms via
     // vchord). Cross-page duplicates from identical embeddings are caught by
-    // the frontend dedup in web/src/lib/components/search/smart-search-results.svelte.
+    // the frontend dedup in web/src/lib/utils/search-dedup.ts.
     .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
 ```
 
@@ -461,10 +525,10 @@ using vchord's ordered index scan — 17/17 slow-query EXPLAIN plans on a
 instead of Index Scan using clip_index.
 
 Cross-page duplicates from identical CLIP embeddings (byte-identical
-image content) are caught by the frontend dedup in smart-search-results
-.svelte:50-51, which was previously the second half of a belt-and-braces
-defence and is now the primary guard. Frontend regression tests added
-in the previous commit.
+image content) are caught by the frontend dedup in the dedupeAppend
+utility (web/src/lib/utils/search-dedup.ts), which was previously the
+second half of a belt-and-braces defence and is now the primary guard.
+Utility unit tests added in the preceding refactor commit.
 
 Known trade-off: users with byte-identical duplicate image content may
 see fewer unique results than exist in infinite scroll (same asset can
@@ -478,7 +542,7 @@ Design: docs/plans/2026-04-21-search-tiebreaker-design.md"
 
 ## Task 4: Extend unit spec with permutation coverage
 
-The first test locks down the non-CTE path. Add the remaining three permutations from the design: CTE `desc`, CTE `asc`, no-maxDistance.
+The first test locks down the non-CTE path. Add the remaining permutations from the design: CTE `desc`, CTE `asc`, no-maxDistance. Each test verifies BOTH the count (exactly one inner ORDER BY expression) AND the primary-key identity (it is the embedding sort), so a future change that replaces the primary key doesn't silently pass.
 
 **Files:**
 
@@ -489,53 +553,68 @@ The first test locks down the non-CTE path. Add the remaining three permutations
 Inside the `describe('searchSmart query shape', ...)` block, after the first `it`:
 
 ```ts
-it('CTE path with orderDirection=desc: inner has single ORDER BY, outer retains candidates.id', () => {
+it('CTE path orderDirection=desc: inner single key is embedding, outer has fileCreatedAt + candidates.id', () => {
   const { base, outer } = buildQueries(
     sut,
     { page: 1, size: 100 },
     { ...baseOptions, orderDirection: AssetOrder.Desc },
   );
 
-  const innerKeys = countOrderByExpressions(base.compile().sql + ' limit', 'limit');
-  expect(innerKeys, FAILURE_MESSAGE).toBe(1);
+  // Inner query (subject to vchord): single-key ORDER BY on embedding.
+  const innerSql = base.compile().sql;
+  expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+  expect(innerSql, 'inner primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+    /order by\s+smart_search\.embedding\s*<=>/i,
+  );
 
+  // Outer (CTE wrapper, materialized 500 rows): tiebreaker IS retained here by design.
   const outerSql = outer.compile().sql;
   expect(outerSql).toMatch(/"candidates"\."fileCreatedAt"\s+desc/i);
   expect(outerSql).toContain('"candidates"."id"');
+  // Also: outer ORDER BY must have exactly 2 keys (fileCreatedAt + candidates.id);
+  // any third key here would be a new, undocumented tiebreaker.
+  const outerKeys = countOrderByExpressions(outerSql + ' limit', 'limit');
+  expect(outerKeys, 'outer CTE ORDER BY must be exactly (fileCreatedAt, candidates.id)').toBe(2);
 });
 ```
 
 **Step 2: Add the CTE `orderDirection: 'asc'` test**
 
 ```ts
-it('CTE path with orderDirection=asc: inner has single ORDER BY, outer sorts ascending', () => {
+it('CTE path orderDirection=asc: inner single key is embedding, outer sorts ascending', () => {
   const { base, outer } = buildQueries(
     sut,
     { page: 1, size: 100 },
     { ...baseOptions, orderDirection: AssetOrder.Asc },
   );
 
-  const innerKeys = countOrderByExpressions(base.compile().sql + ' limit', 'limit');
-  expect(innerKeys, FAILURE_MESSAGE).toBe(1);
+  const innerSql = base.compile().sql;
+  expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+  expect(innerSql, 'inner primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+    /order by\s+smart_search\.embedding\s*<=>/i,
+  );
 
   const outerSql = outer.compile().sql;
   expect(outerSql).toMatch(/"candidates"\."fileCreatedAt"\s+asc/i);
   expect(outerSql).toContain('"candidates"."id"');
+  expect(countOrderByExpressions(outerSql + ' limit', 'limit'), 'outer must be 2 keys').toBe(2);
 });
 ```
 
 **Step 3: Add the no-maxDistance test**
 
 ```ts
-it('no-maxDistance path: single ORDER BY, no distance WHERE predicate', () => {
+it('no-maxDistance path: single key is embedding, no distance WHERE predicate', () => {
   const { base } = buildQueries(sut, { page: 1, size: 100 }, { ...baseOptions, maxDistance: undefined });
-  const { sql } = base.compile();
+  const innerSql = base.compile().sql;
 
-  const keys = countOrderByExpressions(sql + ' limit', 'limit');
-  expect(keys, FAILURE_MESSAGE).toBe(1);
+  expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+  expect(innerSql, 'primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+    /order by\s+smart_search\.embedding\s*<=>/i,
+  );
 
-  // No WHERE on the distance operator (<=>).
-  expect(sql).not.toMatch(/\(smart_search\.embedding <=> \$\d+\)\s*<=/i);
+  // No WHERE predicate on the distance operator (<=>).
+  expect(innerSql).not.toMatch(/\(smart_search\.embedding <=> \$\d+\)\s*<=/i);
 });
 ```
 
@@ -556,7 +635,10 @@ git commit -m "test(search): cover CTE asc/desc and no-maxDistance permutations
 
 Locks down the inner ORDER BY across all four searchSmart code paths so
 a future change that re-introduces a secondary sort key (regardless of
-which column) surfaces via a test failure with a pointed message."
+which column) surfaces via a test failure with a pointed message. Each
+test also verifies the primary ORDER BY key IS the embedding sort — not
+just that the count is one — which catches accidental replacement of
+the primary key."
 ```
 
 ---
@@ -587,19 +669,31 @@ pnpm sync:sql
 
 Per `feedback_make_sql_no_db`: never run `sync:sql` without a running DB. If the DB is down, the script deletes all query files instead of regenerating them.
 
-**Step 3: Inspect the diff**
+**Step 3: Inspect the diff — expected changes only**
 
 ```bash
 git diff src/queries/search.repository.sql
 ```
 
-Expected changes:
+**Automated sanity (complements visual inspection):**
 
-- Non-CTE path: removal of `"asset"."id"` from the ORDER BY list.
-- CTE path inner subquery: removal of `"asset"."id"` from the inner ORDER BY.
-- CTE path outer: unchanged (`"candidates"."fileCreatedAt" desc nulls last, "candidates"."id"` both retained).
+```bash
+# Should show exactly two "- ..." lines removing `"asset"."id"` from ORDER BY
+# (one for the non-CTE path, one for the CTE's inner query).
+git diff src/queries/search.repository.sql | grep -cE '^-\s*"asset"\."id"'
+# Expect: 2
 
-Any other change in this file means something else drifted — investigate before committing.
+# Added lines should not reintroduce a secondary key — they should be ORDER BY
+# continuation lines that no longer end in a comma.
+git diff src/queries/search.repository.sql | grep -E '^\+' | grep -v '^\+\+\+' | grep -cE '"asset"\."id"'
+# Expect: 0
+
+# "candidates"."id" must still be present (unchanged outer CTE tiebreaker).
+grep -c '"candidates"\."id"' src/queries/search.repository.sql
+# Expect: 1
+```
+
+If any expectation doesn't match, investigate before committing.
 
 **Step 4: Commit**
 
@@ -624,12 +718,13 @@ pnpm test
 
 Expected: all green.
 
-**Step 2: Web type check + web unit tests (smart-search-results area)**
+**Step 2: Web type check + web unit tests (search area and utils)**
 
 ```bash
 cd web
 pnpm check
 pnpm test -- --run src/lib/components/search/
+pnpm test -- --run src/lib/utils/__tests__/
 ```
 
 Expected: all green.
@@ -652,37 +747,53 @@ git push -u origin fix/search-tiebreaker-vchord
 
 Then use the `rc-personal` skill (or invoke the `gallery-rc-build` workflow manually): build the fork's `gallery-server` image from `fix/search-tiebreaker-vchord`, push to GHCR, pin via the compose override in the personal gitops repo.
 
-**Step 2: Enable diagnostics on pierre's instance**
+**Step 2: Determine pierre's container names**
+
+Personal instance container names may differ from `immich_postgres` / `immich_server`. SSH into pierre and run:
+
+```bash
+docker ps --format '{{.Names}}' | grep -iE 'postgres|server'
+```
+
+Record the actual container names for use in Steps 3-4.
+
+**Step 3: Enable diagnostics on pierre's instance**
 
 On pierre's box, via SSH:
 
 1. Set `GALLERY_SEARCH_TIMING=true` in the personal instance's compose env.
-2. Run the enable script from https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102 (`enable-auto-explain.sh`) against the pierre Postgres container.
-3. Restart the server container so the env var and auto_explain are both active.
+2. Run the enable script from https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102 (`enable-auto-explain.sh <postgres-container-name>`) against pierre's Postgres container.
+3. Restart the server container so the env var takes effect.
 
-**Step 3: Smoke test from the UI**
+**Step 4: Smoke test from the UI**
 
 Open pierre.opennoodle.de. Run at least 3 distinct smart search queries ("mountains", "books", "trees"). Use both the command palette (size=5) and the /search page (size=100).
 
-**Step 4: Inspect the phase timings + plan**
+**Step 5: Inspect the phase timings + plan**
+
+On pierre's box (use the container names recorded in Step 2):
 
 ```bash
-# On pierre's box:
-docker logs immich_postgres --since=5m | grep -E "duration|Index Scan"
-docker logs immich_server --since=5m | grep searchSmart
+# Scope to smart_search plans specifically, not any Index Scan anywhere.
+docker logs <postgres-container-name> --since=5m | \
+  grep -B2 -A20 'Query Text:.*smart_search' | \
+  grep -E 'duration|Seq Scan|Index Scan using'
+
+# Phase timing from the server.
+docker logs <server-container-name> --since=5m | grep searchSmart
 ```
 
 **Success criteria:**
 
-- At least one `Index Scan using clip_index` appears in Postgres logs.
-- No `Parallel Seq Scan on smart_search` for smart-search-shaped queries.
+- At least one `Index Scan using clip_index` appears in Postgres logs scoped to smart-search queries.
+- No `Parallel Seq Scan on smart_search` for smart-search-shaped queries in this 5-minute window.
 - `db=` phase in `GALLERY_SEARCH_TIMING` logs < 500ms for cache-hit embeddings.
 
 If any criterion fails: do NOT proceed to open a PR. Re-investigate (the helper refactor may have subtly altered the query; or `maxDistance=0.95` may need its own handling). Capture the EXPLAIN output and iterate.
 
-**Step 5: Tear down diagnostics**
+**Step 6: Tear down diagnostics**
 
-Run `disable-auto-explain.sh` from the gist. Unset `GALLERY_SEARCH_TIMING=true` (or leave it — atlasshrugged keeps it on for measurement and it's cheap).
+Run `disable-auto-explain.sh <postgres-container-name>` from the gist. Unset `GALLERY_SEARCH_TIMING=true` (or leave it — atlasshrugged keeps it on for measurement and it's cheap).
 
 Also: remove the pierre compose override per `feedback_pierre_rc_override_cleanup` when the PR is merged to main, so release deploys don't silently keep shipping the RC image.
 
@@ -692,39 +803,45 @@ Also: remove the pierre compose override per `feedback_pierre_rc_override_cleanu
 
 ## Task 8: Open the PR
 
-**Step 1: Create PR with a body that includes the risk disclosure**
+**Step 1: Create PR via gh editor for safety**
+
+The PR body contains backticks, `$(...)` substitutions, and other shell-sensitive characters. Use `gh pr create` with the body passed via file or interactive editor rather than shell heredoc to avoid escaping bugs.
 
 ```bash
-gh pr create --title "fix(search): drop asset.id tiebreaker from searchSmart to restore vchord" --body "$(cat <<'EOF'
+# Write body to a temp file to avoid heredoc escaping pitfalls.
+cat > /tmp/pr-body.md <<'PRBODY'
 ## Summary
-Remove the fork-added \`.orderBy('asset.id')\` secondary sort from \`searchSmart\`'s inner query. This restores Postgres's use of the vchord \`clip_index\` ordered scan, closing the 3-5× perf gap with upstream Immich on instances with many photos.
+Remove the fork-added `.orderBy('asset.id')` secondary sort from `searchSmart`'s inner query. This restores Postgres's use of the vchord `clip_index` ordered scan, closing the 3-5× perf gap with upstream Immich on instances with many photos.
 
 ## Root cause
-\`asset.id\` is on a joined table (not \`smart_search\`), so vchord's ordered index scan can't satisfy the multi-key ORDER BY. The planner falls back to Parallel Seq Scan over the full \`smart_search\` table + in-memory sort. On a 200k-photo reporter instance: 17/17 slow smart-search queries showed \`Parallel Seq Scan on smart_search\` instead of \`Index Scan using clip_index\`, producing db-phase times of 3-16s vs upstream's <1s.
+`asset.id` is on a joined table (not `smart_search`), so vchord's ordered index scan can't satisfy the multi-key ORDER BY. The planner falls back to Parallel Seq Scan over the full `smart_search` table + in-memory sort. On a 200k-photo reporter instance: 17/17 slow smart-search queries showed `Parallel Seq Scan on smart_search` instead of `Index Scan using clip_index`, producing db-phase times of 3-16s vs upstream's <1s.
 
-The outer CTE tiebreaker on \`candidates.id\` is retained — it sorts a materialized 500-row set with zero perf cost, and preserves determinism when multiple photos share the same \`fileCreatedAt\`.
+The outer CTE tiebreaker on `candidates.id` is retained — it sorts a materialized 500-row set with zero perf cost, and preserves determinism when multiple photos share the same `fileCreatedAt`.
 
 ## Known trade-off
 For users with byte-identical duplicate image content (rare), infinite scroll may surface fewer unique results than exist: the same asset.id can appear on both pages 1 and 2, and while the frontend dedup prevents duplicate rendering, it pushes a different asset off the viewed window. **This is not self-healing.** Consistent with upstream Immich, which ships without any tiebreaker. Future bug reports mentioning "missing results after infinite scroll" should land here.
 
 ## Test plan
-- [x] Unit tests added for searchSmart SQL shape (all four permutations: non-CTE, CTE desc, CTE asc, no-maxDistance)
-- [x] Frontend dedup regression tests added (two new \`it\` blocks)
-- [x] Reference SQL regenerated
-- [ ] Local reproducer on pierre.opennoodle.de: auto_explain shows \`Index Scan using clip_index\` and \`db=\` phase <500ms
-- [ ] atlasshrugged verifies on 200k-photo instance after release: 3-16s → <1s
+- [x] Unit tests added for searchSmart SQL shape (all four permutations: non-CTE, CTE desc, CTE asc, no-maxDistance); each asserts exactly one inner ORDER BY expression AND that the primary key is `smart_search.embedding <=>`.
+- [x] Frontend dedup extracted to `web/src/lib/utils/search-dedup.ts` and unit-tested (5 cases).
+- [x] Reference SQL regenerated.
+- [ ] Local reproducer on pierre.opennoodle.de: auto_explain shows `Index Scan using clip_index` and `db=` phase <500ms.
+- [ ] atlasshrugged verifies on 200k-photo instance after release: 3-16s → <1s.
 
 ## Follow-ups (separate PRs, not this one)
-- Filter-suggestions batch burst caching (\`getFilterSuggestions\` fires 6 parallel seq-scans per call)
-- \`maxDistance\` docs note (pending atlasshrugged's post-fix report)
-- \`asset.type\` and composite \`(ownerId, visibility, deletedAt, fileCreatedAt)\` indexes (upstream candidates)
+- Filter-suggestions batch burst caching (`getFilterSuggestions` fires 6 parallel seq-scans per call).
+- `maxDistance` docs note (pending atlasshrugged's post-fix report).
+- `asset.type` and composite `(ownerId, visibility, deletedAt, fileCreatedAt)` indexes (upstream candidates).
 
-Design: \`docs/plans/2026-04-21-search-tiebreaker-design.md\`
-EOF
-)"
+Design: `docs/plans/2026-04-21-search-tiebreaker-design.md`
+PRBODY
+
+gh pr create \
+  --title "fix(search): drop asset.id tiebreaker from searchSmart to restore vchord" \
+  --body-file /tmp/pr-body.md
+
+rm /tmp/pr-body.md
 ```
-
-(Note: when running, escape shell-sensitive characters or just author the body in the gh editor.)
 
 **Step 2: Monitor CI**
 
@@ -732,13 +849,21 @@ Expect checks to go green. If the "Schema Check" workflow fails with a diff on `
 
 ---
 
-## Follow-up memory update (after PR merges and atlasshrugged confirms)
+## Task 9: Post-merge memory update
 
-Update `project_search_perf_investigation.md`:
+After PR merges and atlasshrugged confirms the fix on his 200k instance, update memory to reflect the shipped state.
 
-- Status line: `"Status 2026-04-20: ..."` → `"Status 2026-04-2X: Tiebreaker removed in PR #XXX, atlasshrugged's db-phase dropped from 3-16s to NNms."`
-- Link the PR.
-- Move the `asset.id tiebreaker` item out of "Ranked fix impact" and note it's shipped.
+**Step 1: Edit `~/.claude/projects/-home-pierre-dev-gallery/memory/project_search_perf_investigation.md`**
+
+- Change the "Status" line to reflect shipment date, PR number, and atlasshrugged's reported new `db=` value.
+- Move the `asset.id tiebreaker` bullet out of "Ranked fix impact" and into a "Shipped" section (link PR).
+- Leave the filter-suggestions follow-up in place — that's the next iteration.
+
+**Step 2: Edit `~/.claude/projects/-home-pierre-dev-gallery/memory/MEMORY.md`**
+
+- Shorten the `project_search_perf_investigation.md` index line to reflect that the fix shipped and what's still open.
+
+(No source-tree commit; memory edits are local to the session's user memory store.)
 
 ---
 
@@ -748,3 +873,4 @@ Update `project_search_perf_investigation.md`:
 - Index additions — upstream candidates, not fork-only.
 - `maxDistance` default change — deferred pending real-world validation.
 - Medium EXPLAIN-based regression test — deferred; unit + local reproducer + real-data validation is sufficient for this fix.
+- Resolving the 4 `it.todo` entries in `smart-search-results.spec.ts` about loadMore testability — separate refactor; orthogonal to this perf fix.

--- a/docs/plans/2026-04-21-search-tiebreaker-impl.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-impl.md
@@ -88,19 +88,13 @@ describe('dedupeAppend', () => {
   it('appends new items and de-duplicates by id (primary cross-page scenario)', () => {
     // Page 1 returned [a, b, c]; page 2 returned [b, d].
     // After append + dedup, searchResults should be [a, b, c, d].
-    const result = dedupeAppend(
-      [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
-      [{ id: 'b' }, { id: 'd' }],
-    );
+    const result = dedupeAppend([{ id: 'a' }, { id: 'b' }, { id: 'c' }], [{ id: 'b' }, { id: 'd' }]);
     expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c', 'd']);
   });
 
   it('returns existing array unchanged when every incoming item is a duplicate', () => {
     // Byte-identical images scenario: page 2 returns the same assets as page 1.
-    const result = dedupeAppend(
-      [{ id: 'a' }, { id: 'b' }],
-      [{ id: 'a' }, { id: 'b' }],
-    );
+    const result = dedupeAppend([{ id: 'a' }, { id: 'b' }], [{ id: 'a' }, { id: 'b' }]);
     expect(result.map((r) => r.id)).toEqual(['a', 'b']);
     // No duplicates in output.
     expect(new Set(result.map((r) => r.id)).size).toBe(result.length);
@@ -117,10 +111,7 @@ describe('dedupeAppend', () => {
   });
 
   it('preserves order — new items append after existing, no reordering', () => {
-    const result = dedupeAppend(
-      [{ id: 'a' }, { id: 'b' }],
-      [{ id: 'c' }, { id: 'a' }, { id: 'd' }],
-    );
+    const result = dedupeAppend([{ id: 'a' }, { id: 'b' }], [{ id: 'c' }, { id: 'a' }, { id: 'd' }]);
     // 'a' is dropped from incoming; 'c' and 'd' append in the order they arrived.
     expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c', 'd']);
   });
@@ -149,30 +140,30 @@ import { dedupeAppend } from '$lib/utils/search-dedup';
 Then replace lines 47-55 (the `if (append) { ... } else { ... }` block). Old:
 
 ```ts
-      if (append) {
-        // Defend against pagination overlaps (e.g., backend tie-breaker gaps or
-        // race-y page boundaries) so Svelte's keyed {#each} doesn't crash on duplicate IDs.
-        const existingIds = new Set(searchResults.map((a) => a.id));
-        const deduped = assets.items.filter((a) => !existingIds.has(a.id));
-        searchResults = [...searchResults, ...deduped];
-      } else {
-        searchResults = assets.items;
-      }
+if (append) {
+  // Defend against pagination overlaps (e.g., backend tie-breaker gaps or
+  // race-y page boundaries) so Svelte's keyed {#each} doesn't crash on duplicate IDs.
+  const existingIds = new Set(searchResults.map((a) => a.id));
+  const deduped = assets.items.filter((a) => !existingIds.has(a.id));
+  searchResults = [...searchResults, ...deduped];
+} else {
+  searchResults = assets.items;
+}
 ```
 
 New:
 
 ```ts
-      if (append) {
-        // Primary guard against duplicate IDs across paginated searchSmart
-        // responses. The server's ORDER BY is single-key (smart_search.embedding
-        // <=>) so that vchord's ordered index scan can be used; identical
-        // embeddings (byte-identical image content) can then yield the same
-        // asset.id on adjacent pages. See docs/plans/2026-04-21-search-tiebreaker-design.md.
-        searchResults = dedupeAppend(searchResults, assets.items);
-      } else {
-        searchResults = assets.items;
-      }
+if (append) {
+  // Primary guard against duplicate IDs across paginated searchSmart
+  // responses. The server's ORDER BY is single-key (smart_search.embedding
+  // <=>) so that vchord's ordered index scan can be used; identical
+  // embeddings (byte-identical image content) can then yield the same
+  // asset.id on adjacent pages. See docs/plans/2026-04-21-search-tiebreaker-design.md.
+  searchResults = dedupeAppend(searchResults, assets.items);
+} else {
+  searchResults = assets.items;
+}
 ```
 
 **Step 5: Run the component's existing spec to catch regressions**
@@ -582,11 +573,7 @@ it('CTE path orderDirection=desc: inner single key is embedding, outer has fileC
 
 ```ts
 it('CTE path orderDirection=asc: inner single key is embedding, outer sorts ascending', () => {
-  const { base, outer } = buildQueries(
-    sut,
-    { page: 1, size: 100 },
-    { ...baseOptions, orderDirection: AssetOrder.Asc },
-  );
+  const { base, outer } = buildQueries(sut, { page: 1, size: 100 }, { ...baseOptions, orderDirection: AssetOrder.Asc });
 
   const innerSql = base.compile().sql;
   expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);

--- a/docs/plans/2026-04-21-search-tiebreaker-impl.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-impl.md
@@ -1,0 +1,750 @@
+# Smart Search Tiebreaker Removal — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the fork-added `asset.id` secondary ORDER BY from `searchSmart` to restore Postgres's use of the vchord `clip_index` ordered scan. Expected perf gain: 3-16s → <1s on 200k-photo instances.
+
+**Architecture:** The change is intentionally small — one `.orderBy('asset.id')` call removed from `server/src/repositories/search.repository.ts`. Supporting work: (1) extract a private query-builder helper so the SQL shape is testable offline via Kysely's `DummyDriver`, (2) add a unit spec that asserts "exactly one ORDER BY expression" on the inner query to prevent any future secondary-key regression (not just the specific `asset.id` case), (3) add frontend dedup regression tests since that dedup is now the load-bearing safety net, (4) regenerate reference SQL and update the load-bearing code comment.
+
+**Tech Stack:** NestJS + Kysely 0.28.15 (server), SvelteKit + Svelte 5 + Vitest (web), `vchordrq` pgvector extension (DB). Design doc: `docs/plans/2026-04-21-search-tiebreaker-design.md`.
+
+---
+
+## Pre-flight
+
+Before starting, from repo root:
+
+```bash
+# 1. Confirm dev stack is running (needed for `make sql` in Task 4).
+docker ps --filter name=immich_postgres --format '{{.Names}} {{.Status}}'
+# Expect: immich_postgres Up (healthy)
+
+# 2. Confirm clean working tree.
+git status
+# Expect: "nothing to commit, working tree clean"
+
+# 3. Create a feature branch.
+git switch -c fix/search-tiebreaker-vchord
+```
+
+---
+
+## Task 1: Add frontend dedup regression tests
+
+The frontend dedup at `smart-search-results.svelte:50-51` is the sole cross-page duplicate guard after this change. It currently has zero test coverage. Add tests FIRST so we validate the safety net while the backend tiebreaker still exists — if anything in the dedup logic is subtly wrong, we want to know before removing the backend guard.
+
+**Files:**
+
+- Modify: `web/src/lib/components/search/smart-search-results.spec.ts`
+
+**Step 1: Read the existing spec to match its style**
+
+```bash
+head -50 web/src/lib/components/search/smart-search-results.spec.ts
+```
+
+Note the mocking pattern — it mocks `searchSmart` from `@immich/sdk` via `vi.mock`. All new tests follow the same pattern.
+
+**Step 2: Add the first dedup test (RED)**
+
+Inside the `describe('SmartSearchResults', ...)` block, after the existing `'handles empty results'` test, add:
+
+```ts
+it('de-duplicates cross-page results on append by asset id', async () => {
+  const page1 = [
+    { id: 'asset-a' } as AssetResponseDto,
+    { id: 'asset-b' } as AssetResponseDto,
+    { id: 'asset-c' } as AssetResponseDto,
+  ];
+  const page2 = [
+    // asset-b repeats (identical embedding scenario)
+    { id: 'asset-b' } as AssetResponseDto,
+    { id: 'asset-d' } as AssetResponseDto,
+  ];
+
+  mockedSearchSmart
+    .mockResolvedValueOnce({ assets: { items: page1, nextPage: '2' } } as never)
+    .mockResolvedValueOnce({ assets: { items: page2, nextPage: null } } as never);
+
+  const { component } = render(SmartSearchResults, {
+    props: { query: 'trees', filters: defaultFilters() },
+  });
+  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(1));
+
+  // Load page 2 via component's public loadMore method (adjust to whatever the
+  // component actually exposes — inspect smart-search-results.svelte for the
+  // trigger; may be an IntersectionObserver effect or a bindable).
+  await component.loadMore();
+  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(2));
+
+  const finalResults = component.searchResults;
+  expect(finalResults.map((r) => r.id)).toEqual(['asset-a', 'asset-b', 'asset-c', 'asset-d']);
+});
+```
+
+**Step 3: Run test to confirm it fails or passes correctly**
+
+```bash
+cd web
+pnpm test -- --run src/lib/components/search/smart-search-results.spec.ts
+```
+
+If the test framework can't reach `component.loadMore()` / `component.searchResults`, the test needs to be rewritten to drive the component through its public interface (props, user events). Inspect `smart-search-results.svelte` and adjust. **Key invariant to test: after page 1 + page 2 load, no duplicate IDs appear in the rendered list.** The test as written above is illustrative — rewrite to match how the component actually exposes pagination state.
+
+Once adjusted: the test should PASS against current code (backend tiebreaker + frontend dedup together prevent dups). The point is to lock in the frontend behavior.
+
+**Step 4: Add the second dedup test**
+
+```ts
+it('does not render duplicate assets when every page-2 result was on page 1', async () => {
+  const page1 = [{ id: 'asset-a' } as AssetResponseDto, { id: 'asset-b' } as AssetResponseDto];
+  const page2 = [{ id: 'asset-a' } as AssetResponseDto, { id: 'asset-b' } as AssetResponseDto];
+
+  mockedSearchSmart
+    .mockResolvedValueOnce({ assets: { items: page1, nextPage: '2' } } as never)
+    .mockResolvedValueOnce({ assets: { items: page2, nextPage: null } } as never);
+
+  const { component } = render(SmartSearchResults, {
+    props: { query: 'trees', filters: defaultFilters() },
+  });
+  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(1));
+  await component.loadMore();
+  await vi.waitFor(() => expect(mockedSearchSmart).toHaveBeenCalledTimes(2));
+
+  const ids = component.searchResults.map((r) => r.id);
+  expect(new Set(ids).size).toBe(ids.length); // no duplicates
+  expect(ids).toEqual(['asset-a', 'asset-b']);
+});
+```
+
+**Step 5: Update the frontend comment**
+
+Edit `web/src/lib/components/search/smart-search-results.svelte:48-49`:
+
+Old:
+
+```
+// Defend against pagination overlaps (e.g., backend tie-breaker gaps or
+// race-y page boundaries) so Svelte's keyed {#each} doesn't crash on duplicate IDs.
+```
+
+New:
+
+```
+// Primary guard against duplicate IDs across paginated responses from searchSmart.
+// vchord's ordered scan does not guarantee a stable tiebreaker for assets with
+// identical CLIP embeddings (byte-identical image content), so offset pagination
+// can return the same asset.id on adjacent pages. Dedup here keeps Svelte's
+// keyed {#each} from crashing with each_key_duplicate.
+```
+
+**Step 6: Run ALL frontend specs in this file to ensure no regression**
+
+```bash
+cd web
+pnpm test -- --run src/lib/components/search/smart-search-results.spec.ts
+```
+
+Expected: all existing tests pass + both new tests pass.
+
+**Step 7: Commit**
+
+```bash
+git add web/src/lib/components/search/smart-search-results.spec.ts \
+         web/src/lib/components/search/smart-search-results.svelte
+git commit -m "test(web): cover cross-page dedup in smart-search-results spec
+
+The dedup at smart-search-results.svelte:50-51 is the sole guard against
+Svelte each_key_duplicate crashes when searchSmart returns the same asset
+on adjacent pages. It previously had zero coverage — the next commit
+removes the backend tiebreaker that was the other half of the belt-and-
+braces defence, making this test the primary regression guard."
+```
+
+---
+
+## Task 2: Extract `buildSearchSmartQueries` helper (pure refactor, no behavior change)
+
+Extract the query-construction logic out of the transaction closure in `searchSmart` so unit tests can invoke it with an offline `Kysely<DB>` (via `DummyDriver`) and call `.compile()`. This refactor preserves the `asset.id` tiebreaker — it's a no-op SQL-wise. The next task does the actual behavior change.
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts` (searchSmart method + new private helper)
+
+**Step 1: Add the helper above `searchSmart`**
+
+Insert immediately before the `@GenerateSql({ ... })` decorator for `searchSmart` (approximately line 337):
+
+```ts
+private buildSearchSmartQueries(
+  kysely: Kysely<DB>,
+  pagination: SearchPaginationOptions,
+  options: SmartSearchOptions,
+) {
+  const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);
+
+  const baseQuery = searchAssetBuilder(kysely, options)
+    .selectAll('asset')
+    .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
+    .$if(hasDistanceThreshold, (qb) =>
+      qb.where(sql<SqlBool>`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
+    )
+    .orderBy(sql`smart_search.embedding <=> ${options.embedding}`)
+    // Stable tiebreaker so offset-based pagination doesn't return overlapping pages
+    // when multiple assets have identical CLIP distances.
+    .orderBy('asset.id');
+
+  if (options.orderDirection) {
+    const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;
+    const candidates = baseQuery.limit(500).as('candidates');
+    const outerQuery = kysely
+      .selectFrom(candidates)
+      .selectAll()
+      // sql.raw is safe here — orderDirection is validated to 'asc'|'desc' by the AssetOrder enum
+      .orderBy(sql`"candidates"."fileCreatedAt" ${sql.raw(orderDirection)} nulls last`)
+      // Stable tiebreaker (same rationale as the base query)
+      .orderBy('candidates.id')
+      .limit(pagination.size + 1)
+      .offset((pagination.page - 1) * pagination.size);
+    return { kind: 'cte' as const, base: baseQuery, outer: outerQuery };
+  }
+
+  const outerQuery = baseQuery
+    .limit(pagination.size + 1)
+    .offset((pagination.page - 1) * pagination.size);
+
+  return { kind: 'simple' as const, base: baseQuery, outer: outerQuery };
+}
+```
+
+Note: this is a **verbatim extraction** — the tiebreaker stays in the helper exactly as it was. We remove it in Task 3.
+
+**Step 2: Replace the body of `searchSmart` to call the helper**
+
+Current body (lines 349-384 approx):
+
+```ts
+return this.db.transaction().execute(async (trx) => {
+  await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
+
+  const baseQuery = searchAssetBuilder(trx, options)
+    .selectAll('asset')
+    .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
+    .$if(hasDistanceThreshold, (qb) =>
+      qb.where(sql<SqlBool>`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
+    )
+    .orderBy(sql`smart_search.embedding <=> ${options.embedding}`)
+    .orderBy('asset.id');
+
+  if (options.orderDirection) {
+    const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;
+    const candidates = baseQuery.limit(500).as('candidates');
+    const items = await trx
+      .selectFrom(candidates)
+      .selectAll()
+      .orderBy(sql`"candidates"."fileCreatedAt" ${sql.raw(orderDirection)} nulls last`)
+      .orderBy('candidates.id')
+      .limit(pagination.size + 1)
+      .offset((pagination.page - 1) * pagination.size)
+      .execute();
+    return paginationHelper(items as MapAsset[], pagination.size);
+  }
+
+  const items = await baseQuery
+    .limit(pagination.size + 1)
+    .offset((pagination.page - 1) * pagination.size)
+    .execute();
+  return paginationHelper(items, pagination.size);
+});
+```
+
+Replace with:
+
+```ts
+return this.db.transaction().execute(async (trx) => {
+  await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
+
+  const { kind, outer } = this.buildSearchSmartQueries(trx, pagination, options);
+  const items = await outer.execute();
+  return paginationHelper(kind === 'cte' ? (items as MapAsset[]) : items, pagination.size);
+});
+```
+
+Also remove the now-unused local `const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);` declaration from the top of `searchSmart` (it moved into the helper).
+
+**Step 3: Regenerate reference SQL and verify diff is empty**
+
+```bash
+cd server
+pnpm build
+pnpm sync:sql
+git diff src/queries/search.repository.sql
+```
+
+Expected: **zero diff**. The refactor changes TypeScript organization only — generated SQL must be byte-identical. If there is a diff, something about the refactor changed query shape. Investigate and fix before moving on.
+
+**Step 4: Run existing service specs to catch any regression**
+
+```bash
+cd server
+pnpm test -- --run src/services/search.service.spec.ts
+```
+
+Expected: all tests pass.
+
+**Step 5: Run type check**
+
+```bash
+cd server
+pnpm check
+```
+
+Expected: no errors.
+
+**Step 6: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts
+git commit -m "refactor(search): extract buildSearchSmartQueries helper
+
+Pure refactor, zero SQL diff. Extracts the query-construction logic from
+searchSmart's transaction closure into a testable private method. This
+enables offline SQL-shape assertions via Kysely's DummyDriver — required
+by the next commit, which removes the secondary ORDER BY that was
+preventing vchord index usage."
+```
+
+---
+
+## Task 3: TDD — remove tiebreaker (RED → GREEN)
+
+Now the real fix. Write the failing test first; watch it fail against the refactored code (which still has the tiebreaker); remove the tiebreaker; watch the test pass.
+
+**Files:**
+
+- Create: `server/src/repositories/search.repository.spec.ts`
+- Modify: `server/src/repositories/search.repository.ts` (remove tiebreaker + update comment)
+
+**Step 1: Create the spec file with the first failing assertion**
+
+```ts
+// server/src/repositories/search.repository.spec.ts
+import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } from 'kysely';
+import { AssetOrder } from 'src/enum';
+import { SearchRepository } from 'src/repositories/search.repository';
+import type { DB } from 'src/schema';
+
+// Offline Kysely — compiles SQL without executing it. No DB connection needed.
+const offlineKysely = () =>
+  new Kysely<DB>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+// Access the private helper via `any` — private methods are implementation
+// detail, but testing SQL shape is the whole point of this spec.
+const buildQueries = (
+  sut: SearchRepository,
+  pagination: { page: number; size: number },
+  options: Record<string, unknown>,
+) => (sut as any).buildSearchSmartQueries(offlineKysely(), pagination, options);
+
+const FAILURE_MESSAGE =
+  'Do not add any secondary ORDER BY key to the inner searchSmart query. ' +
+  'See comment at src/repositories/search.repository.ts (above the orderBy call). ' +
+  'Secondary ORDER BY keys force Parallel Seq Scan on smart_search instead of ' +
+  'the vchord clip_index ordered scan (~100× slowdown at 200k rows).';
+
+const countOrderByExpressions = (compiledSql: string, anchor: string): number => {
+  // Find the ORDER BY that immediately precedes the given anchor (or LIMIT/OFFSET).
+  // Kysely's PostgresQueryCompiler emits a single-line compact SQL string.
+  const orderByRegex = /order by\s+(.+?)\s+(?:limit\b|offset\b|\)\s+as\b)/gi;
+  const matches = Array.from(compiledSql.matchAll(orderByRegex));
+  const match = matches.find((m) => compiledSql.indexOf(anchor) > compiledSql.indexOf(m[0]));
+  if (!match) throw new Error(`no ORDER BY before anchor "${anchor}" in: ${compiledSql}`);
+  return match[1].split(',').filter((s) => s.trim().length > 0).length;
+};
+
+describe(SearchRepository.name, () => {
+  // SearchRepository needs a Kysely<DB>; DummyDriver is fine because searchSmart
+  // itself is never called here — we only exercise the private query builder.
+  const sut = new SearchRepository(offlineKysely());
+
+  const baseOptions = {
+    embedding: `[${Array.from({ length: 512 }, () => 0.01).join(',')}]`,
+    userIds: ['00000000-0000-0000-0000-000000000000'],
+    maxDistance: 0.5,
+  };
+
+  describe('searchSmart query shape', () => {
+    it('non-CTE inner ORDER BY has exactly one expression (vchord index guard)', () => {
+      const { base } = buildQueries(sut, { page: 1, size: 100 }, baseOptions);
+      const { sql } = base.compile();
+      const keys = countOrderByExpressions(sql + ' limit', 'limit');
+      expect(keys, FAILURE_MESSAGE).toBe(1);
+    });
+  });
+});
+```
+
+**Step 2: Run the test — expect it to FAIL (RED)**
+
+```bash
+cd server
+pnpm test -- --run src/repositories/search.repository.spec.ts
+```
+
+Expected: FAIL with message matching `FAILURE_MESSAGE` — the current compiled SQL still has `"asset"."id"` as the second ORDER BY expression after the refactor.
+
+If the test PASSES unexpectedly, the regex or SQL format is wrong. Fix the regex before proceeding (a common cause: Kysely emits newlines instead of spaces in some versions — adjust the regex to `[\s\S]+?`).
+
+**Step 3: Remove the tiebreaker from the helper**
+
+In `server/src/repositories/search.repository.ts`, inside `buildSearchSmartQueries`, change:
+
+```ts
+    .orderBy(sql`smart_search.embedding <=> ${options.embedding}`)
+    // Stable tiebreaker so offset-based pagination doesn't return overlapping pages
+    // when multiple assets have identical CLIP distances.
+    .orderBy('asset.id');
+```
+
+To:
+
+```ts
+    // DO NOT add a secondary ORDER BY key on any column here.
+    // vchord's ordered index scan can only satisfy a single-key ORDER BY on
+    // `smart_search.embedding <=>`. Any additional sort key forces the planner
+    // to Parallel Seq Scan + in-memory sort (~15s on 200k rows vs ~200ms via
+    // vchord). Cross-page duplicates from identical embeddings are caught by
+    // the frontend dedup in web/src/lib/components/search/smart-search-results.svelte.
+    .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
+```
+
+Keep the outer-CTE `.orderBy('candidates.id')` on the outer wrapping untouched. That sort runs on a materialized 500-row CTE — zero perf cost, preserves fileCreatedAt-tie determinism.
+
+**Step 4: Run the test — expect it to PASS (GREEN)**
+
+```bash
+cd server
+pnpm test -- --run src/repositories/search.repository.spec.ts
+```
+
+Expected: PASS.
+
+**Step 5: Run type check + service specs**
+
+```bash
+cd server
+pnpm check
+pnpm test -- --run src/services/search.service.spec.ts
+```
+
+Expected: both pass. The service spec doesn't assert ordering of identical-embedding ties, so no regression.
+
+**Step 6: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts \
+         server/src/repositories/search.repository.spec.ts
+git commit -m "fix(search): drop asset.id tiebreaker from searchSmart inner ORDER BY
+
+Closes the 3-5× smart search perf gap vs upstream on instances with many
+photos. The fork-added '.orderBy(asset.id)' secondary sort was forcing
+Postgres to materialize all matching rows and in-memory sort instead of
+using vchord's ordered index scan — 17/17 slow-query EXPLAIN plans on a
+200k-photo reporter instance showed Parallel Seq Scan on smart_search
+instead of Index Scan using clip_index.
+
+Cross-page duplicates from identical CLIP embeddings (byte-identical
+image content) are caught by the frontend dedup in smart-search-results
+.svelte:50-51, which was previously the second half of a belt-and-braces
+defence and is now the primary guard. Frontend regression tests added
+in the previous commit.
+
+Known trade-off: users with byte-identical duplicate image content may
+see fewer unique results than exist in infinite scroll (same asset can
+'spend' a slot on both pages 1 and 2, pushing a different asset off the
+window). Not self-healing, but rare and consistent with upstream Immich.
+
+Design: docs/plans/2026-04-21-search-tiebreaker-design.md"
+```
+
+---
+
+## Task 4: Extend unit spec with permutation coverage
+
+The first test locks down the non-CTE path. Add the remaining three permutations from the design: CTE `desc`, CTE `asc`, no-maxDistance.
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.spec.ts`
+
+**Step 1: Add the CTE `orderDirection: 'desc'` test**
+
+Inside the `describe('searchSmart query shape', ...)` block, after the first `it`:
+
+```ts
+it('CTE path with orderDirection=desc: inner has single ORDER BY, outer retains candidates.id', () => {
+  const { base, outer } = buildQueries(
+    sut,
+    { page: 1, size: 100 },
+    { ...baseOptions, orderDirection: AssetOrder.Desc },
+  );
+
+  const innerKeys = countOrderByExpressions(base.compile().sql + ' limit', 'limit');
+  expect(innerKeys, FAILURE_MESSAGE).toBe(1);
+
+  const outerSql = outer.compile().sql;
+  expect(outerSql).toMatch(/"candidates"\."fileCreatedAt"\s+desc/i);
+  expect(outerSql).toContain('"candidates"."id"');
+});
+```
+
+**Step 2: Add the CTE `orderDirection: 'asc'` test**
+
+```ts
+it('CTE path with orderDirection=asc: inner has single ORDER BY, outer sorts ascending', () => {
+  const { base, outer } = buildQueries(
+    sut,
+    { page: 1, size: 100 },
+    { ...baseOptions, orderDirection: AssetOrder.Asc },
+  );
+
+  const innerKeys = countOrderByExpressions(base.compile().sql + ' limit', 'limit');
+  expect(innerKeys, FAILURE_MESSAGE).toBe(1);
+
+  const outerSql = outer.compile().sql;
+  expect(outerSql).toMatch(/"candidates"\."fileCreatedAt"\s+asc/i);
+  expect(outerSql).toContain('"candidates"."id"');
+});
+```
+
+**Step 3: Add the no-maxDistance test**
+
+```ts
+it('no-maxDistance path: single ORDER BY, no distance WHERE predicate', () => {
+  const { base } = buildQueries(sut, { page: 1, size: 100 }, { ...baseOptions, maxDistance: undefined });
+  const { sql } = base.compile();
+
+  const keys = countOrderByExpressions(sql + ' limit', 'limit');
+  expect(keys, FAILURE_MESSAGE).toBe(1);
+
+  // No WHERE on the distance operator (<=>).
+  expect(sql).not.toMatch(/\(smart_search\.embedding <=> \$\d+\)\s*<=/i);
+});
+```
+
+**Step 4: Run all four tests**
+
+```bash
+cd server
+pnpm test -- --run src/repositories/search.repository.spec.ts
+```
+
+Expected: 4 tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add server/src/repositories/search.repository.spec.ts
+git commit -m "test(search): cover CTE asc/desc and no-maxDistance permutations
+
+Locks down the inner ORDER BY across all four searchSmart code paths so
+a future change that re-introduces a secondary sort key (regardless of
+which column) surfaces via a test failure with a pointed message."
+```
+
+---
+
+## Task 5: Regenerate reference SQL
+
+The tiebreaker removal changes the generated SQL. `server/src/queries/search.repository.sql` must be updated and committed.
+
+**Files:**
+
+- Modify: `server/src/queries/search.repository.sql`
+
+**Step 1: Confirm dev DB is running**
+
+```bash
+docker ps --filter name=immich_postgres --format '{{.Names}} {{.Status}}'
+```
+
+If not healthy, start the stack first: `make dev` and wait for the postgres container to report healthy.
+
+**Step 2: Build the server and regenerate SQL**
+
+```bash
+cd server
+pnpm build
+pnpm sync:sql
+```
+
+Per `feedback_make_sql_no_db`: never run `sync:sql` without a running DB. If the DB is down, the script deletes all query files instead of regenerating them.
+
+**Step 3: Inspect the diff**
+
+```bash
+git diff src/queries/search.repository.sql
+```
+
+Expected changes:
+
+- Non-CTE path: removal of `"asset"."id"` from the ORDER BY list.
+- CTE path inner subquery: removal of `"asset"."id"` from the inner ORDER BY.
+- CTE path outer: unchanged (`"candidates"."fileCreatedAt" desc nulls last, "candidates"."id"` both retained).
+
+Any other change in this file means something else drifted — investigate before committing.
+
+**Step 4: Commit**
+
+```bash
+git add server/src/queries/search.repository.sql
+git commit -m "chore(sql): regenerate reference SQL after tiebreaker removal"
+```
+
+---
+
+## Task 6: Full check + lint gate
+
+Run the fork's canonical pre-commit gates to catch anything the focused specs missed.
+
+**Step 1: Server type check + server unit tests**
+
+```bash
+cd server
+pnpm check
+pnpm test
+```
+
+Expected: all green.
+
+**Step 2: Web type check + web unit tests (smart-search-results area)**
+
+```bash
+cd web
+pnpm check
+pnpm test -- --run src/lib/components/search/
+```
+
+Expected: all green.
+
+**Step 3: If any step failed, stop here.** Do NOT push. Debug the failure in place.
+
+(No commit for this task — it's verification only.)
+
+---
+
+## Task 7: Local reproducer on pierre.opennoodle.de
+
+Validate the fix on real data before shipping to users. Pierre's personal instance (~40k photos) is the fastest feedback loop. If vchord wins there, it wins on atlasshrugged's 200k.
+
+**Step 1: Push the branch and ship an RC**
+
+```bash
+git push -u origin fix/search-tiebreaker-vchord
+```
+
+Then use the `rc-personal` skill (or invoke the `gallery-rc-build` workflow manually): build the fork's `gallery-server` image from `fix/search-tiebreaker-vchord`, push to GHCR, pin via the compose override in the personal gitops repo.
+
+**Step 2: Enable diagnostics on pierre's instance**
+
+On pierre's box, via SSH:
+
+1. Set `GALLERY_SEARCH_TIMING=true` in the personal instance's compose env.
+2. Run the enable script from https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102 (`enable-auto-explain.sh`) against the pierre Postgres container.
+3. Restart the server container so the env var and auto_explain are both active.
+
+**Step 3: Smoke test from the UI**
+
+Open pierre.opennoodle.de. Run at least 3 distinct smart search queries ("mountains", "books", "trees"). Use both the command palette (size=5) and the /search page (size=100).
+
+**Step 4: Inspect the phase timings + plan**
+
+```bash
+# On pierre's box:
+docker logs immich_postgres --since=5m | grep -E "duration|Index Scan"
+docker logs immich_server --since=5m | grep searchSmart
+```
+
+**Success criteria:**
+
+- At least one `Index Scan using clip_index` appears in Postgres logs.
+- No `Parallel Seq Scan on smart_search` for smart-search-shaped queries.
+- `db=` phase in `GALLERY_SEARCH_TIMING` logs < 500ms for cache-hit embeddings.
+
+If any criterion fails: do NOT proceed to open a PR. Re-investigate (the helper refactor may have subtly altered the query; or `maxDistance=0.95` may need its own handling). Capture the EXPLAIN output and iterate.
+
+**Step 5: Tear down diagnostics**
+
+Run `disable-auto-explain.sh` from the gist. Unset `GALLERY_SEARCH_TIMING=true` (or leave it — atlasshrugged keeps it on for measurement and it's cheap).
+
+Also: remove the pierre compose override per `feedback_pierre_rc_override_cleanup` when the PR is merged to main, so release deploys don't silently keep shipping the RC image.
+
+(No commit for this task — it's out-of-tree validation.)
+
+---
+
+## Task 8: Open the PR
+
+**Step 1: Create PR with a body that includes the risk disclosure**
+
+```bash
+gh pr create --title "fix(search): drop asset.id tiebreaker from searchSmart to restore vchord" --body "$(cat <<'EOF'
+## Summary
+Remove the fork-added \`.orderBy('asset.id')\` secondary sort from \`searchSmart\`'s inner query. This restores Postgres's use of the vchord \`clip_index\` ordered scan, closing the 3-5× perf gap with upstream Immich on instances with many photos.
+
+## Root cause
+\`asset.id\` is on a joined table (not \`smart_search\`), so vchord's ordered index scan can't satisfy the multi-key ORDER BY. The planner falls back to Parallel Seq Scan over the full \`smart_search\` table + in-memory sort. On a 200k-photo reporter instance: 17/17 slow smart-search queries showed \`Parallel Seq Scan on smart_search\` instead of \`Index Scan using clip_index\`, producing db-phase times of 3-16s vs upstream's <1s.
+
+The outer CTE tiebreaker on \`candidates.id\` is retained — it sorts a materialized 500-row set with zero perf cost, and preserves determinism when multiple photos share the same \`fileCreatedAt\`.
+
+## Known trade-off
+For users with byte-identical duplicate image content (rare), infinite scroll may surface fewer unique results than exist: the same asset.id can appear on both pages 1 and 2, and while the frontend dedup prevents duplicate rendering, it pushes a different asset off the viewed window. **This is not self-healing.** Consistent with upstream Immich, which ships without any tiebreaker. Future bug reports mentioning "missing results after infinite scroll" should land here.
+
+## Test plan
+- [x] Unit tests added for searchSmart SQL shape (all four permutations: non-CTE, CTE desc, CTE asc, no-maxDistance)
+- [x] Frontend dedup regression tests added (two new \`it\` blocks)
+- [x] Reference SQL regenerated
+- [ ] Local reproducer on pierre.opennoodle.de: auto_explain shows \`Index Scan using clip_index\` and \`db=\` phase <500ms
+- [ ] atlasshrugged verifies on 200k-photo instance after release: 3-16s → <1s
+
+## Follow-ups (separate PRs, not this one)
+- Filter-suggestions batch burst caching (\`getFilterSuggestions\` fires 6 parallel seq-scans per call)
+- \`maxDistance\` docs note (pending atlasshrugged's post-fix report)
+- \`asset.type\` and composite \`(ownerId, visibility, deletedAt, fileCreatedAt)\` indexes (upstream candidates)
+
+Design: \`docs/plans/2026-04-21-search-tiebreaker-design.md\`
+EOF
+)"
+```
+
+(Note: when running, escape shell-sensitive characters or just author the body in the gh editor.)
+
+**Step 2: Monitor CI**
+
+Expect checks to go green. If the "Schema Check" workflow fails with a diff on `search.repository.sql`, someone rebased or the regen missed something — update locally and push.
+
+---
+
+## Follow-up memory update (after PR merges and atlasshrugged confirms)
+
+Update `project_search_perf_investigation.md`:
+
+- Status line: `"Status 2026-04-20: ..."` → `"Status 2026-04-2X: Tiebreaker removed in PR #XXX, atlasshrugged's db-phase dropped from 3-16s to NNms."`
+- Link the PR.
+- Move the `asset.id tiebreaker` item out of "Ranked fix impact" and note it's shipped.
+
+---
+
+## Out of scope for this plan
+
+- Filter suggestions caching — separate design + PR (see follow-ups in `2026-04-21-search-tiebreaker-design.md`).
+- Index additions — upstream candidates, not fork-only.
+- `maxDistance` default change — deferred pending real-world validation.
+- Medium EXPLAIN-based regression test — deferred; unit + local reproducer + real-data validation is sufficient for this fix.

--- a/docs/plans/2026-04-21-search-tiebreaker-impl.md
+++ b/docs/plans/2026-04-21-search-tiebreaker-impl.md
@@ -735,9 +735,9 @@ Expected: all green.
 
 ---
 
-## Task 7: Local reproducer on pierre.opennoodle.de
+## Task 7: Local reproducer on a smaller personal instance
 
-Validate the fix on real data before shipping to users. Pierre's personal instance (~40k photos) is the fastest feedback loop. If vchord wins there, it wins on atlasshrugged's 200k.
+Validate the fix on real data before shipping to users. A personal dev instance (~40k photos) is the fastest feedback loop. If vchord wins there, it wins on a 200k-photo instance too.
 
 **Step 1: Push the branch and ship an RC**
 
@@ -745,11 +745,11 @@ Validate the fix on real data before shipping to users. Pierre's personal instan
 git push -u origin fix/search-tiebreaker-vchord
 ```
 
-Then use the `rc-personal` skill (or invoke the `gallery-rc-build` workflow manually): build the fork's `gallery-server` image from `fix/search-tiebreaker-vchord`, push to GHCR, pin via the compose override in the personal gitops repo.
+Build an RC of `gallery-server` from the fix branch, push to the image registry, and pin via a compose override on the personal instance.
 
-**Step 2: Determine pierre's container names**
+**Step 2: Determine the instance's container names**
 
-Personal instance container names may differ from `immich_postgres` / `immich_server`. SSH into pierre and run:
+Container names may differ from `immich_postgres` / `immich_server`. SSH into the instance and run:
 
 ```bash
 docker ps --format '{{.Names}}' | grep -iE 'postgres|server'
@@ -757,21 +757,21 @@ docker ps --format '{{.Names}}' | grep -iE 'postgres|server'
 
 Record the actual container names for use in Steps 3-4.
 
-**Step 3: Enable diagnostics on pierre's instance**
+**Step 3: Enable diagnostics on the instance**
 
-On pierre's box, via SSH:
+On the instance, via SSH:
 
-1. Set `GALLERY_SEARCH_TIMING=true` in the personal instance's compose env.
-2. Run the enable script from https://gist.github.com/Deeds67/75bb0e5b2c1443402454068adb0cd102 (`enable-auto-explain.sh <postgres-container-name>`) against pierre's Postgres container.
+1. Set `GALLERY_SEARCH_TIMING=true` in the compose env.
+2. Run the enable script from the diagnostic gist (`enable-auto-explain.sh <postgres-container-name>`) against the Postgres container.
 3. Restart the server container so the env var takes effect.
 
 **Step 4: Smoke test from the UI**
 
-Open pierre.opennoodle.de. Run at least 3 distinct smart search queries ("mountains", "books", "trees"). Use both the command palette (size=5) and the /search page (size=100).
+Open the instance. Run at least 3 distinct smart search queries ("mountains", "books", "trees"). Use both the command palette (size=5) and the /search page (size=100).
 
 **Step 5: Inspect the phase timings + plan**
 
-On pierre's box (use the container names recorded in Step 2):
+On the instance (use the container names recorded in Step 2):
 
 ```bash
 # Scope to smart_search plans specifically, not any Index Scan anywhere.
@@ -793,9 +793,9 @@ If any criterion fails: do NOT proceed to open a PR. Re-investigate (the helper 
 
 **Step 6: Tear down diagnostics**
 
-Run `disable-auto-explain.sh <postgres-container-name>` from the gist. Unset `GALLERY_SEARCH_TIMING=true` (or leave it — atlasshrugged keeps it on for measurement and it's cheap).
+Run `disable-auto-explain.sh <postgres-container-name>` from the diagnostic gist. Unset `GALLERY_SEARCH_TIMING=true` (or leave it on — it's cheap).
 
-Also: remove the pierre compose override per `feedback_pierre_rc_override_cleanup` when the PR is merged to main, so release deploys don't silently keep shipping the RC image.
+Also: remove the personal-instance compose override when the PR is merged to main, so release deploys don't silently keep shipping the RC image.
 
 (No commit for this task — it's out-of-tree validation.)
 
@@ -825,12 +825,12 @@ For users with byte-identical duplicate image content (rare), infinite scroll ma
 - [x] Unit tests added for searchSmart SQL shape (all four permutations: non-CTE, CTE desc, CTE asc, no-maxDistance); each asserts exactly one inner ORDER BY expression AND that the primary key is `smart_search.embedding <=>`.
 - [x] Frontend dedup extracted to `web/src/lib/utils/search-dedup.ts` and unit-tested (5 cases).
 - [x] Reference SQL regenerated.
-- [ ] Local reproducer on pierre.opennoodle.de: auto_explain shows `Index Scan using clip_index` and `db=` phase <500ms.
-- [ ] atlasshrugged verifies on 200k-photo instance after release: 3-16s → <1s.
+- [ ] Local reproducer on a personal dev instance: auto_explain shows `Index Scan using clip_index` and `db=` phase <500ms.
+- [ ] Reporter verifies on their 200k-photo instance after release: 3-16s → <1s.
 
 ## Follow-ups (separate PRs, not this one)
 - Filter-suggestions batch burst caching (`getFilterSuggestions` fires 6 parallel seq-scans per call).
-- `maxDistance` docs note (pending atlasshrugged's post-fix report).
+- `maxDistance` docs note (pending the reporter's post-fix report).
 - `asset.type` and composite `(ownerId, visibility, deletedAt, fileCreatedAt)` indexes (upstream candidates).
 
 Design: `docs/plans/2026-04-21-search-tiebreaker-design.md`
@@ -849,21 +849,11 @@ Expect checks to go green. If the "Schema Check" workflow fails with a diff on `
 
 ---
 
-## Task 9: Post-merge memory update
+## Task 9: Post-merge notes update
 
-After PR merges and atlasshrugged confirms the fix on his 200k instance, update memory to reflect the shipped state.
+After PR merges and the reporter confirms the fix on a 200k instance, update any local notes or tracking to reflect the shipped state: shipment date, PR number, the reporter's new `db=` value. Leave the filter-suggestions follow-up in place — that's the next iteration.
 
-**Step 1: Edit `~/.claude/projects/-home-pierre-dev-gallery/memory/project_search_perf_investigation.md`**
-
-- Change the "Status" line to reflect shipment date, PR number, and atlasshrugged's reported new `db=` value.
-- Move the `asset.id tiebreaker` bullet out of "Ranked fix impact" and into a "Shipped" section (link PR).
-- Leave the filter-suggestions follow-up in place — that's the next iteration.
-
-**Step 2: Edit `~/.claude/projects/-home-pierre-dev-gallery/memory/MEMORY.md`**
-
-- Shorten the `project_search_perf_investigation.md` index line to reflect that the fix shipped and what's still open.
-
-(No source-tree commit; memory edits are local to the session's user memory store.)
+(No source-tree commit; notes are out-of-tree.)
 
 ---
 

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -132,8 +132,7 @@ from
       and "asset"."deletedAt" is null
       and (smart_search.embedding <=> $9) <= $10
     order by
-      smart_search.embedding <=> $11,
-      "asset"."id"
+      smart_search.embedding <=> $11
     limit
       $12
   ) as "candidates"

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -50,7 +50,7 @@ const countOuterOrderByExpressions = (compiledSql: string): number => {
   if (matches.length === 0) {
     throw new Error(`no ORDER BY in: ${compiledSql}`);
   }
-  const last = matches[matches.length - 1];
+  const last = matches.at(-1)!;
   return last[1].split(',').filter((s) => s.trim().length > 0).length;
 };
 

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -1,0 +1,65 @@
+// server/src/repositories/search.repository.spec.ts
+import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } from 'kysely';
+import { SearchRepository } from 'src/repositories/search.repository';
+import type { DB } from 'src/schema';
+
+// Offline Kysely — compiles SQL without executing it. No DB connection needed.
+const offlineKysely = () =>
+  new Kysely<DB>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+// Access the private helper via `any` — private methods are implementation
+// detail, but testing SQL shape is the whole point of this spec.
+const buildQueries = (
+  sut: SearchRepository,
+  pagination: { page: number; size: number },
+  options: Record<string, unknown>,
+) => (sut as any).buildSearchSmartQueries(offlineKysely(), pagination, options);
+
+const FAILURE_MESSAGE =
+  'Do not add any secondary ORDER BY key to the inner searchSmart query. ' +
+  'See comment at src/repositories/search.repository.ts (above the orderBy call). ' +
+  'Secondary ORDER BY keys force Parallel Seq Scan on smart_search instead of ' +
+  'the vchord clip_index ordered scan (~100× slowdown at 200k rows).';
+
+const countOrderByExpressions = (compiledSql: string, anchor: string): number => {
+  // Find the ORDER BY that immediately precedes the given anchor (or LIMIT/OFFSET).
+  // Kysely's PostgresQueryCompiler emits a single-line compact SQL string.
+  const orderByRegex = /order by\s+([\s\S]+?)\s+(?:limit\b|offset\b|\)\s+as\b)/gi;
+  const matches = [...compiledSql.matchAll(orderByRegex)];
+  const match = matches.find((m) => compiledSql.indexOf(anchor) > compiledSql.indexOf(m[0]));
+  if (!match) {
+    throw new Error(`no ORDER BY before anchor "${anchor}" in: ${compiledSql}`);
+  }
+  return match[1].split(',').filter((s) => s.trim().length > 0).length;
+};
+
+describe(SearchRepository.name, () => {
+  const sut = new SearchRepository(offlineKysely());
+
+  const baseOptions = {
+    embedding: `[${Array.from({ length: 512 }, () => 0.01).join(',')}]`,
+    userIds: ['00000000-0000-0000-0000-000000000000'],
+    maxDistance: 0.5,
+  };
+
+  describe('searchSmart query shape', () => {
+    it('non-CTE inner ORDER BY: exactly one expression AND primary key is smart_search.embedding', () => {
+      const { base } = buildQueries(sut, { page: 1, size: 100 }, baseOptions);
+      const innerSql = base.compile().sql;
+
+      const keys = countOrderByExpressions(innerSql + ' limit', 'limit');
+      expect(keys, FAILURE_MESSAGE).toBe(1);
+
+      expect(innerSql, 'primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+        /order by\s+smart_search\.embedding\s*<=>/i,
+      );
+    });
+  });
+});

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -1,5 +1,6 @@
 // server/src/repositories/search.repository.spec.ts
 import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } from 'kysely';
+import { AssetOrder } from 'src/enum';
 import { SearchRepository } from 'src/repositories/search.repository';
 import type { DB } from 'src/schema';
 
@@ -40,6 +41,19 @@ const countOrderByExpressions = (compiledSql: string, anchor: string): number =>
   return match[1].split(',').filter((s) => s.trim().length > 0).length;
 };
 
+// Count ORDER BY expressions in the OUTER (last) ORDER BY clause — the one after
+// `) as "candidates"`. Used for the CTE path, where the inner subquery also has
+// its own ORDER BY.
+const countOuterOrderByExpressions = (compiledSql: string): number => {
+  const orderByRegex = /order by\s+([\s\S]+?)\s+(?:limit\b|offset\b)/gi;
+  const matches = [...compiledSql.matchAll(orderByRegex)];
+  if (matches.length === 0) {
+    throw new Error(`no ORDER BY in: ${compiledSql}`);
+  }
+  const last = matches[matches.length - 1];
+  return last[1].split(',').filter((s) => s.trim().length > 0).length;
+};
+
 describe(SearchRepository.name, () => {
   const sut = new SearchRepository(offlineKysely());
 
@@ -60,6 +74,62 @@ describe(SearchRepository.name, () => {
       expect(innerSql, 'primary ORDER BY must be on smart_search.embedding <=>').toMatch(
         /order by\s+smart_search\.embedding\s*<=>/i,
       );
+    });
+
+    it('CTE path orderDirection=desc: inner single key is embedding, outer has fileCreatedAt + candidates.id', () => {
+      const { base, outer } = buildQueries(
+        sut,
+        { page: 1, size: 100 },
+        { ...baseOptions, orderDirection: AssetOrder.Desc },
+      );
+
+      // Inner query (subject to vchord): single-key ORDER BY on embedding.
+      const innerSql = base.compile().sql;
+      expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+      expect(innerSql, 'inner primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+        /order by\s+smart_search\.embedding\s*<=>/i,
+      );
+
+      // Outer (CTE wrapper, materialized 500 rows): tiebreaker IS retained here by design.
+      const outerSql = outer.compile().sql;
+      expect(outerSql).toMatch(/"candidates"\."fileCreatedAt"\s+desc/i);
+      expect(outerSql).toContain('"candidates"."id"');
+      // Also: outer ORDER BY must have exactly 2 keys (fileCreatedAt + candidates.id);
+      // any third key here would be a new, undocumented tiebreaker.
+      const outerKeys = countOuterOrderByExpressions(outerSql);
+      expect(outerKeys, 'outer CTE ORDER BY must be exactly (fileCreatedAt, candidates.id)').toBe(2);
+    });
+
+    it('CTE path orderDirection=asc: inner single key is embedding, outer sorts ascending', () => {
+      const { base, outer } = buildQueries(
+        sut,
+        { page: 1, size: 100 },
+        { ...baseOptions, orderDirection: AssetOrder.Asc },
+      );
+
+      const innerSql = base.compile().sql;
+      expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+      expect(innerSql, 'inner primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+        /order by\s+smart_search\.embedding\s*<=>/i,
+      );
+
+      const outerSql = outer.compile().sql;
+      expect(outerSql).toMatch(/"candidates"\."fileCreatedAt"\s+asc/i);
+      expect(outerSql).toContain('"candidates"."id"');
+      expect(countOuterOrderByExpressions(outerSql), 'outer must be 2 keys').toBe(2);
+    });
+
+    it('no-maxDistance path: single key is embedding, no distance WHERE predicate', () => {
+      const { base } = buildQueries(sut, { page: 1, size: 100 }, { ...baseOptions, maxDistance: undefined });
+      const innerSql = base.compile().sql;
+
+      expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+      expect(innerSql, 'primary ORDER BY must be on smart_search.embedding <=>').toMatch(
+        /order by\s+smart_search\.embedding\s*<=>/i,
+      );
+
+      // No WHERE predicate on the distance operator (<=>).
+      expect(innerSql).not.toMatch(/\(smart_search\.embedding <=> \$\d+\)\s*<=/i);
     });
   });
 });

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -322,6 +322,44 @@ export class SearchRepository {
       .execute();
   }
 
+  private buildSearchSmartQueries(
+    kysely: Kysely<DB>,
+    pagination: SearchPaginationOptions,
+    options: SmartSearchOptions,
+  ) {
+    const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);
+
+    const baseQuery = searchAssetBuilder(kysely, options)
+      .selectAll('asset')
+      .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
+      .$if(hasDistanceThreshold, (qb) =>
+        qb.where(sql<SqlBool>`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
+      )
+      .orderBy(sql`smart_search.embedding <=> ${options.embedding}`)
+      // Stable tiebreaker so offset-based pagination doesn't return overlapping pages
+      // when multiple assets have identical CLIP distances.
+      .orderBy('asset.id');
+
+    if (options.orderDirection) {
+      const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;
+      const candidates = baseQuery.limit(500).as('candidates');
+      const outerQuery = kysely
+        .selectFrom(candidates)
+        .selectAll()
+        // sql.raw is safe here — orderDirection is validated to 'asc'|'desc' by the AssetOrder enum
+        .orderBy(sql`"candidates"."fileCreatedAt" ${sql.raw(orderDirection)} nulls last`)
+        // Stable tiebreaker (same rationale as the base query)
+        .orderBy('candidates.id')
+        .limit(pagination.size + 1)
+        .offset((pagination.page - 1) * pagination.size);
+      return { kind: 'cte' as const, base: baseQuery, outer: outerQuery };
+    }
+
+    const outerQuery = baseQuery.limit(pagination.size + 1).offset((pagination.page - 1) * pagination.size);
+
+    return { kind: 'simple' as const, base: baseQuery, outer: outerQuery };
+  }
+
   @GenerateSql({
     params: [
       { page: 1, size: 200 },
@@ -344,42 +382,15 @@ export class SearchRepository {
       throw new Error(`Invalid value for 'size': ${pagination.size}`);
     }
 
-    const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);
-
     return this.db.transaction().execute(async (trx) => {
       await sql`set local vchordrq.probes = ${sql.lit(probes[VectorIndex.Clip])}`.execute(trx);
 
-      const baseQuery = searchAssetBuilder(trx, options)
-        .selectAll('asset')
-        .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
-        .$if(hasDistanceThreshold, (qb) =>
-          qb.where(sql<SqlBool>`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
-        )
-        .orderBy(sql`smart_search.embedding <=> ${options.embedding}`)
-        // Stable tiebreaker so offset-based pagination doesn't return overlapping pages
-        // when multiple assets have identical CLIP distances.
-        .orderBy('asset.id');
-
-      if (options.orderDirection) {
-        const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;
-        const candidates = baseQuery.limit(500).as('candidates');
-        const items = await trx
-          .selectFrom(candidates)
-          .selectAll()
-          // sql.raw is safe here — orderDirection is validated to 'asc'|'desc' by the AssetOrder enum
-          .orderBy(sql`"candidates"."fileCreatedAt" ${sql.raw(orderDirection)} nulls last`)
-          // Stable tiebreaker (same rationale as the base query)
-          .orderBy('candidates.id')
-          .limit(pagination.size + 1)
-          .offset((pagination.page - 1) * pagination.size)
-          .execute();
-        return paginationHelper(items as MapAsset[], pagination.size);
+      const { kind, outer } = this.buildSearchSmartQueries(trx, pagination, options);
+      if (kind === 'cte') {
+        const items = (await outer.execute()) as MapAsset[];
+        return paginationHelper(items, pagination.size);
       }
-
-      const items = await baseQuery
-        .limit(pagination.size + 1)
-        .offset((pagination.page - 1) * pagination.size)
-        .execute();
+      const items = await outer.execute();
       return paginationHelper(items, pagination.size);
     });
   }

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -335,10 +335,13 @@ export class SearchRepository {
       .$if(hasDistanceThreshold, (qb) =>
         qb.where(sql<SqlBool>`(smart_search.embedding <=> ${options.embedding}) <= ${options.maxDistance!}`),
       )
-      .orderBy(sql`smart_search.embedding <=> ${options.embedding}`)
-      // Stable tiebreaker so offset-based pagination doesn't return overlapping pages
-      // when multiple assets have identical CLIP distances.
-      .orderBy('asset.id');
+      // DO NOT add a secondary ORDER BY key on any column here.
+      // vchord's ordered index scan can only satisfy a single-key ORDER BY on
+      // `smart_search.embedding <=>`. Any additional sort key forces the planner
+      // to Parallel Seq Scan + in-memory sort (~15s on 200k rows vs ~200ms via
+      // vchord). Cross-page duplicates from identical embeddings are caught by
+      // the frontend dedup in web/src/lib/utils/search-dedup.ts.
+      .orderBy(sql`smart_search.embedding <=> ${options.embedding}`);
 
     if (options.orderDirection) {
       const orderDirection = options.orderDirection.toLowerCase() as OrderByDirection;

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -45,16 +45,13 @@
         return;
       }
 
-      if (append) {
-        // Primary guard against duplicate IDs across paginated searchSmart
-        // responses. The server's ORDER BY is single-key (smart_search.embedding
-        // <=>) so that vchord's ordered index scan can be used; identical
-        // embeddings (byte-identical image content) can then yield the same
-        // asset.id on adjacent pages. See docs/plans/2026-04-21-search-tiebreaker-design.md.
-        searchResults = dedupeAppend(searchResults, assets.items);
-      } else {
-        searchResults = assets.items;
-      }
+      // On append, dedupe by id — primary guard against duplicate rows across
+      // paginated searchSmart responses. The server's ORDER BY is single-key
+      // (smart_search.embedding <=>) so that vchord's ordered index scan can
+      // be used; identical embeddings (byte-identical image content) can then
+      // yield the same asset.id on adjacent pages. See
+      // docs/plans/2026-04-21-search-tiebreaker-design.md.
+      searchResults = append ? dedupeAppend(searchResults, assets.items) : assets.items;
       searchPage = page;
       hasMoreResults = assets.nextPage !== null;
     } catch {

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import SpaceSearchResults from '$lib/components/spaces/space-search-results.svelte';
   import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+  import { dedupeAppend } from '$lib/utils/search-dedup';
   import { buildSmartSearchParams, SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
   import { searchSmart, type AssetResponseDto } from '@immich/sdk';
 
@@ -45,11 +46,12 @@
       }
 
       if (append) {
-        // Defend against pagination overlaps (e.g., backend tie-breaker gaps or
-        // race-y page boundaries) so Svelte's keyed {#each} doesn't crash on duplicate IDs.
-        const existingIds = new Set(searchResults.map((a) => a.id));
-        const deduped = assets.items.filter((a) => !existingIds.has(a.id));
-        searchResults = [...searchResults, ...deduped];
+        // Primary guard against duplicate IDs across paginated searchSmart
+        // responses. The server's ORDER BY is single-key (smart_search.embedding
+        // <=>) so that vchord's ordered index scan can be used; identical
+        // embeddings (byte-identical image content) can then yield the same
+        // asset.id on adjacent pages. See docs/plans/2026-04-21-search-tiebreaker-design.md.
+        searchResults = dedupeAppend(searchResults, assets.items);
       } else {
         searchResults = assets.items;
       }

--- a/web/src/lib/utils/__tests__/search-dedup.spec.ts
+++ b/web/src/lib/utils/__tests__/search-dedup.spec.ts
@@ -1,0 +1,30 @@
+import { dedupeAppend } from '$lib/utils/search-dedup';
+import { describe, expect, it } from 'vitest';
+
+describe('dedupeAppend', () => {
+  it('appends new items and de-duplicates by id (primary cross-page scenario)', () => {
+    const result = dedupeAppend([{ id: 'a' }, { id: 'b' }, { id: 'c' }], [{ id: 'b' }, { id: 'd' }]);
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('returns existing array unchanged when every incoming item is a duplicate', () => {
+    const result = dedupeAppend([{ id: 'a' }, { id: 'b' }], [{ id: 'a' }, { id: 'b' }]);
+    expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(new Set(result.map((r) => r.id)).size).toBe(result.length);
+  });
+
+  it('handles empty existing (first page)', () => {
+    const result = dedupeAppend([], [{ id: 'a' }, { id: 'b' }]);
+    expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('handles empty incoming (end of pagination)', () => {
+    const result = dedupeAppend([{ id: 'a' }], []);
+    expect(result.map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('preserves order — new items append after existing, no reordering', () => {
+    const result = dedupeAppend([{ id: 'a' }, { id: 'b' }], [{ id: 'c' }, { id: 'a' }, { id: 'd' }]);
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+});

--- a/web/src/lib/utils/search-dedup.ts
+++ b/web/src/lib/utils/search-dedup.ts
@@ -1,0 +1,17 @@
+/**
+ * Append new paginated items to an existing array, de-duplicating by `id`.
+ *
+ * Used by smart-search-results.svelte to guard against the same asset.id
+ * appearing on adjacent paginated responses from searchSmart. The server
+ * does not currently apply a stable tiebreaker to identical CLIP distances
+ * (byte-identical image content), so offset pagination can yield the same
+ * asset.id on both pages 1 and 2. Dedup here prevents Svelte's keyed
+ * {#each} from crashing with each_key_duplicate.
+ *
+ * Pure function by design — both for testability and because the dedup
+ * is load-bearing (this is the only cross-page duplicate guard now).
+ */
+export function dedupeAppend<T extends { id: string }>(existing: T[], incoming: T[]): T[] {
+  const existingIds = new Set(existing.map((a) => a.id));
+  return existing.concat(incoming.filter((a) => !existingIds.has(a.id)));
+}


### PR DESCRIPTION
## Summary

Remove the fork-added `.orderBy('asset.id')` secondary sort from `searchSmart`'s inner query. This restores Postgres's use of the vchord `clip_index` ordered scan, closing the 3-5× perf gap with upstream Immich on instances with many photos.

## Root cause

`asset.id` is on a joined table (not `smart_search`), so vchord's ordered index scan can't satisfy the multi-key ORDER BY. The planner falls back to Parallel Seq Scan over the full `smart_search` table + in-memory sort. On a 200k-photo reporter instance (atlasshrugged), 17/17 slow smart-search queries showed `Parallel Seq Scan on smart_search` instead of `Index Scan using clip_index`, producing db-phase times of 3-16s vs upstream's <1s.

The outer CTE tiebreaker on `candidates.id` is retained — it sorts a materialized 500-row set with zero perf cost, and preserves determinism when multiple photos share the same `fileCreatedAt`.

## Known trade-off

For users with byte-identical duplicate image content (rare), infinite scroll may surface fewer unique results than exist: the same asset id can appear on both pages 1 and 2, and while the frontend dedup prevents duplicate rendering, it pushes a different asset off the viewed window. **This is not self-healing.** Consistent with upstream Immich, which ships without any tiebreaker. Future bug reports mentioning "missing results after infinite scroll" should land here.

## Test plan

- [x] Unit tests added for searchSmart SQL shape (all four permutations: non-CTE, CTE desc, CTE asc, no-maxDistance); each asserts exactly one inner ORDER BY expression AND that the primary key is `smart_search.embedding <=>`.
- [x] Frontend dedup extracted to `web/src/lib/utils/search-dedup.ts` and unit-tested (5 cases covering cross-page dedup, all-duplicate, empty existing, empty incoming, order preservation).
- [x] Reference SQL regenerated and verified (removed inner `"asset"."id"` from ORDER BY; outer `"candidates"."id"` retained).
- [x] Server + web: full `tsc --noEmit`, `svelte-check`, and unit suites green (3865 server tests, 1942 web tests).
- [ ] atlasshrugged verifies on 200k-photo instance after release: 3-16s → <1s, auto_explain shows `Index Scan using clip_index`.

## Follow-ups (separate PRs)

- Filter-suggestions batch burst caching (`getFilterSuggestions` fires 6 parallel seq-scans per call).
- `maxDistance` docs note (pending atlasshrugged's post-fix report).
- `asset.type` and composite `(ownerId, visibility, deletedAt, fileCreatedAt)` indexes (upstream candidates).

Design: `docs/plans/2026-04-21-search-tiebreaker-design.md`
Implementation plan: `docs/plans/2026-04-21-search-tiebreaker-impl.md`
