### PR TITLE
fix(download): serialize archive.append to fix S3 archive hang

### DIFF
--- a/server/src/repositories/storage.repository.spec.ts
+++ b/server/src/repositories/storage.repository.spec.ts
@@ -1,4 +1,5 @@
 import mockfs from 'mock-fs';
+import { Readable } from 'node:stream';
 import { CrawlOptionsDto } from 'src/dtos/library.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
@@ -204,5 +205,70 @@ describe(StorageRepository.name, () => {
         expect(actual.toSorted()).toEqual(expected.toSorted());
       });
     }
+  });
+
+  describe('createZipStream', () => {
+    it('does not start subsequent Readable entries until the previous one is drained', async () => {
+      // Regression for S3 archive hang: archiver-utils `normalizeInputSource()` pipes every
+      // input stream to a PassThrough immediately, which triggers `_read()` on the source via
+      // pipe's `resume()`. If `addFile()` forwards all inputs to `archive.append()` synchronously,
+      // every LazyS3Readable opens its S3 socket up-front — the exact behaviour that stalls the
+      // archive in `redirect` serve mode on a large selection.
+      const readCalls = [0, 0, 0];
+      const sources = readCalls.map(
+        (_, i) =>
+          new Readable({
+            read() {
+              readCalls[i]++;
+            },
+          }),
+      );
+
+      const zip = sut.createZipStream();
+      zip.stream.on('error', () => {}); // silence archive errors on test cleanup
+
+      for (const [i, source] of sources.entries()) {
+        zip.addFile(source, `file-${i}.txt`);
+      }
+
+      // Drain microtasks and process.nextTick callbacks so any eagerly-scheduled
+      // `_read()` fires before we assert.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(readCalls[1]).toBe(0);
+      expect(readCalls[2]).toBe(0);
+
+      zip.stream.destroy();
+      for (const source of sources) {
+        source.destroy();
+      }
+    });
+
+    it('produces an archive containing every Readable entry', async () => {
+      const sources = [
+        Readable.from([Buffer.from('content-0')]),
+        Readable.from([Buffer.from('content-1')]),
+        Readable.from([Buffer.from('content-2')]),
+      ];
+
+      const zip = sut.createZipStream();
+      for (const [i, source] of sources.entries()) {
+        zip.addFile(source, `file-${i}.txt`);
+      }
+      void zip.finalize();
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of zip.stream) {
+        chunks.push(chunk as Buffer);
+      }
+      const output = Buffer.concat(chunks).toString('binary');
+
+      expect(output).toContain('file-0.txt');
+      expect(output).toContain('file-1.txt');
+      expect(output).toContain('file-2.txt');
+      expect(output).toContain('content-0');
+      expect(output).toContain('content-1');
+      expect(output).toContain('content-2');
+    });
   });
 });

--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -84,16 +84,57 @@ export class StorageRepository {
 
   createZipStream(): ImmichZipStream {
     const archive = archiver('zip', { store: true });
+    let chain: Promise<void> = Promise.resolve();
 
-    const addFile = (input: string | Readable, filename: string) => {
-      if (typeof input === 'string') {
-        archive.file(input, { name: filename, mode: 0o644 });
-      } else {
-        archive.append(input, { name: filename, mode: 0o644 });
-      }
+    // archiver-utils' normalizeInputSource() pipes every Readable to a PassThrough as soon
+    // as archive.append() is called, which triggers _read() on the source. For S3-backed
+    // assets that maps 1:1 to an S3 socket open, so forwarding every source up-front saturates
+    // the connection pool and stalls the archive. Serialize archive.append() calls via a
+    // promise chain gated on the 'entry' event so only one source is ever being consumed.
+    const addFile = (input: string | Readable, filename: string): void => {
+      chain = chain
+        .then(
+          () =>
+            new Promise<void>((resolve, reject) => {
+              if (archive.destroyed) {
+                resolve();
+                return;
+              }
+              const source = typeof input === 'string' ? createReadStream(input) : input;
+              const onEntry = () => {
+                archive.off('error', onError);
+                archive.off('close', onClose);
+                resolve();
+              };
+              const onError = (error: Error) => {
+                archive.off('entry', onEntry);
+                archive.off('close', onClose);
+                reject(error);
+              };
+              const onClose = () => {
+                archive.off('entry', onEntry);
+                archive.off('error', onError);
+                resolve();
+              };
+              archive.once('entry', onEntry);
+              archive.once('error', onError);
+              archive.once('close', onClose);
+              archive.append(source, { name: filename, mode: 0o644 });
+            }),
+        )
+        .catch((error) => {
+          this.logger.warn(
+            `Failed to add '${filename}' to archive: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
     };
 
-    const finalize = () => archive.finalize();
+    const finalize = (): Promise<void> =>
+      chain.then(() => {
+        if (!archive.destroyed) {
+          return archive.finalize();
+        }
+      });
 
     return { stream: archive, addFile, finalize };
   }


### PR DESCRIPTION
## Summary

- Serialize `archive.append()` in `createZipStream()` via a promise chain gated on the `'entry'` event, so only one source is ever piped to its `PassThrough`.
- With this in place, `LazyS3Readable` from PR #397 finally keeps its promise: exactly one S3 socket open at a time, as originally intended.
- Regression test in `storage.repository.spec.ts` proves the eager-read bug and guards against it.

## Why

`archiver-utils.normalizeInputSource()` pipes every Readable to a fresh `PassThrough` the moment `archive.append()` is called, and the subsequent `source.resume()` triggers `_read()` on every source up-front. So every S3-backed entry opens its socket before archiver has consumed anything.

See `node_modules/.pnpm/archiver-utils@5.0.2/node_modules/archiver-utils/index.js` — `normalizeInputSource` always does `source.pipe(new PassThrough())` synchronously.

## Not caused by #397 — this is a pre-existing bug in `createZipStream()`

Before PR #397, the socket pile-up came from two compounding sources:

1. The `await backend.get()` loop in `downloadArchive` itself.
2. The eager `archive.append()` inside `createZipStream` / `addFile`.

#397 removed (1) by introducing `LazyS3Readable`, but (2) was left intact — and (2) alone is sufficient to re-open all N sockets, because the eager pipe triggers `LazyS3Readable._read()` which in turn fires `backend.get()`. Net effect after #397 is the same as before: N simultaneous S3 connections.

The 150-asset hang therefore existed both before and after #397; the symptoms just shifted (thumbnails keep working in `redirect` mode now, but the archive still stalls at 0%).

## Effect by serve mode

- **`serveMode: proxy`** (original report): both thumbnails and the archive stall, because all N S3 sockets are held by pending archive entries, exhausting the AWS SDK connection pool.
- **`serveMode: redirect`** (follow-up report after #397 merged): thumbnails keep working — presigned URLs, no server-side socket — but the archive itself still stalls at 0% because entry 1's socket competes with entries 2..N for pool capacity.

Both modes are fixed by making `createZipStream()` serialize its `append()`s.

## Why this approach

The `2026-04-21-s3-download-hang-design.md` plan considered "Sequential `await`-before-append" and rejected it on the grounds that "archiver does not expose per-entry completion signals." That's not quite accurate: archiver emits an `'entry'` event per finished entry, which is exactly the signal needed. Using it lets us keep `download.service.ts` and `LazyS3Readable` unchanged.

## Process

TDD with red-validation per house rules:
1. Wrote failing test (`readCalls[1] !== 0` on buggy code).
2. Confirmed RED against unmodified `createZipStream()`.
3. Applied sequential-chain fix.
4. Confirmed GREEN.
5. Reverted fix → RED again; restored fix → GREEN again.

## Test plan

- [x] `pnpm test` (server) — 3869 pass, 8 skipped, 0 fail
- [x] `pnpm run lint --max-warnings 0` — clean
- [x] `pnpm run check` (tsc --noEmit) — clean
- [ ] Manual smoke on an S3 instance in `serveMode: redirect`: download ~150 assets, confirm the archive actually starts streaming, confirm `ss -tnp | grep <s3-port>` shows only 1 ESTABLISHED connection at a time
- [ ] Manual smoke on `serveMode: proxy`: same download flow; thumbnails keep loading, archive streams

## Files changed

| File | Change |
| --- | --- |
| `server/src/repositories/storage.repository.ts` | Replace the fire-and-forget `archive.append()` in `createZipStream()` with a chain that awaits `'entry'` per source. |
| `server/src/repositories/storage.repository.spec.ts` | Two tests: the bug regression (serialization), and an end-to-end archive-correctness guard. |

No changes to `download.service.ts`, the controller, `S3StorageBackend`, or any interface.