### PR TITLE
ci(release-mobile): reject version override without v prefix

### DIFF
--- a/.github/workflows/gallery-release-mobile.yml
+++ b/.github/workflows/gallery-release-mobile.yml
@@ -100,8 +100,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Manual override always wins.
+          # Manual override always wins. Enforce the same v-prefixed semver
+          # phase 2's discover step requires — a bare "4.53.0" draft is
+          # invisible to phase 2 and silently fails the release.
           if [[ -n "$INPUT_VERSION" ]]; then
+            if [[ ! "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid version override: '$INPUT_VERSION' (expected v<major>.<minor>.<patch>, e.g. v4.53.0)"
+              exit 1
+            fi
             echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
             echo "Version: $INPUT_VERSION — manual override"
             exit 0


### PR DESCRIPTION
## Summary

- Phase 2 (`gallery-release.yml`) discovers drafts via `^v[0-9]+\.[0-9]+\.[0-9]+$`, so a `workflow_dispatch` of `gallery-release-mobile.yml` with `version: 4.53.0` (no `v`) creates a draft that's invisible to the server release.
- This actually happened on v4.53.0 — phase 2 ran 7 minutes in and failed with "No pending mobile release draft found." before anything else surfaced.
- Validate the override at the entry point so the mistake stops phase 1 immediately with a clear, actionable message instead of silently producing a broken draft.

## Test plan

- [ ] Trigger `Release Mobile P1` with `version=4.99.0` (no `v`) — version job should fail with the new error.
- [ ] Trigger with `version=v4.99.0` — version job should accept it.
- [ ] Trigger with no `version` input — auto-version path unchanged.