### PR TITLE
fix(server): clean user-scoped S3 prefixes on user delete

### DIFF
--- a/.github/workflows/storage-migration-tests.yml
+++ b/.github/workflows/storage-migration-tests.yml
@@ -87,6 +87,9 @@ jobs:
       - name: 'Phase: copy-asset-sidecar-s3'
         run: pnpm tsx src/storage-migration.ts copy-asset-sidecar-s3
 
+      - name: 'Phase: user-delete-s3-orphans'
+        run: pnpm tsx src/storage-migration.ts user-delete-s3-orphans
+
       - name: 'Phase: no-files'
         run: pnpm tsx src/storage-migration.ts no-files
 

--- a/docs/plans/2026-04-22-s3-orphan-cleanup-user-delete-design.md
+++ b/docs/plans/2026-04-22-s3-orphan-cleanup-user-delete-design.md
@@ -1,0 +1,171 @@
+# S3 Orphan Cleanup on User Delete — Design
+
+## Context
+
+`handleUserDelete` (`server/src/services/user.service.ts:261`) removes a deleted user's 5 disk folders via `fs.rm` and silently skips S3. On instances running `IMMICH_STORAGE_BACKEND=s3`, every deleted user's data stays in the bucket forever — assets, thumbnails, encoded video, profile images. Flagged as "tracked separately" in `2026-04-21-s3-relative-path-audit-design.md`; this design is the follow-up.
+
+S3 key layout (all writes route through `StorageCore.getRelative*Path`): `<folder>/<ownerId>/<nested>/<filename>`. The four user-scoped folders written on S3:
+
+- `upload/<userId>/<nested>/<assetId><ext>` — originals, sidecars, motion-photo `-MP.mp4`
+- `profile/<userId>/<filename>` — profile images
+- `thumbs/<userId>/<assetId>_*.{webp,jpeg}` and `thumbs/<userId>/<personId>.jpeg` — asset and person thumbnails (same prefix, both swept)
+- `encoded-video/<userId>/<assetId>.mp4` — transcodes
+
+Two `StorageFolder` enum values are intentionally excluded from the S3 sweep:
+
+- `Library` — storage-template migration is a no-op on S3 (guard at `StorageCore.moveFile:189`, added by PR #391), so S3 never writes to `library/`. Disk cleanup for `library/<storageLabel ?? userId>/…` remains via existing `fs.rm`.
+- `Backups` — admin/global scope, not per-user.
+
+Related prior work: PR #398 (S3-relative-path audit). That PR's design doc flagged this exact bug as out of scope.
+
+## Out of scope
+
+- Backfill of orphans from pre-fix deletions. Documented workaround: `aws s3 rm --recursive s3://<bucket>/upload/<userId>/` per prefix, one prefix at a time. If an operator reports meaningful bucket bloat, add an admin endpoint as a follow-up PR.
+- Shared/album assets — no duplication; S3 objects live under the owner's prefix only.
+- External library assets — always absolute disk paths, never in the S3 bucket.
+- Disk-only deployments — `StorageService.getS3Backend()` returns `undefined`, the S3 block is skipped (no client construction cost).
+- Per-prefix object-count telemetry — cosmetic, adds SDK accounting complexity for no functional value.
+- Concurrent deletion across prefixes — sequential execution deliberately bounds the throttling risk flagged below.
+
+## Changes
+
+### C1. Add `deletePrefix(prefix)` to the `StorageBackend` interface
+
+```ts
+// server/src/interfaces/storage-backend.interface.ts
+interface StorageBackend {
+  // ... existing ...
+  /** Delete all objects/files under the given key prefix. Idempotent. No-op if nothing matches. */
+  deletePrefix(prefix: string): Promise<void>;
+}
+```
+
+**DiskStorageBackend**: `fs.rm(join(this.mediaLocation, prefix), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })`. Retry options mirror the existing `storageRepository.unlinkDir` (`storage.repository.ts:159`) to preserve current semantics.
+
+**S3StorageBackend**: `ListObjectsV2` paginated via `ContinuationToken` feeding `DeleteObjects` in 1000-key batches (both the `MaxKeys` and `DeleteObjects.Objects` SDK caps). Sequential; no concurrency — worsens throttling risk. Continue-on-error: on per-batch failures log at `warn` with the error's `Code`/`Message` (for `DeleteObjectsOutput.Errors`) or the thrown exception (for `List`/`Delete` transport errors); do not throw.
+
+**No input validation on prefix.** A bare trailing-slash guard (e.g. rejecting `""`) is a half-measure — `"a/"` would still wipe anything under `a/` across the bucket. The real invariant lives at the call site: prefixes are always `<StorageFolder>/<uuid>/` built from an enum value and a UUID-validated `user.id`. If another caller adopts `deletePrefix`, their own review carries the scope-correctness check.
+
+**Rationale for `deletePrefix` over a narrower `deleteUserScope(user)` helper**: composable, matches the S3 SDK primitive, reusable if future bulk-delete needs emerge, and keeps the backend interface domain-agnostic.
+
+### C2. Rewrite `handleUserDelete` to call both backends
+
+```ts
+const diskFolders = [
+  StorageCore.getLibraryFolder(user),
+  StorageCore.getFolderLocation(StorageFolder.Upload, user.id),
+  StorageCore.getFolderLocation(StorageFolder.Profile, user.id),
+  StorageCore.getFolderLocation(StorageFolder.Thumbnails, user.id),
+  StorageCore.getFolderLocation(StorageFolder.EncodedVideo, user.id),
+];
+
+// Disk: unchanged. Safe no-op if nothing lives there (fs.rm with force:true swallows ENOENT).
+for (const folder of diskFolders) {
+  this.logger.warn(`Removing user from filesystem: ${folder}`);
+  await this.storageRepository.unlinkDir(folder, { recursive: true, force: true });
+}
+
+// S3: if configured, delete each user-scoped relative prefix.
+// Library/Backups intentionally excluded — see Context.
+const s3 = StorageService.getS3Backend();
+if (s3) {
+  const userScopedS3Folders = [
+    StorageFolder.Upload,
+    StorageFolder.Profile,
+    StorageFolder.Thumbnails,
+    StorageFolder.EncodedVideo,
+  ] as const;
+  for (const folder of userScopedS3Folders) {
+    const prefix = `${folder}/${user.id}/`;
+    try {
+      await s3.deletePrefix(prefix);
+      this.logger.log(`Cleaned S3 prefix ${prefix}`);
+    } catch (error) {
+      this.logger.warn(`Failed to clean S3 prefix ${prefix} for user ${user.id}`, error);
+    }
+  }
+}
+```
+
+**Mixed-backend semantics**: both blocks run unconditionally (mod the S3-configured check). A disk instance skips S3 via `!getS3Backend()`. An S3 instance still runs the disk loop — safe because `/data/library/…` etc. are empty or absent on an S3-born instance (`fs.rm {force:true}` swallows ENOENT).
+
+### C3. Logging
+
+Per-prefix success log: `Cleaned S3 prefix upload/<uuid>/`. No object count — the SDK doesn't expose a cheap cumulative count without extra accounting, and the value is cosmetic. Per-prefix failure log: `warn` with the error object. On BullMQ retry, cleaned-prefix logs appear twice — acceptable; retries are rare and a duplicate log is harmless.
+
+## Testing
+
+### Unit
+
+`server/src/backends/s3-storage.backend.spec.ts` — new `describe('deletePrefix', ...)`:
+
+- 0 matches (`ListObjectsV2` returns empty `Contents`) → no `DeleteObjectsCommand` sent; returns cleanly.
+- 1 batch (`Contents: [3 keys]`, `IsTruncated: false`) → 1 list call, 1 delete call with the 3 `Key`s.
+- 2 list pages (`IsTruncated: true` + `NextContinuationToken` on first call, false on second) → 2 list calls, 2 delete calls.
+- Partial failure: `DeleteObjectsCommand` resolves with `Errors: [{Key, Code, Message}]` (HTTP 200, not a thrown exception) → method logs the error entries at `warn`, does not throw, pagination continues.
+- `ListObjectsV2Command` throws (transport/auth) → logs at `warn`, returns without attempting delete.
+
+`server/src/backends/disk-storage.backend.spec.ts` — `deletePrefix` delegates to `fs.rm` with `{recursive: true, force: true, maxRetries: 5, retryDelay: 100}` on the `mediaLocation`-joined path.
+
+`server/src/services/user.service.spec.ts` — extend `handleUserDelete` block:
+
+- S3 configured → 5 `unlinkDir` calls AND 4 `s3.deletePrefix` calls with exactly `upload/<id>/`, `profile/<id>/`, `thumbs/<id>/`, `encoded-video/<id>/`.
+- S3 not configured (`getS3Backend` returns `undefined`) → only `unlinkDir`, no S3 mock reached. Regression guard.
+- One `s3.deletePrefix` throws → other 3 prefixes still attempted, disk loop still runs, `albumRepository.deleteAll` + `userRepository.delete` still run, `UserDelete` event still emitted. No orphan DB state.
+
+### Integration
+
+`server/src/backends/s3-storage.backend.integration.spec.ts` (gated on `IMMICH_TEST_DOCKER=true`): single case.
+
+Pre-populate MinIO with 2500 keys under `test-prefix/`. Call `deletePrefix('test-prefix/')`. Assert `ListObjectsV2` on that prefix returns 0 keys post-delete. 2500 was chosen to cross both the 1000-key `ListObjectsV2` pagination boundary AND the 1000-key `DeleteObjects` batch boundary — one test exercises both.
+
+### E2E
+
+New phase `phaseUserDeleteS3Orphans` in `e2e/src/storage-migration.ts`:
+
+1. Admin login.
+2. `POST /admin/users` — create a disposable user (unique email: `orphan-test-<uniqueSuffix>@example.com`; capture the returned `id` from the response).
+3. Login as the disposable user.
+4. Upload 2 PNGs via the harness's `uploadAsset` helper.
+5. `waitForProcessing` (drain metadata/thumbnails/etc.).
+6. Enumerate MinIO keys under `upload/<id>/`, `thumbs/<id>/`, `profile/<id>/`, `encoded-video/<id>/`. Assert `upload/` and `thumbs/` non-empty. Do not assert `profile/` or `encoded-video/` — they may be empty depending on upload timing.
+7. `DELETE /admin/users/<id>` body `{ force: true }` — queues `UserDelete` immediately (bypasses `deleteDelay`).
+8. `waitForProcessing` (drain the `BackgroundTask` queue, where `UserDelete` runs).
+9. Re-enumerate all 4 prefixes → assert all return 0 keys.
+
+One new helper needed: MinIO list-by-prefix wrapper using `mc ls --recursive` (or AWS CLI). Chosen during implementation. Per `feedback_storage_migration_harness_conventions.md` the harness is self-contained; `createPng()` counter burn may be required if other phases collide.
+
+Wire into `.github/workflows/storage-migration-tests.yml` after `phaseCopyAssetSidecarS3` — keeps the S3-live phases grouped.
+
+### Manual smoke (via `/rc-personal`)
+
+1. Create a disposable user on pierre.opennoodle.de, upload 2–3 photos, wait for thumbs.
+2. Admin delete with `force: true`.
+3. `docker logs gallery-server | grep 'Cleaned S3 prefix'` → see 4 lines.
+4. Wasabi console → confirm `upload/<deleted-uuid>/` returns 0 objects.
+
+## Rollout
+
+- Single PR off today's `main` (already contains PR #398 — S3-relative-path audit).
+- No database migration, no new env vars, no feature flag. Strictly additive; disk-only deployments see no difference.
+- Rough diff budget: ~120 LOC production (interface + 2 impls + user.service changes) + ~220 LOC unit tests + ~60 LOC integration test + ~100 LOC e2e phase + workflow wire-up. If the plan grows materially beyond this, re-scope before continuing.
+- Branch: `fix/s3-orphan-cleanup-user-delete`. PR title prefix: `fix(server)`.
+
+## Risks
+
+- **Bucket-wide delete from a misconstructed prefix.** Prefix is always `<StorageFolder enum>/<UUID>/`, never user-controlled input. Integration test uses non-overlapping `test-prefix/` scope. No guard inside `deletePrefix` itself — scope correctness lives at the call site.
+- **Silent S3 throttling under high key counts.** Per-prefix `try/catch` with `warn` log. Operator-visible via log stream. Sequential (not parallel) across prefixes and inside pagination naturally bounds request rate. If throttling becomes an ops issue in practice, add backoff in `S3StorageBackend.deletePrefix` as a follow-up.
+- **Interface churn breaks mocked tests.** Adding `deletePrefix` will cause TS errors wherever a mock `StorageBackend` literal is constructed. Known sites: `test/utils.ts` mock factory (if backends are covered) and `base.service.spec.ts`. Sweep during TDD — budget ~5 spec files for `deletePrefix: vi.fn()` stubs.
+- **Job retry logs a duplicate "Cleaned" line.** BullMQ can re-run `UserDelete`. A retry will log `Cleaned S3 prefix …` again for an already-empty prefix. Acceptable — no data integrity impact; alternative (count-before-log) adds a round trip.
+- **E2E test-user collisions.** Unique email suffix per phase invocation. Capture ID from `POST /admin/users` response, never assume a fixed UUID.
+
+## Self-review findings (fixed before presenting)
+
+Ran `code-reviewer` subagent on the draft. Issues surfaced and addressed:
+
+- Library/Backups exclusion documented explicitly rather than hardcoded 4 strings without justification.
+- Pagination numbers corrected: `ListObjectsV2.MaxKeys` and `DeleteObjects.Objects` are both capped at 1000. Integration test targets 2500 keys to exercise both boundaries.
+- `DeleteObjects` partial-failure is HTTP 200 with `Errors` field, not a thrown exception. Unit test updated to assert log inspection of `response.Errors`.
+- Force-delete API verified: `DELETE /admin/users/:id` body `{ force: true }` queues `JobName.UserDelete` immediately (via `user-admin.controller.ts:73` → `user-admin.service.ts:109`).
+- Trailing-slash guard dropped as a half-measure; scope correctness documented as call-site invariant instead.
+- Shared/album/external-library assets explicitly documented as no-ops in Out of scope.

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -438,6 +438,15 @@ export function minioSetupAlias(): void {
   dockerExec('minio', 'mc alias set local http://localhost:9000 minioadmin minioadmin');
 }
 
+export function minioCountPrefix(prefix: string): number {
+  try {
+    const out = dockerExec('minio', `mc ls --recursive local/immich-test/${prefix} 2>/dev/null | wc -l`);
+    return Number.parseInt(out, 10);
+  } catch {
+    return 0;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Phase 1: Setup
 // ---------------------------------------------------------------------------
@@ -1916,6 +1925,69 @@ async function phaseCopyAssetSidecarS3(): Promise<void> {
   console.log('=== Phase: copy-asset-sidecar-s3 complete ===');
 }
 
+async function phaseUserDeleteS3Orphans(): Promise<void> {
+  console.log('=== Phase: user-delete-s3-orphans ===');
+  const adminToken = await loginAdmin();
+
+  // Unique email per run so the phase is idempotent when re-run standalone against
+  // a DB that already has a soft-deleted orphan-test user from a previous attempt.
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const email = `orphan-test-${suffix}@example.com`;
+  const password = 'orphanTest1234';
+
+  const created = await api('POST', '/admin/users', {
+    body: { email, password, name: 'Orphan Test User' },
+    token: adminToken,
+  });
+  const userId: string = created.id;
+  assert.ok(userId, 'Expected created user to have an id');
+
+  const userToken = await loginUser(email, password);
+
+  // Burn the createPng counter past any reuse overlap with other phases.
+  for (let i = 0; i < 50; i++) {
+    createPng();
+  }
+  const firstUpload = await uploadAsset(userToken, `orphan-${suffix}-1.png`, createPng());
+  const secondUpload = await uploadAsset(userToken, `orphan-${suffix}-2.png`, createPng());
+  assert.ok(firstUpload.id && secondUpload.id, 'Expected both uploads to return an id');
+
+  await waitForProcessing(adminToken);
+
+  minioSetupAlias();
+
+  const uploadPrefix = `upload/${userId}/`;
+  const profilePrefix = `profile/${userId}/`;
+  const thumbsPrefix = `thumbs/${userId}/`;
+  const encodedVideoPrefix = `encoded-video/${userId}/`;
+
+  const preUpload = minioCountPrefix(uploadPrefix);
+  const preThumbs = minioCountPrefix(thumbsPrefix);
+  assert.ok(preUpload > 0, `Pre-delete: expected objects under ${uploadPrefix}, got ${preUpload}`);
+  assert.ok(preThumbs > 0, `Pre-delete: expected objects under ${thumbsPrefix}, got ${preThumbs}`);
+  console.log(
+    `  Pre-delete: upload=${preUpload} thumbs=${preThumbs} profile=${minioCountPrefix(
+      profilePrefix,
+    )} encoded-video=${minioCountPrefix(encodedVideoPrefix)}`,
+  );
+
+  await api('DELETE', `/admin/users/${userId}`, { body: { force: true }, token: adminToken });
+
+  await waitForProcessing(adminToken);
+
+  const postUpload = minioCountPrefix(uploadPrefix);
+  const postProfile = minioCountPrefix(profilePrefix);
+  const postThumbs = minioCountPrefix(thumbsPrefix);
+  const postEncodedVideo = minioCountPrefix(encodedVideoPrefix);
+  assert.equal(postUpload, 0, `Post-delete: ${uploadPrefix} should be empty, got ${postUpload}`);
+  assert.equal(postProfile, 0, `Post-delete: ${profilePrefix} should be empty, got ${postProfile}`);
+  assert.equal(postThumbs, 0, `Post-delete: ${thumbsPrefix} should be empty, got ${postThumbs}`);
+  assert.equal(postEncodedVideo, 0, `Post-delete: ${encodedVideoPrefix} should be empty, got ${postEncodedVideo}`);
+
+  console.log(`  User ${userId} deleted; all 4 S3 prefixes report 0 objects.`);
+  console.log('=== Phase: user-delete-s3-orphans complete ===');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -2005,9 +2077,13 @@ async function main() {
         await phaseCopyAssetSidecarS3();
         break;
       }
+      case 'user-delete-s3-orphans': {
+        await phaseUserDeleteS3Orphans();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped, template-disk-baseline, copy-asset-sidecar-s3`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped, template-disk-baseline, copy-asset-sidecar-s3, user-delete-s3-orphans`,
         );
       }
     }

--- a/server/src/backends/disk-storage.backend.spec.ts
+++ b/server/src/backends/disk-storage.backend.spec.ts
@@ -97,4 +97,37 @@ describe('DiskStorageBackend', () => {
       expect(existsSync(filePath)).toBe(true);
     });
   });
+
+  describe('deletePrefix', () => {
+    it('should recursively remove all files under the prefix', async () => {
+      await mkdir(join(testDir, 'upload/user-a/aa/bb'), { recursive: true });
+      await writeFile(join(testDir, 'upload/user-a/aa/bb/one.jpg'), 'one');
+      await writeFile(join(testDir, 'upload/user-a/aa/bb/two.jpg'), 'two');
+      await mkdir(join(testDir, 'upload/user-a/cc/dd'), { recursive: true });
+      await writeFile(join(testDir, 'upload/user-a/cc/dd/three.jpg'), 'three');
+
+      await backend.deletePrefix('upload/user-a/');
+
+      expect(existsSync(join(testDir, 'upload/user-a'))).toBe(false);
+    });
+
+    it('should be idempotent when the prefix does not exist', async () => {
+      await expect(backend.deletePrefix('upload/ghost/')).resolves.toBeUndefined();
+    });
+
+    it('should not touch siblings outside the prefix', async () => {
+      await mkdir(join(testDir, 'upload/user-a/aa'), { recursive: true });
+      await writeFile(join(testDir, 'upload/user-a/aa/victim.jpg'), 'victim');
+      await mkdir(join(testDir, 'upload/user-b/aa'), { recursive: true });
+      await writeFile(join(testDir, 'upload/user-b/aa/survivor.jpg'), 'survivor');
+      await mkdir(join(testDir, 'thumbs/user-a'), { recursive: true });
+      await writeFile(join(testDir, 'thumbs/user-a/thumb.webp'), 'thumb');
+
+      await backend.deletePrefix('upload/user-a/');
+
+      expect(existsSync(join(testDir, 'upload/user-a'))).toBe(false);
+      expect(existsSync(join(testDir, 'upload/user-b/aa/survivor.jpg'))).toBe(true);
+      expect(existsSync(join(testDir, 'thumbs/user-a/thumb.webp'))).toBe(true);
+    });
+  });
 });

--- a/server/src/backends/disk-storage.backend.ts
+++ b/server/src/backends/disk-storage.backend.ts
@@ -1,5 +1,5 @@
 import { createReadStream, createWriteStream } from 'node:fs';
-import { access, mkdir, stat, unlink, writeFile } from 'node:fs/promises';
+import { access, mkdir, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -48,6 +48,10 @@ export class DiskStorageBackend implements StorageBackend {
 
   async delete(key: string): Promise<void> {
     await unlink(this.resolvePath(key));
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    await rm(this.resolvePath(prefix), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 
   getServeStrategy(key: string, _contentType: string): Promise<ServeStrategy> {

--- a/server/src/backends/s3-storage.backend.integration.spec.ts
+++ b/server/src/backends/s3-storage.backend.integration.spec.ts
@@ -1,4 +1,4 @@
-import { CreateBucketCommand, S3Client } from '@aws-sdk/client-s3';
+import { CreateBucketCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
@@ -6,6 +6,19 @@ import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainer
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const canRunDocker = process.env.IMMICH_TEST_DOCKER === 'true';
+
+async function countKeysForPrefix(client: S3Client, bucket: string, prefix: string): Promise<number> {
+  let count = 0;
+  let continuationToken: string | undefined;
+  do {
+    const page = await client.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix, ContinuationToken: continuationToken }),
+    );
+    count += page.Contents?.length ?? 0;
+    continuationToken = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (continuationToken);
+  return count;
+}
 
 describe.skipIf(!canRunDocker)('S3StorageBackend integration (MinIO)', () => {
   let container: StartedTestContainer;
@@ -94,6 +107,44 @@ describe.skipIf(!canRunDocker)('S3StorageBackend integration (MinIO)', () => {
       expect(strategy.url).toContain('X-Amz');
     }
   });
+
+  it(
+    'deletePrefix sweeps objects across list-pagination and delete-batch boundaries',
+    async () => {
+      // 2500 keys exercises both SDK caps in one test: ListObjectsV2 returns 1000 per page,
+      // DeleteObjects takes 1000 per call. Three pages in, three batches out.
+      const endpoint = `http://${container.getHost()}:${container.getMappedPort(9000)}`;
+      const verifyClient = new S3Client({
+        region: 'us-east-1',
+        endpoint,
+        forcePathStyle: true,
+        credentials: { accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin' },
+      });
+
+      const prefix = 'delete-prefix-boundary/';
+      const totalKeys = 2500;
+      const body = Buffer.from('x');
+      const concurrency = 100;
+      for (let offset = 0; offset < totalKeys; offset += concurrency) {
+        const batch: Promise<unknown>[] = [];
+        for (let i = 0; i < concurrency && offset + i < totalKeys; i++) {
+          batch.push(backend.put(`${prefix}object-${offset + i}.txt`, body));
+        }
+        await Promise.all(batch);
+      }
+
+      const preCount = await countKeysForPrefix(verifyClient, bucket, prefix);
+      expect(preCount).toBe(totalKeys);
+
+      await backend.deletePrefix(prefix);
+
+      const postCount = await countKeysForPrefix(verifyClient, bucket, prefix);
+      expect(postCount).toBe(0);
+
+      verifyClient.destroy();
+    },
+    120_000,
+  );
 
   it('should stream content in proxy mode', async () => {
     // Create a second backend instance in proxy mode

--- a/server/src/backends/s3-storage.backend.integration.spec.ts
+++ b/server/src/backends/s3-storage.backend.integration.spec.ts
@@ -108,43 +108,39 @@ describe.skipIf(!canRunDocker)('S3StorageBackend integration (MinIO)', () => {
     }
   });
 
-  it(
-    'deletePrefix sweeps objects across list-pagination and delete-batch boundaries',
-    async () => {
-      // 2500 keys exercises both SDK caps in one test: ListObjectsV2 returns 1000 per page,
-      // DeleteObjects takes 1000 per call. Three pages in, three batches out.
-      const endpoint = `http://${container.getHost()}:${container.getMappedPort(9000)}`;
-      const verifyClient = new S3Client({
-        region: 'us-east-1',
-        endpoint,
-        forcePathStyle: true,
-        credentials: { accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin' },
-      });
+  it('deletePrefix sweeps objects across list-pagination and delete-batch boundaries', async () => {
+    // 2500 keys exercises both SDK caps in one test: ListObjectsV2 returns 1000 per page,
+    // DeleteObjects takes 1000 per call. Three pages in, three batches out.
+    const endpoint = `http://${container.getHost()}:${container.getMappedPort(9000)}`;
+    const verifyClient = new S3Client({
+      region: 'us-east-1',
+      endpoint,
+      forcePathStyle: true,
+      credentials: { accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin' },
+    });
 
-      const prefix = 'delete-prefix-boundary/';
-      const totalKeys = 2500;
-      const body = Buffer.from('x');
-      const concurrency = 100;
-      for (let offset = 0; offset < totalKeys; offset += concurrency) {
-        const batch: Promise<unknown>[] = [];
-        for (let i = 0; i < concurrency && offset + i < totalKeys; i++) {
-          batch.push(backend.put(`${prefix}object-${offset + i}.txt`, body));
-        }
-        await Promise.all(batch);
+    const prefix = 'delete-prefix-boundary/';
+    const totalKeys = 2500;
+    const body = Buffer.from('x');
+    const concurrency = 100;
+    for (let offset = 0; offset < totalKeys; offset += concurrency) {
+      const batch: Promise<unknown>[] = [];
+      for (let i = 0; i < concurrency && offset + i < totalKeys; i++) {
+        batch.push(backend.put(`${prefix}object-${offset + i}.txt`, body));
       }
+      await Promise.all(batch);
+    }
 
-      const preCount = await countKeysForPrefix(verifyClient, bucket, prefix);
-      expect(preCount).toBe(totalKeys);
+    const preCount = await countKeysForPrefix(verifyClient, bucket, prefix);
+    expect(preCount).toBe(totalKeys);
 
-      await backend.deletePrefix(prefix);
+    await backend.deletePrefix(prefix);
 
-      const postCount = await countKeysForPrefix(verifyClient, bucket, prefix);
-      expect(postCount).toBe(0);
+    const postCount = await countKeysForPrefix(verifyClient, bucket, prefix);
+    expect(postCount).toBe(0);
 
-      verifyClient.destroy();
-    },
-    120_000,
-  );
+    verifyClient.destroy();
+  }, 120_000);
 
   it('should stream content in proxy mode', async () => {
     // Create a second backend instance in proxy mode

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -12,6 +12,8 @@ vi.mock('@aws-sdk/client-s3', () => {
     GetObjectCommand: vi.fn((input: any) => ({ input, _type: 'GetObjectCommand' })),
     HeadObjectCommand: vi.fn((input: any) => ({ input, _type: 'HeadObjectCommand' })),
     DeleteObjectCommand: vi.fn((input: any) => ({ input, _type: 'DeleteObjectCommand' })),
+    ListObjectsV2Command: vi.fn((input: any) => ({ input, _type: 'ListObjectsV2Command' })),
+    DeleteObjectsCommand: vi.fn((input: any) => ({ input, _type: 'DeleteObjectsCommand' })),
   };
 });
 
@@ -161,6 +163,87 @@ describe('S3StorageBackend', () => {
 
       await cleanup();
       expect(existsSync(tempPath)).toBe(false);
+    });
+  });
+
+  describe('deletePrefix', () => {
+    it('should not send DeleteObjectsCommand when the prefix matches nothing', async () => {
+      mockSend.mockResolvedValueOnce({ Contents: [], IsTruncated: false });
+
+      await backend.deletePrefix('upload/ghost/');
+
+      const listInputs = mockSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'ListObjectsV2Command')
+        .map(([cmd]) => cmd.input);
+      const deleteInputs = mockSend.mock.calls.filter(([cmd]) => cmd._type === 'DeleteObjectsCommand');
+      expect(listInputs).toEqual([expect.objectContaining({ Bucket: 'test-bucket', Prefix: 'upload/ghost/' })]);
+      expect(deleteInputs).toEqual([]);
+    });
+
+    it('should list then delete in a single batch for one page of results', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'upload/u/aa/1.jpg' }, { Key: 'upload/u/aa/2.jpg' }, { Key: 'upload/u/bb/3.jpg' }],
+          IsTruncated: false,
+        })
+        .mockResolvedValueOnce({ Deleted: [{}, {}, {}] });
+
+      await backend.deletePrefix('upload/u/');
+
+      const listCalls = mockSend.mock.calls.filter(([cmd]) => cmd._type === 'ListObjectsV2Command');
+      const deleteInputs = mockSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'DeleteObjectsCommand')
+        .map(([cmd]) => cmd.input);
+      expect(listCalls).toHaveLength(1);
+      expect(deleteInputs).toEqual([
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          Delete: {
+            Objects: [{ Key: 'upload/u/aa/1.jpg' }, { Key: 'upload/u/aa/2.jpg' }, { Key: 'upload/u/bb/3.jpg' }],
+          },
+        }),
+      ]);
+    });
+
+    it('should paginate via ContinuationToken across multiple pages', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'upload/u/a.jpg' }],
+          IsTruncated: true,
+          NextContinuationToken: 'token-page-2',
+        })
+        .mockResolvedValueOnce({ Deleted: [{}] })
+        .mockResolvedValueOnce({ Contents: [{ Key: 'upload/u/b.jpg' }], IsTruncated: false })
+        .mockResolvedValueOnce({ Deleted: [{}] });
+
+      await backend.deletePrefix('upload/u/');
+
+      const listInputs = mockSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'ListObjectsV2Command')
+        .map(([cmd]) => cmd.input);
+      const deleteCalls = mockSend.mock.calls.filter(([cmd]) => cmd._type === 'DeleteObjectsCommand');
+      expect(listInputs).toHaveLength(2);
+      expect(listInputs[0].ContinuationToken).toBeUndefined();
+      expect(listInputs[1].ContinuationToken).toBe('token-page-2');
+      expect(deleteCalls).toHaveLength(2);
+    });
+
+    it('should throw when DeleteObjects returns a non-empty Errors field', async () => {
+      mockSend
+        .mockResolvedValueOnce({ Contents: [{ Key: 'upload/u/x.jpg' }], IsTruncated: false })
+        .mockResolvedValueOnce({
+          Deleted: [],
+          Errors: [{ Key: 'upload/u/x.jpg', Code: 'AccessDenied', Message: 'no perms' }],
+        });
+
+      await expect(backend.deletePrefix('upload/u/')).rejects.toThrow(/AccessDenied/);
+    });
+
+    it('should propagate exceptions from ListObjectsV2Command', async () => {
+      mockSend.mockRejectedValueOnce(new Error('throttled'));
+
+      await expect(backend.deletePrefix('upload/u/')).rejects.toThrow('throttled');
+      expect(mockSend.mock.calls.filter(([cmd]) => cmd._type === 'DeleteObjectsCommand')).toEqual([]);
     });
   });
 });

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -1,4 +1,11 @@
-import { DeleteObjectCommand, GetObjectCommand, HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'node:crypto';
@@ -83,6 +90,26 @@ export class S3StorageBackend implements StorageBackend {
 
   async delete(key: string): Promise<void> {
     await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    let continuationToken: string | undefined;
+    do {
+      const page = await this.client.send(
+        new ListObjectsV2Command({ Bucket: this.bucket, Prefix: prefix, ContinuationToken: continuationToken }),
+      );
+      const keys = (page.Contents ?? []).map((o) => ({ Key: o.Key! }));
+      if (keys.length > 0) {
+        const result = await this.client.send(
+          new DeleteObjectsCommand({ Bucket: this.bucket, Delete: { Objects: keys } }),
+        );
+        if (result.Errors && result.Errors.length > 0) {
+          const first = result.Errors[0];
+          throw new Error(`S3 deletePrefix partial failure: ${first.Code}: ${first.Message} (key=${first.Key})`);
+        }
+      }
+      continuationToken = page.IsTruncated ? page.NextContinuationToken : undefined;
+    } while (continuationToken);
   }
 
   async getServeStrategy(key: string, contentType: string): Promise<ServeStrategy> {

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -18,6 +18,9 @@ export interface StorageBackend {
   /** Delete the content at the given key */
   delete(key: string): Promise<void>;
 
+  /** Delete all objects/files under the given key prefix. Idempotent. No-op if nothing matches. */
+  deletePrefix(prefix: string): Promise<void>;
+
   /** Determine how to serve this file to a client */
   getServeStrategy(key: string, contentType: string): Promise<ServeStrategy>;
 

--- a/server/src/services/user.service.spec.ts
+++ b/server/src/services/user.service.spec.ts
@@ -826,6 +826,62 @@ describe(UserService.name, () => {
       expect(mocks.storage.unlinkDir).toHaveBeenCalledTimes(5);
       expect(mocks.user.delete).toHaveBeenCalledWith(user, true);
     });
+
+    describe('with S3 write backend', () => {
+      let mockS3Backend: { deletePrefix: ReturnType<typeof vitest.fn> };
+
+      beforeEach(() => {
+        mockS3Backend = { deletePrefix: vi.fn().mockResolvedValue(void 0) };
+        (StorageService as any).s3Backend = mockS3Backend;
+      });
+
+      afterEach(() => {
+        (StorageService as any).s3Backend = void 0;
+      });
+
+      it('should delete the four user-scoped S3 prefixes in addition to disk folders', async () => {
+        const user = { id: 'deleted-s3-user', deletedAt: makeDeletedAt(10) } as UserAdmin;
+        mocks.user.get.mockResolvedValue(user);
+
+        await sut.handleUserDelete({ id: user.id });
+
+        expect(mocks.storage.unlinkDir).toHaveBeenCalledTimes(5);
+        expect(mockS3Backend.deletePrefix).toHaveBeenCalledTimes(4);
+        expect(mockS3Backend.deletePrefix).toHaveBeenCalledWith(`upload/${user.id}/`);
+        expect(mockS3Backend.deletePrefix).toHaveBeenCalledWith(`profile/${user.id}/`);
+        expect(mockS3Backend.deletePrefix).toHaveBeenCalledWith(`thumbs/${user.id}/`);
+        expect(mockS3Backend.deletePrefix).toHaveBeenCalledWith(`encoded-video/${user.id}/`);
+      });
+
+      it('should still attempt remaining prefixes, disk deletion, and DB cleanup when one S3 prefix fails', async () => {
+        const user = { id: 'partial-fail-user', deletedAt: makeDeletedAt(10) } as UserAdmin;
+        mocks.user.get.mockResolvedValue(user);
+        mockS3Backend.deletePrefix
+          .mockResolvedValueOnce(void 0)
+          .mockRejectedValueOnce(new Error('throttled'))
+          .mockResolvedValueOnce(void 0)
+          .mockResolvedValueOnce(void 0);
+
+        await sut.handleUserDelete({ id: user.id });
+
+        expect(mockS3Backend.deletePrefix).toHaveBeenCalledTimes(4);
+        expect(mocks.storage.unlinkDir).toHaveBeenCalledTimes(5);
+        expect(mocks.album.deleteAll).toHaveBeenCalledWith(user.id);
+        expect(mocks.user.delete).toHaveBeenCalledWith(user, true);
+        expect(mocks.event.emit).toHaveBeenCalledWith('UserDelete', user);
+      });
+    });
+
+    it('should not reach any S3 backend when S3 is not configured (regression guard)', async () => {
+      const user = { id: 'disk-only-user', deletedAt: makeDeletedAt(10) } as UserAdmin;
+      mocks.user.get.mockResolvedValue(user);
+      expect((StorageService as any).s3Backend).toBeUndefined();
+
+      await sut.handleUserDelete({ id: user.id });
+
+      expect(mocks.storage.unlinkDir).toHaveBeenCalledTimes(5);
+      expect((StorageService as any).s3Backend).toBeUndefined();
+    });
   });
 
   describe('handleUserSyncUsage', () => {

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -286,6 +286,28 @@ export class UserService extends BaseService {
       await this.storageRepository.unlinkDir(folder, { recursive: true, force: true });
     }
 
+    // S3: clean the user-scoped relative prefixes. Library and Backups are intentionally
+    // excluded — storage-template migration is a no-op on S3 (StorageCore.moveFile guard),
+    // so S3 never writes to library/; Backups is admin/global scope.
+    const s3 = StorageService.getS3Backend();
+    if (s3) {
+      const userScopedS3Folders = [
+        StorageFolder.Upload,
+        StorageFolder.Profile,
+        StorageFolder.Thumbnails,
+        StorageFolder.EncodedVideo,
+      ] as const;
+      for (const folder of userScopedS3Folders) {
+        const prefix = `${folder}/${user.id}/`;
+        try {
+          await s3.deletePrefix(prefix);
+          this.logger.log(`Cleaned S3 prefix ${prefix}`);
+        } catch (error) {
+          this.logger.warn(`Failed to clean S3 prefix ${prefix} for user ${user.id}`, error);
+        }
+      }
+    }
+
     this.logger.warn(`Removing user from database: ${user.id}`);
     await this.albumRepository.deleteAll(user.id);
     await this.userRepository.delete(user, true);


### PR DESCRIPTION
## Summary

- `handleUserDelete` now sweeps the four user-scoped S3 prefixes (`upload/<id>/`, `profile/<id>/`, `thumbs/<id>/`, `encoded-video/<id>/`) after the existing disk `unlinkDir` pass. Previously, S3 objects stayed in the bucket forever on every user delete.
- Adds `deletePrefix(prefix)` to the `StorageBackend` interface. Disk impl delegates to `fs.rm(recursive)`; S3 impl paginates `ListObjectsV2` + batched `DeleteObjects` (1000 keys/call).
- `library/` and `backups/` are intentionally excluded — storage-template migration is a no-op on S3 (guard at `StorageCore.moveFile:189`, PR #391), so S3 never writes to `library/`; Backups is admin/global scope.
- Per-prefix `try/catch` with `warn` log preserves the rest of the delete flow on transient S3 failures.

Design: [`docs/plans/2026-04-22-s3-orphan-cleanup-user-delete-design.md`](docs/plans/2026-04-22-s3-orphan-cleanup-user-delete-design.md).

Backfill for users deleted before this fix is out of scope — documented as a one-off `aws s3 rm --recursive` in the design doc's "Out of scope" section.

## Test plan

- [x] Unit: 3 new cases in `disk-storage.backend.spec.ts`, 5 in `s3-storage.backend.spec.ts`, 3 in `user.service.spec.ts`. All red-validated (stash impl → RED → restore → GREEN).
- [x] Integration: 2500-key boundary in `s3-storage.backend.integration.spec.ts` against testcontainers MinIO (crosses both `ListObjectsV2` 1000-key page and `DeleteObjects` 1000-key batch caps in one assertion). Runs in ~2.3s.
- [x] E2E: new `phaseUserDeleteS3Orphans` in `e2e/src/storage-migration.ts`. End-to-end red-validated against the storage-migration stack — with the fix reverted, the phase fails with 2 objects still under `upload/<uuid>/`; with the fix restored, all 4 prefixes report 0 objects post-delete.
- [x] Typecheck + lint + prettier all clean.
- [x] Storage Migration Tests workflow on this PR (ARM64 + AMD64).
- [x] Manual smoke on `pierre.opennoodle.de` via `/rc-personal`: create disposable user, upload 2–3 photos, force-delete via admin, confirm 4 `Cleaned S3 prefix …` log lines and empty `upload/<uuid>/` in the Wasabi console.