### PR TITLE
fix(search): use inclusive smart-search rating filters

### DIFF
--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -26,7 +26,9 @@ const buildQueries = (
 ) => (sut as any).buildSearchSmartQueries(offlineKysely(), pagination, options);
 
 const buildAssetSearchSql = (options: Record<string, unknown>) =>
-  searchAssetBuilder(offlineKysely(), options as any).selectAll('asset').compile().sql;
+  searchAssetBuilder(offlineKysely(), options as any)
+    .selectAll('asset')
+    .compile().sql;
 
 const FAILURE_MESSAGE =
   'Do not add any secondary ORDER BY key to the inner searchSmart query. ' +

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -3,6 +3,7 @@ import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQue
 import { AssetOrder } from 'src/enum';
 import { SearchRepository } from 'src/repositories/search.repository';
 import type { DB } from 'src/schema';
+import { searchAssetBuilder } from 'src/utils/database';
 import { describe, expect, it } from 'vitest';
 
 // Offline Kysely — compiles SQL without executing it. No DB connection needed.
@@ -23,6 +24,9 @@ const buildQueries = (
   pagination: { page: number; size: number },
   options: Record<string, unknown>,
 ) => (sut as any).buildSearchSmartQueries(offlineKysely(), pagination, options);
+
+const buildAssetSearchSql = (options: Record<string, unknown>) =>
+  searchAssetBuilder(offlineKysely(), options as any).selectAll('asset').compile().sql;
 
 const FAILURE_MESSAGE =
   'Do not add any secondary ORDER BY key to the inner searchSmart query. ' +
@@ -79,6 +83,30 @@ describe(SearchRepository.name, () => {
 
       expect(innerSql).toMatch(/rating"?\s*>=\s*\$\d+/i);
       expect(innerSql).not.toMatch(/rating"?\s*=\s*\$\d+/i);
+    });
+
+    it('keeps unrated smart-search filters as IS NULL', () => {
+      const { base } = buildQueries(sut, { page: 1, size: 100 }, { ...baseOptions, rating: null });
+      const innerSql = base.compile().sql;
+
+      expect(innerSql).toMatch(/rating"?\s+is\s+null/i);
+      expect(innerSql).not.toMatch(/rating"?\s*>=\s*\$\d+/i);
+      expect(innerSql).not.toMatch(/rating"?\s*=\s*\$\d+/i);
+    });
+
+    it('keeps the inner smart-search ORDER BY single-key when rating uses the CTE path', () => {
+      const { base, outer } = buildQueries(
+        sut,
+        { page: 1, size: 100 },
+        { ...baseOptions, orderDirection: AssetOrder.Desc, rating: 4 },
+      );
+
+      const innerSql = base.compile().sql;
+      expect(innerSql).toMatch(/rating"?\s*>=\s*\$\d+/i);
+      expect(countOrderByExpressions(innerSql + ' limit', 'limit'), FAILURE_MESSAGE).toBe(1);
+
+      const outerSql = outer.compile().sql;
+      expect(countOuterOrderByExpressions(outerSql), 'outer CTE ORDER BY must stay at 2 keys').toBe(2);
     });
 
     it('non-CTE inner ORDER BY: exactly one expression AND primary key is smart_search.embedding', () => {
@@ -147,6 +175,23 @@ describe(SearchRepository.name, () => {
 
       // No WHERE predicate on the distance operator (<=>).
       expect(innerSql).not.toMatch(/\(smart_search\.embedding <=> \$\d+\)\s*<=/i);
+    });
+  });
+
+  describe('searchAssetBuilder rating semantics', () => {
+    it('keeps non-smart rating filters as exact match', () => {
+      const sql = buildAssetSearchSql({ rating: 2 });
+
+      expect(sql).toMatch(/rating"?\s*=\s*\$\d+/i);
+      expect(sql).not.toMatch(/rating"?\s*>=\s*\$\d+/i);
+    });
+
+    it('keeps unrated non-smart filters as IS NULL', () => {
+      const sql = buildAssetSearchSql({ rating: null });
+
+      expect(sql).toMatch(/rating"?\s+is\s+null/i);
+      expect(sql).not.toMatch(/rating"?\s*>=\s*\$\d+/i);
+      expect(sql).not.toMatch(/rating"?\s*=\s*\$\d+/i);
     });
   });
 });

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -66,11 +66,15 @@ describe(SearchRepository.name, () => {
 
   describe('searchSmart query shape', () => {
     it('applies rating as an inclusive threshold when combined with other filters', () => {
-      const { base } = buildQueries(sut, { page: 1, size: 100 }, {
-        ...baseOptions,
-        personIds: ['00000000-0000-0000-0000-000000000001'],
-        rating: 2,
-      });
+      const { base } = buildQueries(
+        sut,
+        { page: 1, size: 100 },
+        {
+          ...baseOptions,
+          personIds: ['00000000-0000-0000-0000-000000000001'],
+          rating: 2,
+        },
+      );
       const innerSql = base.compile().sql;
 
       expect(innerSql).toMatch(/rating"?\s*>=\s*\$\d+/i);

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -3,6 +3,7 @@ import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQue
 import { AssetOrder } from 'src/enum';
 import { SearchRepository } from 'src/repositories/search.repository';
 import type { DB } from 'src/schema';
+import { describe, expect, it } from 'vitest';
 
 // Offline Kysely — compiles SQL without executing it. No DB connection needed.
 const offlineKysely = () =>
@@ -64,6 +65,18 @@ describe(SearchRepository.name, () => {
   };
 
   describe('searchSmart query shape', () => {
+    it('applies rating as an inclusive threshold when combined with other filters', () => {
+      const { base } = buildQueries(sut, { page: 1, size: 100 }, {
+        ...baseOptions,
+        personIds: ['00000000-0000-0000-0000-000000000001'],
+        rating: 2,
+      });
+      const innerSql = base.compile().sql;
+
+      expect(innerSql).toMatch(/rating"?\s*>=\s*\$\d+/i);
+      expect(innerSql).not.toMatch(/rating"?\s*=\s*\$\d+/i);
+    });
+
     it('non-CTE inner ORDER BY: exactly one expression AND primary key is smart_search.embedding', () => {
       const { base } = buildQueries(sut, { page: 1, size: 100 }, baseOptions);
       const innerSql = base.compile().sql;

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -75,6 +75,7 @@ export interface SearchExifOptions {
   state?: string | null;
   description?: string | null;
   rating?: number | null;
+  ratingIsMinimum?: boolean;
 }
 
 export interface SearchEmbeddingOptions {
@@ -329,7 +330,7 @@ export class SearchRepository {
   ) {
     const hasDistanceThreshold = isActiveDistanceThreshold(options.maxDistance);
 
-    const baseQuery = searchAssetBuilder(kysely, options)
+    const baseQuery = searchAssetBuilder(kysely, { ...options, ratingIsMinimum: true })
       .selectAll('asset')
       .innerJoin('smart_search', 'asset.id', 'smart_search.assetId')
       .$if(hasDistanceThreshold, (qb) =>

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -11,7 +11,7 @@ import { authStub } from 'test/fixtures/auth.stub';
 import { getForAsset } from 'test/mappers';
 import { newUuid } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
-import { beforeEach, vitest } from 'vitest';
+import { beforeEach, describe, expect, it, vitest } from 'vitest';
 
 vitest.useFakeTimers();
 

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -447,7 +447,7 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(options.rating !== undefined, (qb) =>
       qb
         .innerJoin('asset_exif', 'asset.id', 'asset_exif.assetId')
-        .where('asset_exif.rating', options.rating === null ? 'is' : '=', options.rating!),
+        .where('asset_exif.rating', options.rating === null ? 'is' : '>=', options.rating!),
     )
     .$if(!!options.checksum, (qb) => qb.where('asset.checksum', '=', options.checksum!))
     .$if(!!options.id, (qb) => qb.where('asset.id', '=', asUuid(options.id!)))

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -447,7 +447,11 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(options.rating !== undefined, (qb) =>
       qb
         .innerJoin('asset_exif', 'asset.id', 'asset_exif.assetId')
-        .where('asset_exif.rating', options.rating === null ? 'is' : '>=', options.rating!),
+        .where(
+          'asset_exif.rating',
+          options.rating === null ? 'is' : options.ratingIsMinimum ? '>=' : '=',
+          options.rating!,
+        ),
     )
     .$if(!!options.checksum, (qb) => qb.where('asset.checksum', '=', options.checksum!))
     .$if(!!options.id, (qb) => qb.where('asset.id', '=', asUuid(options.id!)))


### PR DESCRIPTION
## Summary
- make smart-search rating filters use minimum-star semantics for numeric ratings
- add a repository regression test covering smart search with another filter plus a rating threshold
- fix missing Vitest imports in the touched targeted specs so the verification commands run in isolation

Closes #407.

## Verification
- pnpm --filter immich exec vitest run src/repositories/search.repository.spec.ts
- pnpm --filter immich exec vitest run src/services/search.service.spec.ts
- pnpm --filter immich exec eslint src/repositories/search.repository.spec.ts src/services/search.service.spec.ts src/utils/database.ts