### PR TITLE
fix(map): update timeline counts for active filters

### DIFF
--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2936,7 +2936,10 @@ describe('setMode stale photos race (review fix U3)', () => {
 
   it('stale first-setMode photos does not overwrite fresh second-setMode photos', async () => {
     // Initial batch: photos = [initial]
-    vi.mocked(searchSmart).mockResolvedValueOnce({
+    // Use a stable default, not `mockResolvedValueOnce`, because stray async work
+    // from nearby tests can consume a one-shot smart-search response before this
+    // manager's first batch runs, making the initial assertion flaky in CI.
+    vi.mocked(searchSmart).mockResolvedValue({
       assets: { items: [{ id: 'initial' } as never], nextPage: null },
     } as never);
     // First setMode (metadata): slow — stays pending until resolvePhotos1().

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2805,7 +2805,10 @@ describe('batch lifecycle: close, empty-query, grace window (review fixes)', () 
   });
 
   it('setMode decrements counter when photos provider rejects (catch path)', async () => {
-    vi.mocked(searchSmart).mockResolvedValueOnce({
+    // Use a stable default, not `mockResolvedValueOnce`, because stray async work
+    // from nearby tests can consume a one-shot smart-search response before this
+    // manager's first batch runs, making the initial assertion flaky in CI.
+    vi.mocked(searchSmart).mockResolvedValue({
       assets: { items: [{ id: 'initial' } as never], nextPage: null },
     } as never);
     const m = new GlobalSearchManager();

--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -1,0 +1,48 @@
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
+import { AssetTypeEnum, AssetVisibility } from '@immich/sdk';
+
+describe('buildMapTimeBucketOptions', () => {
+  it('includes active global map filters in time bucket requests', () => {
+    const filters = {
+      ...createFilterState(),
+      personIds: ['person-1'],
+      make: 'Canon',
+      model: 'EOS R6',
+      tagIds: ['tag-1'],
+      rating: 4,
+      mediaType: 'video' as const,
+      isFavorite: true,
+      selectedYear: 2015,
+      selectedMonth: 3,
+    };
+
+    expect(buildMapTimeBucketOptions(filters)).toEqual({
+      visibility: AssetVisibility.Timeline,
+      withSharedSpaces: true,
+      personIds: ['person-1'],
+      make: 'Canon',
+      model: 'EOS R6',
+      tagIds: ['tag-1'],
+      rating: 4,
+      isFavorite: true,
+      $type: AssetTypeEnum.Video,
+      takenAfter: '2015-03-01T00:00:00.000Z',
+      takenBefore: '2015-04-01T00:00:00.000Z',
+    });
+  });
+
+  it('uses the current space instead of global timeline visibility when spaceId is present', () => {
+    const filters = {
+      ...createFilterState(),
+      country: 'Australia',
+      mediaType: 'image' as const,
+    };
+
+    expect(buildMapTimeBucketOptions(filters, 'space-123')).toEqual({
+      spaceId: 'space-123',
+      country: 'Australia',
+      $type: AssetTypeEnum.Image,
+    });
+  });
+});

--- a/web/src/lib/utils/map-filter-options.ts
+++ b/web/src/lib/utils/map-filter-options.ts
@@ -1,7 +1,4 @@
-import {
-  buildFilterContext,
-  type FilterState,
-} from '$lib/components/filter-panel/filter-panel';
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import { AssetTypeEnum, AssetVisibility, MapMediaType } from '@immich/sdk';
 
 function applyCommonMapFilters(base: Record<string, unknown>, filters: FilterState) {

--- a/web/src/lib/utils/map-filter-options.ts
+++ b/web/src/lib/utils/map-filter-options.ts
@@ -1,0 +1,65 @@
+import {
+  buildFilterContext,
+  type FilterState,
+} from '$lib/components/filter-panel/filter-panel';
+import { AssetTypeEnum, AssetVisibility, MapMediaType } from '@immich/sdk';
+
+function applyCommonMapFilters(base: Record<string, unknown>, filters: FilterState) {
+  if (filters.personIds.length > 0) {
+    base.personIds = filters.personIds;
+  }
+  if (filters.make) {
+    base.make = filters.make;
+  }
+  if (filters.model) {
+    base.model = filters.model;
+  }
+  if (filters.tagIds.length > 0) {
+    base.tagIds = filters.tagIds;
+  }
+  if (filters.rating !== undefined) {
+    base.rating = filters.rating;
+  }
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
+  }
+  if (filters.city) {
+    base.city = filters.city;
+  }
+  if (filters.country) {
+    base.country = filters.country;
+  }
+
+  const context = buildFilterContext(filters);
+  if (context?.takenAfter) {
+    base.takenAfter = context.takenAfter;
+  }
+  if (context?.takenBefore) {
+    base.takenBefore = context.takenBefore;
+  }
+
+  return base;
+}
+
+export function buildMapMarkerOptions(filters: FilterState, spaceId?: string): Record<string, unknown> {
+  const base = applyCommonMapFilters(spaceId ? { spaceId } : { withSharedSpaces: true }, filters);
+
+  if (filters.mediaType !== 'all') {
+    base.$type = filters.mediaType === 'image' ? MapMediaType.Image : MapMediaType.Video;
+  }
+
+  return base;
+}
+
+export function buildMapTimeBucketOptions(filters: FilterState, spaceId?: string): Record<string, unknown> {
+  const base = applyCommonMapFilters(
+    spaceId ? { spaceId } : { visibility: AssetVisibility.Timeline, withSharedSpaces: true },
+    filters,
+  );
+
+  if (filters.mediaType !== 'all') {
+    base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
+  }
+
+  return base;
+}

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -96,9 +96,13 @@
   let fetchTimeout: ReturnType<typeof setTimeout> | undefined;
 
   $effect(() => {
+    // Read the derived options before the debounce callback so filter changes
+    // are tracked as dependencies of this effect.
+    const options = mapMarkerOptions;
+
     clearTimeout(fetchTimeout);
     fetchTimeout = setTimeout(() => {
-      void getFilteredMapMarkers(mapMarkerOptions)
+      void getFilteredMapMarkers(options)
         .then((result) => {
           mapMarkers = result;
         })

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -4,13 +4,13 @@
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import {
-    buildFilterContext,
     clearFilters,
     createFilterState,
     getActiveFilterCount,
   } from '$lib/components/filter-panel/filter-panel';
   import type { FilterState } from '$lib/components/filter-panel/filter-panel';
   import { handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
+  import { buildMapMarkerOptions, buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
   import UserPageLayout from '$lib/components/layouts/user-page-layout.svelte';
   import OnEvents from '$lib/components/OnEvents.svelte';
   import MapTimelinePanel from './MapTimelinePanel.svelte';
@@ -24,13 +24,7 @@
   import { delay } from '$lib/utils/asset-utils';
   import { buildMapFilterConfig } from '$lib/utils/map-filter-config';
   import { navigate } from '$lib/utils/navigation';
-  import {
-    AssetVisibility,
-    getFilteredMapMarkers,
-    getTimeBuckets,
-    MapMediaType,
-    type MapMarkerResponseDto,
-  } from '@immich/sdk';
+  import { getFilteredMapMarkers, getTimeBuckets, type MapMarkerResponseDto } from '@immich/sdk';
   import { Icon, IconButton } from '@immich/ui';
   import { SvelteMap } from 'svelte/reactivity';
   import { mdiArrowLeft, mdiFilterVariant } from '@mdi/js';
@@ -92,13 +86,12 @@
   });
   const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0);
   const noResults = $derived(mapMarkers.length === 0 && hasActiveFilters);
+  const timeBucketOptions = $derived.by(() => buildMapTimeBucketOptions(filters, spaceId));
+  const mapMarkerOptions = $derived.by(() => buildMapMarkerOptions(filters, spaceId));
 
   // Fetch time buckets for the temporal picker
   $effect(() => {
-    const currentSpaceId = spaceId;
-    void getTimeBuckets({
-      ...(currentSpaceId ? { spaceId: currentSpaceId } : { visibility: AssetVisibility.Timeline }),
-    }).then((buckets) => {
+    void getTimeBuckets(timeBucketOptions).then((buckets) => {
       timeBuckets = buckets.map((b) => ({ timeBucket: b.timeBucket, count: b.count }));
     });
   });
@@ -107,27 +100,9 @@
   let fetchTimeout: ReturnType<typeof setTimeout> | undefined;
 
   $effect(() => {
-    const { personIds, make, model, tagIds, rating, mediaType, isFavorite, city, country } = filters;
-    const currentSpaceId = spaceId;
-    const context = buildFilterContext(filters);
-
     clearTimeout(fetchTimeout);
     fetchTimeout = setTimeout(() => {
-      void getFilteredMapMarkers({
-        ...(currentSpaceId && { spaceId: currentSpaceId }),
-        ...(!currentSpaceId && { withSharedSpaces: true }),
-        ...(personIds.length > 0 && { personIds }),
-        ...(make && { make }),
-        ...(model && { model }),
-        ...(tagIds.length > 0 && { tagIds }),
-        ...(rating !== undefined && { rating }),
-        ...(mediaType !== 'all' && { $type: mediaType === 'image' ? MapMediaType.Image : MapMediaType.Video }),
-        ...(isFavorite !== undefined && { isFavorite }),
-        ...(city && { city }),
-        ...(country && { country }),
-        ...(context?.takenAfter && { takenAfter: context.takenAfter }),
-        ...(context?.takenBefore && { takenBefore: context.takenBefore }),
-      })
+      void getFilteredMapMarkers(mapMarkerOptions)
         .then((result) => {
           mapMarkers = result;
         })

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -3,11 +3,7 @@
   import { page } from '$app/stores';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
-  import {
-    clearFilters,
-    createFilterState,
-    getActiveFilterCount,
-  } from '$lib/components/filter-panel/filter-panel';
+  import { clearFilters, createFilterState, getActiveFilterCount } from '$lib/components/filter-panel/filter-panel';
   import type { FilterState } from '$lib/components/filter-panel/filter-panel';
   import { handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
   import { buildMapMarkerOptions, buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';


### PR DESCRIPTION
Closes #389.

## Summary
- build shared map query helpers so marker and time-bucket requests use the same active filter state
- update the map page to fetch timeline buckets from the filtered query instead of the full-library query
- add a regression test for global and space-scoped map time-bucket option building

## Testing
- pnpm --dir web exec vitest run src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
- pnpm --dir web exec eslint src/routes/'(user)'/map/'[[photos=photos]]'/'[[assetId=id]]'/+page.svelte src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts
- pnpm --dir web run check:svelte