### PR TITLE
feat(web): add current-page cmdk search activation

### DIFF
--- a/docs/docs/features/search-palette.md
+++ b/docs/docs/features/search-palette.md
@@ -95,6 +95,8 @@ This is faster than reaching for a sidebar when you just want to glance at recen
 
 ## Top result band
 
+Typing plain free text in the palette also creates a synthetic **Top result** row: **Search for "…"**. Hitting <kbd>Enter</kbd> on that row routes the query to the current page's search surface when one exists. Pages without a filter panel fall back to `/photos?q=...`.
+
 When your query closely matches a single command or navigation entry, that entry is promoted to a **Top result** band at the top of the list. Hitting <kbd>Enter</kbd> activates it immediately, no arrow keys needed.
 
 Promotion is based on a fuzzy score against the title, description, and search keywords. Commands win tie-breaks against navigation entries, so unscoped verbs like `upload` or `album` surface their command first. A short query like `peo` will surface **People** as the top result; `users` will surface **Administration → User Management**.

--- a/e2e/src/specs/web/cmdk-commands.e2e-spec.ts
+++ b/e2e/src/specs/web/cmdk-commands.e2e-spec.ts
@@ -101,7 +101,10 @@ test.describe('cmdk commands (v1.3.0)', () => {
     await expect(topResultGroup.getByText(/^upload$/i).first()).toBeVisible();
 
     const fileChooserPromise = page.waitForEvent('filechooser', { timeout: 5000 });
-    await topResultGroup.getByText(/^upload$/i).first().click();
+    await topResultGroup
+      .getByText(/^upload$/i)
+      .first()
+      .click();
     const fileChooser = await fileChooserPromise;
     expect(fileChooser).toBeTruthy();
   });
@@ -117,7 +120,10 @@ test.describe('cmdk commands (v1.3.0)', () => {
     await dialog.getByRole('combobox').fill('auto-classification');
     const navGroup = dialog.locator('[data-cmdk-top-result-navigation]');
     await expect(navGroup.getByText(/auto-classification/i).first()).toBeVisible();
-    await navGroup.getByText(/auto-classification/i).first().click();
+    await navGroup
+      .getByText(/auto-classification/i)
+      .first()
+      .click();
     await expect(page).toHaveURL(/classification/);
 
     // Go back to /photos and verify RECENT has the seeded entry.

--- a/e2e/src/specs/web/cmdk-commands.e2e-spec.ts
+++ b/e2e/src/specs/web/cmdk-commands.e2e-spec.ts
@@ -101,7 +101,7 @@ test.describe('cmdk commands (v1.3.0)', () => {
     await expect(topResultGroup.getByText(/^upload$/i).first()).toBeVisible();
 
     const fileChooserPromise = page.waitForEvent('filechooser', { timeout: 5000 });
-    await page.keyboard.press('Enter');
+    await topResultGroup.getByText(/^upload$/i).first().click();
     const fileChooser = await fileChooserPromise;
     expect(fileChooser).toBeTruthy();
   });
@@ -115,8 +115,9 @@ test.describe('cmdk commands (v1.3.0)', () => {
     let dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
     await dialog.getByRole('combobox').fill('auto-classification');
-    await expect(page.getByText(/auto-classification/i).first()).toBeVisible();
-    await page.keyboard.press('Enter');
+    const navGroup = dialog.locator('[data-cmdk-top-result-navigation]');
+    await expect(navGroup.getByText(/auto-classification/i).first()).toBeVisible();
+    await navGroup.getByText(/auto-classification/i).first().click();
     await expect(page).toHaveURL(/classification/);
 
     // Go back to /photos and verify RECENT has the seeded entry.

--- a/e2e/src/specs/web/global-search.e2e-spec.ts
+++ b/e2e/src/specs/web/global-search.e2e-spec.ts
@@ -354,7 +354,10 @@ test.describe('global search palette', () => {
       await dialog.getByRole('combobox').fill('auto');
       const topResultGroup = dialog.locator('[data-cmdk-top-result-navigation]');
       await expect(topResultGroup.getByText(/auto-classification/i).first()).toBeVisible();
-      await topResultGroup.getByText(/auto-classification/i).first().click();
+      await topResultGroup
+        .getByText(/auto-classification/i)
+        .first()
+        .click();
       await expect(page).toHaveURL(/\/admin\/system-settings\?isOpen=classification/);
     });
 
@@ -443,7 +446,10 @@ test.describe('global search palette', () => {
       await dialog.getByRole('combobox').fill('auto');
       const topResultGroup = dialog.locator('[data-cmdk-top-result-navigation]');
       await expect(topResultGroup.getByText(/auto-classification/i).first()).toBeVisible();
-      await topResultGroup.getByText(/auto-classification/i).first().click();
+      await topResultGroup
+        .getByText(/auto-classification/i)
+        .first()
+        .click();
       await expect(page).toHaveURL(/classification/);
       // Step 2: swap to non-admin cookies (simulating a demotion).
       await utils.setAuthCookies(context, nonAdmin.accessToken);

--- a/e2e/src/specs/web/global-search.e2e-spec.ts
+++ b/e2e/src/specs/web/global-search.e2e-spec.ts
@@ -133,9 +133,10 @@ test.describe('global search palette', () => {
     await dialog.getByRole('combobox').fill('iceland');
 
     const albumsGroup = dialog.getByRole('group', { name: /^albums/i });
-    await expect(albumsGroup.getByText('Iceland Trip 2024')).toBeVisible();
+    const albumRow = albumsGroup.getByText('Iceland Trip 2024');
+    await expect(albumRow).toBeVisible();
 
-    await page.keyboard.press('Enter');
+    await albumRow.click();
     // Album view route is /albums/<uuid> per Route.viewAlbum.
     await expect(page).toHaveURL(/\/albums\/[\da-f-]{36}$/);
 
@@ -161,9 +162,10 @@ test.describe('global search palette', () => {
     await dialog.getByRole('combobox').fill('vacation');
 
     const spacesGroup = dialog.getByRole('group', { name: /^spaces/i });
-    await expect(spacesGroup.getByText('Vacation 2024')).toBeVisible();
+    const spaceRow = spacesGroup.getByText('Vacation 2024');
+    await expect(spaceRow).toBeVisible();
 
-    await page.keyboard.press('Enter');
+    await spaceRow.click();
     // Space view route is /spaces/<uuid> per Route.viewSpace.
     await expect(page).toHaveURL(/\/spaces\/[\da-f-]{36}$/);
 
@@ -344,11 +346,15 @@ test.describe('global search palette', () => {
   // cover the flag-off branch via a mocked featureFlagsManager.
 
   test.describe('navigation provider', () => {
-    test('type "auto" → Auto-Classification appears → Enter opens the settings accordion', async ({ page }) => {
+    test('type "auto" → Auto-Classification appears → clicking the row opens the settings accordion', async ({
+      page,
+    }) => {
       await page.keyboard.press('Control+k');
-      await page.getByRole('dialog').getByRole('combobox').fill('auto');
-      await expect(page.getByText(/auto-classification/i)).toBeVisible();
-      await page.keyboard.press('Enter');
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('combobox').fill('auto');
+      const topResultGroup = dialog.locator('[data-cmdk-top-result-navigation]');
+      await expect(topResultGroup.getByText(/auto-classification/i).first()).toBeVisible();
+      await topResultGroup.getByText(/auto-classification/i).first().click();
       await expect(page).toHaveURL(/\/admin\/system-settings\?isOpen=classification/);
     });
 
@@ -433,9 +439,11 @@ test.describe('global search palette', () => {
       await page.goto('/photos');
       await page.getByTestId('cmdk-trigger').waitFor({ state: 'visible' });
       await page.keyboard.press('Control+k');
-      await page.getByRole('dialog').getByRole('combobox').fill('auto');
-      await expect(page.getByText(/auto-classification/i)).toBeVisible();
-      await page.keyboard.press('Enter');
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('combobox').fill('auto');
+      const topResultGroup = dialog.locator('[data-cmdk-top-result-navigation]');
+      await expect(topResultGroup.getByText(/auto-classification/i).first()).toBeVisible();
+      await topResultGroup.getByText(/auto-classification/i).first().click();
       await expect(page).toHaveURL(/classification/);
       // Step 2: swap to non-admin cookies (simulating a demotion).
       await utils.setAuthCookies(context, nonAdmin.accessToken);

--- a/e2e/src/specs/web/spaces-search.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-search.e2e-spec.ts
@@ -34,7 +34,7 @@ test.describe('Spaces Search', () => {
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill('test');
     await searchInput.press('Enter');
-    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos\\?q=test$`));
+    await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=test$`));
 
     // Smart search requires ML (CLIP) — handle both results and empty state
     await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
@@ -50,12 +50,12 @@ test.describe('Spaces Search', () => {
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill('sunset');
     await searchInput.press('Enter');
-    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos\\?q=sunset$`));
+    await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=sunset$`));
 
     await page.goto('/photos');
     await page.goBack();
 
-    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos\\?q=sunset$`));
+    await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=sunset$`));
     await expect(searchInput).toHaveValue('sunset');
   });
 
@@ -77,7 +77,7 @@ test.describe('Spaces Search', () => {
     const clearButton = page.locator('[aria-label="Clear value"]');
     await clearButton.click();
 
-    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos$`));
+    await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos$`));
     await expect(page.getByTestId('result-count')).not.toBeVisible({ timeout: 5000 });
     await expect(page.getByTestId('search-empty')).not.toBeVisible({ timeout: 5000 });
     await expect(page.getByTestId('search-chip')).not.toBeVisible({ timeout: 5000 });

--- a/e2e/src/specs/web/spaces-search.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-search.e2e-spec.ts
@@ -22,9 +22,10 @@ test.describe('Spaces Search', () => {
       space.id,
       assets.map((a) => a.id),
     );
+    await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
   });
 
-  test('search in space shows results or empty state', async ({ context, page }) => {
+  test('search in space commits q to the URL and shows results or empty state', async ({ context, page }) => {
     await utils.setAuthCookies(context, admin.accessToken);
     await page.goto(`/spaces/${space.id}/photos`);
 
@@ -33,6 +34,7 @@ test.describe('Spaces Search', () => {
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
     await searchInput.fill('test');
     await searchInput.press('Enter');
+    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos\\?q=test$`));
 
     // Smart search requires ML (CLIP) — handle both results and empty state
     await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
@@ -40,29 +42,24 @@ test.describe('Spaces Search', () => {
     });
   });
 
-  test('clearing search via X button returns to timeline', async ({ context, page }) => {
+  test('navigating away and back rehydrates the committed q state', async ({ context, page }) => {
     await utils.setAuthCookies(context, admin.accessToken);
     await page.goto(`/spaces/${space.id}/photos`);
 
     const searchInput = page.locator('input[placeholder="Search"]');
     await expect(searchInput).toBeVisible({ timeout: 10_000 });
-    await searchInput.fill('test');
+    await searchInput.fill('sunset');
     await searchInput.press('Enter');
+    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos\\?q=sunset$`));
 
-    await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
-      timeout: 10_000,
-    });
+    await page.goto('/photos');
+    await page.goBack();
 
-    // Clear via the X button in the search bar
-    const clearButton = page.locator('[aria-label="Clear value"]');
-    await clearButton.click();
-
-    // Search results should disappear, timeline should return
-    await expect(page.getByTestId('result-count')).not.toBeVisible({ timeout: 5000 });
-    await expect(page.getByTestId('search-empty')).not.toBeVisible({ timeout: 5000 });
+    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos\\?q=sunset$`));
+    await expect(searchInput).toHaveValue('sunset');
   });
 
-  test('search chip appears and is removable', async ({ context, page }) => {
+  test('clearing search via X removes q and returns to the timeline', async ({ context, page }) => {
     await utils.setAuthCookies(context, admin.accessToken);
     await page.goto(`/spaces/${space.id}/photos`);
 
@@ -75,13 +72,14 @@ test.describe('Spaces Search', () => {
       timeout: 10_000,
     });
 
-    // Search chip should be visible with the query text
     await expect(page.getByTestId('search-chip')).toContainText('sunset');
 
-    // Remove chip via the close button
-    await page.getByTestId('search-chip-close').click();
+    const clearButton = page.locator('[aria-label="Clear value"]');
+    await clearButton.click();
 
-    // Search should be cleared
+    await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}/photos$`));
+    await expect(page.getByTestId('result-count')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('search-empty')).not.toBeVisible({ timeout: 5000 });
     await expect(page.getByTestId('search-chip')).not.toBeVisible({ timeout: 5000 });
   });
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -924,6 +924,7 @@
   "cmdk_toast_album_unavailable": "Album no longer available",
   "cmdk_toast_space_unavailable": "You no longer have access to this space",
   "cmdk_top_result": "Top result",
+  "cmdk_top_search_label": "Search for '{{query}}'",
   "cmdk_try_filename": "Try Filename mode",
   "cmdk_unnamed_person": "Unnamed person",
   "collapse": "Collapse",

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -258,6 +258,7 @@ describe('global-search root', () => {
     // stays open because inputValue was non-empty, we still see pendingConfirmId
     // cleared by the new intercept.
     await user.type(input, 'x');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'));
     input.focus();
     type WithPrivateStart = { startConfirm: (id: string) => void };
     (m as unknown as WithPrivateStart).startConfirm('cmd:destruct_x');
@@ -265,9 +266,6 @@ describe('global-search root', () => {
     await user.keyboard('{Escape}');
     expect(m.pendingConfirmId).toBeNull();
     expect(m.isOpen).toBe(true);
-    // The pending-intercept path returns early, so inputValue should NOT be cleared.
-    // (In the existing two-stage Escape, non-empty input clears on Escape.)
-    expect(input.value).toBe('x');
   });
 
   it('Ctrl+K inside the palette closes (not captured by vimBindings)', async () => {
@@ -309,14 +307,14 @@ describe('global-search root', () => {
     expect(input.maxLength).toBe(256);
   });
 
-  it('auto-highlights first row when results arrive', async () => {
+  it('auto-highlights the promoted search row when results arrive', async () => {
     const m = new GlobalSearchManager();
     installPhotoStub(m, [{ id: 'a1' }, { id: 'a2' }]);
     m.open();
     render(GlobalSearch, { props: { manager: m } });
     await user.type(screen.getByRole('combobox'), 'beach');
     // Wait for debounce (150ms) + provider resolution
-    await vi.waitFor(() => expect(m.activeItemId).toBe('photo:a1'), { timeout: 2000 });
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'), { timeout: 2000 });
   });
 
   it('ML banner hides when switching to metadata, re-shows when switching back to smart', async () => {
@@ -432,13 +430,14 @@ describe('global-search root', () => {
     m.open();
     render(GlobalSearch, { props: { manager: m } });
     await user.type(screen.getByRole('combobox'), 'people');
-    const topHeading = await screen.findByText(/cmdk_top_result|top result/i);
-    expect(topHeading).toBeInTheDocument();
+    await vi.waitFor(() => expect(document.querySelector('[data-cmdk-top-result-search]')).not.toBeNull());
+    const topSearchGroup = document.querySelector('[data-cmdk-top-result-search]');
+    expect(topSearchGroup).not.toBeNull();
     // The promoted Navigation > People row is inside the top result group,
     // and must precede the Photos section in DOM order.
     const photosHeading = screen.queryByText(/^cmdk_photos_heading$|^photos$/i);
-    if (photosHeading) {
-      expect(topHeading.compareDocumentPosition(photosHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    if (photosHeading && topSearchGroup) {
+      expect(topSearchGroup.compareDocumentPosition(photosHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     }
   });
 
@@ -451,10 +450,79 @@ describe('global-search root', () => {
     m.open();
     render(GlobalSearch, { props: { manager: m } });
     await user.type(screen.getByRole('combobox'), 'people');
-    await screen.findByText(/cmdk_top_result|top result/i);
+    await vi.waitFor(() => expect(document.querySelector('[data-cmdk-top-result-navigation]')).not.toBeNull());
     // There should be exactly one row carrying the People nav id.
     const rows = document.querySelectorAll('[data-command-item][data-value="nav:userPages:people"]');
     expect(rows).toHaveLength(1);
+  });
+
+  it('pressing Enter on typed text activates the promoted search row', async () => {
+    const m = new GlobalSearchManager();
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'beach{enter}');
+
+    expect(activateSearchSpy).toHaveBeenCalledWith('beach');
+  });
+
+  it('does not steal selection back from a real row until the query changes again', async () => {
+    const m = new GlobalSearchManager();
+    installPhotoStub(m, [{ id: 'photo-1', originalFileName: 'beach.jpg' }]);
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'beach');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'));
+    await vi.waitFor(
+      () => expect(document.querySelector('[data-command-item][data-value="photo:photo-1"]')).not.toBeNull(),
+      { timeout: 2000 },
+    );
+
+    await user.keyboard('{ArrowDown}');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('photo:photo-1'));
+
+    m.sections.photos = {
+      status: 'ok',
+      items: [{ id: 'photo-1', originalFileName: 'beach.jpg' } as never],
+      total: 1,
+    };
+    m.reconcileCursor();
+
+    expect(m.activeItemId).toBe('photo:photo-1');
+
+    await user.type(input, 's');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'));
+  });
+
+  it('keeps the preview pane in its neutral state while top-search is selected', async () => {
+    mediaState.minLg = true;
+    const m = new GlobalSearchManager();
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'beach');
+
+    expect(m.activeItemId).toBe('top-search');
+    expect(screen.queryByText(/cmdk_nothing_to_preview|select a result|nothing to preview/i)).not.toBeNull();
+  });
+
+  it('clearing typed text returns selection to the newest recent row', async () => {
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', mode: 'smart', lastUsed: 1 } as never);
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', mode: 'smart', lastUsed: 2 } as never);
+    const m = new GlobalSearchManager();
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'b');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'));
+
+    await user.clear(input);
+
+    await vi.waitFor(() => expect(m.activeItemId).toBe('query:sunset'));
   });
 
   it('renders recent entries when store is non-empty and query is blank', () => {
@@ -549,6 +617,11 @@ describe('global-search root', () => {
     m.open();
     render(GlobalSearch, { props: { manager: m } });
     await user.type(screen.getByRole('combobox'), 'beach');
+    await vi.waitFor(
+      () => expect(document.querySelector('[data-command-item][data-value="photo:a1"]')).not.toBeNull(),
+      { timeout: 2000 },
+    );
+    await user.keyboard('{ArrowDown}');
     await vi.waitFor(() => expect(m.activeItemId).toBe('photo:a1'), { timeout: 2000 });
     await user.keyboard('{Enter}');
     expect(activateSpy).toHaveBeenCalledWith('photo', expect.objectContaining({ id: 'a1' }));

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -493,13 +493,12 @@
                     <button
                       type="button"
                       onclick={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
-                      class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId ===
-                      manager.topSearchMatch.id
+                      class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId === manager.topSearchMatch.id
                         ? 'bg-primary/10'
                         : ''}"
                     >
-                        <Icon icon={mdiMagnify} />
-                        <span>{$t('cmdk_top_search_label', { values: { query: manager.topSearchMatch.query } })}</span>
+                      <Icon icon={mdiMagnify} />
+                      <span>{$t('cmdk_top_search_label', { values: { query: manager.topSearchMatch.query } })}</span>
                     </button>
                   </div>
                 </Command.Group>

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Icon, IconButton, Modal, modalManager, ModalBody } from '@immich/ui';
-  import { mdiClose } from '@mdi/js';
+  import { mdiClose, mdiMagnify } from '@mdi/js';
   import { Command } from 'bits-ui';
   import { t } from 'svelte-i18n';
   import type { GlobalSearchManager, SearchMode } from '$lib/managers/global-search-manager.svelte';
@@ -93,6 +93,19 @@
   $effect(() => {
     if (manager.activeItemId && manager.activeItemId !== selectedValue) {
       selectedValue = manager.activeItemId;
+    }
+  });
+
+  let lastAutoSelectedTopSearchQuery = $state<string | null>(null);
+  $effect(() => {
+    const topSearchMatch = manager.topSearchMatch;
+    if (!topSearchMatch) {
+      lastAutoSelectedTopSearchQuery = null;
+      return;
+    }
+    if (lastAutoSelectedTopSearchQuery !== topSearchMatch.query) {
+      selectedValue = topSearchMatch.id;
+      lastAutoSelectedTopSearchQuery = topSearchMatch.query;
     }
   });
 
@@ -221,6 +234,7 @@
     if (e.key === 'Escape' && manager.pendingConfirmId !== null) {
       manager.cancelConfirm();
       e.preventDefault();
+      e.stopPropagation();
       return;
     }
     if (e.key === 'Escape') {
@@ -411,6 +425,27 @@
                 </div>
               {/if}
             {:else if manager.scope === 'all'}
+              {#if manager.topSearchMatch}
+                <Command.Group class="mb-4" data-cmdk-top-result-search>
+                  <Command.GroupHeading
+                    class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {$t('cmdk_top_result')}
+                  </Command.GroupHeading>
+                  <Command.GroupItems>
+                    <Command.Item
+                      value={manager.topSearchMatch.id}
+                      onSelect={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
+                      class="group"
+                    >
+                      <div class="flex items-center gap-3 rounded-lg px-3 py-2 group-data-[selected]:bg-primary/10">
+                        <Icon icon={mdiMagnify} />
+                        <span>{$t('cmdk_top_search_label', { values: { query: manager.topSearchMatch.query } })}</span>
+                      </div>
+                    </Command.Item>
+                  </Command.GroupItems>
+                </Command.Group>
+              {/if}
               {#if manager.topCommandMatch}
                 <Command.Group class="mb-4" data-cmdk-top-result-commands>
                   <Command.GroupHeading
@@ -429,7 +464,7 @@
                   </Command.GroupItems>
                 </Command.Group>
               {:else if manager.topNavigationMatch}
-                <Command.Group class="mb-4">
+                <Command.Group class="mb-4" data-cmdk-top-result-navigation>
                   <Command.GroupHeading
                     class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                   >

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -493,7 +493,8 @@
                     <button
                       type="button"
                       onclick={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
-                      class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId === manager.topSearchMatch.id
+                      class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId ===
+                      manager.topSearchMatch.id
                         ? 'bg-primary/10'
                         : ''}"
                     >

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -44,14 +44,21 @@
   });
   let selectedValue = $state<string>('');
 
-  $effect(() => {
-    manager.setQuery(inputValue);
-  });
+  function setSelectedValue(value: string | null) {
+    selectedValue = value ?? '';
+    manager.setActiveItem(value);
+  }
+
+  function syncSelectedValueFromBits(value: string) {
+    if (manager.activeItemId === manager.topSearchMatch?.id) {
+      selectedValue = '';
+      return;
+    }
+    setSelectedValue(value);
+  }
 
   $effect(() => {
-    if (selectedValue) {
-      manager.setActiveItem(selectedValue);
-    }
+    manager.setQuery(inputValue);
   });
 
   // bits-ui's built-in scroll-into-view logic has a quirk: when the selected item is
@@ -91,33 +98,40 @@
   });
 
   $effect(() => {
+    if (manager.activeItemId === manager.topSearchMatch?.id) {
+      if (selectedValue !== '') {
+        selectedValue = '';
+      }
+      return;
+    }
     if (manager.activeItemId && manager.activeItemId !== selectedValue) {
-      selectedValue = manager.activeItemId;
+      setSelectedValue(manager.activeItemId);
     }
   });
 
   let lastAutoSelectedTopSearchQuery = $state<string | null>(null);
   let lastDismissedTopSearchQuery = $state<string | null>(null);
-  let previousSelectedValue = $state('');
+  let previousActiveItemId = $state<string | null>(null);
   $effect(() => {
     const topSearchMatch = manager.topSearchMatch;
     if (!topSearchMatch) {
       lastAutoSelectedTopSearchQuery = null;
       lastDismissedTopSearchQuery = null;
-      previousSelectedValue = selectedValue;
+      previousActiveItemId = manager.activeItemId;
       return;
     }
-    if (previousSelectedValue === topSearchMatch.id && selectedValue !== topSearchMatch.id) {
+    if (previousActiveItemId === topSearchMatch.id && manager.activeItemId !== topSearchMatch.id) {
       lastDismissedTopSearchQuery = topSearchMatch.query;
     }
     if (
       lastAutoSelectedTopSearchQuery !== topSearchMatch.query &&
       lastDismissedTopSearchQuery !== topSearchMatch.query
     ) {
-      selectedValue = topSearchMatch.id;
+      selectedValue = '';
+      manager.setActiveItem(topSearchMatch.id);
       lastAutoSelectedTopSearchQuery = topSearchMatch.query;
     }
-    previousSelectedValue = selectedValue;
+    previousActiveItemId = manager.activeItemId;
   });
 
   // Render-time filter: drop unreachable navigate recents before they hit the DOM.
@@ -230,6 +244,25 @@
     manager.close();
   }
 
+  function moveSelectionFromTopSearch(direction: 1 | -1) {
+    const topSearchId = manager.topSearchMatch?.id;
+    const currentValue = selectedValue || manager.activeItemId;
+    if (!topSearchId || currentValue !== topSearchId) {
+      return false;
+    }
+    const items = [...document.querySelectorAll<HTMLElement>('[data-command-item]')];
+    if (items.length === 0) {
+      return false;
+    }
+    const target = direction === 1 ? items[0] : items.at(-1);
+    const nextValue = target?.dataset.value;
+    if (!nextValue) {
+      return false;
+    }
+    setSelectedValue(nextValue);
+    return true;
+  }
+
   function onKeyDown(e: KeyboardEvent) {
     // Bare `?` opens the app-wide keyboard shortcuts modal. No modifiers — Ctrl/Alt/Meta
     // fall through so browser chords (e.g. a custom user-agent binding) still work.
@@ -280,6 +313,19 @@
       e.preventDefault();
       return;
     }
+    if (e.key === 'Enter' && manager.topSearchMatch && manager.activeItemId === manager.topSearchMatch.id) {
+      manager.activateSearch(manager.topSearchMatch.query);
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowDown' && moveSelectionFromTopSearch(1)) {
+      e.preventDefault();
+      return;
+    }
+    if (e.key === 'ArrowUp' && moveSelectionFromTopSearch(-1)) {
+      e.preventDefault();
+      return;
+    }
     if (e.key === 'Home' || e.key === 'End') {
       // bits-ui tags each Command.Item with a data-command-item attribute (see
       // bits-ui command.svelte.js:1204 — `createBitsAttrs({ component: 'command' ... })`
@@ -312,8 +358,9 @@
       shouldFilter={false}
       vimBindings={false}
       loop
-      bind:value={selectedValue}
+      bind:value={() => selectedValue, syncSelectedValueFromBits}
       aria-labelledby="global-search-label"
+      onkeydown={onKeyDown}
       class="flex h-full min-h-0 flex-col"
     >
       <div class="flex items-center border-b border-gray-200 dark:border-gray-700">
@@ -322,7 +369,6 @@
           autofocus
           placeholder={$t('cmdk_placeholder')}
           maxlength={256}
-          onkeydown={onKeyDown}
           class="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm focus:outline-none"
         />
         <IconButton
@@ -443,18 +489,19 @@
                   >
                     {$t('cmdk_top_result')}
                   </Command.GroupHeading>
-                  <Command.GroupItems>
-                    <Command.Item
-                      value={manager.topSearchMatch.id}
-                      onSelect={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
-                      class="group"
+                  <div class="px-1">
+                    <button
+                      type="button"
+                      onclick={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
+                      class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId ===
+                      manager.topSearchMatch.id
+                        ? 'bg-primary/10'
+                        : ''}"
                     >
-                      <div class="flex items-center gap-3 rounded-lg px-3 py-2 group-data-[selected]:bg-primary/10">
                         <Icon icon={mdiMagnify} />
                         <span>{$t('cmdk_top_search_label', { values: { query: manager.topSearchMatch.query } })}</span>
-                      </div>
-                    </Command.Item>
-                  </Command.GroupItems>
+                    </button>
+                  </div>
                 </Command.Group>
               {/if}
               {#if manager.topCommandMatch}

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -97,16 +97,27 @@
   });
 
   let lastAutoSelectedTopSearchQuery = $state<string | null>(null);
+  let lastDismissedTopSearchQuery = $state<string | null>(null);
+  let previousSelectedValue = $state('');
   $effect(() => {
     const topSearchMatch = manager.topSearchMatch;
     if (!topSearchMatch) {
       lastAutoSelectedTopSearchQuery = null;
+      lastDismissedTopSearchQuery = null;
+      previousSelectedValue = selectedValue;
       return;
     }
-    if (lastAutoSelectedTopSearchQuery !== topSearchMatch.query) {
+    if (previousSelectedValue === topSearchMatch.id && selectedValue !== topSearchMatch.id) {
+      lastDismissedTopSearchQuery = topSearchMatch.query;
+    }
+    if (
+      lastAutoSelectedTopSearchQuery !== topSearchMatch.query &&
+      lastDismissedTopSearchQuery !== topSearchMatch.query
+    ) {
       selectedValue = topSearchMatch.id;
       lastAutoSelectedTopSearchQuery = topSearchMatch.query;
     }
+    previousSelectedValue = selectedValue;
   });
 
   // Render-time filter: drop unreachable navigate recents before they hit the DOM.

--- a/web/src/lib/elements/SearchBar.spec.ts
+++ b/web/src/lib/elements/SearchBar.spec.ts
@@ -3,14 +3,16 @@ import SearchBar from '$lib/elements/SearchBar.svelte';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 
+type SearchBarWrapperProps = {
+  component: typeof SearchBar;
+  componentProps: Record<string, unknown>;
+};
+
 function renderSearchBar(props: Record<string, unknown>) {
-  return render(
-    TestWrapper as Component<{ component: typeof SearchBar; componentProps: typeof props }>,
-    {
-      component: SearchBar,
-      componentProps: props,
-    },
-  );
+  return render(TestWrapper as Component<SearchBarWrapperProps>, {
+    component: SearchBar,
+    componentProps: props,
+  });
 }
 
 describe('SearchBar', () => {

--- a/web/src/lib/elements/SearchBar.spec.ts
+++ b/web/src/lib/elements/SearchBar.spec.ts
@@ -1,0 +1,62 @@
+import TestWrapper from '$lib/components/TestWrapper.svelte';
+import SearchBar from '$lib/elements/SearchBar.svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+
+function renderSearchBar(props: Record<string, unknown>) {
+  return render(
+    TestWrapper as Component<{ component: typeof SearchBar; componentProps: typeof props }>,
+    {
+      component: SearchBar,
+      componentProps: props,
+    },
+  );
+}
+
+describe('SearchBar', () => {
+  it('calls onBlurSearch when focus leaves the search bar', async () => {
+    const onBlurSearch = vi.fn();
+    const outsideButton = document.createElement('button');
+    document.body.append(outsideButton);
+
+    renderSearchBar({
+      name: 'beach',
+      placeholder: 'Search',
+      showLoadingSpinner: false,
+      onBlurSearch,
+    });
+
+    await fireEvent.blur(screen.getByPlaceholderText('Search'), { relatedTarget: outsideButton });
+
+    expect(onBlurSearch).toHaveBeenCalledTimes(1);
+    outsideButton.remove();
+  });
+
+  it('does not call onBlurSearch when focus moves to an internal control', async () => {
+    const onBlurSearch = vi.fn();
+
+    renderSearchBar({
+      name: 'beach',
+      placeholder: 'Search',
+      showLoadingSpinner: false,
+      onBlurSearch,
+    });
+
+    const input = screen.getByPlaceholderText('Search');
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+
+    await fireEvent.blur(input, { relatedTarget: clearButton });
+
+    expect(onBlurSearch).not.toHaveBeenCalled();
+  });
+
+  it('does not fail when onBlurSearch is omitted', async () => {
+    renderSearchBar({
+      name: 'beach',
+      placeholder: 'Search',
+      showLoadingSpinner: false,
+    });
+
+    await fireEvent.blur(screen.getByPlaceholderText('Search'));
+  });
+});

--- a/web/src/lib/elements/SearchBar.svelte
+++ b/web/src/lib/elements/SearchBar.svelte
@@ -12,6 +12,7 @@
     placeholder: string;
     onSearch?: (options: SearchOptions) => void;
     onReset?: () => void;
+    onBlurSearch?: () => void;
   }
 
   let {
@@ -21,9 +22,11 @@
     placeholder,
     onSearch = () => {},
     onReset = () => {},
+    onBlurSearch,
   }: Props = $props();
 
-  let inputRef = $state<HTMLElement>();
+  let containerRef = $state<HTMLDivElement>();
+  let inputRef = $state<HTMLInputElement>();
 
   const resetSearch = () => {
     name = '';
@@ -36,9 +39,18 @@
       onSearch({ force: true });
     }
   };
+
+  const handleInputBlur = (event: FocusEvent) => {
+    const nextFocusTarget = event.relatedTarget;
+    if (nextFocusTarget instanceof Node && containerRef?.contains(nextFocusTarget)) {
+      return;
+    }
+    onBlurSearch?.();
+  };
 </script>
 
 <div
+  bind:this={containerRef}
   class="flex items-center text-sm {roundedBottom
     ? 'rounded-2xl'
     : 'rounded-t-lg'} bg-gray-200 p-2 dark:bg-immich-dark-gray gap-2 place-items-center h-full"
@@ -60,6 +72,7 @@
     bind:this={inputRef}
     onkeydown={handleSearch}
     oninput={() => onSearch({ force: false })}
+    onblur={handleInputBlur}
   />
   {#if showLoadingSpinner}
     <div class="flex place-items-center">

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2631,24 +2631,30 @@ describe('SWR loading rules', () => {
   });
 
   it('stale-batch providers do not deadlock batchInFlight after a new batch supersedes', async () => {
-    let resolveStalePhotos!: () => void;
-    vi.mocked(searchSmart).mockImplementationOnce(
-      () => new Promise((r) => (resolveStalePhotos = () => r({ assets: { items: [], nextPage: null } } as never))),
-    );
     const m = new GlobalSearchManager();
-    m.open();
-    m.setQuery('first');
-    await vi.advanceTimersByTimeAsync(200);
-    expect(m.batchInFlight).toBe(true);
-    // Second query — runBatch2 resets counter and uses the default empty mock so it settles fast.
-    m.setQuery('second');
-    await vi.advanceTimersByTimeAsync(200);
-    expect(m.batchInFlight).toBe(false);
-    // Release stale photos — check-before-decrement guard must prevent corruption.
-    resolveStalePhotos();
-    await vi.advanceTimersByTimeAsync(10);
-    expect((m as unknown as { inFlightCounter: number }).inFlightCounter).toBe(0);
-    expect(m.batchInFlight).toBe(false);
+    const photosProvider = (m as unknown as { providers: { photos: Provider } }).providers.photos;
+    const originalPhotosRun = photosProvider.run;
+    let resolveStalePhotos!: () => void;
+    photosProvider.run = vi.fn(
+      () => new Promise((r) => (resolveStalePhotos = () => r({ status: 'empty' } as ProviderStatus<EntityItem>))),
+    );
+    try {
+      m.open();
+      m.setQuery('first');
+      await vi.advanceTimersByTimeAsync(200);
+      expect(m.batchInFlight).toBe(true);
+      // Second query — runBatch2 resets counter and uses the default empty mock so it settles fast.
+      m.setQuery('second');
+      await vi.advanceTimersByTimeAsync(200);
+      expect(m.batchInFlight).toBe(false);
+      // Release stale photos — check-before-decrement guard must prevent corruption.
+      resolveStalePhotos();
+      await vi.advanceTimersByTimeAsync(10);
+      expect((m as unknown as { inFlightCounter: number }).inFlightCounter).toBe(0);
+      expect(m.batchInFlight).toBe(false);
+    } finally {
+      photosProvider.run = originalPhotosRun;
+    }
   });
 
   it('runBatch entry resets inFlightCounter to zero before incrementing per-provider', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -52,9 +52,9 @@ import { installFakeAbortTimeout, restoreAbortTimeout } from './__tests__/fake-a
 import { commandContextManager } from './command-context-manager.svelte';
 import { COMMAND_ITEMS, type CommandItem } from './command-items';
 import {
-  type EntityItem,
   GlobalSearchManager,
   RECONCILE_ORDER_BY_SCOPE,
+  type EntityItem,
   type Provider,
   type ProviderStatus,
   type SearchMode,

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -4174,16 +4174,16 @@ describe('prefix scoping — runBatch gating', () => {
 
   it('scope people with bare @ bypasses minQueryLength', async () => {
     const m = new GlobalSearchManager();
-    const searchPersonSpy = vi.mocked(searchPerson);
-    searchPersonSpy.mockClear();
+    const getAllPeopleSpy = vi.mocked(getAllPeople);
+    getAllPeopleSpy.mockClear();
 
     m.setQuery('@'); // payload.length = 0, below people.minQueryLength = 2
     await vi.advanceTimersByTimeAsync(150);
 
     // people.minQueryLength=2 would normally set section to idle; bypass
-    // dispatches to the provider's bare branch instead (which does NOT call searchPerson).
+    // dispatches to the bare-suggestions branch instead.
     expect(m.sections.people.status).not.toBe('idle');
-    expect(searchPersonSpy).not.toHaveBeenCalled();
+    expect(getAllPeopleSpy).toHaveBeenCalledTimes(1);
   });
 
   it('scope people with single-char payload relaxes minQueryLength to 1', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -93,7 +93,11 @@ vi.mock('$app/navigation', () => ({
 }));
 
 const { mockPage } = vi.hoisted(() => ({
-  mockPage: { route: { id: null as string | null }, params: {} as Record<string, string> },
+  mockPage: {
+    route: { id: null as string | null },
+    params: {} as Record<string, string>,
+    url: new URL('https://gallery.test/photos'),
+  },
 }));
 vi.mock('$app/state', () => ({ page: mockPage }));
 
@@ -146,6 +150,9 @@ describe('GlobalSearchManager (skeleton)', () => {
 
   beforeEach(() => {
     localStorage.clear();
+    mockPage.route.id = null;
+    mockPage.params = {};
+    mockPage.url = new URL('https://gallery.test/photos');
     manager = new GlobalSearchManager();
   });
 
@@ -1158,6 +1165,33 @@ describe('activate("command")', () => {
     manager.close();
     manager.open();
     expect(getEntries()).toEqual([]);
+  });
+
+  it('activateSearch preserves same-route params but drops stale space asset ids', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos/asset-123?view=grid');
+
+    m.activateSearch('beach');
+
+    expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach');
+  });
+
+  it('activateSearch falls back to /photos and drops unrelated params', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums?view=list');
+
+    m.activateSearch('beach');
+
+    expect(goto).toHaveBeenCalledWith('/photos?q=beach');
+  });
+
+  it('activateSearch falls back from /spaces/:id/people to /photos', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/people');
+
+    m.activateSearch('beach');
+
+    expect(goto).toHaveBeenCalledWith('/photos?q=beach');
   });
 });
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2635,9 +2635,16 @@ describe('SWR loading rules', () => {
     const photosProvider = (m as unknown as { providers: { photos: Provider } }).providers.photos;
     const originalPhotosRun = photosProvider.run;
     let resolveStalePhotos!: () => void;
-    photosProvider.run = vi.fn(
-      () => new Promise((r) => (resolveStalePhotos = () => r({ status: 'empty' } as ProviderStatus<EntityItem>))),
-    );
+    let invocationCount = 0;
+    photosProvider.run = vi.fn((...args) => {
+      invocationCount++;
+      if (invocationCount === 1) {
+        return new Promise(
+          (r) => (resolveStalePhotos = () => r({ status: 'empty' } as ProviderStatus<EntityItem>)),
+        ) as Promise<ProviderStatus<EntityItem>>;
+      }
+      return originalPhotosRun(...args);
+    });
     try {
       m.open();
       m.setQuery('first');
@@ -4167,13 +4174,16 @@ describe('prefix scoping — runBatch gating', () => {
     ]) {
       s.mockClear();
     }
+    const searchSmartCallsBefore = searchSmartSpy.mock.calls.length;
+    const searchPersonCallsBefore = searchPersonSpy.mock.calls.length;
+    const searchPlacesCallsBefore = searchPlacesSpy.mock.calls.length;
 
     m.setQuery('>theme');
     await vi.advanceTimersByTimeAsync(150);
 
-    expect(searchSmartSpy).not.toHaveBeenCalled();
-    expect(searchPersonSpy).not.toHaveBeenCalled();
-    expect(searchPlacesSpy).not.toHaveBeenCalled();
+    expect(searchSmartSpy).toHaveBeenCalledTimes(searchSmartCallsBefore);
+    expect(searchPersonSpy).toHaveBeenCalledTimes(searchPersonCallsBefore);
+    expect(searchPlacesSpy).toHaveBeenCalledTimes(searchPlacesCallsBefore);
     // Navigation section populated via synchronous runNavigationProvider, not runBatch.
     expect(m.sections.navigation.status).toBe('ok');
   });

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1468,6 +1468,20 @@ describe('topNavigationMatch', () => {
   });
 });
 
+describe('topSearchMatch', () => {
+  it('is present only for non-empty all-scope queries', () => {
+    const m = new GlobalSearchManager();
+    m.query = ' beach ';
+    expect(m.topSearchMatch).toEqual({ id: 'top-search', query: 'beach' });
+
+    m.query = '';
+    expect(m.topSearchMatch).toBeNull();
+
+    m.query = '@alice';
+    expect(m.topSearchMatch).toBeNull();
+  });
+});
+
 describe('removeRecent()', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -52,6 +52,7 @@ import { installFakeAbortTimeout, restoreAbortTimeout } from './__tests__/fake-a
 import { commandContextManager } from './command-context-manager.svelte';
 import { COMMAND_ITEMS, type CommandItem } from './command-items';
 import {
+  type EntityItem,
   GlobalSearchManager,
   RECONCILE_ORDER_BY_SCOPE,
   type Provider,
@@ -2632,18 +2633,18 @@ describe('SWR loading rules', () => {
 
   it('stale-batch providers do not deadlock batchInFlight after a new batch supersedes', async () => {
     const m = new GlobalSearchManager();
-    const photosProvider = (m as unknown as { providers: { photos: Provider } }).providers.photos;
+    const photosProvider = (m as unknown as { providers: { photos: Provider<EntityItem> } }).providers.photos;
     const originalPhotosRun = photosProvider.run;
     let resolveStalePhotos!: () => void;
     let invocationCount = 0;
-    photosProvider.run = vi.fn((...args) => {
+    photosProvider.run = vi.fn((query: string, mode: SearchMode, signal: AbortSignal) => {
       invocationCount++;
       if (invocationCount === 1) {
         return new Promise(
           (r) => (resolveStalePhotos = () => r({ status: 'empty' } as ProviderStatus<EntityItem>)),
         ) as Promise<ProviderStatus<EntityItem>>;
       }
-      return originalPhotosRun(...args);
+      return originalPhotosRun(query, mode, signal);
     });
     try {
       m.open();

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -85,6 +85,8 @@ export type ActiveItem =
   | { kind: 'nav'; data: NavigationItem }
   | { kind: 'command'; data: CommandItem };
 
+type TopSearchMatch = { id: 'top-search'; query: string };
+
 const VALID_MODES: ReadonlySet<SearchMode> = new Set(['smart', 'metadata', 'description', 'ocr']);
 // Slice size for the albums section. Kept as a named constant so the buildProviders
 // `topN: 5` and the runAlbums slice cannot drift apart silently.
@@ -1102,6 +1104,9 @@ export class GlobalSearchManager {
   }
 
   reconcileCursor() {
+    if (this.activeItemId === this.topSearchMatch?.id) {
+      return;
+    }
     if (this.getActiveItem() !== null) {
       return;
     }
@@ -1613,6 +1618,14 @@ export class GlobalSearchManager {
       }
     }
     return null;
+  });
+
+  topSearchMatch = $derived.by<TopSearchMatch | null>(() => {
+    const query = this.query.trim();
+    if (this.scope !== 'all' || query.length === 0) {
+      return null;
+    }
+    return { id: 'top-search', query };
   });
 
   /**

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -26,7 +26,7 @@ import {
 import { toastManager } from '@immich/ui';
 import { computeCommandScore } from 'bits-ui';
 import { locale as i18nLocale, t, type Translations } from 'svelte-i18n';
-import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
 import { get } from 'svelte/store';
 import { parseScope, personSuggestionsComparator, type ParsedQuery, type Scope } from './cmdk-prefix';
 import { commandContextManager } from './command-context-manager.svelte';
@@ -1186,7 +1186,7 @@ export class GlobalSearchManager {
 
   private buildSearchDestination(text: string): string {
     const pathname = page.url.pathname;
-    const params = new URLSearchParams(page.url.searchParams);
+    const params = new SvelteURLSearchParams(page.url.searchParams);
     params.set('q', text);
 
     if (pathname.startsWith('/photos')) {
@@ -1202,7 +1202,7 @@ export class GlobalSearchManager {
       return `/map?${params.toString()}`;
     }
 
-    const fresh = new URLSearchParams();
+    const fresh = new SvelteURLSearchParams();
     fresh.set('q', text);
     return `/photos?${fresh.toString()}`;
   }

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
+import { page } from '$app/state';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
 import { Route } from '$lib/route';
@@ -1162,6 +1163,59 @@ export class GlobalSearchManager {
       // Fall through to goto if URL parsing fails.
     }
     void goto(route);
+  }
+
+  private getSpaceSearchBasePath(pathname: string): string | null {
+    const parts = pathname.split('/').filter(Boolean);
+    if (parts[0] !== 'spaces' || parts[1] === undefined) {
+      return null;
+    }
+    if (parts.length === 2) {
+      return `/spaces/${parts[1]}`;
+    }
+    if (parts[2] === 'photos') {
+      return `/spaces/${parts[1]}/photos`;
+    }
+    return null;
+  }
+
+  private buildSearchDestination(text: string): string {
+    const pathname = page.url.pathname;
+    const params = new URLSearchParams(page.url.searchParams);
+    params.set('q', text);
+
+    if (pathname.startsWith('/photos')) {
+      return `/photos?${params.toString()}`;
+    }
+
+    const spaceBasePath = this.getSpaceSearchBasePath(pathname);
+    if (spaceBasePath) {
+      return `${spaceBasePath}?${params.toString()}`;
+    }
+
+    if (pathname.startsWith('/map')) {
+      return `/map?${params.toString()}`;
+    }
+
+    const fresh = new URLSearchParams();
+    fresh.set('q', text);
+    return `/photos?${fresh.toString()}`;
+  }
+
+  activateSearch(text: string): void {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    addEntry({
+      kind: 'query',
+      id: `query:${trimmed.toLowerCase()}`,
+      text: trimmed,
+      mode: this.mode,
+      lastUsed: Date.now(),
+    });
+    void goto(this.buildSearchDestination(trimmed));
   }
 
   activate(kind: 'photo' | 'person' | 'place' | 'tag' | 'nav' | 'command', item: unknown) {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -3,7 +3,11 @@
   import { page } from '$app/state';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
-  import { clearFilters, createFilterState, getActiveFilterCount } from '$lib/components/filter-panel/filter-panel';
+  import {
+    clearFilters,
+    createFilterState,
+    getActiveFilterCount,
+  } from '$lib/components/filter-panel/filter-panel';
   import type { FilterState } from '$lib/components/filter-panel/filter-panel';
   import { handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
   import { buildMapMarkerOptions, buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
@@ -87,7 +91,9 @@
       },
     };
   });
-  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0 || committedQuery.trim().length > 0);
+  const hasActiveFilters = $derived(
+    getActiveFilterCount(filters) > 0 || committedQuery.trim().length > 0,
+  );
   const noResults = $derived(mapMarkers.length === 0 && hasActiveFilters);
   const timeBucketOptions = $derived.by(() => buildMapTimeBucketOptions(filters, spaceId));
   const mapMarkerOptions = $derived.by(() => buildMapMarkerOptions(filters, spaceId));
@@ -165,7 +171,7 @@
               break;
             }
 
-            nextPage = assets.nextPage;
+            nextPage = assets.nextPage === null ? null : Number(assets.nextPage);
           }
 
           if (controller.signal.aborted) {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -3,11 +3,7 @@
   import { page } from '$app/state';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
-  import {
-    clearFilters,
-    createFilterState,
-    getActiveFilterCount,
-  } from '$lib/components/filter-panel/filter-panel';
+  import { clearFilters, createFilterState, getActiveFilterCount } from '$lib/components/filter-panel/filter-panel';
   import type { FilterState } from '$lib/components/filter-panel/filter-panel';
   import { handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
   import { buildMapMarkerOptions, buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
@@ -25,12 +21,7 @@
   import { buildMapFilterConfig } from '$lib/utils/map-filter-config';
   import { navigate } from '$lib/utils/navigation';
   import { buildSmartSearchParams, SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
-  import {
-    getFilteredMapMarkers,
-    getTimeBuckets,
-    type MapMarkerResponseDto,
-    searchSmart,
-  } from '@immich/sdk';
+  import { getFilteredMapMarkers, getTimeBuckets, type MapMarkerResponseDto, searchSmart } from '@immich/sdk';
   import { Icon, IconButton } from '@immich/ui';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { mdiArrowLeft, mdiFilterVariant } from '@mdi/js';
@@ -91,9 +82,7 @@
       },
     };
   });
-  const hasActiveFilters = $derived(
-    getActiveFilterCount(filters) > 0 || committedQuery.trim().length > 0,
-  );
+  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0 || committedQuery.trim().length > 0);
   const noResults = $derived(mapMarkers.length === 0 && hasActiveFilters);
   const timeBucketOptions = $derived.by(() => buildMapTimeBucketOptions(filters, spaceId));
   const mapMarkerOptions = $derived.by(() => buildMapMarkerOptions(filters, spaceId));

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import { clearFilters, createFilterState, getActiveFilterCount } from '$lib/components/filter-panel/filter-panel';
@@ -20,7 +20,13 @@
   import { delay } from '$lib/utils/asset-utils';
   import { buildMapFilterConfig } from '$lib/utils/map-filter-config';
   import { navigate } from '$lib/utils/navigation';
-  import { getFilteredMapMarkers, getTimeBuckets, type MapMarkerResponseDto } from '@immich/sdk';
+  import { buildSmartSearchParams, SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
+  import {
+    getFilteredMapMarkers,
+    getTimeBuckets,
+    type MapMarkerResponseDto,
+    searchSmart,
+  } from '@immich/sdk';
   import { Icon, IconButton } from '@immich/ui';
   import { SvelteMap } from 'svelte/reactivity';
   import { mdiArrowLeft, mdiFilterVariant } from '@mdi/js';
@@ -35,7 +41,8 @@
 
   let { data }: Props = $props();
 
-  const spaceId = $derived($page.url.searchParams.get(QueryParameter.SPACE_ID) || undefined);
+  const spaceId = $derived(page.url.searchParams.get(QueryParameter.SPACE_ID) || undefined);
+  const committedQuery = $derived(page.url.searchParams.get('q') ?? '');
 
   let selectedClusterIds = $state.raw(new Set<string>());
   let selectedClusterBBox = $state.raw<SelectionBBox>();
@@ -80,7 +87,7 @@
       },
     };
   });
-  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0);
+  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0 || committedQuery.trim().length > 0);
   const noResults = $derived(mapMarkers.length === 0 && hasActiveFilters);
   const timeBucketOptions = $derived.by(() => buildMapTimeBucketOptions(filters, spaceId));
   const mapMarkerOptions = $derived.by(() => buildMapMarkerOptions(filters, spaceId));
@@ -94,25 +101,103 @@
 
   // Debounced marker fetch when filters change
   let fetchTimeout: ReturnType<typeof setTimeout> | undefined;
+  let queryAbortController: AbortController | undefined;
 
   $effect(() => {
     // Read the derived options before the debounce callback so filter changes
     // are tracked as dependencies of this effect.
     const options = mapMarkerOptions;
+    const currentSpaceId = spaceId;
+    const query = committedQuery.trim();
 
     clearTimeout(fetchTimeout);
-    fetchTimeout = setTimeout(() => {
-      void getFilteredMapMarkers(options)
-        .then((result) => {
-          mapMarkers = result;
-        })
-        .catch((error: unknown) => {
-          console.error('Failed to fetch filtered map markers:', error);
-        });
-    }, 200);
+    queryAbortController?.abort();
+    const controller = new AbortController();
+    queryAbortController = controller;
 
-    return () => clearTimeout(fetchTimeout);
+    fetchTimeout = setTimeout(() => {
+      void (async () => {
+        try {
+          const markers = await getFilteredMapMarkers(options);
+
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          if (!query) {
+            mapMarkers = markers;
+            return;
+          }
+
+          if (markers.length === 0) {
+            mapMarkers = [];
+            return;
+          }
+
+          const matchingIds = new Set<string>();
+          const unmatchedMarkerIds = new Set(markers.map((marker) => marker.id));
+          let nextPage: number | null = 1;
+
+          while (nextPage !== null && !controller.signal.aborted) {
+            const { assets } = await searchSmart({
+              smartSearchDto: {
+                ...buildSmartSearchParams({
+                  query,
+                  filters,
+                  spaceId: currentSpaceId,
+                  withSharedSpaces: !currentSpaceId,
+                }),
+                page: nextPage,
+                size: 100,
+              },
+            });
+
+            if (controller.signal.aborted) {
+              return;
+            }
+
+            for (const asset of assets.items) {
+              matchingIds.add(asset.id);
+              unmatchedMarkerIds.delete(asset.id);
+            }
+
+            if (unmatchedMarkerIds.size === 0) {
+              break;
+            }
+
+            nextPage = assets.nextPage;
+          }
+
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          mapMarkers = markers.filter((marker) => matchingIds.has(marker.id));
+        } catch (error: unknown) {
+          if (controller.signal.aborted) {
+            return;
+          }
+          console.error('Failed to fetch filtered map markers:', error);
+          mapMarkers = [];
+        }
+      })();
+    }, SEARCH_FILTER_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(fetchTimeout);
+      controller.abort();
+    };
   });
+
+  function clearCommittedQuery() {
+    const url = new URL(page.url);
+    url.searchParams.delete('q');
+    void goto(`${url.pathname}${url.search}${url.hash}`, {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  }
 
   function closeTimelinePanel() {
     isTimelinePanelVisible = false;
@@ -200,6 +285,8 @@
             <ActiveFiltersBar
               {filters}
               resultCount={mapMarkers.length}
+              searchQuery={committedQuery}
+              onClearSearch={clearCommittedQuery}
               {personNames}
               {tagNames}
               onRemoveFilter={(type, id) => {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -28,7 +28,7 @@
     searchSmart,
   } from '@immich/sdk';
   import { Icon, IconButton } from '@immich/ui';
-  import { SvelteMap } from 'svelte/reactivity';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { mdiArrowLeft, mdiFilterVariant } from '@mdi/js';
   import { onDestroy, onMount } from 'svelte';
   import { t } from 'svelte-i18n';
@@ -134,8 +134,8 @@
             return;
           }
 
-          const matchingIds = new Set<string>();
-          const unmatchedMarkerIds = new Set(markers.map((marker) => marker.id));
+          const matchingIds = new SvelteSet<string>();
+          const unmatchedMarkerIds = new SvelteSet(markers.map((marker) => marker.id));
           let nextPage: number | null = 1;
 
           while (nextPage !== null && !controller.signal.aborted) {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -133,7 +133,9 @@ describe('Map page query intersection', () => {
       expect(screen.getByTestId('search-chip')).toHaveTextContent('beach');
       expect(sdkMock.getFilteredMapMarkers).toHaveBeenCalledTimes(1);
       expect(sdkMock.searchSmart).toHaveBeenCalledWith(
-        expect.objectContaining({ smartSearchDto: expect.objectContaining({ query: 'beach', page: 1, size: 100 }) }),
+        expect.objectContaining({
+          smartSearchDto: expect.objectContaining({ query: 'beach', page: 1, size: 100 }),
+        }),
       );
       expect(screen.getByTestId('map-stub')).toHaveAttribute('data-marker-ids', 'asset-2');
     });

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -1,0 +1,172 @@
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import TestWrapper from '$lib/components/TestWrapper.svelte';
+import { SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import MapPage from './+page.svelte';
+
+const { gotoMock, mockPage, mockAssetViewerManager } = vi.hoisted(() => ({
+  gotoMock: vi.fn().mockResolvedValue(undefined),
+  mockPage: {
+    url: new URL('https://gallery.test/map'),
+    route: { id: '/(user)/map/[[photos=photos]]/[[assetId=id]]' },
+    params: {},
+  },
+  mockAssetViewerManager: {
+    isViewing: false,
+    asset: undefined,
+    showAssetViewer: vi.fn(),
+    setAssetId: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('$app/navigation', () => ({ goto: gotoMock }));
+vi.mock('$app/state', () => ({ page: mockPage }));
+
+vi.mock('$lib/components/layouts/user-page-layout.svelte', async () => {
+  const { default: MockComponent } = await import('$lib/components/spaces/mock-user-page-layout.test-wrapper.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/OnEvents.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/bindable-filter-panel.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('./MapTimelinePanel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/elements/Portal.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/shared-components/map/map.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/map-component.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/managers/asset-viewer-manager.svelte', () => ({
+  assetViewerManager: mockAssetViewerManager,
+}));
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: { value: { map: true } },
+}));
+
+vi.mock('$lib/utils/navigation', () => ({ navigate: vi.fn() }));
+
+function renderPage() {
+  const props = {
+    data: {
+      meta: { title: 'Map' },
+    },
+  };
+
+  return render(
+    TestWrapper as Component<{ component: typeof MapPage; componentProps: typeof props }>,
+    {
+      component: MapPage,
+      componentProps: props,
+    },
+  );
+}
+
+async function flushQueryDebounce() {
+  await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+}
+
+describe('Map page query intersection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetAllMocks();
+    gotoMock.mockResolvedValue(undefined);
+    mockPage.url = new URL('https://gallery.test/map');
+    sdkMock.getTimeBuckets.mockResolvedValue([]);
+    sdkMock.getFilteredMapMarkers.mockResolvedValue([]);
+    sdkMock.searchSmart.mockResolvedValue({
+      assets: { items: [], nextPage: null },
+      albums: { items: [], nextPage: null },
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the existing marker flow when q is absent', async () => {
+    sdkMock.getFilteredMapMarkers.mockResolvedValue([{ id: 'asset-1', lat: 1, lon: 2 } as never]);
+
+    renderPage();
+    await flushQueryDebounce();
+
+    await waitFor(() => {
+      expect(sdkMock.getFilteredMapMarkers).toHaveBeenCalledTimes(1);
+      expect(sdkMock.searchSmart).not.toHaveBeenCalled();
+      expect(screen.getByTestId('map-stub')).toHaveAttribute('data-marker-ids', 'asset-1');
+    });
+  });
+
+  it('intersects map markers with paginated searchSmart ids when q is present', async () => {
+    mockPage.url = new URL('https://gallery.test/map?q=beach');
+    sdkMock.getFilteredMapMarkers.mockResolvedValue([
+      { id: 'asset-1', lat: 1, lon: 2 } as never,
+      { id: 'asset-2', lat: 2, lon: 3 } as never,
+    ]);
+    sdkMock.searchSmart.mockResolvedValueOnce({
+      assets: { items: [{ id: 'asset-2' }], nextPage: null },
+      albums: { items: [], nextPage: null },
+    } as never);
+
+    renderPage();
+    await flushQueryDebounce();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-chip')).toHaveTextContent('beach');
+      expect(sdkMock.getFilteredMapMarkers).toHaveBeenCalledTimes(1);
+      expect(sdkMock.searchSmart).toHaveBeenCalledWith(
+        expect.objectContaining({ smartSearchDto: expect.objectContaining({ query: 'beach', page: 1, size: 100 }) }),
+      );
+      expect(screen.getByTestId('map-stub')).toHaveAttribute('data-marker-ids', 'asset-2');
+    });
+  });
+
+  it('stops paging once every currently fetched marker id has been matched', async () => {
+    mockPage.url = new URL('https://gallery.test/map?q=beach');
+    sdkMock.getFilteredMapMarkers.mockResolvedValue([{ id: 'asset-2', lat: 2, lon: 3 } as never]);
+    sdkMock.searchSmart.mockResolvedValueOnce({
+      assets: { items: [{ id: 'asset-2' }], nextPage: 2 },
+      albums: { items: [], nextPage: null },
+    } as never);
+
+    renderPage();
+    await flushQueryDebounce();
+
+    await waitFor(() => {
+      expect(sdkMock.searchSmart).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('map-stub')).toHaveAttribute('data-marker-ids', 'asset-2');
+    });
+  });
+
+  it('clears q through the URL while preserving the map hash', async () => {
+    mockPage.url = new URL('https://gallery.test/map?q=beach#12/48.8566/2.3522');
+
+    renderPage();
+
+    await fireEvent.click(screen.getByTestId('search-chip-close'));
+
+    expect(gotoMock).toHaveBeenCalledWith('/map#12/48.8566/2.3522', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+});

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -71,13 +71,10 @@ function renderPage() {
     },
   };
 
-  return render(
-    TestWrapper as Component<{ component: typeof MapPage; componentProps: typeof props }>,
-    {
-      component: MapPage,
-      componentProps: props,
-    },
-  );
+  return render(TestWrapper as Component<{ component: typeof MapPage; componentProps: typeof props }>, {
+    component: MapPage,
+    componentProps: props,
+  });
 }
 
 async function flushQueryDebounce() {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -93,7 +93,7 @@
   } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import { untrack } from 'svelte';
-  import { SvelteMap } from 'svelte/reactivity';
+  import { SvelteMap, SvelteURLSearchParams } from 'svelte/reactivity';
   import type { PageData } from './$types';
 
   type ViewMode = 'view' | 'select-assets' | 'select-cover';
@@ -611,22 +611,25 @@
 
   const commitSearch = async (nextQuery = draftSearchQuery) => {
     const trimmed = nextQuery.trim();
-    const url = new URL(page.url);
-    url.pathname = getSearchPathname(url.pathname);
+    const pathname = getSearchPathname(page.url.pathname);
+    const searchParams = new SvelteURLSearchParams(page.url.searchParams);
 
     if (trimmed) {
-      url.searchParams.set('q', trimmed);
+      searchParams.set('q', trimmed);
     } else {
-      url.searchParams.delete('q');
+      searchParams.delete('q');
     }
 
     draftSearchQuery = trimmed;
 
-    if (url.pathname + url.search === page.url.pathname + page.url.search) {
+    const search = searchParams.toString();
+    const nextUrl = pathname + (search ? `?${search}` : '');
+
+    if (nextUrl === page.url.pathname + page.url.search) {
       return;
     }
 
-    await goto(url.pathname + url.search, {
+    await goto(nextUrl, {
       replaceState: true,
       keepFocus: true,
       noScroll: true,

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -869,7 +869,13 @@
       {/if}
 
       {#if showSearchResults}
-        <SmartSearchResults searchQuery={committedSearchQuery} bind:isLoading {filters} spaceId={space.id} isShared={true} />
+        <SmartSearchResults
+          searchQuery={committedSearchQuery}
+          bind:isLoading
+          {filters}
+          spaceId={space.id}
+          isShared={true}
+        />
       {/if}
 
       {#if !showSearchResults}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
@@ -91,6 +92,7 @@
     mdiPlus,
   } from '@mdi/js';
   import { t } from 'svelte-i18n';
+  import { untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import type { PageData } from './$types';
 
@@ -112,18 +114,23 @@
   // Sync when navigating between spaces (component persists, data updates)
   $effect(() => {
     if (data.space.id !== space.id) {
+      const nextCommittedSearchQuery = page.url.searchParams.get('q') ?? '';
       space = data.space;
       members = data.members;
-      filters = createFilterState();
+      filters = {
+        ...createFilterState(),
+        sortOrder: nextCommittedSearchQuery.trim().length > 0 ? 'relevance' : 'desc',
+      };
       activities = [];
       hasMoreActivities = false;
       activityOffset = 0;
       spacePeople = [];
       personNames.clear();
       tagNames.clear();
-      searchQuery = '';
       isLoading = false;
-      showSearchResults = false;
+      draftSearchQuery = nextCommittedSearchQuery;
+      lastHydratedSearchQuery = nextCommittedSearchQuery;
+      lastHandledCommittedSearchQuery = nextCommittedSearchQuery;
       heroCollapsed = loadHeroCollapsed(data.space.id);
       panelOpen = false;
       viewMode = 'view';
@@ -147,7 +154,11 @@
   let timelineManager = $state<TimelineManager>() as TimelineManager;
 
   // Filter state
-  let filters = $state(createFilterState());
+  const initialCommittedSearchQuery = page.url.searchParams.get('q') ?? '';
+  let filters = $state({
+    ...createFilterState(),
+    sortOrder: initialCommittedSearchQuery.trim().length > 0 ? 'relevance' : 'desc',
+  });
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
 
@@ -576,21 +587,90 @@
     await Promise.all([refreshSpace(), loadActivities()]);
   };
 
-  let searchQuery = $state('');
+  const committedSearchQuery = $derived(page.url.searchParams.get('q') ?? '');
+  let draftSearchQuery = $state(initialCommittedSearchQuery);
+  let lastHydratedSearchQuery = $state(initialCommittedSearchQuery);
+  let lastHandledCommittedSearchQuery = $state(initialCommittedSearchQuery);
   let isLoading = $state(false);
-  let showSearchResults = $state(false);
+  const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
+
+  const getSearchPathname = (pathname: string) => {
+    const spaceBasePath = `/spaces/${space.id}`;
+    const photosPath = `${spaceBasePath}/photos`;
+
+    if (pathname === spaceBasePath || pathname === photosPath) {
+      return pathname;
+    }
+
+    if (pathname.startsWith(`${photosPath}/`)) {
+      return photosPath;
+    }
+
+    return pathname;
+  };
+
+  const commitSearch = async (nextQuery = draftSearchQuery) => {
+    const trimmed = nextQuery.trim();
+    const url = new URL(page.url);
+    url.pathname = getSearchPathname(url.pathname);
+
+    if (trimmed) {
+      url.searchParams.set('q', trimmed);
+    } else {
+      url.searchParams.delete('q');
+    }
+
+    draftSearchQuery = trimmed;
+
+    if (url.pathname + url.search === page.url.pathname + page.url.search) {
+      return;
+    }
+
+    await goto(url.pathname + url.search, {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  };
 
   const handleSearchSubmit = () => {
-    filters = { ...filters, sortOrder: 'relevance' };
-    showSearchResults = true;
+    void commitSearch();
   };
 
   const clearSearch = () => {
-    searchQuery = '';
     isLoading = false;
-    showSearchResults = false;
-    filters = { ...filters, sortOrder: 'desc' };
+    void commitSearch('');
   };
+
+  $effect(() => {
+    const nextCommittedSearchQuery = committedSearchQuery;
+
+    if (nextCommittedSearchQuery === lastHydratedSearchQuery) {
+      return;
+    }
+
+    untrack(() => {
+      draftSearchQuery = nextCommittedSearchQuery;
+      lastHydratedSearchQuery = nextCommittedSearchQuery;
+    });
+  });
+
+  $effect(() => {
+    const nextCommittedSearchQuery = committedSearchQuery;
+
+    if (nextCommittedSearchQuery === lastHandledCommittedSearchQuery) {
+      return;
+    }
+
+    untrack(() => {
+      isLoading = false;
+      filters = {
+        ...filters,
+        sortOrder: nextCommittedSearchQuery.trim().length > 0 ? 'relevance' : 'desc',
+      };
+      lastHandledCommittedSearchQuery = nextCommittedSearchQuery;
+    });
+  });
 
   const gradientClasses: Record<string, string> = {
     [UserAvatarColor.Primary]: 'from-immich-primary/60 to-immich-primary',
@@ -644,13 +724,14 @@
           <div class="hidden h-10 sm:block sm:w-40 xl:w-60">
             <SearchBar
               placeholder={$t('search')}
-              bind:name={searchQuery}
+              bind:name={draftSearchQuery}
               showLoadingSpinner={isLoading}
               onSearch={({ force }) => {
                 if (force) {
-                  void handleSearchSubmit();
+                  handleSearchSubmit();
                 }
               }}
+              onBlurSearch={handleSearchSubmit}
               onReset={clearSearch}
             />
           </div>
@@ -765,7 +846,7 @@
     <!-- Main Content — pl-4 adds breathing room between filter panel and content -->
     <div class="flex flex-1 flex-col overflow-hidden pl-4">
       <!-- Active filter chips -->
-      {#if viewMode === 'view' && (getActiveFilterCount(filters) > 0 || searchQuery.trim().length > 0)}
+      {#if viewMode === 'view' && (getActiveFilterCount(filters) > 0 || committedSearchQuery.trim().length > 0)}
         <ActiveFiltersBar
           {filters}
           resultCount={showSearchResults ? undefined : totalAssetCount}
@@ -775,13 +856,13 @@
           onClearAll={() => {
             filters = clearFilters(filters);
           }}
-          {searchQuery}
+          searchQuery={committedSearchQuery}
           onClearSearch={clearSearch}
         />
       {/if}
 
       {#if showSearchResults}
-        <SmartSearchResults bind:isLoading {searchQuery} {filters} spaceId={space.id} isShared={true} />
+        <SmartSearchResults searchQuery={committedSearchQuery} bind:isLoading {filters} spaceId={space.id} isShared={true} />
       {/if}
 
       {#if !showSearchResults}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -111,6 +111,10 @@
     () => members,
   );
 
+  function getSearchSortOrder(query: string): FilterState['sortOrder'] {
+    return query.trim().length > 0 ? 'relevance' : 'desc';
+  }
+
   // Sync when navigating between spaces (component persists, data updates)
   $effect(() => {
     if (data.space.id !== space.id) {
@@ -119,7 +123,7 @@
       members = data.members;
       filters = {
         ...createFilterState(),
-        sortOrder: nextCommittedSearchQuery.trim().length > 0 ? 'relevance' : 'desc',
+        sortOrder: getSearchSortOrder(nextCommittedSearchQuery),
       };
       activities = [];
       hasMoreActivities = false;
@@ -155,9 +159,9 @@
 
   // Filter state
   const initialCommittedSearchQuery = page.url.searchParams.get('q') ?? '';
-  let filters = $state({
+  let filters = $state<FilterState>({
     ...createFilterState(),
-    sortOrder: initialCommittedSearchQuery.trim().length > 0 ? 'relevance' : 'desc',
+    sortOrder: getSearchSortOrder(initialCommittedSearchQuery),
   });
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
@@ -669,7 +673,7 @@
       isLoading = false;
       filters = {
         ...filters,
-        sortOrder: nextCommittedSearchQuery.trim().length > 0 ? 'relevance' : 'desc',
+        sortOrder: getSearchSortOrder(nextCommittedSearchQuery),
       };
       lastHandledCommittedSearchQuery = nextCommittedSearchQuery;
     });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -1,0 +1,245 @@
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import TestWrapper from '$lib/components/TestWrapper.svelte';
+import type { SharedSpaceMemberResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
+import { SharedSpaceRole } from '@immich/sdk';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import SpacesPage from './+page.svelte';
+
+const { gotoMock, mockPage, mockAssetMultiSelectManager, mockAuthManager, mockEventManager } = vi.hoisted(() => ({
+  gotoMock: vi.fn().mockResolvedValue(undefined),
+  mockPage: {
+    url: new URL('https://gallery.test/spaces/space-1/photos'),
+    route: { id: '/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]' },
+    params: { spaceId: 'space-1' },
+  },
+  mockAssetMultiSelectManager: {
+    selectionActive: false,
+    assets: [],
+    clear: vi.fn(),
+    isAllUserOwned: true,
+  },
+  mockAuthManager: {
+    user: { id: 'user-1', isAdmin: false, name: 'Owner', email: 'owner@example.com' },
+  },
+  mockEventManager: {
+    emit: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+vi.mock('$app/navigation', () => ({ goto: gotoMock }));
+vi.mock('$app/state', () => ({ page: mockPage }));
+
+vi.mock('$lib/components/layouts/user-page-layout.svelte', async () => {
+  const { default: MockComponent } = await import('$lib/components/spaces/mock-user-page-layout.test-wrapper.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/OnEvents.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/bindable-filter-panel.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/search-sort-dropdown.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/sort-toggle.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/search/smart-search-results.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/smart-search-results.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/shared-components/context-menu/button-context-menu.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/spaces/space-map.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/spaces/space-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/Timeline.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/bindable-timeline.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/managers/asset-multi-select-manager.svelte', () => ({
+  assetMultiSelectManager: mockAssetMultiSelectManager,
+}));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({ authManager: mockAuthManager }));
+vi.mock('$lib/managers/command-context-manager.svelte', () => ({ registerSpaceContext: vi.fn() }));
+vi.mock('$lib/managers/event-manager.svelte', () => ({ eventManager: mockEventManager }));
+vi.mock('$lib/utils/space-hero-storage', () => ({
+  loadHeroCollapsed: vi.fn().mockReturnValue(false),
+  persistHeroCollapsed: vi.fn(),
+}));
+
+function makeSpace(overrides: Partial<SharedSpaceResponseDto> = {}): SharedSpaceResponseDto {
+  return {
+    id: 'space-1',
+    name: 'Test Space',
+    createdById: 'user-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    assetCount: 3,
+    memberCount: 1,
+    faceRecognitionEnabled: false,
+    hasPets: false,
+    petsEnabled: false,
+    color: 'primary',
+    recentAssetIds: [],
+    recentAssetThumbhashes: [],
+    members: [],
+    thumbnailAssetId: null,
+    thumbnailCropY: null,
+    newAssetCount: 0,
+    ...overrides,
+  } as SharedSpaceResponseDto;
+}
+
+function makeMember(overrides: Partial<SharedSpaceMemberResponseDto> = {}): SharedSpaceMemberResponseDto {
+  return {
+    userId: 'user-1',
+    email: 'owner@example.com',
+    name: 'Owner',
+    role: SharedSpaceRole.Owner,
+    showInTimeline: true,
+    joinedAt: '2026-01-01T00:00:00.000Z',
+    contributionCount: 0,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const props = {
+    data: {
+      space: makeSpace(),
+      members: [makeMember()],
+      meta: { title: 'Test Space' },
+    },
+  };
+
+  return render(
+    TestWrapper as Component<{ component: typeof SpacesPage; componentProps: typeof props }>,
+    {
+      component: SpacesPage,
+      componentProps: props,
+    },
+  );
+}
+
+describe('Spaces page search URL sync', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    gotoMock.mockResolvedValue(undefined);
+    mockAssetMultiSelectManager.selectionActive = false;
+    mockAssetMultiSelectManager.assets = [];
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+    sdkMock.markSpaceViewed.mockResolvedValue(undefined);
+    sdkMock.getSpaceActivities.mockResolvedValue([]);
+    sdkMock.getSpacePeople.mockResolvedValue([]);
+  });
+
+  it('hydrates the in-page search input from q', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+
+    renderPage();
+
+    expect(screen.getByPlaceholderText(/search/i)).toHaveValue('beach');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+  });
+
+  it('commits a trimmed query on Enter and preserves other params', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?view=grid');
+
+    renderPage();
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await fireEvent.input(input, { target: { value: '  beach  ' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
+  it('drops a stale asset id when committing a search', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos/asset-123?view=grid');
+
+    renderPage();
+
+    const input = screen.getByPlaceholderText(/search/i);
+    await fireEvent.input(input, { target: { value: 'beach' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
+  it('commits the draft query on blur', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    renderPage();
+
+    const input = screen.getByPlaceholderText(/search/i);
+    const outsideButton = document.createElement('button');
+    document.body.append(outsideButton);
+
+    await fireEvent.input(input, { target: { value: 'beach' } });
+    await fireEvent.blur(input, { relatedTarget: outsideButton });
+
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?q=beach', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+
+    outsideButton.remove();
+  });
+
+  it('clears q while preserving unrelated params', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&view=grid');
+
+    renderPage();
+
+    await fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+    expect(screen.getByPlaceholderText(/search/i)).toHaveValue('');
+  });
+});

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -161,7 +161,7 @@ describe('Spaces page search URL sync', () => {
     mockAssetMultiSelectManager.selectionActive = false;
     mockAssetMultiSelectManager.assets = [];
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
-    sdkMock.markSpaceViewed.mockResolvedValue(undefined);
+    vi.mocked(sdkMock.markSpaceViewed).mockResolvedValue(void 0 as never);
     sdkMock.getSpaceActivities.mockResolvedValue([]);
     sdkMock.getSpacePeople.mockResolvedValue([]);
   });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -145,13 +145,10 @@ function renderPage() {
     },
   };
 
-  return render(
-    TestWrapper as Component<{ component: typeof SpacesPage; componentProps: typeof props }>,
-    {
-      component: SpacesPage,
-      componentProps: props,
-    },
-  );
+  return render(TestWrapper as Component<{ component: typeof SpacesPage; componentProps: typeof props }>, {
+    component: SpacesPage,
+    componentProps: props,
+  });
 }
 
 describe('Spaces page search URL sync', () => {

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    filters?: unknown;
+    [key: string]: unknown;
+  }
+
+  let { filters = $bindable() }: Props = $props();
+</script>
+
+<div data-testid="filter-panel-stub" data-has-filters={String(filters !== undefined)}></div>

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -4,7 +4,7 @@
     [key: string]: unknown;
   }
 
-  let { filters = $bindable() }: Props = $props();
+  let { filters = $bindable(), ...rest }: Props = $props();
 </script>
 
-<div data-testid="filter-panel-stub" data-has-filters={String(filters !== undefined)}></div>
+<div {...rest} data-testid="filter-panel-stub" data-has-filters={String(filters !== undefined)}></div>

--- a/web/src/test-data/mocks/bindable-timeline.stub.svelte
+++ b/web/src/test-data/mocks/bindable-timeline.stub.svelte
@@ -4,7 +4,7 @@
     [key: string]: unknown;
   }
 
-  let { timelineManager = $bindable() }: Props = $props();
+  let { timelineManager = $bindable(), ...rest }: Props = $props();
 </script>
 
-<div data-testid="timeline-stub" data-has-timeline={String(timelineManager !== undefined)}></div>
+<div {...rest} data-testid="timeline-stub" data-has-timeline={String(timelineManager !== undefined)}></div>

--- a/web/src/test-data/mocks/bindable-timeline.stub.svelte
+++ b/web/src/test-data/mocks/bindable-timeline.stub.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    timelineManager?: unknown;
+    [key: string]: unknown;
+  }
+
+  let { timelineManager = $bindable() }: Props = $props();
+</script>
+
+<div data-testid="timeline-stub" data-has-timeline={String(timelineManager !== undefined)}></div>

--- a/web/src/test-data/mocks/map-component.stub.svelte
+++ b/web/src/test-data/mocks/map-component.stub.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  interface Props {
+    mapMarkers?: Array<{ id: string }>;
+    [key: string]: unknown;
+  }
+
+  let { mapMarkers = [] }: Props = $props();
+</script>
+
+<div
+  data-testid="map-stub"
+  data-marker-count={String(mapMarkers.length)}
+  data-marker-ids={mapMarkers.map((marker) => marker.id).join(',')}
+></div>

--- a/web/src/test-data/mocks/map-component.stub.svelte
+++ b/web/src/test-data/mocks/map-component.stub.svelte
@@ -4,10 +4,11 @@
     [key: string]: unknown;
   }
 
-  let { mapMarkers = [] }: Props = $props();
+  let { mapMarkers = [], ...rest }: Props = $props();
 </script>
 
 <div
+  {...rest}
   data-testid="map-stub"
   data-marker-count={String(mapMarkers.length)}
   data-marker-ids={mapMarkers.map((marker) => marker.id).join(',')}

--- a/web/src/test-data/mocks/noop-component.svelte
+++ b/web/src/test-data/mocks/noop-component.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  const props = $props();
+</script>
+
+<div data-testid="noop-component" data-prop-count={String(Object.keys(props).length)}></div>

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -5,7 +5,7 @@
     [key: string]: unknown;
   }
 
-  let { isLoading = $bindable(false), searchQuery = '' }: Props = $props();
+  let { isLoading = $bindable(false), searchQuery = '', ...rest }: Props = $props();
 </script>
 
-<div data-testid="smart-search-results" data-loading={String(isLoading)} data-search-query={searchQuery}></div>
+<div {...rest} data-testid="smart-search-results" data-loading={String(isLoading)} data-search-query={searchQuery}></div>

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -8,4 +8,9 @@
   let { isLoading = $bindable(false), searchQuery = '', ...rest }: Props = $props();
 </script>
 
-<div {...rest} data-testid="smart-search-results" data-loading={String(isLoading)} data-search-query={searchQuery}></div>
+<div
+  {...rest}
+  data-testid="smart-search-results"
+  data-loading={String(isLoading)}
+  data-search-query={searchQuery}
+></div>

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  interface Props {
+    isLoading?: boolean;
+    searchQuery?: string;
+    [key: string]: unknown;
+  }
+
+  let { isLoading = $bindable(false), searchQuery = '' }: Props = $props();
+</script>
+
+<div data-testid="smart-search-results" data-loading={String(isLoading)} data-search-query={searchQuery}></div>


### PR DESCRIPTION
## Summary
- add `activateSearch()` and promote free-text Enter handling through the cmdk top search row
- route palette search activation to the current page for `/photos`, `/spaces/:id`, and `/map`
- sync `/spaces` search state through URL `?q=` and add `/map?q=` marker intersection behavior

## Testing
- `./node_modules/.bin/vitest run src/lib/managers/global-search-manager.svelte.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts src/lib/elements/SearchBar.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts' 'src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts' src/lib/components/filter-panel/active-filters-bar.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts src/lib/utils/__tests__/space-search.spec.ts`\n- Updated Playwright coverage in `e2e/src/specs/web/spaces-search.e2e-spec.ts` but could not run it locally because Playwright browsers are not installed in this environment.