### PR TITLE
feat(web): add query recents to the cmdk palette

### DIFF
--- a/e2e/src/specs/web/global-search.e2e-spec.ts
+++ b/e2e/src/specs/web/global-search.e2e-spec.ts
@@ -178,6 +178,24 @@ test.describe('global search palette', () => {
     await expect(recentGroup.getByText('Vacation 2024')).toBeVisible();
   });
 
+  test('query recents replay on /photos', async ({ page }) => {
+    await page.getByTestId('cmdk-trigger').click();
+    let dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('combobox').fill('beach');
+    await page.keyboard.press('Enter');
+    await expect(page).toHaveURL(/\/photos\?q=beach$/);
+
+    await page.goto('/photos');
+    await page.getByTestId('cmdk-trigger').waitFor({ state: 'visible' });
+    await page.getByTestId('cmdk-trigger').click();
+    dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    const recentGroup = dialog.getByRole('group', { name: /^recent$/i });
+    await recentGroup.getByText('beach').click();
+    await expect(page).toHaveURL(/\/photos\?q=beach$/);
+  });
+
   test('stale RECENT space entry triggers toast + removal on activate', async ({ page }) => {
     // Seed a RECENT entry pointing at a well-formed-but-unallocated space UUID
     // for the admin user. The localStorage write happens on the page that's

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -385,7 +385,7 @@ describe('global-search root', () => {
   it('quick-links fallback is replaced by recents once any recent exists', () => {
     // Recents take priority — the empty-empty nav fallback is only the cold
     // path, so a single recent entry must collapse it.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach-query-text', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:beach-query-text', text: 'beach-query-text', lastUsed: 1 });
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
@@ -510,8 +510,8 @@ describe('global-search root', () => {
   });
 
   it('clearing typed text returns selection to the newest recent row', async () => {
-    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', mode: 'smart', lastUsed: 1 } as never);
-    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', mode: 'smart', lastUsed: 2 } as never);
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 2 });
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
@@ -526,7 +526,7 @@ describe('global-search root', () => {
   });
 
   it('renders recent entries when store is non-empty and query is blank', () => {
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
     addEntry({ kind: 'photo', id: 'photo:a1', assetId: 'a1', label: 'sunset.jpg', lastUsed: 2 });
     const m = new GlobalSearchManager();
     m.open();
@@ -539,8 +539,8 @@ describe('global-search root', () => {
     // Seed two recents, highlight the newest, press Delete, assert the row
     // disappears from the DOM in the same tick. This pins the reactive-tick
     // contract between the component and manager.removeRecent/recentsRevision.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
-    addEntry({ kind: 'query', id: 'q:sunset', text: 'sunset', mode: 'smart', lastUsed: 2 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 2 });
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
@@ -550,35 +550,35 @@ describe('global-search root', () => {
     // Highlight the newer entry — mirrors what the auto-highlight / ArrowDown
     // path would do. `{Delete}` is the forward-delete key on full keyboards; on
     // Mac laptops the OS maps Fn+Backspace to it.
-    m.setActiveItem('q:sunset');
+    m.setActiveItem('query:sunset');
     await user.keyboard('{Delete}');
     await vi.waitFor(() => expect(screen.queryByText('sunset')).toBeNull());
     expect(screen.getByText('beach')).toBeInTheDocument();
-    expect(getEntries().map((e) => e.id)).toEqual(['q:beach']);
+    expect(getEntries().map((e) => e.id)).toEqual(['query:beach']);
   });
 
   it('Backspace on a highlighted recent (empty input) removes it', async () => {
     // Backspace is a safe alternative to Delete because it is a no-op in an
     // empty text input — users on Mac laptops without a forward-delete key can
     // still prune recents without an Fn chord.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
-    addEntry({ kind: 'query', id: 'q:sunset', text: 'sunset', mode: 'smart', lastUsed: 2 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 2 });
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
     const input = screen.getByRole('combobox');
     input.focus();
-    m.setActiveItem('q:sunset');
+    m.setActiveItem('query:sunset');
     await user.keyboard('{Backspace}');
     await vi.waitFor(() => expect(screen.queryByText('sunset')).toBeNull());
-    expect(getEntries().map((e) => e.id)).toEqual(['q:beach']);
+    expect(getEntries().map((e) => e.id)).toEqual(['query:beach']);
   });
 
   it('Backspace does NOT remove a recent while the input has text', async () => {
     // Regression guard: Backspace in the empty-input "recents mode" prunes, but
     // once the user has typed something Backspace must revert to its usual text
     // behaviour (delete a character) so the combobox is still editable.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
@@ -588,7 +588,7 @@ describe('global-search root', () => {
     await user.keyboard('{Backspace}');
     // Backspace ate the 'i'; the recent entry is still in the store.
     expect(input.value).toBe('h');
-    expect(getEntries().map((e) => e.id)).toEqual(['q:beach']);
+    expect(getEntries().map((e) => e.id)).toEqual(['query:beach']);
   });
 
   it('per-row X button removes the recent entry without activating the row', async () => {
@@ -596,7 +596,7 @@ describe('global-search root', () => {
     // call removeRecent, NOT activateRecent — clicking it should never navigate
     // away from the palette. `stopPropagation` on the button click is the key
     // implementation detail this regression guards.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
     const m = new GlobalSearchManager();
     const activateSpy = vi.spyOn(m, 'activateRecent').mockImplementation(() => {});
     m.open();
@@ -627,16 +627,16 @@ describe('global-search root', () => {
     expect(activateSpy).toHaveBeenCalledWith('photo', expect.objectContaining({ id: 'a1' }));
   });
 
-  it('activateRecent("query", ...) updates the input value via manager.query sync', async () => {
-    addEntry({ kind: 'query', id: 'q:sunset', text: 'sunset', mode: 'smart', lastUsed: 1 });
+  it('activateRecent("query", ...) replays through activateSearch on the current page', async () => {
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 1 });
     const m = new GlobalSearchManager();
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
     m.open();
     render(GlobalSearch, { props: { manager: m } });
-    const input = screen.getByRole('combobox') as HTMLInputElement;
-    expect(input.value).toBe('');
-    // Directly invoke activateRecent on the manager — the effect should sync inputValue.
-    m.activateRecent({ kind: 'query', id: 'q:sunset', text: 'sunset', mode: 'smart', lastUsed: 1 });
-    await vi.waitFor(() => expect(input.value).toBe('sunset'));
+
+    m.activateRecent({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 1 });
+
+    expect(activateSearchSpy).toHaveBeenCalledWith('sunset');
   });
 
   it('preview pane is not mounted below 1024 px', () => {

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -627,7 +627,7 @@ describe('global-search root', () => {
     expect(activateSpy).toHaveBeenCalledWith('photo', expect.objectContaining({ id: 'a1' }));
   });
 
-  it('activateRecent("query", ...) replays through activateSearch on the current page', async () => {
+  it('activateRecent("query", ...) replays through activateSearch on the current page', () => {
     addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 1 });
     const m = new GlobalSearchManager();
     const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});

--- a/web/src/lib/components/global-search/__tests__/query-row.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/query-row.spec.ts
@@ -1,0 +1,14 @@
+import QueryRow from '$lib/components/global-search/rows/query-row.svelte';
+import { render, screen } from '@testing-library/svelte';
+
+describe('query-row', () => {
+  it('renders the query recent row with a magnify icon and text', () => {
+    const { container } = render(QueryRow, {
+      props: { entry: { text: 'beach' } },
+    });
+
+    expect(screen.getByTestId('query-row')).toBeInTheDocument();
+    expect(screen.getByText('beach')).toBeVisible();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/web/src/lib/components/global-search/__tests__/recent-row.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/recent-row.spec.ts
@@ -20,8 +20,9 @@ describe('recent-row', () => {
 
   it('renders query kind with text', () => {
     render(RecentRow, {
-      props: { entry: { kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 } },
+      props: { entry: { kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 } },
     });
+    expect(screen.getByTestId('query-row')).toBeInTheDocument();
     expect(screen.getByText('beach')).toBeInTheDocument();
   });
 

--- a/web/src/lib/components/global-search/rows/query-row.svelte
+++ b/web/src/lib/components/global-search/rows/query-row.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { Icon } from '@immich/ui';
+  import { mdiMagnify } from '@mdi/js';
+
+  interface Props {
+    entry: { text: string };
+  }
+
+  let { entry }: Props = $props();
+</script>
+
+<div
+  data-testid="query-row"
+  class="flex h-[52px] items-center gap-3 rounded-lg px-3 py-2 transition-colors duration-[80ms] ease-out group-data-[selected]:bg-primary/10"
+>
+  <div class="flex h-10 w-10 items-center justify-center rounded-md bg-subtle/40">
+    <Icon icon={mdiMagnify} size="1.125em" class="text-gray-500 dark:text-gray-400" />
+  </div>
+  <div class="min-w-0 flex-1">
+    <div class="truncate text-sm font-medium">{entry.text}</div>
+  </div>
+</div>

--- a/web/src/lib/components/global-search/rows/recent-row.svelte
+++ b/web/src/lib/components/global-search/rows/recent-row.svelte
@@ -6,6 +6,7 @@
   import PhotoRow from './photo-row.svelte';
   import PersonRow from './person-row.svelte';
   import PlaceRow from './place-row.svelte';
+  import QueryRow from './query-row.svelte';
   import SpaceRow from './space-row.svelte';
   import TagRow from './tag-row.svelte';
 
@@ -16,12 +17,7 @@
 </script>
 
 {#if entry.kind === 'query'}
-  <div
-    class="flex h-[52px] items-center gap-3 rounded-lg px-3 py-2 transition-colors duration-[80ms] ease-out group-data-[selected]:bg-primary/10"
-  >
-    <span class="text-sm text-gray-500 dark:text-gray-400" aria-hidden="true">🔍</span>
-    <div class="truncate text-sm">{entry.text}</div>
-  </div>
+  <QueryRow {entry} />
 {:else if entry.kind === 'photo'}
   <PhotoRow item={{ id: entry.assetId, originalFileName: entry.label } as never} />
 {:else if entry.kind === 'person'}

--- a/web/src/lib/managers/command-items.spec.ts
+++ b/web/src/lib/managers/command-items.spec.ts
@@ -190,7 +190,7 @@ describe('cmd:clear_recents', () => {
 
   it('clears recents when user is logged in', async () => {
     const key = 'cmdk.recent:test-user';
-    localStorage.setItem(key, JSON.stringify([{ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 }]));
+    localStorage.setItem(key, JSON.stringify([{ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 }]));
     const cmd = COMMAND_ITEMS.find((c) => c.id === 'cmd:clear_recents')!;
     await cmd.handler();
     expect(localStorage.getItem(key)).toBe(JSON.stringify([]));

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1154,7 +1154,7 @@ describe('activate("command")', () => {
   });
 
   it('cmd:clear_recents activated through the manager empties RECENT across open/close/open', async () => {
-    addEntry({ kind: 'query', id: 'q:hello', text: 'hello', mode: 'smart', lastUsed: Date.now() });
+    addEntry({ kind: 'query', id: 'query:hello', text: 'hello', lastUsed: Date.now() });
     expect(getEntries().length).toBeGreaterThan(0);
 
     const cmd = COMMAND_ITEMS.find((c) => c.id === 'cmd:clear_recents')!;
@@ -1218,14 +1218,15 @@ describe('activateRecent()', () => {
     vi.useRealTimers();
   });
 
-  it('query entry re-runs the search in place without closing', () => {
+  it('query entries replay through activateSearch without changing mode', () => {
     const m = new GlobalSearchManager();
-    m.open();
-    m.activateRecent({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'metadata', lastUsed: 1 });
-    expect(m.mode).toBe('metadata');
-    expect(m.query).toBe('beach');
-    expect(m.isOpen).toBe(true);
-    expect(goto).not.toHaveBeenCalled();
+    const spy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+
+    m.mode = 'ocr';
+    m.activateRecent({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+
+    expect(spy).toHaveBeenCalledWith('beach');
+    expect(m.mode).toBe('ocr');
   });
 
   it('photo entry navigates and closes', () => {
@@ -1491,11 +1492,11 @@ describe('removeRecent()', () => {
   });
 
   it('removes the matching recent entry from the store', () => {
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
-    addEntry({ kind: 'query', id: 'q:sunset', text: 'sunset', mode: 'smart', lastUsed: 2 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 2 });
     const m = new GlobalSearchManager();
-    m.removeRecent('q:beach');
-    expect(getEntries().map((e) => e.id)).toEqual(['q:sunset']);
+    m.removeRecent('query:beach');
+    expect(getEntries().map((e) => e.id)).toEqual(['query:sunset']);
   });
 
   it('bumps recentsRevision so Svelte-derived views can re-read', () => {
@@ -1503,10 +1504,10 @@ describe('removeRecent()', () => {
     // because cmdk-recent is a plain-function store (not a Svelte store). Without
     // a reactive tick, a mid-session mutation would leave the deleted row in the
     // DOM until the palette closed and reopened.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
     const m = new GlobalSearchManager();
     const before = m.recentsRevision;
-    m.removeRecent('q:beach');
+    m.removeRecent('query:beach');
     expect(m.recentsRevision).toBeGreaterThan(before);
   });
 
@@ -1520,14 +1521,14 @@ describe('removeRecent()', () => {
   it('reconciles the cursor after removing the currently-highlighted recent', () => {
     // When the user deletes the active row, the highlight must move to the next
     // available entry so keyboard users do not end up on a dead cursor.
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
-    addEntry({ kind: 'query', id: 'q:sunset', text: 'sunset', mode: 'smart', lastUsed: 2 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 2 });
     const m = new GlobalSearchManager();
     m.open();
-    m.setActiveItem('q:sunset');
-    m.removeRecent('q:sunset');
-    // 'q:sunset' is gone, the remaining entry 'q:beach' must take the highlight.
-    expect(m.activeItemId).toBe('q:beach');
+    m.setActiveItem('query:sunset');
+    m.removeRecent('query:sunset');
+    // 'query:sunset' is gone, the remaining entry 'query:beach' must take the highlight.
+    expect(m.activeItemId).toBe('query:beach');
   });
 });
 
@@ -1717,15 +1718,14 @@ describe('edge-case guards', () => {
     warnSpy.mockRestore();
   });
 
-  it('activateRecent with corrupt query entry (invalid mode) no-ops and closes', () => {
+  it('activateRecent with corrupt query entry (blank text) no-ops and closes', () => {
     const m = new GlobalSearchManager();
     m.open();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     m.activateRecent({
       kind: 'query',
-      id: 'q:bad',
-      text: 'x',
-      mode: 'evil' as unknown as 'smart',
+      id: 'query:bad',
+      text: '   ',
       lastUsed: 1,
     });
     expect(warnSpy).toHaveBeenCalled();
@@ -3209,10 +3209,10 @@ describe('getActiveItem recent-entry preview lookup (cold open)', () => {
   });
 
   it('returns null for a query-kind recent (no meaningful preview)', () => {
-    addEntry({ kind: 'query', id: 'q:beach', text: 'beach', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
     const m = new GlobalSearchManager();
     m.open();
-    m.activeItemId = 'q:beach';
+    m.activeItemId = 'query:beach';
     expect(m.getActiveItem()).toBeNull();
   });
 
@@ -4895,11 +4895,12 @@ describe('prefix scoping — defensive recent replay of scoped query', () => {
     localStorage.clear();
   });
 
-  it('activateRecent({kind:query, text:"@alice"}) re-derives scope=people, payload=alice', () => {
+  it('activateRecent({kind:query, text:"@alice"}) replays the raw scoped text through activateSearch', () => {
     const m = new GlobalSearchManager();
-    m.open();
-    m.activateRecent({ kind: 'query', id: 'query:@alice:smart', text: '@alice', mode: 'smart', lastUsed: Date.now() });
-    expect(m.scope).toBe('people');
-    expect(m.payload).toBe('alice');
+    const spy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+
+    m.activateRecent({ kind: 'query', id: 'query:@alice', text: '@alice', lastUsed: Date.now() });
+
+    expect(spy).toHaveBeenCalledWith('@alice');
   });
 });

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -143,7 +143,7 @@ export const RECONCILE_ORDER_BY_SCOPE: Record<Scope, ReadonlyArray<keyof Section
 function isValidRecentEntry(e: RecentEntry): boolean {
   switch (e.kind) {
     case 'query': {
-      return typeof e.text === 'string' && e.text.length > 0 && VALID_MODES.has(e.mode);
+      return typeof e.text === 'string' && e.text.trim().length > 0;
     }
     case 'photo': {
       return typeof e.assetId === 'string' && e.assetId.length > 0;
@@ -1217,7 +1217,6 @@ export class GlobalSearchManager {
       kind: 'query',
       id: `query:${trimmed.toLowerCase()}`,
       text: trimmed,
-      mode: this.mode,
       lastUsed: Date.now(),
     });
     void goto(this.buildSearchDestination(trimmed));
@@ -1384,13 +1383,12 @@ export class GlobalSearchManager {
       void this.activateSpace(entry.spaceId);
       return;
     }
-    const now = Date.now();
-    addEntry({ ...entry, lastUsed: now });
     if (entry.kind === 'query') {
-      this.setMode(entry.mode);
-      this.setQuery(entry.text);
+      this.activateSearch(entry.text);
       return;
     }
+    const now = Date.now();
+    addEntry({ ...entry, lastUsed: now });
     switch (entry.kind) {
       case 'photo': {
         void goto(Route.viewAsset({ id: entry.assetId }));

--- a/web/src/lib/stores/cmdk-recent.spec.ts
+++ b/web/src/lib/stores/cmdk-recent.spec.ts
@@ -32,10 +32,26 @@ describe('cmdk-recent', () => {
     expect(getEntries()).toEqual([]);
   });
 
+  it('normalizes legacy q:* query entries into query:* entries', () => {
+    localStorage.setItem(
+      'cmdk.recent:test-user',
+      JSON.stringify([{ kind: 'query', id: 'q:Beach', text: 'Beach', mode: 'smart', lastUsed: 1 }]),
+    );
+
+    expect(getEntries()).toEqual([{ kind: 'query', id: 'query:beach', text: 'Beach', lastUsed: 1 }]);
+  });
+
+  it('canonicalizes query recents on write and dedupes by lowered trimmed text', () => {
+    addEntry({ kind: 'query', id: 'q: Beach ', text: ' Beach ', lastUsed: 1 } as never);
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 2 });
+
+    expect(getEntries()).toEqual([{ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 2 }]);
+  });
+
   it('addEntry persists, returns newest first', () => {
-    addEntry({ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 });
-    addEntry({ kind: 'query', id: 'q:b', text: 'b', mode: 'smart', lastUsed: 2 });
-    expect(getEntries().map((e) => e.id)).toEqual(['q:b', 'q:a']);
+    addEntry({ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:b', text: 'b', lastUsed: 2 });
+    expect(getEntries().map((e) => e.id)).toEqual(['query:b', 'query:a']);
   });
 
   it('dedupes by id, updating lastUsed', () => {
@@ -48,34 +64,34 @@ describe('cmdk-recent', () => {
 
   it('trims to 20, keeping newest', () => {
     for (let i = 0; i < 25; i++) {
-      addEntry({ kind: 'query', id: `q:${i}`, text: `q${i}`, mode: 'smart', lastUsed: i });
+      addEntry({ kind: 'query', id: `query:${i}`, text: `q${i}`, lastUsed: i });
     }
     const entries = getEntries();
     expect(entries).toHaveLength(20);
-    expect(entries[0].id).toBe('q:24');
-    expect(entries[19].id).toBe('q:5');
+    expect(entries[0].id).toBe('query:q24');
+    expect(entries[19].id).toBe('query:q5');
   });
 
   it('treats corrupt JSON as empty; next write overwrites', () => {
     localStorage.setItem('cmdk.recent:test-user', 'not-valid-json');
     __resetForTests();
     expect(getEntries()).toEqual([]);
-    addEntry({ kind: 'query', id: 'q:x', text: 'x', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:x', text: 'x', lastUsed: 1 });
     expect(getEntries()).toHaveLength(1);
   });
 
   it('QuotaExceededError does not throw; the failing write is silently dropped', () => {
-    addEntry({ kind: 'query', id: 'q:initial', text: 'initial', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:initial', text: 'initial', lastUsed: 1 });
     const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw Object.assign(new Error('quota'), { name: 'QuotaExceededError' });
     });
-    expect(() => addEntry({ kind: 'query', id: 'q:new', text: 'new', mode: 'smart', lastUsed: 2 })).not.toThrow();
+    expect(() => addEntry({ kind: 'query', id: 'query:new', text: 'new', lastUsed: 2 })).not.toThrow();
     spy.mockRestore();
     // The successful write from before the spy is still there; the failed write
     // didn't make it through. No in-memory caching means no "last-known good"
     // state to preserve — the palette will simply miss the newest entry.
     const entries = getEntries();
-    expect(entries.some((e) => e.id === 'q:initial')).toBe(true);
+    expect(entries.some((e) => e.id === 'query:initial')).toBe(true);
   });
 
   it('handles localStorage unavailable (getItem throws)', () => {
@@ -83,12 +99,12 @@ describe('cmdk-recent', () => {
       throw new Error('SecurityError');
     });
     expect(getEntries()).toEqual([]);
-    expect(() => addEntry({ kind: 'query', id: 'q:x', text: 'x', mode: 'smart', lastUsed: 1 })).not.toThrow();
+    expect(() => addEntry({ kind: 'query', id: 'query:x', text: 'x', lastUsed: 1 })).not.toThrow();
     spy.mockRestore();
   });
 
   it('clearEntries empties the store', () => {
-    addEntry({ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 });
     clearEntries();
     expect(getEntries()).toEqual([]);
   });
@@ -99,14 +115,14 @@ describe('cmdk-recent', () => {
     // same browser, opens the palette, and sees user A's recents — including
     // potentially private filenames and query text.
     mockUser.current = { id: 'user-a' };
-    addEntry({ kind: 'query', id: 'q:secret', text: 'secret-query', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:secret-query', text: 'secret-query', lastUsed: 1 });
     addEntry({ kind: 'photo', id: 'photo:p1', assetId: 'p1', label: 'a-private.jpg', lastUsed: 2 });
 
     mockUser.current = { id: 'user-b' };
     expect(getEntries()).toEqual([]);
 
     mockUser.current = { id: 'user-a' };
-    expect(getEntries().map((e) => e.id)).toEqual(['photo:p1', 'q:secret']);
+    expect(getEntries().map((e) => e.id)).toEqual(['photo:p1', 'query:secret-query']);
   });
 
   it('scopes writes per user: user B writes never appear for user A', () => {
@@ -114,14 +130,14 @@ describe('cmdk-recent', () => {
     // logs back in — user A's existing entries are intact and user B's entries
     // are nowhere to be seen.
     mockUser.current = { id: 'user-a' };
-    addEntry({ kind: 'query', id: 'q:a-first', text: 'from-a', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:from-a', text: 'from-a', lastUsed: 1 });
 
     mockUser.current = { id: 'user-b' };
-    addEntry({ kind: 'query', id: 'q:b-first', text: 'from-b', mode: 'smart', lastUsed: 2 });
-    expect(getEntries().map((e) => e.id)).toEqual(['q:b-first']);
+    addEntry({ kind: 'query', id: 'query:from-b', text: 'from-b', lastUsed: 2 });
+    expect(getEntries().map((e) => e.id)).toEqual(['query:from-b']);
 
     mockUser.current = { id: 'user-a' };
-    expect(getEntries().map((e) => e.id)).toEqual(['q:a-first']);
+    expect(getEntries().map((e) => e.id)).toEqual(['query:from-a']);
   });
 
   it('returns [] and silently drops writes when no user is logged in', () => {
@@ -129,7 +145,7 @@ describe('cmdk-recent', () => {
     // must not populate an "anonymous" bucket that the next logged-in user could
     // then inherit. Reads return empty, writes are no-ops.
     mockUser.current = null;
-    addEntry({ kind: 'query', id: 'q:anon', text: 'anonymous', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:anonymous', text: 'anonymous', lastUsed: 1 });
     expect(getEntries()).toEqual([]);
     // Sanity: the entry is not persisted under ANY scoped key either — fetch the
     // whole localStorage snapshot and assert nothing matches the cmdk prefix.
@@ -142,12 +158,12 @@ describe('cmdk-recent', () => {
     // current user's key) is visible on the very next call without any explicit
     // cache-invalidation plumbing. This replaces the previous storage-event
     // listener that existed solely to invalidate a shared in-memory cache.
-    addEntry({ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 });
     localStorage.setItem(
       'cmdk.recent:test-user',
-      JSON.stringify([{ kind: 'query', id: 'q:b', text: 'b', mode: 'smart', lastUsed: 2 }]),
+      JSON.stringify([{ kind: 'query', id: 'query:b', text: 'b', lastUsed: 2 }]),
     );
-    expect(getEntries().map((e) => e.id)).toEqual(['q:b']);
+    expect(getEntries().map((e) => e.id)).toEqual(['query:b']);
   });
 });
 
@@ -209,22 +225,22 @@ describe('removeEntry', () => {
   });
 
   it('removes the matching entry and preserves order', () => {
-    addEntry({ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 });
-    addEntry({ kind: 'query', id: 'q:b', text: 'b', mode: 'smart', lastUsed: 2 });
-    addEntry({ kind: 'query', id: 'q:c', text: 'c', mode: 'smart', lastUsed: 3 });
-    removeEntry('q:b');
-    expect(getEntries().map((e) => e.id)).toEqual(['q:c', 'q:a']);
+    addEntry({ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:b', text: 'b', lastUsed: 2 });
+    addEntry({ kind: 'query', id: 'query:c', text: 'c', lastUsed: 3 });
+    removeEntry('query:b');
+    expect(getEntries().map((e) => e.id)).toEqual(['query:c', 'query:a']);
   });
 
   it('no-op on missing id', () => {
-    addEntry({ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 });
+    addEntry({ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 });
     removeEntry('does-not-exist');
-    expect(getEntries().map((e) => e.id)).toEqual(['q:a']);
+    expect(getEntries().map((e) => e.id)).toEqual(['query:a']);
   });
 
   it('persists the removal to localStorage', () => {
-    addEntry({ kind: 'query', id: 'q:a', text: 'a', mode: 'smart', lastUsed: 1 });
-    removeEntry('q:a');
+    addEntry({ kind: 'query', id: 'query:a', text: 'a', lastUsed: 1 });
+    removeEntry('query:a');
     const raw = localStorage.getItem('cmdk.recent:test-user');
     expect(JSON.parse(raw ?? '[]')).toEqual([]);
   });

--- a/web/src/lib/stores/cmdk-recent.ts
+++ b/web/src/lib/stores/cmdk-recent.ts
@@ -10,7 +10,7 @@ const STORAGE_KEY_PREFIX = 'cmdk.recent:';
 const MAX_ENTRIES = 20;
 
 export type RecentEntry =
-  | { kind: 'query'; id: string; text: string; mode: SearchMode; lastUsed: number }
+  | { kind: 'query'; id: string; text: string; lastUsed: number }
   | { kind: 'photo'; id: string; assetId: string; label: string; lastUsed: number }
   | { kind: 'person'; id: string; personId: string; label: string; lastUsed: number }
   | { kind: 'place'; id: string; latitude: number; longitude: number; label: string; lastUsed: number }
@@ -36,6 +36,16 @@ export type RecentEntry =
 
 let warnedOnce = false;
 
+type LegacyQueryRecentEntry = {
+  kind: 'query';
+  id: string;
+  text: string;
+  mode?: SearchMode;
+  lastUsed: number;
+};
+
+type StoredRecentEntry = RecentEntry | LegacyQueryRecentEntry;
+
 function warn(err: unknown) {
   if (warnedOnce) {
     return;
@@ -50,6 +60,24 @@ function currentStorageKey(): string | null {
   return id ? `${STORAGE_KEY_PREFIX}${id}` : null;
 }
 
+function normalizeRecentEntry(entry: StoredRecentEntry): RecentEntry | null {
+  if (entry.kind !== 'query') {
+    return entry;
+  }
+
+  const text = entry.text.trim();
+  if (text.length === 0) {
+    return null;
+  }
+
+  return {
+    kind: 'query',
+    id: `query:${text.toLowerCase()}`,
+    text,
+    lastUsed: entry.lastUsed,
+  };
+}
+
 function rawRead(key: string): RecentEntry[] {
   try {
     const raw = localStorage.getItem(key);
@@ -57,7 +85,19 @@ function rawRead(key: string): RecentEntry[] {
       return [];
     }
     const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as RecentEntry[]) : [];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const normalized = parsed
+      .map((entry) => normalizeRecentEntry(entry as StoredRecentEntry))
+      .filter(Boolean) as RecentEntry[];
+
+    if (JSON.stringify(parsed) !== JSON.stringify(normalized)) {
+      rawWrite(key, normalized);
+    }
+
+    return normalized;
   } catch (error) {
     warn(error);
     return [];
@@ -85,9 +125,13 @@ export function addEntry(entry: RecentEntry) {
   if (key === null) {
     return;
   }
+  const normalized = normalizeRecentEntry(entry);
+  if (!normalized) {
+    return;
+  }
   const existing = rawRead(key);
-  const deduped = existing.filter((e) => e.id !== entry.id);
-  deduped.push(entry);
+  const deduped = existing.filter((e) => e.id !== normalized.id);
+  deduped.push(normalized);
   deduped.sort((a, b) => b.lastUsed - a.lastUsed);
   rawWrite(key, deduped.slice(0, MAX_ENTRIES));
 }


### PR DESCRIPTION
## Summary
- normalize query recents to canonical `query:*` storage
- replay query recents through `activateSearch()` on the current page instead of restoring a stored mode
- render query recents through a dedicated cmdk `query-row`

## Testing
- `./node_modules/.bin/vitest run src/lib/stores/cmdk-recent.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts src/lib/components/global-search/__tests__/recent-row.spec.ts src/lib/managers/command-items.spec.ts`
- `./node_modules/.bin/vitest run src/lib/components/global-search/__tests__/query-row.spec.ts src/lib/components/global-search/__tests__/recent-row.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts`
- Updated Playwright coverage in `e2e/src/specs/web/global-search.e2e-spec.ts` but could not run it locally because Playwright browsers are not installed in this environment.