### PR TITLE
feat(server): add birthday memory fallback

### DIFF
--- a/docs/plans/2026-04-24-birthday-memory-fallback-design.md
+++ b/docs/plans/2026-04-24-birthday-memory-fallback-design.md
@@ -56,6 +56,7 @@ The fallback path only runs when the throwback path fails, so the multi-year ret
 
 - changing birthday-rule eligibility in `server/src/services/memory-rules/birthday.rule.ts`
 - adding fallback birthday candidate generation for single-year photo sets
+- slightly changing birthday-only asset selection so the fallback path can actually produce `4` same-year assets
 - adjusting birthday rule scoring so:
   - multi-year throwback remains preferred
   - fallback birthday still outranks `recent_trip` on the same day
@@ -90,6 +91,7 @@ Presentation:
 Scoring:
 
 - keep this above the fallback path
+- move birthday memories into a dedicated score band above the current `recent_trip` maximum so birthday wins without changing service orchestration
 
 ### Snapshot Fallback Path
 
@@ -109,17 +111,19 @@ Presentation:
 Scoring:
 
 - lower than the throwback path
-- higher than the current `recent_trip` candidate range so a birthday memory wins on that day
+- higher than the current `recent_trip` maximum so a birthday memory wins on that day
 
 ## Asset Selection
 
-Do not change the repository query or the selection algorithm in this change.
+Do not change the repository query in this change.
 
 That means:
 
 - qualifying assets still come from `getMemoryAssetsForPerson`
-- the rule still groups by year
-- the rule still keeps at most `2` assets per year
+- the throwback path still groups by year
+- the throwback path still keeps at most `2` assets per year
+- the fallback path does **not** reuse the `2`-per-year cap
+- instead, the fallback path takes the `4` most recent qualifying assets overall
 - the fallback path may therefore use multiple assets from the same year and same day
 
 This is intentional for this change. Duplicate suppression and burst-thinning are a separate follow-up.
@@ -141,7 +145,7 @@ Birthday candidates should continue to outrank `recent_trip`.
 Implementation requirement:
 
 - multi-year throwback score stays above fallback birthday score
-- fallback birthday score stays above plausible `recent_trip` scores produced by the current rule
+- fallback birthday score stays above the current `recent_trip` maximum produced by the current rule for the 30-day window
 
 The exact numeric values can be chosen during implementation, but this ordering must be covered by tests.
 
@@ -174,11 +178,12 @@ Required cases:
 
 4. Ranking against recent trip
    - when a fallback birthday and a recent trip candidate exist on the same day
-   - the birthday candidate should be selected ahead of the trip candidate
+   - the birthday candidate should be selected ahead of the highest-scoring `recent_trip` case supported by the current formula
 
 5. Live Pierre regression shape
    - `4` qualifying assets in one year only
    - birthday candidate is generated
+   - all `4` assets are included despite the throwback path's `2`-per-year cap
 
 ## TDD Order
 

--- a/docs/plans/2026-04-24-birthday-memory-fallback-design.md
+++ b/docs/plans/2026-04-24-birthday-memory-fallback-design.md
@@ -1,0 +1,199 @@
+# Birthday Memory Fallback Design
+
+## Goal
+
+Relax the birthday memory rule so a person can still receive a birthday memory when there is not enough multi-year history, while preserving the current retrospective behavior when that history exists.
+
+This is motivated by the current live behavior on April 24, 2026:
+
+- `Pierre` has a matching `birthDate`
+- `Pierre` has exactly `4` visible face-linked timeline assets
+- all `4` assets are from `2026`
+- the current rule emits nothing because it requires `6+` assets across `2+` distinct years
+
+The desired outcome is that Pierre should receive a birthday memory from those `4` qualifying photos.
+
+## Current Behavior
+
+Birthday memories are generated in `server/src/services/memory-rules/birthday.rule.ts`.
+
+Today the rule:
+
+- fetches people whose `birthDate` month/day matches the target date
+- loads visible face-linked timeline assets for each person
+- groups those assets by year
+- keeps at most `2` assets per year
+- requires both:
+  - at least `6` selected assets total
+  - at least `2` distinct years
+- emits a candidate with:
+  - title `Happy birthday, <name>`
+  - subtitle `Photos from different years`
+
+This makes the feature read as a birthday throwback, but it rejects people who only have recent qualifying photos.
+
+## Chosen Approach
+
+Keep one birthday rule with two eligibility paths:
+
+1. `Throwback path`
+   Preserve the current behavior when the person has enough qualifying assets across multiple years.
+2. `Snapshot fallback path`
+   If the throwback path does not qualify, allow a birthday memory from recent photos only.
+
+The fallback path should:
+
+- require at least `4` qualifying assets total
+- not require multiple years
+- keep the title `Happy birthday, <name>`
+- use subtitle `Recent photos of <name>`
+
+The fallback path only runs when the throwback path fails, so the multi-year retrospective memory remains the preferred form.
+
+## Scope
+
+### In Scope
+
+- changing birthday-rule eligibility in `server/src/services/memory-rules/birthday.rule.ts`
+- adding fallback birthday candidate generation for single-year photo sets
+- adjusting birthday rule scoring so:
+  - multi-year throwback remains preferred
+  - fallback birthday still outranks `recent_trip` on the same day
+- adding focused server test coverage for both paths
+
+### Out of Scope
+
+- burst-thinning or near-duplicate filtering
+- changes to repository queries
+- changes to DTOs or API shape
+- changes to web or mobile rendering
+- changes to recent-trip behavior
+- introducing a new memory type or rule id
+
+## Rule Semantics
+
+### Throwback Path
+
+The current path remains the preferred birthday candidate.
+
+Eligibility:
+
+- month/day matches the target date
+- selected asset pool yields at least `6` assets total
+- selected asset pool spans at least `2` distinct years
+
+Presentation:
+
+- title `Happy birthday, <name>`
+- subtitle `Photos from different years`
+
+Scoring:
+
+- keep this above the fallback path
+
+### Snapshot Fallback Path
+
+This path runs only when the throwback path does not qualify.
+
+Eligibility:
+
+- month/day matches the target date
+- at least `4` qualifying assets total after the existing asset selection logic
+- no distinct-year requirement
+
+Presentation:
+
+- title `Happy birthday, <name>`
+- subtitle `Recent photos of <name>`
+
+Scoring:
+
+- lower than the throwback path
+- higher than the current `recent_trip` candidate range so a birthday memory wins on that day
+
+## Asset Selection
+
+Do not change the repository query or the selection algorithm in this change.
+
+That means:
+
+- qualifying assets still come from `getMemoryAssetsForPerson`
+- the rule still groups by year
+- the rule still keeps at most `2` assets per year
+- the fallback path may therefore use multiple assets from the same year and same day
+
+This is intentional for this change. Duplicate suppression and burst-thinning are a separate follow-up.
+
+## Data And API Impact
+
+No schema changes.
+
+No API changes.
+
+No UI changes.
+
+The existing memory payload shape remains valid because the server already owns `title` and `subtitle`.
+
+## Ranking
+
+Birthday candidates should continue to outrank `recent_trip`.
+
+Implementation requirement:
+
+- multi-year throwback score stays above fallback birthday score
+- fallback birthday score stays above plausible `recent_trip` scores produced by the current rule
+
+The exact numeric values can be chosen during implementation, but this ordering must be covered by tests.
+
+## Testing
+
+Add focused coverage in:
+
+- `server/src/services/memory-rules/birthday.rule.spec.ts`
+- `server/src/services/memory.service.spec.ts`
+- `server/src/dtos/memory.dto.spec.ts` if needed to confirm display fields remain correct for fallback birthday memories
+
+Required cases:
+
+1. Single-year fallback qualifies
+   - matching birthday
+   - exactly `4` qualifying assets from one year
+   - emits one birthday candidate
+   - subtitle is `Recent photos of <name>`
+
+2. Single-year fallback does not qualify below threshold
+   - matching birthday
+   - only `3` qualifying assets
+   - emits no candidate
+
+3. Multi-year throwback still wins
+   - matching birthday
+   - `6+` qualifying assets across `2+` years
+   - emits the existing throwback variant only
+   - subtitle remains `Photos from different years`
+
+4. Ranking against recent trip
+   - when a fallback birthday and a recent trip candidate exist on the same day
+   - the birthday candidate should be selected ahead of the trip candidate
+
+5. Live Pierre regression shape
+   - `4` qualifying assets in one year only
+   - birthday candidate is generated
+
+## TDD Order
+
+1. Add failing birthday-rule tests for the `4`-asset fallback and the `3`-asset rejection.
+2. Add a service-level failing test proving fallback birthday outranks `recent_trip`.
+3. Implement the minimal eligibility and scoring change in `birthday.rule.ts`.
+4. Update any title/subtitle assertions needed for DTO or service tests.
+5. Re-run focused server tests.
+
+## Risks
+
+The main product risk is that fallback birthday memories can be visually repetitive because this change does not thin burst shots.
+
+That is acceptable for this task because:
+
+- the user explicitly wants eligibility relaxed first
+- the rule currently emits nothing for people like Pierre
+- asset curation quality can be improved in a separate follow-up once the eligibility behavior is correct

--- a/docs/plans/2026-04-24-birthday-memory-fallback-plan.md
+++ b/docs/plans/2026-04-24-birthday-memory-fallback-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Let birthday memories fall back to a `4`-photo single-year snapshot when the multi-year throwback path does not qualify, while keeping multi-year birthdays preferred.
 
-**Architecture:** Keep all changes server-side. Preserve the existing throwback path in `BirthdayMemoryRule`, add a snapshot fallback path that only runs when throwback fails, and verify the new score ordering through unit and medium tests. One design clarification is required: the fallback path cannot reuse the current `2`-assets-per-year cap, or a single-year `4`-photo birthday can never qualify; instead, fallback should reuse the same repository query but select the `4` most recent qualifying assets overall.
+**Architecture:** Keep all changes server-side. Preserve the existing throwback path in `BirthdayMemoryRule`, add a snapshot fallback path that only runs when throwback fails, and verify the new score ordering through unit and medium tests. The fallback path cannot reuse the current `2`-assets-per-year cap, or a single-year `4`-photo birthday can never qualify; instead, fallback should reuse the same repository query but select the `4` most recent qualifying assets overall. To keep birthday memories preferred without changing service orchestration, birthday scores should move into a dedicated band above the current `recent_trip` maximum, with throwback still above fallback.
 
 **Tech Stack:** NestJS, Luxon, Vitest, medium Vitest integration tests, Kysely-backed repositories.
 
@@ -64,7 +64,7 @@ Append these tests to `server/src/services/memory-rules/birthday.rule.spec.ts`:
       dedupeKey: 'birthday:person-1:2026-04-24',
       title: 'Happy birthday, Pierre',
       subtitle: 'Recent photos of Pierre',
-      score: 94,
+      score: 254,
       assetIds: ['a-4', 'a-3', 'a-2', 'a-1'],
       context: { personId: 'person-1', distinctYears: 1 },
     });
@@ -120,7 +120,7 @@ Append these tests to `server/src/services/memory-rules/birthday.rule.spec.ts`:
     expect(candidates).toEqual([
       expect.objectContaining({
         subtitle: 'Photos from different years',
-        score: 146,
+        score: 356,
         assetIds: ['a-2025-1', 'a-2025-2', 'a-2024-1', 'a-2023-1', 'a-2022-1', 'a-2021-1'],
       }),
     ]);
@@ -178,7 +178,7 @@ Replace the body of `evaluate()` in `server/src/services/memory-rules/birthday.r
           dedupeKey: `birthday:${person.id}:${target.toFormat('yyyy-MM-dd')}`,
           title: `Happy birthday, ${person.name}`,
           subtitle: 'Photos from different years',
-          score: 100 + byYear.size * 10 + throwbackAssetIds.length,
+          score: 300 + byYear.size * 10 + throwbackAssetIds.length,
           assetIds: throwbackAssetIds,
           memoryAt: target,
           context: { personId: person.id, distinctYears: byYear.size },
@@ -200,7 +200,7 @@ Replace the body of `evaluate()` in `server/src/services/memory-rules/birthday.r
         dedupeKey: `birthday:${person.id}:${target.toFormat('yyyy-MM-dd')}`,
         title: `Happy birthday, ${person.name}`,
         subtitle: `Recent photos of ${person.name}`,
-        score: 90 + fallbackAssetIds.length,
+        score: 250 + fallbackAssetIds.length,
         assetIds: fallbackAssetIds,
         memoryAt: target,
         context: { personId: person.id, distinctYears: byYear.size },
@@ -222,7 +222,7 @@ pnpm --dir server test --run src/services/memory-rules/birthday.rule.spec.ts
 Expected:
 
 - all tests in `birthday.rule.spec.ts` pass
-- the fallback test shows `score: 94`
+- the fallback test shows `score: 254`
 - the throwback-preference test still returns only one candidate
 
 - [ ] **Step 5: Commit the rule change**
@@ -278,7 +278,7 @@ Append this test to the `describe('onMemoriesCreate')` block in `server/src/serv
             dedupeKey: 'birthday:person-1:2026-04-24',
             title: 'Happy birthday, Pierre',
             subtitle: 'Recent photos of Pierre',
-            score: 94,
+            score: 254,
             assetIds: ['a-1', 'a-2', 'a-3', 'a-4'],
             memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
           },
@@ -291,8 +291,8 @@ Append this test to the `describe('onMemoriesCreate')` block in `server/src/serv
             ruleId: 'recent_trip',
             dedupeKey: 'recent_trip:germany:nurnberg:2026-04-24',
             title: 'Recent trip to Nürnberg, Germany',
-            subtitle: '12 photos over 2 days',
-            score: 72,
+            subtitle: '20 photos over 30 days',
+            score: 220,
             assetIds: ['t-1', 't-2', 't-3'],
             memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
           },
@@ -312,7 +312,7 @@ Append this test to the `describe('onMemoriesCreate')` block in `server/src/serv
             ruleId: 'birthday',
             title: 'Happy birthday, Pierre',
             subtitle: 'Recent photos of Pierre',
-            score: 94,
+            score: 254,
           }),
         }),
         new Set(['a-1', 'a-2', 'a-3', 'a-4']),
@@ -340,13 +340,13 @@ Expected:
 If the new test still fails after Task 1, keep the fallback score line in `server/src/services/memory-rules/birthday.rule.ts` exactly as:
 
 ```ts
-        score: 90 + fallbackAssetIds.length,
+        score: 250 + fallbackAssetIds.length,
 ```
 
 Do not raise the throwback score above its current formula:
 
 ```ts
-          score: 100 + byYear.size * 10 + throwbackAssetIds.length,
+          score: 300 + byYear.size * 10 + throwbackAssetIds.length,
 ```
 
 - [ ] **Step 4: Re-run the service test and the birthday rule test together**

--- a/docs/plans/2026-04-24-birthday-memory-fallback-plan.md
+++ b/docs/plans/2026-04-24-birthday-memory-fallback-plan.md
@@ -1,0 +1,496 @@
+# Birthday Memory Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let birthday memories fall back to a `4`-photo single-year snapshot when the multi-year throwback path does not qualify, while keeping multi-year birthdays preferred.
+
+**Architecture:** Keep all changes server-side. Preserve the existing throwback path in `BirthdayMemoryRule`, add a snapshot fallback path that only runs when throwback fails, and verify the new score ordering through unit and medium tests. One design clarification is required: the fallback path cannot reuse the current `2`-assets-per-year cap, or a single-year `4`-photo birthday can never qualify; instead, fallback should reuse the same repository query but select the `4` most recent qualifying assets overall.
+
+**Tech Stack:** NestJS, Luxon, Vitest, medium Vitest integration tests, Kysely-backed repositories.
+
+---
+
+## File map
+
+- Modify: `server/src/services/memory-rules/birthday.rule.ts`
+  Keep the throwback path intact and add the snapshot fallback path plus explicit score ordering.
+- Modify: `server/src/services/memory-rules/birthday.rule.spec.ts`
+  Add focused rule-level coverage for fallback qualification, fallback rejection below threshold, and throwback preference.
+- Modify: `server/src/services/memory.service.spec.ts`
+  Add a service-level ranking regression proving fallback birthday wins when only one daily rule slot remains.
+- Modify: `server/test/medium/specs/services/memory.service.spec.ts`
+  Add a real-DB regression for the live Pierre shape: `4` face-linked photos from one year produce a birthday rule memory with the fallback subtitle.
+
+## Preconditions
+
+- Work from `/home/pierre/dev/gallery/.worktrees/memories-rules-exploration`.
+- Keep untracked `.tmp/` and `web/.tmp/` untouched.
+- Do not change repository queries, DTOs, web code, or mobile code in this task.
+
+## Task 1: Add Birthday Rule Fallback And Rule-Level Coverage
+
+**Files:**
+- Modify: `server/src/services/memory-rules/birthday.rule.spec.ts`
+- Modify: `server/src/services/memory-rules/birthday.rule.ts`
+
+- [ ] **Step 1: Write the failing rule tests**
+
+Append these tests to `server/src/services/memory-rules/birthday.rule.spec.ts`:
+
+```ts
+  it('creates a snapshot fallback birthday candidate from four single-year assets', async () => {
+    const personRepository = {
+      getBirthdaysForDay: vi
+        .fn()
+        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('2025-04-24T00:00:00Z') }]),
+    };
+    const assetRepository = {
+      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+        { id: 'a-4', localDateTime: new Date('2026-04-18T15:25:11.543Z') },
+        { id: 'a-3', localDateTime: new Date('2026-04-18T15:25:09.803Z') },
+        { id: 'a-2', localDateTime: new Date('2026-04-18T15:25:08.244Z') },
+        { id: 'a-1', localDateTime: new Date('2026-04-18T15:25:07.335Z') },
+      ]),
+    };
+
+    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
+    });
+
+    expect(candidate).toMatchObject({
+      ruleId: 'birthday',
+      dedupeKey: 'birthday:person-1:2026-04-24',
+      title: 'Happy birthday, Pierre',
+      subtitle: 'Recent photos of Pierre',
+      score: 94,
+      assetIds: ['a-4', 'a-3', 'a-2', 'a-1'],
+      context: { personId: 'person-1', distinctYears: 1 },
+    });
+  });
+
+  it('skips the snapshot fallback when only three single-year assets qualify', async () => {
+    const personRepository = {
+      getBirthdaysForDay: vi
+        .fn()
+        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('2025-04-24T00:00:00Z') }]),
+    };
+    const assetRepository = {
+      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+        { id: 'a-3', localDateTime: new Date('2026-04-18T15:25:09.803Z') },
+        { id: 'a-2', localDateTime: new Date('2026-04-18T15:25:08.244Z') },
+        { id: 'a-1', localDateTime: new Date('2026-04-18T15:25:07.335Z') },
+      ]),
+    };
+
+    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+
+    await expect(
+      rule.evaluate({
+        ownerId: 'user-1',
+        target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('prefers the throwback path over the snapshot fallback when multiple years qualify', async () => {
+    const personRepository = {
+      getBirthdaysForDay: vi
+        .fn()
+        .mockResolvedValue([{ id: 'person-1', name: 'Alice', birthDate: new Date('1990-04-24T00:00:00Z') }]),
+    };
+    const assetRepository = {
+      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+        { id: 'a-2025-1', localDateTime: new Date('2025-04-01T12:00:00Z') },
+        { id: 'a-2025-2', localDateTime: new Date('2025-03-01T12:00:00Z') },
+        { id: 'a-2024-1', localDateTime: new Date('2024-04-01T12:00:00Z') },
+        { id: 'a-2023-1', localDateTime: new Date('2023-04-01T12:00:00Z') },
+        { id: 'a-2022-1', localDateTime: new Date('2022-04-01T12:00:00Z') },
+        { id: 'a-2021-1', localDateTime: new Date('2021-04-01T12:00:00Z') },
+      ]),
+    };
+
+    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+    const candidates = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
+    });
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        subtitle: 'Photos from different years',
+        score: 146,
+        assetIds: ['a-2025-1', 'a-2025-2', 'a-2024-1', 'a-2023-1', 'a-2022-1', 'a-2021-1'],
+      }),
+    ]);
+  });
+```
+
+- [ ] **Step 2: Run the rule tests to verify the fallback cases fail**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/birthday.rule.spec.ts
+```
+
+Expected:
+
+- the new `snapshot fallback` test fails because the rule currently requires `6` assets across `2` years
+- the new `three single-year assets` test may pass already
+- the existing throwback test still passes
+
+- [ ] **Step 3: Implement the minimal birthday-rule change**
+
+Replace the body of `evaluate()` in `server/src/services/memory-rules/birthday.rule.ts` with the following structure:
+
+```ts
+  async evaluate({ ownerId, target }: MemoryRuleContext): Promise<MemoryRuleCandidate[]> {
+    const people = await this.personRepository.getBirthdaysForDay(ownerId, { month: target.month, day: target.day });
+    const candidates: MemoryRuleCandidate[] = [];
+
+    for (const person of people) {
+      const assets = await this.assetRepository.getMemoryAssetsForPerson(
+        ownerId,
+        person.id,
+        target.endOf('day').toJSDate(),
+      );
+      const byYear = new Map<number, string[]>();
+
+      for (const asset of assets) {
+        const year = DateTime.fromJSDate(asset.localDateTime, { zone: 'utc' }).year;
+        const ids = byYear.get(year) ?? [];
+        if (ids.length < 2) {
+          ids.push(asset.id);
+          byYear.set(year, ids);
+        }
+      }
+
+      const throwbackAssetIds = [...byYear.keys()]
+        .toSorted((a, b) => b - a)
+        .flatMap((year) => byYear.get(year) ?? [])
+        .slice(0, 12);
+
+      if (throwbackAssetIds.length >= 6 && byYear.size >= 2) {
+        candidates.push({
+          ruleId: this.id,
+          dedupeKey: `birthday:${person.id}:${target.toFormat('yyyy-MM-dd')}`,
+          title: `Happy birthday, ${person.name}`,
+          subtitle: 'Photos from different years',
+          score: 100 + byYear.size * 10 + throwbackAssetIds.length,
+          assetIds: throwbackAssetIds,
+          memoryAt: target,
+          context: { personId: person.id, distinctYears: byYear.size },
+        });
+        continue;
+      }
+
+      const fallbackAssetIds = [...assets]
+        .toSorted((left, right) => right.localDateTime.getTime() - left.localDateTime.getTime())
+        .slice(0, 4)
+        .map(({ id }) => id);
+
+      if (fallbackAssetIds.length < 4) {
+        continue;
+      }
+
+      candidates.push({
+        ruleId: this.id,
+        dedupeKey: `birthday:${person.id}:${target.toFormat('yyyy-MM-dd')}`,
+        title: `Happy birthday, ${person.name}`,
+        subtitle: `Recent photos of ${person.name}`,
+        score: 90 + fallbackAssetIds.length,
+        assetIds: fallbackAssetIds,
+        memoryAt: target,
+        context: { personId: person.id, distinctYears: byYear.size },
+      });
+    }
+
+    return candidates;
+  }
+```
+
+- [ ] **Step 4: Re-run the rule tests**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/birthday.rule.spec.ts
+```
+
+Expected:
+
+- all tests in `birthday.rule.spec.ts` pass
+- the fallback test shows `score: 94`
+- the throwback-preference test still returns only one candidate
+
+- [ ] **Step 5: Commit the rule change**
+
+```bash
+git add server/src/services/memory-rules/birthday.rule.ts server/src/services/memory-rules/birthday.rule.spec.ts
+git commit -m "feat(server): add birthday memory fallback"
+```
+
+## Task 2: Lock Ranking Through The Memory Service
+
+**Files:**
+- Modify: `server/src/services/memory.service.spec.ts`
+
+- [ ] **Step 1: Write the failing service-level ranking test**
+
+Append this test to the `describe('onMemoriesCreate')` block in `server/src/services/memory.service.spec.ts`:
+
+```ts
+    it('prefers a fallback birthday candidate over recent trip when only one rule slot remains', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-24T12:00:00Z'));
+
+      const user = factory.userAdmin();
+      mocks.user.getList.mockResolvedValue([user]);
+      mocks.systemMetadata.get.mockResolvedValue({
+        lastOnThisDayDate: '2026-04-26T00:00:00.000Z',
+        lastRuleDate: '2026-04-23T00:00:00.000Z',
+      });
+      mocks.asset.getByDayOfYear.mockResolvedValue([]);
+      mocks.memory.search.mockResolvedValue([
+        getForMemory(
+          MemoryFactory.create({
+            ownerId: user.id,
+            type: MemoryType.Rule,
+            memoryAt: new Date('2026-04-24T00:00:00Z'),
+            data: {
+              ruleId: 'existing',
+              dedupeKey: 'existing',
+              title: 'Existing',
+            } satisfies RuleMemoryData,
+          }),
+        ),
+      ]);
+      mocks.memory.hasRuleMemory.mockResolvedValue(false);
+      mocks.memory.create.mockResolvedValue(MemoryFactory.create() as any);
+
+      const birthdayRule = {
+        id: 'birthday',
+        evaluate: vi.fn().mockResolvedValue([
+          {
+            ruleId: 'birthday',
+            dedupeKey: 'birthday:person-1:2026-04-24',
+            title: 'Happy birthday, Pierre',
+            subtitle: 'Recent photos of Pierre',
+            score: 94,
+            assetIds: ['a-1', 'a-2', 'a-3', 'a-4'],
+            memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
+          },
+        ]),
+      };
+      const recentTripRule = {
+        id: 'recent_trip',
+        evaluate: vi.fn().mockResolvedValue([
+          {
+            ruleId: 'recent_trip',
+            dedupeKey: 'recent_trip:germany:nurnberg:2026-04-24',
+            title: 'Recent trip to Nürnberg, Germany',
+            subtitle: '12 photos over 2 days',
+            score: 72,
+            assetIds: ['t-1', 't-2', 't-3'],
+            memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
+          },
+        ]),
+      };
+
+      vi.spyOn(sut as never, 'getMemoryRules').mockReturnValue([recentTripRule, birthdayRule] as never);
+
+      await sut.onMemoriesCreate();
+
+      expect(mocks.memory.create).toHaveBeenCalledTimes(1);
+      expect(mocks.memory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerId: user.id,
+          type: MemoryType.Rule,
+          data: expect.objectContaining({
+            ruleId: 'birthday',
+            title: 'Happy birthday, Pierre',
+            subtitle: 'Recent photos of Pierre',
+            score: 94,
+          }),
+        }),
+        new Set(['a-1', 'a-2', 'a-3', 'a-4']),
+      );
+
+      vi.useRealTimers();
+    });
+```
+
+- [ ] **Step 2: Run the focused service test**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory.service.spec.ts
+```
+
+Expected:
+
+- the new ranking test fails before Task 1 is implemented
+- after Task 1, it passes without further production changes
+
+- [ ] **Step 3: Lock the score contract if the test still fails**
+
+If the new test still fails after Task 1, keep the fallback score line in `server/src/services/memory-rules/birthday.rule.ts` exactly as:
+
+```ts
+        score: 90 + fallbackAssetIds.length,
+```
+
+Do not raise the throwback score above its current formula:
+
+```ts
+          score: 100 + byYear.size * 10 + throwbackAssetIds.length,
+```
+
+- [ ] **Step 4: Re-run the service test and the birthday rule test together**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/birthday.rule.spec.ts src/services/memory.service.spec.ts
+```
+
+Expected:
+
+- both files pass
+- the service test proves birthday wins when only one slot remains
+
+- [ ] **Step 5: Commit the ranking regression**
+
+```bash
+git add server/src/services/memory.service.spec.ts server/src/services/memory-rules/birthday.rule.ts
+git commit -m "test(server): cover birthday fallback ranking"
+```
+
+## Task 3: Add A Real-DB Pierre Regression
+
+**Files:**
+- Modify: `server/test/medium/specs/services/memory.service.spec.ts`
+
+- [ ] **Step 1: Add the medium test for the live Pierre shape**
+
+Append this test immediately after `it('creates a birthday rule memory on the birthday itself', ...)` in `server/test/medium/specs/services/memory.service.spec.ts`:
+
+```ts
+    it('creates a fallback birthday memory from four single-year Pierre photos', async () => {
+      const { sut, ctx } = setup();
+      const assetRepo = ctx.get(AssetRepository);
+      const memoryRepo = ctx.get(MemoryRepository);
+      const now = DateTime.fromObject({ year: 2026, month: 4, day: 24 }, { zone: 'utc' }) as DateTime<true>;
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({
+        ownerId: user.id,
+        name: 'Pierre',
+        birthDate: new Date('2025-04-24T00:00:00Z'),
+      });
+
+      const addPierreAsset = async (localDateTime: string) => {
+        const { asset } = await ctx.newAsset({ ownerId: user.id, localDateTime });
+        await Promise.all([
+          ctx.newExif({ assetId: asset.id, city: 'Berlin', country: 'Germany' }),
+          ctx.newJobStatus({ assetId: asset.id }),
+          ctx.newAssetFace({ assetId: asset.id, personId: person.id }),
+          assetRepo.upsertFiles([
+            { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
+            { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
+          ]),
+        ]);
+      };
+
+      await addPierreAsset('2026-04-18T15:25:07.335Z');
+      await addPierreAsset('2026-04-18T15:25:08.244Z');
+      await addPierreAsset('2026-04-18T15:25:09.803Z');
+      await addPierreAsset('2026-04-18T15:25:11.543Z');
+
+      vi.setSystemTime(now.toJSDate());
+      await sut.onMemoriesCreate();
+
+      const memories = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
+      expect(memories).toEqual([
+        expect.objectContaining({
+          type: MemoryType.Rule,
+          data: expect.objectContaining({
+            ruleId: 'birthday',
+            title: 'Happy birthday, Pierre',
+            subtitle: 'Recent photos of Pierre',
+          }),
+          assets: expect.arrayContaining([
+            expect.objectContaining({}),
+            expect.objectContaining({}),
+            expect.objectContaining({}),
+            expect.objectContaining({}),
+          ]),
+        }),
+      ]);
+      expect(memories[0]?.assets).toHaveLength(4);
+    });
+```
+
+- [ ] **Step 2: Run the focused medium test file**
+
+Run:
+
+```bash
+pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts
+```
+
+Expected:
+
+- the new Pierre regression fails before Task 1 is implemented
+- after Task 1, the file passes and returns a fallback birthday memory with `4` assets
+
+- [ ] **Step 3: If the medium test still fails, keep the fallback asset block exactly as written**
+
+The medium regression should pass with the Task 1 implementation. If it does not, verify `server/src/services/memory-rules/birthday.rule.ts` still uses this exact fallback selection:
+
+```ts
+      const fallbackAssetIds = [...assets]
+        .toSorted((left, right) => right.localDateTime.getTime() - left.localDateTime.getTime())
+        .slice(0, 4)
+        .map(({ id }) => id);
+```
+
+Do not reintroduce the throwback `2`-per-year cap into the fallback branch.
+
+- [ ] **Step 4: Run the full targeted verification set**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/birthday.rule.spec.ts src/services/memory.service.spec.ts
+pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts
+```
+
+Expected:
+
+- both unit files pass
+- the medium file passes
+- no DTO, controller, or web tests need updates
+
+- [ ] **Step 5: Commit the medium regression**
+
+```bash
+git add server/test/medium/specs/services/memory.service.spec.ts server/src/services/memory-rules/birthday.rule.ts
+git commit -m "test(server): add Pierre birthday fallback regression"
+```
+
+## Self-check Against The Design
+
+- Spec coverage:
+  - fallback eligibility: Task 1
+  - throwback remains preferred: Task 1
+  - service-level ranking above `recent_trip`: Task 2
+  - live Pierre regression: Task 3
+- No placeholder scan:
+  - all file paths are concrete
+  - all test snippets are concrete
+  - all commands are concrete
+- Type consistency:
+  - uses the existing `BirthdayMemoryRule`, `RuleMemoryData`, `MemoryType.Rule`, and `MemoryRepository.search()` shapes already present on `main`

--- a/docs/plans/2026-04-24-birthday-memory-fallback-plan.md
+++ b/docs/plans/2026-04-24-birthday-memory-fallback-plan.md
@@ -30,6 +30,7 @@
 ## Task 1: Add Birthday Rule Fallback And Rule-Level Coverage
 
 **Files:**
+
 - Modify: `server/src/services/memory-rules/birthday.rule.spec.ts`
 - Modify: `server/src/services/memory-rules/birthday.rule.ts`
 
@@ -38,93 +39,93 @@
 Append these tests to `server/src/services/memory-rules/birthday.rule.spec.ts`:
 
 ```ts
-  it('creates a snapshot fallback birthday candidate from four single-year assets', async () => {
-    const personRepository = {
-      getBirthdaysForDay: vi
-        .fn()
-        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('2025-04-24T00:00:00Z') }]),
-    };
-    const assetRepository = {
-      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
-        { id: 'a-4', localDateTime: new Date('2026-04-18T15:25:11.543Z') },
-        { id: 'a-3', localDateTime: new Date('2026-04-18T15:25:09.803Z') },
-        { id: 'a-2', localDateTime: new Date('2026-04-18T15:25:08.244Z') },
-        { id: 'a-1', localDateTime: new Date('2026-04-18T15:25:07.335Z') },
-      ]),
-    };
+it('creates a snapshot fallback birthday candidate from four single-year assets', async () => {
+  const personRepository = {
+    getBirthdaysForDay: vi
+      .fn()
+      .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('2025-04-24T00:00:00Z') }]),
+  };
+  const assetRepository = {
+    getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+      { id: 'a-4', localDateTime: new Date('2026-04-18T15:25:11.543Z') },
+      { id: 'a-3', localDateTime: new Date('2026-04-18T15:25:09.803Z') },
+      { id: 'a-2', localDateTime: new Date('2026-04-18T15:25:08.244Z') },
+      { id: 'a-1', localDateTime: new Date('2026-04-18T15:25:07.335Z') },
+    ]),
+  };
 
-    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
-    const [candidate] = await rule.evaluate({
+  const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+  const [candidate] = await rule.evaluate({
+    ownerId: 'user-1',
+    target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
+  });
+
+  expect(candidate).toMatchObject({
+    ruleId: 'birthday',
+    dedupeKey: 'birthday:person-1:2026-04-24',
+    title: 'Happy birthday, Pierre',
+    subtitle: 'Recent photos of Pierre',
+    score: 254,
+    assetIds: ['a-4', 'a-3', 'a-2', 'a-1'],
+    context: { personId: 'person-1', distinctYears: 1 },
+  });
+});
+
+it('skips the snapshot fallback when only three single-year assets qualify', async () => {
+  const personRepository = {
+    getBirthdaysForDay: vi
+      .fn()
+      .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('2025-04-24T00:00:00Z') }]),
+  };
+  const assetRepository = {
+    getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+      { id: 'a-3', localDateTime: new Date('2026-04-18T15:25:09.803Z') },
+      { id: 'a-2', localDateTime: new Date('2026-04-18T15:25:08.244Z') },
+      { id: 'a-1', localDateTime: new Date('2026-04-18T15:25:07.335Z') },
+    ]),
+  };
+
+  const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+
+  await expect(
+    rule.evaluate({
       ownerId: 'user-1',
       target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
-    });
+    }),
+  ).resolves.toEqual([]);
+});
 
-    expect(candidate).toMatchObject({
-      ruleId: 'birthday',
-      dedupeKey: 'birthday:person-1:2026-04-24',
-      title: 'Happy birthday, Pierre',
-      subtitle: 'Recent photos of Pierre',
-      score: 254,
-      assetIds: ['a-4', 'a-3', 'a-2', 'a-1'],
-      context: { personId: 'person-1', distinctYears: 1 },
-    });
+it('prefers the throwback path over the snapshot fallback when multiple years qualify', async () => {
+  const personRepository = {
+    getBirthdaysForDay: vi
+      .fn()
+      .mockResolvedValue([{ id: 'person-1', name: 'Alice', birthDate: new Date('1990-04-24T00:00:00Z') }]),
+  };
+  const assetRepository = {
+    getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+      { id: 'a-2025-1', localDateTime: new Date('2025-04-01T12:00:00Z') },
+      { id: 'a-2025-2', localDateTime: new Date('2025-03-01T12:00:00Z') },
+      { id: 'a-2024-1', localDateTime: new Date('2024-04-01T12:00:00Z') },
+      { id: 'a-2023-1', localDateTime: new Date('2023-04-01T12:00:00Z') },
+      { id: 'a-2022-1', localDateTime: new Date('2022-04-01T12:00:00Z') },
+      { id: 'a-2021-1', localDateTime: new Date('2021-04-01T12:00:00Z') },
+    ]),
+  };
+
+  const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+  const candidates = await rule.evaluate({
+    ownerId: 'user-1',
+    target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
   });
 
-  it('skips the snapshot fallback when only three single-year assets qualify', async () => {
-    const personRepository = {
-      getBirthdaysForDay: vi
-        .fn()
-        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('2025-04-24T00:00:00Z') }]),
-    };
-    const assetRepository = {
-      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
-        { id: 'a-3', localDateTime: new Date('2026-04-18T15:25:09.803Z') },
-        { id: 'a-2', localDateTime: new Date('2026-04-18T15:25:08.244Z') },
-        { id: 'a-1', localDateTime: new Date('2026-04-18T15:25:07.335Z') },
-      ]),
-    };
-
-    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
-
-    await expect(
-      rule.evaluate({
-        ownerId: 'user-1',
-        target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
-      }),
-    ).resolves.toEqual([]);
-  });
-
-  it('prefers the throwback path over the snapshot fallback when multiple years qualify', async () => {
-    const personRepository = {
-      getBirthdaysForDay: vi
-        .fn()
-        .mockResolvedValue([{ id: 'person-1', name: 'Alice', birthDate: new Date('1990-04-24T00:00:00Z') }]),
-    };
-    const assetRepository = {
-      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
-        { id: 'a-2025-1', localDateTime: new Date('2025-04-01T12:00:00Z') },
-        { id: 'a-2025-2', localDateTime: new Date('2025-03-01T12:00:00Z') },
-        { id: 'a-2024-1', localDateTime: new Date('2024-04-01T12:00:00Z') },
-        { id: 'a-2023-1', localDateTime: new Date('2023-04-01T12:00:00Z') },
-        { id: 'a-2022-1', localDateTime: new Date('2022-04-01T12:00:00Z') },
-        { id: 'a-2021-1', localDateTime: new Date('2021-04-01T12:00:00Z') },
-      ]),
-    };
-
-    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
-    const candidates = await rule.evaluate({
-      ownerId: 'user-1',
-      target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
-    });
-
-    expect(candidates).toEqual([
-      expect.objectContaining({
-        subtitle: 'Photos from different years',
-        score: 356,
-        assetIds: ['a-2025-1', 'a-2025-2', 'a-2024-1', 'a-2023-1', 'a-2022-1', 'a-2021-1'],
-      }),
-    ]);
-  });
+  expect(candidates).toEqual([
+    expect.objectContaining({
+      subtitle: 'Photos from different years',
+      score: 356,
+      assetIds: ['a-2025-1', 'a-2025-2', 'a-2024-1', 'a-2023-1', 'a-2022-1', 'a-2021-1'],
+    }),
+  ]);
+});
 ```
 
 - [ ] **Step 2: Run the rule tests to verify the fallback cases fail**
@@ -235,6 +236,7 @@ git commit -m "feat(server): add birthday memory fallback"
 ## Task 2: Lock Ranking Through The Memory Service
 
 **Files:**
+
 - Modify: `server/src/services/memory.service.spec.ts`
 
 - [ ] **Step 1: Write the failing service-level ranking test**
@@ -242,84 +244,84 @@ git commit -m "feat(server): add birthday memory fallback"
 Append this test to the `describe('onMemoriesCreate')` block in `server/src/services/memory.service.spec.ts`:
 
 ```ts
-    it('prefers a fallback birthday candidate over recent trip when only one rule slot remains', async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date('2026-04-24T12:00:00Z'));
+it('prefers a fallback birthday candidate over recent trip when only one rule slot remains', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-24T12:00:00Z'));
 
-      const user = factory.userAdmin();
-      mocks.user.getList.mockResolvedValue([user]);
-      mocks.systemMetadata.get.mockResolvedValue({
-        lastOnThisDayDate: '2026-04-26T00:00:00.000Z',
-        lastRuleDate: '2026-04-23T00:00:00.000Z',
-      });
-      mocks.asset.getByDayOfYear.mockResolvedValue([]);
-      mocks.memory.search.mockResolvedValue([
-        getForMemory(
-          MemoryFactory.create({
-            ownerId: user.id,
-            type: MemoryType.Rule,
-            memoryAt: new Date('2026-04-24T00:00:00Z'),
-            data: {
-              ruleId: 'existing',
-              dedupeKey: 'existing',
-              title: 'Existing',
-            } satisfies RuleMemoryData,
-          }),
-        ),
-      ]);
-      mocks.memory.hasRuleMemory.mockResolvedValue(false);
-      mocks.memory.create.mockResolvedValue(MemoryFactory.create() as any);
+  const user = factory.userAdmin();
+  mocks.user.getList.mockResolvedValue([user]);
+  mocks.systemMetadata.get.mockResolvedValue({
+    lastOnThisDayDate: '2026-04-26T00:00:00.000Z',
+    lastRuleDate: '2026-04-23T00:00:00.000Z',
+  });
+  mocks.asset.getByDayOfYear.mockResolvedValue([]);
+  mocks.memory.search.mockResolvedValue([
+    getForMemory(
+      MemoryFactory.create({
+        ownerId: user.id,
+        type: MemoryType.Rule,
+        memoryAt: new Date('2026-04-24T00:00:00Z'),
+        data: {
+          ruleId: 'existing',
+          dedupeKey: 'existing',
+          title: 'Existing',
+        } satisfies RuleMemoryData,
+      }),
+    ),
+  ]);
+  mocks.memory.hasRuleMemory.mockResolvedValue(false);
+  mocks.memory.create.mockResolvedValue(MemoryFactory.create() as any);
 
-      const birthdayRule = {
-        id: 'birthday',
-        evaluate: vi.fn().mockResolvedValue([
-          {
-            ruleId: 'birthday',
-            dedupeKey: 'birthday:person-1:2026-04-24',
-            title: 'Happy birthday, Pierre',
-            subtitle: 'Recent photos of Pierre',
-            score: 254,
-            assetIds: ['a-1', 'a-2', 'a-3', 'a-4'],
-            memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
-          },
-        ]),
-      };
-      const recentTripRule = {
-        id: 'recent_trip',
-        evaluate: vi.fn().mockResolvedValue([
-          {
-            ruleId: 'recent_trip',
-            dedupeKey: 'recent_trip:germany:nurnberg:2026-04-24',
-            title: 'Recent trip to Nürnberg, Germany',
-            subtitle: '20 photos over 30 days',
-            score: 220,
-            assetIds: ['t-1', 't-2', 't-3'],
-            memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
-          },
-        ]),
-      };
+  const birthdayRule = {
+    id: 'birthday',
+    evaluate: vi.fn().mockResolvedValue([
+      {
+        ruleId: 'birthday',
+        dedupeKey: 'birthday:person-1:2026-04-24',
+        title: 'Happy birthday, Pierre',
+        subtitle: 'Recent photos of Pierre',
+        score: 254,
+        assetIds: ['a-1', 'a-2', 'a-3', 'a-4'],
+        memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
+      },
+    ]),
+  };
+  const recentTripRule = {
+    id: 'recent_trip',
+    evaluate: vi.fn().mockResolvedValue([
+      {
+        ruleId: 'recent_trip',
+        dedupeKey: 'recent_trip:germany:nurnberg:2026-04-24',
+        title: 'Recent trip to Nürnberg, Germany',
+        subtitle: '20 photos over 30 days',
+        score: 220,
+        assetIds: ['t-1', 't-2', 't-3'],
+        memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
+      },
+    ]),
+  };
 
-      vi.spyOn(sut as never, 'getMemoryRules').mockReturnValue([recentTripRule, birthdayRule] as never);
+  vi.spyOn(sut as never, 'getMemoryRules').mockReturnValue([recentTripRule, birthdayRule] as never);
 
-      await sut.onMemoriesCreate();
+  await sut.onMemoriesCreate();
 
-      expect(mocks.memory.create).toHaveBeenCalledTimes(1);
-      expect(mocks.memory.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          ownerId: user.id,
-          type: MemoryType.Rule,
-          data: expect.objectContaining({
-            ruleId: 'birthday',
-            title: 'Happy birthday, Pierre',
-            subtitle: 'Recent photos of Pierre',
-            score: 254,
-          }),
-        }),
-        new Set(['a-1', 'a-2', 'a-3', 'a-4']),
-      );
+  expect(mocks.memory.create).toHaveBeenCalledTimes(1);
+  expect(mocks.memory.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ownerId: user.id,
+      type: MemoryType.Rule,
+      data: expect.objectContaining({
+        ruleId: 'birthday',
+        title: 'Happy birthday, Pierre',
+        subtitle: 'Recent photos of Pierre',
+        score: 254,
+      }),
+    }),
+    new Set(['a-1', 'a-2', 'a-3', 'a-4']),
+  );
 
-      vi.useRealTimers();
-    });
+  vi.useRealTimers();
+});
 ```
 
 - [ ] **Step 2: Run the focused service test**
@@ -372,6 +374,7 @@ git commit -m "test(server): cover birthday fallback ranking"
 ## Task 3: Add A Real-DB Pierre Regression
 
 **Files:**
+
 - Modify: `server/test/medium/specs/services/memory.service.spec.ts`
 
 - [ ] **Step 1: Add the medium test for the live Pierre shape**
@@ -379,58 +382,58 @@ git commit -m "test(server): cover birthday fallback ranking"
 Append this test immediately after `it('creates a birthday rule memory on the birthday itself', ...)` in `server/test/medium/specs/services/memory.service.spec.ts`:
 
 ```ts
-    it('creates a fallback birthday memory from four single-year Pierre photos', async () => {
-      const { sut, ctx } = setup();
-      const assetRepo = ctx.get(AssetRepository);
-      const memoryRepo = ctx.get(MemoryRepository);
-      const now = DateTime.fromObject({ year: 2026, month: 4, day: 24 }, { zone: 'utc' }) as DateTime<true>;
-      const { user } = await ctx.newUser();
-      const { person } = await ctx.newPerson({
-        ownerId: user.id,
-        name: 'Pierre',
-        birthDate: new Date('2025-04-24T00:00:00Z'),
-      });
+it('creates a fallback birthday memory from four single-year Pierre photos', async () => {
+  const { sut, ctx } = setup();
+  const assetRepo = ctx.get(AssetRepository);
+  const memoryRepo = ctx.get(MemoryRepository);
+  const now = DateTime.fromObject({ year: 2026, month: 4, day: 24 }, { zone: 'utc' }) as DateTime<true>;
+  const { user } = await ctx.newUser();
+  const { person } = await ctx.newPerson({
+    ownerId: user.id,
+    name: 'Pierre',
+    birthDate: new Date('2025-04-24T00:00:00Z'),
+  });
 
-      const addPierreAsset = async (localDateTime: string) => {
-        const { asset } = await ctx.newAsset({ ownerId: user.id, localDateTime });
-        await Promise.all([
-          ctx.newExif({ assetId: asset.id, city: 'Berlin', country: 'Germany' }),
-          ctx.newJobStatus({ assetId: asset.id }),
-          ctx.newAssetFace({ assetId: asset.id, personId: person.id }),
-          assetRepo.upsertFiles([
-            { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
-            { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
-          ]),
-        ]);
-      };
+  const addPierreAsset = async (localDateTime: string) => {
+    const { asset } = await ctx.newAsset({ ownerId: user.id, localDateTime });
+    await Promise.all([
+      ctx.newExif({ assetId: asset.id, city: 'Berlin', country: 'Germany' }),
+      ctx.newJobStatus({ assetId: asset.id }),
+      ctx.newAssetFace({ assetId: asset.id, personId: person.id }),
+      assetRepo.upsertFiles([
+        { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
+        { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
+      ]),
+    ]);
+  };
 
-      await addPierreAsset('2026-04-18T15:25:07.335Z');
-      await addPierreAsset('2026-04-18T15:25:08.244Z');
-      await addPierreAsset('2026-04-18T15:25:09.803Z');
-      await addPierreAsset('2026-04-18T15:25:11.543Z');
+  await addPierreAsset('2026-04-18T15:25:07.335Z');
+  await addPierreAsset('2026-04-18T15:25:08.244Z');
+  await addPierreAsset('2026-04-18T15:25:09.803Z');
+  await addPierreAsset('2026-04-18T15:25:11.543Z');
 
-      vi.setSystemTime(now.toJSDate());
-      await sut.onMemoriesCreate();
+  vi.setSystemTime(now.toJSDate());
+  await sut.onMemoriesCreate();
 
-      const memories = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
-      expect(memories).toEqual([
-        expect.objectContaining({
-          type: MemoryType.Rule,
-          data: expect.objectContaining({
-            ruleId: 'birthday',
-            title: 'Happy birthday, Pierre',
-            subtitle: 'Recent photos of Pierre',
-          }),
-          assets: expect.arrayContaining([
-            expect.objectContaining({}),
-            expect.objectContaining({}),
-            expect.objectContaining({}),
-            expect.objectContaining({}),
-          ]),
-        }),
-      ]);
-      expect(memories[0]?.assets).toHaveLength(4);
-    });
+  const memories = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
+  expect(memories).toEqual([
+    expect.objectContaining({
+      type: MemoryType.Rule,
+      data: expect.objectContaining({
+        ruleId: 'birthday',
+        title: 'Happy birthday, Pierre',
+        subtitle: 'Recent photos of Pierre',
+      }),
+      assets: expect.arrayContaining([
+        expect.objectContaining({}),
+        expect.objectContaining({}),
+        expect.objectContaining({}),
+        expect.objectContaining({}),
+      ]),
+    }),
+  ]);
+  expect(memories[0]?.assets).toHaveLength(4);
+});
 ```
 
 - [ ] **Step 2: Run the focused medium test file**
@@ -451,10 +454,10 @@ Expected:
 The medium regression should pass with the Task 1 implementation. If it does not, verify `server/src/services/memory-rules/birthday.rule.ts` still uses this exact fallback selection:
 
 ```ts
-      const fallbackAssetIds = [...assets]
-        .toSorted((left, right) => right.localDateTime.getTime() - left.localDateTime.getTime())
-        .slice(0, 4)
-        .map(({ id }) => id);
+const fallbackAssetIds = [...assets]
+  .toSorted((left, right) => right.localDateTime.getTime() - left.localDateTime.getTime())
+  .slice(0, 4)
+  .map(({ id }) => id);
 ```
 
 Do not reintroduce the throwback `2`-per-year cap into the fallback branch.

--- a/e2e/src/specs/maintenance/server/database-backups.e2e-spec.ts
+++ b/e2e/src/specs/maintenance/server/database-backups.e2e-spec.ts
@@ -1,5 +1,6 @@
-import { LoginResponseDto, ManualJobName } from '@immich/sdk';
+import { LoginResponseDto, ManualJobName, login } from '@immich/sdk';
 import { errorDto } from 'src/responses';
+import { loginDto } from 'src/fixtures';
 import { app, utils } from 'src/utils';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -207,6 +208,10 @@ describe('/admin/database-backups', () => {
           },
         )
         .toBeFalsy();
+
+      // A full database restore replaces the session table, so acquire a fresh
+      // admin session before the next restore scenarios run.
+      admin = await login({ loginCredentialDto: loginDto.admin });
     });
 
     it.sequential('fail to restore a corrupted backup', { timeout: 60_000 }, async () => {

--- a/e2e/src/specs/maintenance/server/database-backups.e2e-spec.ts
+++ b/e2e/src/specs/maintenance/server/database-backups.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { LoginResponseDto, ManualJobName, login } from '@immich/sdk';
-import { errorDto } from 'src/responses';
 import { loginDto } from 'src/fixtures';
+import { errorDto } from 'src/responses';
 import { app, utils } from 'src/utils';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -230,13 +230,16 @@ export const utils = {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        // E2E files reuse the same Docker stack. Clearing Redis first drops
-        // stale BullMQ jobs from the previous file before we truncate Postgres.
+        // E2E files reuse the same Docker stack. Clear only BullMQ keys so
+        // stale jobs from the previous file do not outlive the Postgres reset.
         const { exitCode, stderr } = await executeCommand('docker', [
           'exec',
           'immich-e2e-redis',
-          'redis-cli',
-          'FLUSHALL',
+          'sh',
+          '-lc',
+          `for key in $(redis-cli --scan --pattern 'immich_bull:*'); do
+             redis-cli DEL "$key" >/dev/null
+           done`,
         ]).promise;
         if (exitCode !== 0) {
           throw new Error(`Failed to flush Redis queues: ${stderr || `exit code ${exitCode}`}`);

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -230,6 +230,17 @@ export const utils = {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
+        // E2E files reuse the same Docker stack. Clearing Redis first drops
+        // stale BullMQ jobs from the previous file before we truncate Postgres.
+        const { exitCode, stderr } = await executeCommand('docker', [
+          'exec',
+          'immich-e2e-redis',
+          'redis-cli',
+          'FLUSHALL',
+        ]).promise;
+        if (exitCode !== 0) {
+          throw new Error(`Failed to flush Redis queues: ${stderr || `exit code ${exitCode}`}`);
+        }
         await client.query(query);
         return;
       } catch (error: any) {

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -137,7 +137,7 @@ const requireFromServer = createRequire('/usr/src/app/server/package.json');
 const { Queue } = requireFromServer('bullmq');
 
 const queueNames = ${JSON.stringify(Object.values(QueueName))};
-const pausableQueueNames = queueNames.filter((name) => name !== 'backgroundTask');
+const cleanupQueueNames = queueNames.filter((name) => name !== 'backgroundTask');
 const connection = {
   host: process.env.REDIS_HOSTNAME || 'redis',
   port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
@@ -146,16 +146,16 @@ const connection = {
 };
 
 const queues = queueNames.map((name) => new Queue(name, { connection, prefix: 'immich_bull' }));
-const pausableQueues = queues.filter((queue) => pausableQueueNames.includes(queue.name));
+const cleanupQueues = queues.filter((queue) => cleanupQueueNames.includes(queue.name));
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const cleanup = async () => {
   try {
-    await Promise.all(pausableQueues.map((queue) => queue.pause()));
+    await Promise.all(cleanupQueues.map((queue) => queue.pause()));
 
     const deadline = Date.now() + 30_000;
     while (true) {
-      const counts = await Promise.all(queues.map((queue) => queue.getJobCounts('active')));
+      const counts = await Promise.all(cleanupQueues.map((queue) => queue.getJobCounts('active')));
       const active = counts.reduce((sum, count) => sum + (count.active || 0), 0);
 
       if (active === 0) {
@@ -170,14 +170,14 @@ const cleanup = async () => {
     }
 
     await Promise.all(
-      queues.map(async (queue) => {
+      cleanupQueues.map(async (queue) => {
         await queue.drain(true);
         await queue.clean(0, 1000, 'failed');
       }),
     );
   } finally {
     await Promise.all(
-      pausableQueues.map(async (queue) => {
+      cleanupQueues.map(async (queue) => {
         try {
           await queue.resume();
         } catch {}

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -132,7 +132,9 @@ const executeCommand = (command: string, args: string[], options?: { cwd?: strin
 };
 
 const queueCleanupScript = `
-const { Queue } = require('/usr/src/app/node_modules/bullmq');
+const { createRequire } = require('node:module');
+const requireFromServer = createRequire('/usr/src/app/server/package.json');
+const { Queue } = requireFromServer('bullmq');
 
 const queueNames = ${JSON.stringify(Object.values(QueueName))};
 const connection = {

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -131,6 +131,67 @@ const executeCommand = (command: string, args: string[], options?: { cwd?: strin
   return { promise, child };
 };
 
+const queueCleanupScript = `
+const { Queue } = require('/usr/src/app/node_modules/bullmq');
+
+const queueNames = ${JSON.stringify(Object.values(QueueName))};
+const connection = {
+  host: process.env.REDIS_HOSTNAME || 'redis',
+  port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
+  ...(process.env.REDIS_USERNAME ? { username: process.env.REDIS_USERNAME } : {}),
+  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
+};
+
+const queues = queueNames.map((name) => new Queue(name, { connection, prefix: 'immich_bull' }));
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const cleanup = async () => {
+  try {
+    await Promise.all(queues.map((queue) => queue.pause()));
+
+    const deadline = Date.now() + 30_000;
+    while (true) {
+      const counts = await Promise.all(queues.map((queue) => queue.getJobCounts('active')));
+      const active = counts.reduce((sum, count) => sum + (count.active || 0), 0);
+
+      if (active === 0) {
+        break;
+      }
+
+      if (Date.now() > deadline) {
+        throw new Error(\`Timed out waiting for active BullMQ jobs to finish (\${active} still active)\`);
+      }
+
+      await sleep(250);
+    }
+
+    await Promise.all(
+      queues.map(async (queue) => {
+        await queue.drain(true);
+        await queue.clean(0, 1000, 'failed');
+      }),
+    );
+  } finally {
+    await Promise.all(
+      queues.map(async (queue) => {
+        try {
+          await queue.resume();
+        } catch {}
+
+        try {
+          await queue.close();
+        } catch {}
+      }),
+    );
+  }
+};
+
+cleanup().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+
 let client: pg.Client | null = null;
 
 const events: Record<EventType, Set<string>> = {
@@ -230,19 +291,17 @@ export const utils = {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        // E2E files reuse the same Docker stack. Clear only BullMQ keys so
-        // stale jobs from the previous file do not outlive the Postgres reset.
+        // E2E files reuse the same Docker stack. Pause and drain BullMQ queues
+        // through the official API so stale jobs do not survive the DB reset.
         const { exitCode, stderr } = await executeCommand('docker', [
           'exec',
-          'immich-e2e-redis',
-          'sh',
-          '-lc',
-          `for key in $(redis-cli --scan --pattern 'immich_bull:*'); do
-             redis-cli DEL "$key" >/dev/null
-           done`,
+          'immich-e2e-server',
+          'node',
+          '-e',
+          queueCleanupScript,
         ]).promise;
         if (exitCode !== 0) {
-          throw new Error(`Failed to flush Redis queues: ${stderr || `exit code ${exitCode}`}`);
+          throw new Error(`Failed to clean BullMQ queues: ${stderr || `exit code ${exitCode}`}`);
         }
         await client.query(query);
         return;

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -131,71 +131,6 @@ const executeCommand = (command: string, args: string[], options?: { cwd?: strin
   return { promise, child };
 };
 
-const queueCleanupScript = `
-const { createRequire } = require('node:module');
-const requireFromServer = createRequire('/usr/src/app/server/package.json');
-const { Queue } = requireFromServer('bullmq');
-
-const queueNames = ${JSON.stringify(Object.values(QueueName))};
-const cleanupQueueNames = queueNames.filter((name) => name !== 'backgroundTask');
-const connection = {
-  host: process.env.REDIS_HOSTNAME || 'redis',
-  port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
-  ...(process.env.REDIS_USERNAME ? { username: process.env.REDIS_USERNAME } : {}),
-  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
-};
-
-const queues = queueNames.map((name) => new Queue(name, { connection, prefix: 'immich_bull' }));
-const cleanupQueues = queues.filter((queue) => cleanupQueueNames.includes(queue.name));
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const cleanup = async () => {
-  try {
-    await Promise.all(cleanupQueues.map((queue) => queue.pause()));
-
-    const deadline = Date.now() + 30_000;
-    while (true) {
-      const counts = await Promise.all(cleanupQueues.map((queue) => queue.getJobCounts('active')));
-      const active = counts.reduce((sum, count) => sum + (count.active || 0), 0);
-
-      if (active === 0) {
-        break;
-      }
-
-      if (Date.now() > deadline) {
-        throw new Error(\`Timed out waiting for active BullMQ jobs to finish (\${active} still active)\`);
-      }
-
-      await sleep(250);
-    }
-
-    await Promise.all(
-      cleanupQueues.map(async (queue) => {
-        await queue.drain(true);
-        await queue.clean(0, 1000, 'failed');
-      }),
-    );
-  } finally {
-    await Promise.all(
-      cleanupQueues.map(async (queue) => {
-        try {
-          await queue.resume();
-        } catch {}
-
-        try {
-          await queue.close();
-        } catch {}
-      }),
-    );
-  }
-};
-
-cleanup().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
-`;
-
 let client: pg.Client | null = null;
 
 const events: Record<EventType, Set<string>> = {
@@ -295,18 +230,6 @@ export const utils = {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        // E2E files reuse the same Docker stack. Pause and drain BullMQ queues
-        // through the official API so stale jobs do not survive the DB reset.
-        const { exitCode, stderr } = await executeCommand('docker', [
-          'exec',
-          'immich-e2e-server',
-          'node',
-          '-e',
-          queueCleanupScript,
-        ]).promise;
-        if (exitCode !== 0) {
-          throw new Error(`Failed to clean BullMQ queues: ${stderr || `exit code ${exitCode}`}`);
-        }
         await client.query(query);
         return;
       } catch (error: any) {

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -137,6 +137,7 @@ const requireFromServer = createRequire('/usr/src/app/server/package.json');
 const { Queue } = requireFromServer('bullmq');
 
 const queueNames = ${JSON.stringify(Object.values(QueueName))};
+const pausableQueueNames = queueNames.filter((name) => name !== 'backgroundTask');
 const connection = {
   host: process.env.REDIS_HOSTNAME || 'redis',
   port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
@@ -145,11 +146,12 @@ const connection = {
 };
 
 const queues = queueNames.map((name) => new Queue(name, { connection, prefix: 'immich_bull' }));
+const pausableQueues = queues.filter((queue) => pausableQueueNames.includes(queue.name));
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const cleanup = async () => {
   try {
-    await Promise.all(queues.map((queue) => queue.pause()));
+    await Promise.all(pausableQueues.map((queue) => queue.pause()));
 
     const deadline = Date.now() + 30_000;
     while (true) {
@@ -175,7 +177,7 @@ const cleanup = async () => {
     );
   } finally {
     await Promise.all(
-      queues.map(async (queue) => {
+      pausableQueues.map(async (queue) => {
         try {
           await queue.resume();
         } catch {}

--- a/server/src/services/memory-rules/birthday.rule.spec.ts
+++ b/server/src/services/memory-rules/birthday.rule.spec.ts
@@ -2,43 +2,43 @@ import { DateTime } from 'luxon';
 import { BirthdayMemoryRule } from 'src/services/memory-rules/birthday.rule';
 
 describe(BirthdayMemoryRule.name, () => {
-  it('creates one curated birthday candidate per matching person', async () => {
+  it('creates a snapshot fallback birthday candidate from four single-year assets', async () => {
     const personRepository = {
       getBirthdaysForDay: vi
         .fn()
-        .mockResolvedValue([{ id: 'person-1', name: 'Alice', birthDate: new Date('1990-04-23T00:00:00Z') }]),
+        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('1990-04-24T00:00:00Z') }]),
     };
     const assetRepository = {
       getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
-        { id: 'a-2025-1', localDateTime: new Date('2025-04-01T12:00:00Z') },
-        { id: 'a-2025-2', localDateTime: new Date('2025-03-01T12:00:00Z') },
-        { id: 'a-2024-1', localDateTime: new Date('2024-04-01T12:00:00Z') },
-        { id: 'a-2023-1', localDateTime: new Date('2023-04-01T12:00:00Z') },
-        { id: 'a-2022-1', localDateTime: new Date('2022-04-01T12:00:00Z') },
-        { id: 'a-2021-1', localDateTime: new Date('2021-04-01T12:00:00Z') },
+        { id: 'a-1', localDateTime: new Date('2026-04-01T12:00:00Z') },
+        { id: 'a-2', localDateTime: new Date('2026-04-02T12:00:00Z') },
+        { id: 'a-3', localDateTime: new Date('2026-04-03T12:00:00Z') },
+        { id: 'a-4', localDateTime: new Date('2026-04-04T12:00:00Z') },
       ]),
     };
 
     const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
     const [candidate] = await rule.evaluate({
       ownerId: 'user-1',
-      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+      target: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
     });
 
     expect(candidate).toMatchObject({
       ruleId: 'birthday',
-      dedupeKey: 'birthday:person-1:2026-04-23',
-      title: 'Happy birthday, Alice',
-      subtitle: 'Photos from different years',
-      assetIds: ['a-2025-1', 'a-2025-2', 'a-2024-1', 'a-2023-1', 'a-2022-1', 'a-2021-1'],
+      dedupeKey: 'birthday:person-1:2025-04-24',
+      title: 'Happy birthday, Pierre',
+      subtitle: 'Recent photos of Pierre',
+      score: 254,
+      assetIds: ['a-4', 'a-3', 'a-2', 'a-1'],
+      context: { personId: 'person-1', distinctYears: 1 },
     });
   });
 
-  it('skips people with too few assets or only one year represented', async () => {
+  it('skips the snapshot fallback when only three single-year assets qualify', async () => {
     const personRepository = {
       getBirthdaysForDay: vi
         .fn()
-        .mockResolvedValue([{ id: 'person-1', name: 'Alice', birthDate: new Date('1990-04-23T00:00:00Z') }]),
+        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('1990-04-24T00:00:00Z') }]),
     };
     const assetRepository = {
       getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
@@ -52,8 +52,45 @@ describe(BirthdayMemoryRule.name, () => {
     await expect(
       rule.evaluate({
         ownerId: 'user-1',
-        target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+        target: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
       }),
     ).resolves.toEqual([]);
+  });
+
+  it('prefers the throwback path over the snapshot fallback when multiple years qualify', async () => {
+    const personRepository = {
+      getBirthdaysForDay: vi
+        .fn()
+        .mockResolvedValue([{ id: 'person-2', name: 'Alice', birthDate: new Date('1990-04-24T00:00:00Z') }]),
+    };
+    const assetRepository = {
+      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+        { id: 'a-1', localDateTime: new Date('2025-04-01T12:00:00Z') },
+        { id: 'a-2', localDateTime: new Date('2025-03-01T12:00:00Z') },
+        { id: 'a-3', localDateTime: new Date('2024-04-01T12:00:00Z') },
+        { id: 'a-4', localDateTime: new Date('2023-04-01T12:00:00Z') },
+        { id: 'a-5', localDateTime: new Date('2022-04-01T12:00:00Z') },
+        { id: 'a-6', localDateTime: new Date('2021-04-01T12:00:00Z') },
+      ]),
+    };
+
+    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+    const candidates = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
+    });
+
+    expect(candidates).toEqual([
+      {
+        ruleId: 'birthday',
+        dedupeKey: 'birthday:person-2:2025-04-24',
+        title: 'Happy birthday, Alice',
+        subtitle: 'Photos from different years',
+        score: 356,
+        assetIds: ['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6'],
+        memoryAt: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
+        context: { personId: 'person-2', distinctYears: 5 },
+      },
+    ]);
   });
 });

--- a/server/src/services/memory-rules/birthday.rule.spec.ts
+++ b/server/src/services/memory-rules/birthday.rule.spec.ts
@@ -20,12 +20,12 @@ describe(BirthdayMemoryRule.name, () => {
     const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
     const [candidate] = await rule.evaluate({
       ownerId: 'user-1',
-      target: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
+      target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
     });
 
     expect(candidate).toMatchObject({
       ruleId: 'birthday',
-      dedupeKey: 'birthday:person-1:2025-04-24',
+      dedupeKey: 'birthday:person-1:2026-04-24',
       title: 'Happy birthday, Pierre',
       subtitle: 'Recent photos of Pierre',
       score: 254,
@@ -52,9 +52,38 @@ describe(BirthdayMemoryRule.name, () => {
     await expect(
       rule.evaluate({
         ownerId: 'user-1',
-        target: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
+        target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
       }),
     ).resolves.toEqual([]);
+  });
+
+  it('uses the four most recent qualifying assets for the snapshot fallback', async () => {
+    const personRepository = {
+      getBirthdaysForDay: vi
+        .fn()
+        .mockResolvedValue([{ id: 'person-1', name: 'Pierre', birthDate: new Date('1990-04-24T00:00:00Z') }]),
+    };
+    const assetRepository = {
+      getMemoryAssetsForPerson: vi.fn().mockResolvedValue([
+        { id: 'a-1', localDateTime: new Date('2026-04-01T12:00:00Z') },
+        { id: 'a-2', localDateTime: new Date('2026-04-02T12:00:00Z') },
+        { id: 'a-3', localDateTime: new Date('2026-04-03T12:00:00Z') },
+        { id: 'a-4', localDateTime: new Date('2026-04-04T12:00:00Z') },
+        { id: 'a-5', localDateTime: new Date('2026-04-05T12:00:00Z') },
+      ]),
+    };
+
+    const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
+    });
+
+    expect(candidate).toMatchObject({
+      subtitle: 'Recent photos of Pierre',
+      score: 254,
+      assetIds: ['a-5', 'a-4', 'a-3', 'a-2'],
+    });
   });
 
   it('prefers the throwback path over the snapshot fallback when multiple years qualify', async () => {
@@ -77,18 +106,18 @@ describe(BirthdayMemoryRule.name, () => {
     const rule = new BirthdayMemoryRule(personRepository as never, assetRepository as never);
     const candidates = await rule.evaluate({
       ownerId: 'user-1',
-      target: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
+      target: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
     });
 
     expect(candidates).toEqual([
       {
         ruleId: 'birthday',
-        dedupeKey: 'birthday:person-2:2025-04-24',
+        dedupeKey: 'birthday:person-2:2026-04-24',
         title: 'Happy birthday, Alice',
         subtitle: 'Photos from different years',
         score: 356,
         assetIds: ['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6'],
-        memoryAt: DateTime.fromISO('2025-04-24', { zone: 'utc' }),
+        memoryAt: DateTime.fromISO('2026-04-24', { zone: 'utc' }),
         context: { personId: 'person-2', distinctYears: 5 },
       },
     ]);

--- a/server/src/services/memory-rules/birthday.rule.ts
+++ b/server/src/services/memory-rules/birthday.rule.ts
@@ -37,7 +37,27 @@ export class BirthdayMemoryRule implements MemoryRule {
         .flatMap((year) => byYear.get(year) ?? [])
         .slice(0, 12);
 
-      if (assetIds.length < 6 || byYear.size < 2) {
+      if (assetIds.length >= 6 && byYear.size >= 2) {
+        candidates.push({
+          ruleId: this.id,
+          dedupeKey: `birthday:${person.id}:${target.toFormat('yyyy-MM-dd')}`,
+          title: `Happy birthday, ${person.name}`,
+          subtitle: 'Photos from different years',
+          score: 300 + byYear.size * 10 + assetIds.length,
+          assetIds,
+          memoryAt: target,
+          context: { personId: person.id, distinctYears: byYear.size },
+        });
+
+        continue;
+      }
+
+      const fallbackAssetIds = assets
+        .toSorted((a, b) => b.localDateTime.getTime() - a.localDateTime.getTime())
+        .slice(0, 4)
+        .map((asset) => asset.id);
+
+      if (fallbackAssetIds.length < 4) {
         continue;
       }
 
@@ -45,9 +65,9 @@ export class BirthdayMemoryRule implements MemoryRule {
         ruleId: this.id,
         dedupeKey: `birthday:${person.id}:${target.toFormat('yyyy-MM-dd')}`,
         title: `Happy birthday, ${person.name}`,
-        subtitle: 'Photos from different years',
-        score: 100 + byYear.size * 10 + assetIds.length,
-        assetIds,
+        subtitle: `Recent photos of ${person.name}`,
+        score: 250 + fallbackAssetIds.length,
+        assetIds: fallbackAssetIds,
         memoryAt: target,
         context: { personId: person.id, distinctYears: byYear.size },
       });

--- a/server/src/services/memory.service.spec.ts
+++ b/server/src/services/memory.service.spec.ts
@@ -289,6 +289,85 @@ describe(MemoryService.name, () => {
       vi.useRealTimers();
     });
 
+    it('prefers a fallback birthday candidate over recent trip when only one rule slot remains', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-24T12:00:00Z'));
+
+      const user = factory.userAdmin();
+      mocks.user.getList.mockResolvedValue([user]);
+      mocks.systemMetadata.get.mockResolvedValue({
+        lastOnThisDayDate: '2026-04-26T00:00:00.000Z',
+        lastRuleDate: '2026-04-23T00:00:00.000Z',
+      });
+      mocks.asset.getByDayOfYear.mockResolvedValue([]);
+      mocks.memory.search.mockResolvedValue([
+        getForMemory(
+          MemoryFactory.create({
+            ownerId: user.id,
+            type: MemoryType.Rule,
+            memoryAt: new Date('2026-04-24T00:00:00Z'),
+            data: {
+              ruleId: 'existing',
+              dedupeKey: 'existing',
+              title: 'Existing',
+            } satisfies RuleMemoryData,
+          }),
+        ),
+      ]);
+      mocks.memory.hasRuleMemory.mockResolvedValue(false);
+      mocks.memory.create.mockResolvedValue(MemoryFactory.create() as any);
+
+      const birthdayRule = {
+        id: 'birthday',
+        evaluate: vi.fn().mockResolvedValue([
+          {
+            ruleId: 'birthday',
+            dedupeKey: 'birthday:person-1:2026-04-24',
+            title: 'Happy birthday, Pierre',
+            subtitle: 'Recent photos of Pierre',
+            score: 254,
+            assetIds: ['a-1', 'a-2', 'a-3', 'a-4'],
+            memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
+          },
+        ]),
+      };
+      const recentTripRule = {
+        id: 'recent_trip',
+        evaluate: vi.fn().mockResolvedValue([
+          {
+            ruleId: 'recent_trip',
+            dedupeKey: 'recent_trip:germany:nurnberg:2026-04-24',
+            title: 'Recent trip to Nurnberg, Germany',
+            subtitle: '20 photos over 30 days',
+            score: 220,
+            assetIds: ['t-1', 't-2', 't-3'],
+            memoryAt: DateTime.fromISO('2026-04-24T00:00:00Z'),
+          },
+        ]),
+      };
+
+      vi.spyOn(sut as never, 'getMemoryRules').mockReturnValue([recentTripRule, birthdayRule] as never);
+
+      await sut.onMemoriesCreate();
+
+      expect(mocks.memory.create).toHaveBeenCalledTimes(1);
+      expect(mocks.memory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerId: user.id,
+          type: MemoryType.Rule,
+          data: expect.objectContaining({
+            ruleId: 'birthday',
+            title: 'Happy birthday, Pierre',
+            subtitle: 'Recent photos of Pierre',
+            score: 254,
+          }),
+        }),
+        new Set(['a-1', 'a-2', 'a-3', 'a-4']),
+      );
+
+      vi.useRealTimers();
+    });
+
     it('should not advance the rule cursor when any owner run fails', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-04-23T12:00:00Z'));

--- a/server/test/medium/specs/services/memory.service.spec.ts
+++ b/server/test/medium/specs/services/memory.service.spec.ts
@@ -286,6 +286,56 @@ describe(MemoryService.name, () => {
       ]);
     });
 
+    it('creates a fallback birthday memory from four single-year Pierre photos', async () => {
+      const { sut, ctx } = setup();
+      const assetRepo = ctx.get(AssetRepository);
+      const memoryRepo = ctx.get(MemoryRepository);
+      const now = DateTime.fromObject({ year: 2026, month: 4, day: 24 }, { zone: 'utc' }) as DateTime<true>;
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({
+        ownerId: user.id,
+        name: 'Pierre',
+        birthDate: new Date('2025-04-24T00:00:00Z'),
+      });
+      const pierreAssetIds: string[] = [];
+
+      const addPierreAsset = async (localDateTime: string) => {
+        const { asset } = await ctx.newAsset({ ownerId: user.id, localDateTime });
+        pierreAssetIds.push(asset.id);
+        await Promise.all([
+          ctx.newExif({ assetId: asset.id, city: 'Berlin', country: 'Germany' }),
+          ctx.newJobStatus({ assetId: asset.id }),
+          ctx.newAssetFace({ assetId: asset.id, personId: person.id }),
+          assetRepo.upsertFiles([
+            { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
+            { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
+          ]),
+        ]);
+      };
+
+      await addPierreAsset('2026-04-18T15:25:07.335Z');
+      await addPierreAsset('2026-04-18T15:25:08.244Z');
+      await addPierreAsset('2026-04-18T15:25:09.803Z');
+      await addPierreAsset('2026-04-18T15:25:11.543Z');
+
+      vi.setSystemTime(now.toJSDate());
+      await sut.onMemoriesCreate();
+
+      const memories = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
+      expect(memories).toEqual([
+        expect.objectContaining({
+          type: MemoryType.Rule,
+          data: expect.objectContaining({
+            ruleId: 'birthday',
+            title: 'Happy birthday, Pierre',
+            subtitle: 'Recent photos of Pierre',
+          }),
+        }),
+      ]);
+      expect(memories[0]?.assets).toHaveLength(4);
+      expect(memories[0]?.assets.map(({ id }) => id).sort()).toEqual([...pierreAssetIds].sort());
+    });
+
     it('creates a recent-trip rule memory for a dense non-home cluster', async () => {
       const { sut, ctx } = setup();
       const assetRepo = ctx.get(AssetRepository);

--- a/server/test/medium/specs/services/memory.service.spec.ts
+++ b/server/test/medium/specs/services/memory.service.spec.ts
@@ -333,7 +333,7 @@ describe(MemoryService.name, () => {
         }),
       ]);
       expect(memories[0]?.assets).toHaveLength(4);
-      expect(memories[0]?.assets.map(({ id }) => id).sort()).toEqual([...pierreAssetIds].sort());
+      expect(memories[0]?.assets.map(({ id }) => id).toSorted()).toEqual([...pierreAssetIds].toSorted());
     });
 
     it('creates a recent-trip rule memory for a dense non-home cluster', async () => {


### PR DESCRIPTION
## Summary
- add a birthday snapshot fallback when the multi-year throwback path does not qualify
- keep birthday memories ranked above `recent_trip` and preserve the existing throwback path when enough multi-year history exists
- add unit, service, and medium coverage for the Pierre-style four-photo single-year case

## Test Plan
- [x] `pnpm --dir server test --run src/services/memory-rules/birthday.rule.spec.ts src/services/memory.service.spec.ts`
- [x] `pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts`
- [x] `pnpm --dir server check`
