### PR TITLE
feat(server): curate recent trip memories

### DIFF
--- a/docs/plans/2026-04-24-recent-trip-curation-design.md
+++ b/docs/plans/2026-04-24-recent-trip-curation-design.md
@@ -246,6 +246,11 @@ Add focused coverage in `server/src/services/memory-rules/recent-trip.rule.spec.
    - when the representative pool is already `<= 6`
    - the rule returns all representatives unchanged
 
+6. `Long trip caps at ten while spanning the trip timeline`
+   - more representative days than the target allows
+   - curated output caps at `10`
+   - first and last trip days can still appear
+
 ### Medium Tests
 
 Add a real-DB regression in `server/test/medium/specs/services/memory.service.spec.ts`:

--- a/docs/plans/2026-04-24-recent-trip-curation-design.md
+++ b/docs/plans/2026-04-24-recent-trip-curation-design.md
@@ -1,0 +1,257 @@
+# Recent Trip Memory Curation Design
+
+## Goal
+
+Improve `recent_trip` memories so they feel curated instead of dumping a burst-heavy run of nearly identical photos.
+
+The target behavior is:
+
+- most trips show `6-8` photos
+- longer trips can show up to `10`
+- picks should cover the trip timeline instead of clustering around one moment
+- photos taken within roughly the same moment should usually collapse to one representative
+- the final memory should still read like a chronological trip recap
+
+## Current Behavior
+
+`server/src/services/memory-rules/recent-trip.rule.ts` currently:
+
+- detects a trip candidate from recent location clusters
+- fetches matching assets for the chosen place via `getMemoryAssetsForLocation`
+- takes the returned asset IDs as-is
+- returns them in the memory candidate without any curation
+
+`server/src/repositories/asset.repository.ts` currently returns:
+
+- only asset IDs
+- ordered by `localDateTime asc`
+- limited to `20`
+
+That means the memory often shows:
+
+- too many photos
+- several nearly identical shots from one burst
+- early-trip bias when a location has more than `20` qualifying assets
+
+## Chosen Approach
+
+Keep trip detection unchanged and add a deterministic curation pass after the trip location has already been chosen.
+
+The curation pass should:
+
+- operate entirely on the chosen trip asset pool
+- collapse bursty adjacent shots using a `2` minute window
+- favor coverage across trip days first
+- fill extra slots with well-spaced moments across the full trip timeline
+- return the final curated subset in chronological order
+
+This keeps the behavioral change narrow:
+
+- no change to home detection
+- no change to trip qualification thresholds
+- no change to cooldown behavior
+- no change to other memory types
+
+## Scope
+
+### In Scope
+
+- recent-trip asset curation in `server/src/services/memory-rules/recent-trip.rule.ts`
+- expanding `getMemoryAssetsForLocation` so the rule can curate using timestamps
+- adjusting the raw location asset pool so curation can cover the full trip timeline
+- rule and medium test coverage for burst thinning, adaptive sizing, and chronological ordering
+
+### Out of Scope
+
+- visual similarity analysis
+- favorites or rating-based selection
+- randomization
+- changing recent-trip qualification thresholds
+- changing birthday or on-this-day memories
+- UI or DTO changes
+
+## Architecture
+
+### Rule Boundary
+
+`RecentTripMemoryRule` remains responsible for:
+
+- detecting baseline home
+- selecting the winning recent trip candidate
+- enforcing same-place cooldown
+- generating the final `recent_trip` memory candidate
+
+The new responsibility added to the rule is a local curation step between:
+
+1. `getMemoryAssetsForLocation(...)`
+2. final `assetIds` assignment in the memory candidate
+
+### Repository Boundary
+
+`AssetRepository.getMemoryAssetsForLocation(...)` should change from returning only `{ id }` rows to returning:
+
+- `id`
+- `localDateTime`
+
+The method should also stop using the current `limit 20` raw-pool cap.
+
+Instead, it should return the full qualifying trip pool for the chosen location and time window, ordered by `localDateTime asc`.
+
+Rationale:
+
+- curation needs timestamps
+- a hard `20`-asset cap biases selection toward the start of long burst-heavy trips
+- this query only runs for one chosen trip candidate per owner per day, so a fuller pool is acceptable for this feature
+
+## Curation Pipeline
+
+### Step 1: Build Burst Groups
+
+Start from the trip asset pool ordered by `localDateTime asc`.
+
+Create burst groups by scanning adjacent assets:
+
+- if the gap from the previous asset is `<= 2` minutes, keep it in the same burst group
+- if the gap is `> 2` minutes, start a new burst group
+
+For v1, each burst group keeps exactly one representative asset:
+
+- use the earliest asset in the burst group
+
+This is intentionally simple and deterministic. It removes obvious repetition without introducing subjective quality scoring.
+
+### Step 2: Group Burst Representatives By Day
+
+After burst collapse, group the remaining representatives by trip day using the same `localDateTime` day semantics already used by memory clustering.
+
+Each day bucket is ordered chronologically.
+
+### Step 3: Choose Target Size
+
+The curated target size should be adaptive:
+
+- if the burst-representative count is `<= 6`, keep them all
+- if the trip has at least `5` distinct days or at least `18` burst representatives, target `10`
+- if the trip has at least `4` distinct days or at least `12` burst representatives, target `8`
+- otherwise target `7`
+
+This yields:
+
+- `6-8` photos for most trips
+- `10` only for clearly longer trips
+
+### Step 4: Day Coverage First
+
+First pass selection should maximize trip-day coverage:
+
+- if the number of distinct day buckets is less than or equal to the target, pick one representative from every day
+- if the number of day buckets exceeds the target, sample day buckets evenly across the trip timeline so the first and last trip days can both appear
+
+When selecting one representative for a day:
+
+- choose the representative nearest the midpoint of that day's representatives
+
+This avoids bias toward just the earliest photo on a day while still remaining deterministic.
+
+### Step 5: Fill Remaining Slots With Spaced Moments
+
+If the first pass does not fill the target:
+
+- flatten the remaining unselected burst representatives in chronological order
+- select additional representatives evenly across that remaining timeline until the target is reached
+
+This second pass allows larger trips to show multiple moments from a day without collapsing back into burst-heavy runs.
+
+### Step 6: Return Chronological Order
+
+After selection:
+
+- sort the chosen representatives back into chronological order
+- use their IDs for the memory candidate
+
+The memory should read as a coherent trip recap rather than a scored gallery.
+
+## Presentation And Ranking
+
+This change does not alter:
+
+- the memory title
+- the memory subtitle
+- the rule score formula
+- the rule dedupe key
+- trip qualification thresholds
+
+The subtitle should still describe the full detected trip cluster, for example:
+
+- `12 photos over 2 days`
+
+even if the curated memory only shows `7` selected photos.
+
+## Edge Cases
+
+If burst collapsing leaves only a small number of representatives:
+
+- return the smaller curated set
+- do not pad with near-duplicate burst shots just to hit the target
+
+If one day contains only bursty photos:
+
+- that day can still contribute one representative
+
+If a trip spans many days but each day has only one representative:
+
+- the memory may return more than `6` and up to the adaptive target, still in chronological order
+
+If the trip has fewer than `7` qualifying raw assets or fewer than `2` days:
+
+- trip qualification should still fail exactly as it does today
+
+## Testing
+
+### Rule Tests
+
+Add focused coverage in `server/src/services/memory-rules/recent-trip.rule.spec.ts` for:
+
+1. `Burst-heavy trip is curated down`
+   - a qualifying trip pool with many adjacent shots
+   - curated output is smaller than the raw pool
+   - output stays within the adaptive target
+
+2. `Two-minute burst collapse`
+   - assets within `2` minutes collapse to one representative
+   - assets outside the burst window can both remain
+
+3. `Chronological order is preserved`
+   - selected asset IDs are returned in chronological order after curation
+
+4. `Coverage across multiple trip days`
+   - a burst-heavy first day and a lighter second day
+   - curated output still includes both days
+
+5. `Small well-spaced trip pool stays intact`
+   - when the representative pool is already `<= 6`
+   - the rule returns all representatives unchanged
+
+### Medium Tests
+
+Add a real-DB regression in `server/test/medium/specs/services/memory.service.spec.ts`:
+
+- seed a qualifying recent trip with:
+  - one burst-heavy day
+  - one lighter day
+  - a valid home baseline
+- assert the generated `recent_trip` memory:
+  - is created successfully
+  - contains fewer assets than the raw qualifying trip pool
+  - includes both trip days
+  - keeps the assets in chronological order
+
+## Risks
+
+The main tradeoff is that pure time-based burst thinning can still keep a suboptimal frame from a burst, because this design intentionally avoids visual scoring.
+
+That is acceptable for v1 because:
+
+- it solves the obvious repetition problem the user reported
+- it stays lightweight and deterministic
+- it creates a clean base for future quality signals like favorites, ratings, or visual similarity

--- a/docs/plans/2026-04-24-recent-trip-curation-design.md
+++ b/docs/plans/2026-04-24-recent-trip-curation-design.md
@@ -59,6 +59,7 @@ This keeps the behavioral change narrow:
 - recent-trip asset curation in `server/src/services/memory-rules/recent-trip.rule.ts`
 - expanding `getMemoryAssetsForLocation` so the rule can curate using timestamps
 - adjusting the raw location asset pool so curation can cover the full trip timeline
+- updating memory asset readback ordering so curated trip memories stay chronological when fetched back from the repository
 - rule and medium test coverage for burst thinning, adaptive sizing, and chronological ordering
 
 ### Out of Scope
@@ -102,6 +103,16 @@ Rationale:
 - curation needs timestamps
 - a hard `20`-asset cap biases selection toward the start of long burst-heavy trips
 - this query only runs for one chosen trip candidate per owner per day, so a fuller pool is acceptable for this feature
+
+`MemoryRepository.search(...)` and `getByIdBuilder(...)` should also stop ordering memory assets by `asset.fileCreatedAt` for this feature path.
+
+They should order by `asset.localDateTime asc` instead.
+
+Rationale:
+
+- the trip rule now curates by capture timeline, not file import time
+- if memory readback stays on `fileCreatedAt`, the UI can still display the curated subset in the wrong order
+- ordering memory assets by `localDateTime asc` is a better fit for memory recap presentation in general
 
 ## Curation Pipeline
 
@@ -150,6 +161,7 @@ First pass selection should maximize trip-day coverage:
 When selecting one representative for a day:
 
 - choose the representative nearest the midpoint of that day's representatives
+- if the day has an even number of representatives, use the earlier of the two middle representatives
 
 This avoids bias toward just the earliest photo on a day while still remaining deterministic.
 
@@ -180,6 +192,8 @@ This change does not alter:
 - the rule score formula
 - the rule dedupe key
 - trip qualification thresholds
+
+It does intentionally alter memory asset ordering on readback from `fileCreatedAt asc` to `localDateTime asc` so the curated recap order survives through the repository layer.
 
 The subtitle should still describe the full detected trip cluster, for example:
 
@@ -244,7 +258,7 @@ Add a real-DB regression in `server/test/medium/specs/services/memory.service.sp
   - is created successfully
   - contains fewer assets than the raw qualifying trip pool
   - includes both trip days
-  - keeps the assets in chronological order
+  - keeps the assets in chronological `localDateTime` order after readback
 
 ## Risks
 

--- a/docs/plans/2026-04-24-recent-trip-curation-plan.md
+++ b/docs/plans/2026-04-24-recent-trip-curation-plan.md
@@ -37,6 +37,7 @@
 ## Task 1: Add Rule-Level Trip Curation
 
 **Files:**
+
 - Modify: `server/src/services/memory-rules/recent-trip.rule.spec.ts`
 - Modify: `server/src/services/memory-rules/recent-trip.rule.ts`
 - Modify: `server/src/repositories/asset.repository.ts`
@@ -56,31 +57,33 @@ const makeAsset = (id: string, localDateTime: string) => ({
 Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` instead of `{ id: 'asset-1' }`, then append these focused curation tests:
 
 ```ts
-  it('curates a burst-heavy trip down to seven chronological assets', async () => {
-    const assetRepository = {
-      getMemoryLocationClusters: vi
-        .fn()
-        .mockResolvedValueOnce([
-          {
-            country: 'Germany',
-            city: 'Berlin',
-            assetCount: 20,
-            dayCount: 12,
-            firstDate: new Date('2026-01-01T00:00:00Z'),
-            lastDate: new Date('2026-03-20T00:00:00Z'),
-          },
-        ])
-        .mockResolvedValueOnce([
-          {
-            country: 'France',
-            city: 'Paris',
-            assetCount: 12,
-            dayCount: 3,
-            firstDate: new Date('2026-04-15T00:00:00Z'),
-            lastDate: new Date('2026-04-17T00:00:00Z'),
-          },
-        ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+it('curates a burst-heavy trip down to seven chronological assets', async () => {
+  const assetRepository = {
+    getMemoryLocationClusters: vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          country: 'Germany',
+          city: 'Berlin',
+          assetCount: 20,
+          dayCount: 12,
+          firstDate: new Date('2026-01-01T00:00:00Z'),
+          lastDate: new Date('2026-03-20T00:00:00Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          country: 'France',
+          city: 'Paris',
+          assetCount: 12,
+          dayCount: 3,
+          firstDate: new Date('2026-04-15T00:00:00Z'),
+          lastDate: new Date('2026-04-17T00:00:00Z'),
+        },
+      ]),
+    getMemoryAssetsForLocation: vi
+      .fn()
+      .mockResolvedValue([
         makeAsset('a-1', '2026-04-15T10:00:00Z'),
         makeAsset('a-2', '2026-04-15T10:01:00Z'),
         makeAsset('a-3', '2026-04-15T10:05:00Z'),
@@ -94,47 +97,49 @@ Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` i
         makeAsset('a-11', '2026-04-17T13:00:00Z'),
         makeAsset('a-12', '2026-04-17T17:00:00Z'),
       ]),
-    };
-    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+  };
+  const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
-    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
-    const [candidate] = await rule.evaluate({
-      ownerId: 'user-1',
-      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
-    });
-
-    expect(candidate).toMatchObject({
-      title: 'Recent trip to Paris, France',
-      subtitle: '12 photos over 3 days',
-      assetIds: ['a-1', 'a-3', 'a-5', 'a-6', 'a-9', 'a-11', 'a-12'],
-    });
+  const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+  const [candidate] = await rule.evaluate({
+    ownerId: 'user-1',
+    target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
   });
 
-  it('collapses adjacent assets inside the two-minute burst window', async () => {
-    const assetRepository = {
-      getMemoryLocationClusters: vi
-        .fn()
-        .mockResolvedValueOnce([
-          {
-            country: 'Germany',
-            city: 'Berlin',
-            assetCount: 20,
-            dayCount: 12,
-            firstDate: new Date('2026-01-01T00:00:00Z'),
-            lastDate: new Date('2026-03-20T00:00:00Z'),
-          },
-        ])
-        .mockResolvedValueOnce([
-          {
-            country: 'France',
-            city: 'Paris',
-            assetCount: 8,
-            dayCount: 2,
-            firstDate: new Date('2026-04-15T00:00:00Z'),
-            lastDate: new Date('2026-04-16T00:00:00Z'),
-          },
-        ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+  expect(candidate).toMatchObject({
+    title: 'Recent trip to Paris, France',
+    subtitle: '12 photos over 3 days',
+    assetIds: ['a-1', 'a-3', 'a-5', 'a-6', 'a-9', 'a-11', 'a-12'],
+  });
+});
+
+it('collapses adjacent assets inside the two-minute burst window', async () => {
+  const assetRepository = {
+    getMemoryLocationClusters: vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          country: 'Germany',
+          city: 'Berlin',
+          assetCount: 20,
+          dayCount: 12,
+          firstDate: new Date('2026-01-01T00:00:00Z'),
+          lastDate: new Date('2026-03-20T00:00:00Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          country: 'France',
+          city: 'Paris',
+          assetCount: 8,
+          dayCount: 2,
+          firstDate: new Date('2026-04-15T00:00:00Z'),
+          lastDate: new Date('2026-04-16T00:00:00Z'),
+        },
+      ]),
+    getMemoryAssetsForLocation: vi
+      .fn()
+      .mockResolvedValue([
         makeAsset('a-1', '2026-04-15T10:00:00Z'),
         makeAsset('a-2', '2026-04-15T10:01:00Z'),
         makeAsset('a-3', '2026-04-15T10:03:00Z'),
@@ -143,43 +148,45 @@ Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` i
         makeAsset('a-6', '2026-04-16T09:01:00Z'),
         makeAsset('a-7', '2026-04-16T13:00:00Z'),
       ]),
-    };
-    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+  };
+  const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
-    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
-    const [candidate] = await rule.evaluate({
-      ownerId: 'user-1',
-      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
-    });
-
-    expect(candidate?.assetIds).toEqual(['a-1', 'a-4', 'a-5', 'a-7']);
+  const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+  const [candidate] = await rule.evaluate({
+    ownerId: 'user-1',
+    target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
   });
 
-  it('keeps a small well-spaced representative pool intact', async () => {
-    const assetRepository = {
-      getMemoryLocationClusters: vi
-        .fn()
-        .mockResolvedValueOnce([
-          {
-            country: 'Germany',
-            city: 'Berlin',
-            assetCount: 20,
-            dayCount: 12,
-            firstDate: new Date('2026-01-01T00:00:00Z'),
-            lastDate: new Date('2026-03-20T00:00:00Z'),
-          },
-        ])
-        .mockResolvedValueOnce([
-          {
-            country: 'France',
-            city: 'Paris',
-            assetCount: 9,
-            dayCount: 2,
-            firstDate: new Date('2026-04-15T00:00:00Z'),
-            lastDate: new Date('2026-04-16T00:00:00Z'),
-          },
-        ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+  expect(candidate?.assetIds).toEqual(['a-1', 'a-4', 'a-5', 'a-7']);
+});
+
+it('keeps a small well-spaced representative pool intact', async () => {
+  const assetRepository = {
+    getMemoryLocationClusters: vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          country: 'Germany',
+          city: 'Berlin',
+          assetCount: 20,
+          dayCount: 12,
+          firstDate: new Date('2026-01-01T00:00:00Z'),
+          lastDate: new Date('2026-03-20T00:00:00Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          country: 'France',
+          city: 'Paris',
+          assetCount: 9,
+          dayCount: 2,
+          firstDate: new Date('2026-04-15T00:00:00Z'),
+          lastDate: new Date('2026-04-16T00:00:00Z'),
+        },
+      ]),
+    getMemoryAssetsForLocation: vi
+      .fn()
+      .mockResolvedValue([
         makeAsset('a-1', '2026-04-15T08:00:00Z'),
         makeAsset('a-2', '2026-04-15T10:30:00Z'),
         makeAsset('a-3', '2026-04-15T14:00:00Z'),
@@ -187,43 +194,45 @@ Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` i
         makeAsset('a-5', '2026-04-16T12:00:00Z'),
         makeAsset('a-6', '2026-04-16T18:00:00Z'),
       ]),
-    };
-    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+  };
+  const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
-    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
-    const [candidate] = await rule.evaluate({
-      ownerId: 'user-1',
-      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
-    });
-
-    expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6']);
+  const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+  const [candidate] = await rule.evaluate({
+    ownerId: 'user-1',
+    target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
   });
 
-  it('caps a long trip at ten assets while preserving the trip endpoints', async () => {
-    const assetRepository = {
-      getMemoryLocationClusters: vi
-        .fn()
-        .mockResolvedValueOnce([
-          {
-            country: 'Germany',
-            city: 'Berlin',
-            assetCount: 20,
-            dayCount: 12,
-            firstDate: new Date('2026-01-01T00:00:00Z'),
-            lastDate: new Date('2026-03-20T00:00:00Z'),
-          },
-        ])
-        .mockResolvedValueOnce([
-          {
-            country: 'France',
-            city: 'Paris',
-            assetCount: 21,
-            dayCount: 11,
-            firstDate: new Date('2026-04-01T00:00:00Z'),
-            lastDate: new Date('2026-04-11T00:00:00Z'),
-          },
-        ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+  expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6']);
+});
+
+it('caps a long trip at ten assets while preserving the trip endpoints', async () => {
+  const assetRepository = {
+    getMemoryLocationClusters: vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          country: 'Germany',
+          city: 'Berlin',
+          assetCount: 20,
+          dayCount: 12,
+          firstDate: new Date('2026-01-01T00:00:00Z'),
+          lastDate: new Date('2026-03-20T00:00:00Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          country: 'France',
+          city: 'Paris',
+          assetCount: 21,
+          dayCount: 11,
+          firstDate: new Date('2026-04-01T00:00:00Z'),
+          lastDate: new Date('2026-04-11T00:00:00Z'),
+        },
+      ]),
+    getMemoryAssetsForLocation: vi
+      .fn()
+      .mockResolvedValue([
         makeAsset('a-1', '2026-04-01T09:00:00Z'),
         makeAsset('a-2', '2026-04-02T09:00:00Z'),
         makeAsset('a-3', '2026-04-03T09:00:00Z'),
@@ -236,17 +245,17 @@ Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` i
         makeAsset('a-10', '2026-04-10T09:00:00Z'),
         makeAsset('a-11', '2026-04-11T09:00:00Z'),
       ]),
-    };
-    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+  };
+  const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
-    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
-    const [candidate] = await rule.evaluate({
-      ownerId: 'user-1',
-      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
-    });
-
-    expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-7', 'a-8', 'a-9', 'a-10', 'a-11']);
+  const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+  const [candidate] = await rule.evaluate({
+    ownerId: 'user-1',
+    target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
   });
+
+  expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-7', 'a-8', 'a-9', 'a-10', 'a-11']);
+});
 ```
 
 - [ ] **Step 2: Run the rule spec to verify it fails**
@@ -376,10 +385,7 @@ export class RecentTripMemoryRule implements MemoryRule {
       return [items[Math.floor((items.length - 1) / 2)]!];
     }
 
-    const indexes = Array.from(
-      { length: count },
-      (_, index) => Math.round((index * (items.length - 1)) / (count - 1)),
-    );
+    const indexes = Array.from({ length: count }, (_, index) => Math.round((index * (items.length - 1)) / (count - 1)));
 
     return indexes.map((index) => items[index]!);
   }
@@ -468,6 +474,7 @@ git commit -m "feat(server): curate recent trip memory assets"
 ## Task 2: Preserve Curated Order Through Memory Readback
 
 **Files:**
+
 - Modify: `server/test/medium/specs/services/memory.service.spec.ts`
 - Modify: `server/src/repositories/memory.repository.ts`
 - Regenerate: `server/src/queries/memory.repository.sql`
@@ -477,174 +484,174 @@ git commit -m "feat(server): curate recent trip memory assets"
 Append this test after the existing `creates a recent-trip rule memory for a dense non-home cluster` case in `server/test/medium/specs/services/memory.service.spec.ts`:
 
 ```ts
-    it('reads back curated recent-trip assets in chronological localDateTime order', async () => {
-      const { sut, ctx } = setup();
-      const assetRepo = ctx.get(AssetRepository);
-      const memoryRepo = ctx.get(MemoryRepository);
-      const now = DateTime.fromObject({ year: 2026, month: 4, day: 23 }, { zone: 'utc' }) as DateTime<true>;
-      const { user } = await ctx.newUser();
+it('reads back curated recent-trip assets in chronological localDateTime order', async () => {
+  const { sut, ctx } = setup();
+  const assetRepo = ctx.get(AssetRepository);
+  const memoryRepo = ctx.get(MemoryRepository);
+  const now = DateTime.fromObject({ year: 2026, month: 4, day: 23 }, { zone: 'utc' }) as DateTime<true>;
+  const { user } = await ctx.newUser();
 
-      const addTripAsset = async ({
-        localDateTime,
-        fileCreatedAt,
-        city,
-        country,
-      }: {
-        localDateTime: string;
-        fileCreatedAt: string;
-        city: string;
-        country: string;
-      }) => {
-        const { asset } = await ctx.newAsset({
-          ownerId: user.id,
-          localDateTime: new Date(localDateTime),
-          fileCreatedAt: new Date(fileCreatedAt),
-        });
-        await Promise.all([
-          ctx.newExif({ assetId: asset.id, city, country }),
-          ctx.newJobStatus({ assetId: asset.id }),
-          assetRepo.upsertFiles([
-            { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
-            { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
-          ]),
-        ]);
-        return asset.id;
-      };
-
-      await addTripAsset({
-        localDateTime: '2026-01-15T12:00:00Z',
-        fileCreatedAt: '2026-01-15T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-      await addTripAsset({
-        localDateTime: '2026-01-22T12:00:00Z',
-        fileCreatedAt: '2026-01-22T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-      await addTripAsset({
-        localDateTime: '2026-02-01T12:00:00Z',
-        fileCreatedAt: '2026-02-01T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-      await addTripAsset({
-        localDateTime: '2026-02-10T12:00:00Z',
-        fileCreatedAt: '2026-02-10T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-      await addTripAsset({
-        localDateTime: '2026-02-18T12:00:00Z',
-        fileCreatedAt: '2026-02-18T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-      await addTripAsset({
-        localDateTime: '2026-03-01T12:00:00Z',
-        fileCreatedAt: '2026-03-01T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-      await addTripAsset({
-        localDateTime: '2026-03-12T12:00:00Z',
-        fileCreatedAt: '2026-03-12T12:00:00Z',
-        city: 'Berlin',
-        country: 'Germany',
-      });
-
-      const expectedTripIds = [
-        await addTripAsset({
-          localDateTime: '2026-04-15T10:00:00Z',
-          fileCreatedAt: '2026-04-16T20:00:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-15T10:01:00Z',
-          fileCreatedAt: '2026-04-16T19:59:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-15T12:00:00Z',
-          fileCreatedAt: '2026-04-16T19:58:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-15T12:01:00Z',
-          fileCreatedAt: '2026-04-16T19:57:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-15T16:00:00Z',
-          fileCreatedAt: '2026-04-16T19:56:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-16T09:00:00Z',
-          fileCreatedAt: '2026-04-16T19:55:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-16T09:01:00Z',
-          fileCreatedAt: '2026-04-16T19:54:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-16T13:00:00Z',
-          fileCreatedAt: '2026-04-16T19:53:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-16T17:00:00Z',
-          fileCreatedAt: '2026-04-16T19:52:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-        await addTripAsset({
-          localDateTime: '2026-04-16T20:00:00Z',
-          fileCreatedAt: '2026-04-16T19:51:00Z',
-          city: 'Paris',
-          country: 'France',
-        }),
-      ];
-
-      vi.setSystemTime(now.toJSDate());
-      await sut.onMemoriesCreate();
-
-      const [memory] = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
-      expect(memory?.data).toMatchObject({
-        ruleId: 'recent_trip',
-        title: 'Recent trip to Paris, France',
-      });
-      expect(memory?.assets).toHaveLength(7);
-      expect(memory?.assets.map(({ id }) => id)).toEqual([
-        expectedTripIds[0],
-        expectedTripIds[2],
-        expectedTripIds[4],
-        expectedTripIds[5],
-        expectedTripIds[7],
-        expectedTripIds[8],
-        expectedTripIds[9],
-      ]);
-      expect(memory?.assets.map(({ localDateTime }) => localDateTime.toISOString())).toEqual([
-        '2026-04-15T10:00:00.000Z',
-        '2026-04-15T12:00:00.000Z',
-        '2026-04-15T16:00:00.000Z',
-        '2026-04-16T09:00:00.000Z',
-        '2026-04-16T13:00:00.000Z',
-        '2026-04-16T17:00:00.000Z',
-        '2026-04-16T20:00:00.000Z',
-      ]);
+  const addTripAsset = async ({
+    localDateTime,
+    fileCreatedAt,
+    city,
+    country,
+  }: {
+    localDateTime: string;
+    fileCreatedAt: string;
+    city: string;
+    country: string;
+  }) => {
+    const { asset } = await ctx.newAsset({
+      ownerId: user.id,
+      localDateTime: new Date(localDateTime),
+      fileCreatedAt: new Date(fileCreatedAt),
     });
+    await Promise.all([
+      ctx.newExif({ assetId: asset.id, city, country }),
+      ctx.newJobStatus({ assetId: asset.id }),
+      assetRepo.upsertFiles([
+        { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
+        { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
+      ]),
+    ]);
+    return asset.id;
+  };
+
+  await addTripAsset({
+    localDateTime: '2026-01-15T12:00:00Z',
+    fileCreatedAt: '2026-01-15T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+  await addTripAsset({
+    localDateTime: '2026-01-22T12:00:00Z',
+    fileCreatedAt: '2026-01-22T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+  await addTripAsset({
+    localDateTime: '2026-02-01T12:00:00Z',
+    fileCreatedAt: '2026-02-01T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+  await addTripAsset({
+    localDateTime: '2026-02-10T12:00:00Z',
+    fileCreatedAt: '2026-02-10T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+  await addTripAsset({
+    localDateTime: '2026-02-18T12:00:00Z',
+    fileCreatedAt: '2026-02-18T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+  await addTripAsset({
+    localDateTime: '2026-03-01T12:00:00Z',
+    fileCreatedAt: '2026-03-01T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+  await addTripAsset({
+    localDateTime: '2026-03-12T12:00:00Z',
+    fileCreatedAt: '2026-03-12T12:00:00Z',
+    city: 'Berlin',
+    country: 'Germany',
+  });
+
+  const expectedTripIds = [
+    await addTripAsset({
+      localDateTime: '2026-04-15T10:00:00Z',
+      fileCreatedAt: '2026-04-16T20:00:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-15T10:01:00Z',
+      fileCreatedAt: '2026-04-16T19:59:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-15T12:00:00Z',
+      fileCreatedAt: '2026-04-16T19:58:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-15T12:01:00Z',
+      fileCreatedAt: '2026-04-16T19:57:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-15T16:00:00Z',
+      fileCreatedAt: '2026-04-16T19:56:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-16T09:00:00Z',
+      fileCreatedAt: '2026-04-16T19:55:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-16T09:01:00Z',
+      fileCreatedAt: '2026-04-16T19:54:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-16T13:00:00Z',
+      fileCreatedAt: '2026-04-16T19:53:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-16T17:00:00Z',
+      fileCreatedAt: '2026-04-16T19:52:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+    await addTripAsset({
+      localDateTime: '2026-04-16T20:00:00Z',
+      fileCreatedAt: '2026-04-16T19:51:00Z',
+      city: 'Paris',
+      country: 'France',
+    }),
+  ];
+
+  vi.setSystemTime(now.toJSDate());
+  await sut.onMemoriesCreate();
+
+  const [memory] = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
+  expect(memory?.data).toMatchObject({
+    ruleId: 'recent_trip',
+    title: 'Recent trip to Paris, France',
+  });
+  expect(memory?.assets).toHaveLength(7);
+  expect(memory?.assets.map(({ id }) => id)).toEqual([
+    expectedTripIds[0],
+    expectedTripIds[2],
+    expectedTripIds[4],
+    expectedTripIds[5],
+    expectedTripIds[7],
+    expectedTripIds[8],
+    expectedTripIds[9],
+  ]);
+  expect(memory?.assets.map(({ localDateTime }) => localDateTime.toISOString())).toEqual([
+    '2026-04-15T10:00:00.000Z',
+    '2026-04-15T12:00:00.000Z',
+    '2026-04-15T16:00:00.000Z',
+    '2026-04-16T09:00:00.000Z',
+    '2026-04-16T13:00:00.000Z',
+    '2026-04-16T17:00:00.000Z',
+    '2026-04-16T20:00:00.000Z',
+  ]);
+});
 ```
 
 - [ ] **Step 2: Run the medium spec to verify the ordering regression fails**
@@ -744,6 +751,7 @@ git commit -m "fix(server): preserve curated memory chronology"
 ## Task 3: Final Verification
 
 **Files:**
+
 - No new files
 
 - [ ] **Step 1: Run the focused unit, medium, and typecheck suites**

--- a/docs/plans/2026-04-24-recent-trip-curation-plan.md
+++ b/docs/plans/2026-04-24-recent-trip-curation-plan.md
@@ -198,6 +198,55 @@ Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` i
 
     expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6']);
   });
+
+  it('caps a long trip at ten assets while preserving the trip endpoints', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 21,
+            dayCount: 11,
+            firstDate: new Date('2026-04-01T00:00:00Z'),
+            lastDate: new Date('2026-04-11T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-01T09:00:00Z'),
+        makeAsset('a-2', '2026-04-02T09:00:00Z'),
+        makeAsset('a-3', '2026-04-03T09:00:00Z'),
+        makeAsset('a-4', '2026-04-04T09:00:00Z'),
+        makeAsset('a-5', '2026-04-05T09:00:00Z'),
+        makeAsset('a-6', '2026-04-06T09:00:00Z'),
+        makeAsset('a-7', '2026-04-07T09:00:00Z'),
+        makeAsset('a-8', '2026-04-08T09:00:00Z'),
+        makeAsset('a-9', '2026-04-09T09:00:00Z'),
+        makeAsset('a-10', '2026-04-10T09:00:00Z'),
+        makeAsset('a-11', '2026-04-11T09:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-7', 'a-8', 'a-9', 'a-10', 'a-11']);
+  });
 ```
 
 - [ ] **Step 2: Run the rule spec to verify it fails**
@@ -210,8 +259,8 @@ pnpm --dir server test --run src/services/memory-rules/recent-trip.rule.spec.ts
 
 Expected:
 
-- existing `recent_trip` tests start failing because the mocks no longer match the rule contract
 - the new curation tests fail because the rule still returns the raw asset IDs
+- the long-trip test fails because the rule does not cap output at `10`
 
 - [ ] **Step 3: Implement the curation helpers and widen the repository contract**
 
@@ -273,8 +322,8 @@ export class RecentTripMemoryRule implements MemoryRule {
         asset.localDateTime.getTime() - previous.localDateTime.getTime() > RecentTripMemoryRule.BURST_WINDOW_MS
       ) {
         representatives.push(asset);
-        previous = asset;
       }
+      previous = asset;
     }
 
     return representatives;
@@ -387,6 +436,7 @@ Expected:
 
 - all `recent-trip.rule.spec.ts` tests pass
 - the new burst-heavy test returns exactly `7` curated IDs
+- the long-trip test returns exactly `10` curated IDs
 - the existing non-home and cooldown behavior remains intact
 
 - [ ] **Step 5: Rebuild and regenerate the asset repository SQL snapshot**

--- a/docs/plans/2026-04-24-recent-trip-curation-plan.md
+++ b/docs/plans/2026-04-24-recent-trip-curation-plan.md
@@ -1,0 +1,750 @@
+# Recent Trip Memory Curation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Curate `recent_trip` memories down to a tighter `6-8` photo recap for most trips, up to `10` for longer trips, while collapsing burst-adjacent shots and preserving chronological trip coverage.
+
+**Architecture:** Keep trip detection in `RecentTripMemoryRule` unchanged and add a deterministic curation pass after the winning location cluster has been selected. Expand the location asset query to return `localDateTime` and the full trip pool, then preserve the curated chronology through `MemoryRepository` readback by ordering memory assets on `localDateTime` instead of `fileCreatedAt`.
+
+**Tech Stack:** NestJS, Luxon, Vitest, medium Vitest integration tests, Kysely, generated SQL snapshots.
+
+---
+
+## File map
+
+- Modify: `server/src/services/memory-rules/recent-trip.rule.ts`
+  Add burst collapse, adaptive target sizing, day-coverage selection, and chronological curation helpers.
+- Modify: `server/src/services/memory-rules/recent-trip.rule.spec.ts`
+  Add rule-level curation coverage and update existing mocks to return `localDateTime`.
+- Modify: `server/src/repositories/asset.repository.ts`
+  Return `MemoryAsset` rows from `getMemoryAssetsForLocation(...)` and remove the raw `limit 20` cap.
+- Regenerate: `server/src/queries/asset.repository.sql`
+  Snapshot the repository query change after rebuilding the server.
+- Modify: `server/src/repositories/memory.repository.ts`
+  Order memory asset readback by `asset.localDateTime asc` instead of `asset.fileCreatedAt asc`.
+- Modify: `server/test/medium/specs/services/memory.service.spec.ts`
+  Add a real-DB regression for curated recent-trip output and readback order.
+- Regenerate: `server/src/queries/memory.repository.sql`
+  Snapshot the memory repository ordering change after rebuilding the server.
+
+## Preconditions
+
+- Work from `/home/pierre/dev/gallery/.worktrees/memories-trip-curation`.
+- Keep the birthday PR branch and worktree untouched.
+- Build the server before running `pnpm --dir server sync:sql`, because `sync:sql` uses `dist/bin/sync-sql.js`.
+- Do not change web code, mobile code, DTO shapes, or trip qualification thresholds.
+
+## Task 1: Add Rule-Level Trip Curation
+
+**Files:**
+- Modify: `server/src/services/memory-rules/recent-trip.rule.spec.ts`
+- Modify: `server/src/services/memory-rules/recent-trip.rule.ts`
+- Modify: `server/src/repositories/asset.repository.ts`
+- Regenerate: `server/src/queries/asset.repository.sql`
+
+- [ ] **Step 1: Write the failing rule tests**
+
+Add a local helper near the top of `server/src/services/memory-rules/recent-trip.rule.spec.ts` so all trip asset mocks include timestamps:
+
+```ts
+const makeAsset = (id: string, localDateTime: string) => ({
+  id,
+  localDateTime: new Date(localDateTime),
+});
+```
+
+Update the existing `getMemoryAssetsForLocation` mocks to use `makeAsset(...)` instead of `{ id: 'asset-1' }`, then append these focused curation tests:
+
+```ts
+  it('curates a burst-heavy trip down to seven chronological assets', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 12,
+            dayCount: 3,
+            firstDate: new Date('2026-04-15T00:00:00Z'),
+            lastDate: new Date('2026-04-17T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-15T10:00:00Z'),
+        makeAsset('a-2', '2026-04-15T10:01:00Z'),
+        makeAsset('a-3', '2026-04-15T10:05:00Z'),
+        makeAsset('a-4', '2026-04-15T10:06:00Z'),
+        makeAsset('a-5', '2026-04-15T12:00:00Z'),
+        makeAsset('a-6', '2026-04-16T09:00:00Z'),
+        makeAsset('a-7', '2026-04-16T09:01:00Z'),
+        makeAsset('a-8', '2026-04-16T15:00:00Z'),
+        makeAsset('a-9', '2026-04-17T08:00:00Z'),
+        makeAsset('a-10', '2026-04-17T08:01:00Z'),
+        makeAsset('a-11', '2026-04-17T13:00:00Z'),
+        makeAsset('a-12', '2026-04-17T17:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate).toMatchObject({
+      title: 'Recent trip to Paris, France',
+      subtitle: '12 photos over 3 days',
+      assetIds: ['a-1', 'a-3', 'a-5', 'a-6', 'a-9', 'a-11', 'a-12'],
+    });
+  });
+
+  it('collapses adjacent assets inside the two-minute burst window', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 8,
+            dayCount: 2,
+            firstDate: new Date('2026-04-15T00:00:00Z'),
+            lastDate: new Date('2026-04-16T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-15T10:00:00Z'),
+        makeAsset('a-2', '2026-04-15T10:01:00Z'),
+        makeAsset('a-3', '2026-04-15T10:03:00Z'),
+        makeAsset('a-4', '2026-04-15T10:06:00Z'),
+        makeAsset('a-5', '2026-04-16T09:00:00Z'),
+        makeAsset('a-6', '2026-04-16T09:01:00Z'),
+        makeAsset('a-7', '2026-04-16T13:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate?.assetIds).toEqual(['a-1', 'a-4', 'a-5', 'a-7']);
+  });
+
+  it('keeps a small well-spaced representative pool intact', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 9,
+            dayCount: 2,
+            firstDate: new Date('2026-04-15T00:00:00Z'),
+            lastDate: new Date('2026-04-16T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-15T08:00:00Z'),
+        makeAsset('a-2', '2026-04-15T10:30:00Z'),
+        makeAsset('a-3', '2026-04-15T14:00:00Z'),
+        makeAsset('a-4', '2026-04-16T09:00:00Z'),
+        makeAsset('a-5', '2026-04-16T12:00:00Z'),
+        makeAsset('a-6', '2026-04-16T18:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6']);
+  });
+```
+
+- [ ] **Step 2: Run the rule spec to verify it fails**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/recent-trip.rule.spec.ts
+```
+
+Expected:
+
+- existing `recent_trip` tests start failing because the mocks no longer match the rule contract
+- the new curation tests fail because the rule still returns the raw asset IDs
+
+- [ ] **Step 3: Implement the curation helpers and widen the repository contract**
+
+Update `server/src/services/memory-rules/recent-trip.rule.ts` to import `MemoryAsset` and route the selected trip pool through a curation helper:
+
+```ts
+import { AssetRepository, MemoryAsset, MemoryLocationCluster } from 'src/repositories/asset.repository';
+
+export class RecentTripMemoryRule implements MemoryRule {
+  readonly id = 'recent_trip';
+  private static readonly HOME_DOMINANCE_RATIO = 1.25;
+  private static readonly BURST_WINDOW_MS = 2 * 60 * 1000;
+  private static readonly SMALL_TRIP_MAX = 6;
+
+  // constructor unchanged
+
+  async evaluate({ ownerId, target }: MemoryRuleContext): Promise<MemoryRuleCandidate[]> {
+    // existing detection code unchanged
+
+    const locationAssets = await this.assetRepository.getMemoryAssetsForLocation(ownerId, {
+      country: candidate.country,
+      city: candidate.city,
+      takenAfter: recentFrom.toJSDate(),
+      takenBefore: target.endOf('day').toJSDate(),
+    });
+    const assetIds = this.curateTripAssets(locationAssets);
+
+    // candidate construction unchanged except assetIds now comes from curateTripAssets(...)
+  }
+
+  private curateTripAssets(assets: MemoryAsset[]): string[] {
+    const representatives = this.collapseBurstAssets(assets);
+    if (representatives.length <= RecentTripMemoryRule.SMALL_TRIP_MAX) {
+      return representatives.map(({ id }) => id);
+    }
+
+    const dayBuckets = this.groupAssetsByDay(representatives);
+    const targetSize = this.getTripTargetSize(dayBuckets.length, representatives.length);
+    const selected = this.pickDayCoverage(dayBuckets, targetSize);
+    const selectedIds = new Set(selected.map(({ id }) => id));
+
+    if (selected.length < targetSize) {
+      const remaining = representatives.filter(({ id }) => !selectedIds.has(id));
+      selected.push(...this.pickEvenlySpaced(remaining, targetSize - selected.length));
+    }
+
+    return selected
+      .toSorted((left, right) => left.localDateTime.getTime() - right.localDateTime.getTime())
+      .map(({ id }) => id);
+  }
+
+  private collapseBurstAssets(assets: MemoryAsset[]): MemoryAsset[] {
+    const representatives: MemoryAsset[] = [];
+    let previous: MemoryAsset | undefined;
+
+    for (const asset of assets) {
+      if (
+        !previous ||
+        asset.localDateTime.getTime() - previous.localDateTime.getTime() > RecentTripMemoryRule.BURST_WINDOW_MS
+      ) {
+        representatives.push(asset);
+        previous = asset;
+      }
+    }
+
+    return representatives;
+  }
+
+  private groupAssetsByDay(assets: MemoryAsset[]): MemoryAsset[][] {
+    const byDay = new Map<string, MemoryAsset[]>();
+
+    for (const asset of assets) {
+      const dayKey = DateTime.fromJSDate(asset.localDateTime, { zone: 'utc' }).toISODate()!;
+      const dayAssets = byDay.get(dayKey) ?? [];
+      dayAssets.push(asset);
+      byDay.set(dayKey, dayAssets);
+    }
+
+    return [...byDay.values()];
+  }
+
+  private getTripTargetSize(dayCount: number, representativeCount: number) {
+    if (representativeCount <= RecentTripMemoryRule.SMALL_TRIP_MAX) {
+      return representativeCount;
+    }
+
+    if (dayCount >= 5 || representativeCount >= 18) {
+      return 10;
+    }
+
+    if (dayCount >= 4 || representativeCount >= 12) {
+      return 8;
+    }
+
+    return 7;
+  }
+
+  private pickDayCoverage(dayBuckets: MemoryAsset[][], targetSize: number): MemoryAsset[] {
+    const buckets = dayBuckets.length <= targetSize ? dayBuckets : this.pickEvenlySpaced(dayBuckets, targetSize);
+    return buckets.map((assets) => assets[Math.floor((assets.length - 1) / 2)]!);
+  }
+
+  private pickEvenlySpaced<T>(items: T[], count: number): T[] {
+    if (count <= 0 || items.length === 0) {
+      return [];
+    }
+
+    if (count >= items.length) {
+      return [...items];
+    }
+
+    if (count === 1) {
+      return [items[Math.floor((items.length - 1) / 2)]!];
+    }
+
+    const indexes = Array.from(
+      { length: count },
+      (_, index) => Math.round((index * (items.length - 1)) / (count - 1)),
+    );
+
+    return indexes.map((index) => items[index]!);
+  }
+}
+```
+
+Update `server/src/repositories/asset.repository.ts` so `getMemoryAssetsForLocation(...)` returns `MemoryAsset[]` with timestamps and no raw-pool cap:
+
+```ts
+  getMemoryAssetsForLocation(
+    ownerId: string,
+    {
+      country,
+      city,
+      takenAfter,
+      takenBefore,
+    }: { country: string; city: string | null; takenAfter: Date; takenBefore: Date },
+  ): Promise<MemoryAsset[]> {
+    return this.db
+      .selectFrom('asset')
+      .select(['asset.id', 'asset.localDateTime'])
+      .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .where('asset.ownerId', '=', ownerId)
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.localDateTime', '>=', takenAfter)
+      .where('asset.localDateTime', '<=', takenBefore)
+      .where('asset_exif.country', '=', country)
+      .$if(city !== null, (qb) => qb.where('asset_exif.city', '=', city))
+      .$if(city === null, (qb) => qb.where('asset_exif.city', 'is', null))
+      .where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom('asset_file')
+            .select('asset_file.assetId')
+            .whereRef('asset_file.assetId', '=', 'asset.id')
+            .where('asset_file.type', '=', AssetFileType.Preview),
+        ),
+      )
+      .orderBy('asset.localDateTime', 'asc')
+      .execute();
+  }
+```
+
+- [ ] **Step 4: Re-run the rule spec**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/recent-trip.rule.spec.ts
+```
+
+Expected:
+
+- all `recent-trip.rule.spec.ts` tests pass
+- the new burst-heavy test returns exactly `7` curated IDs
+- the existing non-home and cooldown behavior remains intact
+
+- [ ] **Step 5: Rebuild and regenerate the asset repository SQL snapshot**
+
+Run:
+
+```bash
+pnpm --dir server build
+pnpm --dir server sync:sql
+```
+
+Expected:
+
+- `server/src/queries/asset.repository.sql` changes
+- the generated query no longer limits `getMemoryAssetsForLocation(...)` to `20`
+- the generated query now selects `asset."localDateTime"`
+
+- [ ] **Step 6: Commit the rule and repository curation work**
+
+```bash
+git add \
+  server/src/services/memory-rules/recent-trip.rule.ts \
+  server/src/services/memory-rules/recent-trip.rule.spec.ts \
+  server/src/repositories/asset.repository.ts \
+  server/src/queries/asset.repository.sql
+git commit -m "feat(server): curate recent trip memory assets"
+```
+
+## Task 2: Preserve Curated Order Through Memory Readback
+
+**Files:**
+- Modify: `server/test/medium/specs/services/memory.service.spec.ts`
+- Modify: `server/src/repositories/memory.repository.ts`
+- Regenerate: `server/src/queries/memory.repository.sql`
+
+- [ ] **Step 1: Write the failing medium regression**
+
+Append this test after the existing `creates a recent-trip rule memory for a dense non-home cluster` case in `server/test/medium/specs/services/memory.service.spec.ts`:
+
+```ts
+    it('reads back curated recent-trip assets in chronological localDateTime order', async () => {
+      const { sut, ctx } = setup();
+      const assetRepo = ctx.get(AssetRepository);
+      const memoryRepo = ctx.get(MemoryRepository);
+      const now = DateTime.fromObject({ year: 2026, month: 4, day: 23 }, { zone: 'utc' }) as DateTime<true>;
+      const { user } = await ctx.newUser();
+
+      const addTripAsset = async ({
+        localDateTime,
+        fileCreatedAt,
+        city,
+        country,
+      }: {
+        localDateTime: string;
+        fileCreatedAt: string;
+        city: string;
+        country: string;
+      }) => {
+        const { asset } = await ctx.newAsset({
+          ownerId: user.id,
+          localDateTime: new Date(localDateTime),
+          fileCreatedAt: new Date(fileCreatedAt),
+        });
+        await Promise.all([
+          ctx.newExif({ assetId: asset.id, city, country }),
+          ctx.newJobStatus({ assetId: asset.id }),
+          assetRepo.upsertFiles([
+            { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
+            { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
+          ]),
+        ]);
+        return asset.id;
+      };
+
+      await addTripAsset({
+        localDateTime: '2026-01-15T12:00:00Z',
+        fileCreatedAt: '2026-01-15T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-01-22T12:00:00Z',
+        fileCreatedAt: '2026-01-22T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-02-01T12:00:00Z',
+        fileCreatedAt: '2026-02-01T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-02-10T12:00:00Z',
+        fileCreatedAt: '2026-02-10T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-02-18T12:00:00Z',
+        fileCreatedAt: '2026-02-18T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-03-01T12:00:00Z',
+        fileCreatedAt: '2026-03-01T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-03-12T12:00:00Z',
+        fileCreatedAt: '2026-03-12T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+
+      const expectedTripIds = [
+        await addTripAsset({
+          localDateTime: '2026-04-15T10:00:00Z',
+          fileCreatedAt: '2026-04-16T20:00:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T10:01:00Z',
+          fileCreatedAt: '2026-04-16T19:59:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T12:00:00Z',
+          fileCreatedAt: '2026-04-16T19:58:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T12:01:00Z',
+          fileCreatedAt: '2026-04-16T19:57:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T16:00:00Z',
+          fileCreatedAt: '2026-04-16T19:56:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T09:00:00Z',
+          fileCreatedAt: '2026-04-16T19:55:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T09:01:00Z',
+          fileCreatedAt: '2026-04-16T19:54:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T13:00:00Z',
+          fileCreatedAt: '2026-04-16T19:53:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T17:00:00Z',
+          fileCreatedAt: '2026-04-16T19:52:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T20:00:00Z',
+          fileCreatedAt: '2026-04-16T19:51:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+      ];
+
+      vi.setSystemTime(now.toJSDate());
+      await sut.onMemoriesCreate();
+
+      const [memory] = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
+      expect(memory?.data).toMatchObject({
+        ruleId: 'recent_trip',
+        title: 'Recent trip to Paris, France',
+      });
+      expect(memory?.assets).toHaveLength(7);
+      expect(memory?.assets.map(({ id }) => id)).toEqual([
+        expectedTripIds[0],
+        expectedTripIds[2],
+        expectedTripIds[4],
+        expectedTripIds[5],
+        expectedTripIds[7],
+        expectedTripIds[8],
+        expectedTripIds[9],
+      ]);
+      expect(memory?.assets.map(({ localDateTime }) => localDateTime.toISOString())).toEqual([
+        '2026-04-15T10:00:00.000Z',
+        '2026-04-15T12:00:00.000Z',
+        '2026-04-15T16:00:00.000Z',
+        '2026-04-16T09:00:00.000Z',
+        '2026-04-16T13:00:00.000Z',
+        '2026-04-16T17:00:00.000Z',
+        '2026-04-16T20:00:00.000Z',
+      ]);
+    });
+```
+
+- [ ] **Step 2: Run the medium spec to verify the ordering regression fails**
+
+Run:
+
+```bash
+pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts
+```
+
+Expected:
+
+- the new medium test fails because memory asset readback still sorts on `fileCreatedAt`
+- the retrieved trip asset order comes back reversed or otherwise non-chronological
+
+- [ ] **Step 3: Order memory asset readback on `localDateTime`**
+
+Update both asset subqueries in `server/src/repositories/memory.repository.ts`:
+
+```ts
+  search(ownerId: string, dto: MemorySearchDto) {
+    return this.searchBuilder(ownerId, dto)
+      .select((eb) =>
+        jsonArrayFrom(
+          eb
+            .selectFrom('asset')
+            .selectAll('asset')
+            .innerJoin('memory_asset', 'asset.id', 'memory_asset.assetId')
+            .whereRef('memory_asset.memoriesId', '=', 'memory.id')
+            .orderBy('asset.localDateTime', 'asc')
+            .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+            .where('asset.deletedAt', 'is', null),
+        ).as('assets'),
+      )
+      .selectAll('memory')
+      // rest unchanged
+  }
+
+  private getByIdBuilder(id: string) {
+    return this.db
+      .selectFrom('memory')
+      .selectAll('memory')
+      .select((eb) =>
+        jsonArrayFrom(
+          eb
+            .selectFrom('asset')
+            .selectAll('asset')
+            .innerJoin('memory_asset', 'asset.id', 'memory_asset.assetId')
+            .whereRef('memory_asset.memoriesId', '=', 'memory.id')
+            .orderBy('asset.localDateTime', 'asc')
+            .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+            .where('asset.deletedAt', 'is', null),
+        ).as('assets'),
+      )
+      .where('id', '=', id)
+      .where('deletedAt', 'is', null);
+  }
+```
+
+- [ ] **Step 4: Re-run the medium spec**
+
+Run:
+
+```bash
+pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts
+```
+
+Expected:
+
+- the new curated-trip medium test passes
+- the existing recent-trip and birthday medium tests stay green
+
+- [ ] **Step 5: Rebuild and regenerate the memory repository SQL snapshot**
+
+Run:
+
+```bash
+pnpm --dir server build
+pnpm --dir server sync:sql
+```
+
+Expected:
+
+- `server/src/queries/memory.repository.sql` changes
+- both memory asset subqueries now order by `asset."localDateTime" asc`
+
+- [ ] **Step 6: Commit the readback-ordering and medium regression work**
+
+```bash
+git add \
+  server/src/repositories/memory.repository.ts \
+  server/test/medium/specs/services/memory.service.spec.ts \
+  server/src/queries/memory.repository.sql
+git commit -m "fix(server): preserve curated memory chronology"
+```
+
+## Task 3: Final Verification
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run the focused unit, medium, and typecheck suites**
+
+Run:
+
+```bash
+pnpm --dir server test --run src/services/memory-rules/recent-trip.rule.spec.ts
+pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts
+pnpm --dir server check
+```
+
+Expected:
+
+- unit `recent_trip` spec passes
+- medium memory service spec passes
+- TypeScript check passes with `0` errors
+
+- [ ] **Step 2: Confirm only the planned files changed**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected tracked files:
+
+```text
+M server/src/repositories/asset.repository.ts
+M server/src/repositories/memory.repository.ts
+M server/src/services/memory-rules/recent-trip.rule.ts
+M server/src/services/memory-rules/recent-trip.rule.spec.ts
+M server/test/medium/specs/services/memory.service.spec.ts
+M server/src/queries/asset.repository.sql
+M server/src/queries/memory.repository.sql
+```
+
+If the task commits were already created as written above, `git status --short` should be empty.
+
+- [ ] **Step 3: Confirm the plan matches the approved design**
+
+Check manually that the final implementation does all of the following:
+
+- `2` minute burst collapse
+- adaptive `6-8`, with `10` only for longer trips
+- day coverage before extra same-day moments
+- chronological `localDateTime` output
+- no changes to trip qualification thresholds
+
+Expected:
+
+- no missing spec requirements
+- no extra scope beyond recent-trip curation and memory readback ordering

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -233,7 +233,8 @@ order by
 
 -- AssetRepository.getMemoryAssetsForLocation
 select
-  "asset"."id"
+  "asset"."id",
+  "asset"."localDateTime"
 from
   "asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "asset"."id"
@@ -256,8 +257,6 @@ where
   )
 order by
   "asset"."localDateTime" asc
-limit
-  $8
 
 -- AssetRepository.getByIds
 select

--- a/server/src/queries/memory.repository.sql
+++ b/server/src/queries/memory.repository.sql
@@ -43,7 +43,7 @@ select
           and "asset"."visibility" = 'timeline'
           and "asset"."deletedAt" is null
         order by
-          "asset"."fileCreatedAt" asc
+          "asset"."localDateTime" asc
       ) as agg
   ) as "assets",
   "memory".*
@@ -72,7 +72,7 @@ select
           and "asset"."visibility" = 'timeline'
           and "asset"."deletedAt" is null
         order by
-          "asset"."fileCreatedAt" asc
+          "asset"."localDateTime" asc
       ) as agg
   ) as "assets",
   "memory".*
@@ -110,7 +110,7 @@ select
           and "asset"."visibility" = 'timeline'
           and "asset"."deletedAt" is null
         order by
-          "asset"."fileCreatedAt" asc
+          "asset"."localDateTime" asc
       ) as agg
   ) as "assets"
 from
@@ -143,7 +143,7 @@ select
           and "asset"."visibility" = 'timeline'
           and "asset"."deletedAt" is null
         order by
-          "asset"."fileCreatedAt" asc
+          "asset"."localDateTime" asc
       ) as agg
   ) as "assets"
 from

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -540,10 +540,10 @@ export class AssetRepository {
       takenAfter,
       takenBefore,
     }: { country: string; city: string | null; takenAfter: Date; takenBefore: Date },
-  ) {
+  ): Promise<MemoryAsset[]> {
     return this.db
       .selectFrom('asset')
-      .select(['asset.id'])
+      .select(['asset.id', 'asset.localDateTime'])
       .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
       .where('asset.ownerId', '=', ownerId)
       .where('asset.visibility', '=', AssetVisibility.Timeline)
@@ -563,7 +563,6 @@ export class AssetRepository {
         ),
       )
       .orderBy('asset.localDateTime', 'asc')
-      .limit(20)
       .execute();
   }
 

--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -66,7 +66,7 @@ export class MemoryRepository implements IBulkAsset {
             .selectAll('asset')
             .innerJoin('memory_asset', 'asset.id', 'memory_asset.assetId')
             .whereRef('memory_asset.memoriesId', '=', 'memory.id')
-            .orderBy('asset.fileCreatedAt', 'asc')
+            .orderBy('asset.localDateTime', 'asc')
             .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
             .where('asset.deletedAt', 'is', null),
         ).as('assets'),
@@ -177,7 +177,7 @@ export class MemoryRepository implements IBulkAsset {
             .selectAll('asset')
             .innerJoin('memory_asset', 'asset.id', 'memory_asset.assetId')
             .whereRef('memory_asset.memoriesId', '=', 'memory.id')
-            .orderBy('asset.fileCreatedAt', 'asc')
+            .orderBy('asset.localDateTime', 'asc')
             .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
             .where('asset.deletedAt', 'is', null),
         ).as('assets'),

--- a/server/src/services/memory-rules/recent-trip.rule.spec.ts
+++ b/server/src/services/memory-rules/recent-trip.rule.spec.ts
@@ -270,20 +270,22 @@ describe(RecentTripMemoryRule.name, () => {
             lastDate: new Date('2026-04-17T00:00:00Z'),
           },
         ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
-        makeAsset('a-1', '2026-04-15T10:00:00Z'),
-        makeAsset('a-2', '2026-04-15T10:01:00Z'),
-        makeAsset('a-3', '2026-04-15T10:05:00Z'),
-        makeAsset('a-4', '2026-04-15T10:06:00Z'),
-        makeAsset('a-5', '2026-04-15T12:00:00Z'),
-        makeAsset('a-6', '2026-04-16T09:00:00Z'),
-        makeAsset('a-7', '2026-04-16T09:01:00Z'),
-        makeAsset('a-8', '2026-04-16T15:00:00Z'),
-        makeAsset('a-9', '2026-04-17T08:00:00Z'),
-        makeAsset('a-10', '2026-04-17T08:01:00Z'),
-        makeAsset('a-11', '2026-04-17T13:00:00Z'),
-        makeAsset('a-12', '2026-04-17T17:00:00Z'),
-      ]),
+      getMemoryAssetsForLocation: vi
+        .fn()
+        .mockResolvedValue([
+          makeAsset('a-1', '2026-04-15T10:00:00Z'),
+          makeAsset('a-2', '2026-04-15T10:01:00Z'),
+          makeAsset('a-3', '2026-04-15T10:05:00Z'),
+          makeAsset('a-4', '2026-04-15T10:06:00Z'),
+          makeAsset('a-5', '2026-04-15T12:00:00Z'),
+          makeAsset('a-6', '2026-04-16T09:00:00Z'),
+          makeAsset('a-7', '2026-04-16T09:01:00Z'),
+          makeAsset('a-8', '2026-04-16T15:00:00Z'),
+          makeAsset('a-9', '2026-04-17T08:00:00Z'),
+          makeAsset('a-10', '2026-04-17T08:01:00Z'),
+          makeAsset('a-11', '2026-04-17T13:00:00Z'),
+          makeAsset('a-12', '2026-04-17T17:00:00Z'),
+        ]),
     };
     const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
@@ -324,15 +326,17 @@ describe(RecentTripMemoryRule.name, () => {
             lastDate: new Date('2026-04-16T00:00:00Z'),
           },
         ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
-        makeAsset('a-1', '2026-04-15T10:00:00Z'),
-        makeAsset('a-2', '2026-04-15T10:01:00Z'),
-        makeAsset('a-3', '2026-04-15T10:03:00Z'),
-        makeAsset('a-4', '2026-04-15T10:06:00Z'),
-        makeAsset('a-5', '2026-04-16T09:00:00Z'),
-        makeAsset('a-6', '2026-04-16T09:01:00Z'),
-        makeAsset('a-7', '2026-04-16T13:00:00Z'),
-      ]),
+      getMemoryAssetsForLocation: vi
+        .fn()
+        .mockResolvedValue([
+          makeAsset('a-1', '2026-04-15T10:00:00Z'),
+          makeAsset('a-2', '2026-04-15T10:01:00Z'),
+          makeAsset('a-3', '2026-04-15T10:03:00Z'),
+          makeAsset('a-4', '2026-04-15T10:06:00Z'),
+          makeAsset('a-5', '2026-04-16T09:00:00Z'),
+          makeAsset('a-6', '2026-04-16T09:01:00Z'),
+          makeAsset('a-7', '2026-04-16T13:00:00Z'),
+        ]),
     };
     const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
@@ -369,14 +373,16 @@ describe(RecentTripMemoryRule.name, () => {
             lastDate: new Date('2026-04-16T00:00:00Z'),
           },
         ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
-        makeAsset('a-1', '2026-04-15T08:00:00Z'),
-        makeAsset('a-2', '2026-04-15T10:30:00Z'),
-        makeAsset('a-3', '2026-04-15T14:00:00Z'),
-        makeAsset('a-4', '2026-04-16T09:00:00Z'),
-        makeAsset('a-5', '2026-04-16T12:00:00Z'),
-        makeAsset('a-6', '2026-04-16T18:00:00Z'),
-      ]),
+      getMemoryAssetsForLocation: vi
+        .fn()
+        .mockResolvedValue([
+          makeAsset('a-1', '2026-04-15T08:00:00Z'),
+          makeAsset('a-2', '2026-04-15T10:30:00Z'),
+          makeAsset('a-3', '2026-04-15T14:00:00Z'),
+          makeAsset('a-4', '2026-04-16T09:00:00Z'),
+          makeAsset('a-5', '2026-04-16T12:00:00Z'),
+          makeAsset('a-6', '2026-04-16T18:00:00Z'),
+        ]),
     };
     const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 
@@ -413,19 +419,21 @@ describe(RecentTripMemoryRule.name, () => {
             lastDate: new Date('2026-04-11T00:00:00Z'),
           },
         ]),
-      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
-        makeAsset('a-1', '2026-04-01T09:00:00Z'),
-        makeAsset('a-2', '2026-04-02T09:00:00Z'),
-        makeAsset('a-3', '2026-04-03T09:00:00Z'),
-        makeAsset('a-4', '2026-04-04T09:00:00Z'),
-        makeAsset('a-5', '2026-04-05T09:00:00Z'),
-        makeAsset('a-6', '2026-04-06T09:00:00Z'),
-        makeAsset('a-7', '2026-04-07T09:00:00Z'),
-        makeAsset('a-8', '2026-04-08T09:00:00Z'),
-        makeAsset('a-9', '2026-04-09T09:00:00Z'),
-        makeAsset('a-10', '2026-04-10T09:00:00Z'),
-        makeAsset('a-11', '2026-04-11T09:00:00Z'),
-      ]),
+      getMemoryAssetsForLocation: vi
+        .fn()
+        .mockResolvedValue([
+          makeAsset('a-1', '2026-04-01T09:00:00Z'),
+          makeAsset('a-2', '2026-04-02T09:00:00Z'),
+          makeAsset('a-3', '2026-04-03T09:00:00Z'),
+          makeAsset('a-4', '2026-04-04T09:00:00Z'),
+          makeAsset('a-5', '2026-04-05T09:00:00Z'),
+          makeAsset('a-6', '2026-04-06T09:00:00Z'),
+          makeAsset('a-7', '2026-04-07T09:00:00Z'),
+          makeAsset('a-8', '2026-04-08T09:00:00Z'),
+          makeAsset('a-9', '2026-04-09T09:00:00Z'),
+          makeAsset('a-10', '2026-04-10T09:00:00Z'),
+          makeAsset('a-11', '2026-04-11T09:00:00Z'),
+        ]),
     };
     const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
 

--- a/server/src/services/memory-rules/recent-trip.rule.spec.ts
+++ b/server/src/services/memory-rules/recent-trip.rule.spec.ts
@@ -2,6 +2,11 @@ import { DateTime } from 'luxon';
 import { AssetOrder, MemoryType } from 'src/enum';
 import { RecentTripMemoryRule } from 'src/services/memory-rules/recent-trip.rule';
 
+const makeAsset = (id: string, localDateTime: string) => ({
+  id,
+  localDateTime: new Date(localDateTime),
+});
+
 describe(RecentTripMemoryRule.name, () => {
   it('creates a recent-trip candidate for a strong non-home cluster', async () => {
     const assetRepository = {
@@ -30,13 +35,13 @@ describe(RecentTripMemoryRule.name, () => {
       getMemoryAssetsForLocation: vi
         .fn()
         .mockResolvedValue([
-          { id: 'asset-1' },
-          { id: 'asset-2' },
-          { id: 'asset-3' },
-          { id: 'asset-4' },
-          { id: 'asset-5' },
-          { id: 'asset-6' },
-          { id: 'asset-7' },
+          makeAsset('asset-1', '2026-04-15T09:00:00Z'),
+          makeAsset('asset-2', '2026-04-15T11:00:00Z'),
+          makeAsset('asset-3', '2026-04-15T14:00:00Z'),
+          makeAsset('asset-4', '2026-04-16T09:00:00Z'),
+          makeAsset('asset-5', '2026-04-16T13:00:00Z'),
+          makeAsset('asset-6', '2026-04-17T09:00:00Z'),
+          makeAsset('asset-7', '2026-04-17T15:00:00Z'),
         ]),
     };
     const memoryRepository = {
@@ -135,13 +140,13 @@ describe(RecentTripMemoryRule.name, () => {
       getMemoryAssetsForLocation: vi
         .fn()
         .mockResolvedValue([
-          { id: 'asset-1' },
-          { id: 'asset-2' },
-          { id: 'asset-3' },
-          { id: 'asset-4' },
-          { id: 'asset-5' },
-          { id: 'asset-6' },
-          { id: 'asset-7' },
+          makeAsset('asset-1', '2026-04-15T09:00:00Z'),
+          makeAsset('asset-2', '2026-04-15T11:00:00Z'),
+          makeAsset('asset-3', '2026-04-15T14:00:00Z'),
+          makeAsset('asset-4', '2026-04-16T09:00:00Z'),
+          makeAsset('asset-5', '2026-04-16T13:00:00Z'),
+          makeAsset('asset-6', '2026-04-16T16:00:00Z'),
+          makeAsset('asset-7', '2026-04-16T18:00:00Z'),
         ]),
     };
     const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
@@ -239,5 +244,197 @@ describe(RecentTripMemoryRule.name, () => {
         target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
       }),
     ).resolves.toEqual([]);
+  });
+
+  it('curates a burst-heavy trip down to seven chronological assets', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 12,
+            dayCount: 3,
+            firstDate: new Date('2026-04-15T00:00:00Z'),
+            lastDate: new Date('2026-04-17T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-15T10:00:00Z'),
+        makeAsset('a-2', '2026-04-15T10:01:00Z'),
+        makeAsset('a-3', '2026-04-15T10:05:00Z'),
+        makeAsset('a-4', '2026-04-15T10:06:00Z'),
+        makeAsset('a-5', '2026-04-15T12:00:00Z'),
+        makeAsset('a-6', '2026-04-16T09:00:00Z'),
+        makeAsset('a-7', '2026-04-16T09:01:00Z'),
+        makeAsset('a-8', '2026-04-16T15:00:00Z'),
+        makeAsset('a-9', '2026-04-17T08:00:00Z'),
+        makeAsset('a-10', '2026-04-17T08:01:00Z'),
+        makeAsset('a-11', '2026-04-17T13:00:00Z'),
+        makeAsset('a-12', '2026-04-17T17:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate).toMatchObject({
+      title: 'Recent trip to Paris, France',
+      subtitle: '12 photos over 3 days',
+      assetIds: ['a-1', 'a-3', 'a-5', 'a-6', 'a-9', 'a-11', 'a-12'],
+    });
+  });
+
+  it('collapses adjacent assets inside the two-minute burst window', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 8,
+            dayCount: 2,
+            firstDate: new Date('2026-04-15T00:00:00Z'),
+            lastDate: new Date('2026-04-16T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-15T10:00:00Z'),
+        makeAsset('a-2', '2026-04-15T10:01:00Z'),
+        makeAsset('a-3', '2026-04-15T10:03:00Z'),
+        makeAsset('a-4', '2026-04-15T10:06:00Z'),
+        makeAsset('a-5', '2026-04-16T09:00:00Z'),
+        makeAsset('a-6', '2026-04-16T09:01:00Z'),
+        makeAsset('a-7', '2026-04-16T13:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate?.assetIds).toEqual(['a-1', 'a-4', 'a-5', 'a-7']);
+  });
+
+  it('keeps a small well-spaced representative pool intact', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 9,
+            dayCount: 2,
+            firstDate: new Date('2026-04-15T00:00:00Z'),
+            lastDate: new Date('2026-04-16T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-15T08:00:00Z'),
+        makeAsset('a-2', '2026-04-15T10:30:00Z'),
+        makeAsset('a-3', '2026-04-15T14:00:00Z'),
+        makeAsset('a-4', '2026-04-16T09:00:00Z'),
+        makeAsset('a-5', '2026-04-16T12:00:00Z'),
+        makeAsset('a-6', '2026-04-16T18:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-6']);
+  });
+
+  it('caps a long trip at ten assets while preserving the trip endpoints', async () => {
+    const assetRepository = {
+      getMemoryLocationClusters: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            country: 'Germany',
+            city: 'Berlin',
+            assetCount: 20,
+            dayCount: 12,
+            firstDate: new Date('2026-01-01T00:00:00Z'),
+            lastDate: new Date('2026-03-20T00:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            country: 'France',
+            city: 'Paris',
+            assetCount: 21,
+            dayCount: 11,
+            firstDate: new Date('2026-04-01T00:00:00Z'),
+            lastDate: new Date('2026-04-11T00:00:00Z'),
+          },
+        ]),
+      getMemoryAssetsForLocation: vi.fn().mockResolvedValue([
+        makeAsset('a-1', '2026-04-01T09:00:00Z'),
+        makeAsset('a-2', '2026-04-02T09:00:00Z'),
+        makeAsset('a-3', '2026-04-03T09:00:00Z'),
+        makeAsset('a-4', '2026-04-04T09:00:00Z'),
+        makeAsset('a-5', '2026-04-05T09:00:00Z'),
+        makeAsset('a-6', '2026-04-06T09:00:00Z'),
+        makeAsset('a-7', '2026-04-07T09:00:00Z'),
+        makeAsset('a-8', '2026-04-08T09:00:00Z'),
+        makeAsset('a-9', '2026-04-09T09:00:00Z'),
+        makeAsset('a-10', '2026-04-10T09:00:00Z'),
+        makeAsset('a-11', '2026-04-11T09:00:00Z'),
+      ]),
+    };
+    const memoryRepository = { search: vi.fn().mockResolvedValue([]) };
+
+    const rule = new RecentTripMemoryRule(assetRepository as never, memoryRepository as never);
+    const [candidate] = await rule.evaluate({
+      ownerId: 'user-1',
+      target: DateTime.fromISO('2026-04-23', { zone: 'utc' }),
+    });
+
+    expect(candidate?.assetIds).toEqual(['a-1', 'a-2', 'a-3', 'a-4', 'a-5', 'a-7', 'a-8', 'a-9', 'a-10', 'a-11']);
   });
 });

--- a/server/src/services/memory-rules/recent-trip.rule.ts
+++ b/server/src/services/memory-rules/recent-trip.rule.ts
@@ -137,7 +137,7 @@ export class RecentTripMemoryRule implements MemoryRule {
     }
 
     return [...selected]
-      .sort((left, right) => left.localDateTime.getTime() - right.localDateTime.getTime())
+      .toSorted((left, right) => left.localDateTime.getTime() - right.localDateTime.getTime())
       .map(({ id }) => id);
   }
 

--- a/server/src/services/memory-rules/recent-trip.rule.ts
+++ b/server/src/services/memory-rules/recent-trip.rule.ts
@@ -1,12 +1,14 @@
 import { DateTime } from 'luxon';
 import { AssetOrderWithRandom, MemoryType } from 'src/enum';
-import { AssetRepository, MemoryLocationCluster } from 'src/repositories/asset.repository';
+import { AssetRepository, MemoryAsset, MemoryLocationCluster } from 'src/repositories/asset.repository';
 import { MemoryRepository } from 'src/repositories/memory.repository';
 import { MemoryRule, MemoryRuleCandidate, MemoryRuleContext } from 'src/services/memory-rules/memory-rule.interface';
 
 export class RecentTripMemoryRule implements MemoryRule {
   readonly id = 'recent_trip';
   private static readonly HOME_DOMINANCE_RATIO = 1.25;
+  private static readonly BURST_WINDOW_MS = 2 * 60 * 1000;
+  private static readonly SMALL_TRIP_MAX = 6;
 
   constructor(
     private assetRepository: Pick<AssetRepository, 'getMemoryLocationClusters' | 'getMemoryAssetsForLocation'>,
@@ -78,7 +80,7 @@ export class RecentTripMemoryRule implements MemoryRule {
       takenAfter: recentFrom.toJSDate(),
       takenBefore: target.endOf('day').toJSDate(),
     });
-    const assetIds = locationAssets.map(({ id }) => id);
+    const assetIds = this.curateTripAssets(locationAssets);
 
     const placeLabel = candidate.city ? `${candidate.city}, ${candidate.country}` : candidate.country;
     const dedupeDay = target.toFormat('yyyy-MM-dd');
@@ -116,5 +118,95 @@ export class RecentTripMemoryRule implements MemoryRule {
     }
 
     return !!home.city && !!item.city && item.city !== home.city;
+  }
+
+  private curateTripAssets(assets: MemoryAsset[]): string[] {
+    const representatives = this.collapseBurstAssets(assets);
+    if (representatives.length <= RecentTripMemoryRule.SMALL_TRIP_MAX) {
+      return representatives.map(({ id }) => id);
+    }
+
+    const dayBuckets = this.groupAssetsByDay(representatives);
+    const targetSize = this.getTripTargetSize(dayBuckets.length, representatives.length);
+    const selected = this.pickDayCoverage(dayBuckets, targetSize);
+    const selectedIds = new Set(selected.map(({ id }) => id));
+
+    if (selected.length < targetSize) {
+      const remaining = representatives.filter(({ id }) => !selectedIds.has(id));
+      selected.push(...this.pickEvenlySpaced(remaining, targetSize - selected.length));
+    }
+
+    return [...selected]
+      .sort((left, right) => left.localDateTime.getTime() - right.localDateTime.getTime())
+      .map(({ id }) => id);
+  }
+
+  private collapseBurstAssets(assets: MemoryAsset[]): MemoryAsset[] {
+    const representatives: MemoryAsset[] = [];
+    let previous: MemoryAsset | undefined;
+
+    for (const asset of assets) {
+      if (
+        !previous ||
+        asset.localDateTime.getTime() - previous.localDateTime.getTime() > RecentTripMemoryRule.BURST_WINDOW_MS
+      ) {
+        representatives.push(asset);
+      }
+      previous = asset;
+    }
+
+    return representatives;
+  }
+
+  private groupAssetsByDay(assets: MemoryAsset[]): MemoryAsset[][] {
+    const byDay = new Map<string, MemoryAsset[]>();
+
+    for (const asset of assets) {
+      const dayKey = DateTime.fromJSDate(asset.localDateTime, { zone: 'utc' }).toISODate();
+      const dayAssets = byDay.get(dayKey!) ?? [];
+      dayAssets.push(asset);
+      byDay.set(dayKey!, dayAssets);
+    }
+
+    return [...byDay.values()];
+  }
+
+  private getTripTargetSize(dayCount: number, representativeCount: number) {
+    if (representativeCount <= RecentTripMemoryRule.SMALL_TRIP_MAX) {
+      return representativeCount;
+    }
+
+    if (dayCount >= 5 || representativeCount >= 18) {
+      return 10;
+    }
+
+    if (dayCount >= 4 || representativeCount >= 12) {
+      return 8;
+    }
+
+    return 7;
+  }
+
+  private pickDayCoverage(dayBuckets: MemoryAsset[][], targetSize: number): MemoryAsset[] {
+    const buckets = dayBuckets.length <= targetSize ? dayBuckets : this.pickEvenlySpaced(dayBuckets, targetSize);
+    return buckets.map((assets) => assets[Math.floor((assets.length - 1) / 2)]!);
+  }
+
+  private pickEvenlySpaced<T>(items: T[], count: number): T[] {
+    if (count <= 0 || items.length === 0) {
+      return [];
+    }
+
+    if (count >= items.length) {
+      return [...items];
+    }
+
+    if (count === 1) {
+      return [items[Math.floor((items.length - 1) / 2)]!];
+    }
+
+    const indexes = Array.from({ length: count }, (_, index) => Math.round((index * (items.length - 1)) / (count - 1)));
+
+    return indexes.map((index) => items[index]!);
   }
 }

--- a/server/test/medium/specs/services/memory.service.spec.ts
+++ b/server/test/medium/specs/services/memory.service.spec.ts
@@ -345,6 +345,175 @@ describe(MemoryService.name, () => {
       );
     });
 
+    it('reads back curated recent-trip assets in chronological localDateTime order', async () => {
+      const { sut, ctx } = setup();
+      const assetRepo = ctx.get(AssetRepository);
+      const memoryRepo = ctx.get(MemoryRepository);
+      const now = DateTime.fromObject({ year: 2026, month: 4, day: 23 }, { zone: 'utc' }) as DateTime<true>;
+      const { user } = await ctx.newUser();
+
+      const addTripAsset = async ({
+        localDateTime,
+        fileCreatedAt,
+        city,
+        country,
+      }: {
+        localDateTime: string;
+        fileCreatedAt: string;
+        city: string;
+        country: string;
+      }) => {
+        const { asset } = await ctx.newAsset({
+          ownerId: user.id,
+          localDateTime: new Date(localDateTime),
+          fileCreatedAt: new Date(fileCreatedAt),
+        });
+        await Promise.all([
+          ctx.newExif({ assetId: asset.id, city, country }),
+          ctx.newJobStatus({ assetId: asset.id }),
+          assetRepo.upsertFiles([
+            { assetId: asset.id, type: AssetFileType.Preview, path: `/preview-${asset.id}.jpg` },
+            { assetId: asset.id, type: AssetFileType.Thumbnail, path: `/thumb-${asset.id}.jpg` },
+          ]),
+        ]);
+        return asset.id;
+      };
+
+      await addTripAsset({
+        localDateTime: '2026-01-15T12:00:00Z',
+        fileCreatedAt: '2026-01-15T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-01-22T12:00:00Z',
+        fileCreatedAt: '2026-01-22T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-02-01T12:00:00Z',
+        fileCreatedAt: '2026-02-01T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-02-10T12:00:00Z',
+        fileCreatedAt: '2026-02-10T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-02-18T12:00:00Z',
+        fileCreatedAt: '2026-02-18T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-03-01T12:00:00Z',
+        fileCreatedAt: '2026-03-01T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+      await addTripAsset({
+        localDateTime: '2026-03-12T12:00:00Z',
+        fileCreatedAt: '2026-03-12T12:00:00Z',
+        city: 'Berlin',
+        country: 'Germany',
+      });
+
+      const expectedTripIds = [
+        await addTripAsset({
+          localDateTime: '2026-04-15T10:00:00Z',
+          fileCreatedAt: '2026-04-16T20:00:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T10:01:00Z',
+          fileCreatedAt: '2026-04-16T19:59:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T12:00:00Z',
+          fileCreatedAt: '2026-04-16T19:58:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T12:01:00Z',
+          fileCreatedAt: '2026-04-16T19:57:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-15T16:00:00Z',
+          fileCreatedAt: '2026-04-16T19:56:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T09:00:00Z',
+          fileCreatedAt: '2026-04-16T19:55:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T09:01:00Z',
+          fileCreatedAt: '2026-04-16T19:54:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T13:00:00Z',
+          fileCreatedAt: '2026-04-16T19:53:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T17:00:00Z',
+          fileCreatedAt: '2026-04-16T19:52:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+        await addTripAsset({
+          localDateTime: '2026-04-16T20:00:00Z',
+          fileCreatedAt: '2026-04-16T19:51:00Z',
+          city: 'Paris',
+          country: 'France',
+        }),
+      ];
+
+      vi.setSystemTime(now.toJSDate());
+      await sut.onMemoriesCreate();
+
+      const [memory] = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
+      expect(memory?.data).toMatchObject({
+        ruleId: 'recent_trip',
+        title: 'Recent trip to Paris, France',
+      });
+      expect(memory?.assets).toHaveLength(7);
+      expect(memory?.assets.map(({ id }) => id)).toEqual([
+        expectedTripIds[0],
+        expectedTripIds[2],
+        expectedTripIds[4],
+        expectedTripIds[5],
+        expectedTripIds[7],
+        expectedTripIds[8],
+        expectedTripIds[9],
+      ]);
+      expect(memory?.assets.map(({ localDateTime }) => new Date(localDateTime).toISOString())).toEqual([
+        '2026-04-15T10:00:00.000Z',
+        '2026-04-15T12:00:00.000Z',
+        '2026-04-15T16:00:00.000Z',
+        '2026-04-16T09:00:00.000Z',
+        '2026-04-16T13:00:00.000Z',
+        '2026-04-16T17:00:00.000Z',
+        '2026-04-16T20:00:00.000Z',
+      ]);
+    });
+
     it('does not create a recent-trip rule memory for weak signals', async () => {
       const { sut, ctx } = setup();
       const assetRepo = ctx.get(AssetRepository);


### PR DESCRIPTION
## Summary
- add adaptive recent-trip asset curation to collapse burst shots and keep a tighter 7 to 10 photo recap
- preserve curated trip chronology through memory readback by ordering memory assets on localDateTime
- add rule-level and medium coverage for burst thinning, long-trip caps, and chronology regressions

## Test Plan
- [x] pnpm --dir server test --run src/services/memory-rules/recent-trip.rule.spec.ts
- [x] pnpm --dir server test:medium --run test/medium/specs/services/memory.service.spec.ts
- [x] pnpm --dir server check