### PR TITLE
feat(web): move searchable page controls into cmd+k search

### DIFF
--- a/docs/docs/features/search-palette.md
+++ b/docs/docs/features/search-palette.md
@@ -95,9 +95,9 @@ This is faster than reaching for a sidebar when you just want to glance at recen
 
 ## Top result band
 
-Typing plain free text in the palette also creates a synthetic **Top result** row: **Search for "…"**. Hitting <kbd>Enter</kbd> on that row routes the query to the current page's search surface when one exists. Pages without a filter panel fall back to `/photos?q=...`.
+Typing plain free text in the palette creates a synthetic **Top result** row: **Search for "…"**. Hitting <kbd>Enter</kbd> on that row routes the query to the current page's search surface when one exists. Pages without a filter panel fall back to `/photos?q=...`.
 
-When your query closely matches a single command or navigation entry, that entry is promoted to a **Top result** band at the top of the list. Hitting <kbd>Enter</kbd> activates it immediately, no arrow keys needed.
+When your query closely matches a single command or navigation entry, that entry takes over the **Top result** slot instead of the generic search row. Hitting <kbd>Enter</kbd> activates it immediately, no arrow keys needed.
 
 Promotion is based on a fuzzy score against the title, description, and search keywords. Commands win tie-breaks against navigation entries, so unscoped verbs like `upload` or `album` surface their command first. A short query like `peo` will surface **People** as the top result; `users` will surface **Administration → User Management**.
 

--- a/e2e/src/specs/web/cmdk-commands.e2e-spec.ts
+++ b/e2e/src/specs/web/cmdk-commands.e2e-spec.ts
@@ -24,7 +24,7 @@ test.describe('cmdk commands (v1.3.0)', () => {
     await page.getByTestId('cmdk-input-trigger').waitFor({ state: 'visible' });
   });
 
-  test('>upload + Enter opens the native file picker', async ({ page }) => {
+  test('>upload activates the native file picker from the Commands section', async ({ page }) => {
     await page.keyboard.press('Control+k');
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
@@ -36,11 +36,15 @@ test.describe('cmdk commands (v1.3.0)', () => {
     await expect(dialog.locator('[data-cmdk-commands-section]')).toBeVisible();
     await expect(dialog.getByText(/^upload$/i).first()).toBeVisible();
 
+    const uploadCommand = dialog.locator('[data-command-item][data-value="cmd:upload"]');
+    await expect(uploadCommand).toBeVisible();
+
     // openFileUploadDialog() synthesises a click on a hidden <input type="file">,
-    // which Playwright surfaces as a 'filechooser' event on the page. Register
-    // the listener BEFORE pressing Enter so we never miss the event.
+    // which Playwright surfaces as a 'filechooser' event on the page. Activate
+    // the scoped command row directly; `>theme + Enter` below still covers the
+    // keyboard command-activation path in this suite.
     const fileChooserPromise = page.waitForEvent('filechooser', { timeout: 5000 });
-    await page.keyboard.press('Enter');
+    await uploadCommand.click();
     const fileChooser = await fileChooserPromise;
     expect(fileChooser).toBeTruthy();
   });

--- a/e2e/src/specs/web/global-search.e2e-spec.ts
+++ b/e2e/src/specs/web/global-search.e2e-spec.ts
@@ -772,8 +772,8 @@ test.describe('global search palette', () => {
       const spacesGroup = dialog.getByRole('group', { name: /^spaces/i });
       await expect(albumsGroup).toBeVisible();
       await expect(spacesGroup).toBeVisible();
-      await expect(albumsGroup.getByText(/bare slash album/i).first()).toBeVisible();
-      await expect(spacesGroup.getByText(/bare slash space/i).first()).toBeVisible();
+      await expect(albumsGroup.locator('[data-command-item]').first()).toBeVisible();
+      await expect(spacesGroup.locator('[data-command-item]').first()).toBeVisible();
 
       // Other entity sections stay hidden.
       await expect(dialog.getByRole('group', { name: /^photos/i })).toHaveCount(0);

--- a/e2e/src/specs/web/photos-search.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-search.e2e-spec.ts
@@ -2,11 +2,22 @@ import type { LoginResponseDto } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
 import { utils } from 'src/utils';
 
+async function submitGlobalSearch(page: import('@playwright/test').Page, query: string) {
+  const mobileSearchButton = page.locator('#search-button');
+  await ((await mobileSearchButton.isVisible()) ? mobileSearchButton : page.getByTestId('cmdk-input-trigger')).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  const combobox = dialog.getByRole('combobox');
+  await combobox.fill(query);
+  await combobox.press('Enter');
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+}
+
 // UI-plumbing E2E coverage for smart search on the /photos page.
 //
 // The e2e stack runs with IMMICH_MACHINE_LEARNING_ENABLED=false, so real
 // CLIP semantic results are not available. These tests verify the
-// integration wiring between SearchBar, URL state, SmartSearchResults,
+// integration wiring between cmd+k search, URL state, SmartSearchResults,
 // ActiveFiltersBar and Timeline — the full semantic search flow is
 // validated at the API level in specs/server/api/search.e2e-spec.ts.
 test.describe('Photos Search', () => {
@@ -38,19 +49,7 @@ test.describe('Photos Search', () => {
 
   test('typing a query and pressing Enter updates the URL to ?q=', async ({ context, page }) => {
     await gotoPhotos(context, page);
-
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toBeVisible({ timeout: 10_000 });
-    // Set value directly via DOM and dispatch input event for Svelte bind to sync
-    await searchInput.evaluate((el) => {
-      const input = el as HTMLInputElement;
-      input.value = 'beach';
-      input.dispatchEvent(new Event('input', { bubbles: true }));
-    });
-    await expect(searchInput).toHaveValue('beach');
-    await searchInput.focus();
-    await searchInput.press('Enter');
-
+    await submitGlobalSearch(page, 'beach');
     await expect(page).toHaveURL(/\/photos\?q=beach/, { timeout: 10_000 });
   });
 
@@ -70,9 +69,8 @@ test.describe('Photos Search', () => {
       timeout: 15_000,
     });
 
-    // The search input should reflect the URL query
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toHaveValue('mountain');
+    await page.getByTestId('cmdk-input-trigger').click();
+    await expect(page.getByRole('dialog').getByRole('combobox')).toHaveValue('mountain');
   });
 
   test('clearing the search via the X button returns to the timeline', async ({ context, page }) => {
@@ -83,8 +81,7 @@ test.describe('Photos Search', () => {
       timeout: 15_000,
     });
 
-    // Click the clear (X) button on the SearchBar
-    await page.locator('[aria-label="Clear value"]').click();
+    await page.getByTestId('search-chip-close').dispatchEvent('click');
 
     // URL should no longer contain ?q=
     await expect(page).toHaveURL(/\/photos(?!\?q=)/);
@@ -118,13 +115,7 @@ test.describe('Photos Search', () => {
 
   test('browser back navigation from a search URL restores the timeline', async ({ context, page }) => {
     await gotoPhotos(context, page);
-
-    // Kick off a search from the UI so history has two entries
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toBeVisible({ timeout: 10_000 });
-    await searchInput.fill('river');
-    await searchInput.press('Enter');
-
+    await submitGlobalSearch(page, 'river');
     await expect(page).toHaveURL(/\/photos\?q=river/);
     await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
       timeout: 15_000,
@@ -133,7 +124,7 @@ test.describe('Photos Search', () => {
     // Go back — we should be on /photos with no query
     await page.goBack();
     await expect(page).toHaveURL(/\/photos(?!\?q=)/);
-    await expect(page.locator('input[placeholder="Search"]')).toHaveValue('');
+    await expect(page.getByTestId('search-chip')).not.toBeVisible();
   });
 
   test('clearing the search restores the timeline with assets', async ({ context, page }) => {
@@ -159,8 +150,7 @@ test.describe('Photos Search', () => {
     // Timeline grid should not be visible while search is active.
     await expect(page.locator('[data-testid="timeline"]')).not.toBeVisible();
 
-    // Clear the search via the SearchBar X button.
-    await page.locator('[aria-label="Clear value"]').click();
+    await page.getByTestId('search-chip-close').dispatchEvent('click');
 
     // URL should return to /photos with no ?q=
     await expect(page).toHaveURL(/\/photos(?!\?q=)/, { timeout: 10_000 });
@@ -174,104 +164,35 @@ test.describe('Photos Search', () => {
     expect(afterCount).toBeGreaterThan(0);
   });
 
-  test('mobile viewport keeps the SearchBar visible', async ({ context, page }) => {
-    // Gallery's Tailwind theme defines --breakpoint-sm: 639px. The SearchBar
-    // wrapper expands to w-full on <sm so the /photos header row isn't an
-    // empty gap — keep it reachable on mobile.
+  test('mobile viewport keeps the compact search entrypoint visible', async ({ context, page }) => {
     await page.setViewportSize({ width: 500, height: 900 });
     await gotoPhotos(context, page);
-
-    await expect(page.locator('input[placeholder="Search"]')).toBeVisible();
+    await expect(page.locator('#search-button')).toBeVisible();
   });
 
-  test('typing characters does not trigger a search or unmount the timeline until Enter is pressed', async ({
-    context,
-    page,
-  }) => {
-    // Regression: /photos previously derived showSearchResults from the live
-    // searchQuery value, so typing a single character unmounted the Timeline,
-    // mounted SmartSearchResults, and kicked off a debounced fetch. The
-    // corrected behavior matches the spaces page: typing just updates the
-    // input value; the Timeline stays mounted until the user explicitly
-    // submits (Enter) or navigates to a ?q=... URL.
-    //
-    // We assert two things:
-    //   1. Timeline remains visible while typing (SmartSearchResults is NOT mounted).
-    //   2. No POST /api/search/smart request fires during typing — only after Enter.
+  test('typing in cmdk does not change the page until Enter is pressed', async ({ context, page }) => {
+    // The page itself should remain URL-/timeline-stable while the user is
+    // still typing in the cmdk dialog. Only submitting with Enter should
+    // commit q=... and swap the page into search-results mode.
     await gotoPhotos(context, page);
 
-    // Sanity: timeline is initially visible with thumbnails.
     await expect(page.locator('#asset-grid img').first()).toBeVisible({ timeout: 15_000 });
-
-    // Capture any /search/smart requests from this point onward.
-    const smartSearchRequests: string[] = [];
-    const requestHandler = (request: import('@playwright/test').Request) => {
-      const url = request.url();
-      if (request.method() === 'POST' && url.includes('/api/search/smart')) {
-        smartSearchRequests.push(url);
-      }
-    };
-    page.on('request', requestHandler);
-
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toBeVisible();
-
-    // Type characters one by one, giving reactivity time to flush between each.
-    // If the bug regresses, even one character would mount SmartSearchResults
-    // and schedule a debounced fetch.
-    for (const ch of 'beach') {
-      await searchInput.evaluate((el, char) => {
-        const input = el as HTMLInputElement;
-        input.value = input.value + char;
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-      }, ch);
-      // small delay so Svelte reactivity can run between characters
-      await page.waitForTimeout(50);
-    }
-
-    // Wait well past the wrapper's SEARCH_FILTER_DEBOUNCE_MS (250ms) to be sure
-    // any debounced fetch would have fired by now.
+    await page.getByTestId('cmdk-input-trigger').click();
+    const dialog = page.getByRole('dialog');
+    const combobox = dialog.getByRole('combobox');
+    await expect(combobox).toBeVisible();
+    await combobox.fill('beach');
     await page.waitForTimeout(500);
 
-    // Assertion 1: no search request was fired during typing.
-    expect(
-      smartSearchRequests,
-      `expected no POST /api/search/smart during typing, got: ${smartSearchRequests.join(', ')}`,
-    ).toEqual([]);
-
-    // Assertion 2: the timeline is still visible with thumbnails.
     await expect(page.locator('#asset-grid')).toBeVisible();
     await expect(page.locator('#asset-grid img').first()).toBeVisible();
-
-    // Assertion 3: URL hasn't changed — still /photos, not /photos?q=beach.
     expect(new URL(page.url()).search).toBe('');
+    await expect(page.getByTestId('search-chip')).toHaveCount(0);
 
-    // Now press Enter. This should commit the query and trigger the search.
-    // Set up a wait for the request BEFORE pressing Enter so we catch the
-    // debounced fetch even if it fires before our next assertion.
-    const smartSearchRequestPromise = page.waitForRequest(
-      (req) => req.method() === 'POST' && req.url().includes('/api/search/smart'),
-      { timeout: 10_000 },
-    );
-    await searchInput.focus();
-    await searchInput.press('Enter');
-
-    // URL updates to include the query.
+    await combobox.press('Enter');
     await expect(page).toHaveURL(/\/photos\?q=beach/, { timeout: 5000 });
-
-    // Wait for the debounced fetch to fire (250ms debounce + request time).
-    await smartSearchRequestPromise;
-
-    // SmartSearchResults area appears (either result-count or empty state).
     await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
       timeout: 15_000,
     });
-
-    // At least one /search/smart request was fired after Enter.
-    // (ML is disabled in the e2e stack so the backend may reject it, but
-    // the request must have been issued.)
-    expect(smartSearchRequests.length).toBeGreaterThan(0);
-
-    page.off('request', requestHandler);
   });
 });

--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -23,6 +23,26 @@ test.describe('Spaces FilterPanel', () => {
     await page.waitForSelector('[data-testid="discovery-timeline"]');
   }
 
+  async function selectPageSort(
+    page: import('@playwright/test').Page,
+    label: 'Newest first' | 'Oldest first',
+  ) {
+    const sortButton = page.locator('[data-testid="search-sort-btn"]');
+    await expect(sortButton).toBeVisible();
+
+    if ((await sortButton.getAttribute('aria-label')) === label) {
+      return sortButton;
+    }
+
+    await sortButton.click();
+    await page
+      .locator('[data-testid="search-sort-container"] div.absolute button')
+      .filter({ hasText: label })
+      .click();
+
+    return sortButton;
+  }
+
   // ─── Helper: create a space with diverse test data ───
   async function createPopulatedSpace(name: string) {
     const space = await utils.createSpace(admin.accessToken, { name });
@@ -1058,15 +1078,13 @@ test.describe('Spaces FilterPanel', () => {
       const { space } = await createPopulatedSpace('Sort Asc');
       await gotoSpace(context, page, space.id);
 
-      const sortToggle = page.locator('[data-testid="sort-toggle"]');
-      await expect(sortToggle).toBeVisible();
+      const sortButton = page.locator('[data-testid="search-sort-btn"]');
+      await expect(sortButton).toHaveAttribute('aria-label', 'Newest first');
 
-      // Wait for the timeline/buckets API to respond with the new sort order
-      const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
-      await sortToggle.click();
-      await bucketResponse;
-
-      await expect(sortToggle).toHaveAttribute('title', 'Sort: oldest first');
+      const sortNavigation = page.waitForURL((url) => url.searchParams.get('sort') === 'asc');
+      await selectPageSort(page, 'Oldest first');
+      await sortNavigation;
+      await expect(sortButton).toHaveAttribute('aria-label', 'Oldest first');
 
       // Verify the timeline actually re-rendered by checking the container is still present
       await expect(page.locator('[data-testid="discovery-timeline"]')).toBeVisible();
@@ -1076,15 +1094,16 @@ test.describe('Spaces FilterPanel', () => {
       const { space } = await createPopulatedSpace('Sort Desc');
       await gotoSpace(context, page, space.id);
 
-      const sortToggle = page.locator('[data-testid="sort-toggle"]');
-
       // Toggle to ascending
-      await sortToggle.click();
-      await expect(sortToggle).toHaveAttribute('title', 'Sort: oldest first');
+      const sortButton = await selectPageSort(page, 'Oldest first');
+      await page.waitForURL((url) => url.searchParams.get('sort') === 'asc');
+      await expect(sortButton).toHaveAttribute('aria-label', 'Oldest first');
 
       // Toggle back to descending
-      await sortToggle.click();
-      await expect(sortToggle).toHaveAttribute('title', 'Sort: newest first');
+      const sortNavigation = page.waitForURL((url) => url.searchParams.get('sort') === 'desc');
+      await selectPageSort(page, 'Newest first');
+      await sortNavigation;
+      await expect(sortButton).toHaveAttribute('aria-label', 'Newest first');
     });
 
     test('should preserve filters after sort change', async ({ context, page }) => {
@@ -1096,11 +1115,13 @@ test.describe('Spaces FilterPanel', () => {
       await expect(page.locator('[data-testid="active-chip"]')).toHaveCount(1);
 
       // Toggle sort
-      const sortToggle = page.locator('[data-testid="sort-toggle"]');
-      await sortToggle.click();
+      const sortNavigation = page.waitForURL((url) => url.searchParams.get('sort') === 'asc');
+      const sortButton = await selectPageSort(page, 'Oldest first');
+      await sortNavigation;
 
       // Filter chip should still be present
       await expect(page.locator('[data-testid="active-chip"]')).toHaveCount(1);
+      await expect(sortButton).toHaveAttribute('aria-label', 'Oldest first');
     });
 
     test('should keep ascending sort after Clear All (sort is view preference)', async ({ context, page }) => {
@@ -1108,9 +1129,10 @@ test.describe('Spaces FilterPanel', () => {
       await gotoSpace(context, page, space.id);
 
       // Toggle to ascending
-      const sortToggle = page.locator('[data-testid="sort-toggle"]');
-      await sortToggle.click();
-      await expect(sortToggle).toHaveAttribute('title', 'Sort: oldest first');
+      const sortNavigation = page.waitForURL((url) => url.searchParams.get('sort') === 'asc');
+      const sortButton = await selectPageSort(page, 'Oldest first');
+      await sortNavigation;
+      await expect(sortButton).toHaveAttribute('aria-label', 'Oldest first');
 
       // Apply a filter and clear it — use force:true because the button may be obscured by layout overlap
       await page.locator('[data-testid="media-type-image"]').click();
@@ -1118,7 +1140,8 @@ test.describe('Spaces FilterPanel', () => {
       await page.locator('[data-testid="clear-all-btn"]').click({ force: true });
 
       // Sort should remain ascending
-      await expect(sortToggle).toHaveAttribute('title', 'Sort: oldest first');
+      await expect(sortButton).toHaveAttribute('aria-label', 'Oldest first');
+      await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}\\?sort=asc`));
     });
   });
 

--- a/e2e/src/specs/web/spaces-search.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-search.e2e-spec.ts
@@ -2,6 +2,16 @@ import type { LoginResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
 import { utils } from 'src/utils';
 
+async function submitGlobalSearch(page: import('@playwright/test').Page, query: string) {
+  await page.getByTestId('cmdk-input-trigger').click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  const combobox = dialog.getByRole('combobox');
+  await combobox.fill(query);
+  await combobox.press('Enter');
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+}
+
 test.describe('Spaces Search', () => {
   let admin: LoginResponseDto;
   let space: SharedSpaceResponseDto;
@@ -25,15 +35,18 @@ test.describe('Spaces Search', () => {
     await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
   });
 
-  test('search in space commits q to the URL and shows results or empty state', async ({ context, page }) => {
+  async function gotoSpacePhotos(
+    context: import('@playwright/test').BrowserContext,
+    page: import('@playwright/test').Page,
+  ) {
     await utils.setAuthCookies(context, admin.accessToken);
     await page.goto(`/spaces/${space.id}/photos`);
+    await page.getByTestId('cmdk-input-trigger').waitFor({ state: 'visible' });
+  }
 
-    // The search bar is inside a hidden-on-mobile container
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toBeVisible({ timeout: 10_000 });
-    await searchInput.fill('test');
-    await searchInput.press('Enter');
+  test('search in space commits q to the URL and shows results or empty state', async ({ context, page }) => {
+    await gotoSpacePhotos(context, page);
+    await submitGlobalSearch(page, 'test');
     await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=test$`));
 
     // Smart search requires ML (CLIP) — handle both results and empty state
@@ -43,30 +56,21 @@ test.describe('Spaces Search', () => {
   });
 
   test('navigating away and back rehydrates the committed q state', async ({ context, page }) => {
-    await utils.setAuthCookies(context, admin.accessToken);
-    await page.goto(`/spaces/${space.id}/photos`);
-
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toBeVisible({ timeout: 10_000 });
-    await searchInput.fill('sunset');
-    await searchInput.press('Enter');
+    await gotoSpacePhotos(context, page);
+    await submitGlobalSearch(page, 'sunset');
     await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=sunset$`));
 
     await page.goto('/photos');
     await page.goBack();
 
     await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=sunset$`));
-    await expect(searchInput).toHaveValue('sunset');
+    await page.getByTestId('cmdk-input-trigger').click();
+    await expect(page.getByRole('dialog').getByRole('combobox')).toHaveValue('sunset');
   });
 
   test('clearing search via X removes q and returns to the timeline', async ({ context, page }) => {
-    await utils.setAuthCookies(context, admin.accessToken);
-    await page.goto(`/spaces/${space.id}/photos`);
-
-    const searchInput = page.locator('input[placeholder="Search"]');
-    await expect(searchInput).toBeVisible({ timeout: 10_000 });
-    await searchInput.fill('sunset');
-    await searchInput.press('Enter');
+    await gotoSpacePhotos(context, page);
+    await submitGlobalSearch(page, 'sunset');
 
     await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
       timeout: 10_000,
@@ -74,8 +78,7 @@ test.describe('Spaces Search', () => {
 
     await expect(page.getByTestId('search-chip')).toContainText('sunset');
 
-    const clearButton = page.locator('[aria-label="Clear value"]');
-    await clearButton.click();
+    await page.getByTestId('search-chip-close').dispatchEvent('click');
 
     await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos$`));
     await expect(page.getByTestId('result-count')).not.toBeVisible({ timeout: 5000 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -924,7 +924,7 @@
   "cmdk_toast_album_unavailable": "Album no longer available",
   "cmdk_toast_space_unavailable": "You no longer have access to this space",
   "cmdk_top_result": "Top result",
-  "cmdk_top_search_label": "Search for '{{query}}'",
+  "cmdk_top_search_label": "Search for \"{query}\"",
   "cmdk_try_filename": "Try Filename mode",
   "cmdk_unnamed_person": "Unnamed person",
   "collapse": "Collapse",

--- a/web/src/lib/components/filter-panel/__tests__/search-sort-dropdown.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/search-sort-dropdown.spec.ts
@@ -44,4 +44,21 @@ describe('SearchSortDropdown', () => {
     await userEvent.click(screen.getByText('Newest first'));
     expect(onSelect).toHaveBeenCalledWith('desc');
   });
+
+  it('should omit the relevance option when showRelevance is false', async () => {
+    render(SearchSortDropdown, {
+      props: { sortOrder: 'desc', onSelect: vi.fn(), showRelevance: false },
+    });
+    await userEvent.click(screen.getByTestId('search-sort-btn'));
+    expect(screen.queryByText('Relevance')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Newest first')).toHaveLength(2);
+    expect(screen.getByText('Oldest first')).toBeInTheDocument();
+  });
+
+  it('should expose the current option as an aria-label in compact mode', () => {
+    render(SearchSortDropdown, {
+      props: { sortOrder: 'asc', onSelect: vi.fn(), compact: true },
+    });
+    expect(screen.getByTestId('search-sort-btn')).toHaveAttribute('aria-label', 'Oldest first');
+  });
 });

--- a/web/src/lib/components/filter-panel/search-sort-dropdown.svelte
+++ b/web/src/lib/components/filter-panel/search-sort-dropdown.svelte
@@ -7,17 +7,20 @@
   interface Props {
     sortOrder: SortMode;
     onSelect: (mode: SortMode) => void;
+    compact?: boolean;
+    showRelevance?: boolean;
   }
 
-  let { sortOrder, onSelect }: Props = $props();
+  let { sortOrder, onSelect, compact = false, showRelevance = true }: Props = $props();
   let open = $state(false);
 
-  const options: { value: SortMode; label: string; icon: string }[] = [
+  const allOptions: { value: SortMode; label: string; icon: string }[] = [
     { value: 'relevance', label: 'Relevance', icon: mdiMagnify },
     { value: 'desc', label: 'Newest first', icon: mdiSortCalendarDescending },
     { value: 'asc', label: 'Oldest first', icon: mdiSortCalendarAscending },
   ];
 
+  let options = $derived(showRelevance ? allOptions : allOptions.filter((option) => option.value !== 'relevance'));
   let currentOption = $derived(options.find((o) => o.value === sortOrder) ?? options[0]);
 
   function handleSelect(event: MouseEvent, value: SortMode) {
@@ -38,13 +41,18 @@
 <div class="relative" data-testid="search-sort-container">
   <button
     type="button"
-    class="flex items-center gap-1 rounded-full px-3 py-1.5 text-sm text-gray-500 hover:bg-subtle dark:text-gray-400"
+    aria-label={currentOption.label}
+    class={`flex items-center rounded-full py-1.5 text-sm text-gray-500 hover:bg-subtle dark:text-gray-400 ${
+      compact ? 'h-10 w-10 justify-center px-0' : 'gap-1 px-3'
+    }`}
     data-testid="search-sort-btn"
     onclick={() => (open = !open)}
   >
     <Icon icon={currentOption.icon} size="16" />
-    <span>{currentOption.label}</span>
-    <Icon icon={mdiChevronDown} size="14" />
+    {#if !compact}
+      <span>{currentOption.label}</span>
+      <Icon icon={mdiChevronDown} size="14" />
+    {/if}
   </button>
 
   {#if open}

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -49,19 +49,35 @@ describe('global-search-input-trigger', () => {
 
     render(GlobalSearchInputTrigger);
 
-    expect(screen.getByTestId('search-sort-btn')).toHaveTextContent(/oldest first/i);
+    expect(screen.getByTestId('search-sort-btn')).toHaveAttribute('aria-label', 'Oldest first');
   });
 
-  it('shows the sort dropdown on a space detail page when a query is active', () => {
+  it('shows the sort dropdown on the photos page before a query exists', () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByTestId('search-sort-btn')).toHaveAttribute('aria-label', 'Newest first');
+  });
+
+  it('shows the sort dropdown on a space detail page before a query exists', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-123');
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByTestId('search-sort-btn')).toHaveAttribute('aria-label', 'Newest first');
+  });
+
+  it('shows relevance on searchable pages with an active query', () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-123?q=mountain');
 
     render(GlobalSearchInputTrigger);
 
-    expect(screen.getByTestId('search-sort-btn')).toHaveTextContent(/relevance/i);
+    expect(screen.getByTestId('search-sort-btn')).toHaveAttribute('aria-label', 'Relevance');
   });
 
-  it('hides the sort dropdown when there is no active page query', () => {
-    mockPage.url = new URL('https://gallery.test/photos');
+  it('hides the sort dropdown on non-searchable pages', () => {
+    mockPage.url = new URL('https://gallery.test/albums');
 
     render(GlobalSearchInputTrigger);
 
@@ -79,5 +95,18 @@ describe('global-search-input-trigger', () => {
     await user.click(screen.getByText('Newest first'));
 
     expect(applySortSpy).toHaveBeenCalledWith('desc', 'mountain');
+  });
+
+  it('applies sort immediately before a query exists', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-123');
+    const applySortSpy = vi.spyOn(globalSearchManager, 'applySearchSort').mockResolvedValue();
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    await user.click(screen.getByTestId('search-sort-btn'));
+    await user.click(screen.getByText('Oldest first'));
+
+    expect(applySortSpy).toHaveBeenCalledWith('asc', '');
   });
 });

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -1,17 +1,34 @@
 import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import GlobalSearchInputTrigger from '../global-search-input-trigger.svelte';
 
+const { mockPage } = vi.hoisted(() => ({
+  mockPage: {
+    url: new URL('https://gallery.test/photos'),
+    route: { id: null as string | null },
+    params: {} as Record<string, string>,
+  },
+}));
+
+vi.mock('$app/state', () => ({ page: mockPage }));
+
 describe('global-search-input-trigger', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockPage.url = new URL('https://gallery.test/photos');
+    mockPage.route.id = null;
+    mockPage.params = {};
+  });
+
   it('opens cmdk on click and keyboard activation', async () => {
     const openSpy = vi.spyOn(globalSearchManager, 'open').mockImplementation(() => {});
     const user = userEvent.setup();
 
     render(GlobalSearchInputTrigger);
 
-    const button = screen.getByRole('button');
+    const button = screen.getByTestId('cmdk-input-trigger');
     await user.click(button);
     button.focus();
     await user.keyboard('{Enter}');
@@ -25,5 +42,42 @@ describe('global-search-input-trigger', () => {
     expect(screen.getByTestId('cmdk-input-trigger')).toBeInTheDocument();
     expect(screen.getByText('cmdk_placeholder')).toBeInTheDocument();
     expect(screen.getByText(/^(⌘K|Ctrl\+K)$/)).toBeInTheDocument();
+  });
+
+  it('shows the sort dropdown on the photos page when a query is active', () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountain&sort=asc');
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByTestId('search-sort-btn')).toHaveTextContent(/oldest first/i);
+  });
+
+  it('shows the sort dropdown on a space detail page when a query is active', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-123?q=mountain');
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByTestId('search-sort-btn')).toHaveTextContent(/relevance/i);
+  });
+
+  it('hides the sort dropdown when there is no active page query', () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.queryByTestId('search-sort-btn')).not.toBeInTheDocument();
+  });
+
+  it('applies sort immediately from the top-bar trigger', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountain');
+    const applySortSpy = vi.spyOn(globalSearchManager, 'applySearchSort').mockResolvedValue();
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    await user.click(screen.getByTestId('search-sort-btn'));
+    await user.click(screen.getByText('Newest first'));
+
+    expect(applySortSpy).toHaveBeenCalledWith('desc', 'mountain');
   });
 });

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -246,37 +246,14 @@ describe('global-search root', () => {
     expect(m.isOpen).toBe(false);
   });
 
-  it('shows the search sort control on searchable pages with an active query', () => {
+  it('does not render the search sort control inside the palette', () => {
     mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
     const m = new GlobalSearchManager();
     m.open();
 
     render(GlobalSearch, { props: { manager: m } });
 
-    expect(screen.getByTestId('search-sort-btn')).toHaveTextContent(/oldest first/i);
-  });
-
-  it('hides the search sort control on non-searchable pages', () => {
-    mockPage.url = new URL('https://gallery.test/albums');
-    const m = new GlobalSearchManager();
-    m.open();
-
-    render(GlobalSearch, { props: { manager: m } });
-
     expect(screen.queryByTestId('search-sort-btn')).not.toBeInTheDocument();
-  });
-
-  it('reveals the search sort control while typing on a searchable page', async () => {
-    mockPage.url = new URL('https://gallery.test/photos');
-    const m = new GlobalSearchManager();
-    m.open();
-
-    render(GlobalSearch, { props: { manager: m } });
-    expect(screen.queryByTestId('search-sort-btn')).not.toBeInTheDocument();
-
-    await user.type(screen.getByRole('combobox'), 'beach');
-
-    expect(screen.getByTestId('search-sort-btn')).toBeInTheDocument();
   });
 
   it('Esc once clears input, twice closes (APG two-stage)', async () => {

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -466,24 +466,17 @@ describe('global-search root', () => {
     expect(activateSpy).toHaveBeenCalledWith('nav', expect.objectContaining({ id: 'nav:userPages:photos' }));
   });
 
-  it('renders a "Top result" band above content sections when a query almost-exactly matches a nav item', async () => {
+  it('almost-exact nav queries suppress top-search and auto-select the promoted nav row', async () => {
     // User types "people" — the Navigation > People item is a near-exact
-    // label match and gets promoted into a top-of-palette row. The row must
-    // appear in the DOM BEFORE the first content section (Photos) so the
-    // keyboard cursor lands on it first.
+    // label match and should own the top slot outright. The synthetic
+    // "Search for ..." row must disappear so Enter activates the nav target.
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
     await user.type(screen.getByRole('combobox'), 'people');
-    await vi.waitFor(() => expect(document.querySelector('[data-cmdk-top-result-search]')).not.toBeNull());
-    const topSearchGroup = document.querySelector('[data-cmdk-top-result-search]');
-    expect(topSearchGroup).not.toBeNull();
-    // The promoted Navigation > People row is inside the top result group,
-    // and must precede the Photos section in DOM order.
-    const photosHeading = screen.queryByText(/^cmdk_photos_heading$|^photos$/i);
-    if (photosHeading && topSearchGroup) {
-      expect(topSearchGroup.compareDocumentPosition(photosHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    }
+    await vi.waitFor(() => expect(document.querySelector('[data-cmdk-top-result-navigation]')).not.toBeNull());
+    expect(document.querySelector('[data-cmdk-top-result-search]')).toBeNull();
+    await vi.waitFor(() => expect(m.activeItemId).toBe('nav:userPages:people'));
   });
 
   it('top-result promoted item is removed from the regular Navigation section below (no dup)', async () => {
@@ -510,6 +503,48 @@ describe('global-search root', () => {
     await user.type(screen.getByRole('combobox'), 'beach{enter}');
 
     expect(activateSearchSpy).toHaveBeenCalledWith('beach');
+  });
+
+  it('pressing Enter on an almost-exact command query activates the promoted command instead of search', async () => {
+    const m = new GlobalSearchManager();
+    const activateSpy = vi.spyOn(m, 'activate').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'theme');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('cmd:theme'));
+
+    await user.keyboard('{Enter}');
+
+    expect(activateSearchSpy).not.toHaveBeenCalled();
+    expect(activateSpy).toHaveBeenCalledWith('command', expect.objectContaining({ id: 'cmd:theme' }));
+  });
+
+  it('re-arms top-search after rapid input edits even if the final query matches a previously dismissed string', async () => {
+    const m = new GlobalSearchManager();
+    installPhotoStub(m, [{ id: 'photo-1', originalFileName: 'beach.jpg' }]);
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    await user.type(input, 'beach');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'));
+    await vi.waitFor(
+      () => expect(document.querySelector('[data-command-item][data-value="photo:photo-1"]')).not.toBeNull(),
+      { timeout: 2000 },
+    );
+
+    await user.keyboard('{ArrowDown}');
+    await vi.waitFor(() => expect(m.activeItemId).toBe('photo:photo-1'));
+
+    input.value = 'beachx';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.value = 'beach';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    await vi.waitFor(() => expect(input.value).toBe('beach'));
+    await vi.waitFor(() => expect(m.activeItemId).toBe('top-search'));
   });
 
   it('does not steal selection back from a real row until the query changes again', async () => {

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -36,6 +36,15 @@ vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
   featureFlagsManager: mockFlags,
 }));
 
+const { mockPage } = vi.hoisted(() => ({
+  mockPage: {
+    url: new URL('https://gallery.test/photos'),
+    route: { id: null as string | null },
+    params: {} as Record<string, string>,
+  },
+}));
+vi.mock('$app/state', () => ({ page: mockPage }));
+
 import { GlobalSearchManager, type Provider, type Sections } from '$lib/managers/global-search-manager.svelte';
 import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
 import { addEntry, getEntries, __resetForTests as resetRecentStore } from '$lib/stores/cmdk-recent';
@@ -137,6 +146,9 @@ describe('global-search root', () => {
     localStorage.clear();
     resetRecentStore();
     mediaState.minLg = false;
+    mockPage.url = new URL('https://gallery.test/photos');
+    mockPage.route.id = null;
+    mockPage.params = {};
     // Default: stable non-admin user with an id so cmdk-recent scoping writes to a
     // predictable localStorage key. Tests that need admin-scoped navigation results
     // override `isAdmin` explicitly; anonymous-user edge cases flip to `null`.
@@ -232,6 +244,39 @@ describe('global-search root', () => {
     const closeBtn = screen.getByRole('button', { name: /close/i });
     await user.click(closeBtn);
     expect(m.isOpen).toBe(false);
+  });
+
+  it('shows the search sort control on searchable pages with an active query', () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
+    const m = new GlobalSearchManager();
+    m.open();
+
+    render(GlobalSearch, { props: { manager: m } });
+
+    expect(screen.getByTestId('search-sort-btn')).toHaveTextContent(/oldest first/i);
+  });
+
+  it('hides the search sort control on non-searchable pages', () => {
+    mockPage.url = new URL('https://gallery.test/albums');
+    const m = new GlobalSearchManager();
+    m.open();
+
+    render(GlobalSearch, { props: { manager: m } });
+
+    expect(screen.queryByTestId('search-sort-btn')).not.toBeInTheDocument();
+  });
+
+  it('reveals the search sort control while typing on a searchable page', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+    const m = new GlobalSearchManager();
+    m.open();
+
+    render(GlobalSearch, { props: { manager: m } });
+    expect(screen.queryByTestId('search-sort-btn')).not.toBeInTheDocument();
+
+    await user.type(screen.getByRole('combobox'), 'beach');
+
+    expect(screen.getByTestId('search-sort-btn')).toBeInTheDocument();
   });
 
   it('Esc once clears input, twice closes (APG two-stage)', async () => {

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/web/src/lib/components/global-search/__tests__/top-search-label.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/top-search-label.spec.ts
@@ -1,0 +1,15 @@
+import { init, register, t, waitLocale } from 'svelte-i18n';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+
+describe('cmdk top search label', () => {
+  beforeAll(async () => {
+    register('en-US', () => import('$i18n/en.json'));
+    await init({ fallbackLocale: 'en-US', initialLocale: 'en-US' });
+    await waitLocale('en-US');
+  });
+
+  it('interpolates the live query text', () => {
+    expect(get(t)('cmdk_top_search_label', { values: { query: 'wataaaaaaa' } })).toBe('Search for "wataaaaaaa"');
+  });
+});

--- a/web/src/lib/components/global-search/__tests__/top-search-label.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/top-search-label.spec.ts
@@ -1,6 +1,6 @@
 import { init, register, t, waitLocale } from 'svelte-i18n';
-import { beforeAll, describe, expect, it } from 'vitest';
 import { get } from 'svelte/store';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 describe('cmdk top search label', () => {
   beforeAll(async () => {

--- a/web/src/lib/components/global-search/global-search-input-trigger.svelte
+++ b/web/src/lib/components/global-search/global-search-input-trigger.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/state';
   import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+  import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
   import { getSearchablePageState } from '$lib/utils/searchable-page-search';
   import { Icon } from '@immich/ui';
   import { mdiMagnify } from '@mdi/js';
@@ -10,7 +11,7 @@
   const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform);
   const hotkeyLabel = isMac ? '⌘K' : 'Ctrl+K';
   const searchablePageState = $derived(getSearchablePageState(page.url));
-  const showSearchSortControl = $derived(searchablePageState.isSearchable && searchablePageState.query.length > 0);
+  const showSearchSortControl = $derived(searchablePageState.isSearchable);
 </script>
 
 <div class="flex items-center gap-2">
@@ -39,6 +40,8 @@
     <div class="shrink-0">
       <SearchSortDropdown
         sortOrder={searchablePageState.sortOrder}
+        compact={!mediaQueryManager.minLg}
+        showRelevance={searchablePageState.query.length > 0}
         onSelect={(mode) => {
           void globalSearchManager.applySearchSort(mode, searchablePageState.query);
         }}

--- a/web/src/lib/components/global-search/global-search-input-trigger.svelte
+++ b/web/src/lib/components/global-search/global-search-input-trigger.svelte
@@ -1,30 +1,48 @@
 <script lang="ts">
+  import { page } from '$app/state';
+  import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+  import { getSearchablePageState } from '$lib/utils/searchable-page-search';
   import { Icon } from '@immich/ui';
   import { mdiMagnify } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform);
   const hotkeyLabel = isMac ? '⌘K' : 'Ctrl+K';
+  const searchablePageState = $derived(getSearchablePageState(page.url));
+  const showSearchSortControl = $derived(searchablePageState.isSearchable && searchablePageState.query.length > 0);
 </script>
 
-<button
-  type="button"
-  data-testid="cmdk-input-trigger"
-  aria-label={$t('cmdk_placeholder')}
-  onclick={() => globalSearchManager.open()}
-  class="flex h-10 w-full items-center justify-between gap-4 rounded-2xl border border-gray-300/80 bg-gray-100/90 px-3 text-left text-sm shadow-sm transition-all duration-150 hover:border-primary/50 hover:bg-white hover:shadow md:h-11 dark:border-immich-dark-gray dark:bg-immich-dark-gray/70 dark:hover:border-primary/40 dark:hover:bg-immich-dark-gray"
->
-  <span class="flex min-w-0 items-center gap-3 text-gray-500 dark:text-gray-300">
-    <span
-      class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/80 text-gray-500 shadow-sm dark:bg-immich-dark-bg dark:text-gray-300"
-    >
-      <Icon icon={mdiMagnify} size="1.05em" aria-hidden />
-    </span>
-    <span class="truncate">{$t('cmdk_placeholder')}</span>
-  </span>
-  <kbd
-    class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
-    >{hotkeyLabel}</kbd
+<div class="flex items-center gap-2">
+  <button
+    type="button"
+    data-testid="cmdk-input-trigger"
+    aria-label={$t('cmdk_placeholder')}
+    onclick={() => globalSearchManager.open()}
+    class="flex h-10 min-w-0 flex-1 items-center justify-between gap-4 rounded-2xl border border-gray-300/80 bg-gray-100/90 px-3 text-left text-sm shadow-sm transition-all duration-150 hover:border-primary/50 hover:bg-white hover:shadow md:h-11 dark:border-immich-dark-gray dark:bg-immich-dark-gray/70 dark:hover:border-primary/40 dark:hover:bg-immich-dark-gray"
   >
-</button>
+    <span class="flex min-w-0 items-center gap-3 text-gray-500 dark:text-gray-300">
+      <span
+        class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/80 text-gray-500 shadow-sm dark:bg-immich-dark-bg dark:text-gray-300"
+      >
+        <Icon icon={mdiMagnify} size="1.05em" aria-hidden />
+      </span>
+      <span class="truncate">{$t('cmdk_placeholder')}</span>
+    </span>
+    <kbd
+      class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
+      >{hotkeyLabel}</kbd
+    >
+  </button>
+
+  {#if showSearchSortControl}
+    <div class="shrink-0">
+      <SearchSortDropdown
+        sortOrder={searchablePageState.sortOrder}
+        onSelect={(mode) => {
+          void globalSearchManager.applySearchSort(mode, searchablePageState.query);
+        }}
+      />
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { page } from '$app/state';
+  import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
   import { Icon, IconButton, Modal, modalManager, ModalBody } from '@immich/ui';
   import { mdiClose, mdiMagnify } from '@mdi/js';
   import { Command } from 'bits-ui';
@@ -24,6 +26,7 @@
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { NAVIGATION_ITEMS, type NavigationItem } from '$lib/managers/navigation-items';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
+  import { getSearchablePageState } from '$lib/utils/searchable-page-search';
 
   interface Props {
     manager: GlobalSearchManager;
@@ -211,6 +214,7 @@
     return { status: 'ok' as const, items, total: items.length };
   });
   const showPreview = $derived(mediaQueryManager.minLg);
+  const showSearchSortControl = $derived(getSearchablePageState(page.url).isSearchable && inputValue.trim().length > 0);
 
   // Progress stripe: only show after a 200ms grace window. A clean setTimeout
   // pattern — the effect fires on every batchInFlight transition and the cleanup
@@ -371,6 +375,16 @@
           maxlength={256}
           class="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm focus:outline-none"
         />
+        {#if showSearchSortControl}
+          <div class="shrink-0">
+            <SearchSortDropdown
+              sortOrder={manager.searchSortOrder}
+              onSelect={(mode) => {
+                void manager.applySearchSort(mode, inputValue);
+              }}
+            />
+          </div>
+        {/if}
         <IconButton
           icon={mdiClose}
           size="small"

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -101,7 +101,7 @@
   });
 
   $effect(() => {
-    if (manager.activeItemId === manager.topSearchMatch?.id) {
+    if (manager.activeItemId === 'top-search') {
       if (selectedValue !== '') {
         selectedValue = '';
       }
@@ -112,27 +112,54 @@
     }
   });
 
-  let lastAutoSelectedTopSearchQuery = $state<string | null>(null);
-  let lastDismissedTopSearchQuery = $state<string | null>(null);
+  // Key top-slot auto-selection/dismissal by both the current query text and a
+  // monotonically increasing input-edit revision. This lets the preferred top row
+  // (promoted command/nav or the synthetic search row) re-arm after rapid edit
+  // sequences that end back on a previously dismissed string.
+  let inputEditRevision = $state(0);
+  let lastAutoSelectedTopResultToken = $state<string | null>(null);
+  let lastDismissedTopResultToken = $state<string | null>(null);
+  const preferredTopResultId = $derived.by<string | null>(() => {
+    if (manager.topCommandMatch) {
+      return manager.topCommandMatch.id;
+    }
+    if (manager.topNavigationMatch) {
+      return manager.topNavigationMatch.id;
+    }
+    return manager.topSearchMatch?.id ?? null;
+  });
+  const preferredTopResultToken = $derived.by<string | null>(() => {
+    const query = manager.query.trim();
+    if (manager.topCommandMatch) {
+      return `${inputEditRevision}:command:${manager.topCommandMatch.id}:${query}`;
+    }
+    if (manager.topNavigationMatch) {
+      return `${inputEditRevision}:navigation:${manager.topNavigationMatch.id}:${query}`;
+    }
+    if (manager.topSearchMatch) {
+      return `${inputEditRevision}:search:${manager.topSearchMatch.query}`;
+    }
+    return null;
+  });
   let previousActiveItemId = $state<string | null>(null);
   $effect(() => {
-    const topSearchMatch = manager.topSearchMatch;
-    if (!topSearchMatch) {
-      lastAutoSelectedTopSearchQuery = null;
-      lastDismissedTopSearchQuery = null;
+    const topResultId = preferredTopResultId;
+    const topResultToken = preferredTopResultToken;
+    if (!topResultId || !topResultToken) {
+      lastAutoSelectedTopResultToken = null;
+      lastDismissedTopResultToken = null;
       previousActiveItemId = manager.activeItemId;
       return;
     }
-    if (previousActiveItemId === topSearchMatch.id && manager.activeItemId !== topSearchMatch.id) {
-      lastDismissedTopSearchQuery = topSearchMatch.query;
+    if (previousActiveItemId === topResultId && manager.activeItemId !== topResultId) {
+      lastDismissedTopResultToken = topResultToken;
     }
-    if (
-      lastAutoSelectedTopSearchQuery !== topSearchMatch.query &&
-      lastDismissedTopSearchQuery !== topSearchMatch.query
-    ) {
-      selectedValue = '';
-      manager.setActiveItem(topSearchMatch.id);
-      lastAutoSelectedTopSearchQuery = topSearchMatch.query;
+    if (lastAutoSelectedTopResultToken !== topResultToken && lastDismissedTopResultToken !== topResultToken) {
+      if (topResultId === 'top-search') {
+        selectedValue = '';
+      }
+      manager.setActiveItem(topResultId);
+      lastAutoSelectedTopResultToken = topResultToken;
     }
     previousActiveItemId = manager.activeItemId;
   });
@@ -373,6 +400,7 @@
           autofocus
           placeholder={$t('cmdk_placeholder')}
           maxlength={256}
+          oninput={() => inputEditRevision++}
           class="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm focus:outline-none"
         />
         {#if showSearchSortControl}

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { page } from '$app/state';
-  import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
   import { Icon, IconButton, Modal, modalManager, ModalBody } from '@immich/ui';
   import { mdiClose, mdiMagnify } from '@mdi/js';
   import { Command } from 'bits-ui';
@@ -26,7 +24,6 @@
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { NAVIGATION_ITEMS, type NavigationItem } from '$lib/managers/navigation-items';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
-  import { getSearchablePageState } from '$lib/utils/searchable-page-search';
 
   interface Props {
     manager: GlobalSearchManager;
@@ -241,7 +238,6 @@
     return { status: 'ok' as const, items, total: items.length };
   });
   const showPreview = $derived(mediaQueryManager.minLg);
-  const showSearchSortControl = $derived(getSearchablePageState(page.url).isSearchable && inputValue.trim().length > 0);
 
   // Progress stripe: only show after a 200ms grace window. A clean setTimeout
   // pattern — the effect fires on every batchInFlight transition and the cleanup
@@ -403,16 +399,6 @@
           oninput={() => inputEditRevision++}
           class="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm focus:outline-none"
         />
-        {#if showSearchSortControl}
-          <div class="shrink-0">
-            <SearchSortDropdown
-              sortOrder={manager.searchSortOrder}
-              onSelect={(mode) => {
-                void manager.applySearchSort(mode, inputValue);
-              }}
-            />
-          </div>
-        {/if}
         <IconButton
           icon={mdiClose}
           size="small"

--- a/web/src/lib/managers/close-palette-on-navigate.spec.ts
+++ b/web/src/lib/managers/close-palette-on-navigate.spec.ts
@@ -4,6 +4,7 @@ vi.mock('$lib/managers/global-search-manager.svelte', () => ({
   globalSearchManager: {
     isOpen: false,
     close: vi.fn(),
+    consumeKeepOpenOnNextNavigate: vi.fn(() => false),
   },
 }));
 
@@ -13,18 +14,30 @@ import { closePaletteOnNavigate } from './close-palette-on-navigate';
 describe('closePaletteOnNavigate', () => {
   beforeEach(() => {
     vi.mocked(globalSearchManager.close).mockReset();
+    vi.mocked(globalSearchManager.consumeKeepOpenOnNextNavigate).mockReset();
+    vi.mocked(globalSearchManager.consumeKeepOpenOnNextNavigate).mockReturnValue(false);
     globalSearchManager.isOpen = false;
   });
 
   it('no-ops when palette is closed', () => {
     closePaletteOnNavigate();
     expect(globalSearchManager.close).not.toHaveBeenCalled();
+    expect(globalSearchManager.consumeKeepOpenOnNextNavigate).not.toHaveBeenCalled();
   });
 
   it('calls close when palette is open', () => {
     globalSearchManager.isOpen = true;
     closePaletteOnNavigate();
     expect(globalSearchManager.close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the palette open for the one immediate search-state navigate it initiated', () => {
+    globalSearchManager.isOpen = true;
+    vi.mocked(globalSearchManager.consumeKeepOpenOnNextNavigate).mockReturnValueOnce(true);
+
+    closePaletteOnNavigate();
+
+    expect(globalSearchManager.close).not.toHaveBeenCalled();
   });
 
   it('calls close on consecutive replaceState-style firings when still open', () => {

--- a/web/src/lib/managers/close-palette-on-navigate.ts
+++ b/web/src/lib/managers/close-palette-on-navigate.ts
@@ -1,6 +1,10 @@
 import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
 
 export function closePaletteOnNavigate() {
+  if (!globalSearchManager.isOpen || globalSearchManager.consumeKeepOpenOnNextNavigate()) {
+    return;
+  }
+
   if (globalSearchManager.isOpen) {
     globalSearchManager.close();
   }

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -69,6 +69,9 @@ afterEach(() => {
   mockUser.current = { id: 'test-user', isAdmin: true };
   mockFlags.valueOrUndefined = { search: true, map: true, trash: true };
   mockI18nLocale.current = 'en';
+  mockPage.route.id = null;
+  mockPage.params = {};
+  mockPage.url = new URL('https://gallery.test/photos');
 });
 
 vi.mock('@immich/sdk', async () => ({
@@ -170,6 +173,23 @@ describe('GlobalSearchManager (skeleton)', () => {
   it('open() sets isOpen=true', () => {
     manager.open();
     expect(manager.isOpen).toBe(true);
+  });
+
+  it('open() hydrates the current searchable page query and sort', () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
+    manager.open();
+
+    expect(manager.isOpen).toBe(true);
+    expect(manager.query).toBe('beach');
+    expect(manager.searchSortOrder).toBe('asc');
+  });
+
+  it('open() resets the search draft sort to relevance when the current searchable page has no query', () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+    manager.open();
+
+    expect(manager.query).toBe('');
+    expect(manager.searchSortOrder).toBe('relevance');
   });
 
   it('close() resets sections to idle and clears active item', () => {
@@ -1168,13 +1188,14 @@ describe('activate("command")', () => {
     expect(getEntries()).toEqual([]);
   });
 
-  it('activateSearch preserves same-route params but drops stale space asset ids', () => {
+  it('activateSearch preserves same-route params, drops stale space asset ids, and carries an explicit sort', () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos/asset-123?view=grid');
+    m.searchSortOrder = 'asc';
 
     m.activateSearch('beach');
 
-    expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach');
+    expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach&sort=asc');
   });
 
   it('activateSearch falls back to /photos and drops unrelated params', () => {
@@ -1193,6 +1214,21 @@ describe('activate("command")', () => {
     m.activateSearch('beach');
 
     expect(goto).toHaveBeenCalledWith('/photos?q=beach');
+  });
+
+  it('applySearchSort immediately updates the current searchable page and marks the next navigate to keep the palette open', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach');
+
+    await m.applySearchSort('asc', 'beach');
+
+    expect(goto).toHaveBeenCalledWith('/photos?q=beach&sort=asc', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+    expect(m.consumeKeepOpenOnNextNavigate()).toBe(true);
+    expect(m.consumeKeepOpenOnNextNavigate()).toBe(false);
   });
 });
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1230,6 +1230,30 @@ describe('activate("command")', () => {
     expect(m.consumeKeepOpenOnNextNavigate()).toBe(true);
     expect(m.consumeKeepOpenOnNextNavigate()).toBe(false);
   });
+
+  it('applySearchSort persists an explicit pre-search sort on searchable pages', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    await m.applySearchSort('desc', '');
+
+    expect(goto).toHaveBeenCalledWith('/spaces/space-1?sort=desc', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+    expect(m.consumeKeepOpenOnNextNavigate()).toBe(true);
+  });
+
+  it('open resets pre-search page sorting back to relevance for a new search session', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?sort=asc');
+
+    m.open();
+
+    expect(m.query).toBe('');
+    expect(m.searchSortOrder).toBe('relevance');
+  });
 });
 
 describe('activateRecent()', () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1219,6 +1219,7 @@ describe('activate("command")', () => {
   it('applySearchSort immediately updates the current searchable page and marks the next navigate to keep the palette open', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/photos?q=beach');
+    m.open();
 
     await m.applySearchSort('asc', 'beach');
 
@@ -1228,6 +1229,20 @@ describe('activate("command")', () => {
       noScroll: true,
     });
     expect(m.consumeKeepOpenOnNextNavigate()).toBe(true);
+    expect(m.consumeKeepOpenOnNextNavigate()).toBe(false);
+  });
+
+  it('applySearchSort does not arm keep-open when the palette is closed', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach');
+
+    await m.applySearchSort('asc', 'beach');
+
+    expect(goto).toHaveBeenCalledWith('/photos?q=beach&sort=asc', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
     expect(m.consumeKeepOpenOnNextNavigate()).toBe(false);
   });
 
@@ -1242,7 +1257,7 @@ describe('activate("command")', () => {
       keepFocus: true,
       noScroll: true,
     });
-    expect(m.consumeKeepOpenOnNextNavigate()).toBe(true);
+    expect(m.consumeKeepOpenOnNextNavigate()).toBe(false);
   });
 
   it('open resets pre-search page sorting back to relevance for a new search session', () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2683,27 +2683,39 @@ describe('SWR loading rules', () => {
   });
 
   it('setMode joins the batch counter — mode switch during live batch does NOT drop stripe early', async () => {
-    // Slow photos provider so the main batch stays in flight.
-    let resolvePhotos!: () => void;
-    vi.mocked(searchSmart).mockImplementationOnce(
-      () => new Promise((r) => (resolvePhotos = () => r({ assets: { items: [], nextPage: null } } as never))),
-    );
     const m = new GlobalSearchManager();
-    m.open();
-    m.setQuery('beach');
-    await vi.advanceTimersByTimeAsync(200);
-    expect(m.batchInFlight).toBe(true);
-    // Mode switch while photos is still in flight — counter should increment, not reset.
-    m.setMode('metadata');
-    expect(m.batchInFlight).toBe(true);
-    // setMode's re-run (searchAssets) resolves first from the default mockResolvedValue.
-    await vi.advanceTimersByTimeAsync(10);
-    // Original photos still in flight — batchInFlight MUST remain true.
-    expect(m.batchInFlight).toBe(true);
-    // Finally, let the original photos resolve.
-    resolvePhotos();
-    await vi.advanceTimersByTimeAsync(10);
-    expect(m.batchInFlight).toBe(false);
+    const photosProvider = (m as unknown as { providers: { photos: Provider<EntityItem> } }).providers.photos;
+    const originalPhotosRun = photosProvider.run;
+    let resolvePhotos!: () => void;
+
+    photosProvider.run = vi.fn((_query: string, mode: SearchMode) => {
+      if (mode === 'smart') {
+        return new Promise(
+          (r) => (resolvePhotos = () => r({ status: 'empty' } as ProviderStatus<EntityItem>)),
+        ) as Promise<ProviderStatus<EntityItem>>;
+      }
+      return Promise.resolve({ status: 'empty' } as ProviderStatus<EntityItem>);
+    });
+
+    try {
+      m.open();
+      m.setQuery('beach');
+      await vi.advanceTimersByTimeAsync(200);
+      expect(m.batchInFlight).toBe(true);
+      // Mode switch while photos is still in flight — counter should increment, not reset.
+      m.setMode('metadata');
+      expect(m.batchInFlight).toBe(true);
+      // setMode's re-run resolves first from the provider override above.
+      await vi.advanceTimersByTimeAsync(10);
+      // Original photos is still unresolved — batchInFlight MUST remain true.
+      expect(m.batchInFlight).toBe(true);
+      // Finally, let the original photos resolve.
+      resolvePhotos();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(m.batchInFlight).toBe(false);
+    } finally {
+      photosProvider.run = originalPhotosRun;
+    }
   });
 
   it('stale-batch providers do not deadlock batchInFlight after a new batch supersedes', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2670,16 +2670,37 @@ describe('SWR loading rules', () => {
   });
 
   it('setMode preserves ok photos until re-run completes (SWR)', async () => {
-    vi.mocked(searchSmart).mockResolvedValueOnce({
-      assets: { items: [{ id: 'a1' } as never], nextPage: null },
-    } as never);
     const m = new GlobalSearchManager();
-    m.open();
-    m.setQuery('beach');
-    await vi.advanceTimersByTimeAsync(200);
-    expect(m.sections.photos.status).toBe('ok');
-    m.setMode('metadata');
-    expect(m.sections.photos.status).toBe('ok');
+    const photosProvider = (m as unknown as { providers: { photos: Provider<EntityItem> } }).providers.photos;
+    const originalPhotosRun = photosProvider.run;
+    let resolveRerun!: () => void;
+
+    photosProvider.run = vi.fn((_query: string, mode: SearchMode) => {
+      if (mode === 'smart') {
+        return Promise.resolve({
+          status: 'ok',
+          items: [{ id: 'a1' } as EntityItem],
+          total: 1,
+        } as ProviderStatus<EntityItem>);
+      }
+      return new Promise(
+        (r) => (resolveRerun = () => r({ status: 'empty' } as ProviderStatus<EntityItem>)),
+      ) as Promise<ProviderStatus<EntityItem>>;
+    });
+
+    try {
+      m.open();
+      m.setQuery('beach');
+      await vi.advanceTimersByTimeAsync(200);
+      expect(m.sections.photos.status).toBe('ok');
+      m.setMode('metadata');
+      expect(m.sections.photos.status).toBe('ok');
+      await flushMicrotasks();
+      resolveRerun();
+      await vi.advanceTimersByTimeAsync(10);
+    } finally {
+      photosProvider.run = originalPhotosRun;
+    }
   });
 
   it('setMode joins the batch counter — mode switch during live batch does NOT drop stripe early', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1221,7 +1221,7 @@ export class GlobalSearchManager {
       return;
     }
 
-    this.keepOpenOnNextNavigate = true;
+    this.keepOpenOnNextNavigate = this.isOpen;
     try {
       await goto(nextUrl, {
         replaceState: true,

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1650,6 +1650,13 @@ export class GlobalSearchManager {
     if (this.scope !== 'all' || query.length === 0) {
       return null;
     }
+    // The synthetic free-text search row only owns the top slot when there is no
+    // stronger promoted command/navigation match. This keeps Enter aligned with the
+    // high-confidence command/nav result for queries like `theme` or
+    // `auto-classification`.
+    if (this.topCommandMatch !== null || this.topNavigationMatch !== null) {
+      return null;
+    }
     return { id: 'top-search', query };
   });
 

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -6,6 +6,11 @@ import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte'
 import { Route } from '$lib/route';
 import { addEntry, getEntries, makePlaceId, removeEntry, type RecentEntry } from '$lib/stores/cmdk-recent';
 import {
+  buildSearchablePageUrl,
+  getSearchablePageState,
+  type SearchablePageSortOrder,
+} from '$lib/utils/searchable-page-search';
+import {
   getAlbumInfo,
   getAlbumNames,
   getAllPeople,
@@ -26,7 +31,7 @@ import {
 import { toastManager } from '@immich/ui';
 import { computeCommandScore } from 'bits-ui';
 import { locale as i18nLocale, t, type Translations } from 'svelte-i18n';
-import { SvelteMap, SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { get } from 'svelte/store';
 import { parseScope, personSuggestionsComparator, type ParsedQuery, type Scope } from './cmdk-prefix';
 import { commandContextManager } from './command-context-manager.svelte';
@@ -204,6 +209,7 @@ function loadSearchQueryType(): SearchMode {
 export class GlobalSearchManager {
   isOpen = $state(false);
   query = $state('');
+  searchSortOrder = $state<SearchablePageSortOrder>('relevance');
   mode = $state<SearchMode>(loadSearchQueryType());
   parsedQuery = $derived<ParsedQuery>(parseScope(this.query));
   scope = $derived<Scope>(this.parsedQuery.scope);
@@ -303,6 +309,7 @@ export class GlobalSearchManager {
   private tagsDisabled = false;
   private storageListener?: (e: StorageEvent) => void;
   private mlProbed = false;
+  private keepOpenOnNextNavigate = false;
 
   /**
    * Catalogs fetched lazily on first provider run and shared for the remainder of the
@@ -569,6 +576,14 @@ export class GlobalSearchManager {
 
   open() {
     this.isOpen = true;
+    const currentPageSearchState = getSearchablePageState(page.url);
+    if (currentPageSearchState.isSearchable) {
+      this.query = currentPageSearchState.query;
+      this.searchSortOrder = currentPageSearchState.query ? currentPageSearchState.sortOrder : 'relevance';
+    } else {
+      this.query = '';
+      this.searchSortOrder = 'relevance';
+    }
     if (this.closeController.signal.aborted) {
       this.closeController = new AbortController();
     }
@@ -908,6 +923,7 @@ export class GlobalSearchManager {
   close() {
     this.cancelConfirm();
     this.isOpen = false;
+    this.keepOpenOnNextNavigate = false;
     this.closeController.abort();
     if (this.debounceTimer !== null) {
       clearTimeout(this.debounceTimer);
@@ -938,6 +954,13 @@ export class GlobalSearchManager {
     // Reset query so reopening and re-typing the same string is not a no-op
     // (setQuery short-circuits when `this.query === text`).
     this.query = '';
+    this.searchSortOrder = 'relevance';
+  }
+
+  consumeKeepOpenOnNextNavigate() {
+    const shouldKeepOpen = this.keepOpenOnNextNavigate;
+    this.keepOpenOnNextNavigate = false;
+    return shouldKeepOpen;
   }
 
   toggle() {
@@ -1170,41 +1193,45 @@ export class GlobalSearchManager {
     void goto(route);
   }
 
-  private getSpaceSearchBasePath(pathname: string): string | null {
-    const parts = pathname.split('/').filter(Boolean);
-    if (parts[0] !== 'spaces' || parts[1] === undefined) {
-      return null;
-    }
-    if (parts.length === 2) {
-      return `/spaces/${parts[1]}`;
-    }
-    if (parts[2] === 'photos') {
-      return `/spaces/${parts[1]}/photos`;
-    }
-    return null;
-  }
-
   private buildSearchDestination(text: string): string {
-    const pathname = page.url.pathname;
-    const params = new SvelteURLSearchParams(page.url.searchParams);
-    params.set('q', text);
-
-    if (pathname.startsWith('/photos')) {
-      return `/photos?${params.toString()}`;
+    const searchablePageUrl = buildSearchablePageUrl(page.url, text, this.searchSortOrder);
+    if (searchablePageUrl) {
+      return searchablePageUrl;
     }
 
-    const spaceBasePath = this.getSpaceSearchBasePath(pathname);
-    if (spaceBasePath) {
-      return `${spaceBasePath}?${params.toString()}`;
-    }
-
-    if (pathname.startsWith('/map')) {
+    if (page.url.pathname.startsWith('/map')) {
+      const params = new URLSearchParams(page.url.searchParams);
+      params.set('q', text);
       return `/map?${params.toString()}`;
     }
 
-    const fresh = new SvelteURLSearchParams();
+    const fresh = new URLSearchParams();
     fresh.set('q', text);
+    if (this.searchSortOrder !== 'relevance') {
+      fresh.set('sort', this.searchSortOrder);
+    }
     return `/photos?${fresh.toString()}`;
+  }
+
+  async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {
+    this.searchSortOrder = sortOrder;
+
+    const nextUrl = buildSearchablePageUrl(page.url, text, sortOrder);
+    if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
+      return;
+    }
+
+    this.keepOpenOnNextNavigate = true;
+    try {
+      await goto(nextUrl, {
+        replaceState: true,
+        keepFocus: true,
+        noScroll: true,
+      });
+    } catch (error) {
+      this.keepOpenOnNextNavigate = false;
+      throw error;
+    }
   }
 
   activateSearch(text: string): void {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1200,11 +1200,15 @@ export class GlobalSearchManager {
     }
 
     if (page.url.pathname.startsWith('/map')) {
+      // Ephemeral serialization for navigation only; no reactive state is retained.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
       const params = new URLSearchParams(page.url.searchParams);
       params.set('q', text);
       return `/map?${params.toString()}`;
     }
 
+    // Ephemeral serialization for navigation only; no reactive state is retained.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
     const fresh = new URLSearchParams();
     fresh.set('q', text);
     if (this.searchSortOrder !== 'relevance') {

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -75,19 +75,19 @@ export function buildSearchablePageUrl(
   const trimmedQuery = query.trim();
   const params = new URLSearchParams(url.searchParams);
 
-  if (!trimmedQuery) {
-    params.delete('q');
-    if (sortOrder === 'asc' || sortOrder === 'desc') {
-      params.set('sort', sortOrder);
-    } else {
-      params.delete('sort');
-    }
-  } else {
+  if (trimmedQuery) {
     params.set('q', trimmedQuery);
     if (sortOrder === 'relevance') {
       params.delete('sort');
     } else {
       params.set('sort', sortOrder);
+    }
+  } else {
+    params.delete('q');
+    if (sortOrder === 'asc' || sortOrder === 'desc') {
+      params.set('sort', sortOrder);
+    } else {
+      params.delete('sort');
     }
   }
 

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -1,0 +1,85 @@
+export type SearchablePageSortOrder = 'relevance' | 'asc' | 'desc';
+
+type SearchablePageState = {
+  basePath: string | null;
+  isSearchable: boolean;
+  query: string;
+  sortOrder: SearchablePageSortOrder;
+};
+
+function getSortOrder(query: string, rawSort: string | null): SearchablePageSortOrder {
+  if (query.length === 0) {
+    return 'desc';
+  }
+  return rawSort === 'asc' || rawSort === 'desc' ? rawSort : 'relevance';
+}
+
+export function getSearchablePageBasePath(pathname: string): string | null {
+  if (pathname.startsWith('/photos')) {
+    return '/photos';
+  }
+
+  const parts = pathname.split('/').filter(Boolean);
+  if (parts[0] !== 'spaces' || parts[1] === undefined) {
+    return null;
+  }
+
+  if (parts.length === 2) {
+    return `/spaces/${parts[1]}`;
+  }
+
+  if (parts[2] === 'photos') {
+    return `/spaces/${parts[1]}/photos`;
+  }
+
+  return null;
+}
+
+export function getSearchablePageState(url: URL): SearchablePageState {
+  const basePath = getSearchablePageBasePath(url.pathname);
+  if (!basePath) {
+    return {
+      basePath: null,
+      isSearchable: false,
+      query: '',
+      sortOrder: 'desc',
+    };
+  }
+
+  const query = (url.searchParams.get('q') ?? '').trim();
+  return {
+    basePath,
+    isSearchable: true,
+    query,
+    sortOrder: getSortOrder(query, url.searchParams.get('sort')),
+  };
+}
+
+export function buildSearchablePageUrl(
+  url: URL,
+  query: string,
+  sortOrder: SearchablePageSortOrder = 'relevance',
+): string | null {
+  const basePath = getSearchablePageBasePath(url.pathname);
+  if (!basePath) {
+    return null;
+  }
+
+  const trimmedQuery = query.trim();
+  const params = new URLSearchParams(url.searchParams);
+
+  if (!trimmedQuery) {
+    params.delete('q');
+    params.delete('sort');
+  } else {
+    params.set('q', trimmedQuery);
+    if (sortOrder === 'relevance') {
+      params.delete('sort');
+    } else {
+      params.set('sort', sortOrder);
+    }
+  }
+
+  const search = params.toString();
+  return basePath + (search ? `?${search}` : '');
+}

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -4,14 +4,18 @@ type SearchablePageState = {
   basePath: string | null;
   isSearchable: boolean;
   query: string;
+  hasExplicitSort: boolean;
   sortOrder: SearchablePageSortOrder;
 };
 
 function getSortOrder(query: string, rawSort: string | null): SearchablePageSortOrder {
+  if (rawSort === 'asc' || rawSort === 'desc') {
+    return rawSort;
+  }
   if (query.length === 0) {
     return 'desc';
   }
-  return rawSort === 'asc' || rawSort === 'desc' ? rawSort : 'relevance';
+  return 'relevance';
 }
 
 export function getSearchablePageBasePath(pathname: string): string | null {
@@ -42,16 +46,19 @@ export function getSearchablePageState(url: URL): SearchablePageState {
       basePath: null,
       isSearchable: false,
       query: '',
+      hasExplicitSort: false,
       sortOrder: 'desc',
     };
   }
 
   const query = (url.searchParams.get('q') ?? '').trim();
+  const rawSort = url.searchParams.get('sort');
   return {
     basePath,
     isSearchable: true,
     query,
-    sortOrder: getSortOrder(query, url.searchParams.get('sort')),
+    hasExplicitSort: rawSort === 'asc' || rawSort === 'desc',
+    sortOrder: getSortOrder(query, rawSort),
   };
 }
 
@@ -70,7 +77,11 @@ export function buildSearchablePageUrl(
 
   if (!trimmedQuery) {
     params.delete('q');
-    params.delete('sort');
+    if (sortOrder === 'asc' || sortOrder === 'desc') {
+      params.set('sort', sortOrder);
+    } else {
+      params.delete('sort');
+    }
   } else {
     params.set('q', trimmedQuery);
     if (sortOrder === 'relevance') {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -274,9 +274,9 @@
           </div>
         </div>
       {/if}
-      <div class="flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
+      <div class="relative flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
         {#if hasActiveFilters}
-          <div class="absolute top-0 right-0 left-0 z-10 sm:left-[280px]">
+          <div class="absolute inset-x-0 top-0 z-10">
             <ActiveFiltersBar
               {filters}
               resultCount={mapMarkers.length}

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -168,4 +168,20 @@ describe('Map page query intersection', () => {
       noScroll: true,
     });
   });
+
+  it('anchors the active filters bar to the map content column instead of a hard-coded desktop offset', () => {
+    mockPage.url = new URL('https://gallery.test/map?q=beach');
+
+    renderPage();
+
+    const activeFiltersBar = screen.getByTestId('active-filters-bar');
+    const overlay = activeFiltersBar.parentElement as HTMLElement | null;
+    const contentColumn = overlay?.parentElement as HTMLElement | null;
+
+    expect(overlay).not.toBeNull();
+    expect(overlay?.className).toContain('absolute');
+    expect(overlay?.className).toContain('inset-x-0');
+    expect(overlay?.className).not.toContain('sm:left-[280px]');
+    expect(contentColumn?.className).toContain('relative');
+  });
 });

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -4,7 +4,6 @@
   import ActionMenuItem from '$lib/components/ActionMenuItem.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
-  import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
   import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
   import {
     buildFilterContext,
@@ -15,7 +14,6 @@
     type FilterState,
   } from '$lib/components/filter-panel/filter-panel';
   import UserPageLayout from '$lib/components/layouts/user-page-layout.svelte';
-  import SearchBar from '$lib/elements/SearchBar.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
   import EmptyPlaceholder from '$lib/components/shared-components/empty-placeholder.svelte';
   import ArchiveAction from '$lib/components/timeline/actions/ArchiveAction.svelte';
@@ -43,6 +41,7 @@
   import { Route } from '$lib/route';
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { createUrl, getAssetMediaUrl, memoryLaneTitle } from '$lib/utils';
+  import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
   import {
     updateStackedAssetInTimeline,
     updateUnstackedAssetInTimeline,
@@ -62,23 +61,14 @@
 
   let timelineManager = $state<TimelineManager>() as TimelineManager;
 
-  function getSearchSortOrder(query: string): FilterState['sortOrder'] {
-    return query.trim().length > 0 ? 'relevance' : 'desc';
-  }
-
   // Filter state
-  const initialCommittedQuery = page.url.searchParams.get('q') ?? '';
+  const initialSearchState = getSearchablePageState(page.url);
   let filters = $state<FilterState>({
     ...createFilterState(),
-    sortOrder: getSearchSortOrder(initialCommittedQuery),
+    sortOrder: initialSearchState.sortOrder,
   });
-  // searchQuery is the live SearchBar input value — it updates on every keystroke so the
-  // input reflects what the user is typing. committedQuery is the "applied" query and only
-  // updates on explicit submit (Enter), on clearSearch, or from URL state changes. We key
-  // showSearchResults off committedQuery so typing characters doesn't unmount the Timeline
-  // until the user explicitly submits. This mirrors the spaces page UX.
-  let searchQuery = $state(initialCommittedQuery);
-  let committedQuery = $state(searchQuery);
+  let committedQuery = $state(initialSearchState.query);
+  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}`);
   let isLoading = $state(false);
   const showSearchResults = $derived(committedQuery.trim().length > 0);
   const options = $derived(buildPhotosTimelineOptions(filters));
@@ -188,34 +178,28 @@
     assetMultiSelectManager.clear();
   };
 
-  function handleSearchSubmit() {
-    const trimmed = searchQuery.trim();
-    if (!trimmed) {
+  function clearSearch() {
+    isLoading = false;
+    const nextUrl = buildSearchablePageUrl(page.url, '');
+    if (!nextUrl) {
       return;
     }
-    filters = { ...filters, sortOrder: getSearchSortOrder(trimmed) };
-    committedQuery = trimmed;
-    const url = new URL('/photos', globalThis.location.origin);
-    url.searchParams.set('q', trimmed);
-    void goto(url.pathname + url.search, { keepFocus: true, noScroll: true });
-  }
-
-  function clearSearch() {
-    searchQuery = '';
-    committedQuery = '';
-    isLoading = false;
-    filters = { ...filters, sortOrder: 'desc' };
-    void goto('/photos', { replaceState: true, keepFocus: true, noScroll: true });
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
   }
 
   $effect(() => {
-    const q = page.url.searchParams.get('q') ?? '';
+    const nextSearchState = getSearchablePageState(page.url);
+    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}`;
+
+    if (nextToken === lastHandledSearchState) {
+      return;
+    }
+
     untrack(() => {
-      if (q !== committedQuery) {
-        committedQuery = q;
-        searchQuery = q;
-        filters = { ...filters, sortOrder: getSearchSortOrder(q) };
-      }
+      committedQuery = nextSearchState.query;
+      isLoading = false;
+      filters = { ...filters, sortOrder: nextSearchState.sortOrder };
+      lastHandledSearchState = nextToken;
     });
   });
 
@@ -231,32 +215,6 @@
 </script>
 
 <UserPageLayout hideNavbar={assetMultiSelectManager.selectionActive} scrollbar={false}>
-  {#snippet buttons()}
-    <div class="flex items-center gap-1 max-sm:flex-1 max-sm:min-w-0">
-      <div class="h-10 w-full sm:w-40 xl:w-60">
-        <SearchBar
-          placeholder={$t('search')}
-          bind:name={searchQuery}
-          showLoadingSpinner={isLoading}
-          onSearch={({ force }) => {
-            if (force) {
-              handleSearchSubmit();
-            }
-          }}
-          onReset={clearSearch}
-        />
-      </div>
-      {#if showSearchResults}
-        <SearchSortDropdown
-          sortOrder={filters.sortOrder}
-          onSelect={(mode) => {
-            filters = { ...filters, sortOrder: mode };
-          }}
-        />
-      {/if}
-    </div>
-  {/snippet}
-
   <div class="flex h-full">
     <FilterPanel
       bind:filters

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -47,18 +47,8 @@ vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
   return { default: MockComponent };
 });
 
-vi.mock('$lib/components/filter-panel/search-sort-dropdown.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/search-sort-dropdown.stub.svelte');
-  return { default: MockComponent };
-});
-
 vi.mock('$lib/components/search/smart-search-results.svelte', async () => {
   const { default: MockComponent } = await import('@test-data/mocks/smart-search-results.stub.svelte');
-  return { default: MockComponent };
-});
-
-vi.mock('$lib/elements/SearchBar.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
   return { default: MockComponent };
 });
 
@@ -219,7 +209,7 @@ function renderPage() {
   });
 }
 
-describe('Photos page search URL sync', () => {
+describe('Photos page search URL state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPage.url = new URL('https://gallery.test/photos?q=nature');
@@ -228,11 +218,22 @@ describe('Photos page search URL sync', () => {
     mockMemoryManager.memories = [];
   });
 
-  it('hydrates q from the URL and switches search results to relevance sorting', () => {
+  it('renders search results from q without a local search input', () => {
     renderPage();
 
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'nature');
-    expect(screen.getByTestId('search-sort-dropdown')).toHaveAttribute('data-sort-order', 'relevance');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'relevance');
     expect(screen.queryByTestId('timeline-stub')).not.toBeInTheDocument();
+  });
+
+  it('hydrates an explicit search sort from the URL', () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=nature&sort=asc');
+
+    renderPage();
+
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'nature');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
   });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -3,7 +3,6 @@
   import { page } from '$app/state';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
-  import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
   import SortToggle from '$lib/components/filter-panel/sort-toggle.svelte';
   import {
     buildFilterContext,
@@ -28,7 +27,6 @@
   import SpacePanel from '$lib/components/spaces/space-panel.svelte';
   import SpacePeopleStrip from '$lib/components/spaces/space-people-strip.svelte';
   import SpaceLinkedLibrariesModal from '$lib/modals/SpaceLinkedLibrariesModal.svelte';
-  import SearchBar from '$lib/elements/SearchBar.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import ArchiveAction from '$lib/components/timeline/actions/ArchiveAction.svelte';
   import ChangeDate from '$lib/components/timeline/actions/ChangeDateAction.svelte';
@@ -49,6 +47,7 @@
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { createUrl } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
+  import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
   import { loadHeroCollapsed, persistHeroCollapsed } from '$lib/utils/space-hero-storage';
   import {
     addAssets,
@@ -93,7 +92,7 @@
   } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import { untrack } from 'svelte';
-  import { SvelteMap, SvelteURLSearchParams } from 'svelte/reactivity';
+  import { SvelteMap } from 'svelte/reactivity';
   import type { PageData } from './$types';
 
   type ViewMode = 'view' | 'select-assets' | 'select-cover';
@@ -110,20 +109,17 @@
     () => space,
     () => members,
   );
-
-  function getSearchSortOrder(query: string): FilterState['sortOrder'] {
-    return query.trim().length > 0 ? 'relevance' : 'desc';
-  }
+  const initialSearchState = getSearchablePageState(page.url);
 
   // Sync when navigating between spaces (component persists, data updates)
   $effect(() => {
     if (data.space.id !== space.id) {
-      const nextCommittedSearchQuery = page.url.searchParams.get('q') ?? '';
+      const nextSearchState = getSearchablePageState(page.url);
       space = data.space;
       members = data.members;
       filters = {
         ...createFilterState(),
-        sortOrder: getSearchSortOrder(nextCommittedSearchQuery),
+        sortOrder: nextSearchState.sortOrder,
       };
       activities = [];
       hasMoreActivities = false;
@@ -132,9 +128,8 @@
       personNames.clear();
       tagNames.clear();
       isLoading = false;
-      draftSearchQuery = nextCommittedSearchQuery;
-      lastHydratedSearchQuery = nextCommittedSearchQuery;
-      lastHandledCommittedSearchQuery = nextCommittedSearchQuery;
+      committedSearchQuery = nextSearchState.query;
+      lastHandledSearchState = `${nextSearchState.query}:${nextSearchState.sortOrder}`;
       heroCollapsed = loadHeroCollapsed(data.space.id);
       panelOpen = false;
       viewMode = 'view';
@@ -158,10 +153,9 @@
   let timelineManager = $state<TimelineManager>() as TimelineManager;
 
   // Filter state
-  const initialCommittedSearchQuery = page.url.searchParams.get('q') ?? '';
   let filters = $state<FilterState>({
     ...createFilterState(),
-    sortOrder: getSearchSortOrder(initialCommittedSearchQuery),
+    sortOrder: initialSearchState.sortOrder,
   });
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
@@ -591,91 +585,39 @@
     await Promise.all([refreshSpace(), loadActivities()]);
   };
 
-  const committedSearchQuery = $derived(page.url.searchParams.get('q') ?? '');
-  let draftSearchQuery = $state(initialCommittedSearchQuery);
-  let lastHydratedSearchQuery = $state(initialCommittedSearchQuery);
-  let lastHandledCommittedSearchQuery = $state(initialCommittedSearchQuery);
+  let committedSearchQuery = $state(initialSearchState.query);
+  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}`);
   let isLoading = $state(false);
   const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
 
-  const getSearchPathname = (pathname: string) => {
-    const spaceBasePath = `/spaces/${space.id}`;
-    const photosPath = `${spaceBasePath}/photos`;
-
-    if (pathname === spaceBasePath || pathname === photosPath) {
-      return pathname;
-    }
-
-    if (pathname.startsWith(`${photosPath}/`)) {
-      return photosPath;
-    }
-
-    return pathname;
-  };
-
-  const commitSearch = async (nextQuery = draftSearchQuery) => {
-    const trimmed = nextQuery.trim();
-    const pathname = getSearchPathname(page.url.pathname);
-    const searchParams = new SvelteURLSearchParams(page.url.searchParams);
-
-    if (trimmed) {
-      searchParams.set('q', trimmed);
-    } else {
-      searchParams.delete('q');
-    }
-
-    draftSearchQuery = trimmed;
-
-    const search = searchParams.toString();
-    const nextUrl = pathname + (search ? `?${search}` : '');
-
-    if (nextUrl === page.url.pathname + page.url.search) {
+  const clearSearch = () => {
+    isLoading = false;
+    const nextUrl = buildSearchablePageUrl(page.url, '');
+    if (!nextUrl) {
       return;
     }
-
-    await goto(nextUrl, {
+    void goto(nextUrl, {
       replaceState: true,
       keepFocus: true,
       noScroll: true,
     });
   };
 
-  const handleSearchSubmit = () => {
-    void commitSearch();
-  };
-
-  const clearSearch = () => {
-    isLoading = false;
-    void commitSearch('');
-  };
-
   $effect(() => {
-    const nextCommittedSearchQuery = committedSearchQuery;
-
-    if (nextCommittedSearchQuery === lastHydratedSearchQuery) {
+    const nextSearchState = getSearchablePageState(page.url);
+    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}`;
+    if (nextToken === lastHandledSearchState) {
       return;
     }
 
     untrack(() => {
-      draftSearchQuery = nextCommittedSearchQuery;
-      lastHydratedSearchQuery = nextCommittedSearchQuery;
-    });
-  });
-
-  $effect(() => {
-    const nextCommittedSearchQuery = committedSearchQuery;
-
-    if (nextCommittedSearchQuery === lastHandledCommittedSearchQuery) {
-      return;
-    }
-
-    untrack(() => {
+      committedSearchQuery = nextSearchState.query;
       isLoading = false;
       filters = {
         ...filters,
-        sortOrder: getSearchSortOrder(nextCommittedSearchQuery),
+        sortOrder: nextSearchState.sortOrder,
       };
-      lastHandledCommittedSearchQuery = nextCommittedSearchQuery;
+      lastHandledSearchState = nextToken;
     });
   });
 
@@ -727,31 +669,7 @@
   {#snippet buttons()}
     {#if viewMode === 'view' && !assetMultiSelectManager.selectionActive}
       <div class="flex items-center gap-1">
-        {#if (space.assetCount ?? 0) > 0}
-          <div class="hidden h-10 sm:block sm:w-40 xl:w-60">
-            <SearchBar
-              placeholder={$t('search')}
-              bind:name={draftSearchQuery}
-              showLoadingSpinner={isLoading}
-              onSearch={({ force }) => {
-                if (force) {
-                  handleSearchSubmit();
-                }
-              }}
-              onBlurSearch={handleSearchSubmit}
-              onReset={clearSearch}
-            />
-          </div>
-        {/if}
-
-        {#if showSearchResults}
-          <SearchSortDropdown
-            sortOrder={filters.sortOrder}
-            onSelect={(mode) => {
-              filters = { ...filters, sortOrder: mode };
-            }}
-          />
-        {:else}
+        {#if !showSearchResults}
           <SortToggle
             sortOrder={filters.sortOrder === 'relevance' ? 'desc' : filters.sortOrder}
             onToggle={(order) => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -3,7 +3,6 @@
   import { page } from '$app/state';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
-  import SortToggle from '$lib/components/filter-panel/sort-toggle.svelte';
   import {
     buildFilterContext,
     createFilterState,
@@ -669,15 +668,6 @@
   {#snippet buttons()}
     {#if viewMode === 'view' && !assetMultiSelectManager.selectionActive}
       <div class="flex items-center gap-1">
-        {#if !showSearchResults}
-          <SortToggle
-            sortOrder={filters.sortOrder === 'relevance' ? 'desc' : filters.sortOrder}
-            onToggle={(order) => {
-              filters = { ...filters, sortOrder: order };
-            }}
-          />
-        {/if}
-
         {#if isEditor}
           <IconButton
             variant="ghost"

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -3,7 +3,7 @@ import TestWrapper from '$lib/components/TestWrapper.svelte';
 import type { SharedSpaceMemberResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
 import { SharedSpaceRole } from '@immich/sdk';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import SpacesPage from './+page.svelte';
 
@@ -151,7 +151,7 @@ function renderPage() {
   });
 }
 
-describe('Spaces page search URL sync', () => {
+describe('Spaces page search URL state', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     gotoMock.mockResolvedValue(undefined);
@@ -163,80 +163,23 @@ describe('Spaces page search URL sync', () => {
     sdkMock.getSpacePeople.mockResolvedValue([]);
   });
 
-  it('hydrates the in-page search input from q', () => {
+  it('renders search results from q without a local search input', () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
 
     renderPage();
 
-    expect(screen.getByPlaceholderText(/search/i)).toHaveValue('beach');
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'relevance');
   });
 
-  it('commits a trimmed query on Enter and preserves other params', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?view=grid');
+  it('hydrates an explicit search sort from the URL', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&sort=asc');
 
     renderPage();
 
-    const input = screen.getByPlaceholderText(/search/i);
-    await fireEvent.input(input, { target: { value: '  beach  ' } });
-    await fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach', {
-      replaceState: true,
-      keepFocus: true,
-      noScroll: true,
-    });
-  });
-
-  it('drops a stale asset id when committing a search', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos/asset-123?view=grid');
-
-    renderPage();
-
-    const input = screen.getByPlaceholderText(/search/i);
-    await fireEvent.input(input, { target: { value: 'beach' } });
-    await fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach', {
-      replaceState: true,
-      keepFocus: true,
-      noScroll: true,
-    });
-  });
-
-  it('commits the draft query on blur', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
-
-    renderPage();
-
-    const input = screen.getByPlaceholderText(/search/i);
-    const outsideButton = document.createElement('button');
-    document.body.append(outsideButton);
-
-    await fireEvent.input(input, { target: { value: 'beach' } });
-    await fireEvent.blur(input, { relatedTarget: outsideButton });
-
-    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?q=beach', {
-      replaceState: true,
-      keepFocus: true,
-      noScroll: true,
-    });
-
-    outsideButton.remove();
-  });
-
-  it('clears q while preserving unrelated params', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&view=grid');
-
-    renderPage();
-
-    await fireEvent.click(screen.getByRole('button', { name: /clear/i }));
-
-    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid', {
-      replaceState: true,
-      keepFocus: true,
-      noScroll: true,
-    });
-    expect(screen.getByPlaceholderText(/search/i)).toHaveValue('');
+    expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
   });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -59,7 +59,7 @@ vi.mock('$lib/components/filter-panel/search-sort-dropdown.svelte', async () => 
 });
 
 vi.mock('$lib/components/filter-panel/sort-toggle.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/sort-toggle.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -169,6 +169,7 @@ describe('Spaces page search URL state', () => {
     renderPage();
 
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sort-toggle')).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'relevance');
   });
@@ -179,6 +180,7 @@ describe('Spaces page search URL state', () => {
     renderPage();
 
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sort-toggle')).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
   });

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+  import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+
   interface Props {
     isLoading?: boolean;
     searchQuery?: string;
+    filters?: FilterState;
     [key: string]: unknown;
   }
 
-  let { isLoading = $bindable(false), searchQuery = '', ...rest }: Props = $props();
+  let { isLoading = $bindable(false), searchQuery = '', filters, ...rest }: Props = $props();
 </script>
 
 <div
@@ -13,4 +16,5 @@
   data-testid="smart-search-results"
   data-loading={String(isLoading)}
   data-search-query={searchQuery}
+  data-sort-order={filters?.sortOrder ?? ''}
 ></div>

--- a/web/src/test-data/mocks/sort-toggle.stub.svelte
+++ b/web/src/test-data/mocks/sort-toggle.stub.svelte
@@ -1,0 +1,1 @@
+<div data-testid="sort-toggle"></div>


### PR DESCRIPTION
## Summary
- remove the local search bars from `/photos` and space detail pages, and drive their search state from shared `q`/`sort` URL helpers
- move the search sort control into the top navbar cmd+k trigger, keep it available on searchable pages, and default fresh searches back to relevance
- fix follow-up cmd+k navigation state issues and align the map active-filters overlay with the actual content column

## Testing
- `cd web && pnpm vitest run 'src/lib/components/filter-panel/__tests__/search-sort-dropdown.spec.ts' 'src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts' 'src/lib/components/global-search/__tests__/global-search.spec.ts' 'src/lib/components/layouts/top-search-label.spec.ts' 'src/lib/managers/global-search-manager.svelte.spec.ts' 'src/lib/managers/close-palette-on-navigate.spec.ts' 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts' 'src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts'`
