### PR TITLE
ci: enable Play Store mobile uploads

### DIFF
--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -2,10 +2,9 @@ name: Gallery Build Mobile
 
 # For production releases, trigger via gallery-release-mobile.yml.
 # Manual workflow_dispatch with a non-empty version input here will
-# upload to TestFlight (and Play Store once that fastlane block is
-# re-enabled) WITHOUT creating a release draft, which breaks the
-# phase-1 → phase-2 handoff. Use only for ad-hoc smoke builds (leave
-# version empty).
+# upload to stores WITHOUT creating a release draft, which breaks the
+# phase-1 → phase-2 handoff. Use build_target=android only for a
+# Play-only dry run; otherwise leave version empty for smoke builds.
 
 on:
   workflow_dispatch:
@@ -23,6 +22,15 @@ on:
         required: false
         type: string
         default: ''
+      build_target:
+        description: 'Mobile platform(s) to build. Use android for a Play-only dry run.'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - android
+          - ios
   workflow_call:
     inputs:
       ref:
@@ -38,6 +46,11 @@ on:
         required: false
         type: string
         default: ''
+      build_target:
+        description: 'Mobile platform(s) to build.'
+        required: false
+        type: string
+        default: 'both'
     secrets:
       KEY_JKS:
         required: true
@@ -86,7 +99,7 @@ jobs:
     permissions:
       contents: read
     # Skip when PR from a fork
-    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && (inputs.build_target == '' || inputs.build_target == 'both' || inputs.build_target == 'android') }}
     environment: mobile-build
     runs-on: ubuntu-latest
 
@@ -210,34 +223,30 @@ jobs:
           path: mobile/build/app/outputs/flutter-apk/gallery-${{ inputs.version }}.apk
           if-no-files-found: error
 
-      # Play Store upload temporarily disabled while the app is in review —
-      # new internal-track builds can't be pushed until Google finishes review.
-      # The AAB artifact is still produced above and the APK is attached to the
-      # GitHub Release, so sideload users remain unblocked.
-      # - name: Setup Ruby
-      #   if: inputs.version != ''
-      #   uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
-      #   with:
-      #     ruby-version: '3.3'
-      #     bundler-cache: true
-      #     working-directory: ./mobile/android/gallery-release
-      #
-      # - name: Write Play Store service account key
-      #   if: inputs.version != ''
-      #   working-directory: ./mobile/android/gallery-release
-      #   env:
-      #     PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
-      #   run: printf '%s' "$PLAY_STORE_JSON_KEY" > fastlane/play-store-key.json
-      #
-      # - name: Upload to Play Store internal track
-      #   if: inputs.version != ''
-      #   working-directory: ./mobile/android/gallery-release
-      #   run: bundle exec fastlane android internal
-      #
-      # - name: Remove Play Store service account key
-      #   if: always()
-      #   working-directory: ./mobile/android/gallery-release
-      #   run: rm -f fastlane/play-store-key.json
+      - name: Setup Ruby
+        if: inputs.version != ''
+        uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ./mobile/android/gallery-release
+
+      - name: Write Play Store service account key
+        if: inputs.version != ''
+        working-directory: ./mobile/android/gallery-release
+        env:
+          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
+        run: printf '%s' "$PLAY_STORE_JSON_KEY" > fastlane/play-store-key.json
+
+      - name: Upload to Play Store internal track
+        if: inputs.version != ''
+        working-directory: ./mobile/android/gallery-release
+        run: bundle exec fastlane android internal
+
+      - name: Remove Play Store service account key
+        if: always()
+        working-directory: ./mobile/android/gallery-release
+        run: rm -f fastlane/play-store-key.json
 
       - name: Save Gradle Cache
         id: cache-gradle-save
@@ -256,7 +265,7 @@ jobs:
     name: Build and sign iOS
     permissions:
       contents: read
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork && (inputs.build_target == '' || inputs.build_target == 'both' || inputs.build_target == 'ios') }}
     environment: mobile-build
     runs-on: macos-15
 

--- a/.github/workflows/gallery-release-mobile.yml
+++ b/.github/workflows/gallery-release-mobile.yml
@@ -1,14 +1,11 @@
 name: Release Mobile P1
 
-# Phase 1 of the split release cycle. Builds mobile, uploads iOS IPA to
-# TestFlight, and publishes the Android AAB as a workflow artifact for
-# manual upload to Play Console. (Fastlane Play upload is temporarily
-# disabled while the app is in Google review — re-enable in
-# gallery-build-mobile.yml when review clears.) Creates a draft GitHub
-# Release that pins the version (tag name), commit SHA (target_commitish),
-# and APK (asset). The maintainer uploads the AAB to Play internal, promotes
-# to production, submits App Store for review. Once both are live, trigger
-# gallery-release.yml to build the server and promote the draft. See
+# Phase 1 of the split release cycle. Builds mobile, uploads Android AAB to
+# Play Store internal, uploads iOS IPA to TestFlight, and keeps the AAB as a
+# workflow artifact. Creates a draft GitHub Release that pins the version (tag
+# name), commit SHA (target_commitish), and APK (asset). The maintainer
+# promotes the Play internal build to production, submits App Store for review,
+# then triggers gallery-release.yml once both stores are live. See
 # docs/plans/2026-04-17-split-mobile-server-release-design.md.
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,11 @@ Gallery uses a **two-phase release flow** so mobile app builds are already live 
 ### Release Mobile P1 (`.github/workflows/gallery-release-mobile.yml`)
 
 1. Maintainer triggers the workflow from the Actions tab. Version is computed automatically from commits since the last tag (rules below), or passed explicitly via input.
-2. The mobile app is built and signed. iOS IPA uploads to TestFlight. Android AAB is attached as a workflow artifact and the APK is attached to the draft release for sideload; Play Store upload is currently disabled while the app is in Google review and will be re-enabled once review completes.
+2. The mobile app is built and signed. Android AAB uploads to the Play Store internal track, iOS IPA uploads to TestFlight, the AAB is attached as a workflow artifact, and the APK is attached to the draft release for sideload.
 3. A **draft** GitHub Release is created pinning the version (tag name), commit SHA (`target_commitish`), and APK (asset). The draft is invisible to end users.
-4. The maintainer manually promotes the Play internal build (once Play uploads are re-enabled — currently the AAB must be uploaded by hand) to **production** in Play Console and submits the App Store for review. Once both stores show the new version live to end users, proceed to phase 2. Typically ~24h.
+4. The maintainer manually promotes the Play internal build to **production** in Play Console and submits the App Store build for review. Once both stores show the new version live to end users, proceed to phase 2. Typically ~24h.
+
+To test the Play Store upload without creating a release draft or uploading to TestFlight, manually run `Gallery Build Mobile` with `environment=production`, a throwaway `version`, and `build_target=android`. This uploads a real Play internal-track build and consumes that Android `versionCode`, but does not publish server images or create a draft release.
 
 ### Release Gallery P2 (`.github/workflows/gallery-release.yml`)
 

--- a/docs/plans/2026-04-17-split-mobile-server-release-design.md
+++ b/docs/plans/2026-04-17-split-mobile-server-release-design.md
@@ -41,12 +41,12 @@ Steps:
 
 1. **Dupe guard** — fail if any draft GitHub Release exists where the tag matches `v*.*.*` AND has at least one `.apk` asset attached. This is the same composite predicate phase 2 uses for discovery, so what passes the guard is exactly what phase 2 will find. Filter is intentionally narrow: an unrelated manual draft (docs preview, etc.) does not block.
 2. **Compute version** — same logic as today's `gallery-release.yml` version job, lifted verbatim. Honors manual override.
-3. **Call `gallery-build-mobile.yml`** with `environment: production` and `version: vX.Y.Z`. Builds + signs Android AAB / APK and iOS IPA, uploads IPA to TestFlight. Play Store upload is currently disabled (app is in Google review); the AAB is published as a workflow artifact for manual upload. When Play uploads are re-enabled the fastlane step goes back in. Produces `gallery-vX.Y.Z.apk` artifact.
+3. **Call `gallery-build-mobile.yml`** with `environment: production` and `version: vX.Y.Z`. Builds + signs Android AAB / APK and iOS IPA, uploads the AAB to the Play Store internal track, uploads the IPA to TestFlight, and keeps the AAB as a workflow artifact. Produces `gallery-vX.Y.Z.apk` artifact.
 4. **Create draft GitHub Release** — `gh release create vX.Y.Z --draft --target <sha> --title vX.Y.Z -n "<notes>" ./gallery-vX.Y.Z.apk`. The git tag is **not** created here; `gh` creates it lazily when the draft is published.
 
 ### Manual step between phases (no workflow)
 
-Maintainer uploads the AAB artifact from phase 1 to Play Store **internal** track (manual while fastlane is disabled; fully automated once re-enabled), promotes to **production** in Play Console, submits App Store for review. Once both stores are live to end users, trigger phase 2.
+Maintainer promotes the Play Store internal build to **production** in Play Console and submits App Store for review. Once both stores are live to end users, trigger phase 2.
 
 ### `gallery-release.yml` (phase 2 — modified)
 
@@ -64,7 +64,7 @@ Steps:
 
 ### `gallery-build-mobile.yml` (modified)
 
-- Leave the Play Store fastlane block commented out until the app clears Google review. When it's ready, uncomment and keep the `inputs.version != ''` gate so PR / push-to-main smoke builds remain upload-free.
+- Play Store fastlane upload is enabled and kept behind the `inputs.version != ''` gate so PR / push-to-main smoke builds remain upload-free.
 - No workflow signature change.
 - Add a header comment: _"For production releases, trigger via `gallery-release-mobile.yml`. Manual `workflow_dispatch` with a `version` input bypasses the phase-1 handoff and uploads to Play / TestFlight without creating a release draft."_
 


### PR DESCRIPTION
## Summary
- enable the Play Store fastlane upload steps in the reusable mobile build workflow
- keep Play Store upload gated to versioned release builds only
- add `build_target` so manual dispatch can run an Android-only Play upload without TestFlight or draft release creation
- update release workflow comments and maintainer docs now that Google review has cleared

## Play-only dry run
After this PR is merged, run the reusable mobile workflow directly with a throwaway version and Android target:

```bash
gh workflow run gallery-build-mobile.yml \
  --ref main \
  -f environment=production \
  -f version=v4.999.0 \
  -f build_target=android
```

This uploads a real AAB to the Play Store internal track and consumes its Android versionCode. It does not create a draft release, publish server/ML images, or upload to TestFlight.

## Verification
- `yq '.' .github/workflows/gallery-build-mobile.yml >/dev/null && yq '.' .github/workflows/gallery-release-mobile.yml >/dev/null`\n- `ruby -e 'require "psych"; ARGV.each { |f| Psych.load_file(f) }; puts "yaml ok"' .github/workflows/gallery-build-mobile.yml .github/workflows/gallery-release-mobile.yml`\n- `ruby -c mobile/android/gallery-release/fastlane/Fastfile && ruby -c mobile/android/gallery-release/Gemfile && ruby -c mobile/android/gallery-release/fastlane/Appfile`\n- `git diff --check`