### PR TITLE
fix(web): constrain memory carousel titles

### DIFF
--- a/patches/@immich__ui@0.76.2.patch
+++ b/patches/@immich__ui@0.76.2.patch
@@ -21,3 +21,16 @@ index e649c9c881ff65eb857d14e86f649faed15fe574..a439e0f213231f3c60da9aaf94d4b64a
              on(document.body, 'keydown', (event) => this.#handleKeydown(event));
          }
      }
+diff --git a/dist/components/ImageCarousel/ImageCarousel.svelte b/dist/components/ImageCarousel/ImageCarousel.svelte
+index d0f8cf2a6b4d8ebfcf81ad9bb6744f7c6dd77c45..846ad79556d274e6f646b8841a085f071be13a65 100644
+--- a/dist/components/ImageCarousel/ImageCarousel.svelte
++++ b/dist/components/ImageCarousel/ImageCarousel.svelte
+@@ -39,7 +39,7 @@
+     <div
+       class="absolute start-0 top-0 h-full w-full rounded-xl bg-linear-to-t from-black/40 via-transparent to-transparent transition-all hover:bg-black/20"
+     ></div>
+-    <p class="absolute start-4 bottom-2 text-lg text-white max-md:text-sm">
++    <p class="absolute start-4 bottom-2 w-[calc(100%-2rem)] whitespace-normal text-lg text-white max-md:text-sm">
+       {item.title}
+     </p>
+   </a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ pnpmfileChecksum: sha256-un98do36L0wZyqsjcLozQ3YUadCAn2yz5bXcBbOuyDA=
 
 patchedDependencies:
   '@immich/ui@0.76.2':
-    hash: e24ac47496b797e07df2b49ec20e1e2139c1e7a20eab5ede1ecc5da6d551372c
+    hash: 06872e47079b66b4ad073f5aeaa2258a7efeade20eb3e32de1ca43966d8aed5e
     path: patches/@immich__ui@0.76.2.patch
 
 importers:
@@ -750,7 +750,7 @@ importers:
         version: link:../open-api/typescript-sdk
       '@immich/ui':
         specifier: ^0.76.0
-        version: 0.76.2(patch_hash=e24ac47496b797e07df2b49ec20e1e2139c1e7a20eab5ede1ecc5da6d551372c)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1(@typescript-eslint/types@8.58.2))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))(typescript@6.0.3)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))
+        version: 0.76.2(patch_hash=06872e47079b66b4ad073f5aeaa2258a7efeade20eb3e32de1ca43966d8aed5e)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1(@typescript-eslint/types@8.58.2))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))(typescript@6.0.3)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))
       '@mapbox/mapbox-gl-rtl-text':
         specifier: 0.3.0
         version: 0.3.0
@@ -16222,7 +16222,7 @@ snapshots:
       node-emoji: 2.2.0
       svelte: 5.55.1(@typescript-eslint/types@8.58.2)
 
-  '@immich/ui@0.76.2(patch_hash=e24ac47496b797e07df2b49ec20e1e2139c1e7a20eab5ede1ecc5da6d551372c)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1(@typescript-eslint/types@8.58.2))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))(typescript@6.0.3)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))':
+  '@immich/ui@0.76.2(patch_hash=06872e47079b66b4ad073f5aeaa2258a7efeade20eb3e32de1ca43966d8aed5e)(@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1(@typescript-eslint/types@8.58.2))(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))(typescript@6.0.3)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.1(@typescript-eslint/types@8.58.2))':
     dependencies:
       '@immich/svelte-markdown-preprocess': 0.4.1(svelte@5.55.1(@typescript-eslint/types@8.58.2))
       '@internationalized/date': 3.12.1

--- a/web/src/lib/components/image-carousel.spec.ts
+++ b/web/src/lib/components/image-carousel.spec.ts
@@ -1,0 +1,24 @@
+import { ImageCarousel } from '@immich/ui';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+
+describe('ImageCarousel', () => {
+  it('constrains long card titles inside the card', () => {
+    render(ImageCarousel, {
+      items: [
+        {
+          id: 'memory-id',
+          title: 'Your recent trip to South Africa',
+          href: '/memory?id=asset-id',
+          src: '/thumbnail.jpg',
+          alt: 'Trip photo',
+        },
+      ],
+    });
+
+    expect(screen.getByText('Your recent trip to South Africa')).toHaveClass(
+      'w-[calc(100%-2rem)]',
+      'whitespace-normal',
+    );
+  });
+});

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -54,6 +54,7 @@ import { COMMAND_ITEMS, type CommandItem } from './command-items';
 import {
   GlobalSearchManager,
   RECONCILE_ORDER_BY_SCOPE,
+  type EntityItem,
   type Provider,
   type ProviderStatus,
   type SearchMode,
@@ -2682,9 +2683,9 @@ describe('SWR loading rules', () => {
           total: 1,
         } as ProviderStatus<EntityItem>);
       }
-      return new Promise(
-        (r) => (resolveRerun = () => r({ status: 'empty' } as ProviderStatus<EntityItem>)),
-      ) as Promise<ProviderStatus<EntityItem>>;
+      return new Promise((r) => (resolveRerun = () => r({ status: 'empty' } as ProviderStatus<EntityItem>))) as Promise<
+        ProviderStatus<EntityItem>
+      >;
     });
 
     try {


### PR DESCRIPTION
## Summary
- constrain ImageCarousel titles so mobile memory cards do not overflow
- add a focused regression test for long carousel titles

## Test plan
- pnpm --filter immich-web exec vitest run src/lib/components/image-carousel.spec.ts
- pnpm --filter immich-web exec prettier --check src/lib/components/image-carousel.spec.ts
- git diff --check