### PR TITLE
feat: add phase 1 prometheus metrics

### DIFF
--- a/.github/workflows/gallery-rc-build.yml
+++ b/.github/workflows/gallery-rc-build.yml
@@ -5,8 +5,8 @@ name: Release Candidate Build
 #   - does NOT create git tags (no VERSION, no vN, no `release`)
 #   - does NOT create a GitHub Release
 #   - does NOT publish to the version endpoint
-#   - does NOT touch ML at all — no ML build, no ML retag. Testers pin the server
-#     image via a compose override (see the workflow run summary for copy-paste YAML).
+#   - does NOT touch ML by default. If build_ml=true, it builds only the CPU ML image
+#     under the same RC tag. No ML release/latest/vN tags are moved.
 #
 # Dispatch it from the branch you want to build (or from any branch with `ref` set to
 # the target branch/tag/SHA).
@@ -22,6 +22,11 @@ on:
         description: 'Git ref (branch/tag/SHA) to build. Leave empty to use the ref this workflow was dispatched on.'
         required: false
         type: string
+      build_ml:
+        description: 'Also build the CPU machine-learning image under the same RC tag.'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.rc_tag }}
@@ -167,45 +172,174 @@ jobs:
           sources=$(printf "${IMAGE}@sha256:%s " *)
           docker buildx imagetools create -t "${IMAGE}:${RC_TAG}" ${sources}
 
+  build-ml:
+    name: Build ML (${{ matrix.platform }})
+    needs: validate
+    if: ${{ inputs.build_ml }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+          # Keep this aligned with the server RC build so apply-branding can stamp
+          # a valid semver into pyproject.toml without using the RC docker tag.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply branding
+        uses: ./.github/actions/apply-branding
+
+      - name: Prepare platform pair
+        id: prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "platform-pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: machine-learning
+          file: machine-learning/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            DEVICE=cpu
+            BUILD_ID=${{ github.run_id }}
+            BUILD_IMAGE=ghcr.io/open-noodle/gallery-ml
+            BUILD_SOURCE_REF=${{ github.ref_name }}
+            BUILD_SOURCE_COMMIT=${{ github.sha }}
+          outputs: type=image,"name=ghcr.io/open-noodle/gallery-ml",push-by-digest=true,name-resolution=short,push=true
+          cache-from: type=gha,scope=rc-ml-cpu-${{ steps.prepare.outputs.platform-pair }}
+          cache-to: type=gha,scope=rc-ml-cpu-${{ steps.prepare.outputs.platform-pair }},mode=max
+
+      - name: Export digest
+        run: | # zizmor: ignore[template-injection]
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: rc-ml-digests-${{ steps.prepare.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-ml:
+    name: Merge ML Manifest
+    needs: [validate, build-ml]
+    if: ${{ inputs.build_ml }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: rc-ml-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ghcr.io/open-noodle/gallery-ml
+          RC_TAG: ${{ inputs.rc_tag }}
+        run: |
+          sources=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create -t "${IMAGE}:${RC_TAG}" ${sources}
+
   summary:
     name: RC Ready
-    needs: merge-server
+    needs: [merge-server, merge-ml]
+    if: ${{ always() && needs.merge-server.result == 'success' && (!inputs.build_ml || needs.merge-ml.result == 'success') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Write summary
         env:
           RC_TAG: ${{ inputs.rc_tag }}
+          BUILD_ML: ${{ inputs.build_ml }}
         run: |
           {
             echo "## Release candidate ready"
             echo
             echo "**Tag:** \`${RC_TAG}\`"
             echo
-            echo "Only the server image was built. ML is untouched and continues to be pulled from its usual \`release\` tag."
+            if [[ "$BUILD_ML" == "true" ]]; then
+              echo "Server and CPU machine-learning images were built under this RC tag."
+            else
+              echo "Only the server image was built. ML is untouched and continues to be pulled from its usual \`release\` tag."
+            fi
             echo
             echo "### Tester instructions"
             echo
-            echo "In the directory containing your \`docker-compose.yml\`, create (or append to) a \`docker-compose.override.yml\` file so compose pins the server image to the RC while leaving everything else alone:"
+            echo "In the directory containing your \`docker-compose.yml\`, create (or append to) a \`docker-compose.override.yml\` file so compose pins the RC image tag:"
             echo
             echo '```yaml'
             echo "services:"
             echo "  immich-server:"
             echo "    image: ghcr.io/open-noodle/gallery-server:${RC_TAG}"
+            if [[ "$BUILD_ML" == "true" ]]; then
+              echo "  immich-machine-learning:"
+              echo "    image: ghcr.io/open-noodle/gallery-ml:${RC_TAG}"
+            fi
             echo '```'
             echo
             echo "Then:"
             echo
             echo '```bash'
-            echo "docker compose pull immich-server"
+            if [[ "$BUILD_ML" == "true" ]]; then
+              echo "docker compose pull immich-server immich-machine-learning"
+            else
+              echo "docker compose pull immich-server"
+            fi
             echo "docker compose up -d"
             echo '```'
             echo
-            echo "To roll back, delete the override file (or the \`immich-server\` block in it) and run \`docker compose up -d\` again."
+            echo "To roll back, delete the override file or RC image block(s), then run \`docker compose up -d\` again."
             echo
             echo "### Image published"
             echo
             echo "- \`ghcr.io/open-noodle/gallery-server:${RC_TAG}\` (linux/amd64 + linux/arm64)"
+            if [[ "$BUILD_ML" == "true" ]]; then
+              echo "- \`ghcr.io/open-noodle/gallery-ml:${RC_TAG}\` (CPU, linux/amd64 + linux/arm64)"
+            fi
             echo
-            echo "**No git tags, no GitHub release, no version endpoint updates, no ML changes.** To promote to a stable release, merge the corresponding PR to main."
+            echo "**No git tags, no GitHub release, no version endpoint updates, no release/latest/vN image tags.** To promote to a stable release, merge the corresponding PR to main."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docker/grafana-dashboard.json
+++ b/docker/grafana-dashboard.json
@@ -1,0 +1,607 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(immich_assets_total)",
+          "refId": "A"
+        }
+      ],
+      "title": "Assets",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "sum(immich_assets_storage_bytes)",
+          "refId": "A"
+        }
+      ],
+      "title": "Storage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "immich_users_total",
+          "refId": "A"
+        }
+      ],
+      "title": "Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "immich_search_embedding_coverage_ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Embedding Coverage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (type) (immich_assets_storage_bytes)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Storage by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (user_id) (immich_users_storage_bytes))",
+          "legendFormat": "{{user_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-User Storage",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (type) (immich_assets_total)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Assets by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (queue, status) (immich_queues_jobs)",
+          "legendFormat": "{{queue}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max by (queue, status) (immich_queues_oldest_job_age_seconds)",
+          "legendFormat": "{{queue}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Oldest Stale Jobs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "immich_ml_active_requests",
+          "refId": "A"
+        }
+      ],
+      "title": "Active ML Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 20
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (task, type, status) (rate(immich_ml_requests_total[5m]))",
+          "legendFormat": "{{task}} {{type}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "ML Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 20
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, task, type) (rate(immich_ml_request_duration_ms_bucket[5m])))",
+          "legendFormat": "{{task}} {{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "ML p95 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "id": 13,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "sum by (task, type) (immich_ml_model_cache_entries)",
+          "legendFormat": "{{task}} {{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Model Cache Entries",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "immich_faces_total",
+          "refId": "A"
+        },
+        {
+          "expr": "immich_people_total",
+          "refId": "B"
+        }
+      ],
+      "title": "Faces and People",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["gallery", "immich", "prometheus"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Gallery Monitoring",
+  "uid": "gallery-monitoring",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval:     15s
+  scrape_interval: 15s
   evaluation_interval: 15s
 
 scrape_configs:
@@ -10,3 +10,8 @@ scrape_configs:
   - job_name: immich_microservices
     static_configs:
       - targets: ['immich-server:8082']
+
+  - job_name: immich_machine_learning
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['immich-machine-learning:3003']

--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -23,9 +23,9 @@ These metrics come in a variety of forms:
 
 The metrics in gallery are grouped into API (endpoint calls and response times), host (memory and CPU utilization), app (Gallery domain metrics), IO (internal database queries, image processing, and so on), repo, and job metrics. Each group of metrics can be enabled or disabled independently.
 
-### Phase 1 Gallery Metrics
+### Gallery Metrics
 
-Gallery adds a small set of application metrics on top of the standard OpenTelemetry metrics:
+Gallery adds application metrics on top of the standard OpenTelemetry metrics:
 
 - Asset counts and storage by type.
 - Per-user asset and storage metrics labeled by `user_id` only.
@@ -37,13 +37,39 @@ Gallery adds a small set of application metrics on top of the standard OpenTelem
 
 Per-user metrics intentionally use `user_id` only. Names, emails, filenames, paths, search text, IP addresses, and request payloads are not exported as labels.
 
+The dashboard and examples use the Prometheus-exported metric names:
+
+| Metric                                   | Telemetry group  | Labels                         | Description                                                        |
+| :--------------------------------------- | :--------------- | :----------------------------- | :----------------------------------------------------------------- |
+| `immich_users_total`                     | `api`            | none                           | Total users.                                                       |
+| `immich_assets_total`                    | `app`            | `type`                         | Non-deleted timeline assets by type.                               |
+| `immich_assets_storage_bytes`            | `app`            | `type`                         | Total asset file bytes by type.                                    |
+| `immich_users_assets_total`              | `app`            | `user_id`, `type`              | Non-deleted timeline assets by user and type.                      |
+| `immich_users_storage_bytes`             | `app`            | `user_id`, `type`              | Asset file bytes by user and type.                                 |
+| `immich_search_embedding_coverage_ratio` | `app`            | none                           | Share of eligible image/video assets with smart-search embeddings. |
+| `immich_faces_total`                     | `app`            | none                           | Visible, non-deleted face count.                                   |
+| `immich_people_total`                    | `app`            | none                           | People with at least one visible, non-deleted face.                |
+| `immich_assets_trash_total`              | `app`            | none                           | Trashed asset count.                                               |
+| `immich_assets_external_total`           | `app`            | none                           | External-library asset count.                                      |
+| `immich_queues_jobs`                     | `job`            | `queue`, `status`              | Queue depth by queue and status.                                   |
+| `immich_queues_oldest_job_age_seconds`   | `job`            | `queue`, `status`              | Age of the oldest waiting, delayed, or failed job.                 |
+| `immich_ml_requests_total`               | machine learning | `task`, `type`, `status`       | Machine-learning `/predict` request count.                         |
+| `immich_ml_request_duration_ms`          | machine learning | `task`, `type`, `status`, `le` | Machine-learning `/predict` latency histogram.                     |
+| `immich_ml_active_requests`              | machine learning | none                           | In-flight machine-learning prediction requests.                    |
+| `immich_ml_model_cache_entries`          | machine learning | `task`, `type`                 | Loaded or cached model count.                                      |
+| `immich_ml_model_load_duration_ms`       | machine learning | `task`, `type`, `status`, `le` | Model load latency histogram.                                      |
+
 ### Configuration
 
-Gallery will not expose an endpoint for metrics by default. To enable this endpoint, you can add the `IMMICH_TELEMETRY_INCLUDE=all` environmental variable to your `.env` file. Note that only the server container currently use this variable.
+Gallery will not expose server metrics endpoints by default. To enable them, add the `IMMICH_TELEMETRY_INCLUDE=all` environment variable to your `.env` file.
 
 :::tip
-`IMMICH_TELEMETRY_INCLUDE=all` enables all metrics. For a more granular configuration you can enumerate the telemetry metrics that should be included as a comma separated list (e.g. `IMMICH_TELEMETRY_INCLUDE=repo,api,app`). Alternatively, you can also exclude specific metrics with `IMMICH_TELEMETRY_EXCLUDE`. For more information refer to the [environment section](/install/environment-variables.md#prometheus).
+`IMMICH_TELEMETRY_INCLUDE=all` enables all server telemetry groups. For a more granular configuration, enumerate the telemetry groups that should be included as a comma separated list, for example `IMMICH_TELEMETRY_INCLUDE=api,app,job`.
+
+The starter dashboard expects `api`, `app`, and `job`. Add `host`, `io`, and `repo` if you also want the broader OpenTelemetry metrics. You can exclude specific server groups with `IMMICH_TELEMETRY_EXCLUDE`. For more information, refer to the [environment section](/install/environment-variables.md#prometheus).
 :::
+
+The machine-learning service exposes its own `/metrics` endpoint on port `3003`. It is not controlled by `IMMICH_TELEMETRY_INCLUDE`; Prometheus collects those metrics only when you configure the machine-learning scrape target.
 
 The next step is to configure a new or existing Prometheus instance to scrape this endpoint. The following steps assume that you do not have an existing Prometheus instance, but the steps will be similar either way.
 
@@ -97,7 +123,7 @@ To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_
 
 ### Usage
 
-So after setting up Prometheus, how do you actually view the metrics? The simplest way is to use Prometheus directly. Visiting Prometheus will show you a web UI where you can search for and visualize metrics. You can also view the status of your data sources and configure settings, but this is beyond the scope of this guide.
+So after setting up Prometheus, how do you actually view the metrics? The simplest way is to use Prometheus directly. Visiting Prometheus will show you a web UI where you can search for and visualize metrics. Use **Status > Targets** to confirm that `immich_api`, `immich_microservices`, and `immich_machine_learning` are all `UP`.
 
 ## Grafana
 
@@ -126,17 +152,26 @@ volumes:
   grafana-data:
 ```
 
-After bringing down the services and back up again, you can now visit Grafana to view your metrics. On the first login, enter `admin` for both username and password and update your password. You can then go to the settings and add a data source with `http://immich-prometheus:9090` to point Grafana to your Prometheus instance.
+After bringing down the services and back up again, you can now visit Grafana to view your metrics. On the first login, enter `admin` for both username and password and update your password. You can then add a Prometheus data source with the URL `http://immich-prometheus:9090`.
 
-Gallery ships a starter dashboard at `docker/grafana-dashboard.json`. In Grafana, open **Dashboards > New > Import**, upload the JSON file, and select your Prometheus data source.
+Gallery ships a starter dashboard at [`docker/grafana-dashboard.json`][dashboard-file]. In Grafana, open **Dashboards > New > Import**, upload the JSON file or paste its contents, and select your Prometheus data source when prompted.
 
 ### Usage
 
-You can make your first dashboard to get started. Don't forget to save it frequently, or you'll lose all your progress!
+The starter dashboard covers asset totals, storage, users, queue depth, queue staleness, smart-search embedding coverage, face/person counts, and machine-learning request/model metrics.
 
-You can then make a new panel, specifying Prometheus as the data source for it.
+You can edit the imported dashboard in Grafana and save your own copy. If you want repeatable setup instead of manual import, keep the dashboard JSON in your own configuration repository and provision it with [Grafana dashboard provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards).
 
--- TODO: add images and more details here
+### Troubleshooting
+
+If Prometheus or Grafana does not show data:
+
+- Run `docker compose up -d` after changing `.env`; a simple restart does not apply new environment variables.
+- In Prometheus, open **Status > Targets** and confirm the API, microservices, and machine-learning targets are `UP`.
+- Confirm the server container has `IMMICH_TELEMETRY_INCLUDE=all` or at least `IMMICH_TELEMETRY_INCLUDE=api,app,job`.
+- Confirm `./prometheus.yml` is in the same directory as your Compose file and is mounted into the Prometheus container.
+- If only machine-learning panels are empty, run a smart-search, facial-recognition, or classification task so the ML service has request and model activity to report.
+- If you exposed the metrics ports for inspection, check `http://localhost:8081/metrics`, `http://localhost:8082/metrics`, and `http://localhost:3003/metrics`.
 
 ### Deferred Scope
 
@@ -178,4 +213,5 @@ This format includes:
 
 For more information on log formats, see [`IMMICH_LOG_FORMAT`](/install/environment-variables.md#general).
 
-[prom-file]: https://github.com/open-noodle/gallery/releases/latest/download/prometheus.yml
+[dashboard-file]: https://raw.githubusercontent.com/open-noodle/gallery/main/docker/grafana-dashboard.json
+[prom-file]: https://raw.githubusercontent.com/open-noodle/gallery/main/docker/prometheus.yml

--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -21,14 +21,28 @@ These metrics come in a variety of forms:
 - Histograms, where each observation is assigned to a certain number of "buckets". Example: response time, where each bucket is a number of milliseconds. This one is a bit more complicated.
   - Buckets in this case are _cumulative_; that is, an observation is placed not only into the smallest bucket that contains it, but also to all buckets larger than this. For example, if a histogram has three buckets for 1ms, 5ms and 10ms, an observation of 3ms will be bucketed into both 5ms and 10ms.
 
-The metrics in gallery are grouped into API (endpoint calls and response times), host (memory and CPU utilization), and IO (internal database queries, image processing, and so on). Each group of metrics can be enabled or disabled independently.
+The metrics in gallery are grouped into API (endpoint calls and response times), host (memory and CPU utilization), app (Gallery domain metrics), IO (internal database queries, image processing, and so on), repo, and job metrics. Each group of metrics can be enabled or disabled independently.
+
+### Phase 1 Gallery Metrics
+
+Gallery adds a small set of application metrics on top of the standard OpenTelemetry metrics:
+
+- Asset counts and storage by type.
+- Per-user asset and storage metrics labeled by `user_id` only.
+- Smart-search embedding coverage.
+- Face and person totals.
+- Trash and external-library totals.
+- Queue counts and oldest waiting, delayed, and failed job age.
+- Machine-learning request counts, latency histograms, active requests, model cache entries, and model load latency.
+
+Per-user metrics intentionally use `user_id` only. Names, emails, filenames, paths, search text, IP addresses, and request payloads are not exported as labels.
 
 ### Configuration
 
 Gallery will not expose an endpoint for metrics by default. To enable this endpoint, you can add the `IMMICH_TELEMETRY_INCLUDE=all` environmental variable to your `.env` file. Note that only the server container currently use this variable.
 
 :::tip
-`IMMICH_TELEMETRY_INCLUDE=all` enables all metrics. For a more granular configuration you can enumerate the telemetry metrics that should be included as a comma separated list (e.g. `IMMICH_TELEMETRY_INCLUDE=repo,api`). Alternatively, you can also exclude specific metrics with `IMMICH_TELEMETRY_EXCLUDE`. For more information refer to the [environment section](/install/environment-variables.md#prometheus).
+`IMMICH_TELEMETRY_INCLUDE=all` enables all metrics. For a more granular configuration you can enumerate the telemetry metrics that should be included as a comma separated list (e.g. `IMMICH_TELEMETRY_INCLUDE=repo,api,app`). Alternatively, you can also exclude specific metrics with `IMMICH_TELEMETRY_EXCLUDE`. For more information refer to the [environment section](/install/environment-variables.md#prometheus).
 :::
 
 The next step is to configure a new or existing Prometheus instance to scrape this endpoint. The following steps assume that you do not have an existing Prometheus instance, but the steps will be similar either way.
@@ -63,11 +77,21 @@ The last piece is the [configuration file][prom-file]. This file defines (among 
 The provided file is just a starting point. There are a ton of ways to configure Prometheus, so feel free to experiment!
 :::
 
-After bringing down the containers with `docker compose down` and back up with `docker compose up -d`, a Prometheus instance will now collect metrics from the gallery server and microservices containers. Note that we didn't need to expose any new ports for these containers - the communication is handled in the internal Docker network.
+The provided configuration includes the machine-learning service as a separate scrape target:
+
+```yaml
+- job_name: immich_machine_learning
+  metrics_path: /metrics
+  static_configs:
+    - targets: ['immich-machine-learning:3003']
+```
+
+After bringing down the containers with `docker compose down` and back up with `docker compose up -d`, a Prometheus instance will now collect metrics from the gallery server, microservices, and machine-learning containers. Note that we didn't need to expose any new ports for these containers - the communication is handled in the internal Docker network.
 
 :::note
 To see exactly what metrics are made available, you can additionally add `8081:8081` (API metrics) and `8082:8082` (microservices metrics) to the immich_server container's ports.
 Visiting the `/metrics` endpoint for these services will show the same raw data that Prometheus collects.
+The machine-learning service exposes `/metrics` on its regular `3003` service port, so expose `3003:3003` on the immich_machine_learning container if you also want to inspect those metrics from the host.
 To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](/install/environment-variables/#general).
 :::
 
@@ -104,6 +128,8 @@ volumes:
 
 After bringing down the services and back up again, you can now visit Grafana to view your metrics. On the first login, enter `admin` for both username and password and update your password. You can then go to the settings and add a data source with `http://immich-prometheus:9090` to point Grafana to your Prometheus instance.
 
+Gallery ships a starter dashboard at `docker/grafana-dashboard.json`. In Grafana, open **Dashboards > New > Import**, upload the JSON file, and select your Prometheus data source.
+
 ### Usage
 
 You can make your first dashboard to get started. Don't forget to save it frequently, or you'll lose all your progress!
@@ -111,6 +137,10 @@ You can make your first dashboard to get started. Don't forget to save it freque
 You can then make a new panel, specifying Prometheus as the data source for it.
 
 -- TODO: add images and more details here
+
+### Deferred Scope
+
+Phase 1 does not add auth/IP metrics, upload throughput, face/CLIP score distributions, duplicate metrics, video transcode quality metrics, DB bloat metrics, geocoding/OCR coverage, new memory metrics, cache hit/miss internals, or custom CPU/memory/GPU/network metrics beyond existing host and infrastructure exporters. Those need separate product and privacy decisions.
 
 ## Structured Logging
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -224,10 +224,10 @@ For detailed setup instructions, see the [S3-Compatible Storage](/features/s3-st
 
 ## Prometheus
 
-| Variable                   | Description                                                                                                           | Default | Containers | Workers            |
-| :------------------------- | :-------------------------------------------------------------------------------------------------------------------- | :-----: | :--------- | :----------------- |
-| `IMMICH_TELEMETRY_INCLUDE` | Collect these telemetries. List of `host`, `api`, `io`, `repo`, `job`. Note: You can also specify `all` to enable all |         | server     | api, microservices |
-| `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these telemetries. List of `host`, `api`, `io`, `repo`, `job`                                          |         | server     | api, microservices |
+| Variable                   | Description                                                                                                                  | Default | Containers | Workers            |
+| :------------------------- | :--------------------------------------------------------------------------------------------------------------------------- | :-----: | :--------- | :----------------- |
+| `IMMICH_TELEMETRY_INCLUDE` | Collect these telemetries. List of `host`, `api`, `app`, `io`, `repo`, `job`. Note: You can also specify `all` to enable all |         | server     | api, microservices |
+| `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these telemetries. List of `host`, `api`, `app`, `io`, `repo`, `job`                                          |         | server     | api, microservices |
 
 ## Secrets
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -224,10 +224,12 @@ For detailed setup instructions, see the [S3-Compatible Storage](/features/s3-st
 
 ## Prometheus
 
-| Variable                   | Description                                                                                                                  | Default | Containers | Workers            |
-| :------------------------- | :--------------------------------------------------------------------------------------------------------------------------- | :-----: | :--------- | :----------------- |
-| `IMMICH_TELEMETRY_INCLUDE` | Collect these telemetries. List of `host`, `api`, `app`, `io`, `repo`, `job`. Note: You can also specify `all` to enable all |         | server     | api, microservices |
-| `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these telemetries. List of `host`, `api`, `app`, `io`, `repo`, `job`                                          |         | server     | api, microservices |
+| Variable                   | Description                                                                                                                                               | Default | Containers | Workers            |
+| :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----: | :--------- | :----------------- |
+| `IMMICH_TELEMETRY_INCLUDE` | Collect these server telemetry groups. List of `host`, `api`, `app`, `io`, `repo`, `job`. Specify `all` to enable every server telemetry group.           |         | server     | api, microservices |
+| `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these server telemetry groups. List of `host`, `api`, `app`, `io`, `repo`, `job`. Exclusions are applied after `IMMICH_TELEMETRY_INCLUDE`. |         | server     | api, microservices |
+
+The monitoring dashboard expects the `api`, `app`, and `job` groups. Machine-learning metrics are exposed by the machine-learning service on `/metrics` port `3003` and are not controlled by these variables.
 
 ## Secrets
 

--- a/docs/superpowers/plans/2026-04-25-prometheus-metrics.md
+++ b/docs/superpowers/plans/2026-04-25-prometheus-metrics.md
@@ -1,0 +1,1783 @@
+# Prometheus Metrics Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Phase 1 Prometheus monitoring slice: server domain metrics, queue staleness metrics, ML service metrics, Prometheus scrape config, Grafana dashboard, and docs.
+
+**Architecture:** Keep server metrics inside the existing opt-in OpenTelemetry exporter. Add an `app` telemetry group for domain snapshot metrics, use observable gauges for absolute values, publish queue metrics from the microservices worker, and expose ML metrics from the existing FastAPI app on `/metrics`.
+
+**Tech Stack:** NestJS 11, OpenTelemetry, BullMQ, Kysely, Vitest, Python FastAPI, `prometheus-client`, uv, Grafana dashboard JSON, Docusaurus docs.
+
+---
+
+## File Structure
+
+- Modify `server/src/enum.ts`: add `ImmichTelemetry.App`.
+- Read `server/src/repositories/config.repository.ts`: confirm the existing telemetry parser reads from `Object.values(ImmichTelemetry)`.
+- Modify `server/src/repositories/config.repository.spec.ts`: cover `app` in all/specific/exclusion telemetry config tests.
+- Modify `server/src/repositories/telemetry.repository.ts`: add an `app` metric group and observable gauge support.
+- Add `server/src/repositories/telemetry.repository.spec.ts`: unit coverage for observable gauge registration.
+- Modify `server/test/repositories/telemetry.repository.mock.ts`: mock `app.observeGauge()`.
+- Modify `server/src/repositories/asset.repository.ts`: add typed aggregate queries for server asset/search/storage metrics.
+- Modify `server/test/repositories/asset.repository.mock.ts`: mock the new asset telemetry method.
+- Modify `server/test/medium/specs/repositories/asset.repository.spec.ts`: medium coverage for asset telemetry aggregates.
+- Modify `server/src/repositories/person.repository.ts`: add typed aggregate query for face/person metrics.
+- Modify `server/test/medium/specs/repositories/person.repository.spec.ts`: medium coverage for face/person telemetry aggregates.
+- Modify `server/src/repositories/job.repository.ts`: add queue count and oldest-job-age telemetry methods.
+- Modify `server/test/repositories/job.repository.mock.ts`: mock the new queue telemetry method.
+- Add `server/src/services/app-metrics.service.ts`: registers observable gauges and manages snapshot cache/failure behavior.
+- Add `server/src/services/app-metrics.service.spec.ts`: unit coverage for gauge registration, labels, cache reuse, and failure fallback.
+- Modify `server/src/services/index.ts`: include `AppMetricsService`.
+- Add `machine-learning/immich_ml/metrics.py`: ML Prometheus registry, counters, histograms, gauges, and test reset helper.
+- Modify `machine-learning/immich_ml/main.py`: expose `GET /metrics`, record `/predict` and model-load metrics.
+- Modify `machine-learning/pyproject.toml` and `machine-learning/uv.lock`: add `prometheus-client`.
+- Modify `machine-learning/test_main.py`: ML metrics tests.
+- Modify `docker/prometheus.yml`: scrape the ML service.
+- Add `docker/grafana-dashboard.json`: importable Phase 1 dashboard.
+- Modify `docs/docs/features/monitoring.md`: explain Phase 1 metrics, ML scrape target, dashboard import, privacy, and deferred scope.
+- Modify `docs/docs/install/environment-variables.md`: add `app` to telemetry include/exclude docs.
+
+## Task 1: Telemetry App Group And Observable Gauge Support
+
+**Files:**
+
+- Modify: `server/src/enum.ts`
+- Modify: `server/src/repositories/config.repository.spec.ts`
+- Modify: `server/src/repositories/telemetry.repository.ts`
+- Add: `server/src/repositories/telemetry.repository.spec.ts`
+- Modify: `server/test/repositories/telemetry.repository.mock.ts`
+
+- [ ] **Step 1: Write failing config tests for the `app` telemetry group**
+
+Add these expectations in `server/src/repositories/config.repository.spec.ts`:
+
+```typescript
+it('should run with telemetry app metrics enabled', () => {
+  process.env.IMMICH_TELEMETRY_INCLUDE = 'app';
+  const { telemetry } = getEnv();
+
+  expect(telemetry.metrics).toEqual(new Set([ImmichTelemetry.App]));
+});
+```
+
+Update the existing `IMMICH_TELEMETRY_INCLUDE=all` test to keep using:
+
+```typescript
+expect(telemetry.metrics).toEqual(new Set(Object.values(ImmichTelemetry)));
+```
+
+Update the existing `all` with `job` excluded expectation to include `ImmichTelemetry.App`:
+
+```typescript
+expect(telemetry.metrics).toEqual(
+  new Set([ImmichTelemetry.Api, ImmichTelemetry.App, ImmichTelemetry.Host, ImmichTelemetry.Io, ImmichTelemetry.Repo]),
+);
+```
+
+- [ ] **Step 2: Run config tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/config.repository.spec.ts
+```
+
+Expected: FAIL because `ImmichTelemetry.App` does not exist and `app` is rejected by telemetry validation.
+
+- [ ] **Step 3: Add `ImmichTelemetry.App`**
+
+In `server/src/enum.ts`, update the enum:
+
+```typescript
+export enum ImmichTelemetry {
+  Host = 'host',
+  Api = 'api',
+  App = 'app',
+  Io = 'io',
+  Repo = 'repo',
+  Job = 'job',
+}
+```
+
+`ConfigRepository` builds valid telemetry types from `Object.values(ImmichTelemetry)`, so no parser rewrite is needed.
+
+- [ ] **Step 4: Run config tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/config.repository.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing observable gauge tests**
+
+Create `server/src/repositories/telemetry.repository.spec.ts`:
+
+```typescript
+import { ObservableCallback } from '@opentelemetry/api';
+import { MetricService } from 'nestjs-otel';
+import { MetricGroupRepository } from 'src/repositories/telemetry.repository';
+import { describe, expect, it, vi } from 'vitest';
+
+describe(MetricGroupRepository.name, () => {
+  const newMetricService = () => {
+    const observableGauge = { addCallback: vi.fn() };
+    const metricService = {
+      getCounter: vi.fn(),
+      getUpDownCounter: vi.fn(),
+      getHistogram: vi.fn(),
+      getObservableGauge: vi.fn().mockReturnValue(observableGauge),
+    } as unknown as MetricService;
+
+    return { metricService, observableGauge };
+  };
+
+  it('registers observable gauges when enabled', () => {
+    const { metricService, observableGauge } = newMetricService();
+    const callback: ObservableCallback = vi.fn();
+
+    new MetricGroupRepository(metricService).configure({ enabled: true }).observeGauge('immich.assets.total', callback);
+
+    expect(metricService.getObservableGauge).toHaveBeenCalledWith('immich.assets.total', undefined);
+    expect(observableGauge.addCallback).toHaveBeenCalledWith(callback);
+  });
+
+  it('does not register observable gauges when disabled', () => {
+    const { metricService, observableGauge } = newMetricService();
+    const callback: ObservableCallback = vi.fn();
+
+    new MetricGroupRepository(metricService)
+      .configure({ enabled: false })
+      .observeGauge('immich.assets.total', callback);
+
+    expect(metricService.getObservableGauge).not.toHaveBeenCalled();
+    expect(observableGauge.addCallback).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6: Run telemetry repository tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/telemetry.repository.spec.ts
+```
+
+Expected: FAIL because `MetricGroupRepository.observeGauge()` does not exist.
+
+- [ ] **Step 7: Add observable gauge support and the `app` metric group**
+
+In `server/src/repositories/telemetry.repository.ts`, import `ObservableCallback`:
+
+```typescript
+import { MetricOptions, ObservableCallback } from '@opentelemetry/api';
+```
+
+Add this method to `MetricGroupRepository`:
+
+```typescript
+observeGauge(name: string, callback: ObservableCallback, options?: MetricOptions): void {
+  if (this.enabled) {
+    this.metricService.getObservableGauge(name, options).addCallback(callback);
+  }
+}
+```
+
+Add `app` to `TelemetryRepository`:
+
+```typescript
+app: MetricGroupRepository;
+```
+
+Configure it in the constructor:
+
+```typescript
+this.api = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Api) });
+this.app = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.App) });
+this.host = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Host) });
+this.jobs = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Job) });
+this.repo = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Repo) });
+```
+
+- [ ] **Step 8: Update the telemetry repository mock**
+
+In `server/test/repositories/telemetry.repository.mock.ts`, add `observeGauge` to `newMetricGroupMock()`:
+
+```typescript
+const newMetricGroupMock = () => {
+  return {
+    addToCounter: vitest.fn(),
+    addToGauge: vitest.fn(),
+    addToHistogram: vitest.fn(),
+    configure: vitest.fn(),
+    observeGauge: vitest.fn(),
+  };
+};
+```
+
+Add the `app` group in `newTelemetryRepositoryMock()`:
+
+```typescript
+return {
+  setup: vitest.fn(),
+  api: newMetricGroupMock(),
+  app: newMetricGroupMock(),
+  host: newMetricGroupMock(),
+  jobs: newMetricGroupMock(),
+  repo: newMetricGroupMock(),
+};
+```
+
+- [ ] **Step 9: Run Task 1 tests**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/config.repository.spec.ts src/repositories/telemetry.repository.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 1**
+
+Run:
+
+```bash
+git add server/src/enum.ts server/src/repositories/config.repository.spec.ts server/src/repositories/telemetry.repository.ts server/src/repositories/telemetry.repository.spec.ts server/test/repositories/telemetry.repository.mock.ts
+git commit -m "feat(server): add app telemetry gauges"
+```
+
+## Task 2: Server Domain Metric Repository Queries
+
+**Files:**
+
+- Modify: `server/src/repositories/asset.repository.ts`
+- Modify: `server/test/repositories/asset.repository.mock.ts`
+- Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
+- Modify: `server/src/repositories/person.repository.ts`
+- Modify: `server/test/medium/specs/repositories/person.repository.spec.ts`
+
+- [ ] **Step 1: Write failing medium tests for asset telemetry aggregates**
+
+Append this describe block to `server/test/medium/specs/repositories/asset.repository.spec.ts`:
+
+```typescript
+describe('getTelemetryMetrics', () => {
+  it('returns low-cardinality asset, user, storage, embedding, trash, and external metrics', async () => {
+    const { ctx, sut } = setup();
+    const { user: user1 } = await ctx.newUser();
+    const { user: user2 } = await ctx.newUser();
+
+    const { asset: image1 } = await ctx.newAsset({
+      ownerId: user1.id,
+      type: AssetType.Image,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: video1 } = await ctx.newAsset({
+      ownerId: user1.id,
+      type: AssetType.Video,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: image2 } = await ctx.newAsset({
+      ownerId: user2.id,
+      type: AssetType.Image,
+      visibility: AssetVisibility.Timeline,
+      isExternal: true,
+    });
+    const { asset: hidden } = await ctx.newAsset({
+      ownerId: user2.id,
+      type: AssetType.Image,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: trashed } = await ctx.newAsset({
+      ownerId: user2.id,
+      type: AssetType.Video,
+      visibility: AssetVisibility.Timeline,
+    });
+
+    await Promise.all([
+      ctx.newExif({ assetId: image1.id, fileSizeInByte: 100 }),
+      ctx.newExif({ assetId: video1.id, fileSizeInByte: 200 }),
+      ctx.newExif({ assetId: image2.id, fileSizeInByte: 300 }),
+      ctx.newExif({ assetId: hidden.id, fileSizeInByte: 400 }),
+      ctx.newExif({ assetId: trashed.id, fileSizeInByte: 500 }),
+      ctx.database.insertInto('smart_search').values({ assetId: image1.id, embedding: newEmbedding() }).execute(),
+      ctx.softDeleteAsset(trashed.id),
+    ]);
+
+    const result = await sut.getTelemetryMetrics();
+
+    expect(result.assetsByType).toEqual(
+      expect.arrayContaining([
+        { type: AssetType.Image, count: 2, storageBytes: 400 },
+        { type: AssetType.Video, count: 1, storageBytes: 200 },
+      ]),
+    );
+    expect(result.usersByType).toEqual(
+      expect.arrayContaining([
+        { userId: user1.id, type: AssetType.Image, count: 1, storageBytes: 100 },
+        { userId: user1.id, type: AssetType.Video, count: 1, storageBytes: 200 },
+        { userId: user2.id, type: AssetType.Image, count: 1, storageBytes: 300 },
+      ]),
+    );
+    expect(result.search).toEqual({ eligibleAssets: 3, embeddedAssets: 1 });
+    expect(result.state).toEqual({ externalAssets: 1, trashAssets: 1 });
+  });
+});
+```
+
+Update the imports at the top:
+
+```typescript
+import { AssetFileType, AssetOrder, AssetType, AssetVisibility } from 'src/enum';
+import { factory, newEmbedding } from 'test/small.factory';
+```
+
+- [ ] **Step 2: Run the asset medium test and verify it fails**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/asset.repository.spec.ts
+```
+
+Expected: FAIL because `AssetRepository.getTelemetryMetrics()` does not exist.
+
+- [ ] **Step 3: Add asset telemetry types and query method**
+
+In `server/src/repositories/asset.repository.ts`, add these interfaces near `AssetStats`:
+
+```typescript
+export interface AssetTelemetryByType {
+  type: AssetType;
+  count: number;
+  storageBytes: number;
+}
+
+export interface UserAssetTelemetryByType extends AssetTelemetryByType {
+  userId: string;
+}
+
+export interface SearchTelemetryMetrics {
+  eligibleAssets: number;
+  embeddedAssets: number;
+}
+
+export interface AssetStateTelemetryMetrics {
+  externalAssets: number;
+  trashAssets: number;
+}
+
+export interface AssetTelemetryMetrics {
+  assetsByType: AssetTelemetryByType[];
+  usersByType: UserAssetTelemetryByType[];
+  search: SearchTelemetryMetrics;
+  state: AssetStateTelemetryMetrics;
+}
+```
+
+Add this method inside `AssetRepository`:
+
+```typescript
+async getTelemetryMetrics(): Promise<AssetTelemetryMetrics> {
+  const visibleTimelineAssets = <O extends object>(qb: SelectQueryBuilder<DB, 'asset', O>) =>
+    qb.where('asset.deletedAt', 'is', null).where('asset.visibility', '=', AssetVisibility.Timeline);
+
+  const assetsByType = await visibleTimelineAssets(
+    this.db
+      .selectFrom('asset')
+      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .select(['asset.type'])
+      .select((eb) => [
+        eb.fn.countAll<number>().as('count'),
+        eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
+      ])
+      .groupBy('asset.type'),
+  ).execute();
+
+  const usersByType = await visibleTimelineAssets(
+    this.db
+      .selectFrom('asset')
+      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .select(['asset.ownerId as userId', 'asset.type'])
+      .select((eb) => [
+        eb.fn.countAll<number>().as('count'),
+        eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
+      ])
+      .groupBy(['asset.ownerId', 'asset.type']),
+  ).execute();
+
+  const search = await visibleTimelineAssets(
+    this.db
+      .selectFrom('asset')
+      .leftJoin('smart_search', 'smart_search.assetId', 'asset.id')
+      .select((eb) => [
+        eb.fn.countAll<number>().as('eligibleAssets'),
+        eb.fn.count<number>('smart_search.assetId').as('embeddedAssets'),
+      ])
+      .where('asset.type', 'in', [AssetType.Image, AssetType.Video]),
+  ).executeTakeFirstOrThrow();
+
+  const state = await this.db
+    .selectFrom('asset')
+    .select((eb) => [
+      eb.fn.countAll<number>().filterWhere('asset.deletedAt', 'is not', null).as('trashAssets'),
+      eb.fn
+        .countAll<number>()
+        .filterWhere((eb) => eb.and([eb('asset.deletedAt', 'is', null), eb('asset.isExternal', '=', true)]))
+        .as('externalAssets'),
+    ])
+    .executeTakeFirstOrThrow();
+
+  return {
+    assetsByType: assetsByType.map((item) => ({
+      type: item.type,
+      count: Number(item.count),
+      storageBytes: Number(item.storageBytes),
+    })),
+    usersByType: usersByType.map((item) => ({
+      userId: item.userId,
+      type: item.type,
+      count: Number(item.count),
+      storageBytes: Number(item.storageBytes),
+    })),
+    search: {
+      eligibleAssets: Number(search.eligibleAssets),
+      embeddedAssets: Number(search.embeddedAssets),
+    },
+    state: {
+      externalAssets: Number(state.externalAssets),
+      trashAssets: Number(state.trashAssets),
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Update the asset repository mock**
+
+In `server/test/repositories/asset.repository.mock.ts`, add:
+
+```typescript
+getTelemetryMetrics: vitest.fn(),
+```
+
+- [ ] **Step 5: Run the asset medium test and verify it passes**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/asset.repository.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write failing medium tests for face/person telemetry aggregates**
+
+Append this describe block to `server/test/medium/specs/repositories/person.repository.spec.ts`:
+
+```typescript
+describe('getTelemetryMetrics', () => {
+  it('returns visible face and person counts without exposing names', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: asset1 } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    const { asset: asset2 } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+    const { asset: trashedAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    const { person: person1 } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+    const { person: person2 } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+
+    await Promise.all([
+      ctx.newAssetFace({ assetId: asset1.id, personId: person1.id, isVisible: true }),
+      ctx.newAssetFace({ assetId: asset1.id, personId: person1.id, isVisible: true }),
+      ctx.newAssetFace({ assetId: asset2.id, personId: person2.id, isVisible: true }),
+      ctx.newAssetFace({ assetId: asset2.id, personId: person2.id, isVisible: false }),
+      ctx.newAssetFace({ assetId: asset2.id, personId: null, isVisible: true }),
+      ctx.newAssetFace({ assetId: hiddenAsset.id, personId: person2.id, isVisible: true }),
+      ctx.newAssetFace({ assetId: trashedAsset.id, personId: person2.id, isVisible: true }),
+      ctx.softDeleteAsset(trashedAsset.id),
+    ]);
+
+    const result = await sut.getTelemetryMetrics();
+
+    expect(result).toEqual({ faces: 4, people: 2 });
+  });
+});
+```
+
+Update the imports at the top:
+
+```typescript
+import { AssetFileType, AssetVisibility } from 'src/enum';
+```
+
+- [ ] **Step 7: Run the person medium test and verify it fails**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/person.repository.spec.ts
+```
+
+Expected: FAIL because `PersonRepository.getTelemetryMetrics()` does not exist.
+
+- [ ] **Step 8: Add person telemetry query**
+
+In `server/src/repositories/person.repository.ts`, add:
+
+```typescript
+export interface PersonTelemetryMetrics {
+  faces: number;
+  people: number;
+}
+```
+
+Add this method inside `PersonRepository`:
+
+```typescript
+async getTelemetryMetrics(): Promise<PersonTelemetryMetrics> {
+  const result = await this.db
+    .selectFrom('asset_face')
+    .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+    .select((eb) => [
+      eb.fn.countAll<number>().as('faces'),
+      eb.fn.count<number>(eb.fn('distinct', ['asset_face.personId'])).filterWhere('asset_face.personId', 'is not', null).as('people'),
+    ])
+    .where('asset_face.deletedAt', 'is', null)
+    .where('asset_face.isVisible', 'is', true)
+    .where('asset.deletedAt', 'is', null)
+    .where('asset.visibility', '=', AssetVisibility.Timeline)
+    .executeTakeFirstOrThrow();
+
+  return {
+    faces: Number(result.faces),
+    people: Number(result.people),
+  };
+}
+```
+
+- [ ] **Step 9: Run the person medium test and verify it passes**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/person.repository.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 2**
+
+Run:
+
+```bash
+git add server/src/repositories/asset.repository.ts server/test/repositories/asset.repository.mock.ts server/test/medium/specs/repositories/asset.repository.spec.ts server/src/repositories/person.repository.ts server/test/medium/specs/repositories/person.repository.spec.ts
+git commit -m "feat(server): collect domain metric aggregates"
+```
+
+## Task 3: Queue Telemetry And App Metrics Service
+
+**Files:**
+
+- Modify: `server/src/repositories/job.repository.ts`
+- Add: `server/src/repositories/job.repository.spec.ts`
+- Modify: `server/test/repositories/job.repository.mock.ts`
+- Add: `server/src/services/app-metrics.service.ts`
+- Add: `server/src/services/app-metrics.service.spec.ts`
+- Modify: `server/src/services/index.ts`
+
+- [ ] **Step 1: Write failing unit tests for queue telemetry**
+
+Create `server/src/repositories/job.repository.spec.ts`:
+
+```typescript
+import { ModuleRef } from '@nestjs/core';
+import { QueueName } from 'src/enum';
+import { JobRepository } from 'src/repositories/job.repository';
+import { describe, expect, it, vi } from 'vitest';
+
+describe(JobRepository.name, () => {
+  const setup = () => {
+    const queue = {
+      getJobCounts: vi.fn(),
+      getJobs: vi.fn(),
+    };
+    const moduleRef = { get: vi.fn().mockReturnValue(queue) } as unknown as ModuleRef;
+    const logger = { setContext: vi.fn(), error: vi.fn(), warn: vi.fn(), verbose: vi.fn() };
+    const sut = new JobRepository(moduleRef, {} as never, {} as never, logger as never);
+    return { sut, queue };
+  };
+
+  it('returns queue counts and oldest job ages', async () => {
+    const { sut, queue } = setup();
+    const now = new Date('2026-04-25T12:00:00Z').getTime();
+    queue.getJobCounts.mockResolvedValue({
+      active: 1,
+      completed: 2,
+      failed: 3,
+      delayed: 4,
+      waiting: 5,
+      paused: 6,
+    });
+    queue.getJobs.mockResolvedValue([{ timestamp: now - 120_000 }]);
+
+    const result = await sut.getTelemetryMetrics(now);
+
+    expect(result.counts).toEqual(
+      expect.arrayContaining([
+        { queue: QueueName.ThumbnailGeneration, status: 'active', count: 1 },
+        { queue: QueueName.ThumbnailGeneration, status: 'completed', count: 2 },
+        { queue: QueueName.ThumbnailGeneration, status: 'failed', count: 3 },
+        { queue: QueueName.ThumbnailGeneration, status: 'delayed', count: 4 },
+        { queue: QueueName.ThumbnailGeneration, status: 'waiting', count: 5 },
+        { queue: QueueName.ThumbnailGeneration, status: 'paused', count: 6 },
+      ]),
+    );
+    expect(result.oldestJobAges).toEqual(
+      expect.arrayContaining([
+        { queue: QueueName.ThumbnailGeneration, status: 'waiting', ageSeconds: 120 },
+        { queue: QueueName.ThumbnailGeneration, status: 'delayed', ageSeconds: 120 },
+        { queue: QueueName.ThumbnailGeneration, status: 'failed', ageSeconds: 120 },
+      ]),
+    );
+    expect(queue.getJobs).toHaveBeenCalledWith('waiting', 0, 0, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('delayed', 0, 0, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('failed', 0, 0, true);
+  });
+});
+```
+
+In `server/src/services/app-metrics.service.spec.ts`, start with service-level tests that use the public `JobRepository.getTelemetryMetrics()` mock:
+
+```typescript
+import { ObservableCallback, ObservableResult } from '@opentelemetry/api';
+import { AssetType, ImmichWorker, QueueName } from 'src/enum';
+import { AppMetricsService } from 'src/services/app-metrics.service';
+import { newTestService, ServiceMocks } from 'test/utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const observe = async (callback: ObservableCallback) => {
+  const result = { observe: vi.fn() } as unknown as ObservableResult;
+  await callback(result);
+  return result.observe as ReturnType<typeof vi.fn>;
+};
+
+describe(AppMetricsService.name, () => {
+  let sut: AppMetricsService;
+  let mocks: ServiceMocks;
+  let appCallbacks: Map<string, ObservableCallback>;
+  let jobCallbacks: Map<string, ObservableCallback>;
+
+  beforeEach(() => {
+    ({ sut, mocks } = newTestService(AppMetricsService));
+    appCallbacks = new Map();
+    jobCallbacks = new Map();
+    mocks.telemetry.app.observeGauge.mockImplementation((name, callback) => appCallbacks.set(name, callback));
+    mocks.telemetry.jobs.observeGauge.mockImplementation((name, callback) => jobCallbacks.set(name, callback));
+  });
+
+  it('registers app gauges on the API worker', () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+
+    sut.onBootstrap();
+
+    expect(appCallbacks.has('immich.assets.total')).toBe(true);
+    expect(appCallbacks.has('immich.users.storage_bytes')).toBe(true);
+    expect(jobCallbacks.size).toBe(0);
+  });
+
+  it('registers queue gauges on the microservices worker', () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+
+    sut.onBootstrap();
+
+    expect(jobCallbacks.has('immich.queues.jobs')).toBe(true);
+    expect(jobCallbacks.has('immich.queues.oldest_job_age_seconds')).toBe(true);
+    expect(appCallbacks.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the app metrics tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/services/app-metrics.service.spec.ts
+```
+
+Expected: FAIL because `JobRepository.getTelemetryMetrics()` and `AppMetricsService` do not exist.
+
+- [ ] **Step 3: Add queue telemetry types and repository method**
+
+In `server/src/repositories/job.repository.ts`, add these exports near the other queue types:
+
+```typescript
+export type QueueTelemetryStatus = 'active' | 'completed' | 'failed' | 'delayed' | 'waiting' | 'paused';
+export type QueueTelemetryStalenessStatus = 'waiting' | 'delayed' | 'failed';
+
+export interface QueueTelemetryJobCount {
+  queue: QueueName;
+  status: QueueTelemetryStatus;
+  count: number;
+}
+
+export interface QueueTelemetryOldestJobAge {
+  queue: QueueName;
+  status: QueueTelemetryStalenessStatus;
+  ageSeconds: number;
+}
+
+export interface QueueTelemetryMetrics {
+  counts: QueueTelemetryJobCount[];
+  oldestJobAges: QueueTelemetryOldestJobAge[];
+}
+```
+
+Add this method inside `JobRepository`:
+
+```typescript
+async getTelemetryMetrics(now = Date.now()): Promise<QueueTelemetryMetrics> {
+  const countStatuses: QueueTelemetryStatus[] = ['active', 'completed', 'failed', 'delayed', 'waiting', 'paused'];
+  const stalenessStatuses: QueueTelemetryStalenessStatus[] = ['waiting', 'delayed', 'failed'];
+  const counts: QueueTelemetryJobCount[] = [];
+  const oldestJobAges: QueueTelemetryOldestJobAge[] = [];
+
+  for (const queue of Object.values(QueueName)) {
+    const queueCounts = await this.getJobCounts(queue);
+    for (const status of countStatuses) {
+      counts.push({ queue, status, count: Number(queueCounts[status] ?? 0) });
+    }
+
+    for (const status of stalenessStatuses) {
+      const [job] = await this.getQueue(queue).getJobs(status, 0, 0, true);
+      oldestJobAges.push({
+        queue,
+        status,
+        ageSeconds: job ? Math.max(0, Math.floor((now - job.timestamp) / 1000)) : 0,
+      });
+    }
+  }
+
+  return { counts, oldestJobAges };
+}
+```
+
+- [ ] **Step 4: Update the job repository mock**
+
+In `server/test/repositories/job.repository.mock.ts`, add:
+
+```typescript
+getTelemetryMetrics: vitest.fn(),
+```
+
+- [ ] **Step 5: Implement `AppMetricsService`**
+
+Create `server/src/services/app-metrics.service.ts`:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { ObservableCallback, ObservableResult } from '@opentelemetry/api';
+import { OnEvent } from 'src/decorators';
+import { ImmichWorker } from 'src/enum';
+import { AssetTelemetryMetrics } from 'src/repositories/asset.repository';
+import { QueueTelemetryMetrics } from 'src/repositories/job.repository';
+import { PersonTelemetryMetrics } from 'src/repositories/person.repository';
+import { BaseService } from 'src/services/base.service';
+
+const SNAPSHOT_TTL_MS = 60_000;
+
+type AppSnapshot = {
+  asset: AssetTelemetryMetrics;
+  person: PersonTelemetryMetrics;
+};
+
+@Injectable()
+export class AppMetricsService extends BaseService {
+  private appSnapshot?: AppSnapshot;
+  private appSnapshotAttemptedAt?: number;
+  private appRefresh?: Promise<AppSnapshot | undefined>;
+  private queueSnapshot?: QueueTelemetryMetrics;
+  private queueSnapshotAttemptedAt?: number;
+  private queueRefresh?: Promise<QueueTelemetryMetrics | undefined>;
+  private registered = false;
+
+  @OnEvent({ name: 'AppBootstrap' })
+  onBootstrap() {
+    if (this.registered) {
+      return;
+    }
+    this.registered = true;
+
+    switch (this.worker) {
+      case ImmichWorker.Api: {
+        this.registerAppGauges();
+        break;
+      }
+      case ImmichWorker.Microservices: {
+        this.registerQueueGauges();
+        break;
+      }
+    }
+  }
+
+  private registerAppGauges() {
+    this.observeAppGauge('immich.assets.total', (snapshot, result) => {
+      for (const item of snapshot.asset.assetsByType) {
+        result.observe(item.count, { type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.assets.storage_bytes', (snapshot, result) => {
+      for (const item of snapshot.asset.assetsByType) {
+        result.observe(item.storageBytes, { type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.users.assets.total', (snapshot, result) => {
+      for (const item of snapshot.asset.usersByType) {
+        result.observe(item.count, { user_id: item.userId, type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.users.storage_bytes', (snapshot, result) => {
+      for (const item of snapshot.asset.usersByType) {
+        result.observe(item.storageBytes, { user_id: item.userId, type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.search.embedding_coverage_ratio', (snapshot, result) => {
+      const { eligibleAssets, embeddedAssets } = snapshot.asset.search;
+      result.observe(eligibleAssets === 0 ? 1 : embeddedAssets / eligibleAssets);
+    });
+    this.observeAppGauge('immich.faces.total', (snapshot, result) => result.observe(snapshot.person.faces));
+    this.observeAppGauge('immich.people.total', (snapshot, result) => result.observe(snapshot.person.people));
+    this.observeAppGauge('immich.assets.trash.total', (snapshot, result) =>
+      result.observe(snapshot.asset.state.trashAssets),
+    );
+    this.observeAppGauge('immich.assets.external.total', (snapshot, result) =>
+      result.observe(snapshot.asset.state.externalAssets),
+    );
+  }
+
+  private registerQueueGauges() {
+    this.observeQueueGauge('immich.queues.jobs', (snapshot, result) => {
+      for (const item of snapshot.counts) {
+        result.observe(item.count, { queue: item.queue, status: item.status });
+      }
+    });
+    this.observeQueueGauge('immich.queues.oldest_job_age_seconds', (snapshot, result) => {
+      for (const item of snapshot.oldestJobAges) {
+        result.observe(item.ageSeconds, { queue: item.queue, status: item.status });
+      }
+    });
+  }
+
+  private observeAppGauge(name: string, observeSnapshot: (snapshot: AppSnapshot, result: ObservableResult) => void) {
+    const callback: ObservableCallback = async (result) => {
+      const snapshot = await this.getAppSnapshot();
+      if (snapshot) {
+        observeSnapshot(snapshot, result);
+      }
+    };
+    this.telemetryRepository.app.observeGauge(name, callback);
+  }
+
+  private observeQueueGauge(
+    name: string,
+    observeSnapshot: (snapshot: QueueTelemetryMetrics, result: ObservableResult) => void,
+  ) {
+    const callback: ObservableCallback = async (result) => {
+      const snapshot = await this.getQueueSnapshot();
+      if (snapshot) {
+        observeSnapshot(snapshot, result);
+      }
+    };
+    this.telemetryRepository.jobs.observeGauge(name, callback);
+  }
+
+  private async getAppSnapshot(): Promise<AppSnapshot | undefined> {
+    if (this.appSnapshotAttemptedAt !== undefined && Date.now() - this.appSnapshotAttemptedAt < SNAPSHOT_TTL_MS) {
+      return this.appSnapshot;
+    }
+    this.appRefresh ??= this.refreshAppSnapshot();
+    try {
+      return await this.appRefresh;
+    } finally {
+      this.appRefresh = undefined;
+    }
+  }
+
+  private async refreshAppSnapshot(): Promise<AppSnapshot | undefined> {
+    try {
+      const [asset, person] = await Promise.all([
+        this.assetRepository.getTelemetryMetrics(),
+        this.personRepository.getTelemetryMetrics(),
+      ]);
+      this.appSnapshot = { asset, person };
+    } catch (error: Error | unknown) {
+      this.logger.warn(`Unable to refresh app metrics snapshot: ${error instanceof Error ? error.message : error}`);
+    } finally {
+      this.appSnapshotAttemptedAt = Date.now();
+    }
+    return this.appSnapshot;
+  }
+
+  private async getQueueSnapshot(): Promise<QueueTelemetryMetrics | undefined> {
+    if (this.queueSnapshotAttemptedAt !== undefined && Date.now() - this.queueSnapshotAttemptedAt < SNAPSHOT_TTL_MS) {
+      return this.queueSnapshot;
+    }
+    this.queueRefresh ??= this.refreshQueueSnapshot();
+    try {
+      return await this.queueRefresh;
+    } finally {
+      this.queueRefresh = undefined;
+    }
+  }
+
+  private async refreshQueueSnapshot(): Promise<QueueTelemetryMetrics | undefined> {
+    try {
+      this.queueSnapshot = await this.jobRepository.getTelemetryMetrics();
+    } catch (error: Error | unknown) {
+      this.logger.warn(`Unable to refresh queue metrics snapshot: ${error instanceof Error ? error.message : error}`);
+    } finally {
+      this.queueSnapshotAttemptedAt = Date.now();
+    }
+    return this.queueSnapshot;
+  }
+}
+```
+
+- [ ] **Step 6: Add `AppMetricsService` to service registration**
+
+In `server/src/services/index.ts`, import and register it:
+
+```typescript
+import { AppMetricsService } from 'src/services/app-metrics.service';
+```
+
+Place `AppMetricsService` in `services` near `ApiService`:
+
+```typescript
+ApiService,
+AppMetricsService,
+AssetMediaService,
+```
+
+- [ ] **Step 7: Expand `AppMetricsService` tests for labels/cache/failure**
+
+Add these tests to `server/src/services/app-metrics.service.spec.ts`:
+
+```typescript
+it('observes app metrics with user_id labels only', async () => {
+  mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+  mocks.asset.getTelemetryMetrics.mockResolvedValue({
+    assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+    usersByType: [{ userId: 'user-1', type: AssetType.Image, count: 2, storageBytes: 400 }],
+    search: { eligibleAssets: 4, embeddedAssets: 3 },
+    state: { trashAssets: 1, externalAssets: 1 },
+  });
+  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+
+  sut.onBootstrap();
+  const observed = await observe(appCallbacks.get('immich.users.storage_bytes')!);
+
+  expect(observed).toHaveBeenCalledWith(400, { user_id: 'user-1', type: 'image' });
+  expect(JSON.stringify(observed.mock.calls)).not.toContain('userName');
+  expect(JSON.stringify(observed.mock.calls)).not.toContain('email');
+});
+
+it('serves the cached app snapshot inside the ttl', async () => {
+  mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+  mocks.asset.getTelemetryMetrics
+    .mockResolvedValueOnce({
+      assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+      usersByType: [],
+      search: { eligibleAssets: 4, embeddedAssets: 3 },
+      state: { trashAssets: 1, externalAssets: 1 },
+    })
+    .mockResolvedValueOnce({
+      assetsByType: [{ type: AssetType.Image, count: 9, storageBytes: 900 }],
+      usersByType: [],
+      search: { eligibleAssets: 9, embeddedAssets: 9 },
+      state: { trashAssets: 0, externalAssets: 0 },
+    });
+  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+  vi.useFakeTimers();
+
+  sut.onBootstrap();
+  await observe(appCallbacks.get('immich.assets.total')!);
+  const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+  expect(mocks.asset.getTelemetryMetrics).toHaveBeenCalledTimes(1);
+  expect(observed).toHaveBeenCalledWith(2, { type: 'image' });
+  vi.useRealTimers();
+});
+
+it('keeps the previous app snapshot when refresh fails', async () => {
+  mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+  mocks.asset.getTelemetryMetrics
+    .mockResolvedValueOnce({
+      assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+      usersByType: [],
+      search: { eligibleAssets: 4, embeddedAssets: 3 },
+      state: { trashAssets: 1, externalAssets: 1 },
+    })
+    .mockRejectedValueOnce(new Error('database down'));
+  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+  vi.useFakeTimers();
+
+  sut.onBootstrap();
+  await observe(appCallbacks.get('immich.assets.total')!);
+  vi.advanceTimersByTime(61_000);
+  const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+  expect(observed).toHaveBeenCalledWith(2, { type: 'image' });
+  vi.useRealTimers();
+});
+
+it('omits app metric series when the first refresh fails', async () => {
+  mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+  mocks.asset.getTelemetryMetrics.mockRejectedValue(new Error('database down'));
+  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+
+  sut.onBootstrap();
+  const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+  expect(observed).not.toHaveBeenCalled();
+  expect(mocks.logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unable to refresh app metrics snapshot'));
+});
+
+it('throttles first-refresh failures inside the ttl', async () => {
+  mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+  mocks.asset.getTelemetryMetrics.mockRejectedValue(new Error('database down'));
+  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+  vi.useFakeTimers();
+
+  sut.onBootstrap();
+  await observe(appCallbacks.get('immich.assets.total')!);
+  const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+  expect(observed).not.toHaveBeenCalled();
+  expect(mocks.asset.getTelemetryMetrics).toHaveBeenCalledTimes(1);
+  vi.useRealTimers();
+});
+
+it('observes queue counts and oldest job age', async () => {
+  mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+  mocks.job.getTelemetryMetrics.mockResolvedValue({
+    counts: [{ queue: QueueName.ThumbnailGeneration, status: 'waiting', count: 5 }],
+    oldestJobAges: [{ queue: QueueName.ThumbnailGeneration, status: 'waiting', ageSeconds: 120 }],
+  });
+
+  sut.onBootstrap();
+  const counts = await observe(jobCallbacks.get('immich.queues.jobs')!);
+  const ages = await observe(jobCallbacks.get('immich.queues.oldest_job_age_seconds')!);
+
+  expect(counts).toHaveBeenCalledWith(5, { queue: QueueName.ThumbnailGeneration, status: 'waiting' });
+  expect(ages).toHaveBeenCalledWith(120, { queue: QueueName.ThumbnailGeneration, status: 'waiting' });
+});
+```
+
+- [ ] **Step 8: Run app metrics tests**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/services/app-metrics.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run focused server unit tests**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/config.repository.spec.ts src/repositories/job.repository.spec.ts src/repositories/telemetry.repository.spec.ts src/services/app-metrics.service.spec.ts src/services/telemetry.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit Task 3**
+
+Run:
+
+```bash
+git add server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts server/test/repositories/job.repository.mock.ts server/src/services/app-metrics.service.ts server/src/services/app-metrics.service.spec.ts server/src/services/index.ts
+git commit -m "feat(server): publish prometheus app metrics"
+```
+
+## Task 4: Machine Learning Prometheus Metrics
+
+**Files:**
+
+- Modify: `machine-learning/pyproject.toml`
+- Modify: `machine-learning/uv.lock`
+- Add: `machine-learning/immich_ml/metrics.py`
+- Modify: `machine-learning/immich_ml/main.py`
+- Modify: `machine-learning/test_main.py`
+
+- [ ] **Step 1: Add `prometheus-client` dependency**
+
+In `machine-learning/pyproject.toml`, add to `[project].dependencies`:
+
+```toml
+"prometheus-client>=0.21.0,<1.0",
+```
+
+Run:
+
+```bash
+cd machine-learning && uv lock
+```
+
+Expected: `machine-learning/uv.lock` updates with `prometheus-client`.
+
+- [ ] **Step 2: Write failing ML metrics tests**
+
+Append this test class to `machine-learning/test_main.py`:
+
+```python
+class TestPrometheusMetrics:
+    def test_metrics_endpoint_returns_prometheus_text(self, deployed_app: TestClient) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+        response = deployed_app.get("/metrics")
+
+        assert response.status_code == 200
+        assert "text/plain" in response.headers["content-type"]
+        assert "immich_ml_active_requests" in response.text
+
+    def test_predict_records_success_metrics(self, deployed_app: TestClient, mocker: MockerFixture) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+        mocker.patch("immich_ml.main.run_inference", new_callable=mock.AsyncMock, return_value={"clip": "embedding"})
+        entries = {"clip": {"textual": {"modelName": "ViT-B-32__openai"}}}
+
+        response = deployed_app.post("/predict", data={"entries": orjson.dumps(entries).decode(), "text": "hello"})
+        metrics = deployed_app.get("/metrics").text
+
+        assert response.status_code == 200
+        assert 'immich_ml_requests_total{status="success",task="clip",type="textual"} 1.0' in metrics
+        assert 'immich_ml_request_duration_ms_count{status="success",task="clip",type="textual"} 1.0' in metrics
+        assert "immich_ml_active_requests 0.0" in metrics
+
+    def test_predict_records_validation_failure_with_unknown_labels(self, deployed_app: TestClient) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+
+        response = deployed_app.post("/predict", data={"entries": "{", "text": "hello"})
+        metrics = deployed_app.get("/metrics").text
+
+        assert response.status_code == 422
+        assert 'immich_ml_requests_total{status="validation_error",task="unknown",type="unknown"} 1.0' in metrics
+
+    @pytest.mark.asyncio
+    async def test_model_load_records_success_and_retry_metrics(self, deployed_app: TestClient) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+        mock_model = mock.Mock(spec=InferenceModel)
+        mock_model.model_name = "test_model_name"
+        mock_model.model_type = ModelType.VISUAL
+        mock_model.model_task = ModelTask.SEARCH
+        mock_model.load.side_effect = [OSError, None]
+        mock_model.loaded = False
+        mock_model.load_attempts = 0
+
+        await load(mock_model)
+        metrics = deployed_app.get("/metrics").text
+
+        assert 'immich_ml_model_load_duration_ms_count{status="error",task="clip",type="visual"} 1.0' in metrics
+        assert 'immich_ml_model_load_duration_ms_count{status="success",task="clip",type="visual"} 1.0' in metrics
+```
+
+- [ ] **Step 3: Run ML metrics tests and verify they fail**
+
+Run:
+
+```bash
+cd machine-learning && uv run pytest test_main.py -k PrometheusMetrics -q
+```
+
+Expected: FAIL because `immich_ml.metrics` and `/metrics` do not exist.
+
+- [ ] **Step 4: Add the ML metrics module**
+
+Create `machine-learning/immich_ml/metrics.py`:
+
+```python
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+
+from .schemas import InferenceEntries, ModelTask, ModelType
+
+registry = CollectorRegistry()
+
+REQUESTS = Counter(
+    "immich_ml_requests_total",
+    "Machine-learning prediction requests.",
+    ["task", "type", "status"],
+    registry=registry,
+)
+
+REQUEST_DURATION = Histogram(
+    "immich_ml_request_duration_ms",
+    "Machine-learning prediction request duration in milliseconds.",
+    ["task", "type", "status"],
+    buckets=(10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, float("inf")),
+    registry=registry,
+)
+
+ACTIVE_REQUESTS = Gauge(
+    "immich_ml_active_requests",
+    "In-flight machine-learning prediction requests.",
+    registry=registry,
+)
+
+MODEL_CACHE_ENTRIES = Gauge(
+    "immich_ml_model_cache_entries",
+    "Machine-learning model cache entries.",
+    ["task", "type"],
+    registry=registry,
+)
+
+MODEL_LOAD_DURATION = Histogram(
+    "immich_ml_model_load_duration_ms",
+    "Machine-learning model load duration in milliseconds.",
+    ["task", "type", "status"],
+    buckets=(10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, float("inf")),
+    registry=registry,
+)
+
+
+def labels_from_entries(entries: InferenceEntries) -> list[tuple[str, str]]:
+    without_deps, with_deps = entries
+    labels: list[tuple[str, str]] = []
+    for entry in [*without_deps, *with_deps]:
+        task = entry["task"].value if isinstance(entry["task"], ModelTask) else str(entry["task"])
+        model_type = entry["type"].value if isinstance(entry["type"], ModelType) else str(entry["type"])
+        labels.append((task, model_type))
+    return labels or [("unknown", "unknown")]
+
+
+def record_predict(labels: Iterable[tuple[str, str]], status: str, started: float) -> None:
+    duration_ms = (time.perf_counter() - started) * 1000
+    for task, model_type in labels:
+        REQUESTS.labels(task=task, type=model_type, status=status).inc()
+        REQUEST_DURATION.labels(task=task, type=model_type, status=status).observe(duration_ms)
+
+
+def record_validation_error(started: float) -> None:
+    record_predict([("unknown", "unknown")], "validation_error", started)
+
+
+def record_model_load(task: str, model_type: str, status: str, started: float) -> None:
+    MODEL_LOAD_DURATION.labels(task=task, type=model_type, status=status).observe((time.perf_counter() - started) * 1000)
+
+
+def set_model_cache_entries(labels: Iterable[tuple[str, str]]) -> None:
+    MODEL_CACHE_ENTRIES.clear()
+    counts: dict[tuple[str, str], int] = {}
+    for label in labels:
+        counts[label] = counts.get(label, 0) + 1
+    for (task, model_type), count in counts.items():
+        MODEL_CACHE_ENTRIES.labels(task=task, type=model_type).set(count)
+
+
+def render() -> bytes:
+    return generate_latest(registry)
+
+
+def reset_metrics_for_tests() -> None:
+    REQUESTS.clear()
+    REQUEST_DURATION.clear()
+    ACTIVE_REQUESTS.set(0)
+    MODEL_CACHE_ENTRIES.clear()
+    MODEL_LOAD_DURATION.clear()
+```
+
+- [ ] **Step 5: Wire ML metrics into FastAPI**
+
+In `machine-learning/immich_ml/main.py`, add imports:
+
+```python
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Response
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from . import metrics
+```
+
+Update `update_state()`:
+
+```python
+def update_state() -> Iterator[None]:
+    global active_requests, last_called
+    active_requests += 1
+    metrics.ACTIVE_REQUESTS.inc()
+    last_called = time.time()
+    try:
+        yield
+    finally:
+        active_requests -= 1
+        metrics.ACTIVE_REQUESTS.dec()
+```
+
+Add the endpoint after `/ping`:
+
+```python
+@app.get("/metrics")
+def prometheus_metrics() -> Response:
+    cache_labels = [
+        (model.model_task.value, model.model_type.value)
+        for model in model_cache.cache._cache.values()
+        if isinstance(model, InferenceModel)
+    ]
+    metrics.set_model_cache_entries(cache_labels)
+    return Response(metrics.render(), media_type=CONTENT_TYPE_LATEST)
+```
+
+Update `get_entries()` error handling:
+
+```python
+def get_entries(entries: str = Form()) -> InferenceEntries:
+    started = time.perf_counter()
+    try:
+        request: PipelineRequest = orjson.loads(entries)
+        without_deps: list[InferenceEntry] = []
+        with_deps: list[InferenceEntry] = []
+        for task, types in request.items():
+            for type, entry in types.items():
+                parsed: InferenceEntry = {
+                    "name": entry["modelName"],
+                    "task": task,
+                    "type": type,
+                    "options": entry.get("options", {}),
+                }
+                dep = get_model_deps(parsed["name"], type, task)
+                (with_deps if dep else without_deps).append(parsed)
+        return without_deps, with_deps
+    except (orjson.JSONDecodeError, ValidationError, KeyError, AttributeError) as e:
+        metrics.record_validation_error(started)
+        log.error(f"Invalid request format: {e}")
+        raise HTTPException(422, "Invalid request format.")
+```
+
+Update `predict()`:
+
+```python
+async def predict(
+    entries: InferenceEntries = Depends(get_entries),
+    image: bytes | None = File(default=None),
+    text: str | None = Form(default=None),
+) -> Any:
+    started = time.perf_counter()
+    metric_labels = metrics.labels_from_entries(entries)
+    try:
+        if image is not None:
+            inputs: Image | str = await run(lambda: decode_pil(image))
+        elif text is not None:
+            inputs = text
+        else:
+            raise HTTPException(400, "Either image or text must be provided")
+        response = await run_inference(inputs, entries)
+        metrics.record_predict(metric_labels, "success", started)
+        return ORJSONResponse(response)
+    except Exception:
+        metrics.record_predict(metric_labels, "error", started)
+        raise
+```
+
+Update `load()` to record model load duration:
+
+```python
+async def load(model: InferenceModel) -> InferenceModel:
+    if model.loaded:
+        return model
+
+    def _load(model: InferenceModel) -> InferenceModel:
+        if model.load_attempts > 1:
+            raise HTTPException(500, f"Failed to load model '{model.model_name}'")
+        with lock:
+            try:
+                model.load()
+            except FileNotFoundError as e:
+                if model.model_format == ModelFormat.ONNX:
+                    raise e
+                log.warning(
+                    f"{model.model_format.upper()} is available, but model '{model.model_name}' does not support it.",
+                    exc_info=e,
+                )
+                model.model_format = ModelFormat.ONNX
+                model.load()
+        return model
+
+    started = time.perf_counter()
+    try:
+        result = await run(_load, model)
+        metrics.record_model_load(model.model_task.value, model.model_type.value, "success", started)
+        return result
+    except (OSError, InvalidProtobuf, BadZipFile, NoSuchFile):
+        metrics.record_model_load(model.model_task.value, model.model_type.value, "error", started)
+        log.warning(f"Failed to load {model.model_type.replace('_', ' ')} model '{model.model_name}'. Clearing cache.")
+        model.clear_cache()
+        retry_started = time.perf_counter()
+        try:
+            result = await run(_load, model)
+            metrics.record_model_load(model.model_task.value, model.model_type.value, "success", retry_started)
+            return result
+        except Exception:
+            metrics.record_model_load(model.model_task.value, model.model_type.value, "error", retry_started)
+            raise
+```
+
+Preserve the existing retry behavior in `load()` while adding timing. If a retry succeeds after clearing cache, record `status="error"` for the failed load attempt and add a second `status="success"` observation around the retry.
+
+- [ ] **Step 6: Run ML metrics tests**
+
+Run:
+
+```bash
+cd machine-learning && uv run pytest test_main.py -k PrometheusMetrics -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run ML lint for touched files**
+
+Run:
+
+```bash
+cd machine-learning && uv run ruff check immich_ml/main.py immich_ml/metrics.py test_main.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add machine-learning/pyproject.toml machine-learning/uv.lock machine-learning/immich_ml/metrics.py machine-learning/immich_ml/main.py machine-learning/test_main.py
+git commit -m "feat(ml): expose prometheus metrics"
+```
+
+## Task 5: Prometheus Config, Grafana Dashboard, And Docs
+
+**Files:**
+
+- Modify: `docker/prometheus.yml`
+- Add: `docker/grafana-dashboard.json`
+- Modify: `docs/docs/features/monitoring.md`
+- Modify: `docs/docs/install/environment-variables.md`
+
+- [ ] **Step 1: Update Prometheus scrape config**
+
+Modify `docker/prometheus.yml`:
+
+```yaml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: immich_api
+    static_configs:
+      - targets: ['immich-server:8081']
+
+  - job_name: immich_microservices
+    static_configs:
+      - targets: ['immich-server:8082']
+
+  - job_name: immich_machine_learning
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['immich-machine-learning:3003']
+```
+
+- [ ] **Step 2: Add a valid dashboard JSON**
+
+Create `docker/grafana-dashboard.json` with this structure, then add one panel for every expression listed below before committing:
+
+```json
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [{ "expr": "sum(immich_assets_total)", "refId": "A" }],
+      "title": "Assets",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [{ "expr": "sum(immich_assets_storage_bytes)", "refId": "A" }],
+      "title": "Storage",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["gallery", "immich", "prometheus"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "browser",
+  "title": "Gallery Monitoring",
+  "uid": "gallery-monitoring",
+  "version": 1,
+  "weekStart": ""
+}
+```
+
+Add these additional panels in the same file before committing:
+
+```text
+Storage by type: sum by (type) (immich_assets_storage_bytes)
+Per-user storage: topk(10, sum by (user_id) (immich_users_storage_bytes))
+Assets by type: sum by (type) (immich_assets_total)
+Users: immich_users_total
+Embedding coverage: immich_search_embedding_coverage_ratio
+Queue depth: sum by (queue, status) (immich_queues_jobs)
+Oldest stale jobs: max by (queue, status) (immich_queues_oldest_job_age_seconds)
+Active ML requests: immich_ml_active_requests
+ML request rate: sum by (task, type, status) (rate(immich_ml_requests_total[5m]))
+ML p95 latency: histogram_quantile(0.95, sum by (le, task, type) (rate(immich_ml_request_duration_ms_bucket[5m])))
+Model cache entries: sum by (task, type) (immich_ml_model_cache_entries)
+Faces and people: immich_faces_total, immich_people_total
+```
+
+Use Prometheus-exported underscore names in dashboard expressions.
+
+- [ ] **Step 3: Validate dashboard JSON and required expressions**
+
+Run:
+
+```bash
+jq empty docker/grafana-dashboard.json
+for expr in \
+  'sum(immich_assets_total)' \
+  'sum(immich_assets_storage_bytes)' \
+  'sum by (type) (immich_assets_storage_bytes)' \
+  'topk(10, sum by (user_id) (immich_users_storage_bytes))' \
+  'sum by (type) (immich_assets_total)' \
+  'immich_users_total' \
+  'immich_search_embedding_coverage_ratio' \
+  'sum by (queue, status) (immich_queues_jobs)' \
+  'max by (queue, status) (immich_queues_oldest_job_age_seconds)' \
+  'immich_ml_active_requests' \
+  'sum by (task, type, status) (rate(immich_ml_requests_total[5m]))' \
+  'histogram_quantile(0.95, sum by (le, task, type) (rate(immich_ml_request_duration_ms_bucket[5m])))' \
+  'sum by (task, type) (immich_ml_model_cache_entries)' \
+  'immich_faces_total' \
+  'immich_people_total'; do
+  jq -e --arg expr "$expr" '[.. | objects | .expr? // empty] | index($expr)' docker/grafana-dashboard.json >/dev/null
+done
+```
+
+Expected: no output and exit code 0 for every command.
+
+- [ ] **Step 4: Update monitoring docs**
+
+In `docs/docs/features/monitoring.md`, update the metrics section to include:
+
+```markdown
+### Phase 1 Gallery Metrics
+
+Gallery adds a small set of application metrics on top of the standard OpenTelemetry metrics:
+
+- Asset counts and storage by type.
+- Per-user asset and storage metrics labeled by `user_id` only.
+- Smart-search embedding coverage.
+- Face and person totals.
+- Trash and external-library totals.
+- Queue counts and oldest waiting, delayed, and failed job age.
+- Machine-learning request counts, latency histograms, active requests, model cache entries, and model load latency.
+
+Per-user metrics intentionally use `user_id` only. Names, emails, filenames, paths, search text, IP addresses, and request payloads are not exported as labels.
+```
+
+Update the Prometheus example to mention the ML target:
+
+```yaml
+- job_name: immich_machine_learning
+  metrics_path: /metrics
+  static_configs:
+    - targets: ['immich-machine-learning:3003']
+```
+
+Add a Grafana import note:
+
+```markdown
+Gallery ships a starter dashboard at `docker/grafana-dashboard.json`. In Grafana, open **Dashboards > New > Import**, upload the JSON file, and select your Prometheus data source.
+```
+
+Add a deferred-scope paragraph:
+
+```markdown
+Phase 1 does not add auth/IP metrics, upload throughput, face/CLIP score distributions, duplicate metrics, video transcode quality metrics, DB bloat metrics, geocoding/OCR coverage, new memory metrics, cache hit/miss internals, or custom CPU/memory/GPU/network metrics beyond existing host and infrastructure exporters. Those need separate product and privacy decisions.
+```
+
+- [ ] **Step 5: Update environment variable docs**
+
+In `docs/docs/install/environment-variables.md`, update the Prometheus telemetry rows so `app` is included:
+
+```markdown
+| `IMMICH_TELEMETRY_INCLUDE` | Collect these telemetries. List of `host`, `api`, `app`, `io`, `repo`, `job`. Note: You can also specify `all` to enable all | | server | api, microservices |
+| `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these telemetries. List of `host`, `api`, `app`, `io`, `repo`, `job` | | server | api, microservices |
+```
+
+- [ ] **Step 6: Run docs formatting**
+
+Run:
+
+```bash
+pnpm --dir docs exec prettier --check docs/features/monitoring.md docs/install/environment-variables.md ../docker/prometheus.yml ../docker/grafana-dashboard.json
+```
+
+Expected: PASS. If it fails, run the same command with `--write`, then re-run `--check`.
+
+- [ ] **Step 7: Commit Task 5**
+
+Run:
+
+```bash
+git add docker/prometheus.yml docker/grafana-dashboard.json docs/docs/features/monitoring.md docs/docs/install/environment-variables.md
+git commit -m "docs: add prometheus dashboard"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+
+- Verify all files changed by Tasks 1-5.
+
+- [ ] **Step 1: Run focused server unit tests**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/config.repository.spec.ts src/repositories/job.repository.spec.ts src/repositories/telemetry.repository.spec.ts src/services/app-metrics.service.spec.ts src/services/telemetry.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused server medium repository tests**
+
+Run:
+
+```bash
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/asset.repository.spec.ts test/medium/specs/repositories/person.repository.spec.ts
+```
+
+Expected: PASS. If the medium test database is unavailable, stop and bring up the repo's medium-test database before continuing.
+
+- [ ] **Step 3: Run server type check**
+
+Run:
+
+```bash
+pnpm --dir server check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run ML metrics tests and lint**
+
+Run:
+
+```bash
+cd machine-learning && uv run pytest test_main.py -k PrometheusMetrics -q
+cd machine-learning && uv run ruff check immich_ml/main.py immich_ml/metrics.py test_main.py
+```
+
+Expected: PASS for both commands.
+
+- [ ] **Step 5: Validate dashboard JSON and docs formatting**
+
+Run:
+
+```bash
+jq empty docker/grafana-dashboard.json
+for expr in \
+  'sum(immich_assets_total)' \
+  'sum(immich_assets_storage_bytes)' \
+  'sum by (type) (immich_assets_storage_bytes)' \
+  'topk(10, sum by (user_id) (immich_users_storage_bytes))' \
+  'sum by (type) (immich_assets_total)' \
+  'immich_users_total' \
+  'immich_search_embedding_coverage_ratio' \
+  'sum by (queue, status) (immich_queues_jobs)' \
+  'max by (queue, status) (immich_queues_oldest_job_age_seconds)' \
+  'immich_ml_active_requests' \
+  'sum by (task, type, status) (rate(immich_ml_requests_total[5m]))' \
+  'histogram_quantile(0.95, sum by (le, task, type) (rate(immich_ml_request_duration_ms_bucket[5m])))' \
+  'sum by (task, type) (immich_ml_model_cache_entries)' \
+  'immich_faces_total' \
+  'immich_people_total'; do
+  jq -e --arg expr "$expr" '[.. | objects | .expr? // empty] | index($expr)' docker/grafana-dashboard.json >/dev/null
+done
+pnpm --dir docs exec prettier --check docs/features/monitoring.md docs/install/environment-variables.md ../docker/prometheus.yml ../docker/grafana-dashboard.json
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run final status check**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: branch is ahead with the design commit plus implementation commits, and no unstaged changes remain.

--- a/docs/superpowers/plans/2026-04-25-prometheus-metrics.md
+++ b/docs/superpowers/plans/2026-04-25-prometheus-metrics.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship the Phase 1 Prometheus monitoring slice: server domain metrics, queue staleness metrics, ML service metrics, Prometheus scrape config, Grafana dashboard, and docs.
 
-**Architecture:** Keep server metrics inside the existing opt-in OpenTelemetry exporter. Add an `app` telemetry group for domain snapshot metrics, use observable gauges for absolute values, publish queue metrics from the microservices worker, and expose ML metrics from the existing FastAPI app on `/metrics`.
+**Architecture:** Keep server metrics inside the existing opt-in OpenTelemetry exporter. Add an `app` telemetry group for domain snapshot metrics, keep app aggregate SQL in a dedicated `AppMetricsRepository` to avoid high-conflict domain repository edits, use observable gauges for absolute values, publish queue metrics from the microservices worker, and expose ML metrics from the existing FastAPI app on `/metrics`.
 
 **Tech Stack:** NestJS 11, OpenTelemetry, BullMQ, Kysely, Vitest, Python FastAPI, `prometheus-client`, uv, Grafana dashboard JSON, Docusaurus docs.
 
@@ -18,11 +18,9 @@
 - Modify `server/src/repositories/telemetry.repository.ts`: add an `app` metric group and observable gauge support.
 - Add `server/src/repositories/telemetry.repository.spec.ts`: unit coverage for observable gauge registration.
 - Modify `server/test/repositories/telemetry.repository.mock.ts`: mock `app.observeGauge()`.
-- Modify `server/src/repositories/asset.repository.ts`: add typed aggregate queries for server asset/search/storage metrics.
-- Modify `server/test/repositories/asset.repository.mock.ts`: mock the new asset telemetry method.
-- Modify `server/test/medium/specs/repositories/asset.repository.spec.ts`: medium coverage for asset telemetry aggregates.
-- Modify `server/src/repositories/person.repository.ts`: add typed aggregate query for face/person metrics.
-- Modify `server/test/medium/specs/repositories/person.repository.spec.ts`: medium coverage for face/person telemetry aggregates.
+- Add `server/src/repositories/app-metrics.repository.ts`: typed aggregate queries for asset, user, search, state, face, and person metrics.
+- Add `server/test/medium/specs/repositories/app-metrics.repository.spec.ts`: medium coverage for app telemetry aggregates.
+- Modify `server/src/repositories/index.ts`: register `AppMetricsRepository`.
 - Modify `server/src/repositories/job.repository.ts`: add queue count and oldest-job-age telemetry methods.
 - Modify `server/test/repositories/job.repository.mock.ts`: mock the new queue telemetry method.
 - Add `server/src/services/app-metrics.service.ts`: registers observable gauges and manages snapshot cache/failure behavior.
@@ -36,6 +34,17 @@
 - Add `docker/grafana-dashboard.json`: importable Phase 1 dashboard.
 - Modify `docs/docs/features/monitoring.md`: explain Phase 1 metrics, ML scrape target, dashboard import, privacy, and deferred scope.
 - Modify `docs/docs/install/environment-variables.md`: add `app` to telemetry include/exclude docs.
+
+## Rebase-Friendly Implementation Notes
+
+This plan keeps the high-conflict surface small:
+
+- Do not add telemetry-only methods to `server/src/repositories/asset.repository.ts` or `server/src/repositories/person.repository.ts`.
+- Keep app aggregate SQL in the new `server/src/repositories/app-metrics.repository.ts` file.
+- Keep `AppMetricsService` standalone with explicit constructor dependencies instead of extending `BaseService`.
+- Do not modify `server/test/utils.ts`; instantiate `AppMetricsService` directly in its unit test.
+- Do not modify `server/test/medium.factory.ts`; instantiate `AppMetricsRepository` directly in its medium test and use `BaseService` only to create test data helpers.
+- Limit unavoidable edits to registration and shared telemetry files: `server/src/enum.ts`, `server/src/repositories/index.ts`, `server/src/repositories/telemetry.repository.ts`, `server/src/services/index.ts`, and the existing mocks.
 
 ## Task 1: Telemetry App Group And Observable Gauge Support
 
@@ -250,107 +259,142 @@ git add server/src/enum.ts server/src/repositories/config.repository.spec.ts ser
 git commit -m "feat(server): add app telemetry gauges"
 ```
 
-## Task 2: Server Domain Metric Repository Queries
+## Task 2: Server App Metrics Repository
 
 **Files:**
 
-- Modify: `server/src/repositories/asset.repository.ts`
-- Modify: `server/test/repositories/asset.repository.mock.ts`
-- Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
-- Modify: `server/src/repositories/person.repository.ts`
-- Modify: `server/test/medium/specs/repositories/person.repository.spec.ts`
+- Add: `server/src/repositories/app-metrics.repository.ts`
+- Add: `server/test/medium/specs/repositories/app-metrics.repository.spec.ts`
+- Modify: `server/src/repositories/index.ts`
 
-- [ ] **Step 1: Write failing medium tests for asset telemetry aggregates**
+- [ ] **Step 1: Write failing medium tests for app metric aggregates**
 
-Append this describe block to `server/test/medium/specs/repositories/asset.repository.spec.ts`:
+Create `server/test/medium/specs/repositories/app-metrics.repository.spec.ts`:
 
 ```typescript
-describe('getTelemetryMetrics', () => {
-  it('returns low-cardinality asset, user, storage, embedding, trash, and external metrics', async () => {
-    const { ctx, sut } = setup();
-    const { user: user1 } = await ctx.newUser();
-    const { user: user2 } = await ctx.newUser();
+import { Kysely } from 'kysely';
+import { AssetType, AssetVisibility } from 'src/enum';
+import { AppMetricsRepository } from 'src/repositories/app-metrics.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { newEmbedding } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
 
-    const { asset: image1 } = await ctx.newAsset({
-      ownerId: user1.id,
-      type: AssetType.Image,
-      visibility: AssetVisibility.Timeline,
-    });
-    const { asset: video1 } = await ctx.newAsset({
-      ownerId: user1.id,
-      type: AssetType.Video,
-      visibility: AssetVisibility.Timeline,
-    });
-    const { asset: image2 } = await ctx.newAsset({
-      ownerId: user2.id,
-      type: AssetType.Image,
-      visibility: AssetVisibility.Timeline,
-      isExternal: true,
-    });
-    const { asset: hidden } = await ctx.newAsset({
-      ownerId: user2.id,
-      type: AssetType.Image,
-      visibility: AssetVisibility.Hidden,
-    });
-    const { asset: trashed } = await ctx.newAsset({
-      ownerId: user2.id,
-      type: AssetType.Video,
-      visibility: AssetVisibility.Timeline,
-    });
+let defaultDatabase: Kysely<DB>;
 
-    await Promise.all([
-      ctx.newExif({ assetId: image1.id, fileSizeInByte: 100 }),
-      ctx.newExif({ assetId: video1.id, fileSizeInByte: 200 }),
-      ctx.newExif({ assetId: image2.id, fileSizeInByte: 300 }),
-      ctx.newExif({ assetId: hidden.id, fileSizeInByte: 400 }),
-      ctx.newExif({ assetId: trashed.id, fileSizeInByte: 500 }),
-      ctx.database.insertInto('smart_search').values({ assetId: image1.id, embedding: newEmbedding() }).execute(),
-      ctx.softDeleteAsset(trashed.id),
-    ]);
+const setup = (db?: Kysely<DB>) => {
+  const database = db || defaultDatabase;
+  const { ctx } = newMediumService(BaseService, {
+    database,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: new AppMetricsRepository(database) };
+};
 
-    const result = await sut.getTelemetryMetrics();
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
 
-    expect(result.assetsByType).toEqual(
-      expect.arrayContaining([
-        { type: AssetType.Image, count: 2, storageBytes: 400 },
-        { type: AssetType.Video, count: 1, storageBytes: 200 },
-      ]),
-    );
-    expect(result.usersByType).toEqual(
-      expect.arrayContaining([
-        { userId: user1.id, type: AssetType.Image, count: 1, storageBytes: 100 },
-        { userId: user1.id, type: AssetType.Video, count: 1, storageBytes: 200 },
-        { userId: user2.id, type: AssetType.Image, count: 1, storageBytes: 300 },
-      ]),
-    );
-    expect(result.search).toEqual({ eligibleAssets: 3, embeddedAssets: 1 });
-    expect(result.state).toEqual({ externalAssets: 1, trashAssets: 1 });
+describe(AppMetricsRepository.name, () => {
+  describe('getMetrics', () => {
+    it('returns low-cardinality asset, user, search, state, face, and person metrics', async () => {
+      const { ctx, sut } = setup();
+      const { user: user1 } = await ctx.newUser();
+      const { user: user2 } = await ctx.newUser();
+
+      const { asset: image1 } = await ctx.newAsset({
+        ownerId: user1.id,
+        type: AssetType.Image,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { asset: video1 } = await ctx.newAsset({
+        ownerId: user1.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { asset: image2 } = await ctx.newAsset({
+        ownerId: user2.id,
+        type: AssetType.Image,
+        visibility: AssetVisibility.Timeline,
+        isExternal: true,
+      });
+      const { asset: hidden } = await ctx.newAsset({
+        ownerId: user2.id,
+        type: AssetType.Image,
+        visibility: AssetVisibility.Hidden,
+      });
+      const { asset: trashed } = await ctx.newAsset({
+        ownerId: user2.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { person: person1 } = await ctx.newPerson({ ownerId: user1.id, name: 'Alice' });
+      const { person: person2 } = await ctx.newPerson({ ownerId: user1.id, name: 'Bob' });
+
+      await Promise.all([
+        ctx.newExif({ assetId: image1.id, fileSizeInByte: 100 }),
+        ctx.newExif({ assetId: video1.id, fileSizeInByte: 200 }),
+        ctx.newExif({ assetId: image2.id, fileSizeInByte: 300 }),
+        ctx.newExif({ assetId: hidden.id, fileSizeInByte: 400 }),
+        ctx.newExif({ assetId: trashed.id, fileSizeInByte: 500 }),
+        ctx.database.insertInto('smart_search').values({ assetId: image1.id, embedding: newEmbedding() }).execute(),
+        ctx.newAssetFace({ assetId: image1.id, personId: person1.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: image1.id, personId: person1.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: video1.id, personId: person2.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: video1.id, personId: person2.id, isVisible: false }),
+        ctx.newAssetFace({ assetId: video1.id, personId: null, isVisible: true }),
+        ctx.newAssetFace({ assetId: hidden.id, personId: person2.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: trashed.id, personId: person2.id, isVisible: true }),
+        ctx.softDeleteAsset(trashed.id),
+      ]);
+
+      const result = await sut.getMetrics();
+
+      expect(result.asset.assetsByType).toEqual(
+        expect.arrayContaining([
+          { type: AssetType.Image, count: 2, storageBytes: 400 },
+          { type: AssetType.Video, count: 1, storageBytes: 200 },
+        ]),
+      );
+      expect(result.asset.usersByType).toEqual(
+        expect.arrayContaining([
+          { userId: user1.id, type: AssetType.Image, count: 1, storageBytes: 100 },
+          { userId: user1.id, type: AssetType.Video, count: 1, storageBytes: 200 },
+          { userId: user2.id, type: AssetType.Image, count: 1, storageBytes: 300 },
+        ]),
+      );
+      expect(result.asset.search).toEqual({ eligibleAssets: 3, embeddedAssets: 1 });
+      expect(result.asset.state).toEqual({ externalAssets: 1, trashAssets: 1 });
+      expect(result.person).toEqual({ faces: 4, people: 2 });
+    });
   });
 });
 ```
 
-Update the imports at the top:
-
-```typescript
-import { AssetFileType, AssetOrder, AssetType, AssetVisibility } from 'src/enum';
-import { factory, newEmbedding } from 'test/small.factory';
-```
-
-- [ ] **Step 2: Run the asset medium test and verify it fails**
+- [ ] **Step 2: Run the app metrics repository medium test and verify it fails**
 
 Run:
 
 ```bash
-pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/asset.repository.spec.ts
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/app-metrics.repository.spec.ts
 ```
 
-Expected: FAIL because `AssetRepository.getTelemetryMetrics()` does not exist.
+Expected: FAIL because `AppMetricsRepository` does not exist.
 
-- [ ] **Step 3: Add asset telemetry types and query method**
+- [ ] **Step 3: Add the app metrics repository**
 
-In `server/src/repositories/asset.repository.ts`, add these interfaces near `AssetStats`:
+Create `server/src/repositories/app-metrics.repository.ts`:
 
 ```typescript
+import { Injectable } from '@nestjs/common';
+import { Kysely, SelectQueryBuilder } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { AssetType, AssetVisibility } from 'src/enum';
+import { DB } from 'src/schema';
+
 export interface AssetTelemetryByType {
   type: AssetType;
   count: number;
@@ -377,205 +421,157 @@ export interface AssetTelemetryMetrics {
   search: SearchTelemetryMetrics;
   state: AssetStateTelemetryMetrics;
 }
-```
 
-Add this method inside `AssetRepository`:
-
-```typescript
-async getTelemetryMetrics(): Promise<AssetTelemetryMetrics> {
-  const visibleTimelineAssets = <O extends object>(qb: SelectQueryBuilder<DB, 'asset', O>) =>
-    qb.where('asset.deletedAt', 'is', null).where('asset.visibility', '=', AssetVisibility.Timeline);
-
-  const assetsByType = await visibleTimelineAssets(
-    this.db
-      .selectFrom('asset')
-      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
-      .select(['asset.type'])
-      .select((eb) => [
-        eb.fn.countAll<number>().as('count'),
-        eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
-      ])
-      .groupBy('asset.type'),
-  ).execute();
-
-  const usersByType = await visibleTimelineAssets(
-    this.db
-      .selectFrom('asset')
-      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
-      .select(['asset.ownerId as userId', 'asset.type'])
-      .select((eb) => [
-        eb.fn.countAll<number>().as('count'),
-        eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
-      ])
-      .groupBy(['asset.ownerId', 'asset.type']),
-  ).execute();
-
-  const search = await visibleTimelineAssets(
-    this.db
-      .selectFrom('asset')
-      .leftJoin('smart_search', 'smart_search.assetId', 'asset.id')
-      .select((eb) => [
-        eb.fn.countAll<number>().as('eligibleAssets'),
-        eb.fn.count<number>('smart_search.assetId').as('embeddedAssets'),
-      ])
-      .where('asset.type', 'in', [AssetType.Image, AssetType.Video]),
-  ).executeTakeFirstOrThrow();
-
-  const state = await this.db
-    .selectFrom('asset')
-    .select((eb) => [
-      eb.fn.countAll<number>().filterWhere('asset.deletedAt', 'is not', null).as('trashAssets'),
-      eb.fn
-        .countAll<number>()
-        .filterWhere((eb) => eb.and([eb('asset.deletedAt', 'is', null), eb('asset.isExternal', '=', true)]))
-        .as('externalAssets'),
-    ])
-    .executeTakeFirstOrThrow();
-
-  return {
-    assetsByType: assetsByType.map((item) => ({
-      type: item.type,
-      count: Number(item.count),
-      storageBytes: Number(item.storageBytes),
-    })),
-    usersByType: usersByType.map((item) => ({
-      userId: item.userId,
-      type: item.type,
-      count: Number(item.count),
-      storageBytes: Number(item.storageBytes),
-    })),
-    search: {
-      eligibleAssets: Number(search.eligibleAssets),
-      embeddedAssets: Number(search.embeddedAssets),
-    },
-    state: {
-      externalAssets: Number(state.externalAssets),
-      trashAssets: Number(state.trashAssets),
-    },
-  };
-}
-```
-
-- [ ] **Step 4: Update the asset repository mock**
-
-In `server/test/repositories/asset.repository.mock.ts`, add:
-
-```typescript
-getTelemetryMetrics: vitest.fn(),
-```
-
-- [ ] **Step 5: Run the asset medium test and verify it passes**
-
-Run:
-
-```bash
-pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/asset.repository.spec.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 6: Write failing medium tests for face/person telemetry aggregates**
-
-Append this describe block to `server/test/medium/specs/repositories/person.repository.spec.ts`:
-
-```typescript
-describe('getTelemetryMetrics', () => {
-  it('returns visible face and person counts without exposing names', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { asset: asset1 } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
-    const { asset: asset2 } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
-    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
-    const { asset: trashedAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
-    const { person: person1 } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
-    const { person: person2 } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
-
-    await Promise.all([
-      ctx.newAssetFace({ assetId: asset1.id, personId: person1.id, isVisible: true }),
-      ctx.newAssetFace({ assetId: asset1.id, personId: person1.id, isVisible: true }),
-      ctx.newAssetFace({ assetId: asset2.id, personId: person2.id, isVisible: true }),
-      ctx.newAssetFace({ assetId: asset2.id, personId: person2.id, isVisible: false }),
-      ctx.newAssetFace({ assetId: asset2.id, personId: null, isVisible: true }),
-      ctx.newAssetFace({ assetId: hiddenAsset.id, personId: person2.id, isVisible: true }),
-      ctx.newAssetFace({ assetId: trashedAsset.id, personId: person2.id, isVisible: true }),
-      ctx.softDeleteAsset(trashedAsset.id),
-    ]);
-
-    const result = await sut.getTelemetryMetrics();
-
-    expect(result).toEqual({ faces: 4, people: 2 });
-  });
-});
-```
-
-Update the imports at the top:
-
-```typescript
-import { AssetFileType, AssetVisibility } from 'src/enum';
-```
-
-- [ ] **Step 7: Run the person medium test and verify it fails**
-
-Run:
-
-```bash
-pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/person.repository.spec.ts
-```
-
-Expected: FAIL because `PersonRepository.getTelemetryMetrics()` does not exist.
-
-- [ ] **Step 8: Add person telemetry query**
-
-In `server/src/repositories/person.repository.ts`, add:
-
-```typescript
 export interface PersonTelemetryMetrics {
   faces: number;
   people: number;
 }
-```
 
-Add this method inside `PersonRepository`:
+export interface AppMetricsSnapshot {
+  asset: AssetTelemetryMetrics;
+  person: PersonTelemetryMetrics;
+}
 
-```typescript
-async getTelemetryMetrics(): Promise<PersonTelemetryMetrics> {
-  const result = await this.db
-    .selectFrom('asset_face')
-    .innerJoin('asset', 'asset.id', 'asset_face.assetId')
-    .select((eb) => [
-      eb.fn.countAll<number>().as('faces'),
-      eb.fn.count<number>(eb.fn('distinct', ['asset_face.personId'])).filterWhere('asset_face.personId', 'is not', null).as('people'),
-    ])
-    .where('asset_face.deletedAt', 'is', null)
-    .where('asset_face.isVisible', 'is', true)
-    .where('asset.deletedAt', 'is', null)
-    .where('asset.visibility', '=', AssetVisibility.Timeline)
-    .executeTakeFirstOrThrow();
+@Injectable()
+export class AppMetricsRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
 
-  return {
-    faces: Number(result.faces),
-    people: Number(result.people),
-  };
+  async getMetrics(): Promise<AppMetricsSnapshot> {
+    const [asset, person] = await Promise.all([this.getAssetMetrics(), this.getPersonMetrics()]);
+    return { asset, person };
+  }
+
+  private visibleTimelineAssets<O extends object>(qb: SelectQueryBuilder<DB, 'asset', O>) {
+    return qb.where('asset.deletedAt', 'is', null).where('asset.visibility', '=', AssetVisibility.Timeline);
+  }
+
+  private async getAssetMetrics(): Promise<AssetTelemetryMetrics> {
+    const assetsByType = await this.visibleTimelineAssets(
+      this.db
+        .selectFrom('asset')
+        .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+        .select(['asset.type'])
+        .select((eb) => [
+          eb.fn.countAll<number>().as('count'),
+          eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
+        ])
+        .groupBy('asset.type'),
+    ).execute();
+
+    const usersByType = await this.visibleTimelineAssets(
+      this.db
+        .selectFrom('asset')
+        .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+        .select(['asset.ownerId as userId', 'asset.type'])
+        .select((eb) => [
+          eb.fn.countAll<number>().as('count'),
+          eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
+        ])
+        .groupBy(['asset.ownerId', 'asset.type']),
+    ).execute();
+
+    const search = await this.visibleTimelineAssets(
+      this.db
+        .selectFrom('asset')
+        .leftJoin('smart_search', 'smart_search.assetId', 'asset.id')
+        .select((eb) => [
+          eb.fn.countAll<number>().as('eligibleAssets'),
+          eb.fn.count<number>('smart_search.assetId').as('embeddedAssets'),
+        ])
+        .where('asset.type', 'in', [AssetType.Image, AssetType.Video]),
+    ).executeTakeFirstOrThrow();
+
+    const state = await this.db
+      .selectFrom('asset')
+      .select((eb) => [
+        eb.fn.countAll<number>().filterWhere('asset.deletedAt', 'is not', null).as('trashAssets'),
+        eb.fn
+          .countAll<number>()
+          .filterWhere((eb) => eb.and([eb('asset.deletedAt', 'is', null), eb('asset.isExternal', '=', true)]))
+          .as('externalAssets'),
+      ])
+      .executeTakeFirstOrThrow();
+
+    return {
+      assetsByType: assetsByType.map((item) => ({
+        type: item.type,
+        count: Number(item.count),
+        storageBytes: Number(item.storageBytes),
+      })),
+      usersByType: usersByType.map((item) => ({
+        userId: item.userId,
+        type: item.type,
+        count: Number(item.count),
+        storageBytes: Number(item.storageBytes),
+      })),
+      search: {
+        eligibleAssets: Number(search.eligibleAssets),
+        embeddedAssets: Number(search.embeddedAssets),
+      },
+      state: {
+        externalAssets: Number(state.externalAssets),
+        trashAssets: Number(state.trashAssets),
+      },
+    };
+  }
+
+  private async getPersonMetrics(): Promise<PersonTelemetryMetrics> {
+    const result = await this.db
+      .selectFrom('asset_face')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .select((eb) => [
+        eb.fn.countAll<number>().as('faces'),
+        eb.fn
+          .count<number>(eb.fn('distinct', ['asset_face.personId']))
+          .filterWhere('asset_face.personId', 'is not', null)
+          .as('people'),
+      ])
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', 'is', true)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .executeTakeFirstOrThrow();
+
+    return {
+      faces: Number(result.faces),
+      people: Number(result.people),
+    };
+  }
 }
 ```
 
-- [ ] **Step 9: Run the person medium test and verify it passes**
+- [ ] **Step 4: Register `AppMetricsRepository`**
+
+In `server/src/repositories/index.ts`, add the import:
+
+```typescript
+import { AppMetricsRepository } from 'src/repositories/app-metrics.repository';
+```
+
+Add it to `repositories` near `AppRepository`:
+
+```typescript
+AppMetricsRepository,
+AppRepository,
+```
+
+- [ ] **Step 5: Run the app metrics repository medium test and verify it passes**
 
 Run:
 
 ```bash
-pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/person.repository.spec.ts
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/app-metrics.repository.spec.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 10: Commit Task 2**
+- [ ] **Step 6: Commit Task 2**
 
 Run:
 
 ```bash
-git add server/src/repositories/asset.repository.ts server/test/repositories/asset.repository.mock.ts server/test/medium/specs/repositories/asset.repository.spec.ts server/src/repositories/person.repository.ts server/test/medium/specs/repositories/person.repository.spec.ts
-git commit -m "feat(server): collect domain metric aggregates"
+git add server/src/repositories/app-metrics.repository.ts server/src/repositories/index.ts server/test/medium/specs/repositories/app-metrics.repository.spec.ts
+git commit -m "feat(server): collect app metric aggregates"
 ```
 
 ## Task 3: Queue Telemetry And App Metrics Service
@@ -650,14 +646,20 @@ describe(JobRepository.name, () => {
 });
 ```
 
-In `server/src/services/app-metrics.service.spec.ts`, start with service-level tests that use the public `JobRepository.getTelemetryMetrics()` mock:
+In `server/src/services/app-metrics.service.spec.ts`, start with service-level tests that use direct
+`AppMetricsRepository` and `JobRepository.getTelemetryMetrics()` mocks:
 
 ```typescript
 import { ObservableCallback, ObservableResult } from '@opentelemetry/api';
 import { AssetType, ImmichWorker, QueueName } from 'src/enum';
+import { AppMetricsRepository } from 'src/repositories/app-metrics.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { TelemetryRepository } from 'src/repositories/telemetry.repository';
 import { AppMetricsService } from 'src/services/app-metrics.service';
-import { newTestService, ServiceMocks } from 'test/utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { newTelemetryRepositoryMock } from 'test/repositories/telemetry.repository.mock';
+import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
 
 const observe = async (callback: ObservableCallback) => {
   const result = { observe: vi.fn() } as unknown as ObservableResult;
@@ -665,18 +667,43 @@ const observe = async (callback: ObservableCallback) => {
   return result.observe as ReturnType<typeof vi.fn>;
 };
 
+type AppMetricsServiceMocks = {
+  logger: Mocked<Pick<LoggingRepository, 'setContext' | 'warn'>>;
+  config: Mocked<Pick<ConfigRepository, 'getWorker'>>;
+  telemetry: ReturnType<typeof newTelemetryRepositoryMock>;
+  appMetrics: Mocked<Pick<AppMetricsRepository, 'getMetrics'>>;
+  job: Mocked<Pick<JobRepository, 'getTelemetryMetrics'>>;
+};
+
 describe(AppMetricsService.name, () => {
   let sut: AppMetricsService;
-  let mocks: ServiceMocks;
+  let mocks: AppMetricsServiceMocks;
   let appCallbacks: Map<string, ObservableCallback>;
   let jobCallbacks: Map<string, ObservableCallback>;
 
   beforeEach(() => {
-    ({ sut, mocks } = newTestService(AppMetricsService));
+    mocks = {
+      logger: { setContext: vi.fn(), warn: vi.fn() },
+      config: { getWorker: vi.fn() },
+      telemetry: newTelemetryRepositoryMock(),
+      appMetrics: { getMetrics: vi.fn() },
+      job: { getTelemetryMetrics: vi.fn() },
+    };
+    sut = new AppMetricsService(
+      mocks.logger as unknown as LoggingRepository,
+      mocks.config as unknown as ConfigRepository,
+      mocks.telemetry as unknown as TelemetryRepository,
+      mocks.appMetrics as unknown as AppMetricsRepository,
+      mocks.job as unknown as JobRepository,
+    );
     appCallbacks = new Map();
     jobCallbacks = new Map();
-    mocks.telemetry.app.observeGauge.mockImplementation((name, callback) => appCallbacks.set(name, callback));
-    mocks.telemetry.jobs.observeGauge.mockImplementation((name, callback) => jobCallbacks.set(name, callback));
+    mocks.telemetry.app.observeGauge.mockImplementation((name, callback) => {
+      appCallbacks.set(name, callback);
+    });
+    mocks.telemetry.jobs.observeGauge.mockImplementation((name, callback) => {
+      jobCallbacks.set(name, callback);
+    });
   });
 
   it('registers app gauges on the API worker', () => {
@@ -783,27 +810,34 @@ import { Injectable } from '@nestjs/common';
 import { ObservableCallback, ObservableResult } from '@opentelemetry/api';
 import { OnEvent } from 'src/decorators';
 import { ImmichWorker } from 'src/enum';
-import { AssetTelemetryMetrics } from 'src/repositories/asset.repository';
+import { AppMetricsRepository, AppMetricsSnapshot } from 'src/repositories/app-metrics.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
 import { QueueTelemetryMetrics } from 'src/repositories/job.repository';
-import { PersonTelemetryMetrics } from 'src/repositories/person.repository';
-import { BaseService } from 'src/services/base.service';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { TelemetryRepository } from 'src/repositories/telemetry.repository';
 
 const SNAPSHOT_TTL_MS = 60_000;
 
-type AppSnapshot = {
-  asset: AssetTelemetryMetrics;
-  person: PersonTelemetryMetrics;
-};
-
 @Injectable()
-export class AppMetricsService extends BaseService {
-  private appSnapshot?: AppSnapshot;
+export class AppMetricsService {
+  private appSnapshot?: AppMetricsSnapshot;
   private appSnapshotAttemptedAt?: number;
-  private appRefresh?: Promise<AppSnapshot | undefined>;
+  private appRefresh?: Promise<AppMetricsSnapshot | undefined>;
   private queueSnapshot?: QueueTelemetryMetrics;
   private queueSnapshotAttemptedAt?: number;
   private queueRefresh?: Promise<QueueTelemetryMetrics | undefined>;
   private registered = false;
+
+  constructor(
+    private logger: LoggingRepository,
+    private configRepository: ConfigRepository,
+    private telemetryRepository: TelemetryRepository,
+    private appMetricsRepository: AppMetricsRepository,
+    private jobRepository: JobRepository,
+  ) {
+    this.logger.setContext(AppMetricsService.name);
+  }
 
   @OnEvent({ name: 'AppBootstrap' })
   onBootstrap() {
@@ -812,7 +846,7 @@ export class AppMetricsService extends BaseService {
     }
     this.registered = true;
 
-    switch (this.worker) {
+    switch (this.configRepository.getWorker()) {
       case ImmichWorker.Api: {
         this.registerAppGauges();
         break;
@@ -872,7 +906,10 @@ export class AppMetricsService extends BaseService {
     });
   }
 
-  private observeAppGauge(name: string, observeSnapshot: (snapshot: AppSnapshot, result: ObservableResult) => void) {
+  private observeAppGauge(
+    name: string,
+    observeSnapshot: (snapshot: AppMetricsSnapshot, result: ObservableResult) => void,
+  ) {
     const callback: ObservableCallback = async (result) => {
       const snapshot = await this.getAppSnapshot();
       if (snapshot) {
@@ -895,7 +932,7 @@ export class AppMetricsService extends BaseService {
     this.telemetryRepository.jobs.observeGauge(name, callback);
   }
 
-  private async getAppSnapshot(): Promise<AppSnapshot | undefined> {
+  private async getAppSnapshot(): Promise<AppMetricsSnapshot | undefined> {
     if (this.appSnapshotAttemptedAt !== undefined && Date.now() - this.appSnapshotAttemptedAt < SNAPSHOT_TTL_MS) {
       return this.appSnapshot;
     }
@@ -907,13 +944,9 @@ export class AppMetricsService extends BaseService {
     }
   }
 
-  private async refreshAppSnapshot(): Promise<AppSnapshot | undefined> {
+  private async refreshAppSnapshot(): Promise<AppMetricsSnapshot | undefined> {
     try {
-      const [asset, person] = await Promise.all([
-        this.assetRepository.getTelemetryMetrics(),
-        this.personRepository.getTelemetryMetrics(),
-      ]);
-      this.appSnapshot = { asset, person };
+      this.appSnapshot = await this.appMetricsRepository.getMetrics();
     } catch (error: Error | unknown) {
       this.logger.warn(`Unable to refresh app metrics snapshot: ${error instanceof Error ? error.message : error}`);
     } finally {
@@ -970,13 +1003,15 @@ Add these tests to `server/src/services/app-metrics.service.spec.ts`:
 ```typescript
 it('observes app metrics with user_id labels only', async () => {
   mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
-  mocks.asset.getTelemetryMetrics.mockResolvedValue({
-    assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
-    usersByType: [{ userId: 'user-1', type: AssetType.Image, count: 2, storageBytes: 400 }],
-    search: { eligibleAssets: 4, embeddedAssets: 3 },
-    state: { trashAssets: 1, externalAssets: 1 },
+  mocks.appMetrics.getMetrics.mockResolvedValue({
+    asset: {
+      assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+      usersByType: [{ userId: 'user-1', type: AssetType.Image, count: 2, storageBytes: 400 }],
+      search: { eligibleAssets: 4, embeddedAssets: 3 },
+      state: { trashAssets: 1, externalAssets: 1 },
+    },
+    person: { faces: 8, people: 2 },
   });
-  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
 
   sut.onBootstrap();
   const observed = await observe(appCallbacks.get('immich.users.storage_bytes')!);
@@ -988,42 +1023,49 @@ it('observes app metrics with user_id labels only', async () => {
 
 it('serves the cached app snapshot inside the ttl', async () => {
   mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
-  mocks.asset.getTelemetryMetrics
+  mocks.appMetrics.getMetrics
     .mockResolvedValueOnce({
-      assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
-      usersByType: [],
-      search: { eligibleAssets: 4, embeddedAssets: 3 },
-      state: { trashAssets: 1, externalAssets: 1 },
+      asset: {
+        assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+        usersByType: [],
+        search: { eligibleAssets: 4, embeddedAssets: 3 },
+        state: { trashAssets: 1, externalAssets: 1 },
+      },
+      person: { faces: 8, people: 2 },
     })
     .mockResolvedValueOnce({
-      assetsByType: [{ type: AssetType.Image, count: 9, storageBytes: 900 }],
-      usersByType: [],
-      search: { eligibleAssets: 9, embeddedAssets: 9 },
-      state: { trashAssets: 0, externalAssets: 0 },
+      asset: {
+        assetsByType: [{ type: AssetType.Image, count: 9, storageBytes: 900 }],
+        usersByType: [],
+        search: { eligibleAssets: 9, embeddedAssets: 9 },
+        state: { trashAssets: 0, externalAssets: 0 },
+      },
+      person: { faces: 9, people: 3 },
     });
-  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
   vi.useFakeTimers();
 
   sut.onBootstrap();
   await observe(appCallbacks.get('immich.assets.total')!);
   const observed = await observe(appCallbacks.get('immich.assets.total')!);
 
-  expect(mocks.asset.getTelemetryMetrics).toHaveBeenCalledTimes(1);
+  expect(mocks.appMetrics.getMetrics).toHaveBeenCalledTimes(1);
   expect(observed).toHaveBeenCalledWith(2, { type: 'image' });
   vi.useRealTimers();
 });
 
 it('keeps the previous app snapshot when refresh fails', async () => {
   mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
-  mocks.asset.getTelemetryMetrics
+  mocks.appMetrics.getMetrics
     .mockResolvedValueOnce({
-      assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
-      usersByType: [],
-      search: { eligibleAssets: 4, embeddedAssets: 3 },
-      state: { trashAssets: 1, externalAssets: 1 },
+      asset: {
+        assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+        usersByType: [],
+        search: { eligibleAssets: 4, embeddedAssets: 3 },
+        state: { trashAssets: 1, externalAssets: 1 },
+      },
+      person: { faces: 8, people: 2 },
     })
     .mockRejectedValueOnce(new Error('database down'));
-  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
   vi.useFakeTimers();
 
   sut.onBootstrap();
@@ -1037,8 +1079,7 @@ it('keeps the previous app snapshot when refresh fails', async () => {
 
 it('omits app metric series when the first refresh fails', async () => {
   mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
-  mocks.asset.getTelemetryMetrics.mockRejectedValue(new Error('database down'));
-  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+  mocks.appMetrics.getMetrics.mockRejectedValue(new Error('database down'));
 
   sut.onBootstrap();
   const observed = await observe(appCallbacks.get('immich.assets.total')!);
@@ -1049,8 +1090,7 @@ it('omits app metric series when the first refresh fails', async () => {
 
 it('throttles first-refresh failures inside the ttl', async () => {
   mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
-  mocks.asset.getTelemetryMetrics.mockRejectedValue(new Error('database down'));
-  mocks.person.getTelemetryMetrics.mockResolvedValue({ faces: 8, people: 2 });
+  mocks.appMetrics.getMetrics.mockRejectedValue(new Error('database down'));
   vi.useFakeTimers();
 
   sut.onBootstrap();
@@ -1058,7 +1098,7 @@ it('throttles first-refresh failures inside the ttl', async () => {
   const observed = await observe(appCallbacks.get('immich.assets.total')!);
 
   expect(observed).not.toHaveBeenCalled();
-  expect(mocks.asset.getTelemetryMetrics).toHaveBeenCalledTimes(1);
+  expect(mocks.appMetrics.getMetrics).toHaveBeenCalledTimes(1);
   vi.useRealTimers();
 });
 
@@ -1716,7 +1756,7 @@ Expected: PASS.
 Run:
 
 ```bash
-pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/asset.repository.spec.ts test/medium/specs/repositories/person.repository.spec.ts
+pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/app-metrics.repository.spec.ts
 ```
 
 Expected: PASS. If the medium test database is unavailable, stop and bring up the repo's medium-test database before continuing.

--- a/docs/superpowers/specs/2026-04-25-prometheus-metrics-design.md
+++ b/docs/superpowers/specs/2026-04-25-prometheus-metrics-design.md
@@ -58,9 +58,14 @@ Server metrics remain opt-in. If `IMMICH_TELEMETRY_INCLUDE` is empty, no server 
 started. If telemetry is enabled, the new app snapshot metrics are published through the existing
 server OpenTelemetry metric service. Snapshot values must be exported with observable or settable
 gauge instruments, not the existing additive `MetricGroupRepository.addToGauge()` helper, because
-these metrics represent absolute counts instead of deltas. The implementation should live close to
-the existing telemetry layer, while SQL queries live in repositories so they stay typed, testable, and
-generated where appropriate.
+these metrics represent absolute counts instead of deltas.
+
+The server app aggregate SQL should live in a dedicated `AppMetricsRepository` rather than adding
+telemetry-only methods to high-churn domain repositories such as `AssetRepository` and
+`PersonRepository`. This keeps the feature additive, reduces upstream rebase conflicts, and still
+keeps SQL in a typed, testable repository boundary. `AppMetricsService` should be a standalone
+service with explicit dependencies instead of extending `BaseService`, which avoids changing global
+service test helpers for this feature.
 
 The implementation should introduce an `app` telemetry group for these domain metrics so admins can
 enable them separately from HTTP API request metrics. `IMMICH_TELEMETRY_INCLUDE=all` includes `app`.
@@ -118,15 +123,22 @@ For requests that include multiple entries, the implementation should record one
 
 Server metrics are exposed from a cached snapshot.
 
-The snapshot collector refreshes at most once every 30 to 60 seconds. Prometheus scrapes can happen more often, but they should serve the cached values unless the cache is stale. This avoids turning frequent scrapes into repeated full-table database scans.
+The snapshot collector refreshes at most once every 30 to 60 seconds. Prometheus scrapes can happen
+more often, but they should serve the cached values unless the cache is stale. This avoids turning
+frequent scrapes into repeated aggregate database scans. Phase 1 should not add indexes
+preemptively; the initial queries should rely on existing asset, face, visibility, deletion, and
+smart-search indexes, with query tuning deferred until real deployments show a bottleneck.
 
-The snapshot fetches:
+`AppMetricsRepository` fetches:
 
 - Aggregated asset and storage counts from the database.
 - Per-user asset and storage counts from the database.
 - Smart-search embedding coverage from the asset and smart-search tables.
 - Face/person totals from face and person tables.
 - Trash and external-library totals from asset fields.
+
+`JobRepository` fetches:
+
 - Queue counts from BullMQ `getJobCounts()` for every `QueueName`.
 - Oldest waiting, delayed, and failed job age from BullMQ job timestamps for every `QueueName`.
 
@@ -181,8 +193,8 @@ Update `docker/prometheus.yml` to scrape:
 
 Server tests:
 
-- Snapshot repository/service returns the expected asset, storage, per-user, embedding, face/person,
-  trash, external, queue count, and queue staleness values.
+- `AppMetricsRepository` and `AppMetricsService` return the expected asset, storage, per-user,
+  embedding, face/person, trash, external, queue count, and queue staleness values.
 - Per-user metric labels contain `user_id` and no user name or email.
 - Snapshot cache serves previous values within the refresh window.
 - Failed refresh preserves the previous successful snapshot.

--- a/docs/superpowers/specs/2026-04-25-prometheus-metrics-design.md
+++ b/docs/superpowers/specs/2026-04-25-prometheus-metrics-design.md
@@ -1,0 +1,215 @@
+# Prometheus Metrics Phase 1 Design
+
+## Context
+
+Discussion #426 requests richer Prometheus metrics for Gallery monitoring, including storage per user,
+asset counts, embedding coverage, queue staleness, face/person stats, ML service latency, and an
+ergonomic Grafana dashboard.
+
+Gallery already has an opt-in OpenTelemetry/Prometheus exporter in the server:
+
+- `IMMICH_TELEMETRY_INCLUDE` enables telemetry groups.
+- API metrics are exported on `IMMICH_API_METRICS_PORT`, default `8081`.
+- Microservices metrics are exported on `IMMICH_MICROSERVICES_METRICS_PORT`, default `8082`.
+- Existing custom metrics cover user totals and live job counters.
+- Existing docs and compose files include Prometheus and Grafana setup, but not a curated Gallery dashboard.
+
+Phase 1 should deliver a useful end-to-end monitoring slice instead of implementing every metric from the discussion at once.
+
+## Goals
+
+- Add a practical server metrics snapshot for asset, storage, search coverage, face/person, trash,
+  external-library, queue health, and queue staleness.
+- Add a Prometheus `/metrics` endpoint to the Python machine-learning service for request and model-load metrics.
+- Update Prometheus scrape configuration to include the ML service.
+- Provide a ready-to-import Grafana dashboard for the Phase 1 metrics.
+- Keep metric cardinality controlled and avoid exposing user names, emails, paths, search text, IP addresses, or request payloads.
+- Document Phase 1 clearly, including deferred metrics.
+
+## Non-Goals
+
+- Do not expose auth attempts or failures by IP address in Phase 1.
+- Do not expose user display names, emails, storage labels, original paths, or filenames as metric labels.
+- Do not implement upload throughput per user in Phase 1.
+- Do not implement face-score or CLIP-score distributions in Phase 1.
+- Do not implement duplicate quality metrics, video transcode quality metrics, new memory metrics,
+  geocoding/OCR coverage, cache hit/miss internals, or DB bloat metrics in Phase 1.
+- Do not add new custom CPU, memory, GPU, or network metrics in Phase 1. The dashboard may use the
+  existing `host` telemetry group where it is already available.
+- Do not require a separate sidecar for ML metrics.
+
+## Phase Plan
+
+Phase 1 is a thin vertical slice:
+
+1. Server app metrics for high-value totals and coverage.
+2. ML service metrics on the existing FastAPI port.
+3. Prometheus config that scrapes API, microservices, and ML.
+4. One curated Grafana dashboard.
+5. Monitoring docs updated with the Phase 1 metric list and deferred scope.
+
+Later phases can deepen individual domains once the first dashboard is useful in real deployments.
+
+## Architecture
+
+The server implementation extends the existing telemetry system rather than creating a new monitoring endpoint.
+
+Server metrics remain opt-in. If `IMMICH_TELEMETRY_INCLUDE` is empty, no server Prometheus endpoint is
+started. If telemetry is enabled, the new app snapshot metrics are published through the existing
+server OpenTelemetry metric service. Snapshot values must be exported with observable or settable
+gauge instruments, not the existing additive `MetricGroupRepository.addToGauge()` helper, because
+these metrics represent absolute counts instead of deltas. The implementation should live close to
+the existing telemetry layer, while SQL queries live in repositories so they stay typed, testable, and
+generated where appropriate.
+
+The implementation should introduce an `app` telemetry group for these domain metrics so admins can
+enable them separately from HTTP API request metrics. `IMMICH_TELEMETRY_INCLUDE=all` includes `app`.
+Queue metrics remain part of the `job` telemetry group.
+
+The ML service exposes Prometheus text output from `GET /metrics` on the existing FastAPI app and port. Metrics are updated in-process around `/predict` and model loading. Prometheus scrapes `immich-machine-learning:3003/metrics` in addition to the existing API and microservices targets.
+
+Grafana uses Prometheus as its data source. The dashboard is shipped as JSON in the repository and documented as importable by users. Compose comments can point users at the dashboard, but Phase 1 does not need full Grafana provisioning unless it fits cleanly with existing compose patterns.
+
+## Server Metrics
+
+Phase 1 server metrics:
+
+| Metric                                   | Type  | Labels            | Description                                                                                         |
+| ---------------------------------------- | ----- | ----------------- | --------------------------------------------------------------------------------------------------- |
+| `immich.assets.total`                    | Gauge | `type`            | Non-deleted timeline asset count by asset type: `image`, `video`, `audio`, `other`.                 |
+| `immich.assets.storage_bytes`            | Gauge | `type`            | Total file bytes by asset type.                                                                     |
+| `immich.users.storage_bytes`             | Gauge | `user_id`, `type` | Per-user storage bytes by asset type.                                                               |
+| `immich.users.assets.total`              | Gauge | `user_id`, `type` | Per-user non-deleted timeline asset count by asset type.                                            |
+| `immich.search.embedding_coverage_ratio` | Gauge | none              | Assets with smart-search embedding divided by eligible image/video assets.                          |
+| `immich.faces.total`                     | Gauge | none              | Visible, non-deleted face count.                                                                    |
+| `immich.people.total`                    | Gauge | none              | People with at least one visible, non-deleted face.                                                 |
+| `immich.assets.trash.total`              | Gauge | none              | Trashed asset count.                                                                                |
+| `immich.assets.external.total`           | Gauge | none              | External-library asset count.                                                                       |
+| `immich.queues.jobs`                     | Gauge | `queue`, `status` | BullMQ counts by queue and status: `active`, `waiting`, `delayed`, `failed`, `completed`, `paused`. |
+| `immich.queues.oldest_job_age_seconds`   | Gauge | `queue`, `status` | Age in seconds of the oldest job for staleness-oriented statuses: `waiting`, `delayed`, `failed`.   |
+
+Per-user labels use `user_id` only. They must not include names, emails, storage labels, or quota labels. This keeps the dashboard useful while avoiding readable personal data in Prometheus.
+
+The server snapshot should use low-cardinality labels only. Asset `type`, queue `queue`, queue
+`status`, and `user_id` are allowed in Phase 1. File paths, filenames, search terms, IP addresses,
+model inputs, and exception messages are not allowed as labels.
+
+OpenTelemetry instrument names may use dot-separated names for consistency with existing code, but
+Grafana and documentation must query the actual Prometheus-exported names after sanitization, such as
+`immich_assets_total`.
+
+## ML Metrics
+
+Phase 1 ML metrics:
+
+| Metric                             | Type      | Labels                   | Description                                                           |
+| ---------------------------------- | --------- | ------------------------ | --------------------------------------------------------------------- |
+| `immich_ml_requests_total`         | Counter   | `task`, `type`, `status` | Count of `/predict` requests by requested model task/type and status. |
+| `immich_ml_request_duration_ms`    | Histogram | `task`, `type`, `status` | End-to-end `/predict` duration in milliseconds.                       |
+| `immich_ml_active_requests`        | Gauge     | none                     | Number of in-flight prediction requests.                              |
+| `immich_ml_model_cache_entries`    | Gauge     | `task`, `type`           | Loaded or cached model count by task/type.                            |
+| `immich_ml_model_load_duration_ms` | Histogram | `task`, `type`, `status` | Model load duration in milliseconds.                                  |
+
+`status` should use a bounded set such as `success`, `error`, and `validation_error`. It must not include exception text.
+
+For requests that include multiple entries, the implementation should record one metric observation per requested task/type. If task/type parsing fails, record the request under `task="unknown"` and `type="unknown"` with `status="validation_error"`.
+
+## Data Flow
+
+Server metrics are exposed from a cached snapshot.
+
+The snapshot collector refreshes at most once every 30 to 60 seconds. Prometheus scrapes can happen more often, but they should serve the cached values unless the cache is stale. This avoids turning frequent scrapes into repeated full-table database scans.
+
+The snapshot fetches:
+
+- Aggregated asset and storage counts from the database.
+- Per-user asset and storage counts from the database.
+- Smart-search embedding coverage from the asset and smart-search tables.
+- Face/person totals from face and person tables.
+- Trash and external-library totals from asset fields.
+- Queue counts from BullMQ `getJobCounts()` for every `QueueName`.
+- Oldest waiting, delayed, and failed job age from BullMQ job timestamps for every `QueueName`.
+
+The collector should preserve the previous successful snapshot if a refresh fails. If no snapshot has succeeded yet, it should omit the affected custom metric series until a successful refresh. Refresh failures should be logged once per failed refresh attempt and must not break the server or the Prometheus endpoint.
+
+ML metrics are in-process counters, gauges, and histograms. Request counters and duration histograms
+are updated around `/predict`. Active request gauge increments and decrements using the existing
+request state dependency. Model cache gauges are derived from the current cache contents when
+`/metrics` is rendered or updated when models load, whichever is simpler and reliable.
+
+## Grafana Dashboard
+
+The Phase 1 dashboard should emphasize operational signal over exhaustive panels:
+
+- Overview: total assets, storage bytes, users, embedding coverage, active ML requests.
+- Storage: total bytes by type and per-user storage by `user_id`.
+- Assets: total asset counts by type and per-user asset counts.
+- Jobs: queue depth by queue/status, failed jobs by queue, and oldest waiting/delayed/failed job age.
+- Search/AI: embedding coverage, ML request rate, ML latency percentiles, model cache entries.
+- Faces: visible face count and people count.
+- Exceptions or warning panels should be based on existing counters where available, not log scraping.
+
+The dashboard should avoid panels that imply deferred metrics exist. Deferred areas can be mentioned in docs, not represented as empty dashboard panels.
+
+## Documentation
+
+Update the existing monitoring docs to cover:
+
+- Enabling telemetry with `IMMICH_TELEMETRY_INCLUDE=all`.
+- The `app` telemetry group for server domain metrics and the `job` telemetry group for queue metrics.
+- The three scrape targets: API, microservices, and ML.
+- The Phase 1 custom metric list.
+- The privacy rule that per-user metrics use `user_id` only.
+- Importing the bundled Grafana dashboard.
+- Deferred metrics and why they are out of Phase 1.
+
+Update `docker/prometheus.yml` to scrape:
+
+- `immich-server:8081`
+- `immich-server:8082`
+- `immich-machine-learning:3003`
+
+## Error Handling
+
+- Server snapshot refresh failure logs a warning and keeps the previous snapshot.
+- Server metric export must not throw from the Prometheus scrape path.
+- ML `/metrics` must continue to work even if the model cache is empty.
+- ML failed requests should increment bounded failure metrics without leaking payload contents or exception strings into labels.
+- If ML metrics dependencies are unavailable during development, the implementation should either use a minimal local Prometheus text renderer or add a small dependency with tests and lockfile updates.
+
+## Testing
+
+Server tests:
+
+- Snapshot repository/service returns the expected asset, storage, per-user, embedding, face/person,
+  trash, external, queue count, and queue staleness values.
+- Per-user metric labels contain `user_id` and no user name or email.
+- Snapshot cache serves previous values within the refresh window.
+- Failed refresh preserves the previous successful snapshot.
+- Failed first refresh omits custom app series rather than returning invalid values.
+- Absolute snapshot gauges are recorded through observable/settable gauge instruments, not additive
+  delta helpers.
+
+ML tests:
+
+- `GET /metrics` returns Prometheus text.
+- Successful `/predict` updates request count and duration metrics.
+- Validation failures are counted under bounded `unknown` labels.
+- Active request gauge returns to zero after a request.
+- Model load duration records bounded status labels.
+
+Config/docs tests:
+
+- `docker/prometheus.yml` contains API, microservices, and ML targets.
+- Grafana dashboard JSON parses successfully.
+- Relevant docs mention Phase 1 scope and user-ID-only labels.
+
+## Acceptance Criteria
+
+- With telemetry enabled, Prometheus can scrape API, microservices, and ML metrics.
+- The dashboard imports into Grafana and renders meaningful panels against the Phase 1 metrics.
+- Server custom metrics do not expose names, emails, paths, filenames, IP addresses, or payload text.
+- ML metrics expose bounded labels for task/type/status only.
+- Queue staleness is visible through oldest waiting, delayed, and failed job age panels.
+- The server keeps serving previous custom metric values if a snapshot refresh fails.
+- Unit tests cover the snapshot collector and ML metrics behavior.

--- a/machine-learning/immich_ml/__main__.py
+++ b/machine-learning/immich_ml/__main__.py
@@ -5,11 +5,14 @@ from ipaddress import ip_address
 from pathlib import Path
 
 from .config import log, non_prefixed_settings, settings
+from .prometheus import prepare_prometheus_multiprocess_dir
 
 if source_ref := os.getenv("IMMICH_SOURCE_REF"):
     log.info(f"Initializing Immich ML [{source_ref}]")
 else:
     log.info("Initializing Immich ML")
+
+prepare_prometheus_multiprocess_dir()
 
 module_dir = Path(__file__).parent
 

--- a/machine-learning/immich_ml/gunicorn_conf.py
+++ b/machine-learning/immich_ml/gunicorn_conf.py
@@ -2,6 +2,7 @@ import os
 
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
+from prometheus_client import multiprocess
 
 device_ids = os.environ.get("MACHINE_LEARNING_DEVICE_IDS", "0").replace(" ", "").split(",")
 env = os.environ
@@ -10,3 +11,7 @@ env = os.environ
 # Round-robin device assignment for each worker
 def pre_fork(arbiter: Arbiter, _: Worker) -> None:
     env["MACHINE_LEARNING_DEVICE_ID"] = device_ids[len(arbiter.WORKERS) % len(device_ids)]
+
+
+def child_exit(_: Arbiter, worker: Worker) -> None:
+    multiprocess.mark_process_dead(worker.pid)

--- a/machine-learning/immich_ml/gunicorn_conf.py
+++ b/machine-learning/immich_ml/gunicorn_conf.py
@@ -1,4 +1,6 @@
 import os
+from collections.abc import Callable
+from typing import cast
 
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
@@ -14,4 +16,5 @@ def pre_fork(arbiter: Arbiter, _: Worker) -> None:
 
 
 def child_exit(_: Arbiter, worker: Worker) -> None:
-    multiprocess.mark_process_dead(worker.pid)
+    mark_process_dead = cast(Callable[[int], None], multiprocess.mark_process_dead)
+    mark_process_dead(worker.pid)

--- a/machine-learning/immich_ml/main.py
+++ b/machine-learning/immich_ml/main.py
@@ -40,6 +40,8 @@ from .schemas import (
 
 MultiPartParser.spool_max_size = 2**26  # spools to disk if payload is 64 MiB or larger
 
+MODEL_CACHE_METRICS_INTERVAL_S = 15
+
 model_cache = ModelCache(revalidate=settings.model_ttl > 0)
 thread_pool: ThreadPoolExecutor | None = None
 lock = threading.Lock()
@@ -66,6 +68,8 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
             asyncio.ensure_future(idle_shutdown_task())
         if settings.preload is not None:
             await preload_models(settings.preload)
+        if metrics.is_multiprocess_enabled():
+            asyncio.ensure_future(model_cache_metrics_task())
         yield
     finally:
         log.handlers.clear()
@@ -182,14 +186,18 @@ def ping() -> PlainTextResponse:
     return PlainTextResponse("pong")
 
 
-@app.get("/metrics")
-def prometheus_metrics() -> Response:
+def refresh_model_cache_metrics() -> None:
     cache_labels = [
         (model.model_task.value, model.model_type.value)
         for model in model_cache.cache._cache.values()
         if isinstance(model, InferenceModel)
     ]
     metrics.set_model_cache_entries(cache_labels)
+
+
+@app.get("/metrics")
+def prometheus_metrics() -> Response:
+    refresh_model_cache_metrics()
     return Response(metrics.render(), media_type=CONTENT_TYPE_LATEST)
 
 
@@ -305,3 +313,9 @@ async def idle_shutdown_task() -> None:
             os.kill(os.getpid(), signal.SIGINT)
             break
         await asyncio.sleep(settings.model_ttl_poll_s)
+
+
+async def model_cache_metrics_task() -> None:
+    while True:
+        refresh_model_cache_metrics()
+        await asyncio.sleep(MODEL_CACHE_METRICS_INTERVAL_S)

--- a/machine-learning/immich_ml/main.py
+++ b/machine-learning/immich_ml/main.py
@@ -11,10 +11,11 @@ from typing import Any, AsyncGenerator, Callable, Iterator
 from zipfile import BadZipFile
 
 import orjson
-from fastapi import Depends, FastAPI, File, Form, HTTPException
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Response
 from fastapi.responses import ORJSONResponse, PlainTextResponse
 from onnxruntime.capi.onnxruntime_pybind11_state import InvalidProtobuf, NoSuchFile
 from PIL.Image import Image
+from prometheus_client import CONTENT_TYPE_LATEST
 from pydantic import ValidationError
 from starlette.formparsers import MultiPartParser
 
@@ -22,6 +23,7 @@ from immich_ml.models import get_model_deps
 from immich_ml.models.base import InferenceModel
 from immich_ml.models.transforms import decode_pil
 
+from . import metrics
 from .config import PreloadModelData, log, settings
 from .models.cache import ModelCache
 from .schemas import (
@@ -135,14 +137,17 @@ async def preload_models(preload: PreloadModelData) -> None:
 def update_state() -> Iterator[None]:
     global active_requests, last_called
     active_requests += 1
+    metrics.ACTIVE_REQUESTS.inc()
     last_called = time.time()
     try:
         yield
     finally:
         active_requests -= 1
+        metrics.ACTIVE_REQUESTS.dec()
 
 
 def get_entries(entries: str = Form()) -> InferenceEntries:
+    started = time.perf_counter()
     try:
         request: PipelineRequest = orjson.loads(entries)
         without_deps: list[InferenceEntry] = []
@@ -159,6 +164,7 @@ def get_entries(entries: str = Form()) -> InferenceEntries:
                 (with_deps if dep else without_deps).append(parsed)
         return without_deps, with_deps
     except (orjson.JSONDecodeError, ValidationError, KeyError, AttributeError) as e:
+        metrics.record_validation_error(started)
         log.error(f"Invalid request format: {e}")
         raise HTTPException(422, "Invalid request format.")
 
@@ -176,20 +182,38 @@ def ping() -> PlainTextResponse:
     return PlainTextResponse("pong")
 
 
+@app.get("/metrics")
+def prometheus_metrics() -> Response:
+    cache_labels = [
+        (model.model_task.value, model.model_type.value)
+        for model in model_cache.cache._cache.values()
+        if isinstance(model, InferenceModel)
+    ]
+    metrics.set_model_cache_entries(cache_labels)
+    return Response(metrics.render(), media_type=CONTENT_TYPE_LATEST)
+
+
 @app.post("/predict", dependencies=[Depends(update_state)])
 async def predict(
     entries: InferenceEntries = Depends(get_entries),
     image: bytes | None = File(default=None),
     text: str | None = Form(default=None),
 ) -> Any:
-    if image is not None:
-        inputs: Image | str = await run(lambda: decode_pil(image))
-    elif text is not None:
-        inputs = text
-    else:
-        raise HTTPException(400, "Either image or text must be provided")
-    response = await run_inference(inputs, entries)
-    return ORJSONResponse(response)
+    started = time.perf_counter()
+    metric_labels = metrics.labels_from_entries(entries)
+    try:
+        if image is not None:
+            inputs: Image | str = await run(lambda: decode_pil(image))
+        elif text is not None:
+            inputs = text
+        else:
+            raise HTTPException(400, "Either image or text must be provided")
+        response = await run_inference(inputs, entries)
+        metrics.record_predict(metric_labels, "success", started)
+        return ORJSONResponse(response)
+    except Exception:
+        metrics.record_predict(metric_labels, "error", started)
+        raise
 
 
 async def run_inference(payload: Image | str, entries: InferenceEntries) -> InferenceResponse:
@@ -250,12 +274,23 @@ async def load(model: InferenceModel) -> InferenceModel:
                 model.load()
         return model
 
+    started = time.perf_counter()
     try:
-        return await run(_load, model)
+        result = await run(_load, model)
+        metrics.record_model_load(model.model_task.value, model.model_type.value, "success", started)
+        return result
     except (OSError, InvalidProtobuf, BadZipFile, NoSuchFile):
+        metrics.record_model_load(model.model_task.value, model.model_type.value, "error", started)
         log.warning(f"Failed to load {model.model_type.replace('_', ' ')} model '{model.model_name}'. Clearing cache.")
         model.clear_cache()
-        return await run(_load, model)
+        retry_started = time.perf_counter()
+        try:
+            result = await run(_load, model)
+            metrics.record_model_load(model.model_task.value, model.model_type.value, "success", retry_started)
+            return result
+        except Exception:
+            metrics.record_model_load(model.model_task.value, model.model_type.value, "error", retry_started)
+            raise
 
 
 async def idle_shutdown_task() -> None:

--- a/machine-learning/immich_ml/metrics.py
+++ b/machine-learning/immich_ml/metrics.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from typing import cast
 
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest, multiprocess
 
@@ -100,7 +101,8 @@ def is_multiprocess_enabled() -> bool:
 def render() -> bytes:
     if is_multiprocess_enabled():
         multiprocess_registry = CollectorRegistry()
-        multiprocess.MultiProcessCollector(multiprocess_registry)
+        multi_process_collector = cast(Callable[[CollectorRegistry], object], multiprocess.MultiProcessCollector)
+        multi_process_collector(multiprocess_registry)
         return generate_latest(multiprocess_registry)
 
     return generate_latest(registry)

--- a/machine-learning/immich_ml/metrics.py
+++ b/machine-learning/immich_ml/metrics.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+
+from .schemas import InferenceEntries, ModelTask, ModelType
+
+registry = CollectorRegistry()
+
+REQUESTS = Counter(
+    "immich_ml_requests_total",
+    "Machine-learning prediction requests.",
+    ["task", "type", "status"],
+    registry=registry,
+)
+
+REQUEST_DURATION = Histogram(
+    "immich_ml_request_duration_ms",
+    "Machine-learning prediction request duration in milliseconds.",
+    ["task", "type", "status"],
+    buckets=(10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, float("inf")),
+    registry=registry,
+)
+
+ACTIVE_REQUESTS = Gauge(
+    "immich_ml_active_requests",
+    "In-flight machine-learning prediction requests.",
+    registry=registry,
+)
+
+MODEL_CACHE_ENTRIES = Gauge(
+    "immich_ml_model_cache_entries",
+    "Machine-learning model cache entries.",
+    ["task", "type"],
+    registry=registry,
+)
+
+MODEL_LOAD_DURATION = Histogram(
+    "immich_ml_model_load_duration_ms",
+    "Machine-learning model load duration in milliseconds.",
+    ["task", "type", "status"],
+    buckets=(10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, float("inf")),
+    registry=registry,
+)
+
+
+def labels_from_entries(entries: InferenceEntries) -> list[tuple[str, str]]:
+    without_deps, with_deps = entries
+    labels: list[tuple[str, str]] = []
+    for entry in [*without_deps, *with_deps]:
+        task = entry["task"].value if isinstance(entry["task"], ModelTask) else str(entry["task"])
+        model_type = entry["type"].value if isinstance(entry["type"], ModelType) else str(entry["type"])
+        labels.append((task, model_type))
+    return labels or [("unknown", "unknown")]
+
+
+def record_predict(labels: Iterable[tuple[str, str]], status: str, started: float) -> None:
+    duration_ms = (time.perf_counter() - started) * 1000
+    for task, model_type in labels:
+        REQUESTS.labels(task=task, type=model_type, status=status).inc()
+        REQUEST_DURATION.labels(task=task, type=model_type, status=status).observe(duration_ms)
+
+
+def record_validation_error(started: float) -> None:
+    record_predict([("unknown", "unknown")], "validation_error", started)
+
+
+def record_model_load(task: str, model_type: str, status: str, started: float) -> None:
+    duration_ms = (time.perf_counter() - started) * 1000
+    MODEL_LOAD_DURATION.labels(task=task, type=model_type, status=status).observe(duration_ms)
+
+
+def set_model_cache_entries(labels: Iterable[tuple[str, str]]) -> None:
+    MODEL_CACHE_ENTRIES.clear()
+    counts: dict[tuple[str, str], int] = {}
+    for label in labels:
+        counts[label] = counts.get(label, 0) + 1
+    for (task, model_type), count in counts.items():
+        MODEL_CACHE_ENTRIES.labels(task=task, type=model_type).set(count)
+
+
+def render() -> bytes:
+    return generate_latest(registry)
+
+
+def reset_metrics_for_tests() -> None:
+    REQUESTS.clear()
+    REQUEST_DURATION.clear()
+    ACTIVE_REQUESTS.set(0)
+    MODEL_CACHE_ENTRIES.clear()
+    MODEL_LOAD_DURATION.clear()

--- a/machine-learning/immich_ml/metrics.py
+++ b/machine-learning/immich_ml/metrics.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Iterable
 
-from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest, multiprocess
 
 from .schemas import InferenceEntries, ModelTask, ModelType
 
@@ -27,6 +28,7 @@ REQUEST_DURATION = Histogram(
 ACTIVE_REQUESTS = Gauge(
     "immich_ml_active_requests",
     "In-flight machine-learning prediction requests.",
+    multiprocess_mode="livesum",
     registry=registry,
 )
 
@@ -34,6 +36,7 @@ MODEL_CACHE_ENTRIES = Gauge(
     "immich_ml_model_cache_entries",
     "Machine-learning model cache entries.",
     ["task", "type"],
+    multiprocess_mode="livesum",
     registry=registry,
 )
 
@@ -44,6 +47,8 @@ MODEL_LOAD_DURATION = Histogram(
     buckets=(10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, float("inf")),
     registry=registry,
 )
+
+_MODEL_CACHE_LABELS: set[tuple[str, str]] = set()
 
 
 def labels_from_entries(entries: InferenceEntries) -> list[tuple[str, str]]:
@@ -73,15 +78,31 @@ def record_model_load(task: str, model_type: str, status: str, started: float) -
 
 
 def set_model_cache_entries(labels: Iterable[tuple[str, str]]) -> None:
-    MODEL_CACHE_ENTRIES.clear()
     counts: dict[tuple[str, str], int] = {}
     for label in labels:
         counts[label] = counts.get(label, 0) + 1
+
+    current_labels = set(counts)
+    for task, model_type in _MODEL_CACHE_LABELS - current_labels:
+        MODEL_CACHE_ENTRIES.labels(task=task, type=model_type).set(0)
+
     for (task, model_type), count in counts.items():
         MODEL_CACHE_ENTRIES.labels(task=task, type=model_type).set(count)
 
+    _MODEL_CACHE_LABELS.clear()
+    _MODEL_CACHE_LABELS.update(current_labels)
+
+
+def is_multiprocess_enabled() -> bool:
+    return bool(os.environ.get("PROMETHEUS_MULTIPROC_DIR"))
+
 
 def render() -> bytes:
+    if is_multiprocess_enabled():
+        multiprocess_registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(multiprocess_registry)
+        return generate_latest(multiprocess_registry)
+
     return generate_latest(registry)
 
 
@@ -90,4 +111,5 @@ def reset_metrics_for_tests() -> None:
     REQUEST_DURATION.clear()
     ACTIVE_REQUESTS.set(0)
     MODEL_CACHE_ENTRIES.clear()
+    _MODEL_CACHE_LABELS.clear()
     MODEL_LOAD_DURATION.clear()

--- a/machine-learning/immich_ml/prometheus.py
+++ b/machine-learning/immich_ml/prometheus.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+PROMETHEUS_MULTIPROC_DIR = "PROMETHEUS_MULTIPROC_DIR"
+DEFAULT_PROMETHEUS_MULTIPROC_DIR = "/tmp/immich_ml_prometheus"
+
+
+def prepare_prometheus_multiprocess_dir(path: Path | str | None = None) -> Path:
+    multiprocess_dir = Path(
+        path or os.environ.get(PROMETHEUS_MULTIPROC_DIR) or DEFAULT_PROMETHEUS_MULTIPROC_DIR
+    ).resolve()
+    multiprocess_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in multiprocess_dir.glob("*.db"):
+        entry.unlink()
+
+    os.environ[PROMETHEUS_MULTIPROC_DIR] = multiprocess_dir.as_posix()
+    return multiprocess_dir

--- a/machine-learning/pyproject.toml
+++ b/machine-learning/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "opencv-python-headless>=4.7.0.72,<5.0",
     "orjson>=3.9.5",
     "pillow>=12.2,<12.3",
+    "prometheus-client>=0.21.0,<1.0",
     "pydantic>=2.0.0,<3",
     "pydantic-settings>=2.5.2,<3",
     "python-multipart>=0.0.6,<1.0",

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -1,5 +1,7 @@
 import json
 import os
+import subprocess
+import sys
 from io import BytesIO
 from pathlib import Path
 from random import randint
@@ -1383,6 +1385,83 @@ class TestPrometheusMetrics:
 
         assert response.status_code == 422
         assert 'immich_ml_requests_total{status="validation_error",task="unknown",type="unknown"} 1.0' in metrics
+
+    def test_render_aggregates_multiprocess_metrics(self, tmp_path: Path) -> None:
+        record_script = """
+from immich_ml import metrics
+metrics.REQUESTS.labels(task="clip", type="textual", status="success").inc()
+"""
+        render_script = """
+from immich_ml import metrics
+print(metrics.render().decode())
+"""
+        env = {**os.environ, "PROMETHEUS_MULTIPROC_DIR": tmp_path.as_posix()}
+
+        subprocess.run([sys.executable, "-c", record_script], check=True, env=env)
+        subprocess.run([sys.executable, "-c", record_script], check=True, env=env)
+        result = subprocess.run(
+            [sys.executable, "-c", render_script],
+            capture_output=True,
+            check=True,
+            env=env,
+            text=True,
+        )
+
+        assert 'immich_ml_requests_total{status="success",task="clip",type="textual"} 2.0' in result.stdout
+
+    def test_model_cache_entries_zeroes_removed_labels(self) -> None:
+        from immich_ml import metrics
+
+        metrics.reset_metrics_for_tests()
+        metrics.set_model_cache_entries([("clip", "visual")])
+        metrics.set_model_cache_entries([])
+
+        rendered = metrics.render().decode()
+
+        assert 'immich_ml_model_cache_entries{task="clip",type="visual"} 0.0' in rendered
+
+    def test_prepare_prometheus_multiprocess_dir_cleans_stale_files(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        from immich_ml.prometheus import prepare_prometheus_multiprocess_dir
+
+        stale_file = tmp_path / "counter_123.db"
+        unrelated_file = tmp_path / "keep.txt"
+        stale_file.write_text("stale")
+        unrelated_file.write_text("keep")
+        monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", tmp_path.as_posix())
+
+        result = prepare_prometheus_multiprocess_dir()
+
+        assert result == tmp_path
+        assert os.environ["PROMETHEUS_MULTIPROC_DIR"] == tmp_path.as_posix()
+        assert not stale_file.exists()
+        assert unrelated_file.exists()
+
+    def test_gunicorn_child_exit_marks_worker_dead(self, mocker: MockerFixture) -> None:
+        from immich_ml import gunicorn_conf
+
+        mark_process_dead = mocker.patch.object(gunicorn_conf.multiprocess, "mark_process_dead")
+
+        gunicorn_conf.child_exit(mock.Mock(), SimpleNamespace(pid=1234))
+
+        mark_process_dead.assert_called_once_with(1234)
+
+    def test_refresh_model_cache_metrics_counts_cached_models(self, monkeypatch: MonkeyPatch) -> None:
+        from immich_ml import metrics
+        from immich_ml.main import refresh_model_cache_metrics
+
+        metrics.reset_metrics_for_tests()
+        mock_model = mock.Mock(spec=InferenceModel)
+        mock_model.model_task = ModelTask.SEARCH
+        mock_model.model_type = ModelType.VISUAL
+        cache = SimpleNamespace(_cache={"model": mock_model})
+        monkeypatch.setattr("immich_ml.main.model_cache", SimpleNamespace(cache=cache))
+
+        refresh_model_cache_metrics()
+        rendered = metrics.render().decode()
+
+        assert 'immich_ml_model_cache_entries{task="clip",type="visual"} 1.0' in rendered
 
     @pytest.mark.asyncio
     async def test_model_load_records_success_and_retry_metrics(self, deployed_app: TestClient) -> None:

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -10,11 +10,11 @@ from unittest import mock
 import cv2
 import numpy as np
 import onnxruntime as ort
-from numpy.typing import NDArray
 import orjson
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from numpy.typing import NDArray
 from PIL import Image
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
@@ -29,8 +29,8 @@ from immich_ml.models.facial_recognition.detection import FaceDetector
 from immich_ml.models.facial_recognition.recognition import FaceRecognizer
 from immich_ml.models.ocr.detection import TextDetector
 from immich_ml.models.ocr.recognition import TextRecognizer
-from immich_ml.models.pet_detection import PetDetector
 from immich_ml.models.ocr.schemas import OcrOptions
+from immich_ml.models.pet_detection import PetDetector
 from immich_ml.schemas import ModelFormat, ModelPrecision, ModelTask, ModelType
 from immich_ml.sessions.ann import AnnSession
 from immich_ml.sessions.ort import OrtSession
@@ -1345,6 +1345,63 @@ def test_ping_endpoint(deployed_app: TestClient) -> None:
 
     assert response.status_code == 200
     assert response.text == "pong"
+
+
+class TestPrometheusMetrics:
+    def test_metrics_endpoint_returns_prometheus_text(self, deployed_app: TestClient) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+        response = deployed_app.get("/metrics")
+
+        assert response.status_code == 200
+        assert "text/plain" in response.headers["content-type"]
+        assert "immich_ml_active_requests" in response.text
+
+    def test_predict_records_success_metrics(self, deployed_app: TestClient, mocker: MockerFixture) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+        mocker.patch("immich_ml.main.run_inference", new_callable=mock.AsyncMock, return_value={"clip": "embedding"})
+        entries = {"clip": {"textual": {"modelName": "ViT-B-32__openai"}}}
+
+        response = deployed_app.post("/predict", data={"entries": orjson.dumps(entries).decode(), "text": "hello"})
+        metrics = deployed_app.get("/metrics").text
+
+        assert response.status_code == 200
+        assert 'immich_ml_requests_total{status="success",task="clip",type="textual"} 1.0' in metrics
+        assert 'immich_ml_request_duration_ms_count{status="success",task="clip",type="textual"} 1.0' in metrics
+        assert "immich_ml_active_requests 0.0" in metrics
+
+    def test_predict_records_validation_failure_with_unknown_labels(self, deployed_app: TestClient) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+
+        response = deployed_app.post("/predict", data={"entries": "{", "text": "hello"})
+        metrics = deployed_app.get("/metrics").text
+
+        assert response.status_code == 422
+        assert 'immich_ml_requests_total{status="validation_error",task="unknown",type="unknown"} 1.0' in metrics
+
+    @pytest.mark.asyncio
+    async def test_model_load_records_success_and_retry_metrics(self, deployed_app: TestClient) -> None:
+        from immich_ml.metrics import reset_metrics_for_tests
+
+        reset_metrics_for_tests()
+        mock_model = mock.Mock(spec=InferenceModel)
+        mock_model.model_name = "test_model_name"
+        mock_model.model_type = ModelType.VISUAL
+        mock_model.model_task = ModelTask.SEARCH
+        mock_model.load.side_effect = [OSError, None]
+        mock_model.loaded = False
+        mock_model.load_attempts = 0
+
+        await load(mock_model)
+        metrics = deployed_app.get("/metrics").text
+
+        assert 'immich_ml_model_load_duration_ms_count{status="error",task="clip",type="visual"} 1.0' in metrics
+        assert 'immich_ml_model_load_duration_ms_count{status="success",task="clip",type="visual"} 1.0' in metrics
 
 
 @pytest.mark.skipif(

--- a/machine-learning/uv.lock
+++ b/machine-learning/uv.lock
@@ -911,6 +911,7 @@ dependencies = [
     { name = "opencv-python-headless" },
     { name = "orjson" },
     { name = "pillow" },
+    { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -999,6 +1000,7 @@ requires-dist = [
     { name = "opencv-python-headless", specifier = ">=4.7.0.72,<5.0" },
     { name = "orjson", specifier = ">=3.9.5" },
     { name = "pillow", specifier = ">=12.2,<12.3" },
+    { name = "prometheus-client", specifier = ">=0.21.0,<1.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "pydantic-settings", specifier = ">=2.5.2,<3" },
     { name = "python-multipart", specifier = ">=0.0.6,<1.0" },
@@ -1992,6 +1994,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/c0/5e9c4d2a643a00a6f67578ef35485173de273a4567279e4f0c200c01386b/prettytable-3.9.0.tar.gz", hash = "sha256:f4ed94803c23073a90620b201965e5dc0bccf1760b7a7eaf3158cab8aaffdf34", size = 47874, upload-time = "2023-09-11T14:04:14.548Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/81/316b6a55a0d1f327d04cc7b0ba9d04058cb62de6c3a4d4b0df280cbe3b0b/prettytable-3.9.0-py3-none-any.whl", hash = "sha256:a71292ab7769a5de274b146b276ce938786f56c31cf7cea88b6f3775d82fe8c8", size = 27772, upload-time = "2023-09-11T14:03:45.582Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -625,6 +625,7 @@ export enum ImmichWorker {
 export enum ImmichTelemetry {
   Host = 'host',
   Api = 'api',
+  App = 'app',
   Io = 'io',
   Repo = 'repo',
   Job = 'job',

--- a/server/src/repositories/app-metrics.repository.ts
+++ b/server/src/repositories/app-metrics.repository.ts
@@ -1,0 +1,149 @@
+import { Injectable } from '@nestjs/common';
+import { Kysely } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { AssetType, AssetVisibility } from 'src/enum';
+import { DB } from 'src/schema';
+
+export interface AssetTelemetryByType {
+  type: AssetType;
+  count: number;
+  storageBytes: number;
+}
+
+export interface UserAssetTelemetryByType extends AssetTelemetryByType {
+  userId: string;
+}
+
+export interface SearchTelemetryMetrics {
+  eligibleAssets: number;
+  embeddedAssets: number;
+}
+
+export interface AssetStateTelemetryMetrics {
+  externalAssets: number;
+  trashAssets: number;
+}
+
+export interface AssetTelemetryMetrics {
+  assetsByType: AssetTelemetryByType[];
+  usersByType: UserAssetTelemetryByType[];
+  search: SearchTelemetryMetrics;
+  state: AssetStateTelemetryMetrics;
+}
+
+export interface PersonTelemetryMetrics {
+  faces: number;
+  people: number;
+}
+
+export interface AppMetricsSnapshot {
+  asset: AssetTelemetryMetrics;
+  person: PersonTelemetryMetrics;
+}
+
+@Injectable()
+export class AppMetricsRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
+
+  async getMetrics(): Promise<AppMetricsSnapshot> {
+    const [asset, person] = await Promise.all([this.getAssetMetrics(), this.getPersonMetrics()]);
+    return { asset, person };
+  }
+
+  private async getAssetMetrics(): Promise<AssetTelemetryMetrics> {
+    const assetsByType = await this.db
+      .selectFrom('asset')
+      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .select(['asset.type'])
+      .select((eb) => [
+        eb.fn.countAll<number>().as('count'),
+        eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
+      ])
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .groupBy('asset.type')
+      .execute();
+
+    const usersByType = await this.db
+      .selectFrom('asset')
+      .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+      .select(['asset.ownerId as userId', 'asset.type'])
+      .select((eb) => [
+        eb.fn.countAll<number>().as('count'),
+        eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('storageBytes'),
+      ])
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .groupBy(['asset.ownerId', 'asset.type'])
+      .execute();
+
+    const search = await this.db
+      .selectFrom('asset')
+      .leftJoin('smart_search', 'smart_search.assetId', 'asset.id')
+      .select((eb) => [
+        eb.fn.countAll<number>().as('eligibleAssets'),
+        eb.fn.count<number>('smart_search.assetId').as('embeddedAssets'),
+      ])
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .where('asset.type', 'in', [AssetType.Image, AssetType.Video])
+      .executeTakeFirstOrThrow();
+
+    const state = await this.db
+      .selectFrom('asset')
+      .select((eb) => [
+        eb.fn.countAll<number>().filterWhere('asset.deletedAt', 'is not', null).as('trashAssets'),
+        eb.fn
+          .countAll<number>()
+          .filterWhere((eb) => eb.and([eb('asset.deletedAt', 'is', null), eb('asset.isExternal', '=', true)]))
+          .as('externalAssets'),
+      ])
+      .executeTakeFirstOrThrow();
+
+    return {
+      assetsByType: assetsByType.map((item) => ({
+        type: item.type,
+        count: Number(item.count),
+        storageBytes: Number(item.storageBytes),
+      })),
+      usersByType: usersByType.map((item) => ({
+        userId: item.userId,
+        type: item.type,
+        count: Number(item.count),
+        storageBytes: Number(item.storageBytes),
+      })),
+      search: {
+        eligibleAssets: Number(search.eligibleAssets),
+        embeddedAssets: Number(search.embeddedAssets),
+      },
+      state: {
+        externalAssets: Number(state.externalAssets),
+        trashAssets: Number(state.trashAssets),
+      },
+    };
+  }
+
+  private async getPersonMetrics(): Promise<PersonTelemetryMetrics> {
+    const result = await this.db
+      .selectFrom('asset_face')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .select((eb) => [
+        eb.fn.countAll<number>().as('faces'),
+        eb.fn
+          .count<number>('asset_face.personId')
+          .distinct()
+          .filterWhere('asset_face.personId', 'is not', null)
+          .as('people'),
+      ])
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', 'is', true)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', AssetVisibility.Timeline)
+      .executeTakeFirstOrThrow();
+
+    return {
+      faces: Number(result.faces),
+      people: Number(result.people),
+    };
+  }
+}

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -323,8 +323,21 @@ describe('getEnv', () => {
       process.env.IMMICH_TELEMETRY_EXCLUDE = 'job';
       const { telemetry } = getEnv();
       expect(telemetry.metrics).toEqual(
-        new Set([ImmichTelemetry.Api, ImmichTelemetry.Host, ImmichTelemetry.Io, ImmichTelemetry.Repo]),
+        new Set([
+          ImmichTelemetry.Api,
+          ImmichTelemetry.App,
+          ImmichTelemetry.Host,
+          ImmichTelemetry.Io,
+          ImmichTelemetry.Repo,
+        ]),
       );
+    });
+
+    it('should run with telemetry app metrics enabled', () => {
+      process.env.IMMICH_TELEMETRY_INCLUDE = 'app';
+      const { telemetry } = getEnv();
+
+      expect(telemetry.metrics).toEqual(new Set([ImmichTelemetry.App]));
     });
 
     it('should run with specific telemetry metrics', () => {

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -3,6 +3,7 @@ import { ActivityRepository } from 'src/repositories/activity.repository';
 import { AlbumUserRepository } from 'src/repositories/album-user.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { ApiKeyRepository } from 'src/repositories/api-key.repository';
+import { AppMetricsRepository } from 'src/repositories/app-metrics.repository';
 import { AppRepository } from 'src/repositories/app.repository';
 import { AssetEditRepository } from 'src/repositories/asset-edit.repository';
 import { AssetJobRepository } from 'src/repositories/asset-job.repository';
@@ -60,6 +61,7 @@ export const repositories = [
   AlbumRepository,
   AlbumUserRepository,
   ApiKeyRepository,
+  AppMetricsRepository,
   AppRepository,
   AssetRepository,
   AssetEditRepository,

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -23,9 +23,10 @@ const emptyCounts = (): JobCounts => ({
   paused: 0,
 });
 
-const setup = (counts: JobCounts[]) => {
+const setup = (counts: JobCounts[] = []) => {
   const queue = {
     getJobCounts: vi.fn().mockResolvedValue(emptyCounts()),
+    getJobs: vi.fn().mockResolvedValue([]),
     isPaused: vi.fn().mockResolvedValue(false),
   };
 
@@ -36,6 +37,7 @@ const setup = (counts: JobCounts[]) => {
   const moduleRef = { get: vi.fn().mockReturnValue(queue) } as unknown as ModuleRef;
   const logger = {
     setContext: vi.fn(),
+    error: vi.fn(),
     verbose: vi.fn(),
     warn: vi.fn(),
   } as unknown as LoggingRepository;
@@ -95,5 +97,42 @@ describe(JobRepository.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(
       `Waiting for ${QueueName.FaceDetection} queue to finish (0 active, 0 waiting, 0 delayed, 1 paused); queue is paused`,
     );
+  });
+
+  it('returns queue counts and oldest job ages', async () => {
+    const { sut, queue } = setup();
+    const now = new Date('2026-04-25T12:00:00Z').getTime();
+    queue.getJobCounts.mockResolvedValue({
+      active: 1,
+      completed: 2,
+      failed: 3,
+      delayed: 4,
+      waiting: 5,
+      paused: 6,
+    });
+    queue.getJobs.mockResolvedValue([{ timestamp: now - 120_000 }]);
+
+    const result = await sut.getTelemetryMetrics(now);
+
+    expect(result.counts).toEqual(
+      expect.arrayContaining([
+        { queue: QueueName.ThumbnailGeneration, status: 'active', count: 1 },
+        { queue: QueueName.ThumbnailGeneration, status: 'completed', count: 2 },
+        { queue: QueueName.ThumbnailGeneration, status: 'failed', count: 3 },
+        { queue: QueueName.ThumbnailGeneration, status: 'delayed', count: 4 },
+        { queue: QueueName.ThumbnailGeneration, status: 'waiting', count: 5 },
+        { queue: QueueName.ThumbnailGeneration, status: 'paused', count: 6 },
+      ]),
+    );
+    expect(result.oldestJobAges).toEqual(
+      expect.arrayContaining([
+        { queue: QueueName.ThumbnailGeneration, status: 'waiting', ageSeconds: 120 },
+        { queue: QueueName.ThumbnailGeneration, status: 'delayed', ageSeconds: 120 },
+        { queue: QueueName.ThumbnailGeneration, status: 'failed', ageSeconds: 120 },
+      ]),
+    );
+    expect(queue.getJobs).toHaveBeenCalledWith('waiting', 0, 0, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('delayed', 0, 0, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('failed', 0, 0, true);
   });
 });

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -19,6 +19,26 @@ type JobMapItem = {
   label: string;
 };
 
+export type QueueTelemetryStatus = 'active' | 'completed' | 'failed' | 'delayed' | 'waiting' | 'paused';
+export type QueueTelemetryStalenessStatus = 'waiting' | 'delayed' | 'failed';
+
+export interface QueueTelemetryJobCount {
+  queue: QueueName;
+  status: QueueTelemetryStatus;
+  count: number;
+}
+
+export interface QueueTelemetryOldestJobAge {
+  queue: QueueName;
+  status: QueueTelemetryStalenessStatus;
+  ageSeconds: number;
+}
+
+export interface QueueTelemetryMetrics {
+  counts: QueueTelemetryJobCount[];
+  oldestJobAges: QueueTelemetryOldestJobAge[];
+}
+
 @Injectable()
 export class JobRepository {
   private workers: Partial<Record<QueueName, Worker>> = {};
@@ -150,6 +170,31 @@ export class JobRepository {
       'waiting',
       'paused',
     ) as unknown as Promise<JobCounts>;
+  }
+
+  async getTelemetryMetrics(now = Date.now()): Promise<QueueTelemetryMetrics> {
+    const countStatuses: QueueTelemetryStatus[] = ['active', 'completed', 'failed', 'delayed', 'waiting', 'paused'];
+    const stalenessStatuses: QueueTelemetryStalenessStatus[] = ['waiting', 'delayed', 'failed'];
+    const counts: QueueTelemetryJobCount[] = [];
+    const oldestJobAges: QueueTelemetryOldestJobAge[] = [];
+
+    for (const queue of Object.values(QueueName)) {
+      const queueCounts = await this.getJobCounts(queue);
+      for (const status of countStatuses) {
+        counts.push({ queue, status, count: Number(queueCounts[status] ?? 0) });
+      }
+
+      for (const status of stalenessStatuses) {
+        const [job] = await this.getQueue(queue).getJobs(status, 0, 0, true);
+        oldestJobAges.push({
+          queue,
+          status,
+          ageSeconds: job ? Math.max(0, Math.floor((now - job.timestamp) / 1000)) : 0,
+        });
+      }
+    }
+
+    return { counts, oldestJobAges };
   }
 
   private getQueueName(name: JobName) {

--- a/server/src/repositories/telemetry.repository.spec.ts
+++ b/server/src/repositories/telemetry.repository.spec.ts
@@ -1,0 +1,40 @@
+import { ObservableCallback } from '@opentelemetry/api';
+import { MetricService } from 'nestjs-otel';
+import { MetricGroupRepository } from 'src/repositories/telemetry.repository';
+import { describe, expect, it, vi } from 'vitest';
+
+const newMetricService = () => {
+  const observableGauge = { addCallback: vi.fn() };
+  const metricService = {
+    getCounter: vi.fn(),
+    getUpDownCounter: vi.fn(),
+    getHistogram: vi.fn(),
+    getObservableGauge: vi.fn().mockReturnValue(observableGauge),
+  } as unknown as MetricService;
+
+  return { metricService, observableGauge };
+};
+
+describe(MetricGroupRepository.name, () => {
+  it('registers observable gauges when enabled', () => {
+    const { metricService, observableGauge } = newMetricService();
+    const callback: ObservableCallback = vi.fn();
+
+    new MetricGroupRepository(metricService).configure({ enabled: true }).observeGauge('immich.assets.total', callback);
+
+    expect(metricService.getObservableGauge).toHaveBeenCalledWith('immich.assets.total', undefined);
+    expect(observableGauge.addCallback).toHaveBeenCalledWith(callback);
+  });
+
+  it('does not register observable gauges when disabled', () => {
+    const { metricService, observableGauge } = newMetricService();
+    const callback: ObservableCallback = vi.fn();
+
+    new MetricGroupRepository(metricService)
+      .configure({ enabled: false })
+      .observeGauge('immich.assets.total', callback);
+
+    expect(metricService.getObservableGauge).not.toHaveBeenCalled();
+    expect(observableGauge.addCallback).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/repositories/telemetry.repository.ts
+++ b/server/src/repositories/telemetry.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { MetricOptions } from '@opentelemetry/api';
+import { MetricOptions, ObservableCallback } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
@@ -41,6 +41,12 @@ export class MetricGroupRepository {
   addToHistogram(name: string, value: number, options?: MetricOptions): void {
     if (this.enabled) {
       this.metricService.getHistogram(name, options).record(value);
+    }
+  }
+
+  observeGauge(name: string, callback: ObservableCallback, options?: MetricOptions): void {
+    if (this.enabled) {
+      this.metricService.getObservableGauge(name, options).addCallback(callback);
     }
   }
 
@@ -98,6 +104,7 @@ export const teardownTelemetry = async () => {
 @Injectable()
 export class TelemetryRepository {
   api: MetricGroupRepository;
+  app: MetricGroupRepository;
   host: MetricGroupRepository;
   jobs: MetricGroupRepository;
   repo: MetricGroupRepository;
@@ -112,6 +119,7 @@ export class TelemetryRepository {
     const { metrics } = telemetry;
 
     this.api = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Api) });
+    this.app = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.App) });
     this.host = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Host) });
     this.jobs = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Job) });
     this.repo = new MetricGroupRepository(metricService).configure({ enabled: metrics.has(ImmichTelemetry.Repo) });

--- a/server/src/services/app-metrics.service.spec.ts
+++ b/server/src/services/app-metrics.service.spec.ts
@@ -1,0 +1,193 @@
+import { ObservableCallback, ObservableResult } from '@opentelemetry/api';
+import { AssetType, ImmichWorker, QueueName } from 'src/enum';
+import { AppMetricsRepository } from 'src/repositories/app-metrics.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { TelemetryRepository } from 'src/repositories/telemetry.repository';
+import { AppMetricsService } from 'src/services/app-metrics.service';
+import { newTelemetryRepositoryMock } from 'test/repositories/telemetry.repository.mock';
+import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+
+const observe = async (callback: ObservableCallback) => {
+  const result = { observe: vi.fn() } as unknown as ObservableResult;
+  await callback(result);
+  return result.observe as ReturnType<typeof vi.fn>;
+};
+
+type AppMetricsServiceMocks = {
+  logger: Mocked<Pick<LoggingRepository, 'setContext' | 'warn'>>;
+  config: Mocked<Pick<ConfigRepository, 'getWorker'>>;
+  telemetry: ReturnType<typeof newTelemetryRepositoryMock>;
+  appMetrics: Mocked<Pick<AppMetricsRepository, 'getMetrics'>>;
+  job: Mocked<Pick<JobRepository, 'getTelemetryMetrics'>>;
+};
+
+describe(AppMetricsService.name, () => {
+  let sut: AppMetricsService;
+  let mocks: AppMetricsServiceMocks;
+  let appCallbacks: Map<string, ObservableCallback>;
+  let jobCallbacks: Map<string, ObservableCallback>;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks = {
+      logger: { setContext: vi.fn(), warn: vi.fn() },
+      config: { getWorker: vi.fn() },
+      telemetry: newTelemetryRepositoryMock(),
+      appMetrics: { getMetrics: vi.fn() },
+      job: { getTelemetryMetrics: vi.fn() },
+    };
+    sut = new AppMetricsService(
+      mocks.logger as unknown as LoggingRepository,
+      mocks.config as unknown as ConfigRepository,
+      mocks.telemetry as unknown as TelemetryRepository,
+      mocks.appMetrics as unknown as AppMetricsRepository,
+      mocks.job as unknown as JobRepository,
+    );
+    appCallbacks = new Map();
+    jobCallbacks = new Map();
+    mocks.telemetry.app.observeGauge.mockImplementation((name, callback) => {
+      appCallbacks.set(name, callback);
+    });
+    mocks.telemetry.jobs.observeGauge.mockImplementation((name, callback) => {
+      jobCallbacks.set(name, callback);
+    });
+  });
+
+  it('registers app gauges on the API worker', () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+
+    sut.onBootstrap();
+
+    expect(appCallbacks.has('immich.assets.total')).toBe(true);
+    expect(appCallbacks.has('immich.users.storage_bytes')).toBe(true);
+    expect(jobCallbacks.size).toBe(0);
+  });
+
+  it('registers queue gauges on the microservices worker', () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+
+    sut.onBootstrap();
+
+    expect(jobCallbacks.has('immich.queues.jobs')).toBe(true);
+    expect(jobCallbacks.has('immich.queues.oldest_job_age_seconds')).toBe(true);
+    expect(appCallbacks.size).toBe(0);
+  });
+
+  it('observes app metrics with user_id labels only', async () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+    mocks.appMetrics.getMetrics.mockResolvedValue({
+      asset: {
+        assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+        usersByType: [{ userId: 'user-1', type: AssetType.Image, count: 2, storageBytes: 400 }],
+        search: { eligibleAssets: 4, embeddedAssets: 3 },
+        state: { trashAssets: 1, externalAssets: 1 },
+      },
+      person: { faces: 8, people: 2 },
+    });
+
+    sut.onBootstrap();
+    const observed = await observe(appCallbacks.get('immich.users.storage_bytes')!);
+
+    expect(observed).toHaveBeenCalledWith(400, { user_id: 'user-1', type: 'image' });
+    expect(JSON.stringify(observed.mock.calls)).not.toContain('userName');
+    expect(JSON.stringify(observed.mock.calls)).not.toContain('email');
+  });
+
+  it('serves the cached app snapshot inside the ttl', async () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+    mocks.appMetrics.getMetrics
+      .mockResolvedValueOnce({
+        asset: {
+          assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+          usersByType: [],
+          search: { eligibleAssets: 4, embeddedAssets: 3 },
+          state: { trashAssets: 1, externalAssets: 1 },
+        },
+        person: { faces: 8, people: 2 },
+      })
+      .mockResolvedValueOnce({
+        asset: {
+          assetsByType: [{ type: AssetType.Image, count: 9, storageBytes: 900 }],
+          usersByType: [],
+          search: { eligibleAssets: 9, embeddedAssets: 9 },
+          state: { trashAssets: 0, externalAssets: 0 },
+        },
+        person: { faces: 9, people: 3 },
+      });
+    vi.useFakeTimers();
+
+    sut.onBootstrap();
+    await observe(appCallbacks.get('immich.assets.total')!);
+    const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+    expect(mocks.appMetrics.getMetrics).toHaveBeenCalledTimes(1);
+    expect(observed).toHaveBeenCalledWith(2, { type: 'image' });
+    vi.useRealTimers();
+  });
+
+  it('keeps the previous app snapshot when refresh fails', async () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+    mocks.appMetrics.getMetrics
+      .mockResolvedValueOnce({
+        asset: {
+          assetsByType: [{ type: AssetType.Image, count: 2, storageBytes: 400 }],
+          usersByType: [],
+          search: { eligibleAssets: 4, embeddedAssets: 3 },
+          state: { trashAssets: 1, externalAssets: 1 },
+        },
+        person: { faces: 8, people: 2 },
+      })
+      .mockRejectedValueOnce(new Error('database down'));
+    vi.useFakeTimers();
+
+    sut.onBootstrap();
+    await observe(appCallbacks.get('immich.assets.total')!);
+    vi.advanceTimersByTime(61_000);
+    const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+    expect(observed).toHaveBeenCalledWith(2, { type: 'image' });
+    vi.useRealTimers();
+  });
+
+  it('omits app metric series when the first refresh fails', async () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+    mocks.appMetrics.getMetrics.mockRejectedValue(new Error('database down'));
+
+    sut.onBootstrap();
+    const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+    expect(observed).not.toHaveBeenCalled();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unable to refresh app metrics snapshot'));
+  });
+
+  it('throttles first-refresh failures inside the ttl', async () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+    mocks.appMetrics.getMetrics.mockRejectedValue(new Error('database down'));
+    vi.useFakeTimers();
+
+    sut.onBootstrap();
+    await observe(appCallbacks.get('immich.assets.total')!);
+    const observed = await observe(appCallbacks.get('immich.assets.total')!);
+
+    expect(observed).not.toHaveBeenCalled();
+    expect(mocks.appMetrics.getMetrics).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('observes queue counts and oldest job age', async () => {
+    mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+    mocks.job.getTelemetryMetrics.mockResolvedValue({
+      counts: [{ queue: QueueName.ThumbnailGeneration, status: 'waiting', count: 5 }],
+      oldestJobAges: [{ queue: QueueName.ThumbnailGeneration, status: 'waiting', ageSeconds: 120 }],
+    });
+
+    sut.onBootstrap();
+    const counts = await observe(jobCallbacks.get('immich.queues.jobs')!);
+    const ages = await observe(jobCallbacks.get('immich.queues.oldest_job_age_seconds')!);
+
+    expect(counts).toHaveBeenCalledWith(5, { queue: QueueName.ThumbnailGeneration, status: 'waiting' });
+    expect(ages).toHaveBeenCalledWith(120, { queue: QueueName.ThumbnailGeneration, status: 'waiting' });
+  });
+});

--- a/server/src/services/app-metrics.service.ts
+++ b/server/src/services/app-metrics.service.ts
@@ -1,0 +1,171 @@
+import { Injectable } from '@nestjs/common';
+import { ObservableCallback, ObservableResult } from '@opentelemetry/api';
+import { OnEvent } from 'src/decorators';
+import { ImmichWorker } from 'src/enum';
+import { AppMetricsRepository, AppMetricsSnapshot } from 'src/repositories/app-metrics.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { JobRepository, QueueTelemetryMetrics } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { TelemetryRepository } from 'src/repositories/telemetry.repository';
+
+const SNAPSHOT_TTL_MS = 60_000;
+
+@Injectable()
+export class AppMetricsService {
+  private appSnapshot?: AppMetricsSnapshot;
+  private appSnapshotAttemptedAt?: number;
+  private appRefresh?: Promise<AppMetricsSnapshot | undefined>;
+  private queueSnapshot?: QueueTelemetryMetrics;
+  private queueSnapshotAttemptedAt?: number;
+  private queueRefresh?: Promise<QueueTelemetryMetrics | undefined>;
+  private registered = false;
+
+  constructor(
+    private logger: LoggingRepository,
+    private configRepository: ConfigRepository,
+    private telemetryRepository: TelemetryRepository,
+    private appMetricsRepository: AppMetricsRepository,
+    private jobRepository: JobRepository,
+  ) {
+    this.logger.setContext(AppMetricsService.name);
+  }
+
+  @OnEvent({ name: 'AppBootstrap' })
+  onBootstrap() {
+    if (this.registered) {
+      return;
+    }
+    this.registered = true;
+
+    switch (this.configRepository.getWorker()) {
+      case ImmichWorker.Api: {
+        this.registerAppGauges();
+        break;
+      }
+      case ImmichWorker.Microservices: {
+        this.registerQueueGauges();
+        break;
+      }
+    }
+  }
+
+  private registerAppGauges() {
+    this.observeAppGauge('immich.assets.total', (snapshot, result) => {
+      for (const item of snapshot.asset.assetsByType) {
+        result.observe(item.count, { type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.assets.storage_bytes', (snapshot, result) => {
+      for (const item of snapshot.asset.assetsByType) {
+        result.observe(item.storageBytes, { type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.users.assets.total', (snapshot, result) => {
+      for (const item of snapshot.asset.usersByType) {
+        result.observe(item.count, { user_id: item.userId, type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.users.storage_bytes', (snapshot, result) => {
+      for (const item of snapshot.asset.usersByType) {
+        result.observe(item.storageBytes, { user_id: item.userId, type: item.type.toLowerCase() });
+      }
+    });
+    this.observeAppGauge('immich.search.embedding_coverage_ratio', (snapshot, result) => {
+      const { eligibleAssets, embeddedAssets } = snapshot.asset.search;
+      result.observe(eligibleAssets === 0 ? 1 : embeddedAssets / eligibleAssets);
+    });
+    this.observeAppGauge('immich.faces.total', (snapshot, result) => result.observe(snapshot.person.faces));
+    this.observeAppGauge('immich.people.total', (snapshot, result) => result.observe(snapshot.person.people));
+    this.observeAppGauge('immich.assets.trash.total', (snapshot, result) =>
+      result.observe(snapshot.asset.state.trashAssets),
+    );
+    this.observeAppGauge('immich.assets.external.total', (snapshot, result) =>
+      result.observe(snapshot.asset.state.externalAssets),
+    );
+  }
+
+  private registerQueueGauges() {
+    this.observeQueueGauge('immich.queues.jobs', (snapshot, result) => {
+      for (const item of snapshot.counts) {
+        result.observe(item.count, { queue: item.queue, status: item.status });
+      }
+    });
+    this.observeQueueGauge('immich.queues.oldest_job_age_seconds', (snapshot, result) => {
+      for (const item of snapshot.oldestJobAges) {
+        result.observe(item.ageSeconds, { queue: item.queue, status: item.status });
+      }
+    });
+  }
+
+  private observeAppGauge(
+    name: string,
+    observeSnapshot: (snapshot: AppMetricsSnapshot, result: ObservableResult) => void,
+  ) {
+    const callback: ObservableCallback = async (result) => {
+      const snapshot = await this.getAppSnapshot();
+      if (snapshot) {
+        observeSnapshot(snapshot, result);
+      }
+    };
+    this.telemetryRepository.app.observeGauge(name, callback);
+  }
+
+  private observeQueueGauge(
+    name: string,
+    observeSnapshot: (snapshot: QueueTelemetryMetrics, result: ObservableResult) => void,
+  ) {
+    const callback: ObservableCallback = async (result) => {
+      const snapshot = await this.getQueueSnapshot();
+      if (snapshot) {
+        observeSnapshot(snapshot, result);
+      }
+    };
+    this.telemetryRepository.jobs.observeGauge(name, callback);
+  }
+
+  private async getAppSnapshot(): Promise<AppMetricsSnapshot | undefined> {
+    if (this.appSnapshotAttemptedAt !== undefined && Date.now() - this.appSnapshotAttemptedAt < SNAPSHOT_TTL_MS) {
+      return this.appSnapshot;
+    }
+    this.appRefresh ??= this.refreshAppSnapshot();
+    try {
+      return await this.appRefresh;
+    } finally {
+      this.appRefresh = undefined;
+    }
+  }
+
+  private async refreshAppSnapshot(): Promise<AppMetricsSnapshot | undefined> {
+    try {
+      this.appSnapshot = await this.appMetricsRepository.getMetrics();
+    } catch (error: Error | unknown) {
+      this.logger.warn(`Unable to refresh app metrics snapshot: ${error instanceof Error ? error.message : error}`);
+    } finally {
+      this.appSnapshotAttemptedAt = Date.now();
+    }
+    return this.appSnapshot;
+  }
+
+  private async getQueueSnapshot(): Promise<QueueTelemetryMetrics | undefined> {
+    if (this.queueSnapshotAttemptedAt !== undefined && Date.now() - this.queueSnapshotAttemptedAt < SNAPSHOT_TTL_MS) {
+      return this.queueSnapshot;
+    }
+    this.queueRefresh ??= this.refreshQueueSnapshot();
+    try {
+      return await this.queueRefresh;
+    } finally {
+      this.queueRefresh = undefined;
+    }
+  }
+
+  private async refreshQueueSnapshot(): Promise<QueueTelemetryMetrics | undefined> {
+    try {
+      this.queueSnapshot = await this.jobRepository.getTelemetryMetrics();
+    } catch (error: Error | unknown) {
+      this.logger.warn(`Unable to refresh queue metrics snapshot: ${error instanceof Error ? error.message : error}`);
+    } finally {
+      this.queueSnapshotAttemptedAt = Date.now();
+    }
+    return this.queueSnapshot;
+  }
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -2,6 +2,7 @@ import { ActivityService } from 'src/services/activity.service';
 import { AlbumService } from 'src/services/album.service';
 import { ApiKeyService } from 'src/services/api-key.service';
 import { ApiService } from 'src/services/api.service';
+import { AppMetricsService } from 'src/services/app-metrics.service';
 import { AssetMediaService } from 'src/services/asset-media.service';
 import { AssetService } from 'src/services/asset.service';
 import { AuthAdminService } from 'src/services/auth-admin.service';
@@ -56,6 +57,7 @@ export const services = [
   ActivityService,
   AlbumService,
   ApiService,
+  AppMetricsService,
   AssetMediaService,
   AssetService,
   AuthService,

--- a/server/test/medium/specs/repositories/app-metrics.repository.spec.ts
+++ b/server/test/medium/specs/repositories/app-metrics.repository.spec.ts
@@ -1,0 +1,100 @@
+import { Kysely } from 'kysely';
+import { AssetType, AssetVisibility } from 'src/enum';
+import { AppMetricsRepository } from 'src/repositories/app-metrics.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { newEmbedding } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const database = db || defaultDatabase;
+  const { ctx } = newMediumService(BaseService, {
+    database,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: new AppMetricsRepository(database) };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(AppMetricsRepository.name, () => {
+  describe('getMetrics', () => {
+    it('returns low-cardinality asset, user, search, state, face, and person metrics', async () => {
+      const { ctx, sut } = setup();
+      const { user: user1 } = await ctx.newUser();
+      const { user: user2 } = await ctx.newUser();
+
+      const { asset: image1 } = await ctx.newAsset({
+        ownerId: user1.id,
+        type: AssetType.Image,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { asset: video1 } = await ctx.newAsset({
+        ownerId: user1.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { asset: image2 } = await ctx.newAsset({
+        ownerId: user2.id,
+        type: AssetType.Image,
+        visibility: AssetVisibility.Timeline,
+        isExternal: true,
+      });
+      const { asset: hidden } = await ctx.newAsset({
+        ownerId: user2.id,
+        type: AssetType.Image,
+        visibility: AssetVisibility.Hidden,
+      });
+      const { asset: trashed } = await ctx.newAsset({
+        ownerId: user2.id,
+        type: AssetType.Video,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { person: person1 } = await ctx.newPerson({ ownerId: user1.id, name: 'Alice' });
+      const { person: person2 } = await ctx.newPerson({ ownerId: user1.id, name: 'Bob' });
+
+      await Promise.all([
+        ctx.newExif({ assetId: image1.id, fileSizeInByte: 100 }),
+        ctx.newExif({ assetId: video1.id, fileSizeInByte: 200 }),
+        ctx.newExif({ assetId: image2.id, fileSizeInByte: 300 }),
+        ctx.newExif({ assetId: hidden.id, fileSizeInByte: 400 }),
+        ctx.newExif({ assetId: trashed.id, fileSizeInByte: 500 }),
+        ctx.database.insertInto('smart_search').values({ assetId: image1.id, embedding: newEmbedding() }).execute(),
+        ctx.newAssetFace({ assetId: image1.id, personId: person1.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: image1.id, personId: person1.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: video1.id, personId: person2.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: video1.id, personId: person2.id, isVisible: false }),
+        ctx.newAssetFace({ assetId: video1.id, personId: null, isVisible: true }),
+        ctx.newAssetFace({ assetId: hidden.id, personId: person2.id, isVisible: true }),
+        ctx.newAssetFace({ assetId: trashed.id, personId: person2.id, isVisible: true }),
+        ctx.softDeleteAsset(trashed.id),
+      ]);
+
+      const result = await sut.getMetrics();
+
+      expect(result.asset.assetsByType).toEqual(
+        expect.arrayContaining([
+          { type: AssetType.Image, count: 2, storageBytes: 400 },
+          { type: AssetType.Video, count: 1, storageBytes: 200 },
+        ]),
+      );
+      expect(result.asset.usersByType).toEqual(
+        expect.arrayContaining([
+          { userId: user1.id, type: AssetType.Image, count: 1, storageBytes: 100 },
+          { userId: user1.id, type: AssetType.Video, count: 1, storageBytes: 200 },
+          { userId: user2.id, type: AssetType.Image, count: 1, storageBytes: 300 },
+        ]),
+      );
+      expect(result.asset.search).toEqual({ eligibleAssets: 3, embeddedAssets: 1 });
+      expect(result.asset.state).toEqual({ externalAssets: 1, trashAssets: 1 });
+      expect(result.person).toEqual({ faces: 4, people: 2 });
+    });
+  });
+});

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -17,6 +17,7 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     isActive: vitest.fn(),
     isPaused: vitest.fn(),
     getJobCounts: vitest.fn(),
+    getTelemetryMetrics: vitest.fn(),
     clear: vitest.fn(),
     waitForQueueCompletion: vitest.fn(),
     removeJob: vitest.fn(),

--- a/server/test/repositories/telemetry.repository.mock.ts
+++ b/server/test/repositories/telemetry.repository.mock.ts
@@ -8,6 +8,7 @@ const newMetricGroupMock = () => {
     addToGauge: vitest.fn(),
     addToHistogram: vitest.fn(),
     configure: vitest.fn(),
+    observeGauge: vitest.fn(),
   };
 };
 
@@ -21,6 +22,7 @@ export const newTelemetryRepositoryMock = (): ITelemetryRepositoryMock => {
   return {
     setup: vitest.fn(),
     api: newMetricGroupMock(),
+    app: newMetricGroupMock(),
     host: newMetricGroupMock(),
     jobs: newMetricGroupMock(),
     repo: newMetricGroupMock(),


### PR DESCRIPTION
## Summary
- Adds opt-in server app telemetry gauges for asset, user, search, queue, face, and person metrics.
- Adds a dedicated app metrics repository/service plus queue telemetry collection with focused unit and medium tests.
- Exposes machine-learning Prometheus metrics, adds the ML scrape target, and ships a starter Grafana dashboard and docs.

## Test Plan
- [x] pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/repositories/config.repository.spec.ts src/repositories/job.repository.spec.ts src/repositories/telemetry.repository.spec.ts src/services/app-metrics.service.spec.ts src/services/telemetry.service.spec.ts
- [x] pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/app-metrics.repository.spec.ts
- [x] pnpm --dir server check
- [x] cd machine-learning && uv run pytest test_main.py -k PrometheusMetrics -q
- [x] cd machine-learning && uv run ruff check immich_ml/main.py immich_ml/metrics.py test_main.py
- [x] jq empty docker/grafana-dashboard.json and required dashboard expression checks
- [x] pnpm --dir docs exec prettier --check docs/features/monitoring.md docs/install/environment-variables.md ../docker/prometheus.yml ../docker/grafana-dashboard.json