### PR TITLE
docs: document 4.54.0 feature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create collaborative photo-sharing spaces where multiple users can contribute an
 
 ### [Smart Search & Filters](https://opennoodle.de/features/smart-search-filters)
 
-A unified FilterPanel available on the Photos timeline, Shared Spaces, and Map view. Filter by people, location, camera, tags, rating, media type, and favorites — with a temporal picker for year/month scoping. Filters are contextual: narrowing the time range automatically refreshes suggestions so you only see cameras, locations, and people that actually appear in that period. Combine filters with CLIP-powered smart search in Spaces for natural language queries scoped to your filtered results. Collapsible section selector lets you show only the filter categories you care about. [Feature page](https://opennoodle.de/features/smart-search-filters) · [Spaces filtering](https://opennoodle.de/features/spaces-filtering) · [Map filtering](https://opennoodle.de/features/map-filtering) · [Documentation](https://docs.opennoodle.de/features/map-filtering)
+A unified FilterPanel available on the Photos timeline, albums, Shared Spaces, and Map view. Filter by people, location, camera, tags, rating, media type, and favorites — with a temporal picker for year/month scoping. Filters are contextual: narrowing the time range automatically refreshes suggestions so you only see cameras, locations, and people that actually appear in that period. Combine filters with CLIP-powered smart search in Spaces and Map for natural language queries scoped to your filtered results. Collapsible section selector lets you show only the filter categories you care about. [Feature page](https://opennoodle.de/features/smart-search-filters) · [Spaces filtering](https://opennoodle.de/features/spaces-filtering) · [Map filtering](https://opennoodle.de/features/map-filtering) · [Documentation](https://docs.opennoodle.de/features/map-filtering)
 
 ### [User Groups](https://opennoodle.de/features/user-groups)
 
@@ -51,7 +51,11 @@ Store your photos and videos in any S3-compatible object storage — AWS S3, Min
 
 ### [Search Palette](https://opennoodle.de/features/search-palette)
 
-A keyboard-driven command palette — press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd> from anywhere to search photos, people, places, and tags, and jump to any admin or settings page from one input. Five providers run in parallel and group into named sections; the Photos section toggles between Smart (CLIP), Filename, Description, and OCR matching modes via <kbd>Ctrl</kbd>+<kbd>/</kbd>. Empty sections collapse, navigation results fuzzy-match the live page catalog, and an unhealthy ML server triggers a one-tap fall back to filename mode. The palette also surfaces context-aware verbs for the page you're on: viewing an album exposes download / rename / share / leave / delete; viewing a shared space exposes add member, manage members, add all my photos, leave, and delete. Destructive commands use an inline two-step confirm — press <kbd>Enter</kbd> once to arm, again to execute, or <kbd>Esc</kbd> to cancel — so you never lose work to a stray keypress. [Feature page](https://opennoodle.de/features/search-palette) · [Documentation](https://docs.opennoodle.de/features/search-palette)
+A keyboard-driven command palette — press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd> from anywhere to search photos, people, places, and tags, and jump to any admin or settings page from one input. Five providers run in parallel and group into named sections; the Photos section toggles between Smart (CLIP), Filename, Description, and OCR matching modes via <kbd>Ctrl</kbd>+<kbd>/</kbd>. Empty sections collapse, navigation results fuzzy-match the live page catalog, and an unhealthy ML server triggers a one-tap fall back to filename mode. The palette also powers page search: submit a free-text query from Photos, Spaces, or Map to update that page's scoped search, with query recents and sort controls in the top bar. The palette surfaces context-aware verbs for the page you're on: viewing an album exposes download / rename / share / leave / delete; viewing a shared space exposes add member, manage members, add all my photos, leave, and delete. Destructive commands use an inline two-step confirm — press <kbd>Enter</kbd> once to arm, again to execute, or <kbd>Esc</kbd> to cancel — so you never lose work to a stray keypress. [Feature page](https://opennoodle.de/features/search-palette) · [Documentation](https://docs.opennoodle.de/features/search-palette)
+
+### [Memories](https://docs.opennoodle.de/features/memories)
+
+Server-curated memories surface meaningful photo sets automatically. Alongside classic "On this day" cards, Gallery can generate rule-based birthday memories from named people with birthdays and recent-trip memories from location patterns that differ from your usual baseline. The nightly memories task deduplicates cards, caps rule memories per day, and sends server-defined titles and subtitles to web and mobile clients. [Documentation](https://docs.opennoodle.de/features/memories)
 
 ### [Auto-Classification](https://opennoodle.de/features/auto-classification)
 
@@ -67,7 +71,7 @@ Automatically detect and tag pets in your photos using YOLO11 object detection. 
 
 ### [Google Photos Import](https://opennoodle.de/features/google-photos-import)
 
-Import your Google Takeout archive directly from the web UI — no command-line tools needed. A guided 5-step wizard walks you through selecting your Takeout zip or folder, scanning and extracting photos, reviewing metadata, and uploading. The importer preserves original dates, GPS coordinates, descriptions, favorite and archived status, and album structure. Everything runs client-side in the browser using zip.js for extraction and the existing upload API, so no additional server configuration is required. [Feature page](https://opennoodle.de/features/google-photos-import)
+Import your Google Takeout archive directly from the web UI — no command-line tools needed. A guided 5-step wizard walks you through selecting your Takeout zip or folder, scanning and extracting photos, reviewing metadata, and uploading. The importer preserves original dates, GPS coordinates, descriptions, favorite and archived status, and album structure, including localized Google Photos folders and newer `.supplemental-metadata.json` sidecars. Everything runs client-side in the browser using zip.js for extraction and the existing upload API, so no additional server configuration is required. [Feature page](https://opennoodle.de/features/google-photos-import) · [Documentation](https://docs.opennoodle.de/features/google-photos-import)
 
 ### [Image Editing & Video Trimming](https://opennoodle.de/features/image-editing)
 
@@ -194,7 +198,7 @@ That's it. To switch back to upstream Immich later, flip the two image names bac
 | Global Map                                   | Yes    | Yes |
 | Partner Sharing                              | Yes    | Yes |
 | Facial recognition and clustering            | Yes    | Yes |
-| Memories (x years ago)                       | Yes    | Yes |
+| Memories (x years ago, birthdays, trips)     | Yes    | Yes |
 | Offline support                              | Yes    | No  |
 | Read-only gallery                            | Yes    | Yes |
 | Stacked Photos                               | Yes    | Yes |

--- a/docs/docs/administration/jobs-workers.md
+++ b/docs/docs/administration/jobs-workers.md
@@ -48,7 +48,7 @@ When a new asset is uploaded it kicks off a series of jobs, which include metada
 
 <img src={require('./img/admin-jobs.webp').default} width="60%" title="Admin jobs" />
 
-Additionally, some jobs (such as memories generation) run on a schedule, which is every night at midnight by default. To change when they run or enable/disable a job navigate to System Settings -> [Nightly Tasks Settings](https://my.immich.app/admin/system-settings?isOpen=nightly-tasks).
+Additionally, some jobs (such as [memories generation](/features/memories)) run on a schedule, which is every night at midnight by default. To change when they run or enable/disable a job navigate to System Settings -> [Nightly Tasks Settings](https://my.immich.app/admin/system-settings?isOpen=nightly-tasks).
 
 <img src={require('./img/admin-nightly-tasks.webp').default} width="80%" title="Admin nightly tasks" />
 

--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -10,7 +10,7 @@ Gallery has a command line interface (CLI) that allows you to perform certain ac
 More features are planned for the future.
 
 :::tip Google Photos Takeout
-If you are looking to import your Google Photos takeout, we recommend this community maintained tool [immich-go](https://github.com/simulot/immich-go)
+If you are looking to import your Google Photos Takeout, use Gallery's [Google Photos Import](/features/google-photos-import) from the web app. The community-maintained [immich-go](https://github.com/simulot/immich-go) tool is still useful for advanced command-line workflows.
 :::
 
 ## Requirements

--- a/docs/docs/features/dynamic-filter-suggestions.md
+++ b/docs/docs/features/dynamic-filter-suggestions.md
@@ -1,6 +1,6 @@
 # Dynamic Filter Suggestions
 
-When you apply a filter on the Photos page, all other filter panels dynamically update to show only values that exist in the current result set. Every visible option is guaranteed to return results.
+When you apply a filter on the Photos page or inside an album, all other filter panels dynamically update to show only values that exist in the current result set. Every visible option is guaranteed to return results.
 
 ## How it works
 
@@ -14,16 +14,16 @@ This is called **faceted search** -- the same pattern used by Amazon, eBay, and 
 
 ## What updates
 
-| Filter     | Updates when other filters change? | Notes                                                  |
-| ---------- | ---------------------------------- | ------------------------------------------------------ |
-| People     | Yes                                | Only people appearing in the filtered photos           |
-| Location   | Yes (countries)                    | Cities update when you expand a country                |
-| Camera     | Yes (makes)                        | Models update when you expand a make                   |
-| Tags       | Yes                                | Only tags assigned to filtered photos                  |
-| Rating     | Yes                                | Stars not present in the result set are hidden         |
-| Media Type | Yes                                | Photo/Video buttons hidden when no assets of that type |
-| Timeline   | Drives filtering                   | Selecting a year/month narrows all other panels        |
-| Favorites  | Not dynamic                        | Simple toggle, always visible                          |
+| Filter     | Updates when other filters change? | Notes                                                    |
+| ---------- | ---------------------------------- | -------------------------------------------------------- |
+| People     | Yes                                | Only people appearing in the filtered photos             |
+| Location   | Yes (countries)                    | Cities update when you expand a country                  |
+| Camera     | Yes (makes)                        | Models update when you expand a make                     |
+| Tags       | Yes                                | Only tags assigned to filtered photos                    |
+| Rating     | Yes                                | Shows ratings that can still satisfy the current minimum |
+| Media Type | Yes                                | Photo/Video buttons hidden when no assets of that type   |
+| Timeline   | Drives filtering                   | Selecting a year/month narrows all other panels          |
+| Favorites  | Not dynamic                        | Simple toggle, always visible                            |
 
 ## Orphaned selections
 
@@ -42,6 +42,8 @@ Previous in-flight requests are automatically cancelled when a new filter change
 ## Architecture
 
 A single API endpoint (`GET /search/suggestions/filters`) returns all suggestion categories in one round trip. The server runs 6 parallel queries -- one per category -- each applying all active filters **except its own category**. This exclusion is what makes it faceted: selecting Germany still shows all countries that match the other filters, not just Germany.
+
+For album detail pages, the same endpoint is scoped with `albumId`. Album scoping cannot be combined with `spaceId` or `withSharedSpaces`, because an album and a space are separate collection boundaries.
 
 ### Server flow
 
@@ -79,10 +81,12 @@ All 6 extraction queries share a common `buildFilteredAssetIds` helper that appl
 
 ## Supported pages
 
-| Page   | Dynamic suggestions? | Notes                                        |
-| ------ | -------------------- | -------------------------------------------- |
-| Photos | Yes                  | Full cross-filter scoping                    |
-| Map    | Not yet              | Uses individual providers (temporal scoping) |
-| Spaces | Not yet              | Uses individual providers (temporal scoping) |
+| Page         | Dynamic suggestions? | Notes                                           |
+| ------------ | -------------------- | ----------------------------------------------- |
+| Photos       | Yes                  | Full cross-filter scoping                       |
+| Album detail | Yes                  | Scoped to assets already in the current album   |
+| Album picker | Yes                  | Filters the assets available to add to an album |
+| Map          | Partial              | Uses individual providers plus active filters   |
+| Spaces       | Partial              | Uses individual providers plus active filters   |
 
 Map and Spaces pages can adopt the unified endpoint in the future with minimal changes -- the `suggestionsProvider` interface is generic and the endpoint supports `spaceId` scoping.

--- a/docs/docs/features/google-photos-import.md
+++ b/docs/docs/features/google-photos-import.md
@@ -1,0 +1,71 @@
+# Google Photos Import
+
+Gallery can import a Google Photos Takeout export directly from the web app. The importer runs in your browser, scans the selected ZIP files or Takeout folder, matches Google metadata sidecars to media files, uploads the media through the normal upload API, and optionally recreates albums from Takeout folders.
+
+Open **Import** from the Gallery app, choose **Google Photos**, then select either:
+
+- one or more `.zip` files from Google Takeout
+- an extracted Takeout folder
+
+Keep the browser tab open until the import finishes.
+
+## Import flow
+
+1. **Source** — choose Google Photos.
+2. **Files** — select Takeout ZIP files or an extracted folder.
+3. **Scan** — Gallery reads media files and Google metadata sidecars locally in the browser.
+4. **Review** — confirm the number of photos, videos, dates, locations, favorites, archived items, and detected albums.
+5. **Import** — Gallery uploads items one by one and creates the selected albums.
+
+The review step lets you choose whether to import favorites, archived state, descriptions, and whether to skip duplicates that already exist on the server.
+
+## Preserved metadata
+
+When a matching Takeout sidecar is available, Gallery imports:
+
+- original taken date
+- GPS coordinates
+- description
+- favorite state
+- archived state
+- album membership derived from Takeout folder names
+
+If an item is missing date metadata, Gallery warns you during review and falls back to the file date during upload.
+
+## Album detection
+
+Takeout albums are detected from paths shaped like:
+
+```text
+Takeout/<Google Photos root>/<Album name>/<file>
+```
+
+Gallery recognizes localized Google Photos root folders such as `Google Fotos` and `Google フォト`, not only the English `Google Photos` folder. This prevents non-English Takeout exports from losing their album structure during scanning.
+
+Auto-generated Takeout folders like **Photos from 2023** are shown but are not selected by default. You can select all albums, deselect all albums, or choose individual albums before importing.
+
+## Sidecar matching
+
+Google has changed Takeout sidecar naming several times. Gallery matches the common forms, including:
+
+| Sidecar shape                                      | Example                                                              |
+| -------------------------------------------------- | -------------------------------------------------------------------- |
+| Classic appended `.json`                           | `IMG_1234.jpg.json`                                                  |
+| 2024+ supplemental metadata suffix                 | `IMG_1234.jpg.supplemental-metadata.json`                            |
+| Truncated supplemental suffixes                    | `IMG_1234.jpg.supplemental-me.json`                                  |
+| Duplicate-index variants                           | `IMG_1234.jpg(1).json`, `IMG_1234.jpg.supplemental(1).json`          |
+| Sidecars missing the media extension               | `Peanut Butter Balls.supplemental-metadata.json`                     |
+| Edited copies sharing the original sidecar         | `IMAG0061.JPG.supplemental-metadata.json` plus `IMAG0061-edited.JPG` |
+| Localized edited suffixes confirmed by Google data | `-edited`, `-modifié`, `-bearbeitet`, `-modificato`                  |
+
+Sidecars are only matched to media files in the same folder. Non-Takeout JSON files such as `metadata.json`, `print-subscriptions.json`, shared album comments, or JSON from other Takeout services are ignored.
+
+## Duplicate behavior
+
+The importer uses stable Takeout-derived upload identifiers and the normal server-side duplicate detection. With **Skip duplicates already in Immich** enabled, duplicates are counted as skipped and can still be used for album creation when the server returns the existing asset id.
+
+## Limits
+
+- The import runs in the browser, so very large Takeouts are limited by browser memory and tab lifetime.
+- Uploads run sequentially. You can pause and resume within the current tab session, but closing the tab stops the import.
+- Live Photo edge cases where the video sidecar uses a different duplicate index than the still photo may still need manual review.

--- a/docs/docs/features/map-filtering.md
+++ b/docs/docs/features/map-filtering.md
@@ -14,7 +14,13 @@ Open the map from the sidebar or from a Space's map button. The filter panel app
 - **Media type** — photos, videos, or both
 - **Timeline** — pick a year or month to see photos from that period
 
-Markers on the map update as you change filters. When you click a cluster, the timeline panel also respects your active filters.
+Markers on the map update as you change filters. When you click a cluster, the timeline panel also respects your active filters and its counts stay scoped to the filtered result set.
+
+## Searching the map
+
+Use <kbd>Cmd</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>K</kbd> from the map and submit a free-text query. Gallery applies the query to the current map URL as `q=...` and combines it with the active map filters.
+
+Map search uses smart search to find matching assets, then intersects those results with the geotagged marker set. Clearing the search chip removes only the query and keeps the other map filters intact.
 
 ## Global map vs. space map
 

--- a/docs/docs/features/memories.md
+++ b/docs/docs/features/memories.md
@@ -1,0 +1,67 @@
+# Memories
+
+Gallery generates memory cards that resurface meaningful groups of photos on the web and mobile apps. Memories are created by the nightly **Generate memories** task and appear in the memory lane when they are due to be shown.
+
+## Memory types
+
+Gallery supports two memory families:
+
+| Type            | What it shows                                               | Title source                       |
+| --------------- | ----------------------------------------------------------- | ---------------------------------- |
+| **On this day** | Photos taken around the same calendar day in previous years | App-generated "N years ago" title  |
+| **Rule memory** | Server-curated sets such as birthdays and recent trips      | Server-provided title and subtitle |
+
+Saved memories stay available after their normal display window. Hidden or deleted assets are excluded from generated memories.
+
+## Birthday memories
+
+Birthday memories are generated from people with a birthday set on their person record.
+
+Gallery looks for photos of that person up to the target day and prefers a cross-year throwback when enough history exists:
+
+- At least 6 qualifying photos across at least 2 distinct years creates **Happy birthday, Name** with the subtitle **Photos from different years**.
+- If there is not enough cross-year history, Gallery can still create a smaller fallback from the 4 most recent qualifying photos, with the subtitle **Recent photos of Name**.
+- At most 2 photos per year are used in the cross-year set, and the memory is capped at 12 assets.
+
+Each birthday memory is deduplicated by person and day, so rerunning the nightly task does not create duplicate birthday cards for the same person.
+
+## Recent trip memories
+
+Recent trip memories find a place that looks unusual compared with your recent baseline.
+
+The rule compares the last 30 days of location clusters with the preceding 90 days:
+
+- Gallery first infers a likely home location from the baseline period.
+- A trip candidate needs at least 7 photos across at least 2 days.
+- The place must be outside the likely home country, or in a different city within the home country.
+- If the home location is ambiguous, Gallery skips the rule instead of guessing.
+- The same place has a 30-day cooldown so a long trip does not create repeated cards every night.
+
+Trip memories are titled **Recent trip to City, Country** or **Recent trip to Country**. The subtitle shows the number of photos and days in the trip window.
+
+### Trip photo curation
+
+Trip memories try to show representative photos instead of every near-duplicate burst:
+
+- Photos taken within 2 minutes of the previous selected photo are collapsed.
+- Small trips keep up to 6 representative photos.
+- Medium trips use 7 or 8 photos depending on day and photo count.
+- Long trips use up to 10 photos and preserve coverage across the trip window.
+
+## Nightly generation
+
+The **Generate memories** nightly task creates both classic **On this day** memories and rule memories.
+
+Rule memories run only through the current day and are capped at 2 rule-generated cards per user per day. If one rule fails for a user, Gallery logs the failure and continues evaluating the remaining users and rules where possible.
+
+You can enable, disable, or reschedule this task from **Administration → Settings → Nightly Tasks**. The same setting is exposed as `nightlyTasks.generateMemories` in the [config file](/install/config-file).
+
+## API behavior
+
+The memory API exposes rule memories with:
+
+- `type: "rule"`
+- a flexible `data` object containing the rule id, dedupe key, title, optional subtitle, score, and rule context
+- top-level `title` and `subtitle` fields for clients that render server-defined memory labels
+
+Classic **On this day** memories still require `data.year`. This keeps existing clients compatible while allowing new server-curated memory types to carry richer display metadata.

--- a/docs/docs/features/s3-storage.md
+++ b/docs/docs/features/s3-storage.md
@@ -247,3 +247,13 @@ When S3 is the write backend, uploads follow this path:
 Profile images (both user-uploaded and OAuth-synced) follow the same pattern: the file is written to disk first, then uploaded to S3 if the write backend is S3, and the local temp file is cleaned up.
 
 For operations that require filesystem access (ffmpeg transcoding, exiftool metadata extraction), the S3 backend provides a `downloadToTemp()` method that streams the object to a local temp file and returns a cleanup function.
+
+### Archive Downloads
+
+Album, selection, and shared-link archive downloads work with both disk and S3-backed assets. For S3 assets, Gallery opens object streams lazily and serializes ZIP entry appends so large archives do not exhaust the S3 connection pool. This is most visible in `proxy` mode or when downloading many S3-only assets through the server.
+
+### Cleanup Behavior
+
+Deleting a user removes that user's storage prefix from the active backend. On S3, Gallery lists and deletes all objects under the user's prefix; on disk, it removes the matching directory tree. The cleanup is idempotent, so rerunning a failed delete is safe.
+
+Sidecar copy operations also respect the target asset's backend. Copying XMP metadata from one asset to another downloads the source sidecar to a temporary local file when needed, then writes the target sidecar either to disk or to the relative S3 key for that asset.

--- a/docs/docs/features/search-palette.md
+++ b/docs/docs/features/search-palette.md
@@ -2,7 +2,7 @@
 
 A keyboard-driven command palette that searches everything in your library — photos, people, places, tags — and jumps to any admin or settings page, all from one input. Press <kbd>Cmd</kbd>+<kbd>K</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>K</kbd> (Windows / Linux) to open it from anywhere in Gallery.
 
-The classic search bar in the navbar still works exactly as before. The palette is a second, faster entry point optimised for "I know what I'm looking for, get me there in three keystrokes".
+The top navigation search field opens this same palette. On searchable pages, the sort control next to the search field applies immediately to the current view, so searching and sorting live in one consistent place instead of separate page-specific search bars.
 
 ## What you can search
 
@@ -101,12 +101,27 @@ When your query closely matches a single command or navigation entry, that entry
 
 Promotion is based on a fuzzy score against the title, description, and search keywords. Commands win tie-breaks against navigation entries, so unscoped verbs like `upload` or `album` surface their command first. A short query like `peo` will surface **People** as the top result; `users` will surface **Administration → User Management**.
 
+### Page-aware search
+
+When you open the palette from a page that supports inline search, Gallery preloads the page's current query and sort mode. Submitting a new free-text query updates the page URL instead of navigating away:
+
+| Current page                          | Where **Search for "…"** applies                                   |
+| ------------------------------------- | ------------------------------------------------------------------ |
+| **Photos**                            | `/photos?q=...` with the selected relevance / newest / oldest sort |
+| **Shared space detail**               | That space's timeline, scoped to the space's assets                |
+| **Shared space photos route**         | That space's photos route, preserving route context                |
+| **Map**                               | The map markers, combined with active map filters                  |
+| Any other page without a search scope | Falls back to the Photos timeline                                  |
+
+The URL carries the query in `q` and, when needed, the sort in `sort=asc` or `sort=desc`. Clearing the search chip removes `q` and returns the page to its normal date ordering.
+
 ## Recents
 
-Every result you activate is added to a **Recent** list (per user, per browser). When you reopen the palette with an empty query, your last few activations are shown immediately so you can repeat a workflow with two keystrokes.
+Every destination or free-text search you activate is added to a **Recent** list (per user, per browser). When you reopen the palette with an empty query, your last few activations are shown immediately so you can repeat a workflow with two keystrokes.
 
 - Recent entries that are no longer accessible (admin pages after a demotion, deleted people, removed tags) are filtered out automatically the next time you open the palette.
 - Remove a single entry with the **×** button on the row, or with <kbd>Delete</kbd> while it's highlighted.
+- Re-activating a query recent runs that query immediately on the current searchable page, instead of just filling the input.
 
 ## Quick links fallback
 

--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -26,7 +26,7 @@ You can search the following types of content:
 | Time frame                          | Start and end date of a specific time bucket          |
 | Media type                          | Image or video or both                                |
 | Display options                     | In Archive, in Favorites or Not in any album          |
-| Star rating                         | User-assigned star rating                             |
+| Star rating                         | Minimum user-assigned star rating                     |
 
 <img src={require('./img/advanced-search-filters.webp').default} width="70%" title='Advanced search filters' />
 

--- a/docs/docs/features/shared-spaces.md
+++ b/docs/docs/features/shared-spaces.md
@@ -244,7 +244,9 @@ This tracking is per-member — your "last viewed" timestamp updates each time y
 
 ## Search
 
-When a space has photos, a search bar appears at the top of the space detail page. Searches use smart/semantic search scoped to only that space's assets, so results are limited to photos within the space.
+Use <kbd>Cmd</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>K</kbd> from a space detail page and submit the **Search for "…"** top result. Searches use smart/semantic search scoped to only that space's assets, so results are limited to photos within the space.
+
+The search query is stored in the space URL as `q=...`. The sort control in the top bar switches between relevance, newest first, and oldest first, and the active search chip can clear the query without clearing your other filters.
 
 ## Map View
 

--- a/docs/docs/features/sharing.md
+++ b/docs/docs/features/sharing.md
@@ -10,6 +10,12 @@ Albums can be shared between users on the same Gallery instance. The shared user
 
 After creating an album, you can access the sharing options by clicking on the share icon. When sharing an album, you can select the users you want to share the album with and assign them permissions either as editors (read-write) or viewers (read-only).
 
+#### Filtering albums on web
+
+Album detail pages include the same filter panel used on the main Photos timeline. You can narrow an album by people, location, camera, tags, rating, media type, favorites, and date range. Filter suggestions are scoped to the current album, so visible options only reflect assets that are actually in that album.
+
+The **Add photos** picker also supports filters. This makes it easier to add a focused set of assets to a large album without leaving the album workflow.
+
 #### Web
 
 <img src={require('./img/shared-album.webp').default} width='60%' title='Shared album option' caption='ok' />

--- a/docs/docs/guides/switch-back-to-immich.md
+++ b/docs/docs/guides/switch-back-to-immich.md
@@ -101,5 +101,6 @@ For transparency, here is what the cleanup script changes:
 - **Drops Gallery-only functions and triggers** that reference the dropped tables.
 - **Strips the `classification` key** out of the `system-config` row in `system_metadata`.
 - **Deletes fork migration rows** from `kysely_migrations` and `migration_overrides`, so upstream Immich's migrator does not see them as unknown migrations.
+- **Rolls back upstream migrations that Gallery pulled in after the currently supported Immich tag** when needed. Gallery may be rebased onto upstream commits newer than the Immich release you switch back to, so the script also removes those migration rows and reverses their schema changes before vanilla Immich starts.
 
 The script's own header documents every step in detail.

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -7,7 +7,7 @@ This script assumes you have a second hard drive connected to your server for on
 The database is saved to your Gallery upload folder in the `database-backup` subdirectory. The database is then backed up and versioned with your assets by Borg. This ensures that the database backup is in sync with your assets in every snapshot.
 
 :::info
-This script makes backups of your database along with your photo/video library. This is redundant with the [automatic database backup tool](/administration/backup-and-restore#automatic-database-dumps) built into Gallery. Using this script to backup your database has two advantages over the built-in backup tool:
+This script makes backups of your database along with your photo/video library. This is redundant with the [automatic database backup tool](/administration/backup-and-restore#automatic-database-backups) built into Gallery. Using this script to backup your database has two advantages over the built-in backup tool:
 
 - This script uses storage more efficiently by versioning your backups instead of making multiple copies.
 - The database backups are performed at the same time as the library backup, ensuring that the backups of your database and the library are always in sync.

--- a/docs/docs/overview/quick-start.mdx
+++ b/docs/docs/overview/quick-start.mdx
@@ -84,7 +84,7 @@ The database only contains metadata and user information. You must setup manual 
 
 You may decide you'd like to install the server a different way; the Install category on the left menu provides many options.
 
-You may decide you'd like to add the _rest_ of your photos from Google Photos, even those not on your mobile device, via Google Takeout. You can use [immich-go](https://github.com/simulot/immich-go) for this.
+You may decide you'd like to add the _rest_ of your photos from Google Photos, even those not on your mobile device, via Google Takeout. Use Gallery's [Google Photos Import](/features/google-photos-import) from the web app, or [immich-go](https://github.com/simulot/immich-go) for advanced command-line imports.
 
 You may want to [upload photos from your own archive](/features/command-line-interface).
 

--- a/docs/docs/overview/release-notes.md
+++ b/docs/docs/overview/release-notes.md
@@ -1,0 +1,42 @@
+# Release Notes
+
+## 4.54.0
+
+Gallery 4.54.0 covers the changes shipped after `v4.53.0` through `v4.54.0`.
+
+### Search and filters
+
+- The global search palette is now the main search entry point from the top navigation.
+- Free-text palette searches apply to the current page when possible, including Photos, Shared Spaces, and Map.
+- Query recents now rerun searches directly, and the page sort control is available beside the top search trigger.
+- Searchable page controls moved into the cmd+k flow, replacing the old page-specific search bars.
+- Album detail pages and the album asset picker now support the full filter panel with album-scoped suggestions.
+- Map marker counts and map timeline results now respect active filters and smart-search queries.
+- Smart search keeps the VectorChord index path for person filters and avoids secondary tie-break ordering that can force slow sequential scans.
+- Smart search rating filters are inclusive minimum-rating filters, and filter suggestion rating facets remain monotonic.
+
+### Memories
+
+- Rule-based memories were added alongside classic **On this day** memories.
+- Birthday memories are generated from people with birthdays and enough qualifying photos.
+- Recent-trip memories are generated from location patterns that differ from the user's recent home baseline.
+- Rule memories include server-defined titles and subtitles for web and mobile clients.
+- Nightly generation tracks a separate rule-memory cursor, deduplicates by rule key, and caps rule memories per user per day.
+
+### Imports and metadata
+
+- Google Photos Takeout import now handles `.supplemental-metadata.json` sidecars, localized Google Photos root folders, duplicate-index sidecars, edited variants, and sidecars that omit the media extension.
+- Google Takeout album detection avoids non-Photos Takeout services in mixed exports.
+- XMP sidecar copy works when the target asset is stored under an S3 relative key.
+
+### Storage and downloads
+
+- Large S3 archive downloads no longer open all object streams at once, avoiding socket exhaustion and stalled ZIP downloads.
+- Archive appends are serialized so S3-backed downloads finish reliably.
+- Deleting a user now cleans up user-scoped disk directories or S3 object prefixes.
+- S3 relative-path handling was audited across copy and cleanup paths.
+
+### Migration and release maintenance
+
+- The switch-back-to-Immich script now accounts for upstream migrations that Gallery has pulled in after the Immich tag it is based on.
+- The mobile release workflow rejects version overrides that do not use a `v` prefix.


### PR DESCRIPTION
## Summary

- add docs for rule-based memories, Google Photos import, and the 4.54.0 release notes
- update global search docs for cmd+k page search, query recents, and sort controls
- document related album filters, map search/count behavior, S3 archive/cleanup fixes, and switch-back cleanup notes

## Verification

- pnpm --filter documentation format
- git diff --check
- pnpm --filter documentation build