### PR TITLE
fix(server): accept cron wildcard steps in system config

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -20548,7 +20548,6 @@
         "properties": {
           "cronExpression": {
             "description": "Cron expression",
-            "pattern": "(((\\d+,)+\\d+|(\\d+(\\/|-)\\d+)|\\d+|\\*) ?){5,7}",
             "type": "string"
           },
           "enabled": {
@@ -28735,7 +28734,6 @@
         "properties": {
           "cronExpression": {
             "description": "Cron expression",
-            "pattern": "(((\\d+,)+\\d+|(\\d+(\\/|-)\\d+)|\\d+|\\*) ?){5,7}",
             "type": "string"
           },
           "enabled": {

--- a/server/src/controllers/system-config.controller.spec.ts
+++ b/server/src/controllers/system-config.controller.spec.ts
@@ -91,6 +91,15 @@ describe(SystemConfigController.name, () => {
       });
     });
 
+    describe('library', () => {
+      it('should accept the six-hour library scan preset', async () => {
+        const config = validConfig();
+        config.library.scan.cronExpression = '0 */6 * * *';
+        const { status } = await request(ctx.getHttpServer()).put('/system-config').send(config);
+        expect(status).toBe(200);
+      });
+    });
+
     describe('image', () => {
       it('should accept config without optional progressive property', async () => {
         const config = validConfig();

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -1,3 +1,4 @@
+import { validateCronExpression } from 'cron';
 import { createZodDto } from 'nestjs-zod';
 import { SystemConfig } from 'src/config';
 import {
@@ -45,7 +46,7 @@ const JobSettingsSchema = z
 
 const cronExpressionSchema = z
   .string()
-  .regex(/(((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7}/, 'Invalid cron expression')
+  .refine((expression) => validateCronExpression(expression).valid, { message: 'Invalid cron expression' })
   .describe('Cron expression');
 
 const DatabaseBackupSchema = z

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -322,6 +322,22 @@ describe(SystemConfigService.name, () => {
       });
     });
 
+    it('should accept cron expressions with wildcard steps', async () => {
+      mocks.config.getEnv.mockReturnValue(mockEnvData({ configFile: 'immich-config.json' }));
+      mocks.systemMetadata.readFile.mockResolvedValue(
+        JSON.stringify({ library: { scan: { cronExpression: '0 */6 * * *' } } }),
+      );
+
+      await expect(sut.getSystemConfig()).resolves.toMatchObject({
+        library: {
+          scan: {
+            enabled: true,
+            cronExpression: '0 */6 * * *',
+          },
+        },
+      });
+    });
+
     it('should reject an invalid issuer URL', async () => {
       mocks.config.getEnv.mockReturnValue(mockEnvData({ configFile: 'immich-config.json' }));
       mocks.systemMetadata.readFile.mockResolvedValue(JSON.stringify({ oauth: { issuerUrl: 'accounts.google.com' } }));


### PR DESCRIPTION
## Summary
- replace the system config cron regex with the runtime cron package validator
- allow valid wildcard-step expressions like the Library Settings preset \`0 */6 * * *\`
- add controller and config-loading regression coverage

Fixes #430

## Red-green check
- Green: \`pnpm test --run src/controllers/system-config.controller.spec.ts src/services/system-config.service.spec.ts\` passed with the fix: 53 tests passed
- Red: temporarily restored the old regex; the same command failed on the two new wildcard-step regression cases
- Green: restored the cron package validator; the same command passed again: 53 tests passed

## Verification
- \`pnpm test --run src/controllers/system-config.controller.spec.ts src/services/system-config.service.spec.ts\`
- \`pnpm check\`
- \`pnpm lint\`