### PR TITLE
fix: scope city suggestions by active filters

### DIFF
--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -316,6 +316,9 @@ class SearchApi {
   /// * [bool] includeNull:
   ///   Include null values in suggestions
   ///
+  /// * [bool] isFavorite:
+  ///   Filter by favorites
+  ///
   /// * [String] lensModel:
   ///   Filter by lens model
   ///
@@ -325,11 +328,20 @@ class SearchApi {
   /// * [String] model:
   ///   Filter by camera model
   ///
+  /// * [List<String>] personIds:
+  ///   Filter by person IDs
+  ///
+  /// * [int] rating:
+  ///   Filter by rating (1-5)
+  ///
   /// * [String] spaceId:
   ///   Scope suggestions to a specific shared space
   ///
   /// * [String] state:
   ///   Filter by state/province
+  ///
+  /// * [List<String>] tagIds:
+  ///   Filter by tag IDs
   ///
   /// * [DateTime] takenAfter:
   ///   Filter suggestions by taken date (after)
@@ -339,7 +351,7 @@ class SearchApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include suggestions from shared spaces the user is a member of
-  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, String? lensModel, String? make, String? model, String? spaceId, String? state, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, bool? isFavorite, String? lensModel, String? make, String? model, List<String>? personIds, int? rating, String? spaceId, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/suggestions';
 
@@ -359,6 +371,9 @@ class SearchApi {
     if (includeNull != null) {
       queryParams.addAll(_queryParams('', 'includeNull', includeNull));
     }
+    if (isFavorite != null) {
+      queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
+    }
     if (lensModel != null) {
       queryParams.addAll(_queryParams('', 'lensModel', lensModel));
     }
@@ -368,11 +383,20 @@ class SearchApi {
     if (model != null) {
       queryParams.addAll(_queryParams('', 'model', model));
     }
+    if (personIds != null) {
+      queryParams.addAll(_queryParams('multi', 'personIds', personIds));
+    }
+    if (rating != null) {
+      queryParams.addAll(_queryParams('', 'rating', rating));
+    }
     if (spaceId != null) {
       queryParams.addAll(_queryParams('', 'spaceId', spaceId));
     }
     if (state != null) {
       queryParams.addAll(_queryParams('', 'state', state));
+    }
+    if (tagIds != null) {
+      queryParams.addAll(_queryParams('multi', 'tagIds', tagIds));
     }
     if (takenAfter != null) {
       queryParams.addAll(_queryParams('', 'takenAfter', takenAfter));
@@ -416,6 +440,9 @@ class SearchApi {
   /// * [bool] includeNull:
   ///   Include null values in suggestions
   ///
+  /// * [bool] isFavorite:
+  ///   Filter by favorites
+  ///
   /// * [String] lensModel:
   ///   Filter by lens model
   ///
@@ -425,11 +452,20 @@ class SearchApi {
   /// * [String] model:
   ///   Filter by camera model
   ///
+  /// * [List<String>] personIds:
+  ///   Filter by person IDs
+  ///
+  /// * [int] rating:
+  ///   Filter by rating (1-5)
+  ///
   /// * [String] spaceId:
   ///   Scope suggestions to a specific shared space
   ///
   /// * [String] state:
   ///   Filter by state/province
+  ///
+  /// * [List<String>] tagIds:
+  ///   Filter by tag IDs
   ///
   /// * [DateTime] takenAfter:
   ///   Filter suggestions by taken date (after)
@@ -439,8 +475,8 @@ class SearchApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include suggestions from shared spaces the user is a member of
-  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, String? lensModel, String? make, String? model, String? spaceId, String? state, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
-    final response = await getSearchSuggestionsWithHttpInfo(type,  albumId: albumId, country: country, includeNull: includeNull, lensModel: lensModel, make: make, model: model, spaceId: spaceId, state: state, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
+  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, bool? isFavorite, String? lensModel, String? make, String? model, List<String>? personIds, int? rating, String? spaceId, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+    final response = await getSearchSuggestionsWithHttpInfo(type,  albumId: albumId, country: country, includeNull: includeNull, isFavorite: isFavorite, lensModel: lensModel, make: make, model: model, personIds: personIds, rating: rating, spaceId: spaceId, state: state, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -10298,6 +10298,15 @@
             }
           },
           {
+            "name": "isFavorite",
+            "required": false,
+            "in": "query",
+            "description": "Filter by favorites",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "lensModel",
             "required": false,
             "in": "query",
@@ -10325,6 +10334,31 @@
             }
           },
           {
+            "name": "personIds",
+            "required": false,
+            "in": "query",
+            "description": "Filter by person IDs",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$"
+              }
+            }
+          },
+          {
+            "name": "rating",
+            "required": false,
+            "in": "query",
+            "description": "Filter by rating (1-5)",
+            "schema": {
+              "minimum": 1,
+              "maximum": 5,
+              "type": "integer"
+            }
+          },
+          {
             "name": "spaceId",
             "required": false,
             "in": "query",
@@ -10342,6 +10376,20 @@
             "description": "Filter by state/province",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "tagIds",
+            "required": false,
+            "in": "query",
+            "description": "Filter by tag IDs",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$"
+              }
             }
           },
           {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -6072,15 +6072,19 @@ export function searchAssetStatistics({ statisticsSearchDto }: {
 /**
  * Retrieve search suggestions
  */
-export function getSearchSuggestions({ albumId, country, includeNull, lensModel, make, model, spaceId, state, takenAfter, takenBefore, $type, withSharedSpaces }: {
+export function getSearchSuggestions({ albumId, country, includeNull, isFavorite, lensModel, make, model, personIds, rating, spaceId, state, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
     albumId?: string;
     country?: string;
     includeNull?: boolean;
+    isFavorite?: boolean;
     lensModel?: string;
     make?: string;
     model?: string;
+    personIds?: string[];
+    rating?: number;
     spaceId?: string;
     state?: string;
+    tagIds?: string[];
     takenAfter?: string;
     takenBefore?: string;
     $type: SearchSuggestionType;
@@ -6093,11 +6097,15 @@ export function getSearchSuggestions({ albumId, country, includeNull, lensModel,
         albumId,
         country,
         includeNull,
+        isFavorite,
         lensModel,
         make,
         model,
+        personIds,
+        rating,
         spaceId,
         state,
+        tagIds,
         takenAfter,
         takenBefore,
         "type": $type,

--- a/server/src/controllers/search.controller.spec.ts
+++ b/server/src/controllers/search.controller.spec.ts
@@ -226,6 +226,27 @@ describe(SearchController.name, () => {
         expect(status).toBe(400);
         expect(body).toEqual(errorDto.badRequest([expect.stringContaining('albumId cannot exist alongside spaceId')]));
       });
+
+      it('accepts personIds for scoped city suggestions', async () => {
+        const personId = '33333333-3333-4333-8333-333333333333';
+        ctx.authenticate.mockResolvedValue({});
+        service.getSearchSuggestions.mockResolvedValue(['Berlin']);
+
+        const { status, body } = await request(ctx.getHttpServer())
+          .get('/search/suggestions')
+          .query({ type: 'city', country: 'Germany', personIds: personId });
+
+        expect(status).toBe(200);
+        expect(body).toEqual(['Berlin']);
+        expect(service.getSearchSuggestions).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            type: 'city',
+            country: 'Germany',
+            personIds: [personId],
+          }),
+        );
+      });
     });
 
     describe('GET /search/suggestions/filters', () => {

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -135,6 +135,16 @@ const SearchSuggestionRequestBaseSchema = z.object({
   albumId: z.uuidv4().optional().describe('Scope suggestions to a specific album'),
   country: z.string().optional().describe('Filter by country'),
   state: z.string().optional().describe('Filter by state/province'),
+  personIds: z
+    .preprocess((v) => (v === undefined ? undefined : Array.isArray(v) ? v : [v]), z.array(z.uuidv4()))
+    .optional()
+    .describe('Filter by person IDs'),
+  tagIds: z
+    .preprocess((v) => (v === undefined ? undefined : Array.isArray(v) ? v : [v]), z.array(z.uuidv4()))
+    .optional()
+    .describe('Filter by tag IDs'),
+  rating: z.coerce.number().int().min(1).max(5).optional().describe('Filter by rating (1-5)'),
+  isFavorite: stringToBool.optional().describe('Filter by favorites'),
   make: z.string().optional().describe('Filter by camera make'),
   model: z.string().optional().describe('Filter by camera model'),
   lensModel: z.string().optional().describe('Filter by lens model'),

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -272,16 +272,24 @@ where
 
 -- SearchRepository.getCities
 select distinct
-  on ("city") "city"
+  "city"
 from
   "asset_exif"
-  inner join "asset" on "asset"."id" = "asset_exif"."assetId"
 where
-  "visibility" = $1
-  and "deletedAt" is null
+  "assetId" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+    where
+      "asset"."visibility" = $1
+      and "asset"."deletedAt" is null
+      and "asset"."ownerId" = any ($2::uuid[])
+  )
   and "city" is not null
-  and "city" != $2
-  and "asset"."ownerId" = any ($3::uuid[])
+  and "city" != $3
+order by
+  "city"
 
 -- SearchRepository.getCameraMakes
 select distinct

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -177,11 +177,23 @@ export interface SuggestionScopeOptions {
   takenBefore?: Date;
 }
 
+interface FilterSuggestionFilterOptions {
+  personIds?: string[];
+  country?: string;
+  city?: string;
+  make?: string;
+  model?: string;
+  tagIds?: string[];
+  rating?: number;
+  mediaType?: AssetType;
+  isFavorite?: boolean;
+}
+
 export interface GetStatesOptions extends SuggestionScopeOptions {
   country?: string;
 }
 
-export interface GetCitiesOptions extends GetStatesOptions {
+export interface GetCitiesOptions extends SuggestionScopeOptions, FilterSuggestionFilterOptions {
   state?: string;
 }
 
@@ -200,17 +212,7 @@ export interface GetCameraLensModelsOptions extends SuggestionScopeOptions {
   model?: string;
 }
 
-export interface FilterSuggestionsOptions extends SuggestionScopeOptions {
-  personIds?: string[];
-  country?: string;
-  city?: string;
-  make?: string;
-  model?: string;
-  tagIds?: string[];
-  rating?: number;
-  mediaType?: AssetType;
-  isFavorite?: boolean;
-}
+export interface FilterSuggestionsOptions extends SuggestionScopeOptions, FilterSuggestionFilterOptions {}
 
 type AccessibleTagScopeOptions = Pick<
   SuggestionScopeOptions,
@@ -579,9 +581,16 @@ export class SearchRepository {
 
   @GenerateSql({ params: [[DummyValue.UUID], DummyValue.STRING, DummyValue.STRING] })
   async getCities(userIds: string[], options: GetCitiesOptions): Promise<string[]> {
-    const res = await this.getExifField('city', userIds, options)
-      .$if(!!options.country, (qb) => qb.where('country', '=', options.country!))
+    const filteredIds = this.buildFilteredAssetIds(userIds, without(options, 'city'));
+    const res = await this.db
+      .selectFrom('asset_exif')
+      .select('city')
+      .distinct()
+      .where('assetId', 'in', filteredIds)
+      .where('city', 'is not', null)
+      .where('city', '!=', '')
       .$if(!!options.state, (qb) => qb.where('state', '=', options.state!))
+      .orderBy('city')
       .execute();
 
     return res.map((row) => row.city!);

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -140,6 +140,24 @@ describe(SearchService.name, () => {
       expect(mocks.search.getCities).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
     });
 
+    it('should pass active filters to city suggestions', async () => {
+      const personIds = [newUuid()];
+      mocks.search.getCities.mockResolvedValue(['Berlin']);
+
+      await sut.getSearchSuggestions(authStub.user1, {
+        includeNull: false,
+        type: SearchSuggestionType.CITY,
+        country: 'Germany',
+        personIds,
+        rating: 4,
+      });
+
+      expect(mocks.search.getCities).toHaveBeenCalledWith(
+        [authStub.user1.user.id],
+        expect.objectContaining({ country: 'Germany', personIds, rating: 4 }),
+      );
+    });
+
     it('should return search suggestions for city (including null)', async () => {
       mocks.search.getCities.mockResolvedValue(['Denver']);
       mocks.partner.getAll.mockResolvedValue([]);

--- a/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
@@ -126,6 +126,31 @@ describe('buildFilterContext', () => {
     });
   });
 
+  it('should include active filters for dependent suggestions', () => {
+    const state = createFilterState();
+    state.personIds = ['person-1'];
+    state.tagIds = ['tag-1'];
+    state.rating = 4;
+    state.isFavorite = true;
+
+    expect(buildFilterContext(state)).toEqual({
+      personIds: ['person-1'],
+      tagIds: ['tag-1'],
+      rating: 4,
+      isFavorite: true,
+    });
+  });
+
+  it('should exclude requested filters from dependent suggestion context', () => {
+    const state = createFilterState();
+    state.personIds = ['person-1'];
+    state.tagIds = ['tag-1'];
+
+    expect(buildFilterContext(state, ['personIds'])).toEqual({
+      tagIds: ['tag-1'],
+    });
+  });
+
   it('should handle December correctly (rolls over to next year)', () => {
     const state = createFilterState();
     state.selectedYear = 2023;

--- a/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
@@ -172,4 +172,32 @@ describe('Unified suggestionsProvider', () => {
       expect(screen.getByText('Germany')).toBeTruthy();
     });
   });
+
+  it('should pass active filters when fetching dependent cities', async () => {
+    const citiesProvider = vi.fn().mockResolvedValue(['Berlin']);
+    const config = createUnifiedConfig({
+      providers: {
+        cities: citiesProvider,
+      },
+    });
+    render(FilterPanel, { props: { config, timeBuckets } });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => expect(screen.getByText('Alice')).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId('people-item-p1'));
+    await vi.advanceTimersByTimeAsync(50);
+    await waitFor(() => expect(config.suggestionsProvider).toHaveBeenCalledTimes(2));
+
+    await fireEvent.click(screen.getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(citiesProvider).toHaveBeenCalledWith(
+        'Germany',
+        expect.objectContaining({
+          personIds: ['p1'],
+        }),
+      );
+    });
+  });
 });

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -81,19 +81,9 @@
   let availableRatings = $state<number[] | undefined>();
   let availableMediaTypes = $state<string[] | undefined>();
 
-  // Stable filterContext that only updates when temporal values actually change.
-  // Derived directly from selectedYear/selectedMonth (not the full filters object)
-  // to prevent $effect blocks in LocationFilter/CameraFilter from re-triggering
-  // on non-temporal filter changes.
-  let filterContext: FilterContext | undefined = $state();
-  $effect(() => {
-    const year = filters.selectedYear;
-    const month = filters.selectedMonth;
-    const next = buildFilterContext({ selectedYear: year, selectedMonth: month } as FilterState);
-    if (filterContext?.takenAfter !== next?.takenAfter || filterContext?.takenBefore !== next?.takenBefore) {
-      filterContext = next;
-    }
-  });
+  let filterContext = $derived(buildFilterContext(filters));
+  let locationFilterContext = $derived(buildFilterContext(filters, ['country', 'city']));
+  let cameraFilterContext = $derived(buildFilterContext(filters, ['make', 'model']));
 
   // Unified suggestions re-fetch: replaces mount effects + temporal re-fetch when suggestionsProvider is set
   let prevFilters: FilterState | undefined = $state();
@@ -664,7 +654,7 @@
                 {countries}
                 selectedCity={filters.city}
                 selectedCountry={filters.country}
-                context={filterContext}
+                context={locationFilterContext}
                 onCityFetch={async (country, ctx) => {
                   if (providers.cities) {
                     return providers.cities(country, ctx);
@@ -678,7 +668,7 @@
                 makes={cameraMakes}
                 selectedMake={filters.make}
                 selectedModel={filters.model}
-                context={filterContext}
+                context={cameraFilterContext}
                 onModelFetch={async (make, ctx) => {
                   if (providers.cameraModels) {
                     return providers.cameraModels(make, ctx);

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -16,7 +16,6 @@
   } from '@mdi/js';
   import { untrack } from 'svelte';
   import type {
-    FilterContext,
     FilterPanelConfig,
     FilterSection as FilterSectionType,
     FilterState,

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -86,22 +86,46 @@ export function getActiveFilterCount(state: FilterState): number {
 export type FilterContext = {
   takenAfter?: string;
   takenBefore?: string;
+  personIds?: string[];
+  tagIds?: string[];
+  rating?: number;
+  isFavorite?: boolean;
 };
 
-export function buildFilterContext(state: FilterState): FilterContext | undefined {
-  if (!state.selectedYear) {
-    return undefined;
+export function buildFilterContext(
+  state: FilterState,
+  exclude: Array<keyof FilterState> = [],
+): FilterContext | undefined {
+  const context: FilterContext = {};
+  const includes = (key: keyof FilterState) => !exclude.includes(key);
+
+  if (includes('personIds') && state.personIds?.length > 0) {
+    context.personIds = state.personIds;
   }
-  if (state.selectedMonth) {
-    return {
-      takenAfter: new Date(Date.UTC(state.selectedYear, state.selectedMonth - 1, 1)).toISOString(),
-      takenBefore: new Date(Date.UTC(state.selectedYear, state.selectedMonth, 1)).toISOString(),
-    };
+
+  if (includes('tagIds') && state.tagIds?.length > 0) {
+    context.tagIds = state.tagIds;
   }
-  return {
-    takenAfter: new Date(Date.UTC(state.selectedYear, 0, 1)).toISOString(),
-    takenBefore: new Date(Date.UTC(state.selectedYear + 1, 0, 1)).toISOString(),
-  };
+
+  if (includes('rating') && state.rating !== undefined) {
+    context.rating = state.rating;
+  }
+
+  if (includes('isFavorite') && state.isFavorite !== undefined) {
+    context.isFavorite = state.isFavorite;
+  }
+
+  if (state.selectedYear && includes('selectedYear')) {
+    if (state.selectedMonth && includes('selectedMonth')) {
+      context.takenAfter = new Date(Date.UTC(state.selectedYear, state.selectedMonth - 1, 1)).toISOString();
+      context.takenBefore = new Date(Date.UTC(state.selectedYear, state.selectedMonth, 1)).toISOString();
+    } else {
+      context.takenAfter = new Date(Date.UTC(state.selectedYear, 0, 1)).toISOString();
+      context.takenBefore = new Date(Date.UTC(state.selectedYear + 1, 0, 1)).toISOString();
+    }
+  }
+
+  return Object.keys(context).length > 0 ? context : undefined;
 }
 
 export function clearFilters(state: FilterState): FilterState {


### PR DESCRIPTION
## Summary
- Pass active filter context into dependent location suggestions in the filter panel.
- Allow `/search/suggestions` city requests to accept scoped filter params such as `personIds`.
- Query city suggestions from the filtered asset set so person-filtered locations hide zero-result cities.

Fixes #429

## Test Plan
- [x] pnpm --filter immich-web test --run src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts src/lib/components/filter-panel/__tests__/filter-state.spec.ts
- [x] pnpm --filter immich test --run src/controllers/search.controller.spec.ts src/services/search.service.spec.ts src/repositories/search.repository.spec.ts
- [x] pnpm --filter immich-web check:typescript
- [x] pnpm --filter immich check
- [x] pnpm --filter @immich/sdk build
- [x] git diff --check