### PR TITLE
fix(server): hide unassigned faces from shared viewers

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -206,10 +206,7 @@ describe(AssetService.name, () => {
     });
 
     it('should strip unassigned faces for space member with spaceId', async () => {
-      const asset = AssetFactory.from()
-        .exif()
-        .face({ id: 'unassigned-face-id' })
-        .build();
+      const asset = AssetFactory.from().exif().face({ id: 'unassigned-face-id' }).build();
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
       mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -205,6 +205,22 @@ describe(AssetService.name, () => {
       expect((result as any).people[0].spacePersonId).toBe('space-person-1');
     });
 
+    it('should strip unassigned faces for space member with spaceId', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({ id: 'unassigned-face-id' })
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(new Map());
+
+      const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('unassignedFaces', []);
+    });
+
     it('should strip people for space member without spaceId', async () => {
       const asset = AssetFactory.from()
         .exif()

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -97,7 +97,10 @@ export class AssetService extends BaseService {
 
     if (auth.sharedLink) {
       data.people = [];
+      data.unassignedFaces = [];
     } else if (data.ownerId !== auth.user.id) {
+      data.unassignedFaces = [];
+
       if (spaceId) {
         const member = await this.sharedSpaceRepository.getMember(spaceId, auth.user.id);
         if (!member) {


### PR DESCRIPTION
## Summary
- hide unassigned face metadata from non-owner asset responses, including shared-space viewers and shared links
- keep owner behavior unchanged so owners can still manage unassigned faces
- add a regression test for shared-space members receiving unassigned face data

## Testing
- pnpm exec vitest --config test/vitest.config.mjs src/services/asset.service.spec.ts --run
- pnpm --filter immich run check
- pnpm --filter immich run lint

Fixes #424