### PR TITLE
feat(web): add custom date range filters

### DIFF
--- a/docs/superpowers/plans/2026-04-26-custom-date-range-filter-panel.md
+++ b/docs/superpowers/plans/2026-04-26-custom-date-range-filter-panel.md
@@ -1,0 +1,1147 @@
+# Custom Date Range Filter Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add custom from/to taken-date filtering to the shared web `FilterPanel` timeline section everywhere it is used, without changing mobile, search-bar syntax, people ordering, or rating/media option stability.
+
+**Architecture:** Extend shared `FilterState` with `dateAfter` and `dateBefore`, make `buildFilterContext()` prefer custom dates over year/month, and wire the shared timeline UI so custom range and year/month are mutually exclusive. Keep route integrations on shared helper APIs, refactoring spaces and smart-search flows where they currently track/build only `selectedYear` and `selectedMonth`.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest, @testing-library/svelte, SvelteKit route components, generated `@immich/sdk`
+
+---
+
+## File Structure
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.ts`
+  Responsibility: add custom temporal fields, UTC date conversion, active count, and clearing semantics.
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts`
+  Responsibility: prove custom range context, open-ended ranges, priority over year/month, and clearing behavior.
+
+- Modify: `web/src/lib/components/filter-panel/temporal-picker.svelte`
+  Responsibility: render From/To controls above the existing year/month picker, validate local input, and emit custom range changes.
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts`
+  Responsibility: prove custom range rendering, valid updates, invalid/inverted range suppression, and year/month switching.
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
+  Responsibility: track custom dates in temporal effects, pass custom props to `TemporalPicker`, clear the opposite temporal mode on selection, and mark the timeline section active for custom dates.
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts`
+  Responsibility: prove custom date changes refetch suggestions, pass custom context to dependent providers, narrow visible people/location/camera/tag options, and keep rating/media controls stable.
+
+- Modify: `web/src/lib/components/filter-panel/active-filters-bar.svelte`
+  Responsibility: show bounded/from-only/to-only temporal chip labels.
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
+  Responsibility: cover custom temporal chip labels and timeline chip removal.
+
+- Modify: `web/src/lib/utils/photos-filter-options.ts`
+  Responsibility: clear both custom dates and year/month when removing timeline filters.
+
+- Modify: `web/src/lib/utils/__tests__/photos-filter-options.spec.ts`
+  Responsibility: cover custom dates in photos timeline options and timeline removal.
+
+- Modify: `web/src/lib/utils/album-filter-options.ts`
+  Responsibility: continue using `buildFilterContext()` for custom dates; no logic split required.
+
+- Modify: `web/src/lib/utils/__tests__/album-filter-options.spec.ts`
+  Responsibility: cover custom dates for album timeline and asset picker options.
+
+- Modify: `web/src/lib/utils/map-filter-options.ts`
+  Responsibility: continue using `buildFilterContext()` for custom dates; no logic split required.
+
+- Modify: `web/src/lib/utils/__tests__/map-filter-options.spec.ts`
+  Responsibility: cover custom dates for marker and time-bucket options.
+
+- Modify: `web/src/lib/utils/space-search.ts`
+  Responsibility: use `buildFilterContext()` for smart-search temporal params.
+
+- Modify: `web/src/lib/utils/__tests__/space-search.spec.ts`
+  Responsibility: cover custom dates in smart-search params and preserve space-person mapping.
+
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+  Responsibility: replace route-local year/month date construction with `buildFilterContext()` and clear custom dates in local timeline removal.
+
+- Modify: `web/src/lib/components/search/smart-search-results.svelte`
+  Responsibility: track `dateAfter` and `dateBefore` as reactive search dependencies.
+
+- Modify: `web/src/lib/components/search/smart-search-results.spec.ts`
+  Responsibility: prove smart-search results rerun and pass custom dates when custom date filters change.
+
+## Task 1: Extend Shared Filter State
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts`
+- Modify: `web/src/lib/components/filter-panel/filter-panel.ts`
+
+- [ ] **Step 1: Add failing tests for custom temporal state**
+
+Add these tests to `filter-state.spec.ts`:
+
+```typescript
+it('should create default state with custom dates undefined', () => {
+  const state = createFilterState();
+  expect(state.dateAfter).toBeUndefined();
+  expect(state.dateBefore).toBeUndefined();
+});
+
+it('should count custom date range as one active temporal filter', () => {
+  const state = createFilterState();
+  state.dateAfter = '2024-01-01';
+  expect(getActiveFilterCount(state)).toBe(1);
+
+  state.dateBefore = '2024-12-31';
+  expect(getActiveFilterCount(state)).toBe(1);
+
+  state.personIds = ['p1'];
+  expect(getActiveFilterCount(state)).toBe(2);
+});
+
+it('should build bounded custom date context with exclusive end date', () => {
+  const state = createFilterState();
+  state.dateAfter = '2024-01-01';
+  state.dateBefore = '2024-12-31';
+  expect(buildFilterContext(state)).toEqual({
+    takenAfter: '2024-01-01T00:00:00.000Z',
+    takenBefore: '2025-01-01T00:00:00.000Z',
+  });
+});
+
+it('should build from-only custom date context', () => {
+  const state = createFilterState();
+  state.dateAfter = '2024-01-01';
+  expect(buildFilterContext(state)).toEqual({
+    takenAfter: '2024-01-01T00:00:00.000Z',
+  });
+});
+
+it('should build to-only custom date context with exclusive end date', () => {
+  const state = createFilterState();
+  state.dateBefore = '2024-12-31';
+  expect(buildFilterContext(state)).toEqual({
+    takenBefore: '2025-01-01T00:00:00.000Z',
+  });
+});
+
+it('should prefer custom date context over year and month context', () => {
+  const state = createFilterState();
+  state.selectedYear = 2023;
+  state.selectedMonth = 8;
+  state.dateAfter = '2024-01-01';
+  expect(buildFilterContext(state)).toEqual({
+    takenAfter: '2024-01-01T00:00:00.000Z',
+  });
+});
+
+it('should clear custom dates on clearFilters', () => {
+  const state = createFilterState();
+  state.dateAfter = '2024-01-01';
+  state.dateBefore = '2024-12-31';
+  state.selectedYear = 2023;
+  state.selectedMonth = 8;
+
+  const cleared = clearFilters(state);
+  expect(cleared.dateAfter).toBeUndefined();
+  expect(cleared.dateBefore).toBeUndefined();
+  expect(cleared.selectedYear).toBeUndefined();
+  expect(cleared.selectedMonth).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+```
+
+Expected: failures for missing `dateAfter` / `dateBefore` properties and missing custom context behavior.
+
+- [ ] **Step 3: Implement custom date fields and context conversion**
+
+Update `filter-panel.ts`:
+
+```typescript
+export interface FilterState {
+  personIds: string[];
+  city?: string;
+  country?: string;
+  make?: string;
+  model?: string;
+  tagIds: string[];
+  rating?: number;
+  mediaType: 'all' | 'image' | 'video';
+  isFavorite?: boolean;
+  sortOrder: 'asc' | 'desc' | 'relevance';
+  dateAfter?: string;
+  dateBefore?: string;
+  selectedYear?: number;
+  selectedMonth?: number;
+}
+```
+
+Add helpers in the same file:
+
+```typescript
+function dateOnlyToUtcStart(value: string): string {
+  return new Date(`${value}T00:00:00.000Z`).toISOString();
+}
+
+function dateOnlyToExclusiveUtcEnd(value: string): string {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString();
+}
+```
+
+Update `getActiveFilterCount()` temporal count:
+
+```typescript
+const hasTemporalFilter =
+  state.dateAfter !== undefined || state.dateBefore !== undefined || state.selectedYear !== undefined;
+```
+
+Use `hasTemporalFilter ? 1 : 0` instead of the existing `selectedYear` count.
+
+Update `buildFilterContext()`:
+
+```typescript
+export function buildFilterContext(state: FilterState): FilterContext | undefined {
+  if (state.dateAfter || state.dateBefore) {
+    return {
+      ...(state.dateAfter ? { takenAfter: dateOnlyToUtcStart(state.dateAfter) } : {}),
+      ...(state.dateBefore ? { takenBefore: dateOnlyToExclusiveUtcEnd(state.dateBefore) } : {}),
+    };
+  }
+  if (!state.selectedYear) {
+    return undefined;
+  }
+  if (state.selectedMonth) {
+    return {
+      takenAfter: new Date(Date.UTC(state.selectedYear, state.selectedMonth - 1, 1)).toISOString(),
+      takenBefore: new Date(Date.UTC(state.selectedYear, state.selectedMonth, 1)).toISOString(),
+    };
+  }
+  return {
+    takenAfter: new Date(Date.UTC(state.selectedYear, 0, 1)).toISOString(),
+    takenBefore: new Date(Date.UTC(state.selectedYear + 1, 0, 1)).toISOString(),
+  };
+}
+```
+
+Update `clearFilters()` to set `dateAfter: undefined` and `dateBefore: undefined`.
+
+- [ ] **Step 4: Run tests and commit**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+```
+
+Expected: all tests in `filter-state.spec.ts` pass.
+
+Commit:
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.ts web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+git commit -m "feat(web): add custom temporal filter state"
+```
+
+## Task 2: Add Custom Range UI To Temporal Picker
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts`
+- Modify: `web/src/lib/components/filter-panel/temporal-picker.svelte`
+
+- [ ] **Step 1: Add failing UI tests**
+
+Add tests to `temporal-picker.spec.ts`:
+
+```typescript
+it('should render custom range inputs above year grid', () => {
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets },
+  });
+  expect(getByTestId('custom-date-range')).toBeTruthy();
+  expect(getByTestId('custom-date-from')).toBeTruthy();
+  expect(getByTestId('custom-date-to')).toBeTruthy();
+  expect(getByTestId('year-grid')).toBeTruthy();
+});
+
+it('should emit from-only custom range', async () => {
+  const spy = vi.fn();
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, onCustomRangeChange: spy },
+  });
+  await fireEvent.input(getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  expect(spy).toHaveBeenCalledWith('2024-01-01', undefined);
+});
+
+it('should emit to-only custom range', async () => {
+  const spy = vi.fn();
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, onCustomRangeChange: spy },
+  });
+  await fireEvent.input(getByTestId('custom-date-to'), { target: { value: '2024-12-31' } });
+  expect(spy).toHaveBeenCalledWith(undefined, '2024-12-31');
+});
+
+it('should show custom date values from props', () => {
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, dateAfter: '2024-01-01', dateBefore: '2024-12-31' },
+  });
+  expect((getByTestId('custom-date-from') as HTMLInputElement).value).toBe('2024-01-01');
+  expect((getByTestId('custom-date-to') as HTMLInputElement).value).toBe('2024-12-31');
+});
+
+it('should not emit inverted custom ranges', async () => {
+  const spy = vi.fn();
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, dateAfter: '2024-12-31', onCustomRangeChange: spy },
+  });
+  await fireEvent.input(getByTestId('custom-date-to'), { target: { value: '2024-01-01' } });
+  expect(spy).not.toHaveBeenCalled();
+  expect(getByTestId('custom-date-error').textContent).toContain('From date must be on or before To date');
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+```
+
+Expected: missing custom date inputs and missing callback props.
+
+- [ ] **Step 3: Implement the custom date inputs**
+
+Update `temporal-picker.svelte` props:
+
+```typescript
+interface Props {
+  timeBuckets: Array<{ timeBucket: string; count: number }>;
+  selectedYear?: number;
+  selectedMonth?: number;
+  dateAfter?: string;
+  dateBefore?: string;
+  onYearSelect?: (year: number | undefined) => void;
+  onMonthSelect?: (year: number, month: number | undefined) => void;
+  onCustomRangeChange?: (dateAfter: string | undefined, dateBefore: string | undefined) => void;
+}
+```
+
+Add local state and validation:
+
+```typescript
+let {
+  timeBuckets,
+  selectedYear,
+  selectedMonth,
+  dateAfter,
+  dateBefore,
+  onYearSelect,
+  onMonthSelect,
+  onCustomRangeChange,
+}: Props = $props();
+
+let localDateAfter = $state(dateAfter ?? '');
+let localDateBefore = $state(dateBefore ?? '');
+let customDateError = $state('');
+
+$effect(() => {
+  localDateAfter = dateAfter ?? '';
+  localDateBefore = dateBefore ?? '';
+});
+
+function isValidDateOnly(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function emitCustomRange(nextAfter: string, nextBefore: string) {
+  customDateError = '';
+  if (nextAfter && !isValidDateOnly(nextAfter)) {
+    customDateError = 'Enter a valid From date';
+    return;
+  }
+  if (nextBefore && !isValidDateOnly(nextBefore)) {
+    customDateError = 'Enter a valid To date';
+    return;
+  }
+  if (nextAfter && nextBefore && nextAfter > nextBefore) {
+    customDateError = 'From date must be on or before To date';
+    return;
+  }
+  onCustomRangeChange?.(nextAfter || undefined, nextBefore || undefined);
+}
+```
+
+Render the custom range before the selected-year branch:
+
+```svelte
+<div class="mb-3 space-y-1" data-testid="custom-date-range">
+  <div class="grid grid-cols-2 gap-2">
+    <label class="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-300">
+      <span>From</span>
+      <input
+        type="date"
+        bind:value={localDateAfter}
+        data-testid="custom-date-from"
+        class="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+        oninput={() => emitCustomRange(localDateAfter, localDateBefore)}
+      />
+    </label>
+    <label class="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-300">
+      <span>To</span>
+      <input
+        type="date"
+        bind:value={localDateBefore}
+        data-testid="custom-date-to"
+        class="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+        oninput={() => emitCustomRange(localDateAfter, localDateBefore)}
+      />
+    </label>
+  </div>
+  {#if customDateError}
+    <p class="text-xs text-red-600 dark:text-red-400" data-testid="custom-date-error">{customDateError}</p>
+  {/if}
+</div>
+```
+
+- [ ] **Step 4: Run tests and commit**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+```
+
+Expected: temporal picker tests pass.
+
+Commit:
+
+```bash
+git add web/src/lib/components/filter-panel/temporal-picker.svelte web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+git commit -m "feat(web): add custom date range picker"
+```
+
+## Task 3: Wire FilterPanel Temporal Reactivity
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
+- Modify: `web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts`
+
+- [ ] **Step 1: Add failing contextual refetch tests**
+
+Add tests to `contextual-refetch.spec.ts`:
+
+```typescript
+it('should re-fetch unified suggestions when custom from date changes', async () => {
+  const suggestionsProvider = vi
+    .fn()
+    .mockResolvedValueOnce({
+      countries: ['Germany', 'France'],
+      cameraMakes: ['Canon', 'Sony'],
+      tags: [
+        { id: 't1', name: 'Vacation' },
+        { id: 't2', name: 'Family' },
+      ],
+      people: [
+        { id: 'p1', name: 'Alice' },
+        { id: 'p2', name: 'Bob' },
+      ],
+      ratings: [1, 2, 3, 4, 5],
+      mediaTypes: ['IMAGE', 'VIDEO'],
+      hasUnnamedPeople: false,
+    })
+    .mockResolvedValueOnce({
+      countries: ['Germany'],
+      cameraMakes: ['Canon'],
+      tags: [{ id: 't1', name: 'Vacation' }],
+      people: [{ id: 'p1', name: 'Alice' }],
+      ratings: [1],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: false,
+    });
+
+  const config: FilterPanelConfig = {
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'],
+    suggestionsProvider,
+  };
+
+  render(FilterPanel, { props: { config, timeBuckets } });
+  await vi.advanceTimersByTimeAsync(0);
+
+  await fireEvent.input(screen.getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(250);
+
+  await waitFor(() => {
+    expect(suggestionsProvider).toHaveBeenCalledTimes(2);
+    expect(suggestionsProvider).toHaveBeenLastCalledWith(
+      expect.objectContaining({ dateAfter: '2024-01-01', selectedYear: undefined, selectedMonth: undefined }),
+    );
+    expect(screen.getByTestId('people-item-p1')).toBeTruthy();
+    expect(screen.queryByTestId('people-item-p2')).toBeNull();
+    expect(screen.getByTestId('tags-item-t1')).toBeTruthy();
+    expect(screen.queryByTestId('tags-item-t2')).toBeNull();
+  });
+});
+
+it('should clear selected year when custom from date changes', async () => {
+  const suggestionsProvider = vi.fn().mockResolvedValue({
+    countries: [],
+    cameraMakes: [],
+    tags: [],
+    people: [],
+    ratings: [1, 2, 3, 4, 5],
+    mediaTypes: ['IMAGE', 'VIDEO'],
+    hasUnnamedPeople: false,
+  });
+
+  render(FilterPanel, {
+    props: { config: { sections: ['timeline'], suggestionsProvider }, timeBuckets },
+  });
+  await vi.advanceTimersByTimeAsync(0);
+
+  await fireEvent.click(screen.getByTestId('year-btn-2023'));
+  await vi.advanceTimersByTimeAsync(250);
+  await fireEvent.input(screen.getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(250);
+
+  expect(suggestionsProvider).toHaveBeenLastCalledWith(
+    expect.objectContaining({ dateAfter: '2024-01-01', selectedYear: undefined, selectedMonth: undefined }),
+  );
+});
+
+it('should clear custom dates when year is selected', async () => {
+  const suggestionsProvider = vi.fn().mockResolvedValue({
+    countries: [],
+    cameraMakes: [],
+    tags: [],
+    people: [],
+    ratings: [1, 2, 3, 4, 5],
+    mediaTypes: ['IMAGE', 'VIDEO'],
+    hasUnnamedPeople: false,
+  });
+
+  render(FilterPanel, {
+    props: { config: { sections: ['timeline'], suggestionsProvider }, timeBuckets },
+  });
+  await vi.advanceTimersByTimeAsync(0);
+
+  await fireEvent.input(screen.getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(250);
+  await fireEvent.click(screen.getByTestId('year-btn-2023'));
+  await vi.advanceTimersByTimeAsync(250);
+
+  expect(suggestionsProvider).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      dateAfter: undefined,
+      dateBefore: undefined,
+      selectedYear: 2023,
+      selectedMonth: undefined,
+    }),
+  );
+});
+
+it('should pass custom date context to dependent city and camera providers', async () => {
+  const config = createConfig({
+    cities: vi.fn().mockResolvedValue(['Berlin']),
+    cameraModels: vi.fn().mockResolvedValue(['EOS R5']),
+  });
+  render(FilterPanel, { props: { config, timeBuckets } });
+  await vi.advanceTimersByTimeAsync(0);
+
+  await fireEvent.input(screen.getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(250);
+
+  await fireEvent.click(screen.getByTestId('location-country-Germany'));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(config.providers!.cities).toHaveBeenLastCalledWith('Germany', {
+    takenAfter: '2024-01-01T00:00:00.000Z',
+  });
+
+  await fireEvent.click(screen.getByTestId('camera-make-Canon'));
+  await vi.advanceTimersByTimeAsync(0);
+  expect(config.providers!.cameraModels).toHaveBeenLastCalledWith('Canon', {
+    takenAfter: '2024-01-01T00:00:00.000Z',
+  });
+});
+
+it('should keep rating and media controls stable when custom date changes', async () => {
+  const suggestionsProvider = vi
+    .fn()
+    .mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [],
+      ratings: [1, 2, 3, 4, 5],
+      mediaTypes: ['IMAGE', 'VIDEO'],
+      hasUnnamedPeople: false,
+    })
+    .mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: false,
+    });
+
+  render(FilterPanel, {
+    props: {
+      config: { sections: ['timeline', 'rating', 'media'], suggestionsProvider },
+      timeBuckets,
+    },
+  });
+  await vi.advanceTimersByTimeAsync(0);
+  await fireEvent.input(screen.getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(250);
+
+  expect(screen.getByTestId('rating-star-1')).toBeTruthy();
+  expect(screen.getByTestId('media-type-image')).toBeTruthy();
+  expect(screen.getByTestId('media-type-video')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run contextual tests and verify failure**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+```
+
+Expected: custom date inputs are not wired through `FilterPanel`, and custom date context is not tracked.
+
+- [ ] **Step 3: Update FilterPanel tracking and handlers**
+
+In `filter-panel.svelte`, update the stable `filterContext` effect to track custom dates:
+
+```typescript
+$effect(() => {
+  const dateAfter = filters.dateAfter;
+  const dateBefore = filters.dateBefore;
+  const year = filters.selectedYear;
+  const month = filters.selectedMonth;
+  const next = buildFilterContext({ dateAfter, dateBefore, selectedYear: year, selectedMonth: month } as FilterState);
+  if (filterContext?.takenAfter !== next?.takenAfter || filterContext?.takenBefore !== next?.takenBefore) {
+    filterContext = next;
+  }
+});
+```
+
+Update the unified suggestions current snapshot:
+
+```typescript
+const current: FilterState = {
+  personIds: filters.personIds,
+  city: filters.city,
+  country: filters.country,
+  make: filters.make,
+  model: filters.model,
+  tagIds: filters.tagIds,
+  rating: filters.rating,
+  mediaType: filters.mediaType,
+  isFavorite: filters.isFavorite,
+  sortOrder: filters.sortOrder,
+  dateAfter: filters.dateAfter,
+  dateBefore: filters.dateBefore,
+  selectedYear: filters.selectedYear,
+  selectedMonth: filters.selectedMonth,
+};
+```
+
+Update temporal change detection:
+
+```typescript
+const temporalChanged =
+  !isInitialMount &&
+  (prev.dateAfter !== current.dateAfter ||
+    prev.dateBefore !== current.dateBefore ||
+    prev.selectedYear !== current.selectedYear ||
+    prev.selectedMonth !== current.selectedMonth);
+const isTemporalClear =
+  temporalChanged &&
+  current.dateAfter === undefined &&
+  current.dateBefore === undefined &&
+  current.selectedYear === undefined;
+```
+
+Update the provider-less temporal effect to track custom dates in the same context snapshot:
+
+```typescript
+const dateAfter = filters.dateAfter;
+const dateBefore = filters.dateBefore;
+const year = filters.selectedYear;
+const month = filters.selectedMonth;
+const currentContext = buildFilterContext({
+  dateAfter,
+  dateBefore,
+  selectedYear: year,
+  selectedMonth: month,
+} as FilterState);
+```
+
+Add the custom range handler:
+
+```typescript
+function handleCustomDateRangeChange(dateAfter: string | undefined, dateBefore: string | undefined) {
+  filters = { ...filters, dateAfter, dateBefore, selectedYear: undefined, selectedMonth: undefined };
+}
+```
+
+Update existing handlers:
+
+```typescript
+function handleYearSelect(year: number | undefined) {
+  filters = { ...filters, dateAfter: undefined, dateBefore: undefined, selectedYear: year, selectedMonth: undefined };
+}
+
+function handleMonthSelect(year: number, month: number | undefined) {
+  filters = { ...filters, dateAfter: undefined, dateBefore: undefined, selectedYear: year, selectedMonth: month };
+}
+```
+
+Update `hasActiveFilter('timeline')`:
+
+```typescript
+return filters.dateAfter !== undefined || filters.dateBefore !== undefined || filters.selectedYear !== undefined;
+```
+
+Pass custom props to `TemporalPicker`:
+
+```svelte
+<TemporalPicker
+  {timeBuckets}
+  dateAfter={filters.dateAfter}
+  dateBefore={filters.dateBefore}
+  selectedYear={filters.selectedYear}
+  selectedMonth={filters.selectedMonth}
+  onCustomRangeChange={handleCustomDateRangeChange}
+  onYearSelect={handleYearSelect}
+  onMonthSelect={handleMonthSelect}
+/>
+```
+
+- [ ] **Step 4: Run contextual tests and commit**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+```
+
+Expected: contextual refetch tests pass.
+
+Commit:
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.svelte web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+git commit -m "feat(web): refetch filters for custom date ranges"
+```
+
+## Task 4: Add Custom Date Active Chips And Removal
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/active-filters-bar.svelte`
+- Modify: `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
+- Modify: `web/src/lib/utils/photos-filter-options.ts`
+- Modify: `web/src/lib/utils/__tests__/photos-filter-options.spec.ts`
+
+- [ ] **Step 1: Add failing active chip and removal tests**
+
+Add tests to `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`:
+
+```typescript
+it('should render bounded custom date range chip', () => {
+  const filters = createFilterState();
+  filters.dateAfter = '2024-01-01';
+  filters.dateBefore = '2024-12-31';
+
+  const { getAllByTestId } = render(ActiveFiltersBar, {
+    props: { filters, onRemoveFilter: () => {}, onClearAll: () => {} },
+  });
+
+  expect(getAllByTestId('active-chip')[0].textContent).toContain('Jan 1, 2024 - Dec 31, 2024');
+});
+
+it('should render from-only custom date chip', () => {
+  const filters = createFilterState();
+  filters.dateAfter = '2024-01-01';
+
+  const { getAllByTestId } = render(ActiveFiltersBar, {
+    props: { filters, onRemoveFilter: () => {}, onClearAll: () => {} },
+  });
+
+  expect(getAllByTestId('active-chip')[0].textContent).toContain('After Jan 1, 2024');
+});
+
+it('should render to-only custom date chip', () => {
+  const filters = createFilterState();
+  filters.dateBefore = '2024-12-31';
+
+  const { getAllByTestId } = render(ActiveFiltersBar, {
+    props: { filters, onRemoveFilter: () => {}, onClearAll: () => {} },
+  });
+
+  expect(getAllByTestId('active-chip')[0].textContent).toContain('Before Dec 31, 2024');
+});
+```
+
+Add tests to `photos-filter-options.spec.ts`:
+
+```typescript
+it('should clear custom dates when removing timeline filter', () => {
+  const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+  const result = handlePhotosRemoveFilter(filters, 'timeline');
+  expect(result.dateAfter).toBeUndefined();
+  expect(result.dateBefore).toBeUndefined();
+});
+
+it('should include custom dates in photos timeline options', () => {
+  const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+  const options = buildPhotosTimelineOptions(filters);
+  expect(options.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+  expect(options.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts
+```
+
+Expected: custom date chips and removal behavior are missing.
+
+- [ ] **Step 3: Implement chip labels and timeline removal**
+
+In `active-filters-bar.svelte`, add date formatting:
+
+```typescript
+function formatDateOnly(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}
+```
+
+Add custom chip logic before the year/month branch:
+
+```typescript
+if (filters.dateAfter || filters.dateBefore) {
+  if (filters.dateAfter && filters.dateBefore) {
+    result.push({
+      type: 'timeline',
+      label: `${formatDateOnly(filters.dateAfter)} - ${formatDateOnly(filters.dateBefore)}`,
+    });
+  } else if (filters.dateAfter) {
+    result.push({ type: 'timeline', label: `After ${formatDateOnly(filters.dateAfter)}` });
+  } else if (filters.dateBefore) {
+    result.push({ type: 'timeline', label: `Before ${formatDateOnly(filters.dateBefore)}` });
+  }
+} else if (filters.selectedYear !== undefined) {
+  const label =
+    filters.selectedMonth === undefined
+      ? `${filters.selectedYear}`
+      : `${MONTH_LABELS[filters.selectedMonth - 1]} ${filters.selectedYear}`;
+  result.push({ type: 'timeline', label });
+}
+```
+
+In `photos-filter-options.ts`, update timeline removal:
+
+```typescript
+case 'timeline': {
+  return {
+    ...filters,
+    dateAfter: undefined,
+    dateBefore: undefined,
+    selectedYear: undefined,
+    selectedMonth: undefined,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests and commit**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts
+```
+
+Expected: active chip and photos option tests pass.
+
+Commit:
+
+```bash
+git add web/src/lib/components/filter-panel/active-filters-bar.svelte web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts web/src/lib/utils/photos-filter-options.ts web/src/lib/utils/__tests__/photos-filter-options.spec.ts
+git commit -m "feat(web): show custom date filter chips"
+```
+
+## Task 5: Wire Route And Search Option Helpers
+
+**Files:**
+
+- Modify: `web/src/lib/utils/__tests__/album-filter-options.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/map-filter-options.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/space-search.spec.ts`
+- Modify: `web/src/lib/utils/space-search.ts`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+- Modify: `web/src/lib/components/search/smart-search-results.spec.ts`
+- Modify: `web/src/lib/components/search/smart-search-results.svelte`
+
+- [ ] **Step 1: Add failing route helper tests**
+
+Add to `album-filter-options.spec.ts`:
+
+```typescript
+it('maps custom dates for album timeline options', () => {
+  const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+  expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, filters)).toEqual(
+    expect.objectContaining({
+      takenAfter: '2024-01-01T00:00:00.000Z',
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    }),
+  );
+});
+
+it('maps custom dates for album asset picker options', () => {
+  const filters = { ...createFilterState(), dateAfter: '2024-01-01' };
+  expect(buildAlbumAssetPickerOptions('album-1', filters)).toEqual(
+    expect.objectContaining({ takenAfter: '2024-01-01T00:00:00.000Z' }),
+  );
+});
+```
+
+Add to `map-filter-options.spec.ts`:
+
+```typescript
+it('includes custom dates in map marker options', () => {
+  const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+  expect(buildMapMarkerOptions(filters)).toEqual(
+    expect.objectContaining({
+      takenAfter: '2024-01-01T00:00:00.000Z',
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    }),
+  );
+});
+
+it('includes custom dates in map time bucket options', () => {
+  const filters = { ...createFilterState(), dateBefore: '2024-12-31' };
+  expect(buildMapTimeBucketOptions(filters)).toEqual(
+    expect.objectContaining({ takenBefore: '2025-01-01T00:00:00.000Z' }),
+  );
+});
+```
+
+Add to `space-search.spec.ts`:
+
+```typescript
+it('builds takenAfter/takenBefore from custom dates', () => {
+  const result = buildSmartSearchParams({
+    query: 'beach',
+    filters: { ...baseFilters, dateAfter: '2024-01-01', dateBefore: '2024-12-31' },
+  });
+  expect(result.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+  expect(result.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+});
+
+it('prefers custom dates over selected year and month', () => {
+  const result = buildSmartSearchParams({
+    query: 'beach',
+    filters: { ...baseFilters, selectedYear: 2023, selectedMonth: 8, dateAfter: '2024-01-01' },
+  });
+  expect(result.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+  expect(result.takenBefore).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Add failing smart search reactivity test**
+
+Add to `smart-search-results.spec.ts`:
+
+```typescript
+it('triggers re-fetch when custom date range changes', async () => {
+  const { rerender } = render(SmartSearchResults, { props: baseProps });
+  await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+  expect(searchSmartMock).toHaveBeenCalledTimes(1);
+
+  await rerender({ ...baseProps, filters: { ...baseFilters, dateAfter: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+  expect(searchSmartMock).toHaveBeenCalledTimes(2);
+  expect(searchSmartMock).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      smartSearchDto: expect.objectContaining({ takenAfter: '2024-01-01T00:00:00.000Z' }),
+    }),
+  );
+});
+```
+
+- [ ] **Step 3: Run route/search tests and verify failure**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
+```
+
+Expected: space search and smart-search result reactivity fail until custom fields are wired. Album/map may pass after Task 1 because they already consume `buildFilterContext()`.
+
+- [ ] **Step 4: Use shared temporal context in smart search params**
+
+Update `space-search.ts`:
+
+```typescript
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+```
+
+Replace local year/month construction:
+
+```typescript
+const context = buildFilterContext(filters);
+if (context?.takenAfter) {
+  params.takenAfter = context.takenAfter;
+}
+if (context?.takenBefore) {
+  params.takenBefore = context.takenBefore;
+}
+```
+
+- [ ] **Step 5: Use shared temporal context in spaces route timeline options**
+
+In the spaces route, replace the route-local temporal block with:
+
+```typescript
+const context = buildFilterContext(filters);
+if (context?.takenAfter) {
+  base.takenAfter = context.takenAfter;
+}
+if (context?.takenBefore) {
+  base.takenBefore = context.takenBefore;
+}
+```
+
+Update `handleRemoveFilter('timeline')`:
+
+```typescript
+filters = {
+  ...filters,
+  dateAfter: undefined,
+  dateBefore: undefined,
+  selectedYear: undefined,
+  selectedMonth: undefined,
+};
+```
+
+- [ ] **Step 6: Track custom dates in smart search result reactivity**
+
+Update the dependency array in `smart-search-results.svelte`:
+
+```typescript
+const _ = [
+  searchQuery,
+  filters.personIds,
+  filters.city,
+  filters.country,
+  filters.make,
+  filters.model,
+  filters.tagIds,
+  filters.rating,
+  filters.mediaType,
+  filters.dateAfter,
+  filters.dateBefore,
+  filters.selectedYear,
+  filters.selectedMonth,
+  filters.sortOrder,
+  filters.isFavorite,
+];
+```
+
+- [ ] **Step 7: Run tests and commit**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
+```
+
+Expected: all route/search helper tests pass.
+
+Commit:
+
+```bash
+git add web/src/lib/utils/__tests__/album-filter-options.spec.ts web/src/lib/utils/__tests__/map-filter-options.spec.ts web/src/lib/utils/__tests__/space-search.spec.ts web/src/lib/utils/space-search.ts 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' web/src/lib/components/search/smart-search-results.svelte web/src/lib/components/search/smart-search-results.spec.ts
+git commit -m "feat(web): apply custom date ranges to search routes"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+
+- Verify all files modified in Tasks 1-5.
+
+- [ ] **Step 1: Run focused web tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
+```
+
+Expected: all listed tests pass.
+
+- [ ] **Step 2: Run type and Svelte checks**
+
+Run:
+
+```bash
+pnpm --dir web run check:svelte
+pnpm --dir web run check:typescript
+```
+
+Expected: both commands pass. Existing Svelte warnings are acceptable only if the command exits `0`; new warnings from edited files must be fixed.
+
+- [ ] **Step 3: Run formatting and lint for touched web files**
+
+Run:
+
+```bash
+pnpm --dir web exec prettier --check src/lib/components/filter-panel/filter-panel.ts src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/temporal-picker.svelte src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/album-filter-options.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/space-search.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.svelte src/lib/components/search/smart-search-results.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte'
+pnpm --dir web exec eslint src/lib/components/filter-panel/filter-panel.ts src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/temporal-picker.svelte src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/album-filter-options.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/space-search.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.svelte src/lib/components/search/smart-search-results.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' --max-warnings 0
+```
+
+Expected: both commands pass. If Prettier fails, run the same file list with `--write`, review the diff, then rerun check.
+
+- [ ] **Step 4: Commit verification fixes when verification changed files**
+
+If Step 2 or Step 3 required additional fixes, commit those changes:
+
+```bash
+git add web/src/lib/components/filter-panel web/src/lib/utils web/src/lib/components/search 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte'
+git commit -m "fix(web): polish custom date range filters"
+```
+
+If `git status --short` is clean after Step 3, skip this step.

--- a/docs/superpowers/plans/2026-04-26-custom-date-range-filter-panel.md
+++ b/docs/superpowers/plans/2026-04-26-custom-date-range-filter-panel.md
@@ -22,7 +22,7 @@
   Responsibility: render From/To controls above the existing year/month picker, validate local input, and emit custom range changes.
 
 - Modify: `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts`
-  Responsibility: prove custom range rendering, valid updates, invalid/inverted range suppression, and year/month switching.
+  Responsibility: prove custom range rendering, valid updates, malformed/impossible/inverted range suppression, invalid-field clearing, and year/month switching.
 
 - Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
   Responsibility: track custom dates in temporal effects, pass custom props to `TemporalPicker`, clear the opposite temporal mode on selection, and mark the timeline section active for custom dates.
@@ -48,6 +48,9 @@
 - Modify: `web/src/lib/utils/__tests__/album-filter-options.spec.ts`
   Responsibility: cover custom dates for album timeline and asset picker options.
 
+- Modify: `web/src/lib/utils/__tests__/album-filter-config.spec.ts`
+  Responsibility: prove album suggestion requests send API-ready custom `takenAfter` and `takenBefore` values.
+
 - Modify: `web/src/lib/utils/map-filter-options.ts`
   Responsibility: continue using `buildFilterContext()` for custom dates; no logic split required.
 
@@ -60,8 +63,14 @@
 - Modify: `web/src/lib/utils/__tests__/space-search.spec.ts`
   Responsibility: cover custom dates in smart-search params and preserve space-person mapping.
 
+- Create: `web/src/lib/utils/space-filter-options.ts`
+  Responsibility: build spaces timeline options with shared temporal context and remove active filter chips.
+
+- Create: `web/src/lib/utils/__tests__/space-filter-options.spec.ts`
+  Responsibility: cover spaces timeline custom dates, space-person mapping, and temporal removal.
+
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
-  Responsibility: replace route-local year/month date construction with `buildFilterContext()` and clear custom dates in local timeline removal.
+  Responsibility: use the tested spaces filter-options helper instead of route-local temporal construction and removal logic.
 
 - Modify: `web/src/lib/components/search/smart-search-results.svelte`
   Responsibility: track `dateAfter` and `dateBefore` as reactive search dependencies.
@@ -308,6 +317,38 @@ it('should not emit inverted custom ranges', async () => {
   expect(spy).not.toHaveBeenCalled();
   expect(getByTestId('custom-date-error').textContent).toContain('From date must be on or before To date');
 });
+
+it('should not emit malformed custom dates', async () => {
+  const spy = vi.fn();
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, onCustomRangeChange: spy },
+  });
+  await fireEvent.input(getByTestId('custom-date-from'), { target: { value: '2024-1-1' } });
+  expect(spy).not.toHaveBeenCalled();
+  expect(getByTestId('custom-date-error').textContent).toContain('Enter a valid From date');
+});
+
+it('should not emit impossible custom dates', async () => {
+  const spy = vi.fn();
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, onCustomRangeChange: spy },
+  });
+  await fireEvent.input(getByTestId('custom-date-to'), { target: { value: '2024-02-31' } });
+  expect(spy).not.toHaveBeenCalled();
+  expect(getByTestId('custom-date-error').textContent).toContain('Enter a valid To date');
+});
+
+it('should emit remaining open-ended range after clearing an invalid field', async () => {
+  const spy = vi.fn();
+  const { getByTestId } = render(TemporalPicker, {
+    props: { timeBuckets: buckets, dateAfter: '2024-01-01', onCustomRangeChange: spy },
+  });
+  await fireEvent.input(getByTestId('custom-date-to'), { target: { value: '2024-02-31' } });
+  expect(spy).not.toHaveBeenCalled();
+
+  await fireEvent.input(getByTestId('custom-date-to'), { target: { value: '' } });
+  expect(spy).toHaveBeenCalledWith('2024-01-01', undefined);
+});
 ```
 
 - [ ] **Step 2: Run tests and verify failure**
@@ -394,7 +435,11 @@ Render the custom range before the selected-year branch:
     <label class="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-300">
       <span>From</span>
       <input
-        type="date"
+        type="text"
+        inputmode="numeric"
+        autocomplete="off"
+        placeholder="YYYY-MM-DD"
+        pattern="\d{4}-\d{2}-\d{2}"
         bind:value={localDateAfter}
         data-testid="custom-date-from"
         class="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
@@ -404,7 +449,11 @@ Render the custom range before the selected-year branch:
     <label class="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-300">
       <span>To</span>
       <input
-        type="date"
+        type="text"
+        inputmode="numeric"
+        autocomplete="off"
+        placeholder="YYYY-MM-DD"
+        pattern="\d{4}-\d{2}-\d{2}"
         bind:value={localDateBefore}
         data-testid="custom-date-to"
         class="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
@@ -524,6 +573,34 @@ it('should clear selected year when custom from date changes', async () => {
   );
 });
 
+it('should clear selected year and month when custom to date changes', async () => {
+  const suggestionsProvider = vi.fn().mockResolvedValue({
+    countries: [],
+    cameraMakes: [],
+    tags: [],
+    people: [],
+    ratings: [1, 2, 3, 4, 5],
+    mediaTypes: ['IMAGE', 'VIDEO'],
+    hasUnnamedPeople: false,
+  });
+
+  render(FilterPanel, {
+    props: { config: { sections: ['timeline'], suggestionsProvider }, timeBuckets },
+  });
+  await vi.advanceTimersByTimeAsync(0);
+
+  await fireEvent.click(screen.getByTestId('year-btn-2023'));
+  await vi.advanceTimersByTimeAsync(250);
+  await fireEvent.click(screen.getByTestId('month-btn-6'));
+  await vi.advanceTimersByTimeAsync(250);
+  await fireEvent.input(screen.getByTestId('custom-date-to'), { target: { value: '2024-12-31' } });
+  await vi.advanceTimersByTimeAsync(250);
+
+  expect(suggestionsProvider).toHaveBeenLastCalledWith(
+    expect.objectContaining({ dateBefore: '2024-12-31', selectedYear: undefined, selectedMonth: undefined }),
+  );
+});
+
 it('should clear custom dates when year is selected', async () => {
   const suggestionsProvider = vi.fn().mockResolvedValue({
     countries: [],
@@ -552,6 +629,34 @@ it('should clear custom dates when year is selected', async () => {
       selectedYear: 2023,
       selectedMonth: undefined,
     }),
+  );
+});
+
+it('should clear custom dates when month is selected', async () => {
+  const suggestionsProvider = vi.fn().mockResolvedValue({
+    countries: [],
+    cameraMakes: [],
+    tags: [],
+    people: [],
+    ratings: [1, 2, 3, 4, 5],
+    mediaTypes: ['IMAGE', 'VIDEO'],
+    hasUnnamedPeople: false,
+  });
+
+  render(FilterPanel, {
+    props: { config: { sections: ['timeline'], suggestionsProvider }, timeBuckets },
+  });
+  await vi.advanceTimersByTimeAsync(0);
+
+  await fireEvent.input(screen.getByTestId('custom-date-from'), { target: { value: '2024-01-01' } });
+  await vi.advanceTimersByTimeAsync(250);
+  await fireEvent.click(screen.getByTestId('year-btn-2023'));
+  await vi.advanceTimersByTimeAsync(250);
+  await fireEvent.click(screen.getByTestId('month-btn-6'));
+  await vi.advanceTimersByTimeAsync(250);
+
+  expect(suggestionsProvider).toHaveBeenLastCalledWith(
+    expect.objectContaining({ dateAfter: undefined, dateBefore: undefined, selectedYear: 2023, selectedMonth: 6 }),
   );
 });
 
@@ -905,14 +1010,17 @@ git commit -m "feat(web): show custom date filter chips"
 **Files:**
 
 - Modify: `web/src/lib/utils/__tests__/album-filter-options.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/album-filter-config.spec.ts`
 - Modify: `web/src/lib/utils/__tests__/map-filter-options.spec.ts`
+- Create: `web/src/lib/utils/__tests__/space-filter-options.spec.ts`
+- Create: `web/src/lib/utils/space-filter-options.ts`
 - Modify: `web/src/lib/utils/__tests__/space-search.spec.ts`
 - Modify: `web/src/lib/utils/space-search.ts`
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
 - Modify: `web/src/lib/components/search/smart-search-results.spec.ts`
 - Modify: `web/src/lib/components/search/smart-search-results.svelte`
 
-- [ ] **Step 1: Add failing route helper tests**
+- [ ] **Step 1: Add failing route option tests**
 
 Add to `album-filter-options.spec.ts`:
 
@@ -956,6 +1064,114 @@ it('includes custom dates in map time bucket options', () => {
 });
 ```
 
+Create `space-filter-options.spec.ts`:
+
+```typescript
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildSpaceTimelineOptions, handleSpaceRemoveFilter } from '$lib/utils/space-filter-options';
+import { AssetOrder, AssetTypeEnum } from '@immich/sdk';
+
+describe('buildSpaceTimelineOptions', () => {
+  it('maps custom dates and people for spaces timeline options', () => {
+    const filters = {
+      ...createFilterState(),
+      personIds: ['space-person-1'],
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        spaceId: 'space-1',
+        withStacked: true,
+        spacePersonIds: ['space-person-1'],
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('prefers custom dates over selected year and month', () => {
+    const filters = {
+      ...createFilterState(),
+      selectedYear: 2023,
+      selectedMonth: 8,
+      dateBefore: '2024-12-31',
+    };
+
+    const result = buildSpaceTimelineOptions('space-1', filters);
+    expect(result.takenAfter).toBeUndefined();
+    expect(result.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  it('maps media type and sort order for spaces timeline options', () => {
+    const filters = { ...createFilterState(), mediaType: 'video' as const, sortOrder: 'asc' as const };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        $type: AssetTypeEnum.Video,
+        order: AssetOrder.Asc,
+      }),
+    );
+  });
+});
+
+describe('handleSpaceRemoveFilter', () => {
+  it('clears both temporal modes when removing timeline filter', () => {
+    const filters = {
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+      selectedYear: 2023,
+      selectedMonth: 8,
+    };
+
+    const result = handleSpaceRemoveFilter(filters, 'timeline');
+    expect(result.dateAfter).toBeUndefined();
+    expect(result.dateBefore).toBeUndefined();
+    expect(result.selectedYear).toBeUndefined();
+    expect(result.selectedMonth).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Add failing suggestion DTO and smart-search tests**
+
+Add to `album-filter-config.spec.ts`:
+
+```typescript
+it('passes custom dates to album detail filter suggestions', async () => {
+  const config = buildAlbumDetailFilterConfig('album-1');
+  await config.suggestionsProvider!({
+    ...createFilterState(),
+    dateAfter: '2024-01-01',
+    dateBefore: '2024-12-31',
+  });
+
+  expect(getFilterSuggestions).toHaveBeenCalledWith(
+    expect.objectContaining({
+      albumId: 'album-1',
+      takenAfter: '2024-01-01T00:00:00.000Z',
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    }),
+  );
+});
+
+it('passes custom dates to album asset picker filter suggestions', async () => {
+  const config = buildAlbumAssetPickerFilterConfig();
+  await config.suggestionsProvider!({
+    ...createFilterState(),
+    dateBefore: '2024-12-31',
+  });
+
+  expect(getFilterSuggestions).toHaveBeenCalledWith(
+    expect.objectContaining({
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    }),
+  );
+});
+```
+
 Add to `space-search.spec.ts`:
 
 ```typescript
@@ -977,8 +1193,6 @@ it('prefers custom dates over selected year and month', () => {
   expect(result.takenBefore).toBeUndefined();
 });
 ```
-
-- [ ] **Step 2: Add failing smart search reactivity test**
 
 Add to `smart-search-results.spec.ts`:
 
@@ -1005,12 +1219,96 @@ it('triggers re-fetch when custom date range changes', async () => {
 Run:
 
 ```bash
-pnpm --dir web exec vitest --run src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
 ```
 
-Expected: space search and smart-search result reactivity fail until custom fields are wired. Album/map may pass after Task 1 because they already consume `buildFilterContext()`.
+Expected: the new spaces helper test fails because the helper does not exist; space search and smart-search result reactivity fail until custom fields are wired. Album/map may pass after Task 1 because they already consume `buildFilterContext()`.
 
-- [ ] **Step 4: Use shared temporal context in smart search params**
+- [ ] **Step 4: Create tested spaces timeline helper**
+
+Create `space-filter-options.ts`:
+
+```typescript
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { AssetOrder, AssetTypeEnum } from '@immich/sdk';
+
+export function buildSpaceTimelineOptions(spaceId: string, filters: FilterState): Record<string, unknown> {
+  const base: Record<string, unknown> = { spaceId, withStacked: true };
+  if (filters.personIds.length > 0) {
+    base.spacePersonIds = filters.personIds;
+  }
+  if (filters.city) {
+    base.city = filters.city;
+  }
+  if (filters.country) {
+    base.country = filters.country;
+  }
+  if (filters.make) {
+    base.make = filters.make;
+  }
+  if (filters.model) {
+    base.model = filters.model;
+  }
+  if (filters.tagIds.length > 0) {
+    base.tagIds = filters.tagIds;
+  }
+  if (filters.rating !== undefined) {
+    base.rating = filters.rating;
+  }
+  if (filters.mediaType !== 'all') {
+    base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
+  }
+  base.order = filters.sortOrder === 'asc' ? AssetOrder.Asc : AssetOrder.Desc;
+
+  const context = buildFilterContext(filters);
+  if (context?.takenAfter) {
+    base.takenAfter = context.takenAfter;
+  }
+  if (context?.takenBefore) {
+    base.takenBefore = context.takenBefore;
+  }
+
+  return base;
+}
+
+export function handleSpaceRemoveFilter(filters: FilterState, type: string, id?: string): FilterState {
+  switch (type) {
+    case 'person': {
+      return { ...filters, personIds: filters.personIds.filter((p) => p !== id) };
+    }
+    case 'location': {
+      return { ...filters, city: undefined, country: undefined };
+    }
+    case 'camera': {
+      return { ...filters, make: undefined, model: undefined };
+    }
+    case 'tag': {
+      return { ...filters, tagIds: filters.tagIds.filter((t) => t !== id) };
+    }
+    case 'rating': {
+      return { ...filters, rating: undefined };
+    }
+    case 'media':
+    case 'mediaType': {
+      return { ...filters, mediaType: 'all' };
+    }
+    case 'timeline': {
+      return {
+        ...filters,
+        dateAfter: undefined,
+        dateBefore: undefined,
+        selectedYear: undefined,
+        selectedMonth: undefined,
+      };
+    }
+    default: {
+      return filters;
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Use shared temporal context in smart search params**
 
 Update `space-search.ts`:
 
@@ -1030,33 +1328,36 @@ if (context?.takenBefore) {
 }
 ```
 
-- [ ] **Step 5: Use shared temporal context in spaces route timeline options**
+- [ ] **Step 6: Use tested helper in spaces route**
 
-In the spaces route, replace the route-local temporal block with:
+In `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`, import the helper:
 
 ```typescript
-const context = buildFilterContext(filters);
-if (context?.takenAfter) {
-  base.takenAfter = context.takenAfter;
-}
-if (context?.takenBefore) {
-  base.takenBefore = context.takenBefore;
+import { buildSpaceTimelineOptions, handleSpaceRemoveFilter } from '$lib/utils/space-filter-options';
+```
+
+Replace `handleRemoveFilter()` with:
+
+```typescript
+function handleRemoveFilter(type: string, id?: string) {
+  filters = handleSpaceRemoveFilter(filters, type, id);
 }
 ```
 
-Update `handleRemoveFilter('timeline')`:
+Replace the view-mode timeline options branch with:
 
 ```typescript
-filters = {
-  ...filters,
-  dateAfter: undefined,
-  dateBefore: undefined,
-  selectedYear: undefined,
-  selectedMonth: undefined,
-};
+const options = $derived.by(() => {
+  if (viewMode === 'select-assets') {
+    return { visibility: AssetVisibility.Timeline, timelineSpaceId: space.id };
+  }
+  return buildSpaceTimelineOptions(space.id, filters);
+});
 ```
 
-- [ ] **Step 6: Track custom dates in smart search result reactivity**
+Remove the route imports for `AssetOrder` and `AssetTypeEnum`; after this replacement those enum usages live in `space-filter-options.ts`.
+
+- [ ] **Step 7: Track custom dates in smart search result reactivity**
 
 Update the dependency array in `smart-search-results.svelte`:
 
@@ -1080,12 +1381,12 @@ const _ = [
 ];
 ```
 
-- [ ] **Step 7: Run tests and commit**
+- [ ] **Step 8: Run tests and commit**
 
 Run:
 
 ```bash
-pnpm --dir web exec vitest --run src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
 ```
 
 Expected: all route/search helper tests pass.
@@ -1093,7 +1394,7 @@ Expected: all route/search helper tests pass.
 Commit:
 
 ```bash
-git add web/src/lib/utils/__tests__/album-filter-options.spec.ts web/src/lib/utils/__tests__/map-filter-options.spec.ts web/src/lib/utils/__tests__/space-search.spec.ts web/src/lib/utils/space-search.ts 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' web/src/lib/components/search/smart-search-results.svelte web/src/lib/components/search/smart-search-results.spec.ts
+git add web/src/lib/utils/__tests__/album-filter-options.spec.ts web/src/lib/utils/__tests__/album-filter-config.spec.ts web/src/lib/utils/__tests__/map-filter-options.spec.ts web/src/lib/utils/__tests__/space-filter-options.spec.ts web/src/lib/utils/space-filter-options.ts web/src/lib/utils/__tests__/space-search.spec.ts web/src/lib/utils/space-search.ts 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' web/src/lib/components/search/smart-search-results.svelte web/src/lib/components/search/smart-search-results.spec.ts
 git commit -m "feat(web): apply custom date ranges to search routes"
 ```
 
@@ -1108,7 +1409,7 @@ git commit -m "feat(web): apply custom date ranges to search routes"
 Run:
 
 ```bash
-pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
 ```
 
 Expected: all listed tests pass.
@@ -1129,8 +1430,8 @@ Expected: both commands pass. Existing Svelte warnings are acceptable only if th
 Run:
 
 ```bash
-pnpm --dir web exec prettier --check src/lib/components/filter-panel/filter-panel.ts src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/temporal-picker.svelte src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/album-filter-options.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/space-search.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.svelte src/lib/components/search/smart-search-results.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte'
-pnpm --dir web exec eslint src/lib/components/filter-panel/filter-panel.ts src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/temporal-picker.svelte src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/album-filter-options.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/space-search.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.svelte src/lib/components/search/smart-search-results.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' --max-warnings 0
+pnpm --dir web exec prettier --check src/lib/components/filter-panel/filter-panel.ts src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/temporal-picker.svelte src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/album-filter-options.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/space-filter-options.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/space-search.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.svelte src/lib/components/search/smart-search-results.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte'
+pnpm --dir web exec eslint src/lib/components/filter-panel/filter-panel.ts src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/temporal-picker.svelte src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/album-filter-options.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/map-filter-options.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/space-filter-options.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/space-search.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.svelte src/lib/components/search/smart-search-results.spec.ts 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' --max-warnings 0
 ```
 
 Expected: both commands pass. If Prettier fails, run the same file list with `--write`, review the diff, then rerun check.

--- a/docs/superpowers/specs/2026-04-26-custom-date-range-filter-panel-design.md
+++ b/docs/superpowers/specs/2026-04-26-custom-date-range-filter-panel-design.md
@@ -32,6 +32,7 @@ Out of scope:
 5. **Invalid typed dates stay local** - invalid input does not update `FilterState` or refetch suggestions.
 6. **Shared state drives every page** - route option builders should continue consuming `buildFilterContext()` instead of duplicating date logic.
 7. **Contextual suggestions must update** - changing custom dates must narrow the available people, locations, cameras, and tags just like changing year/month does today.
+8. **Date inputs are validated text inputs** - use `YYYY-MM-DD` text fields, not native `type="date"`, so malformed and impossible typed dates can stay visible locally while `FilterState` remains unchanged.
 
 ## Interaction Model
 
@@ -68,6 +69,8 @@ If the user types an invalid date:
 - Show a small inline error for that field.
 - Do not update `FilterState`.
 - Do not refetch suggestions until the field is valid or cleared.
+- Treat impossible calendar dates such as `2024-02-31` as invalid, not as normalized JavaScript dates.
+- If the user clears an invalid field while the other side is valid, emit the remaining open-ended range.
 
 ## Data Model
 
@@ -101,6 +104,8 @@ If one custom field is cleared while the other remains valid, keep the remaining
 ## Component Design
 
 Add a focused custom date range control inside the existing timeline section. It can live in `temporal-picker.svelte` or a new child component owned by it; the implementation should keep the public timeline-section API small.
+
+Use text inputs with `inputmode="numeric"`, `placeholder="YYYY-MM-DD"`, and strict parsing. Native date inputs are not used because browsers may prevent or normalize invalid text before the component can preserve the typed value and show the required local validation error.
 
 The control exposes:
 
@@ -153,6 +158,8 @@ This avoids route-specific suggestion behavior and keeps photos, albums, spaces,
 
 Route option builders that already consume `buildFilterContext()` should pick up custom dates through the shared helper. Any route that still builds temporal options locally must be changed to use the shared helper so custom dates and year/month semantics stay consistent.
 
+Route-local temporal option construction should be extracted into helper functions when practical so the custom date behavior can be covered by unit tests. The spaces timeline options currently build date ranges inside the route component, so this slice should introduce a small spaces filter-options helper and make the route consume it.
+
 Expected routes:
 
 - `/photos` timeline options and smart-search filters.
@@ -188,7 +195,8 @@ Add or update focused web tests:
   - entering `To` clears selected year/month
   - selecting a year clears custom dates
   - selecting a month clears custom dates
-  - invalid dates and inverted ranges do not call the change handler
+  - malformed dates, impossible dates, and inverted ranges do not call the change handler
+  - clearing an invalid field emits the remaining valid open-ended range
 
 - `active-filters-bar.spec.ts`
   - bounded custom range chip label
@@ -206,8 +214,10 @@ Add or update focused web tests:
 - route option helper tests
   - photos options include custom `takenAfter` / `takenBefore`
   - album options include custom dates for album and picker modes
+  - real suggestion config builders send custom `takenAfter` / `takenBefore` to `getFilterSuggestions()`
   - map options include custom dates for markers and time buckets
-  - spaces options include custom dates while preserving existing space person behavior
+  - spaces timeline options include custom dates while preserving existing space-person mapping
+  - spaces timeline removal clears both custom dates and year/month
   - smart-search result components rerun when `dateAfter` or `dateBefore` changes
 
 ## Rollout Notes

--- a/docs/superpowers/specs/2026-04-26-custom-date-range-filter-panel-design.md
+++ b/docs/superpowers/specs/2026-04-26-custom-date-range-filter-panel-design.md
@@ -1,0 +1,217 @@
+# Custom Date Range Filter Panel Design
+
+## Goal
+
+Add custom date range filtering to the shared web `FilterPanel` timeline section, above the existing year/month picker, so users can filter by arbitrary taken-date ranges anywhere the panel is used.
+
+This is the first web-only slice of [issue #434](https://github.com/open-noodle/gallery/issues/434). It intentionally does not change mobile, people ordering, or search-bar filter composition.
+
+## Scope
+
+In scope:
+
+- Web `FilterPanel` timeline section.
+- Photos, albums, spaces, and map pages that already consume the shared panel or shared filter-state helpers.
+- Bounded custom ranges, from-only open-ended ranges, and to-only open-ended ranges.
+- Interdependent filter suggestions that narrow when the custom date range changes.
+- Active filter chips and clear/remove behavior.
+
+Out of scope:
+
+- Mobile search/filter UI.
+- Adding filter syntax or structured filters to the global search bar.
+- Changing people ordering or favorite-first sorting.
+- Persisting custom date ranges in URLs or local storage.
+
+## Decisions
+
+1. **Custom range is additive** - render it above the existing year/month picker, not instead of it.
+2. **One temporal mode is active at a time** - custom range and year/month are mutually exclusive.
+3. **Do not disable the inactive mode** - switching modes should be easy; the latest date-selection action wins.
+4. **Open-ended ranges are valid** - a single `From` or `To` value is enough to filter.
+5. **Invalid typed dates stay local** - invalid input does not update `FilterState` or refetch suggestions.
+6. **Shared state drives every page** - route option builders should continue consuming `buildFilterContext()` instead of duplicating date logic.
+7. **Contextual suggestions must update** - changing custom dates must narrow the available people, locations, cameras, and tags just like changing year/month does today.
+
+## Interaction Model
+
+The timeline section has two stacked controls:
+
+```text
+[ From date ] [ To date ]
+
+[ existing year/month timeline picker ]
+```
+
+When the user enters or changes either custom date:
+
+- Clear `selectedYear` and `selectedMonth`.
+- Keep the year/month picker enabled and visible.
+- Update filter context from the custom range.
+- Refetch contextual suggestions for the new date range.
+
+When the user selects a year or month:
+
+- Clear custom `dateAfter` and `dateBefore`.
+- Keep both date inputs enabled and visible, but empty.
+- Update filter context from the selected year/month.
+- Refetch contextual suggestions for that year/month.
+
+When the user clears the temporal chip or uses `Clear all`:
+
+- Clear custom dates.
+- Clear `selectedYear` and `selectedMonth`.
+
+If the user types an invalid date:
+
+- Keep the invalid value in the input field.
+- Show a small inline error for that field.
+- Do not update `FilterState`.
+- Do not refetch suggestions until the field is valid or cleared.
+
+## Data Model
+
+Extend `FilterState` with custom temporal fields:
+
+```typescript
+interface FilterState {
+  dateAfter?: string;
+  dateBefore?: string;
+  selectedYear?: number;
+  selectedMonth?: number;
+}
+```
+
+The custom date values are ISO date strings in `YYYY-MM-DD` form at the UI boundary. `buildFilterContext()` converts them to API-ready `takenAfter` and `takenBefore` ISO datetimes.
+
+`takenAfter` should be inclusive at the start of the selected UTC calendar date. `takenBefore` should be exclusive at the start of the UTC calendar day after the selected `To` date, matching the existing server-side `< takenBefore` convention and the current year/month helper behavior.
+
+Examples:
+
+| User input                         | Filter context                                                                    |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| From `2024-01-01`, To `2024-12-31` | `takenAfter = 2024-01-01T00:00:00.000Z`, `takenBefore = 2025-01-01T00:00:00.000Z` |
+| From `2024-01-01` only             | `takenAfter = 2024-01-01T00:00:00.000Z`                                           |
+| To `2024-12-31` only               | `takenBefore = 2025-01-01T00:00:00.000Z`                                          |
+
+If either custom date is present, `buildFilterContext()` ignores `selectedYear` and `selectedMonth`.
+
+If one custom field is cleared while the other remains valid, keep the remaining open-ended range active. If both custom fields are cleared, clear the custom temporal mode.
+
+## Component Design
+
+Add a focused custom date range control inside the existing timeline section. It can live in `temporal-picker.svelte` or a new child component owned by it; the implementation should keep the public timeline-section API small.
+
+The control exposes:
+
+- current `dateAfter`
+- current `dateBefore`
+- `onCustomRangeChange`
+
+`TemporalPicker` remains responsible for year/month selection. The parent `FilterPanel` remains responsible for mutating `filters`.
+
+Expected handlers:
+
+- `handleCustomDateRangeChange(dateAfter?: string, dateBefore?: string)`
+- `handleYearSelect(year?: number)`
+- `handleMonthSelect(year: number, month?: number)`
+
+`handleCustomDateRangeChange` sets custom dates and clears year/month. `handleYearSelect` and `handleMonthSelect` clear custom dates before applying the bucket selection.
+
+## Active Chips
+
+The active filters bar keeps one temporal chip.
+
+Chip labels:
+
+- Both dates: `Jan 1, 2024 - Dec 31, 2024`
+- From only: `After Jan 1, 2024`
+- To only: `Before Dec 31, 2024`
+- Year: `2024`
+- Month: `Jan 2024`
+
+Removing the temporal chip clears both temporal modes. `Clear all` also clears both temporal modes while preserving the existing sort-order behavior.
+
+## Interdependent Filtering
+
+The existing `FilterPanel` already builds a `filterContext` from temporal state and uses it to fetch/refetch contextual suggestions.
+
+Custom dates must use and extend that same path:
+
+- `suggestionsProvider(filters)` receives the updated custom date state.
+- `getFilterSuggestions()` calls include `takenAfter` and/or `takenBefore` derived from the custom range.
+- Dependent providers such as `cities(country, context)` and `cameraModels(make, context)` receive the same custom range context.
+- Visible people, locations, cameras, and tags narrow to values that exist inside the active date range.
+
+The current unified suggestions path intentionally keeps rating and media options fixed. This feature does not change that behavior. Rating and media controls should stay stable while temporal context narrows people, locations, cameras, and tags.
+
+The `FilterPanel` effects that currently track only `selectedYear` and `selectedMonth` must also track `dateAfter` and `dateBefore`; otherwise custom date changes will not update `filterContext`, dependent providers, or contextual suggestion refetches.
+
+This avoids route-specific suggestion behavior and keeps photos, albums, spaces, and map consistent.
+
+## Route Behavior
+
+Route option builders that already consume `buildFilterContext()` should pick up custom dates through the shared helper. Any route that still builds temporal options locally must be changed to use the shared helper so custom dates and year/month semantics stay consistent.
+
+Expected routes:
+
+- `/photos` timeline options and smart-search filters.
+- Album detail filter options for album timeline and add-assets picker.
+- Spaces filter options, including the space-person mapping already present there. The current spaces route has route-local year/month date construction and should be refactored to use `buildFilterContext()`.
+- Map marker and time-bucket options.
+
+Search-result components that rerun work from reactive filter dependencies must also track `dateAfter` and `dateBefore`. In particular, smart-search result flows should re-search when either custom date field changes, not only when `selectedYear` or `selectedMonth` changes.
+
+No URL persistence is added in this design.
+
+## Error Handling
+
+- Invalid date text is a UI validation error only.
+- Invalid date text does not update route options or suggestion requests.
+- Suggestion fetch failures keep the existing non-fatal behavior: preserve current selections and keep the panel mounted.
+- If `From` is after `To`, show an inline range error and do not update `FilterState` until the range is valid or one side is cleared.
+
+## Testing
+
+Add or update focused web tests:
+
+- `filter-state.spec.ts`
+  - default state includes no custom dates
+  - custom dates count as one temporal filter
+  - custom dates take priority over year/month in `buildFilterContext()`
+  - from-only and to-only open-ended ranges build the expected context
+  - clearing filters clears both custom dates and year/month
+
+- `temporal-picker.spec.ts`
+  - custom range inputs render above the year/month picker
+  - entering `From` clears selected year/month
+  - entering `To` clears selected year/month
+  - selecting a year clears custom dates
+  - selecting a month clears custom dates
+  - invalid dates and inverted ranges do not call the change handler
+
+- `active-filters-bar.spec.ts`
+  - bounded custom range chip label
+  - from-only chip label
+  - to-only chip label
+  - removing temporal chip clears through the existing `timeline` removal path
+
+- `contextual-refetch.spec.ts`
+  - changing custom date range refetches unified suggestions
+  - refetch payload includes `takenAfter` and/or `takenBefore`
+  - visible suggestion lists update to the narrowed response
+  - rating and media controls remain stable when temporal context changes
+  - dependent city and camera-model providers receive the custom date context
+
+- route option helper tests
+  - photos options include custom `takenAfter` / `takenBefore`
+  - album options include custom dates for album and picker modes
+  - map options include custom dates for markers and time buckets
+  - spaces options include custom dates while preserving existing space person behavior
+  - smart-search result components rerun when `dateAfter` or `dateBefore` changes
+
+## Rollout Notes
+
+This should be a web-only change with no server or OpenAPI changes. The server already accepts `takenAfter` and `takenBefore` on the relevant search and suggestion endpoints.
+
+The safest implementation path is to update shared filter-state utilities first, then the timeline section UI, then contextual suggestion tests, and finally route helper coverage.

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -289,6 +289,79 @@ describe('ActiveFiltersBar', () => {
     expect(chips[0].textContent).toContain('Dec 2015');
   });
 
+  it('should render bounded custom date range as one timeline chip', () => {
+    const filters = createFilterState();
+    filters.dateAfter = '2024-01-01';
+    filters.dateBefore = '2024-12-31';
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('Jan 1, 2024 - Dec 31, 2024');
+  });
+
+  it('should render from-only custom date range as one timeline chip', () => {
+    const filters = createFilterState();
+    filters.dateAfter = '2024-01-01';
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('After Jan 1, 2024');
+  });
+
+  it('should render to-only custom date range as one timeline chip', () => {
+    const filters = createFilterState();
+    filters.dateBefore = '2024-12-31';
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('Before Dec 31, 2024');
+  });
+
+  it('should prefer custom date range chip over selected year and month', () => {
+    const filters = createFilterState();
+    filters.dateAfter = '2024-01-01';
+    filters.dateBefore = '2024-12-31';
+    filters.selectedYear = 2023;
+    filters.selectedMonth = 8;
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('Jan 1, 2024 - Dec 31, 2024');
+    expect(chips[0].textContent).not.toContain('Aug 2023');
+  });
+
   it('should remove timeline filter on chip close', async () => {
     let removedType: string | undefined;
     const onRemoveFilter = (type: string) => {
@@ -308,6 +381,24 @@ describe('ActiveFiltersBar', () => {
 
     await fireEvent.click(getByTestId('chip-close'));
     expect(removedType).toBe('timeline');
+  });
+
+  it('should remove custom timeline filter on chip close', async () => {
+    const onRemoveFilter = vi.fn();
+    const filters = createFilterState();
+    filters.dateAfter = '2024-01-01';
+    filters.dateBefore = '2024-12-31';
+
+    const { getByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter,
+        onClearAll: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('chip-close'));
+    expect(onRemoveFilter).toHaveBeenCalledWith('timeline', undefined);
   });
 
   it('should not show Clear All when no filters active', () => {

--- a/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import type { FilterContext, FilterPanelConfig } from '../filter-panel';
+import type { FilterContext, FilterPanelConfig, FilterSuggestionsResponse } from '../filter-panel';
 import FilterPanel from '../filter-panel.svelte';
 
 function createConfig(overrides: Partial<NonNullable<FilterPanelConfig['providers']>> = {}): FilterPanelConfig {
@@ -32,6 +32,22 @@ const timeBuckets = [
   { timeBucket: '2023-08-01', count: 200 },
   { timeBucket: '2024-03-01', count: 50 },
 ];
+
+const defaultSuggestions: FilterSuggestionsResponse = {
+  countries: ['Germany', 'France'],
+  cameraMakes: ['Canon', 'Sony'],
+  tags: [
+    { id: 't1', name: 'Vacation' },
+    { id: 't2', name: 'Family' },
+  ],
+  people: [
+    { id: 'p1', name: 'Alice' },
+    { id: 'p2', name: 'Bob' },
+  ],
+  ratings: [3, 4, 5],
+  mediaTypes: ['IMAGE', 'VIDEO'],
+  hasUnnamedPeople: false,
+};
 
 describe('Contextual re-fetch on temporal change', () => {
   beforeEach(() => {
@@ -246,6 +262,218 @@ describe('Contextual re-fetch on temporal change', () => {
         takenAfter: '2023-08-01T00:00:00.000Z',
         takenBefore: '2023-09-01T00:00:00.000Z',
       });
+    });
+  });
+
+  it('should re-fetch unified suggestions when custom from date changes and narrow people and tags', async () => {
+    const secondSuggestions: FilterSuggestionsResponse = {
+      ...defaultSuggestions,
+      people: [{ id: 'p1', name: 'Alice' }],
+      tags: [{ id: 't1', name: 'Vacation' }],
+    };
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce(defaultSuggestions)
+      .mockResolvedValueOnce(secondSuggestions);
+    const config: FilterPanelConfig = {
+      sections: ['timeline', 'people', 'tags'],
+      suggestionsProvider,
+    };
+
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => {
+      expect(screen.getByTestId('people-item-p2')).toBeTruthy();
+      expect(screen.getByTestId('tags-item-t2')).toBeTruthy();
+    });
+
+    await fireEvent.input(screen.getByTestId('custom-date-from-input'), { target: { value: '2024-01-01' } });
+    await vi.advanceTimersByTimeAsync(200);
+
+    await waitFor(() => {
+      expect(suggestionsProvider).toHaveBeenCalledTimes(2);
+      expect(suggestionsProvider).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          dateAfter: '2024-01-01',
+          dateBefore: undefined,
+          selectedYear: undefined,
+          selectedMonth: undefined,
+        }),
+      );
+      expect(screen.getByTestId('people-item-p1')).toBeTruthy();
+      expect(screen.queryByTestId('people-item-p2')).toBeNull();
+      expect(screen.getByTestId('tags-item-t1')).toBeTruthy();
+      expect(screen.queryByTestId('tags-item-t2')).toBeNull();
+    });
+  });
+
+  it('should clear selected year when custom from date changes', async () => {
+    const config = createConfig();
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByTestId('year-btn-2023'));
+    await vi.advanceTimersByTimeAsync(250);
+    expect(screen.getByTestId('month-grid')).toBeTruthy();
+
+    await fireEvent.input(screen.getByTestId('custom-date-from-input'), { target: { value: '2024-01-01' } });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('month-grid')).toBeNull();
+      expect(screen.getByTestId('year-grid')).toBeTruthy();
+      expect(config.providers!.people).toHaveBeenLastCalledWith({
+        takenAfter: '2024-01-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  it('should clear selected year and month when custom to date changes', async () => {
+    const config = createConfig();
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByTestId('year-btn-2023'));
+    await vi.advanceTimersByTimeAsync(250);
+    await fireEvent.click(screen.getByTestId('month-btn-8'));
+    await vi.advanceTimersByTimeAsync(250);
+    expect(screen.getByTestId('month-grid')).toBeTruthy();
+
+    await fireEvent.input(screen.getByTestId('custom-date-to-input'), { target: { value: '2024-12-31' } });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('month-grid')).toBeNull();
+      expect(screen.getByTestId('year-grid')).toBeTruthy();
+      expect(config.providers!.people).toHaveBeenLastCalledWith({
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  it('should clear custom dates when selecting a year', async () => {
+    const config = createConfig();
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.input(screen.getByTestId('custom-date-from-input'), { target: { value: '2024-01-01' } });
+    await fireEvent.input(screen.getByTestId('custom-date-to-input'), { target: { value: '2024-12-31' } });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await fireEvent.click(screen.getByTestId('year-btn-2023'));
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('custom-date-from-input')).toHaveValue('');
+      expect(screen.getByTestId('custom-date-to-input')).toHaveValue('');
+      expect(config.providers!.people).toHaveBeenLastCalledWith({
+        takenAfter: '2023-01-01T00:00:00.000Z',
+        takenBefore: '2024-01-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  it('should clear custom dates when selecting a month', async () => {
+    const config = createConfig();
+    render(FilterPanel, {
+      props: {
+        config,
+        timeBuckets,
+        filters: {
+          personIds: [],
+          tagIds: [],
+          mediaType: 'all',
+          sortOrder: 'desc',
+          dateAfter: '2024-01-01',
+          dateBefore: '2024-12-31',
+          selectedYear: 2023,
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.click(screen.getByTestId('month-btn-8'));
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('custom-date-from-input')).toHaveValue('');
+      expect(screen.getByTestId('custom-date-to-input')).toHaveValue('');
+      expect(config.providers!.people).toHaveBeenLastCalledWith({
+        takenAfter: '2023-08-01T00:00:00.000Z',
+        takenBefore: '2023-09-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  it('should pass custom from date context to dependent city and camera model providers', async () => {
+    const cities = vi.fn().mockResolvedValue(['Berlin']);
+    const cameraModels = vi.fn().mockResolvedValue(['EOS R5']);
+    const config = createConfig({ cities, cameraModels });
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await fireEvent.input(screen.getByTestId('custom-date-from-input'), { target: { value: '2024-01-01' } });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await fireEvent.click(screen.getByTestId('location-country-Germany'));
+    await fireEvent.click(screen.getByTestId('camera-make-Canon'));
+
+    await waitFor(() => {
+      expect(cities).toHaveBeenLastCalledWith('Germany', {
+        takenAfter: '2024-01-01T00:00:00.000Z',
+      });
+      expect(cameraModels).toHaveBeenLastCalledWith('Canon', {
+        takenAfter: '2024-01-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  it('should keep rating and media controls stable after custom date changes', async () => {
+    const secondSuggestions: FilterSuggestionsResponse = {
+      ...defaultSuggestions,
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+    };
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce(defaultSuggestions)
+      .mockResolvedValueOnce(secondSuggestions);
+    const config: FilterPanelConfig = {
+      sections: ['timeline', 'rating', 'media'],
+      suggestionsProvider,
+    };
+
+    render(FilterPanel, {
+      props: { config, timeBuckets },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => {
+      expect(screen.getByTestId('rating-star-1')).toBeTruthy();
+      expect(screen.getByTestId('media-type-video')).toBeTruthy();
+    });
+
+    await fireEvent.input(screen.getByTestId('custom-date-from-input'), { target: { value: '2024-01-01' } });
+    await vi.advanceTimersByTimeAsync(200);
+
+    await waitFor(() => {
+      expect(suggestionsProvider).toHaveBeenCalledTimes(2);
+      for (const star of [1, 2, 3, 4, 5]) {
+        expect(screen.getByTestId(`rating-star-${star}`)).toBeTruthy();
+      }
+      expect(screen.getByTestId('media-type-image')).toBeTruthy();
+      expect(screen.getByTestId('media-type-video')).toBeTruthy();
     });
   });
 });

--- a/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
@@ -74,6 +74,13 @@ describe('FilterState utilities', () => {
     expect(getActiveFilterCount(state)).toBe(2);
   });
 
+  it('should not count empty custom date strings as active temporal filters', () => {
+    const state = createFilterState();
+    state.dateAfter = '';
+    state.dateBefore = '';
+    expect(getActiveFilterCount(state)).toBe(0);
+  });
+
   it('should not double-count country when city is set', () => {
     const state = createFilterState();
     state.country = 'Germany';
@@ -232,8 +239,40 @@ describe('buildFilterContext', () => {
     });
   });
 
+  it('should not build context for empty custom date strings', () => {
+    const state = createFilterState();
+    state.dateAfter = '';
+    state.dateBefore = '';
+    expect(buildFilterContext(state)).toBeUndefined();
+  });
+
   it('should build to-only custom date context with exclusive end date', () => {
     const state = createFilterState();
+    state.dateBefore = '2024-12-31';
+    expect(buildFilterContext(state)).toEqual({
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('should ignore invalid custom date strings', () => {
+    const state = createFilterState();
+    state.dateAfter = 'not-a-date';
+    state.dateBefore = '2024-02-31';
+    expect(buildFilterContext(state)).toBeUndefined();
+  });
+
+  it('should build from-only context when to date is invalid', () => {
+    const state = createFilterState();
+    state.dateAfter = '2024-01-01';
+    state.dateBefore = '2024-02-31';
+    expect(buildFilterContext(state)).toEqual({
+      takenAfter: '2024-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('should build to-only context when from date is malformed', () => {
+    const state = createFilterState();
+    state.dateAfter = '01/01/2024';
     state.dateBefore = '2024-12-31';
     expect(buildFilterContext(state)).toEqual({
       takenBefore: '2025-01-01T00:00:00.000Z',

--- a/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
@@ -17,6 +17,12 @@ describe('FilterState utilities', () => {
     expect(state.selectedMonth).toBeUndefined();
   });
 
+  it('should create default state with custom dates undefined', () => {
+    const state = createFilterState();
+    expect(state.dateAfter).toBeUndefined();
+    expect(state.dateBefore).toBeUndefined();
+  });
+
   it('should allow setting selectedYear and selectedMonth', () => {
     const state = createFilterState();
     state.selectedYear = 2023;
@@ -52,6 +58,18 @@ describe('FilterState utilities', () => {
     expect(getActiveFilterCount(state)).toBe(1); // year+month counts as one temporal filter
 
     // Other filters should still count normally
+    state.personIds = ['p1'];
+    expect(getActiveFilterCount(state)).toBe(2);
+  });
+
+  it('should count custom date range as one active temporal filter', () => {
+    const state = createFilterState();
+    state.dateAfter = '2024-01-01';
+    expect(getActiveFilterCount(state)).toBe(1);
+
+    state.dateBefore = '2024-12-31';
+    expect(getActiveFilterCount(state)).toBe(1);
+
     state.personIds = ['p1'];
     expect(getActiveFilterCount(state)).toBe(2);
   });
@@ -96,6 +114,20 @@ describe('FilterState utilities', () => {
     expect(cleared.selectedYear).toBeUndefined();
     expect(cleared.selectedMonth).toBeUndefined();
     expect(cleared.personIds).toEqual([]);
+  });
+
+  it('should clear custom dates on clearFilters', () => {
+    const state = createFilterState();
+    state.dateAfter = '2024-01-01';
+    state.dateBefore = '2024-12-31';
+    state.selectedYear = 2023;
+    state.selectedMonth = 8;
+
+    const cleared = clearFilters(state);
+    expect(cleared.dateAfter).toBeUndefined();
+    expect(cleared.dateBefore).toBeUndefined();
+    expect(cleared.selectedYear).toBeUndefined();
+    expect(cleared.selectedMonth).toBeUndefined();
   });
 });
 
@@ -180,5 +212,41 @@ describe('buildFilterContext', () => {
     const ctx = buildFilterContext(state)!;
     expect(ctx.takenAfter).toContain('T00:00:00.000Z');
     expect(ctx.takenBefore).toContain('T00:00:00.000Z');
+  });
+
+  it('should build bounded custom date context with exclusive end date', () => {
+    const state = createFilterState();
+    state.dateAfter = '2024-01-01';
+    state.dateBefore = '2024-12-31';
+    expect(buildFilterContext(state)).toEqual({
+      takenAfter: '2024-01-01T00:00:00.000Z',
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('should build from-only custom date context', () => {
+    const state = createFilterState();
+    state.dateAfter = '2024-01-01';
+    expect(buildFilterContext(state)).toEqual({
+      takenAfter: '2024-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('should build to-only custom date context with exclusive end date', () => {
+    const state = createFilterState();
+    state.dateBefore = '2024-12-31';
+    expect(buildFilterContext(state)).toEqual({
+      takenBefore: '2025-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('should prefer custom date context over year and month context', () => {
+    const state = createFilterState();
+    state.selectedYear = 2023;
+    state.selectedMonth = 8;
+    state.dateAfter = '2024-01-01';
+    expect(buildFilterContext(state)).toEqual({
+      takenAfter: '2024-01-01T00:00:00.000Z',
+    });
   });
 });

--- a/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
@@ -168,6 +168,121 @@ describe('TemporalPicker component', () => {
     }
   });
 
+  it('should clear invalid custom range state before selecting a year', async () => {
+    const { getByTestId, queryByText } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, onYearSelect: vi.fn() },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '2024-1-1' } });
+    expect(queryByText('Enter a valid From date')).toBeTruthy();
+
+    await fireEvent.click(getByTestId('year-btn-2023'));
+
+    expect(getByTestId('custom-date-from-input')).toHaveValue('');
+    expect(getByTestId('custom-date-to-input')).toHaveValue('');
+    expect(queryByText('Enter a valid From date')).toBeNull();
+  });
+
+  it('should clear invalid custom range state before selecting a month', async () => {
+    const { getByTestId, queryByText } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, selectedYear: 2023, onMonthSelect: vi.fn() },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-2-31' } });
+    expect(queryByText('Enter a valid To date')).toBeTruthy();
+
+    await fireEvent.click(getByTestId('month-btn-6'));
+
+    expect(getByTestId('custom-date-from-input')).toHaveValue('');
+    expect(getByTestId('custom-date-to-input')).toHaveValue('');
+    expect(queryByText('Enter a valid To date')).toBeNull();
+  });
+
+  it('should clear stale validation error when props rerender to a valid range', async () => {
+    const { getByTestId, queryByText, rerender } = render(TemporalPicker, {
+      props: { timeBuckets: buckets },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '2024-1-1' } });
+    expect(queryByText('Enter a valid From date')).toBeTruthy();
+
+    await rerender({ timeBuckets: buckets, dateAfter: '2024-01-01', dateBefore: '2024-12-31' });
+
+    expect(getByTestId('custom-date-from-input')).toHaveValue('2024-01-01');
+    expect(getByTestId('custom-date-to-input')).toHaveValue('2024-12-31');
+    expect(queryByText('Enter a valid From date')).toBeNull();
+  });
+
+  it('should clear stale validation error when props rerender to an empty range', async () => {
+    const { getByTestId, queryByText, rerender } = render(TemporalPicker, {
+      props: { timeBuckets: buckets },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-2-31' } });
+    expect(queryByText('Enter a valid To date')).toBeTruthy();
+
+    await rerender({ timeBuckets: buckets });
+
+    expect(getByTestId('custom-date-from-input')).toHaveValue('');
+    expect(getByTestId('custom-date-to-input')).toHaveValue('');
+    expect(queryByText('Enter a valid To date')).toBeNull();
+  });
+
+  it('should associate from validation errors with the from input', async () => {
+    const { getByTestId, getByText } = render(TemporalPicker, {
+      props: { timeBuckets: buckets },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '2024-1-1' } });
+
+    const fromInput = getByTestId('custom-date-from-input');
+    const toInput = getByTestId('custom-date-to-input');
+    const error = getByText('Enter a valid From date');
+
+    expect(fromInput).toHaveAttribute('aria-invalid', 'true');
+    expect(fromInput).toHaveAttribute('aria-describedby', 'custom-date-range-error');
+    expect(toInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(error).toHaveAttribute('id', 'custom-date-range-error');
+    expect(error).toHaveAttribute('role', 'alert');
+  });
+
+  it('should associate to validation errors with the to input', async () => {
+    const { getByTestId, getByText } = render(TemporalPicker, {
+      props: { timeBuckets: buckets },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-2-31' } });
+
+    const fromInput = getByTestId('custom-date-from-input');
+    const toInput = getByTestId('custom-date-to-input');
+    const error = getByText('Enter a valid To date');
+
+    expect(fromInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(toInput).toHaveAttribute('aria-invalid', 'true');
+    expect(toInput).toHaveAttribute('aria-describedby', 'custom-date-range-error');
+    expect(error).toHaveAttribute('id', 'custom-date-range-error');
+    expect(error).toHaveAttribute('role', 'alert');
+  });
+
+  it('should associate inverted range errors with both custom date inputs', async () => {
+    const { getByTestId, getByText } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, dateAfter: '2024-12-31' },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-01-01' } });
+
+    const fromInput = getByTestId('custom-date-from-input');
+    const toInput = getByTestId('custom-date-to-input');
+    const error = getByText('From date must be on or before To date');
+
+    expect(fromInput).toHaveAttribute('aria-invalid', 'true');
+    expect(fromInput).toHaveAttribute('aria-describedby', 'custom-date-range-error');
+    expect(toInput).toHaveAttribute('aria-invalid', 'true');
+    expect(toInput).toHaveAttribute('aria-describedby', 'custom-date-range-error');
+    expect(error).toHaveAttribute('id', 'custom-date-range-error');
+    expect(error).toHaveAttribute('role', 'alert');
+  });
+
   it('should show month grid when selectedYear is set via prop', () => {
     const { getByTestId, queryByTestId } = render(TemporalPicker, {
       props: { timeBuckets: buckets, selectedYear: 2023 },

--- a/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
@@ -61,6 +61,113 @@ describe('TemporalPicker component', () => {
     expect(queryByTestId('month-grid')).toBeNull();
   });
 
+  it('should render custom range inputs above year grid', () => {
+    const { getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets },
+    });
+
+    const customRange = getByTestId('custom-date-range');
+    const yearGrid = getByTestId('year-grid');
+
+    expect(customRange.compareDocumentPosition(yearGrid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('should emit from-only custom range', async () => {
+    const spy = vi.fn();
+    const { getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, onCustomRangeChange: spy },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '2024-01-01' } });
+
+    expect(spy).toHaveBeenCalledWith('2024-01-01', undefined);
+  });
+
+  it('should emit to-only custom range', async () => {
+    const spy = vi.fn();
+    const { getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, onCustomRangeChange: spy },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-12-31' } });
+
+    expect(spy).toHaveBeenCalledWith(undefined, '2024-12-31');
+  });
+
+  it('should populate custom range values from props', () => {
+    const { getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, dateAfter: '2024-01-01', dateBefore: '2024-12-31' },
+    });
+
+    expect(getByTestId('custom-date-from-input')).toHaveValue('2024-01-01');
+    expect(getByTestId('custom-date-to-input')).toHaveValue('2024-12-31');
+  });
+
+  it('should not emit inverted custom ranges and should show an inline error', async () => {
+    const spy = vi.fn();
+    const { getByText, getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, dateAfter: '2024-12-31', onCustomRangeChange: spy },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-01-01' } });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(getByText('From date must be on or before To date')).toBeTruthy();
+  });
+
+  it('should not emit malformed custom dates and should show an inline error', async () => {
+    const spy = vi.fn();
+    const { getByText, getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, onCustomRangeChange: spy },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '2024-1-1' } });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(getByText('Enter a valid From date')).toBeTruthy();
+  });
+
+  it('should not emit impossible custom dates and should show an inline error', async () => {
+    const spy = vi.fn();
+    const { getByText, getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, onCustomRangeChange: spy },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-to-input'), { target: { value: '2024-02-31' } });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(getByText('Enter a valid To date')).toBeTruthy();
+  });
+
+  it('should emit remaining valid open-ended range when clearing an invalid field', async () => {
+    const spy = vi.fn();
+    const { getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets, dateBefore: '2024-12-31', onCustomRangeChange: spy },
+    });
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '2024-1-1' } });
+    expect(spy).not.toHaveBeenCalled();
+
+    await fireEvent.input(getByTestId('custom-date-from-input'), { target: { value: '' } });
+
+    expect(spy).toHaveBeenCalledWith(undefined, '2024-12-31');
+  });
+
+  it('should render custom range controls as numeric text inputs with date-only attributes', () => {
+    const { getByTestId } = render(TemporalPicker, {
+      props: { timeBuckets: buckets },
+    });
+
+    for (const testId of ['custom-date-from-input', 'custom-date-to-input']) {
+      const input = getByTestId(testId);
+      expect(input).toHaveAttribute('type', 'text');
+      expect(input).toHaveAttribute('inputmode', 'numeric');
+      expect(input).toHaveAttribute('autocomplete', 'off');
+      expect(input).toHaveAttribute('placeholder', 'YYYY-MM-DD');
+      expect(input).toHaveAttribute('pattern', '\\d{4}-\\d{2}-\\d{2}');
+    }
+  });
+
   it('should show month grid when selectedYear is set via prop', () => {
     const { getByTestId, queryByTestId } = render(TemporalPicker, {
       props: { timeBuckets: buckets, selectedYear: 2023 },

--- a/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
@@ -164,7 +164,7 @@ describe('TemporalPicker component', () => {
       expect(input).toHaveAttribute('inputmode', 'numeric');
       expect(input).toHaveAttribute('autocomplete', 'off');
       expect(input).toHaveAttribute('placeholder', 'YYYY-MM-DD');
-      expect(input).toHaveAttribute('pattern', '\\d{4}-\\d{2}-\\d{2}');
+      expect(input).toHaveAttribute('pattern', String.raw`\d{4}-\d{2}-\d{2}`);
     }
   });
 

--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -2,6 +2,12 @@
   import type { FilterState } from './filter-panel';
 
   const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 
   interface Props {
     filters: FilterState;
@@ -29,6 +35,22 @@
     type: string;
     id?: string;
     label: string;
+  }
+
+  function formatDateOnly(value: string): string {
+    return DATE_FORMATTER.format(new Date(`${value}T00:00:00.000Z`));
+  }
+
+  function buildCustomDateLabel(dateAfter: string | undefined, dateBefore: string | undefined): string | undefined {
+    if (dateAfter && dateBefore) {
+      return `${formatDateOnly(dateAfter)} - ${formatDateOnly(dateBefore)}`;
+    }
+    if (dateAfter) {
+      return `After ${formatDateOnly(dateAfter)}`;
+    }
+    if (dateBefore) {
+      return `Before ${formatDateOnly(dateBefore)}`;
+    }
   }
 
   let chips = $derived.by(() => {
@@ -73,7 +95,10 @@
     }
 
     // Timeline chip
-    if (filters.selectedYear !== undefined) {
+    const customDateLabel = buildCustomDateLabel(filters.dateAfter, filters.dateBefore);
+    if (customDateLabel) {
+      result.push({ type: 'timeline', label: customDateLabel });
+    } else if (filters.selectedYear !== undefined) {
       const label =
         filters.selectedMonth === undefined
           ? `${filters.selectedYear}`

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -105,6 +105,8 @@
       mediaType: filters.mediaType,
       isFavorite: filters.isFavorite,
       sortOrder: filters.sortOrder,
+      dateAfter: filters.dateAfter,
+      dateBefore: filters.dateBefore,
       selectedYear: filters.selectedYear,
       selectedMonth: filters.selectedMonth,
     };
@@ -113,8 +115,16 @@
 
     const isInitialMount = prev === undefined;
     const temporalChanged =
-      !isInitialMount && (prev.selectedYear !== current.selectedYear || prev.selectedMonth !== current.selectedMonth);
-    const isTemporalClear = temporalChanged && current.selectedYear === undefined;
+      !isInitialMount &&
+      (prev.dateAfter !== current.dateAfter ||
+        prev.dateBefore !== current.dateBefore ||
+        prev.selectedYear !== current.selectedYear ||
+        prev.selectedMonth !== current.selectedMonth);
+    const isTemporalClear =
+      temporalChanged &&
+      current.dateAfter === undefined &&
+      current.dateBefore === undefined &&
+      current.selectedYear === undefined;
 
     const delay = isInitialMount || isTemporalClear ? 0 : temporalChanged ? 200 : 50;
 
@@ -168,18 +178,25 @@
   let isRefetching = $state(false);
 
   // Debounced re-fetch when temporal filter changes.
-  // We track filters.selectedYear and filters.selectedMonth directly instead of
+  // We track temporal fields directly instead of
   // filterContext to avoid re-triggering when non-temporal filters change.
   $effect(() => {
     if (config.suggestionsProvider) {
       return;
     }
 
-    // Track only the two temporal fields — this is what determines re-fetch
+    // Track only temporal fields — this is what determines re-fetch
+    const dateAfter = filters.dateAfter;
+    const dateBefore = filters.dateBefore;
     const year = filters.selectedYear;
     const month = filters.selectedMonth;
     // Build context from tracked values (not from filterContext which would track all of filters)
-    const currentContext = buildFilterContext({ selectedYear: year, selectedMonth: month } as FilterState);
+    const currentContext = buildFilterContext({
+      dateAfter,
+      dateBefore,
+      selectedYear: year,
+      selectedMonth: month,
+    } as FilterState);
     const currentTakenAfter = currentContext?.takenAfter;
     const currentTakenBefore = currentContext?.takenBefore;
 
@@ -492,12 +509,16 @@
     filters = { ...filters, mediaType: type };
   }
 
+  function handleCustomDateRangeChange(dateAfter: string | undefined, dateBefore: string | undefined) {
+    filters = { ...filters, dateAfter, dateBefore, selectedYear: undefined, selectedMonth: undefined };
+  }
+
   function handleYearSelect(year: number | undefined) {
-    filters = { ...filters, selectedYear: year, selectedMonth: undefined };
+    filters = { ...filters, dateAfter: undefined, dateBefore: undefined, selectedYear: year, selectedMonth: undefined };
   }
 
   function handleMonthSelect(year: number, month: number | undefined) {
-    filters = { ...filters, selectedYear: year, selectedMonth: month };
+    filters = { ...filters, dateAfter: undefined, dateBefore: undefined, selectedYear: year, selectedMonth: month };
   }
 
   function hasActiveFilter(section: string): boolean {
@@ -524,7 +545,9 @@
         return filters.isFavorite !== undefined;
       }
       case 'timeline': {
-        return filters.selectedYear !== undefined;
+        return (
+          filters.dateAfter !== undefined || filters.dateBefore !== undefined || filters.selectedYear !== undefined
+        );
       }
       default: {
         return false;
@@ -636,8 +659,11 @@
             {#if section === 'timeline'}
               <TemporalPicker
                 {timeBuckets}
+                dateAfter={filters.dateAfter}
+                dateBefore={filters.dateBefore}
                 selectedYear={filters.selectedYear}
                 selectedMonth={filters.selectedMonth}
+                onCustomRangeChange={handleCustomDateRangeChange}
                 onYearSelect={handleYearSelect}
                 onMonthSelect={handleMonthSelect}
               />

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -56,6 +56,8 @@ export interface FilterState {
   mediaType: 'all' | 'image' | 'video';
   isFavorite?: boolean;
   sortOrder: 'asc' | 'desc' | 'relevance';
+  dateAfter?: string;
+  dateBefore?: string;
   selectedYear?: number;
   selectedMonth?: number;
 }
@@ -70,6 +72,9 @@ export function createFilterState(): FilterState {
 }
 
 export function getActiveFilterCount(state: FilterState): number {
+  const hasTemporalFilter =
+    hasDateValue(state.dateAfter) || hasDateValue(state.dateBefore) || state.selectedYear !== undefined;
+
   return (
     (state.personIds.length > 0 ? 1 : 0) +
     (state.city ? 1 : 0) +
@@ -79,7 +84,7 @@ export function getActiveFilterCount(state: FilterState): number {
     (state.rating === undefined ? 0 : 1) +
     (state.mediaType === 'all' ? 0 : 1) +
     (state.isFavorite === undefined ? 0 : 1) +
-    (state.selectedYear === undefined ? 0 : 1)
+    (hasTemporalFilter ? 1 : 0)
   );
 }
 
@@ -91,6 +96,42 @@ export type FilterContext = {
   rating?: number;
   isFavorite?: boolean;
 };
+
+function parseDateOnly(value: string | undefined): { valid: true; value?: string } | { valid: false } {
+  if (!value) {
+    return { valid: true };
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return { valid: false };
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    return { valid: false };
+  }
+
+  return { valid: true, value };
+}
+
+function hasDateValue(value: string | undefined): boolean {
+  const parsed = parseDateOnly(value);
+  return parsed.valid && parsed.value !== undefined;
+}
+
+function dateOnlyToUtcStart(value: string): string {
+  return new Date(`${value}T00:00:00.000Z`).toISOString();
+}
+
+function dateOnlyToExclusiveUtcEnd(value: string): string {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString();
+}
 
 export function buildFilterContext(
   state: FilterState,
@@ -115,7 +156,19 @@ export function buildFilterContext(
     context.isFavorite = state.isFavorite;
   }
 
-  if (state.selectedYear && includes('selectedYear')) {
+  const parsedDateAfter = includes('dateAfter') ? parseDateOnly(state.dateAfter) : { valid: true as const };
+  const parsedDateBefore = includes('dateBefore') ? parseDateOnly(state.dateBefore) : { valid: true as const };
+  const validDateAfter = parsedDateAfter.valid ? parsedDateAfter.value : undefined;
+  const validDateBefore = parsedDateBefore.valid ? parsedDateBefore.value : undefined;
+
+  if (validDateAfter || validDateBefore) {
+    if (validDateAfter) {
+      context.takenAfter = dateOnlyToUtcStart(validDateAfter);
+    }
+    if (validDateBefore) {
+      context.takenBefore = dateOnlyToExclusiveUtcEnd(validDateBefore);
+    }
+  } else if (state.selectedYear && includes('selectedYear')) {
     if (state.selectedMonth && includes('selectedMonth')) {
       context.takenAfter = new Date(Date.UTC(state.selectedYear, state.selectedMonth - 1, 1)).toISOString();
       context.takenBefore = new Date(Date.UTC(state.selectedYear, state.selectedMonth, 1)).toISOString();
@@ -140,6 +193,8 @@ export function clearFilters(state: FilterState): FilterState {
     rating: undefined,
     mediaType: 'all',
     isFavorite: undefined,
+    dateAfter: undefined,
+    dateBefore: undefined,
     selectedYear: undefined,
     selectedMonth: undefined,
     // sortOrder is NOT cleared — it's a view preference

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -97,38 +97,42 @@ export type FilterContext = {
   isFavorite?: boolean;
 };
 
-function parseDateOnly(value: string | undefined): { valid: true; value?: string } | { valid: false } {
-  if (!value) {
-    return { valid: true };
+function hasDateValue(value: string | undefined): value is string {
+  return value !== undefined && value !== '';
+}
+
+function parseDateOnly(value: string | undefined): Date | undefined {
+  if (!hasDateValue(value)) {
+    return undefined;
   }
 
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
   if (!match) {
-    return { valid: false };
+    return undefined;
   }
 
   const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);
   const date = new Date(Date.UTC(year, month - 1, day));
+
   if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
-    return { valid: false };
+    return undefined;
   }
 
-  return { valid: true, value };
+  return date;
 }
 
-function hasDateValue(value: string | undefined): boolean {
-  const parsed = parseDateOnly(value);
-  return parsed.valid && parsed.value !== undefined;
+function dateOnlyToUtcStart(value: string | undefined): string | undefined {
+  return parseDateOnly(value)?.toISOString();
 }
 
-function dateOnlyToUtcStart(value: string): string {
-  return new Date(`${value}T00:00:00.000Z`).toISOString();
-}
+function dateOnlyToExclusiveUtcEnd(value: string | undefined): string | undefined {
+  const date = parseDateOnly(value);
+  if (!date) {
+    return undefined;
+  }
 
-function dateOnlyToExclusiveUtcEnd(value: string): string {
-  const date = new Date(`${value}T00:00:00.000Z`);
   date.setUTCDate(date.getUTCDate() + 1);
   return date.toISOString();
 }
@@ -156,17 +160,15 @@ export function buildFilterContext(
     context.isFavorite = state.isFavorite;
   }
 
-  const parsedDateAfter = includes('dateAfter') ? parseDateOnly(state.dateAfter) : { valid: true as const };
-  const parsedDateBefore = includes('dateBefore') ? parseDateOnly(state.dateBefore) : { valid: true as const };
-  const validDateAfter = parsedDateAfter.valid ? parsedDateAfter.value : undefined;
-  const validDateBefore = parsedDateBefore.valid ? parsedDateBefore.value : undefined;
+  const validDateAfter = includes('dateAfter') ? dateOnlyToUtcStart(state.dateAfter) : undefined;
+  const validDateBefore = includes('dateBefore') ? dateOnlyToExclusiveUtcEnd(state.dateBefore) : undefined;
 
   if (validDateAfter || validDateBefore) {
     if (validDateAfter) {
-      context.takenAfter = dateOnlyToUtcStart(validDateAfter);
+      context.takenAfter = validDateAfter;
     }
     if (validDateBefore) {
-      context.takenBefore = dateOnlyToExclusiveUtcEnd(validDateBefore);
+      context.takenBefore = validDateBefore;
     }
   } else if (state.selectedYear && includes('selectedYear')) {
     if (state.selectedMonth && includes('selectedMonth')) {

--- a/web/src/lib/components/filter-panel/temporal-picker.svelte
+++ b/web/src/lib/components/filter-panel/temporal-picker.svelte
@@ -2,6 +2,7 @@
   import { aggregateYears, getMonthsForYear } from './temporal-utils';
 
   const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const CUSTOM_RANGE_ERROR_ID = 'custom-date-range-error';
 
   interface Props {
     timeBuckets: Array<{ timeBucket: string; count: number }>;
@@ -30,13 +31,12 @@
   let fromValue = $state('');
   let toValue = $state('');
   let customRangeError = $state<string | undefined>();
+  let customRangeErrorTarget = $state<'from' | 'to' | 'range' | undefined>();
 
   $effect(() => {
     fromValue = dateAfter ?? '';
-  });
-
-  $effect(() => {
     toValue = dateBefore ?? '';
+    clearCustomRangeError();
   });
 
   function parseDateOnly(value: string): { valid: true; value?: string } | { valid: false } {
@@ -59,25 +59,39 @@
     return { valid: true, value };
   }
 
+  function clearCustomRangeError() {
+    customRangeError = undefined;
+    customRangeErrorTarget = undefined;
+  }
+
+  function clearCustomRangeState() {
+    fromValue = '';
+    toValue = '';
+    clearCustomRangeError();
+  }
+
   function validateAndEmitCustomRange() {
     const parsedFrom = parseDateOnly(fromValue);
     if (!parsedFrom.valid) {
       customRangeError = 'Enter a valid From date';
+      customRangeErrorTarget = 'from';
       return;
     }
 
     const parsedTo = parseDateOnly(toValue);
     if (!parsedTo.valid) {
       customRangeError = 'Enter a valid To date';
+      customRangeErrorTarget = 'to';
       return;
     }
 
     if (parsedFrom.value && parsedTo.value && parsedFrom.value > parsedTo.value) {
       customRangeError = 'From date must be on or before To date';
+      customRangeErrorTarget = 'range';
       return;
     }
 
-    customRangeError = undefined;
+    clearCustomRangeError();
     onCustomRangeChange?.(parsedFrom.value, parsedTo.value);
   }
 
@@ -85,6 +99,7 @@
     if (count === 0) {
       return;
     }
+    clearCustomRangeState();
     onYearSelect?.(year);
   }
 
@@ -92,6 +107,7 @@
     if (count === 0) {
       return;
     }
+    clearCustomRangeState();
     if (selectedMonth === month) {
       // Toggle off: deselect month
       onMonthSelect?.(year, undefined);
@@ -101,6 +117,7 @@
   }
 
   function handleBackToAll() {
+    clearCustomRangeState();
     onYearSelect?.(undefined);
   }
 </script>
@@ -118,6 +135,10 @@
           autocomplete="off"
           placeholder="YYYY-MM-DD"
           pattern={'\\d{4}-\\d{2}-\\d{2}'}
+          aria-invalid={customRangeErrorTarget === 'from' || customRangeErrorTarget === 'range' ? 'true' : undefined}
+          aria-describedby={customRangeErrorTarget === 'from' || customRangeErrorTarget === 'range'
+            ? CUSTOM_RANGE_ERROR_ID
+            : undefined}
           class="w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
           data-testid="custom-date-from-input"
         />
@@ -132,13 +153,17 @@
           autocomplete="off"
           placeholder="YYYY-MM-DD"
           pattern={'\\d{4}-\\d{2}-\\d{2}'}
+          aria-invalid={customRangeErrorTarget === 'to' || customRangeErrorTarget === 'range' ? 'true' : undefined}
+          aria-describedby={customRangeErrorTarget === 'to' || customRangeErrorTarget === 'range'
+            ? CUSTOM_RANGE_ERROR_ID
+            : undefined}
           class="w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
           data-testid="custom-date-to-input"
         />
       </label>
     </div>
     {#if customRangeError}
-      <p class="text-xs text-red-600 dark:text-red-400">{customRangeError}</p>
+      <p id={CUSTOM_RANGE_ERROR_ID} role="alert" class="text-xs text-red-600 dark:text-red-400">{customRangeError}</p>
     {/if}
   </div>
 

--- a/web/src/lib/components/filter-panel/temporal-picker.svelte
+++ b/web/src/lib/components/filter-panel/temporal-picker.svelte
@@ -123,10 +123,10 @@
 </script>
 
 <div data-testid="temporal-picker">
-  <div class="mb-3 space-y-1.5" data-testid="custom-date-range">
-    <div class="grid grid-cols-2 gap-2">
-      <label class="space-y-1 text-xs font-medium text-gray-600 dark:text-gray-300">
-        <span>From</span>
+  <div class="mb-4 space-y-2" data-testid="custom-date-range">
+    <div class="grid grid-cols-2 gap-2.5">
+      <label class="flex flex-col gap-1.5 text-[11px] font-medium leading-none text-gray-600 dark:text-gray-300">
+        <span class="px-0.5">From</span>
         <input
           bind:value={fromValue}
           oninput={validateAndEmitCustomRange}
@@ -139,12 +139,12 @@
           aria-describedby={customRangeErrorTarget === 'from' || customRangeErrorTarget === 'range'
             ? CUSTOM_RANGE_ERROR_ID
             : undefined}
-          class="w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
+          class="h-8 w-full rounded-lg border border-gray-200 bg-white px-2.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
           data-testid="custom-date-from-input"
         />
       </label>
-      <label class="space-y-1 text-xs font-medium text-gray-600 dark:text-gray-300">
-        <span>To</span>
+      <label class="flex flex-col gap-1.5 text-[11px] font-medium leading-none text-gray-600 dark:text-gray-300">
+        <span class="px-0.5">To</span>
         <input
           bind:value={toValue}
           oninput={validateAndEmitCustomRange}
@@ -157,7 +157,7 @@
           aria-describedby={customRangeErrorTarget === 'to' || customRangeErrorTarget === 'range'
             ? CUSTOM_RANGE_ERROR_ID
             : undefined}
-          class="w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
+          class="h-8 w-full rounded-lg border border-gray-200 bg-white px-2.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
           data-testid="custom-date-to-input"
         />
       </label>

--- a/web/src/lib/components/filter-panel/temporal-picker.svelte
+++ b/web/src/lib/components/filter-panel/temporal-picker.svelte
@@ -5,16 +5,81 @@
 
   interface Props {
     timeBuckets: Array<{ timeBucket: string; count: number }>;
+    dateAfter?: string;
+    dateBefore?: string;
     selectedYear?: number;
     selectedMonth?: number;
+    onCustomRangeChange?: (dateAfter?: string, dateBefore?: string) => void;
     onYearSelect?: (year: number | undefined) => void;
     onMonthSelect?: (year: number, month: number | undefined) => void;
   }
 
-  let { timeBuckets, selectedYear, selectedMonth, onYearSelect, onMonthSelect }: Props = $props();
+  let {
+    timeBuckets,
+    dateAfter,
+    dateBefore,
+    selectedYear,
+    selectedMonth,
+    onCustomRangeChange,
+    onYearSelect,
+    onMonthSelect,
+  }: Props = $props();
 
   let years = $derived(aggregateYears(timeBuckets));
   let months = $derived(selectedYear === undefined ? [] : getMonthsForYear(timeBuckets, selectedYear));
+  let fromValue = $state('');
+  let toValue = $state('');
+  let customRangeError = $state<string | undefined>();
+
+  $effect(() => {
+    fromValue = dateAfter ?? '';
+  });
+
+  $effect(() => {
+    toValue = dateBefore ?? '';
+  });
+
+  function parseDateOnly(value: string): { valid: true; value?: string } | { valid: false } {
+    if (value === '') {
+      return { valid: true };
+    }
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) {
+      return { valid: false };
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+      return { valid: false };
+    }
+
+    return { valid: true, value };
+  }
+
+  function validateAndEmitCustomRange() {
+    const parsedFrom = parseDateOnly(fromValue);
+    if (!parsedFrom.valid) {
+      customRangeError = 'Enter a valid From date';
+      return;
+    }
+
+    const parsedTo = parseDateOnly(toValue);
+    if (!parsedTo.valid) {
+      customRangeError = 'Enter a valid To date';
+      return;
+    }
+
+    if (parsedFrom.value && parsedTo.value && parsedFrom.value > parsedTo.value) {
+      customRangeError = 'From date must be on or before To date';
+      return;
+    }
+
+    customRangeError = undefined;
+    onCustomRangeChange?.(parsedFrom.value, parsedTo.value);
+  }
 
   function handleYearClick(year: number, count: number) {
     if (count === 0) {
@@ -41,6 +106,42 @@
 </script>
 
 <div data-testid="temporal-picker">
+  <div class="mb-3 space-y-1.5" data-testid="custom-date-range">
+    <div class="grid grid-cols-2 gap-2">
+      <label class="space-y-1 text-xs font-medium text-gray-600 dark:text-gray-300">
+        <span>From</span>
+        <input
+          bind:value={fromValue}
+          oninput={validateAndEmitCustomRange}
+          type="text"
+          inputmode="numeric"
+          autocomplete="off"
+          placeholder="YYYY-MM-DD"
+          pattern={'\\d{4}-\\d{2}-\\d{2}'}
+          class="w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
+          data-testid="custom-date-from-input"
+        />
+      </label>
+      <label class="space-y-1 text-xs font-medium text-gray-600 dark:text-gray-300">
+        <span>To</span>
+        <input
+          bind:value={toValue}
+          oninput={validateAndEmitCustomRange}
+          type="text"
+          inputmode="numeric"
+          autocomplete="off"
+          placeholder="YYYY-MM-DD"
+          pattern={'\\d{4}-\\d{2}-\\d{2}'}
+          class="w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700 outline-none transition-colors placeholder:text-gray-400 focus:border-immich-primary dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:focus:border-immich-dark-primary"
+          data-testid="custom-date-to-input"
+        />
+      </label>
+    </div>
+    {#if customRangeError}
+      <p class="text-xs text-red-600 dark:text-red-400">{customRangeError}</p>
+    {/if}
+  </div>
+
   {#if selectedYear !== undefined}
     <!-- Breadcrumb -->
     <div class="mb-2 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-300">

--- a/web/src/lib/components/filter-panel/temporal-picker.svelte
+++ b/web/src/lib/components/filter-panel/temporal-picker.svelte
@@ -134,7 +134,7 @@
           inputmode="numeric"
           autocomplete="off"
           placeholder="YYYY-MM-DD"
-          pattern={'\\d{4}-\\d{2}-\\d{2}'}
+          pattern={String.raw`\d{4}-\d{2}-\d{2}`}
           aria-invalid={customRangeErrorTarget === 'from' || customRangeErrorTarget === 'range' ? 'true' : undefined}
           aria-describedby={customRangeErrorTarget === 'from' || customRangeErrorTarget === 'range'
             ? CUSTOM_RANGE_ERROR_ID
@@ -152,7 +152,7 @@
           inputmode="numeric"
           autocomplete="off"
           placeholder="YYYY-MM-DD"
-          pattern={'\\d{4}-\\d{2}-\\d{2}'}
+          pattern={String.raw`\d{4}-\d{2}-\d{2}`}
           aria-invalid={customRangeErrorTarget === 'to' || customRangeErrorTarget === 'range' ? 'true' : undefined}
           aria-describedby={customRangeErrorTarget === 'to' || customRangeErrorTarget === 'range'
             ? CUSTOM_RANGE_ERROR_ID

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -79,6 +79,22 @@ describe('SmartSearchResults', () => {
     );
   });
 
+  it('triggers re-fetch when custom date range changes', async () => {
+    const { rerender } = render(SmartSearchResults, { props: baseProps });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+    expect(searchSmartMock).toHaveBeenCalledTimes(1);
+
+    await rerender({ ...baseProps, filters: { ...baseFilters, dateAfter: '2024-01-01' } });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+    expect(searchSmartMock).toHaveBeenCalledTimes(2);
+    expect(searchSmartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        smartSearchDto: expect.objectContaining({ takenAfter: '2024-01-01T00:00:00.000Z' }),
+      }),
+    );
+  });
+
   // Test 42
   it('debounces multiple consecutive filter changes within the window into a single fetch', async () => {
     const { rerender } = render(SmartSearchResults, { props: baseProps });

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -83,6 +83,8 @@
       filters.tagIds,
       filters.rating,
       filters.mediaType,
+      filters.dateAfter,
+      filters.dateBefore,
       filters.selectedYear,
       filters.selectedMonth,
       filters.sortOrder,

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -80,6 +80,23 @@ describe('buildAlbumDetailFilterConfig', () => {
       expect.objectContaining({ albumId: 'album-1', make: 'Sony' }),
     );
   });
+
+  it('passes custom dates to album detail filter suggestions', async () => {
+    const config = buildAlbumDetailFilterConfig('album-1');
+    await config.suggestionsProvider!({
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        albumId: 'album-1',
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
 });
 
 describe('buildAlbumAssetPickerFilterConfig', () => {
@@ -101,5 +118,19 @@ describe('buildAlbumAssetPickerFilterConfig', () => {
     expect(filterRequest).not.toHaveProperty('withSharedSpaces');
     expect(cityRequest).not.toHaveProperty('albumId');
     expect(cityRequest).not.toHaveProperty('withSharedSpaces');
+  });
+
+  it('passes custom dates to album asset picker filter suggestions', async () => {
+    const config = buildAlbumAssetPickerFilterConfig();
+    await config.suggestionsProvider!({
+      ...createFilterState(),
+      dateBefore: '2024-12-31',
+    });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
   });
 });

--- a/web/src/lib/utils/__tests__/album-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-options.spec.ts
@@ -35,6 +35,17 @@ describe('buildAlbumTimelineOptions', () => {
       takenBefore: '2024-03-01T00:00:00.000Z',
     });
   });
+
+  it('maps custom dates for album timeline options', () => {
+    const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+
+    expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, filters)).toEqual(
+      expect.objectContaining({
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
 });
 
 describe('buildAlbumAssetPickerOptions', () => {
@@ -57,5 +68,13 @@ describe('buildAlbumAssetPickerOptions', () => {
       takenAfter: '2023-01-01T00:00:00.000Z',
       takenBefore: '2024-01-01T00:00:00.000Z',
     });
+  });
+
+  it('maps custom dates for album asset picker options', () => {
+    const filters = { ...createFilterState(), dateAfter: '2024-01-01' };
+
+    expect(buildAlbumAssetPickerOptions('album-1', filters)).toEqual(
+      expect.objectContaining({ takenAfter: '2024-01-01T00:00:00.000Z' }),
+    );
   });
 });

--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -1,6 +1,19 @@
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
-import { buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
+import { buildMapMarkerOptions, buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
 import { AssetTypeEnum, AssetVisibility } from '@immich/sdk';
+
+describe('buildMapMarkerOptions', () => {
+  it('includes custom dates in map marker options', () => {
+    const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+
+    expect(buildMapMarkerOptions(filters)).toEqual(
+      expect.objectContaining({
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+});
 
 describe('buildMapTimeBucketOptions', () => {
   it('includes active global map filters in time bucket requests', () => {
@@ -44,5 +57,13 @@ describe('buildMapTimeBucketOptions', () => {
       country: 'Australia',
       $type: AssetTypeEnum.Image,
     });
+  });
+
+  it('includes custom dates in map time bucket options', () => {
+    const filters = { ...createFilterState(), dateBefore: '2024-12-31' };
+
+    expect(buildMapTimeBucketOptions(filters)).toEqual(
+      expect.objectContaining({ takenBefore: '2025-01-01T00:00:00.000Z' }),
+    );
   });
 });

--- a/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
@@ -91,6 +91,27 @@ describe('buildPhotosTimelineOptions', () => {
     expect(options.takenBefore).toBe('2023-09-01T00:00:00.000Z');
   });
 
+  it('should set bounded custom date range using UTC from buildFilterContext', () => {
+    const filters = { ...createFilterState(), dateAfter: '2024-01-01', dateBefore: '2024-12-31' };
+    const options = buildPhotosTimelineOptions(filters);
+    expect(options.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(options.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  it('should set from-only custom date range using UTC from buildFilterContext', () => {
+    const filters = { ...createFilterState(), dateAfter: '2024-01-01' };
+    const options = buildPhotosTimelineOptions(filters);
+    expect(options.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(options).not.toHaveProperty('takenBefore');
+  });
+
+  it('should set to-only custom date range using UTC from buildFilterContext', () => {
+    const filters = { ...createFilterState(), dateBefore: '2024-12-31' };
+    const options = buildPhotosTimelineOptions(filters);
+    expect(options).not.toHaveProperty('takenAfter');
+    expect(options.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+  });
+
   it('should preserve withPartners and withSharedSpaces when filters are active', () => {
     const filters = { ...createFilterState(), country: 'Japan', rating: 5 };
     const options = buildPhotosTimelineOptions(filters);
@@ -206,8 +227,16 @@ describe('handlePhotosRemoveFilter', () => {
   });
 
   it('should clear timeline (both year and month)', () => {
-    const filters = { ...createFilterState(), selectedYear: 2023, selectedMonth: 8 };
+    const filters = {
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+      selectedYear: 2023,
+      selectedMonth: 8,
+    };
     const result = handlePhotosRemoveFilter(filters, 'timeline');
+    expect(result.dateAfter).toBeUndefined();
+    expect(result.dateBefore).toBeUndefined();
     expect(result.selectedYear).toBeUndefined();
     expect(result.selectedMonth).toBeUndefined();
   });

--- a/web/src/lib/utils/__tests__/space-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/space-filter-options.spec.ts
@@ -1,0 +1,90 @@
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildSpaceTimelineOptions, handleSpaceRemoveFilter } from '$lib/utils/space-filter-options';
+import { AssetOrder, AssetTypeEnum } from '@immich/sdk';
+import { describe, expect, it } from 'vitest';
+
+describe('buildSpaceTimelineOptions', () => {
+  it('maps custom dates and people for spaces timeline options', () => {
+    const filters = {
+      ...createFilterState(),
+      personIds: ['space-person-1'],
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        spaceId: 'space-1',
+        withStacked: true,
+        spacePersonIds: ['space-person-1'],
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('prefers custom dates over selected year and month', () => {
+    const filters = {
+      ...createFilterState(),
+      selectedYear: 2023,
+      selectedMonth: 8,
+      dateBefore: '2024-12-31',
+    };
+
+    const result = buildSpaceTimelineOptions('space-1', filters);
+    expect(result.takenAfter).toBeUndefined();
+    expect(result.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  it('maps media type and sort order for spaces timeline options', () => {
+    const filters = { ...createFilterState(), mediaType: 'video' as const, sortOrder: 'asc' as const };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        $type: AssetTypeEnum.Video,
+        order: AssetOrder.Asc,
+      }),
+    );
+  });
+
+  it('preserves location, camera, rating, and tags in spaces timeline options', () => {
+    const filters = {
+      ...createFilterState(),
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Sony',
+      model: 'A7C',
+      rating: 4,
+      tagIds: ['tag-1'],
+    };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        city: 'Berlin',
+        country: 'Germany',
+        make: 'Sony',
+        model: 'A7C',
+        rating: 4,
+        tagIds: ['tag-1'],
+      }),
+    );
+  });
+});
+
+describe('handleSpaceRemoveFilter', () => {
+  it('clears both temporal modes when removing timeline filter', () => {
+    const filters = {
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+      selectedYear: 2023,
+      selectedMonth: 8,
+    };
+
+    const result = handleSpaceRemoveFilter(filters, 'timeline');
+    expect(result.dateAfter).toBeUndefined();
+    expect(result.dateBefore).toBeUndefined();
+    expect(result.selectedYear).toBeUndefined();
+    expect(result.selectedMonth).toBeUndefined();
+  });
+});

--- a/web/src/lib/utils/__tests__/space-search.spec.ts
+++ b/web/src/lib/utils/__tests__/space-search.spec.ts
@@ -132,8 +132,8 @@ describe('buildSmartSearchParams', () => {
         query: 'beach',
         filters: { ...baseFilters, selectedYear: 2024, selectedMonth: 1 },
       });
-      expect(result.takenAfter).toBe(new Date(2024, 0, 1).toISOString());
-      expect(result.takenBefore).toBe(new Date(2024, 1, 0, 23, 59, 59, 999).toISOString());
+      expect(result.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+      expect(result.takenBefore).toBe('2024-02-01T00:00:00.000Z');
     });
 
     it('builds takenAfter/takenBefore for selectedYear only', () => {
@@ -141,8 +141,28 @@ describe('buildSmartSearchParams', () => {
         query: 'beach',
         filters: { ...baseFilters, selectedYear: 2024 },
       });
-      expect(result.takenAfter).toBe(new Date(2024, 0, 1).toISOString());
-      expect(result.takenBefore).toBe(new Date(2024, 11, 31, 23, 59, 59, 999).toISOString());
+      expect(result.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+      expect(result.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('builds takenAfter/takenBefore from custom dates', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: { ...baseFilters, dateAfter: '2024-01-01', dateBefore: '2024-12-31' },
+      });
+
+      expect(result.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+      expect(result.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('prefers custom dates over selected year and month', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: { ...baseFilters, selectedYear: 2023, selectedMonth: 8, dateAfter: '2024-01-01' },
+      });
+
+      expect(result.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+      expect(result.takenBefore).toBeUndefined();
     });
   });
 

--- a/web/src/lib/utils/photos-filter-options.ts
+++ b/web/src/lib/utils/photos-filter-options.ts
@@ -38,8 +38,12 @@ export function buildPhotosTimelineOptions(filters: FilterState): Record<string,
 
   const context = buildFilterContext(filters);
   if (context) {
-    base.takenAfter = context.takenAfter;
-    base.takenBefore = context.takenBefore;
+    if (context.takenAfter) {
+      base.takenAfter = context.takenAfter;
+    }
+    if (context.takenBefore) {
+      base.takenBefore = context.takenBefore;
+    }
   }
 
   return base;
@@ -67,7 +71,13 @@ export function handlePhotosRemoveFilter(filters: FilterState, type: string, id?
       return { ...filters, mediaType: 'all' };
     }
     case 'timeline': {
-      return { ...filters, selectedYear: undefined, selectedMonth: undefined };
+      return {
+        ...filters,
+        dateAfter: undefined,
+        dateBefore: undefined,
+        selectedYear: undefined,
+        selectedMonth: undefined,
+      };
     }
     default: {
       return filters;

--- a/web/src/lib/utils/space-filter-options.ts
+++ b/web/src/lib/utils/space-filter-options.ts
@@ -1,0 +1,78 @@
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { AssetOrder, AssetTypeEnum } from '@immich/sdk';
+
+export function buildSpaceTimelineOptions(spaceId: string, filters: FilterState): Record<string, unknown> {
+  const base: Record<string, unknown> = { spaceId, withStacked: true };
+
+  if (filters.personIds.length > 0) {
+    base.spacePersonIds = filters.personIds;
+  }
+  if (filters.city) {
+    base.city = filters.city;
+  }
+  if (filters.country) {
+    base.country = filters.country;
+  }
+  if (filters.make) {
+    base.make = filters.make;
+  }
+  if (filters.model) {
+    base.model = filters.model;
+  }
+  if (filters.tagIds.length > 0) {
+    base.tagIds = filters.tagIds;
+  }
+  if (filters.rating !== undefined) {
+    base.rating = filters.rating;
+  }
+  if (filters.mediaType !== 'all') {
+    base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
+  }
+  base.order = filters.sortOrder === 'asc' ? AssetOrder.Asc : AssetOrder.Desc;
+
+  const context = buildFilterContext(filters);
+  if (context?.takenAfter) {
+    base.takenAfter = context.takenAfter;
+  }
+  if (context?.takenBefore) {
+    base.takenBefore = context.takenBefore;
+  }
+
+  return base;
+}
+
+export function handleSpaceRemoveFilter(filters: FilterState, type: string, id?: string): FilterState {
+  switch (type) {
+    case 'person': {
+      return { ...filters, personIds: filters.personIds.filter((p) => p !== id) };
+    }
+    case 'location': {
+      return { ...filters, city: undefined, country: undefined };
+    }
+    case 'camera': {
+      return { ...filters, make: undefined, model: undefined };
+    }
+    case 'tag': {
+      return { ...filters, tagIds: filters.tagIds.filter((t) => t !== id) };
+    }
+    case 'rating': {
+      return { ...filters, rating: undefined };
+    }
+    case 'media':
+    case 'mediaType': {
+      return { ...filters, mediaType: 'all' };
+    }
+    case 'timeline': {
+      return {
+        ...filters,
+        dateAfter: undefined,
+        dateBefore: undefined,
+        selectedYear: undefined,
+        selectedMonth: undefined,
+      };
+    }
+    default: {
+      return filters;
+    }
+  }
+}

--- a/web/src/lib/utils/space-search.ts
+++ b/web/src/lib/utils/space-search.ts
@@ -1,4 +1,4 @@
-import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import { AssetOrder, AssetTypeEnum, type SmartSearchDto } from '@immich/sdk';
 
 export const SEARCH_FILTER_DEBOUNCE_MS = 250;
@@ -47,14 +47,12 @@ export function buildSmartSearchParams(args: {
   if (filters.mediaType !== 'all') {
     params.type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
-  if (filters.selectedYear && filters.selectedMonth) {
-    const start = new Date(filters.selectedYear, filters.selectedMonth - 1, 1);
-    const end = new Date(filters.selectedYear, filters.selectedMonth, 0, 23, 59, 59, 999);
-    params.takenAfter = start.toISOString();
-    params.takenBefore = end.toISOString();
-  } else if (filters.selectedYear) {
-    params.takenAfter = new Date(filters.selectedYear, 0, 1).toISOString();
-    params.takenBefore = new Date(filters.selectedYear, 11, 31, 23, 59, 59, 999).toISOString();
+  const context = buildFilterContext(filters);
+  if (context?.takenAfter) {
+    params.takenAfter = context.takenAfter;
+  }
+  if (context?.takenBefore) {
+    params.takenBefore = context.takenBefore;
   }
 
   if (filters.sortOrder === 'asc') {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -48,10 +48,10 @@
   import { handleError } from '$lib/utils/handle-error';
   import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
   import { loadHeroCollapsed, persistHeroCollapsed } from '$lib/utils/space-hero-storage';
+  import { buildSpaceTimelineOptions, handleSpaceRemoveFilter } from '$lib/utils/space-filter-options';
   import {
     addAssets,
     bulkAddAssets,
-    AssetOrder,
     AssetTypeEnum,
     AssetVisibility,
     getFilterSuggestions,
@@ -239,37 +239,7 @@
   };
 
   function handleRemoveFilter(type: string, id?: string) {
-    switch (type) {
-      case 'person': {
-        filters = { ...filters, personIds: filters.personIds.filter((p) => p !== id) };
-        break;
-      }
-      case 'location': {
-        filters = { ...filters, city: undefined, country: undefined };
-        break;
-      }
-      case 'camera': {
-        filters = { ...filters, make: undefined, model: undefined };
-        break;
-      }
-      case 'tag': {
-        filters = { ...filters, tagIds: filters.tagIds.filter((t) => t !== id) };
-        break;
-      }
-      case 'rating': {
-        filters = { ...filters, rating: undefined };
-        break;
-      }
-      case 'media':
-      case 'mediaType': {
-        filters = { ...filters, mediaType: 'all' };
-        break;
-      }
-      case 'timeline': {
-        filters = { ...filters, selectedYear: undefined, selectedMonth: undefined };
-        break;
-      }
-    }
+    filters = handleSpaceRemoveFilter(filters, type, id);
   }
 
   const currentMember = $derived(members.find((m) => m.userId === authManager.user.id));
@@ -288,46 +258,7 @@
     if (viewMode === 'select-assets') {
       return { visibility: AssetVisibility.Timeline, timelineSpaceId: space.id };
     }
-    const base: Record<string, unknown> = { spaceId: space.id, withStacked: true };
-    // Apply filter state — personIds maps to spacePersonIds for Spaces context
-    if (filters.personIds.length > 0) {
-      base.spacePersonIds = filters.personIds;
-    }
-    if (filters.city) {
-      base.city = filters.city;
-    }
-    if (filters.country) {
-      base.country = filters.country;
-    }
-    if (filters.make) {
-      base.make = filters.make;
-    }
-    if (filters.model) {
-      base.model = filters.model;
-    }
-    if (filters.tagIds.length > 0) {
-      base.tagIds = filters.tagIds;
-    }
-    if (filters.rating !== undefined) {
-      base.rating = filters.rating;
-    }
-    if (filters.mediaType !== 'all') {
-      base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
-    }
-    base.order = filters.sortOrder === 'asc' ? AssetOrder.Asc : AssetOrder.Desc;
-
-    // Temporal date-range filtering
-    if (filters.selectedYear && filters.selectedMonth) {
-      const start = new Date(filters.selectedYear, filters.selectedMonth - 1, 1);
-      const end = new Date(filters.selectedYear, filters.selectedMonth, 0, 23, 59, 59, 999);
-      base.takenAfter = start.toISOString();
-      base.takenBefore = end.toISOString();
-    } else if (filters.selectedYear) {
-      base.takenAfter = new Date(filters.selectedYear, 0, 1).toISOString();
-      base.takenBefore = new Date(filters.selectedYear, 11, 31, 23, 59, 59, 999).toISOString();
-    }
-
-    return base;
+    return buildSpaceTimelineOptions(space.id, filters);
   });
 
   const isSelectionMode = $derived(viewMode === 'select-assets' || viewMode === 'select-cover');


### PR DESCRIPTION
## Summary
- add validated From/To date range controls to the web filter panel timeline section
- wire custom dates through contextual suggestions, chips, and photos/albums/spaces/map/smart-search helpers
- keep rating/media filters stable while date context narrows people/location/camera/tag suggestions

Fixes #434

## Local verification
- pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/components/search/smart-search-results.spec.ts
- pnpm --dir web run check:typescript
- pnpm --dir web run check:svelte