### PR TITLE
fix(web): include shared spaces in map cluster timeline

### DIFF
--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -1,8 +1,8 @@
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import {
   buildMapMarkerOptions,
-  buildMapTimelineOptions,
   buildMapTimeBucketOptions,
+  buildMapTimelineOptions,
 } from '$lib/utils/map-filter-options';
 import { AssetTypeEnum, AssetVisibility } from '@immich/sdk';
 

--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -1,5 +1,9 @@
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
-import { buildMapMarkerOptions, buildMapTimeBucketOptions } from '$lib/utils/map-filter-options';
+import {
+  buildMapMarkerOptions,
+  buildMapTimelineOptions,
+  buildMapTimeBucketOptions,
+} from '$lib/utils/map-filter-options';
 import { AssetTypeEnum, AssetVisibility } from '@immich/sdk';
 
 describe('buildMapMarkerOptions', () => {
@@ -65,5 +69,48 @@ describe('buildMapTimeBucketOptions', () => {
     expect(buildMapTimeBucketOptions(filters)).toEqual(
       expect.objectContaining({ takenBefore: '2025-01-01T00:00:00.000Z' }),
     );
+  });
+});
+
+describe('buildMapTimelineOptions', () => {
+  it('includes shared spaces for global map cluster timelines', () => {
+    const filters = {
+      ...createFilterState(),
+      personIds: ['person-1'],
+      tagIds: ['tag-1'],
+      rating: 4,
+      mediaType: 'image' as const,
+      selectedYear: 2024,
+      selectedMonth: 7,
+    };
+    const selectedClusterIds = new Set(['asset-1', 'asset-2']);
+
+    expect(buildMapTimelineOptions(filters, '1,2,3,4', selectedClusterIds)).toEqual({
+      bbox: '1,2,3,4',
+      visibility: AssetVisibility.Timeline,
+      withSharedSpaces: true,
+      assetFilter: selectedClusterIds,
+      personIds: ['person-1'],
+      tagIds: ['tag-1'],
+      rating: 4,
+      $type: AssetTypeEnum.Image,
+      takenAfter: '2024-07-01T00:00:00.000Z',
+      takenBefore: '2024-08-01T00:00:00.000Z',
+    });
+  });
+
+  it('uses space-scoped person filters for space map cluster timelines', () => {
+    const filters = {
+      ...createFilterState(),
+      personIds: ['space-person-1'],
+    };
+    const selectedClusterIds = new Set(['asset-1']);
+
+    expect(buildMapTimelineOptions(filters, '1,2,3,4', selectedClusterIds, 'space-1')).toEqual({
+      bbox: '1,2,3,4',
+      spaceId: 'space-1',
+      assetFilter: selectedClusterIds,
+      spacePersonIds: ['space-person-1'],
+    });
   });
 });

--- a/web/src/lib/utils/map-filter-options.ts
+++ b/web/src/lib/utils/map-filter-options.ts
@@ -1,8 +1,13 @@
 import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import { AssetTypeEnum, AssetVisibility, MapMediaType } from '@immich/sdk';
 
-function applyCommonMapFilters(base: Record<string, unknown>, filters: FilterState) {
-  if (filters.personIds.length > 0) {
+type MapTimelineSettings = {
+  onlyFavorites?: boolean;
+  withPartners?: boolean;
+};
+
+function applyCommonMapFilters(base: Record<string, unknown>, filters: FilterState, includePersonIds = true) {
+  if (includePersonIds && filters.personIds.length > 0) {
     base.personIds = filters.personIds;
   }
   if (filters.make) {
@@ -55,6 +60,48 @@ export function buildMapTimeBucketOptions(filters: FilterState, spaceId?: string
   );
 
   if (filters.mediaType !== 'all') {
+    base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
+  }
+
+  return base;
+}
+
+export function buildMapTimelineOptions(
+  filters: FilterState | undefined,
+  bbox: string,
+  selectedClusterIds: Set<string>,
+  spaceId?: string,
+  settings: MapTimelineSettings = {},
+): Record<string, unknown> {
+  const base = applyCommonMapFilters(
+    {
+      bbox,
+      ...(spaceId ? { spaceId } : { visibility: AssetVisibility.Timeline, withSharedSpaces: true }),
+      assetFilter: selectedClusterIds,
+    },
+    filters ?? {
+      personIds: [],
+      tagIds: [],
+      mediaType: 'all',
+      sortOrder: 'desc',
+    },
+    false,
+  );
+
+  if (filters?.personIds && filters.personIds.length > 0) {
+    if (spaceId) {
+      base.spacePersonIds = filters.personIds;
+    } else {
+      base.personIds = filters.personIds;
+    }
+  }
+
+  if (!spaceId) {
+    base.isFavorite = filters?.isFavorite ?? (settings.onlyFavorites || undefined);
+    base.withPartners = settings.withPartners || undefined;
+  }
+
+  if (filters?.mediaType && filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
 

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/MapTimelinePanel.svelte
@@ -23,7 +23,6 @@
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import type { FilterState } from '$lib/components/filter-panel/filter-panel';
-  import { buildFilterContext } from '$lib/components/filter-panel/filter-panel';
   import { mapSettings } from '$lib/stores/preferences.store';
   import {
     updateStackedAssetInTimeline,
@@ -31,7 +30,7 @@
     type OnLink,
     type OnUnlink,
   } from '$lib/utils/actions';
-  import { AssetTypeEnum, AssetVisibility } from '@immich/sdk';
+  import { buildMapTimelineOptions } from '$lib/utils/map-filter-options';
   import { ActionButton, CloseButton, CommandPaletteDefaultProvider, Icon } from '@immich/ui';
   import { mdiDotsVertical, mdiImageMultiple } from '@mdi/js';
   import { ceil, floor } from 'lodash-es';
@@ -85,30 +84,10 @@
   );
 
   const timelineOptions = $derived.by(() => {
-    const context = filters ? buildFilterContext(filters) : undefined;
-    return {
-      bbox: timelineBoundingBox,
-      visibility: spaceId ? undefined : AssetVisibility.Timeline,
-      isFavorite: filters?.isFavorite ?? (spaceId ? undefined : $mapSettings.onlyFavorites || undefined),
-      withPartners: spaceId ? undefined : $mapSettings.withPartners || undefined,
-      spaceId,
-      assetFilter: selectedClusterIds,
-      ...(filters?.personIds &&
-        filters.personIds.length > 0 && {
-          personIds: spaceId ? undefined : filters.personIds,
-          spacePersonIds: spaceId ? filters.personIds : undefined,
-        }),
-      ...(filters?.make && { make: filters.make }),
-      ...(filters?.model && { model: filters.model }),
-      ...(filters?.tagIds && filters.tagIds.length > 0 && { tagIds: filters.tagIds }),
-      ...(filters?.rating !== undefined && { rating: filters.rating }),
-      ...(filters?.mediaType &&
-        filters.mediaType !== 'all' && {
-          $type: filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video,
-        }),
-      ...(context?.takenAfter && { takenAfter: context.takenAfter }),
-      ...(context?.takenBefore && { takenBefore: context.takenBefore }),
-    };
+    return buildMapTimelineOptions(filters, timelineBoundingBox, selectedClusterIds, spaceId, {
+      onlyFavorites: $mapSettings.onlyFavorites,
+      withPartners: $mapSettings.withPartners,
+    });
   });
 
   $effect.pre(() => {


### PR DESCRIPTION
## Summary
- include shared-space assets when the global map cluster timeline builds its timeline query
- centralize cluster timeline option construction alongside map marker/time-bucket options
- add regression coverage for global shared-space and space-scoped person-filter timeline options

Fixes #390

## Test Plan
- [x] pnpm --filter immich-web exec vitest run src/lib/utils/__tests__/map-filter-options.spec.ts src/routes/\(user\)/map/\[\[photos=photos\]\]/\[\[assetId=id\]\]/map-page.spec.ts
- [x] pnpm --filter immich-web run check:svelte
- [x] pnpm --filter immich-web run check:typescript