### PR TITLE
ci: retry sqlite native asset download flake

### DIFF
--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -188,9 +188,39 @@ jobs:
           VERSION_NAME: ${{ steps.build-meta.outputs.version_name }}
           VERSION_CODE: ${{ steps.build-meta.outputs.version_code }}
         run: |
-          flutter build appbundle --release \
-            --build-name="$VERSION_NAME" \
-            --build-number="$VERSION_CODE"
+          build_appbundle() {
+            flutter build appbundle --release \
+              --build-name="$VERSION_NAME" \
+              --build-number="$VERSION_CODE"
+          }
+
+          attempt=1
+          max_attempts=3
+
+          while true; do
+            log_file="$(mktemp)"
+
+            set +e
+            build_appbundle 2>&1 | tee "$log_file"
+            status=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              rm -f "$log_file"
+              break
+            fi
+
+            if ! grep -q "Hash of downloaded file libsqlite3" "$log_file" || [ "$attempt" -ge "$max_attempts" ]; then
+              rm -f "$log_file"
+              exit "$status"
+            fi
+
+            rm -f "$log_file"
+            echo "::warning::sqlite3 native asset download failed hash verification; retrying app bundle build ($attempt/$max_attempts)."
+            rm -rf .dart_tool/hooks_runner/shared/sqlite3 .dart_tool/hooks_runner/sqlite3 .dart_tool/flutter_build
+            sleep $((attempt * 15))
+            attempt=$((attempt + 1))
+          done
 
       - name: Publish Android App Bundle artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
## Summary
- Retry the Android app bundle build when the sqlite3 native asset hook fails with the known hash-verification download error.
- Clear sqlite3 native-asset hook build state before retrying so the next attempt refetches cleanly.
- Leave non-sqlite build failures unchanged so real release failures still fail immediately.

## Test Plan
- sed -n '191,227p' .github/workflows/gallery-build-mobile.yml | sed 's/^          //' | bash -n
- git diff --check
- cd mobile && mise exec -- flutter pub get && mise exec -- flutter build apk --debug
- unzip -l mobile/build/app/outputs/flutter-apk/app-debug.apk | rg 'libsqlite3\.so'