### PR TITLE
fix(docs): add explicit robots.txt to allow full crawl access

### DIFF
--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://docs.opennoodle.de/sitemap.xml


### PR DESCRIPTION
## Summary
- Adds `docs/static/robots.txt` with `Disallow:` (empty) and a sitemap pointer
- Fixes Google Search Console complaint about robots.txt blocking indexing
- Matches the same fix applied to the marketing site (opennoodle.de)