### PR TITLE
fix(server): restore favorite-first people filter suggestions

### DIFF
--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -36,6 +36,13 @@ const compileFilteredAssetIds = (sut: SearchRepository, options: Record<string, 
 const compileExifField = (sut: SearchRepository, field: 'country' | 'model', options: Record<string, unknown>) =>
   (sut as any).getExifField(field, ['00000000-0000-0000-0000-000000000000'], options).compile().sql;
 
+const compileFilteredPeopleQuery = (sut: SearchRepository, options: Record<string, unknown>) =>
+  (sut as any)
+    .buildFilteredGlobalPeopleQuery(
+      (sut as any).buildFilteredAssetIds(['00000000-0000-0000-0000-000000000000'], options),
+    )
+    .compile().sql;
+
 const FAILURE_MESSAGE =
   'Do not add any secondary ORDER BY key to the inner searchSmart query. ' +
   'See comment at src/repositories/search.repository.ts (above the orderBy call). ' +
@@ -231,6 +238,12 @@ describe(SearchRepository.name, () => {
 
       expect(sql).toMatch(/"asset_exif"\."rating"\s*>=\s*\$\d+/i);
       expect(sql).not.toMatch(/"asset_exif"\."rating"\s*=\s*\$\d+/i);
+    });
+
+    it('orders global people suggestions by favorite first, then name', () => {
+      const sql = compileFilteredPeopleQuery(sut, {});
+
+      expect(sql).toMatch(/order by\s+"person"\."isFavorite"\s+desc,\s*"person"\."name"/i);
     });
   });
 

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -43,6 +43,14 @@ const compileFilteredPeopleQuery = (sut: SearchRepository, options: Record<strin
     )
     .compile().sql;
 
+const compileFilteredSpacePeopleQuery = (sut: SearchRepository, options: Record<string, unknown>) =>
+  (sut as any)
+    .buildFilteredSpacePeopleQuery(
+      (sut as any).buildFilteredAssetIds(['00000000-0000-0000-0000-000000000000'], options),
+      '11111111-1111-1111-1111-111111111111',
+    )
+    .compile().sql;
+
 const FAILURE_MESSAGE =
   'Do not add any secondary ORDER BY key to the inner searchSmart query. ' +
   'See comment at src/repositories/search.repository.ts (above the orderBy call). ' +
@@ -244,6 +252,16 @@ describe(SearchRepository.name, () => {
       const sql = compileFilteredPeopleQuery(sut, {});
 
       expect(sql).toMatch(/order by\s+"person"\."isFavorite"\s+desc,\s*"person"\."name"/i);
+    });
+
+    it('orders space people suggestions by favorite first, then display name', () => {
+      const sql = compileFilteredSpacePeopleQuery(sut, {
+        spaceId: '11111111-1111-1111-1111-111111111111',
+      });
+
+      expect(sql).toMatch(/order by\s+coalesce\("person"\."isFavorite", false\)\s+desc/i);
+      expect(sql).toMatch(/nullif\("shared_space_person"\."name", ''\)/i);
+      expect(sql).toMatch(/nullif\("person"\."name", ''\)/i);
     });
   });
 

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -897,25 +897,7 @@ export class SearchRepository {
 
     // When spaceId is set, return shared_space_person records (space-specific IDs and names)
     if (options.spaceId) {
-      const spacePeople = await this.db
-        .selectFrom('shared_space_person')
-        .leftJoin('asset_face', 'asset_face.id', 'shared_space_person.representativeFaceId')
-        .leftJoin('person', 'person.id', 'asset_face.personId')
-        .select(['shared_space_person.id', 'shared_space_person.name'])
-        .select('person.name as personalName')
-        .where('shared_space_person.spaceId', '=', asUuid(options.spaceId))
-        .where('shared_space_person.isHidden', '=', false)
-        .where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('shared_space_person_face')
-              .innerJoin('asset_face as af', 'af.id', 'shared_space_person_face.assetFaceId')
-              .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id')
-              .where('af.assetId', 'in', filteredIds),
-          ),
-        )
-        .orderBy('shared_space_person.name')
-        .execute();
+      const spacePeople = await this.buildFilteredSpacePeopleQuery(filteredIds, options.spaceId).execute();
 
       // Use space person name, fallback to global person name
       const people = spacePeople
@@ -923,8 +905,7 @@ export class SearchRepository {
           id: p.id,
           name: p.name || (p as any).personalName || '',
         }))
-        .filter((p) => p.name !== '')
-        .toSorted((a, b) => a.name.localeCompare(b.name));
+        .filter((p) => p.name !== '');
 
       const hasUnnamedPeople = spacePeople.some((p) => !p.name && !(p as any).personalName);
 
@@ -932,21 +913,7 @@ export class SearchRepository {
     }
 
     // Global: return person records
-    const people = await this.db
-      .selectFrom('person')
-      .select(['person.id', 'person.name'])
-      .where('person.name', '!=', '')
-      .where('person.isHidden', '=', false)
-      .where((eb) =>
-        eb.exists(
-          eb
-            .selectFrom('asset_face')
-            .whereRef('asset_face.personId', '=', 'person.id')
-            .where('asset_face.assetId', 'in', filteredIds),
-        ),
-      )
-      .orderBy('person.name')
-      .execute();
+    const people = await this.buildFilteredGlobalPeopleQuery(filteredIds).execute();
 
     const unnamed = await this.db
       .selectFrom('person')
@@ -964,6 +931,46 @@ export class SearchRepository {
       .executeTakeFirst();
 
     return { people, hasUnnamedPeople: !!unnamed };
+  }
+
+  private buildFilteredSpacePeopleQuery(filteredIds: SelectQueryBuilder<DB, 'asset', { id: string }>, spaceId: string) {
+    return this.db
+      .selectFrom('shared_space_person')
+      .leftJoin('asset_face', 'asset_face.id', 'shared_space_person.representativeFaceId')
+      .leftJoin('person', 'person.id', 'asset_face.personId')
+      .select(['shared_space_person.id', 'shared_space_person.name'])
+      .select(['person.name as personalName', 'person.isFavorite'])
+      .where('shared_space_person.spaceId', '=', asUuid(spaceId))
+      .where('shared_space_person.isHidden', '=', false)
+      .where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face')
+            .innerJoin('asset_face as af', 'af.id', 'shared_space_person_face.assetFaceId')
+            .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id')
+            .where('af.assetId', 'in', filteredIds),
+        ),
+      )
+      .orderBy(sql`coalesce("person"."isFavorite", false)`, 'desc')
+      .orderBy(sql`coalesce(nullif("shared_space_person"."name", ''), nullif("person"."name", ''), '')`);
+  }
+
+  private buildFilteredGlobalPeopleQuery(filteredIds: SelectQueryBuilder<DB, 'asset', { id: string }>) {
+    return this.db
+      .selectFrom('person')
+      .select(['person.id', 'person.name'])
+      .where('person.name', '!=', '')
+      .where('person.isHidden', '=', false)
+      .where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom('asset_face')
+            .whereRef('asset_face.personId', '=', 'person.id')
+            .where('asset_face.assetId', 'in', filteredIds),
+        ),
+      )
+      .orderBy('person.isFavorite', 'desc')
+      .orderBy('person.name');
   }
 
   private async getFilteredRatings(userIds: string[], options: FilterSuggestionsOptions): Promise<number[]> {

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1335,13 +1335,13 @@ describe(SearchService.name, () => {
       expect(result.hasUnnamedPeople).toBe(true);
     });
 
-    it('should return people sorted alphabetically by name', async () => {
+    it('should preserve repository ordering for people suggestions', async () => {
       const auth = AuthFactory.create();
       mocks.partner.getAll.mockResolvedValue([]);
       mocks.search.getFilterSuggestions.mockResolvedValue({
         ...emptyResult,
         people: [
-          { id: 'p3', name: 'Charlie' },
+          { id: 'p3', name: 'Zelda' },
           { id: 'p1', name: 'Alice' },
           { id: 'p2', name: 'Bob' },
         ],
@@ -1350,9 +1350,9 @@ describe(SearchService.name, () => {
       const result = await sut.getFilterSuggestions(auth, {});
 
       expect(result.people).toEqual([
+        { id: 'p3', name: 'Zelda' },
         { id: 'p1', name: 'Alice' },
         { id: 'p2', name: 'Bob' },
-        { id: 'p3', name: 'Charlie' },
       ]);
     });
 

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -314,8 +314,7 @@ export class SearchService extends BaseService {
       }
     }
 
-    const result = await this.searchRepository.getFilterSuggestions(userIds, { ...dto, timelineSpaceIds });
-    return { ...result, people: result.people.toSorted((a, b) => a.name.localeCompare(b.name)) };
+    return await this.searchRepository.getFilterSuggestions(userIds, { ...dto, timelineSpaceIds });
   }
 
   private getSuggestions(

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -307,5 +307,23 @@ describe(SearchService.name, () => {
 
       expect(result.people.map((p) => p.name)).toContain('Bob');
     });
+
+    it('should return favorite people before alphabetical matches', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+
+      const { asset: favoriteAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { person: favoritePerson } = await ctx.newPerson({ ownerId: user.id, name: 'Zelda', isFavorite: true });
+      await ctx.newAssetFace({ assetId: favoriteAsset.id, personId: favoritePerson.id });
+
+      const { asset: nonFavoriteAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { person: nonFavoritePerson } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isFavorite: false });
+      await ctx.newAssetFace({ assetId: nonFavoriteAsset.id, personId: nonFavoritePerson.id });
+
+      const auth = factory.auth({ user: { id: user.id } });
+      const result = await sut.getFilterSuggestions(auth, {});
+
+      expect(result.people.map((p) => p.name)).toEqual(['Zelda', 'Alice']);
+    });
   });
 });

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -325,5 +325,57 @@ describe(SearchService.name, () => {
 
       expect(result.people.map((p) => p.name)).toEqual(['Zelda', 'Alice']);
     });
+
+    it('should return favorite-backed space people before alphabetical matches', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+
+      const { asset: favoriteAsset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: favoriteAsset.id, addedById: owner.id });
+      const { person: favoritePerson } = await ctx.newPerson({ ownerId: owner.id, name: 'Zelda', isFavorite: true });
+      const { assetFace: favoriteFace } = await ctx.newAssetFace({
+        assetId: favoriteAsset.id,
+        personId: favoritePerson.id,
+      });
+      const favoriteSpacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, name: 'Zelda Space', representativeFaceId: favoriteFace.id })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await ctx.database
+        .insertInto('shared_space_person_face')
+        .values({ personId: favoriteSpacePerson.id, assetFaceId: favoriteFace.id })
+        .execute();
+
+      const { asset: nonFavoriteAsset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: nonFavoriteAsset.id, addedById: owner.id });
+      const { person: nonFavoritePerson } = await ctx.newPerson({
+        ownerId: owner.id,
+        name: 'Alice',
+        isFavorite: false,
+      });
+      const { assetFace: nonFavoriteFace } = await ctx.newAssetFace({
+        assetId: nonFavoriteAsset.id,
+        personId: nonFavoritePerson.id,
+      });
+      const nonFavoriteSpacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, name: 'Alice Space', representativeFaceId: nonFavoriteFace.id })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await ctx.database
+        .insertInto('shared_space_person_face')
+        .values({ personId: nonFavoriteSpacePerson.id, assetFaceId: nonFavoriteFace.id })
+        .execute();
+
+      const auth = factory.auth({ user: { id: member.id } });
+      const result = await sut.getFilterSuggestions(auth, { spaceId: space.id });
+
+      expect(result.people.map((p) => p.name)).toEqual(['Zelda Space', 'Alice Space']);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- preserve repository ordering for filter-suggestion people results
- sort global and space-scoped filter suggestions with favorites first
- add regression coverage for service and repository ordering

## Manual Testing
1. Mark at least one named person as a favorite, and ensure another non-favorite named person would sort alphabetically before it, for example favorite `Zelda` and non-favorite `Alice`.
2. Open Photos, open the filter panel, and confirm the People suggestions show the favorite person before alphabetical non-favorites.
3. Apply another filter such as media type, rating, tag, or date range, then confirm the People suggestions still keep favorites first within the filtered results.
4. In a shared space with space people, open the space filter panel and confirm space-scoped People suggestions also keep favorite-backed people first.
5. Select a suggested person and run the search to confirm results still filter by that person normally.

Closes #434