### PR TITLE
fix(server): preserve shared-space thumbnails for non-admin users

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -205,6 +205,26 @@ describe(AssetService.name, () => {
       expect((result as any).people[0].spacePersonId).toBe('space-person-1');
     });
 
+    it('should map spacePersonId for asset owner in shared space context', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.user1.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.user1.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([['person-1', { id: 'space-person-1', isHidden: false }]]),
+      );
+
+      const result = await sut.get(authStub.user1, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people');
+      expect((result as any).people.length).toBeGreaterThan(0);
+      expect((result as any).people[0].spacePersonId).toBe('space-person-1');
+    });
+
     it('should strip unassigned faces for space member with spaceId', async () => {
       const asset = AssetFactory.from().exif().face({ id: 'unassigned-face-id' }).build();
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -225,6 +225,67 @@ describe(AssetService.name, () => {
       expect((result as any).people[0].spacePersonId).toBe('space-person-1');
     });
 
+    it('should reject asset owner with explicit spaceId when they are not a member', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.user1.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.getMember.mockResolvedValue(void 0 as any);
+
+      await expect(sut.get(authStub.user1, asset.id, 'space-id')).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('should strip people for asset owner when the asset is not in the specified space', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.user1.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.user1.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set());
+
+      const result = await sut.get(authStub.user1, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should filter hidden space persons for asset owner with explicit spaceId', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.user1.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.user1.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([['person-1', { id: 'space-person-1', isHidden: true }]]),
+      );
+
+      const result = await sut.get(authStub.user1, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people', []);
+    });
+
+    it('should filter unmapped people for asset owner with explicit spaceId', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.user1.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(getForAsset(asset));
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.user1.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(new Map());
+
+      const result = await sut.get(authStub.user1, asset.id, 'space-id');
+
+      expect(result).toHaveProperty('people', []);
+    });
+
     it('should strip unassigned faces for space member with spaceId', async () => {
       const asset = AssetFactory.from().exif().face({ id: 'unassigned-face-id' }).build();
       mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -98,56 +98,58 @@ export class AssetService extends BaseService {
     if (auth.sharedLink) {
       data.people = [];
       data.unassignedFaces = [];
+    } else if (spaceId) {
+      if (data.ownerId !== auth.user.id) {
+        data.unassignedFaces = [];
+      }
+
+      const member = await this.sharedSpaceRepository.getMember(spaceId, auth.user.id);
+      if (!member) {
+        throw new ForbiddenException('Not a member of this space');
+      }
+
+      const hasSpaceAccess = await this.accessRepository.asset.checkSpaceAccessForSpace(
+        auth.user.id,
+        spaceId,
+        new Set([id]),
+      );
+      if (hasSpaceAccess.size === 0 || !data.people) {
+        data.people = [];
+      } else {
+        const globalPersonIds = data.people.map((p) => p.id);
+        const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+          spaceId,
+          globalPersonIds,
+        );
+        for (const person of data.people) {
+          const spacePerson = spacePersonMap.get(person.id);
+          if (spacePerson) {
+            person.spacePersonId = spacePerson.id;
+          }
+        }
+        data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
+      }
     } else if (data.ownerId !== auth.user.id) {
       data.unassignedFaces = [];
 
-      if (spaceId) {
-        const member = await this.sharedSpaceRepository.getMember(spaceId, auth.user.id);
-        if (!member) {
-          throw new ForbiddenException('Not a member of this space');
-        }
-
-        const hasSpaceAccess = await this.accessRepository.asset.checkSpaceAccessForSpace(
-          auth.user.id,
-          spaceId,
-          new Set([id]),
+      // No spaceId — try to find a space containing this asset for this user
+      const spaceForAsset = await this.sharedSpaceRepository.findSpaceForAssetAndUser(id, auth.user.id);
+      if (spaceForAsset) {
+        const globalPersonIds = (data.people || []).map((p) => p.id);
+        const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
+          spaceForAsset.spaceId,
+          globalPersonIds,
         );
-        if (hasSpaceAccess.size === 0 || !data.people) {
-          data.people = [];
-        } else {
-          const globalPersonIds = data.people.map((p) => p.id);
-          const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
-            spaceId,
-            globalPersonIds,
-          );
-          for (const person of data.people) {
-            const spacePerson = spacePersonMap.get(person.id);
-            if (spacePerson) {
-              person.spacePersonId = spacePerson.id;
-            }
+        for (const person of data.people || []) {
+          const spacePerson = spacePersonMap.get(person.id);
+          if (spacePerson) {
+            person.spacePersonId = spacePerson.id;
           }
-          data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
         }
+        data.people = (data.people || []).filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
+        data.resolvedSpaceId = spaceForAsset.spaceId;
       } else {
-        // No spaceId — try to find a space containing this asset for this user
-        const spaceForAsset = await this.sharedSpaceRepository.findSpaceForAssetAndUser(id, auth.user.id);
-        if (spaceForAsset) {
-          const globalPersonIds = (data.people || []).map((p) => p.id);
-          const spacePersonMap = await this.sharedSpaceRepository.findSpacePersonsByLinkedPersonIds(
-            spaceForAsset.spaceId,
-            globalPersonIds,
-          );
-          for (const person of data.people || []) {
-            const spacePerson = spacePersonMap.get(person.id);
-            if (spacePerson) {
-              person.spacePersonId = spacePerson.id;
-            }
-          }
-          data.people = (data.people || []).filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
-          data.resolvedSpaceId = spaceForAsset.spaceId;
-        } else {
-          data.people = [];
-        }
+        data.people = [];
       }
     }
 

--- a/web/src/lib/components/asset-viewer/detail-panel.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel.spec.ts
@@ -1,6 +1,6 @@
 import { renderWithTooltips } from '$tests/helpers';
-import '@testing-library/jest-dom';
 import { AssetTypeEnum, AssetVisibility, type AssetResponseDto } from '@immich/sdk';
+import '@testing-library/jest-dom';
 import DetailPanel from './detail-panel.svelte';
 
 const { getAllAlbumsMock, getAssetInfoMock } = vi.hoisted(() => ({

--- a/web/src/lib/components/asset-viewer/detail-panel.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel.spec.ts
@@ -1,6 +1,6 @@
 import { renderWithTooltips } from '$tests/helpers';
 import '@testing-library/jest-dom';
-import type { AssetResponseDto } from '@immich/sdk';
+import { AssetTypeEnum, AssetVisibility, type AssetResponseDto } from '@immich/sdk';
 import DetailPanel from './detail-panel.svelte';
 
 const { getAllAlbumsMock, getAssetInfoMock } = vi.hoisted(() => ({
@@ -106,11 +106,12 @@ describe('DetailPanel', () => {
       id: 'asset-1',
       ownerId: 'owner-1',
       libraryId: 'library-1',
-      type: 'IMAGE',
+      type: AssetTypeEnum.Image,
       originalPath: '/library/asset-1.jpg',
       originalFileName: 'asset-1.jpg',
       originalMimeType: 'image/jpeg',
       thumbhash: 'thumbhash',
+      createdAt: '2026-01-01T00:00:00.000Z',
       fileCreatedAt: '2026-01-01T00:00:00.000Z',
       fileModifiedAt: '2026-01-01T00:00:00.000Z',
       localDateTime: '2026-01-01T00:00:00.000Z',
@@ -122,7 +123,7 @@ describe('DetailPanel', () => {
       checksum: 'checksum',
       isOffline: false,
       hasMetadata: false,
-      visibility: 'timeline',
+      visibility: AssetVisibility.Timeline,
       width: 1000,
       height: 800,
       isEdited: false,

--- a/web/src/lib/components/asset-viewer/detail-panel.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel.spec.ts
@@ -1,0 +1,154 @@
+import { renderWithTooltips } from '$tests/helpers';
+import '@testing-library/jest-dom';
+import type { AssetResponseDto } from '@immich/sdk';
+import DetailPanel from './detail-panel.svelte';
+
+const { getAllAlbumsMock, getAssetInfoMock } = vi.hoisted(() => ({
+  getAllAlbumsMock: vi.fn(),
+  getAssetInfoMock: vi.fn(),
+}));
+
+vi.mock('@immich/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@immich/sdk')>();
+  return {
+    ...actual,
+    getAllAlbums: getAllAlbumsMock,
+    getAssetInfo: getAssetInfoMock,
+  };
+});
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({
+  authManager: {
+    authenticated: true,
+    user: { id: 'owner-1' },
+    isSharedLink: false,
+    params: {},
+    preferences: {
+      tags: { enabled: false },
+      ratings: { enabled: false },
+    },
+  },
+}));
+
+vi.mock('$lib/managers/asset-viewer-manager.svelte', () => ({
+  assetViewerManager: {
+    closeEditFacesPanel: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: {
+    value: { smartSearch: false },
+  },
+}));
+
+vi.mock('$lib/components/asset-viewer/detail-panel-date.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/asset-viewer/detail-panel-description.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/asset-viewer/detail-panel-location.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/asset-viewer/detail-panel-star-rating.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/asset-viewer/detail-panel-tags.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/faces-page/person-side-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/OnEvents.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/shared-components/user-avatar.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/asset-viewer/album-list-item-details.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/shared-components/LoadingSpinner.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+describe('DetailPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllAlbumsMock.mockResolvedValue([]);
+    getAssetInfoMock.mockResolvedValue(undefined);
+  });
+
+  it('uses the shared-space person thumbnail URL when spacePersonId is present', () => {
+    const asset: AssetResponseDto = {
+      id: 'asset-1',
+      ownerId: 'owner-1',
+      libraryId: 'library-1',
+      type: 'IMAGE',
+      originalPath: '/library/asset-1.jpg',
+      originalFileName: 'asset-1.jpg',
+      originalMimeType: 'image/jpeg',
+      thumbhash: 'thumbhash',
+      fileCreatedAt: '2026-01-01T00:00:00.000Z',
+      fileModifiedAt: '2026-01-01T00:00:00.000Z',
+      localDateTime: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      isFavorite: false,
+      isArchived: false,
+      isTrashed: false,
+      duration: null,
+      checksum: 'checksum',
+      isOffline: false,
+      hasMetadata: false,
+      visibility: 'timeline',
+      width: 1000,
+      height: 800,
+      isEdited: false,
+      people: [
+        {
+          id: 'global-person-1',
+          name: 'Alice',
+          thumbnailPath: '/ignored.jpg',
+          updatedAt: '2026-01-02T00:00:00.000Z',
+          isHidden: false,
+          birthDate: null,
+          type: 'person',
+          faces: [],
+          spacePersonId: 'space-person-1',
+        },
+      ],
+      unassignedFaces: [],
+    };
+
+    const { container } = renderWithTooltips(DetailPanel, {
+      asset,
+      currentAlbum: null,
+      spaceId: 'space-1',
+    });
+
+    const image = container.querySelector('img[src*="/shared-spaces/space-1/people/space-person-1/thumbnail"]');
+    expect(image).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- map shared-space people to `spacePersonId` for all members when loading an asset in explicit space context
- preserve the existing non-owner behavior for unassigned faces and implicit fallback space resolution
- add regression coverage for the shared-space owner case and viewer thumbnail URL selection

## Testing
- `pnpm --dir server exec vitest --config test/vitest.config.mjs run src/services/asset.service.spec.ts src/services/shared-space.service.spec.ts`
- `pnpm --dir web exec vitest run src/lib/components/asset-viewer/detail-panel.spec.ts src/lib/components/asset-viewer/detail-panel-description.spec.ts`
- `pnpm --dir web exec tsc --noEmit`
- `pnpm --dir web exec eslint . --max-warnings 0 --concurrency 4`
- `pnpm --dir web exec prettier --cache --check .`
- `pnpm --dir web check:svelte`

## Manual Testing
1. Set up a shared space with an admin/owner account and at least one non-admin member.
2. Use an asset in that shared space that has a recognized person in the People section.
3. Sign in as the non-admin member, open the shared space, open the asset, and expand the info/detail panel.
4. Confirm the person name and thumbnail both render, with no `Error loading image` placeholder.
5. In the browser network panel, confirm the thumbnail request uses `/api/shared-spaces/{spaceId}/people/{spacePersonId}/thumbnail` and succeeds.
6. Repeat the same shared-space asset view as the owner/admin account and confirm the thumbnail still renders from the shared-space person thumbnail route.
7. Open the same asset outside shared-space context as the owner/admin account and confirm normal person thumbnails still render.

Closes #423
