### PR TITLE
fix: add favorites filter parity

### DIFF
--- a/docs/superpowers/plans/2026-04-27-favorites-filter-parity.md
+++ b/docs/superpowers/plans/2026-04-27-favorites-filter-parity.md
@@ -31,6 +31,7 @@
 ### Task 1: Active Favorites Chip
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
 - Modify: `web/src/lib/components/filter-panel/active-filters-bar.svelte`
 
@@ -39,53 +40,53 @@
 Add these tests inside `describe('ActiveFiltersBar', () => { ... })` after the media type tests:
 
 ```ts
-  it('should render chip for favorites filter', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
+it('should render chip for favorites filter', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
 
-    const { getAllByTestId } = render(ActiveFiltersBar, {
-      props: {
-        filters,
-        onRemoveFilter: () => {},
-        onClearAll: () => {},
-      },
-    });
-
-    const chips = getAllByTestId('active-chip');
-    expect(chips).toHaveLength(1);
-    expect(chips[0]).toHaveTextContent('Favorites');
+  const { getAllByTestId } = render(ActiveFiltersBar, {
+    props: {
+      filters,
+      onRemoveFilter: () => {},
+      onClearAll: () => {},
+    },
   });
 
-  it('should remove favorites filter on chip close', async () => {
-    let removedType: string | undefined;
-    const filters = { ...createFilterState(), isFavorite: true };
+  const chips = getAllByTestId('active-chip');
+  expect(chips).toHaveLength(1);
+  expect(chips[0]).toHaveTextContent('Favorites');
+});
 
-    const { getByTestId } = render(ActiveFiltersBar, {
-      props: {
-        filters,
-        onRemoveFilter: (type) => {
-          removedType = type;
-        },
-        onClearAll: () => {},
+it('should remove favorites filter on chip close', async () => {
+  let removedType: string | undefined;
+  const filters = { ...createFilterState(), isFavorite: true };
+
+  const { getByTestId } = render(ActiveFiltersBar, {
+    props: {
+      filters,
+      onRemoveFilter: (type) => {
+        removedType = type;
       },
-    });
-
-    await fireEvent.click(getByTestId('chip-close'));
-    expect(removedType).toBe('favorites');
+      onClearAll: () => {},
+    },
   });
 
-  it('should not render a favorites chip for isFavorite false', () => {
-    const filters = { ...createFilterState(), isFavorite: false };
+  await fireEvent.click(getByTestId('chip-close'));
+  expect(removedType).toBe('favorites');
+});
 
-    const { queryAllByTestId } = render(ActiveFiltersBar, {
-      props: {
-        filters,
-        onRemoveFilter: () => {},
-        onClearAll: () => {},
-      },
-    });
+it('should not render a favorites chip for isFavorite false', () => {
+  const filters = { ...createFilterState(), isFavorite: false };
 
-    expect(queryAllByTestId('active-chip')).toHaveLength(0);
+  const { queryAllByTestId } = render(ActiveFiltersBar, {
+    props: {
+      filters,
+      onRemoveFilter: () => {},
+      onClearAll: () => {},
+    },
   });
+
+  expect(queryAllByTestId('active-chip')).toHaveLength(0);
+});
 ```
 
 - [ ] **Step 2: Run the failing tests**
@@ -131,6 +132,7 @@ git commit -m "fix: show favorites active filter chip"
 ### Task 2: Filter Section Preference Migration
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
 
@@ -139,52 +141,52 @@ git commit -m "fix: show favorites active filter chip"
 In `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`, add these tests in the visible-section persistence describe block after the localStorage restore tests:
 
 ```ts
-  it('should add favorites to legacy visible-section preferences without unhiding known hidden sections', () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(['people']));
+it('should add favorites to legacy visible-section preferences without unhiding known hidden sections', () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(['people']));
 
-    renderPanel(['people', 'rating', 'favorites']);
+  renderPanel(['people', 'rating', 'favorites']);
 
-    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
-    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
-    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
-  });
+  expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+  expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+  expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+});
 
-  it('should add favorites to empty legacy visible-section preferences without unhiding all known sections', () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+it('should add favorites to empty legacy visible-section preferences without unhiding all known sections', () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
 
-    renderPanel(['people', 'rating', 'favorites']);
+  renderPanel(['people', 'rating', 'favorites']);
 
-    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
-    expect(screen.queryByTestId('filter-section-people')).toBeNull();
-    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
-  });
+  expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+  expect(screen.queryByTestId('filter-section-people')).toBeNull();
+  expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+});
 
-  it('should fall back to all visible when legacy visible-section preferences only contain unknown sections', () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(['obsolete-section']));
+it('should fall back to all visible when legacy visible-section preferences only contain unknown sections', () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(['obsolete-section']));
 
-    renderPanel(['people', 'rating', 'favorites']);
+  renderPanel(['people', 'rating', 'favorites']);
 
-    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
-    expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
-    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
-  });
+  expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+  expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
+  expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+});
 
-  it('should add sections missing from stored known-section metadata without unhiding known hidden sections', () => {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        selected: ['people'],
-        known: ['people', 'rating', 'favorites'],
-      }),
-    );
+it('should add sections missing from stored known-section metadata without unhiding known hidden sections', () => {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      selected: ['people'],
+      known: ['people', 'rating', 'favorites'],
+    }),
+  );
 
-    renderPanel(['people', 'rating', 'favorites', 'media']);
+  renderPanel(['people', 'rating', 'favorites', 'media']);
 
-    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
-    expect(screen.getByTestId('filter-section-media')).toBeTruthy();
-    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
-    expect(screen.queryByTestId('filter-section-favorites')).toBeNull();
-  });
+  expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+  expect(screen.getByTestId('filter-section-media')).toBeTruthy();
+  expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+  expect(screen.queryByTestId('filter-section-favorites')).toBeNull();
+});
 ```
 
 - [ ] **Step 2: Add failing expanded-section migration tests**
@@ -192,53 +194,53 @@ In `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`, add the
 In the `Section Accordion Persistence` describe block, add:
 
 ```ts
-  it('should expand favorites for legacy expanded-section preferences without expanding known collapsed sections', () => {
-    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people']));
+it('should expand favorites for legacy expanded-section preferences without expanding known collapsed sections', () => {
+  localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people']));
 
-    renderPanel(['people', 'rating', 'favorites']);
+  renderPanel(['people', 'rating', 'favorites']);
 
-    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
-    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
-    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+  const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+  const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+  const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
 
-    expect(peopleContent).toBeTruthy();
-    expect(favoritesContent).toBeTruthy();
-    expect(ratingContent).toBeNull();
-  });
+  expect(peopleContent).toBeTruthy();
+  expect(favoritesContent).toBeTruthy();
+  expect(ratingContent).toBeNull();
+});
 
-  it('should fall back to all expanded when legacy expanded-section preferences only contain unknown sections', () => {
-    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['obsolete-section']));
+it('should fall back to all expanded when legacy expanded-section preferences only contain unknown sections', () => {
+  localStorage.setItem(EXPANDED_KEY, JSON.stringify(['obsolete-section']));
 
-    renderPanel(['people', 'rating', 'favorites']);
+  renderPanel(['people', 'rating', 'favorites']);
 
-    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
-    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
-    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+  const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+  const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+  const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
 
-    expect(peopleContent).toBeTruthy();
-    expect(ratingContent).toBeTruthy();
-    expect(favoritesContent).toBeTruthy();
-  });
+  expect(peopleContent).toBeTruthy();
+  expect(ratingContent).toBeTruthy();
+  expect(favoritesContent).toBeTruthy();
+});
 
-  it('should expand newly introduced sections from stored known-section metadata', () => {
-    localStorage.setItem(
-      EXPANDED_KEY,
-      JSON.stringify({
-        selected: ['people'],
-        known: ['people', 'rating', 'favorites'],
-      }),
-    );
+it('should expand newly introduced sections from stored known-section metadata', () => {
+  localStorage.setItem(
+    EXPANDED_KEY,
+    JSON.stringify({
+      selected: ['people'],
+      known: ['people', 'rating', 'favorites'],
+    }),
+  );
 
-    renderPanel(['people', 'rating', 'favorites', 'media']);
+  renderPanel(['people', 'rating', 'favorites', 'media']);
 
-    const mediaContent = screen.getByTestId('filter-section-media').querySelector('.filter-section-content');
-    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
-    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+  const mediaContent = screen.getByTestId('filter-section-media').querySelector('.filter-section-content');
+  const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+  const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
 
-    expect(mediaContent).toBeTruthy();
-    expect(ratingContent).toBeNull();
-    expect(favoritesContent).toBeNull();
-  });
+  expect(mediaContent).toBeTruthy();
+  expect(ratingContent).toBeNull();
+  expect(favoritesContent).toBeNull();
+});
 ```
 
 - [ ] **Step 3: Run the failing persistence tests**
@@ -385,6 +387,7 @@ git commit -m "fix: migrate filter section preferences"
 ### Task 3: Album Regression, Utility, And Config Plumbing
 
 **Files:**
+
 - Modify: `web/src/lib/utils/photos-filter-options.ts`
 - Modify: `web/src/lib/utils/space-filter-options.ts`
 - Modify: `web/src/lib/utils/album-filter-options.ts`
@@ -401,27 +404,27 @@ git commit -m "fix: migrate filter section preferences"
 Add this test to `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts`:
 
 ```ts
-  it('applies favorites independently in album view and picker modes', async () => {
-    renderPage();
-    const user = userEvent.setup();
+it('applies favorites independently in album view and picker modes', async () => {
+  renderPage();
+  const user = userEvent.setup();
 
-    await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
-    await user.click(screen.getByTestId('favorites-only'));
+  await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
+  await user.click(screen.getByTestId('favorites-only'));
 
-    expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
-    expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
+  expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
+  expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
 
-    await fireEvent.click(screen.getByLabelText('add_photos'));
-    await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
-    expect(screen.queryByTestId('active-chip')).not.toBeInTheDocument();
+  await fireEvent.click(screen.getByLabelText('add_photos'));
+  await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
+  expect(screen.queryByTestId('active-chip')).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId('favorites-only'));
+  await user.click(screen.getByTestId('favorites-only'));
 
-    expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
-    expect(screen.getByTestId('timeline-options').textContent).toContain('"timelineAlbumId":"');
-    expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
-    expect(screen.getByTestId('timeline-options').textContent).not.toContain('"withPartners":true');
-  });
+  expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
+  expect(screen.getByTestId('timeline-options').textContent).toContain('"timelineAlbumId":"');
+  expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
+  expect(screen.getByTestId('timeline-options').textContent).not.toContain('"withPartners":true');
+});
 ```
 
 - [ ] **Step 2: Add failing utility tests**
@@ -429,99 +432,99 @@ Add this test to `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[
 Add these tests to `web/src/lib/utils/__tests__/photos-filter-options.spec.ts`:
 
 ```ts
-  it('should include isFavorite and omit shared timeline inclusions when favorites is selected', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
-    const options = buildPhotosTimelineOptions(filters);
+it('should include isFavorite and omit shared timeline inclusions when favorites is selected', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
+  const options = buildPhotosTimelineOptions(filters);
 
-    expect(options.isFavorite).toBe(true);
-    expect(options).not.toHaveProperty('withPartners');
-    expect(options).not.toHaveProperty('withSharedSpaces');
-  });
+  expect(options.isFavorite).toBe(true);
+  expect(options).not.toHaveProperty('withPartners');
+  expect(options).not.toHaveProperty('withSharedSpaces');
+});
 ```
 
 Add this test in the `handlePhotosRemoveFilter` describe:
 
 ```ts
-  it('should clear favorites filter', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
+it('should clear favorites filter', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
 
-    expect(handlePhotosRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
-    expect(handlePhotosRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
-  });
+  expect(handlePhotosRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
+  expect(handlePhotosRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
+});
 ```
 
 Add these tests to `web/src/lib/utils/__tests__/space-filter-options.spec.ts`:
 
 ```ts
-  it('preserves favorites in spaces timeline options', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
+it('preserves favorites in spaces timeline options', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
 
-    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
-      expect.objectContaining({
-        spaceId: 'space-1',
-        isFavorite: true,
-      }),
-    );
-  });
+  expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+    expect.objectContaining({
+      spaceId: 'space-1',
+      isFavorite: true,
+    }),
+  );
+});
 
-  it('clears favorites when removing favorites filter', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
+it('clears favorites when removing favorites filter', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
 
-    expect(handleSpaceRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
-    expect(handleSpaceRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
-  });
+  expect(handleSpaceRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
+  expect(handleSpaceRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
+});
 ```
 
 Add these tests to `web/src/lib/utils/__tests__/album-filter-options.spec.ts`:
 
 ```ts
-  it('maps favorites for album timeline options', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
+it('maps favorites for album timeline options', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
 
-    expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, filters)).toEqual(
-      expect.objectContaining({
-        albumId: 'album-1',
-        isFavorite: true,
-      }),
-    );
-  });
+  expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, filters)).toEqual(
+    expect.objectContaining({
+      albumId: 'album-1',
+      isFavorite: true,
+    }),
+  );
+});
 
-  it('maps favorites and omits partners for album asset picker options', () => {
-    const filters = { ...createFilterState(), isFavorite: true };
-    const options = buildAlbumAssetPickerOptions('album-1', filters);
+it('maps favorites and omits partners for album asset picker options', () => {
+  const filters = { ...createFilterState(), isFavorite: true };
+  const options = buildAlbumAssetPickerOptions('album-1', filters);
 
-    expect(options).toEqual(
-      expect.objectContaining({
-        timelineAlbumId: 'album-1',
-        isFavorite: true,
-      }),
-    );
-    expect(options).not.toHaveProperty('withPartners');
-  });
+  expect(options).toEqual(
+    expect.objectContaining({
+      timelineAlbumId: 'album-1',
+      isFavorite: true,
+    }),
+  );
+  expect(options).not.toHaveProperty('withPartners');
+});
 ```
 
 Add tests to `web/src/lib/utils/__tests__/album-filter-config.spec.ts`:
 
 ```ts
-  it('keeps the album filter sections in plan order', () => {
-    const config = buildAlbumDetailFilterConfig('album-1');
-    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
-  });
+it('keeps the album filter sections in plan order', () => {
+  const config = buildAlbumDetailFilterConfig('album-1');
+  expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
+});
 
-  it('passes isFavorite to album detail filter suggestions', async () => {
-    const config = buildAlbumDetailFilterConfig('album-1');
-    await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
+it('passes isFavorite to album detail filter suggestions', async () => {
+  const config = buildAlbumDetailFilterConfig('album-1');
+  await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
 
-    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ albumId: 'album-1', isFavorite: true }));
-  });
+  expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ albumId: 'album-1', isFavorite: true }));
+});
 
-  it('keeps the picker filter sections in plan order and passes isFavorite to suggestions', async () => {
-    const config = buildAlbumAssetPickerFilterConfig();
-    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
+it('keeps the picker filter sections in plan order and passes isFavorite to suggestions', async () => {
+  const config = buildAlbumAssetPickerFilterConfig();
+  expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
 
-    await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
-    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
-  });
+  await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
+  expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
+});
 ```
 
 Update the existing album-config section-order tests to the expectations above instead of leaving duplicate tests with the old seven-section order.
@@ -553,9 +556,9 @@ export function buildPhotosTimelineOptions(filters: FilterState): Record<string,
 Add after the rating block:
 
 ```ts
-  if (filters.isFavorite !== undefined) {
-    base.isFavorite = filters.isFavorite;
-  }
+if (filters.isFavorite !== undefined) {
+  base.isFavorite = filters.isFavorite;
+}
 ```
 
 Add to `handlePhotosRemoveFilter()`:
@@ -572,9 +575,9 @@ Add to `handlePhotosRemoveFilter()`:
 In `web/src/lib/utils/space-filter-options.ts`, add after the rating block:
 
 ```ts
-  if (filters.isFavorite !== undefined) {
-    base.isFavorite = filters.isFavorite;
-  }
+if (filters.isFavorite !== undefined) {
+  base.isFavorite = filters.isFavorite;
+}
 ```
 
 Add to `handleSpaceRemoveFilter()`:
@@ -603,9 +606,9 @@ Add `isFavorite` to `toSuggestionRequest()`:
 In `web/src/lib/utils/album-filter-options.ts`, add after the rating block:
 
 ```ts
-  if (filters.isFavorite !== undefined) {
-    base.isFavorite = filters.isFavorite;
-  }
+if (filters.isFavorite !== undefined) {
+  base.isFavorite = filters.isFavorite;
+}
 ```
 
 Change `buildAlbumAssetPickerOptions()` so `withPartners` is conditional:
@@ -645,6 +648,7 @@ git commit -m "fix: wire favorites filter options"
 ### Task 4: Route Wiring For Photos And Spaces
 
 **Files:**
+
 - Create: `web/src/test-data/mocks/filter-panel-favorites.stub.svelte`
 - Modify: `web/src/test-data/mocks/smart-search-results.stub.svelte`
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
@@ -764,52 +768,52 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 Add tests:
 
 ```ts
-  it('exposes favorites in the Photos filter panel', () => {
-    mockPage.url = new URL('https://gallery.test/photos');
+it('exposes favorites in the Photos filter panel', () => {
+  mockPage.url = new URL('https://gallery.test/photos');
 
-    renderPage();
+  renderPage();
 
-    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
-      'data-sections',
-      'timeline,people,location,camera,tags,rating,media,favorites',
-    );
+  expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+    'data-sections',
+    'timeline,people,location,camera,tags,rating,media,favorites',
+  );
+});
+
+it('selects favorites in Photos timeline mode and uses owner-only timeline options', async () => {
+  mockPage.url = new URL('https://gallery.test/photos');
+
+  renderPage();
+  await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+  await waitFor(() => {
+    expect(buildPhotosTimelineOptions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
   });
+});
 
-  it('selects favorites in Photos timeline mode and uses owner-only timeline options', async () => {
-    mockPage.url = new URL('https://gallery.test/photos');
+it('selects favorites in Photos search mode and disables shared-space search scope', async () => {
+  mockPage.url = new URL('https://gallery.test/photos?q=nature');
 
-    renderPage();
-    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+  renderPage();
+  await fireEvent.click(screen.getByTestId('select-favorites-filter'));
 
-    await waitFor(() => {
-      expect(buildPhotosTimelineOptions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
-    });
-  });
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-with-shared-spaces', 'false');
+});
 
-  it('selects favorites in Photos search mode and disables shared-space search scope', async () => {
-    mockPage.url = new URL('https://gallery.test/photos?q=nature');
+it('selects favorites in Photos and disables shared-space scope for dependent suggestions', async () => {
+  mockPage.url = new URL('https://gallery.test/photos');
 
-    renderPage();
-    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+  renderPage();
+  await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+  await fireEvent.click(screen.getByTestId('load-city-suggestions'));
+  await fireEvent.click(screen.getByTestId('load-camera-model-suggestions'));
 
-    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
-    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-with-shared-spaces', 'false');
-  });
-
-  it('selects favorites in Photos and disables shared-space scope for dependent suggestions', async () => {
-    mockPage.url = new URL('https://gallery.test/photos');
-
-    renderPage();
-    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
-    await fireEvent.click(screen.getByTestId('load-city-suggestions'));
-    await fireEvent.click(screen.getByTestId('load-camera-model-suggestions'));
-
-    expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ country: 'Germany', isFavorite: true }));
-    expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ make: 'Sony', isFavorite: true }));
-    for (const [request] of vi.mocked(getSearchSuggestions).mock.calls) {
-      expect(request).not.toHaveProperty('withSharedSpaces');
-    }
-  });
+  expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ country: 'Germany', isFavorite: true }));
+  expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ make: 'Sony', isFavorite: true }));
+  for (const [request] of vi.mocked(getSearchSuggestions).mock.calls) {
+    expect(request).not.toHaveProperty('withSharedSpaces');
+  }
+});
 ```
 
 - [ ] **Step 4: Add failing Spaces route tests**
@@ -832,24 +836,24 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 Add tests:
 
 ```ts
-  it('exposes favorites in the Spaces view filter panel', () => {
-    renderPage();
+it('exposes favorites in the Spaces view filter panel', () => {
+  renderPage();
 
-    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
-      'data-sections',
-      'timeline,people,location,camera,tags,rating,media,favorites',
-    );
-  });
+  expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+    'data-sections',
+    'timeline,people,location,camera,tags,rating,media,favorites',
+  );
+});
 
-  it('keeps favorites scoped to the concrete space in Spaces search mode', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+it('keeps favorites scoped to the concrete space in Spaces search mode', async () => {
+  mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
 
-    renderPage();
-    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+  renderPage();
+  await fireEvent.click(screen.getByTestId('select-favorites-filter'));
 
-    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
-    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-space-id', 'space-1');
-  });
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-space-id', 'space-1');
+});
 ```
 
 - [ ] **Step 5: Run failing route tests**
@@ -936,6 +940,7 @@ git commit -m "fix: add favorites filter to photos and spaces"
 ### Task 5: Focused Verification And Cleanup
 
 **Files:**
+
 - Review all files modified by Tasks 1-4.
 
 - [ ] **Step 1: Run the full focused test suite**

--- a/docs/superpowers/plans/2026-04-27-favorites-filter-parity.md
+++ b/docs/superpowers/plans/2026-04-27-favorites-filter-parity.md
@@ -1,0 +1,992 @@
+# Favorites Filter Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Favorites filter visible and functional across Map active chips, Photos, Spaces view mode, Album detail, and Album asset picker while preserving existing backend favorite semantics.
+
+**Architecture:** Keep the existing `FilterState.isFavorite` model. First fix shared filter behavior, then wire route-specific config and request builders, then add route regressions for the page-level state flows. Owner-timeline requests must omit partner/shared-space inclusion whenever `isFavorite` is set because the backend rejects those combinations.
+
+**Tech Stack:** Svelte 5, SvelteKit routes, Vitest, Testing Library, `@immich/sdk`, pnpm workspace.
+
+---
+
+## File Structure
+
+- Modify `web/src/lib/components/filter-panel/active-filters-bar.svelte`: render the Favorites active chip for `isFavorite === true`.
+- Modify `web/src/lib/components/filter-panel/filter-panel.svelte`: hydrate visible/expanded sections with known-section metadata so newly introduced sections appear without unhiding existing hidden sections.
+- Modify `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`: cover Favorites chip rendering, removal, and no chip for `false`.
+- Modify `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`: cover visible/expanded section migration.
+- Modify `web/src/lib/utils/photos-filter-options.ts`: pass `isFavorite`, clear it, and omit partner/shared-space inclusions when it is set.
+- Modify `web/src/lib/utils/space-filter-options.ts`: pass and clear `isFavorite` for concrete shared-space scope.
+- Modify `web/src/lib/utils/album-filter-options.ts`: pass `isFavorite`; omit `withPartners` for picker requests when it is set.
+- Modify `web/src/lib/utils/album-filter-config.ts`: add Favorites section and pass `isFavorite` into suggestions.
+- Modify utility specs in `web/src/lib/utils/__tests__`: cover the request-shaping changes.
+- Modify `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`: add Favorites section and drop `withSharedSpaces` for Favorites suggestions/search.
+- Modify `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`: add Favorites section in view mode config.
+- Modify route specs for Photos, Spaces, and Albums to cover page wiring.
+- Create `web/src/test-data/mocks/filter-panel-favorites.stub.svelte`: route-test stub that exposes sections and can set `filters.isFavorite`.
+
+---
+
+### Task 1: Active Favorites Chip
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
+- Modify: `web/src/lib/components/filter-panel/active-filters-bar.svelte`
+
+- [ ] **Step 1: Add failing active-chip tests**
+
+Add these tests inside `describe('ActiveFiltersBar', () => { ... })` after the media type tests:
+
+```ts
+  it('should render chip for favorites filter', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveTextContent('Favorites');
+  });
+
+  it('should remove favorites filter on chip close', async () => {
+    let removedType: string | undefined;
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    const { getByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: (type) => {
+          removedType = type;
+        },
+        onClearAll: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('chip-close'));
+    expect(removedType).toBe('favorites');
+  });
+
+  it('should not render a favorites chip for isFavorite false', () => {
+    const filters = { ...createFilterState(), isFavorite: false };
+
+    const { queryAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    expect(queryAllByTestId('active-chip')).toHaveLength(0);
+  });
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+```
+
+Expected: the first two new tests fail because `ActiveFiltersBar` does not render a Favorites chip yet.
+
+- [ ] **Step 3: Implement the Favorites chip**
+
+In `web/src/lib/components/filter-panel/active-filters-bar.svelte`, add the Favorites chip after the media type chip block and before the timeline chip block:
+
+```svelte
+    // Favorites chip
+    if (filters.isFavorite === true) {
+      result.push({ type: 'favorites', label: 'Favorites' });
+    }
+```
+
+- [ ] **Step 4: Run the active-chip tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/active-filters-bar.svelte web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+git commit -m "fix: show favorites active filter chip"
+```
+
+---
+
+### Task 2: Filter Section Preference Migration
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+
+- [ ] **Step 1: Add failing visible-section migration tests**
+
+In `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`, add these tests in the visible-section persistence describe block after the localStorage restore tests:
+
+```ts
+  it('should add favorites to legacy visible-section preferences without unhiding known hidden sections', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['people']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+  });
+
+  it('should add favorites to empty legacy visible-section preferences without unhiding all known sections', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+    expect(screen.queryByTestId('filter-section-people')).toBeNull();
+    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+  });
+
+  it('should fall back to all visible when legacy visible-section preferences only contain unknown sections', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['obsolete-section']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+  });
+
+  it('should add sections missing from stored known-section metadata without unhiding known hidden sections', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        selected: ['people'],
+        known: ['people', 'rating', 'favorites'],
+      }),
+    );
+
+    renderPanel(['people', 'rating', 'favorites', 'media']);
+
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-media')).toBeTruthy();
+    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+    expect(screen.queryByTestId('filter-section-favorites')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Add failing expanded-section migration tests**
+
+In the `Section Accordion Persistence` describe block, add:
+
+```ts
+  it('should expand favorites for legacy expanded-section preferences without expanding known collapsed sections', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+
+    expect(peopleContent).toBeTruthy();
+    expect(favoritesContent).toBeTruthy();
+    expect(ratingContent).toBeNull();
+  });
+
+  it('should fall back to all expanded when legacy expanded-section preferences only contain unknown sections', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['obsolete-section']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+
+    expect(peopleContent).toBeTruthy();
+    expect(ratingContent).toBeTruthy();
+    expect(favoritesContent).toBeTruthy();
+  });
+
+  it('should expand newly introduced sections from stored known-section metadata', () => {
+    localStorage.setItem(
+      EXPANDED_KEY,
+      JSON.stringify({
+        selected: ['people'],
+        known: ['people', 'rating', 'favorites'],
+      }),
+    );
+
+    renderPanel(['people', 'rating', 'favorites', 'media']);
+
+    const mediaContent = screen.getByTestId('filter-section-media').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+
+    expect(mediaContent).toBeTruthy();
+    expect(ratingContent).toBeNull();
+    expect(favoritesContent).toBeNull();
+  });
+```
+
+- [ ] **Step 3: Run the failing persistence tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+```
+
+Expected: the new tests fail because legacy arrays do not add Favorites and stored metadata is not supported.
+
+- [ ] **Step 4: Implement section-set hydration helpers**
+
+In `web/src/lib/components/filter-panel/filter-panel.svelte`, replace `loadVisibleSections()` and `loadExpandedSections()` with shared helpers. Keep `EXPANDED_SECTIONS_KEY` above the expanded-state loader.
+
+```svelte
+  type StoredSectionSet = string[] | { selected?: string[]; known?: string[] };
+
+  const LEGACY_INTRODUCED_SECTIONS = new Set<FilterSectionType>(['favorites']);
+
+  function isFilterSection(value: string, configSections: FilterSectionType[]): value is FilterSectionType {
+    return configSections.includes(value as FilterSectionType);
+  }
+
+  function getValidSections(values: unknown, configSections: FilterSectionType[]): FilterSectionType[] {
+    if (!Array.isArray(values)) {
+      return [];
+    }
+    return values.filter((value): value is FilterSectionType => {
+      return typeof value === 'string' && isFilterSection(value, configSections);
+    });
+  }
+
+  function getLegacyKnownSections(
+    selected: FilterSectionType[],
+    configSections: FilterSectionType[],
+  ): FilterSectionType[] {
+    const selectedSections = new Set(selected);
+    return configSections.filter((section) => selectedSections.has(section) || !LEGACY_INTRODUCED_SECTIONS.has(section));
+  }
+
+  function getLegacySections(
+    values: unknown,
+    configSections: FilterSectionType[],
+    fallback: () => SvelteSet<FilterSectionType>,
+  ): SvelteSet<FilterSectionType> {
+    if (!Array.isArray(values)) {
+      return fallback();
+    }
+
+    const selected = getValidSections(values, configSections);
+    if (values.length > 0 && selected.length === 0) {
+      return fallback();
+    }
+
+    const known = getLegacyKnownSections(selected, configSections);
+    const knownSet = new Set(known);
+    const introduced = configSections.filter((section) => !knownSet.has(section));
+    return new SvelteSet([...selected, ...introduced]);
+  }
+
+  function hydrateSectionSet(
+    configSections: FilterSectionType[],
+    raw: string | null,
+    fallback: () => SvelteSet<FilterSectionType>,
+  ): SvelteSet<FilterSectionType> {
+    if (raw === null) {
+      return fallback();
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as StoredSectionSet;
+      if (Array.isArray(parsed)) {
+        return getLegacySections(parsed, configSections, fallback);
+      }
+
+      const selected = getValidSections(parsed.selected, configSections);
+      const known = getValidSections(parsed.known, configSections);
+      const knownSet = new Set(known);
+      const introduced = configSections.filter((section) => !knownSet.has(section));
+
+      return new SvelteSet([...selected, ...introduced]);
+    } catch {
+      return fallback();
+    }
+  }
+
+  function serializeSectionSet(sections: SvelteSet<FilterSectionType>, configSections: FilterSectionType[]): string {
+    return JSON.stringify({
+      selected: [...sections],
+      known: [...configSections],
+    });
+  }
+
+  function loadVisibleSections(configSections: FilterSectionType[], key: string): SvelteSet<FilterSectionType> {
+    if (browser) {
+      return hydrateSectionSet(configSections, localStorage.getItem(key), () => new SvelteSet(configSections));
+    }
+    return new SvelteSet(configSections);
+  }
+
+  const EXPANDED_SECTIONS_KEY = 'gallery-filter-expanded-sections';
+
+  function loadExpandedSections(configSections: FilterSectionType[]): SvelteSet<FilterSectionType> {
+    if (browser) {
+      return hydrateSectionSet(configSections, localStorage.getItem(EXPANDED_SECTIONS_KEY), () => new SvelteSet(configSections));
+    }
+    return new SvelteSet(configSections);
+  }
+```
+
+Update the localStorage write effects:
+
+```svelte
+        localStorage.setItem(storageKey, serializeSectionSet(visibleSections, config.sections));
+```
+
+and:
+
+```svelte
+        localStorage.setItem(EXPANDED_SECTIONS_KEY, serializeSectionSet(expandedSections, config.sections));
+```
+
+- [ ] **Step 5: Run the persistence tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+```
+
+Expected: all tests in the file pass. If existing tests assert an array is stored, update them to parse `.selected` from the stored object.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.svelte web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+git commit -m "fix: migrate filter section preferences"
+```
+
+---
+
+### Task 3: Album Regression, Utility, And Config Plumbing
+
+**Files:**
+- Modify: `web/src/lib/utils/photos-filter-options.ts`
+- Modify: `web/src/lib/utils/space-filter-options.ts`
+- Modify: `web/src/lib/utils/album-filter-options.ts`
+- Modify: `web/src/lib/utils/album-filter-config.ts`
+- Modify: `web/src/lib/utils/__tests__/photos-filter-options.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/space-filter-options.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/album-filter-options.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/album-filter-config.spec.ts`
+- Modify: `web/src/lib/utils/__tests__/map-filter-config.spec.ts`
+- Modify: `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts`
+
+- [ ] **Step 1: Add the failing album route regression**
+
+Add this test to `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts`:
+
+```ts
+  it('applies favorites independently in album view and picker modes', async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
+    await user.click(screen.getByTestId('favorites-only'));
+
+    expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
+    expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
+
+    await fireEvent.click(screen.getByLabelText('add_photos'));
+    await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
+    expect(screen.queryByTestId('active-chip')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('favorites-only'));
+
+    expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
+    expect(screen.getByTestId('timeline-options').textContent).toContain('"timelineAlbumId":"');
+    expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
+    expect(screen.getByTestId('timeline-options').textContent).not.toContain('"withPartners":true');
+  });
+```
+
+- [ ] **Step 2: Add failing utility tests**
+
+Add these tests to `web/src/lib/utils/__tests__/photos-filter-options.spec.ts`:
+
+```ts
+  it('should include isFavorite and omit shared timeline inclusions when favorites is selected', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+    const options = buildPhotosTimelineOptions(filters);
+
+    expect(options.isFavorite).toBe(true);
+    expect(options).not.toHaveProperty('withPartners');
+    expect(options).not.toHaveProperty('withSharedSpaces');
+  });
+```
+
+Add this test in the `handlePhotosRemoveFilter` describe:
+
+```ts
+  it('should clear favorites filter', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(handlePhotosRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
+    expect(handlePhotosRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
+  });
+```
+
+Add these tests to `web/src/lib/utils/__tests__/space-filter-options.spec.ts`:
+
+```ts
+  it('preserves favorites in spaces timeline options', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        spaceId: 'space-1',
+        isFavorite: true,
+      }),
+    );
+  });
+
+  it('clears favorites when removing favorites filter', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(handleSpaceRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
+    expect(handleSpaceRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
+  });
+```
+
+Add these tests to `web/src/lib/utils/__tests__/album-filter-options.spec.ts`:
+
+```ts
+  it('maps favorites for album timeline options', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, filters)).toEqual(
+      expect.objectContaining({
+        albumId: 'album-1',
+        isFavorite: true,
+      }),
+    );
+  });
+
+  it('maps favorites and omits partners for album asset picker options', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+    const options = buildAlbumAssetPickerOptions('album-1', filters);
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        timelineAlbumId: 'album-1',
+        isFavorite: true,
+      }),
+    );
+    expect(options).not.toHaveProperty('withPartners');
+  });
+```
+
+Add tests to `web/src/lib/utils/__tests__/album-filter-config.spec.ts`:
+
+```ts
+  it('keeps the album filter sections in plan order', () => {
+    const config = buildAlbumDetailFilterConfig('album-1');
+    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
+  });
+
+  it('passes isFavorite to album detail filter suggestions', async () => {
+    const config = buildAlbumDetailFilterConfig('album-1');
+    await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ albumId: 'album-1', isFavorite: true }));
+  });
+
+  it('keeps the picker filter sections in plan order and passes isFavorite to suggestions', async () => {
+    const config = buildAlbumAssetPickerFilterConfig();
+    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites']);
+
+    await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
+  });
+```
+
+Update the existing album-config section-order tests to the expectations above instead of leaving duplicate tests with the old seven-section order.
+
+- [ ] **Step 3: Run the failing utility and album route tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"
+```
+
+Expected: new tests fail where `isFavorite` and `favorites` are not wired yet. The album route regression should fail before album configs include Favorites and album option builders pass `isFavorite`.
+
+- [ ] **Step 4: Implement Photos utility changes**
+
+Update `buildPhotosTimelineOptions()` in `web/src/lib/utils/photos-filter-options.ts`:
+
+```ts
+export function buildPhotosTimelineOptions(filters: FilterState): Record<string, unknown> {
+  const includeSharedTimelineAssets = filters.isFavorite === undefined;
+  const base: Record<string, unknown> = {
+    visibility: AssetVisibility.Timeline,
+    withStacked: true,
+    ...(includeSharedTimelineAssets ? { withPartners: true, withSharedSpaces: true } : {}),
+  };
+```
+
+Add after the rating block:
+
+```ts
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
+  }
+```
+
+Add to `handlePhotosRemoveFilter()`:
+
+```ts
+    case 'favorites':
+    case 'isFavorite': {
+      return { ...filters, isFavorite: undefined };
+    }
+```
+
+- [ ] **Step 5: Implement Spaces utility changes**
+
+In `web/src/lib/utils/space-filter-options.ts`, add after the rating block:
+
+```ts
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
+  }
+```
+
+Add to `handleSpaceRemoveFilter()`:
+
+```ts
+    case 'favorites':
+    case 'isFavorite': {
+      return { ...filters, isFavorite: undefined };
+    }
+```
+
+- [ ] **Step 6: Implement Album utility/config changes**
+
+In `web/src/lib/utils/album-filter-config.ts`, change the sections constant:
+
+```ts
+const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
+```
+
+Add `isFavorite` to `toSuggestionRequest()`:
+
+```ts
+    isFavorite: filters.isFavorite,
+```
+
+In `web/src/lib/utils/album-filter-options.ts`, add after the rating block:
+
+```ts
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
+  }
+```
+
+Change `buildAlbumAssetPickerOptions()` so `withPartners` is conditional:
+
+```ts
+export function buildAlbumAssetPickerOptions(albumId: string, filters: FilterState): Record<string, unknown> {
+  return applyCommonFilterFields(
+    {
+      visibility: AssetVisibility.Timeline,
+      ...(filters.isFavorite === undefined ? { withPartners: true } : {}),
+      timelineAlbumId: albumId,
+    },
+    filters,
+  );
+}
+```
+
+- [ ] **Step 7: Run utility and album route tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"
+```
+
+Expected: all listed utility tests and the album route spec pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/lib/utils/photos-filter-options.ts web/src/lib/utils/space-filter-options.ts web/src/lib/utils/album-filter-options.ts web/src/lib/utils/album-filter-config.ts web/src/lib/utils/__tests__/photos-filter-options.spec.ts web/src/lib/utils/__tests__/space-filter-options.spec.ts web/src/lib/utils/__tests__/album-filter-options.spec.ts web/src/lib/utils/__tests__/album-filter-config.spec.ts web/src/lib/utils/__tests__/map-filter-config.spec.ts web/src/routes/'(user)'/albums/'[albumId=id]'/'[[photos=photos]]'/'[[assetId=id]]'/page.route.spec.ts
+git commit -m "fix: wire favorites filter options"
+```
+
+---
+
+### Task 4: Route Wiring For Photos And Spaces
+
+**Files:**
+- Create: `web/src/test-data/mocks/filter-panel-favorites.stub.svelte`
+- Modify: `web/src/test-data/mocks/smart-search-results.stub.svelte`
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
+
+- [ ] **Step 1: Create a route-test filter panel stub**
+
+Create `web/src/test-data/mocks/filter-panel-favorites.stub.svelte`:
+
+```svelte
+<script lang="ts">
+  import {
+    buildFilterContext,
+    createFilterState,
+    type FilterPanelConfig,
+    type FilterState,
+  } from '$lib/components/filter-panel/filter-panel';
+
+  interface Props {
+    filters?: FilterState;
+    config?: FilterPanelConfig;
+    [key: string]: unknown;
+  }
+
+  let { filters = $bindable(createFilterState()), config, ...rest }: Props = $props();
+
+  function selectFavorites() {
+    filters = { ...filters, isFavorite: true };
+  }
+
+  function loadCitySuggestions() {
+    void config?.providers?.cities?.('Germany', buildFilterContext(filters, ['country', 'city']));
+  }
+
+  function loadCameraModelSuggestions() {
+    void config?.providers?.cameraModels?.('Sony', buildFilterContext(filters, ['make', 'model']));
+  }
+</script>
+
+<div
+  {...rest}
+  data-testid="filter-panel-stub"
+  data-sections={config?.sections.join(',') ?? ''}
+  data-is-favorite={String(filters?.isFavorite)}
+>
+  <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
+  <button type="button" data-testid="load-city-suggestions" onclick={loadCitySuggestions}>Load cities</button>
+  <button type="button" data-testid="load-camera-model-suggestions" onclick={loadCameraModelSuggestions}>
+    Load camera models
+  </button>
+</div>
+```
+
+- [ ] **Step 2: Expose shared-space scope in smart-search test stub**
+
+Update `web/src/test-data/mocks/smart-search-results.stub.svelte` props and markup:
+
+```svelte
+  interface Props {
+    isLoading?: boolean;
+    searchQuery?: string;
+    filters?: FilterState;
+    withSharedSpaces?: boolean;
+    spaceId?: string;
+    [key: string]: unknown;
+  }
+
+  let {
+    isLoading = $bindable(false),
+    searchQuery = '',
+    filters,
+    withSharedSpaces,
+    spaceId,
+    ...rest
+  }: Props = $props();
+```
+
+Add these attributes to the root `<div>`:
+
+```svelte
+  data-is-favorite={String(filters?.isFavorite)}
+  data-with-shared-spaces={String(withSharedSpaces)}
+  data-space-id={spaceId ?? ''}
+```
+
+- [ ] **Step 3: Add failing Photos route tests**
+
+In `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`, change the FilterPanel mock to:
+
+```ts
+vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/filter-panel-favorites.stub.svelte');
+  return { default: MockComponent };
+});
+```
+
+Import the mocked utility:
+
+```ts
+import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+```
+
+Import mocked SDK suggestions:
+
+```ts
+import { getSearchSuggestions } from '@immich/sdk';
+```
+
+Update the Testing Library import to include `fireEvent` and `waitFor`:
+
+```ts
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+```
+
+Add tests:
+
+```ts
+  it('exposes favorites in the Photos filter panel', () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites',
+    );
+  });
+
+  it('selects favorites in Photos timeline mode and uses owner-only timeline options', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    await waitFor(() => {
+      expect(buildPhotosTimelineOptions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
+    });
+  });
+
+  it('selects favorites in Photos search mode and disables shared-space search scope', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=nature');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-with-shared-spaces', 'false');
+  });
+
+  it('selects favorites in Photos and disables shared-space scope for dependent suggestions', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+    await fireEvent.click(screen.getByTestId('load-city-suggestions'));
+    await fireEvent.click(screen.getByTestId('load-camera-model-suggestions'));
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ country: 'Germany', isFavorite: true }));
+    expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ make: 'Sony', isFavorite: true }));
+    for (const [request] of vi.mocked(getSearchSuggestions).mock.calls) {
+      expect(request).not.toHaveProperty('withSharedSpaces');
+    }
+  });
+```
+
+- [ ] **Step 4: Add failing Spaces route tests**
+
+In `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`, keep the bindable filter-panel mock or switch it to the new favorites stub:
+
+```ts
+vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/filter-panel-favorites.stub.svelte');
+  return { default: MockComponent };
+});
+```
+
+Update the Testing Library import to include `fireEvent`:
+
+```ts
+import { fireEvent, render, screen } from '@testing-library/svelte';
+```
+
+Add tests:
+
+```ts
+  it('exposes favorites in the Spaces view filter panel', () => {
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites',
+    );
+  });
+
+  it('keeps favorites scoped to the concrete space in Spaces search mode', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-space-id', 'space-1');
+  });
+```
+
+- [ ] **Step 5: Run failing route tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"
+```
+
+Expected: Photos and Spaces section tests fail until route configs include `favorites`; Photos search scope test fails until `withSharedSpaces` is conditional.
+
+- [ ] **Step 6: Implement Photos route changes**
+
+In `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`, change the config sections:
+
+```ts
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'],
+```
+
+In the suggestions request, change:
+
+```ts
+        withSharedSpaces: true,
+```
+
+to:
+
+```ts
+        withSharedSpaces: filters.isFavorite === undefined ? true : undefined,
+```
+
+In both dependent providers, change the shared-space spread to:
+
+```ts
+          ...(context?.isFavorite === undefined ? { withSharedSpaces: true } : {}),
+```
+
+In the `SmartSearchResults` usage, change:
+
+```svelte
+          withSharedSpaces={true}
+```
+
+to:
+
+```svelte
+          withSharedSpaces={filters.isFavorite === undefined}
+```
+
+- [ ] **Step 7: Implement Spaces route section change**
+
+In `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`, change:
+
+```ts
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'],
+```
+
+to:
+
+```ts
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'],
+```
+
+- [ ] **Step 8: Run route tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"
+```
+
+Expected: both route spec files pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/test-data/mocks/filter-panel-favorites.stub.svelte web/src/test-data/mocks/smart-search-results.stub.svelte web/src/routes/'(user)'/photos/'[[assetId=id]]'/+page.svelte web/src/routes/'(user)'/photos/'[[assetId=id]]'/photos-page.spec.ts web/src/routes/'(user)'/spaces/'[spaceId]'/'[[photos=photos]]'/'[[assetId=id]]'/+page.svelte web/src/routes/'(user)'/spaces/'[spaceId]'/'[[photos=photos]]'/'[[assetId=id]]'/spaces-page.spec.ts
+git commit -m "fix: add favorites filter to photos and spaces"
+```
+
+---
+
+### Task 5: Focused Verification And Cleanup
+
+**Files:**
+- Review all files modified by Tasks 1-4.
+
+- [ ] **Step 1: Run the full focused test suite**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/components/filter-panel/__tests__/filter-panel.spec.ts src/lib/components/filter-panel/__tests__/favorites-filter.spec.ts src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/space-search.spec.ts "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts" "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"
+```
+
+Expected: all listed tests pass.
+
+- [ ] **Step 2: Run Svelte and TypeScript checks**
+
+Run:
+
+```bash
+pnpm --dir web run check:svelte
+pnpm --dir web run check:typescript
+```
+
+Expected: both commands pass. If `check:svelte` reports unrelated pre-existing warnings, capture the exact output and only fix warnings caused by this branch.
+
+- [ ] **Step 3: Run formatting check on touched files**
+
+Run:
+
+```bash
+pnpm --dir web exec prettier --check src/lib/components/filter-panel/active-filters-bar.svelte src/lib/components/filter-panel/filter-panel.svelte src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/components/filter-panel/__tests__/filter-panel.spec.ts src/lib/utils/photos-filter-options.ts src/lib/utils/space-filter-options.ts src/lib/utils/album-filter-options.ts src/lib/utils/album-filter-config.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/routes/'(user)'/photos/'[[assetId=id]]'/+page.svelte src/routes/'(user)'/photos/'[[assetId=id]]'/photos-page.spec.ts src/routes/'(user)'/spaces/'[spaceId]'/'[[photos=photos]]'/'[[assetId=id]]'/+page.svelte src/routes/'(user)'/spaces/'[spaceId]'/'[[photos=photos]]'/'[[assetId=id]]'/spaces-page.spec.ts src/routes/'(user)'/albums/'[albumId=id]'/'[[photos=photos]]'/'[[assetId=id]]'/page.route.spec.ts src/test-data/mocks/filter-panel-favorites.stub.svelte src/test-data/mocks/smart-search-results.stub.svelte
+```
+
+Expected: Prettier reports all checked files are formatted. If not, run the same command with `--write`, inspect the diff, and include formatting changes in the final commit.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+```
+
+Expected: diff contains only Favorites filter parity changes and no whitespace errors.
+
+- [ ] **Step 5: Final commit if needed**
+
+If Step 2 or Step 3 produced cleanup changes, commit them:
+
+```bash
+git add web
+git commit -m "chore: clean up favorites filter checks"
+```
+
+If there are no cleanup changes, do not create an empty commit.

--- a/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
+++ b/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
@@ -32,7 +32,7 @@ Favorites remains a two-state control everywhere it appears:
 - `All` maps to `filters.isFavorite === undefined`.
 - `Favorites` maps to `filters.isFavorite === true`.
 
-The active filter bar renders one chip labeled with the existing `favorites` i18n key. Closing that chip resets `isFavorite` to `undefined`, returning the control to `All`. The chip appears after media type chips and before timeline chips.
+The active filter bar renders one chip labeled exactly `Favorites`, matching the existing filter control copy. Closing that chip resets `isFavorite` to `undefined`, returning the control to `All`. The chip appears after media type chips and before timeline chips.
 
 Favorites appears after `Media Type` in the filter section order for Map, Photos, Spaces, Album detail view, and Album asset picker.
 
@@ -55,7 +55,7 @@ The changes are expected in these areas:
 - Photos, Spaces, and Album option builders should pass `isFavorite` through to their timeline or picker requests.
 - Owner-timeline option builders should omit `withPartners` and `withSharedSpaces` when `isFavorite` is selected.
 - Photos search and dependent suggestion builders should omit `withSharedSpaces` when `isFavorite` is selected.
-- `FilterPanel` localStorage hydration should merge newly introduced sections into saved visible and expanded section sets.
+- `FilterPanel` localStorage hydration should add newly introduced sections into saved visible and expanded section sets without unhiding sections the user already hid.
 
 Map already includes the `favorites` section and passes `isFavorite` through map marker, time-bucket, and timeline option builders. Its missing behavior comes from the shared active-chip renderer.
 
@@ -77,7 +77,7 @@ For search result mode, `SmartSearchResults` already tracks and passes `filters.
 
 Existing users may have saved visible or expanded section arrays in localStorage. If `favorites` is simply added to a route config, those old saved arrays would omit the new section and make the fix look absent.
 
-`FilterPanel` should handle this generically by merging any sections present in the current config but missing from the saved set into the hydrated visible and expanded sets. This keeps old user preferences for existing sections while showing new first-class sections by default. Users can still hide or collapse Favorites afterward.
+`FilterPanel` should handle this by tracking the section keys known when preferences are saved. On hydration, it should add config sections that are not in the saved known-section set, while preserving hidden or collapsed state for known sections. Legacy array-only entries should be treated as pre-Favorites entries, so `favorites` is added by default without unhiding any other existing section. Users can still hide or collapse Favorites afterward.
 
 ## Testing
 
@@ -90,7 +90,7 @@ Add or update focused tests for:
 - Photos search and dependent suggestions omit shared-space inclusion when `isFavorite` is selected.
 - Photos and Spaces remove-filter handlers clear favorites.
 - Album suggestions include `isFavorite` for detail and picker configs.
-- `FilterPanel` visible and expanded section hydration merges newly introduced sections into saved section sets.
+- `FilterPanel` visible and expanded section hydration adds newly introduced sections without unhiding known sections that were already hidden or collapsed.
 - Album route regression covers Favorites in both album detail mode and asset picker mode.
 - Lightweight Photos and Spaces route regressions verify Favorites wiring without full UI interaction scaffolding.
 

--- a/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
+++ b/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
@@ -35,6 +35,8 @@ The active filter bar renders one chip labeled with the existing `favorites` i18
 
 Favorites appears after `Media Type` in the filter section order for Map, Photos, Spaces, Album detail view, and Album asset picker.
 
+On owner-timeline requests that normally include partner assets or shared-space assets, selecting Favorites narrows the request back to the user's own favorited timeline assets. The backend rejects `isFavorite` when combined with `withPartners` or `withSharedSpaces`, and this design preserves that server contract instead of redefining cross-owner favorite semantics. Concrete shared-space scopes using `spaceId` remain supported.
+
 ## Architecture
 
 The implementation should reuse the existing filter state model. `FilterState.isFavorite` already exists and is already counted by `getActiveFilterCount()` and included in `buildFilterContext()` when requested.
@@ -46,6 +48,7 @@ The changes are expected in these areas:
 - Photos and Spaces filter panel configs should include the `favorites` section.
 - Album filter configs should include the `favorites` section and pass `isFavorite` to filter suggestions.
 - Photos, Spaces, and Album option builders should pass `isFavorite` through to their timeline or picker requests.
+- Owner-timeline option builders should omit `withPartners` and `withSharedSpaces` when `isFavorite` is selected.
 - `FilterPanel` localStorage hydration should merge newly introduced sections into saved visible and expanded section sets.
 
 Map already includes the `favorites` section and passes `isFavorite` through map marker, time-bucket, and timeline option builders. Its missing behavior comes from the shared active-chip renderer.
@@ -57,9 +60,10 @@ When a user selects Favorites:
 1. `FavoritesFilter` sets `filters.isFavorite` to `true`.
 2. `FilterPanel` emits the bound filter state to the owning route.
 3. The route's option builder includes `isFavorite: true` in the timeline, picker, marker, time-bucket, or search request used by that surface.
-4. The route's suggestions provider includes `isFavorite: true`, so dependent filter options narrow to the favorites subset.
-5. `ActiveFiltersBar` renders a `Favorites` chip.
-6. Closing the chip routes through the page's remove-filter handler and clears `isFavorite`.
+4. If the owner timeline request would otherwise include partner or shared-space assets, the option builder removes those inclusions while Favorites is selected.
+5. The route's suggestions provider includes `isFavorite: true`, so dependent filter options narrow to the favorites subset.
+6. `ActiveFiltersBar` renders a `Favorites` chip.
+7. Closing the chip routes through the page's remove-filter handler and clears `isFavorite`.
 
 For search result mode, `SmartSearchResults` already tracks and passes `filters.isFavorite`, so no separate search redesign is needed.
 
@@ -76,6 +80,7 @@ Add or update focused tests for:
 - `ActiveFiltersBar` renders and removes a Favorites chip.
 - Photos, Spaces, Album, and Map filter configs include `favorites` in the expected order.
 - Photos, Spaces, and Album option builders include `isFavorite: true` when selected.
+- Photos and Album picker option builders omit partner/shared-space inclusion when `isFavorite` is selected.
 - Photos and Spaces remove-filter handlers clear favorites.
 - Album suggestions include `isFavorite` for detail and picker configs.
 - `FilterPanel` visible and expanded section hydration merges newly introduced sections into saved section sets.

--- a/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
+++ b/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
@@ -23,6 +23,7 @@ During review, we expanded the scope to include Albums because album assets alre
 - Do not add a redundant Favorites filter to the dedicated `/favorites` page.
 - Do not broaden localization cleanup beyond the newly added Favorites labels.
 - Do not add a Map route-level regression; shared component and utility coverage is sufficient for the reported Map chip gap.
+- Do not change Album asset picker suggestions to exclude assets already in the album; that is an existing picker-suggestion mismatch outside this issue.
 
 ## Behavior
 
@@ -37,6 +38,10 @@ Favorites appears after `Media Type` in the filter section order for Map, Photos
 
 On owner-timeline requests that normally include partner assets or shared-space assets, selecting Favorites narrows the request back to the user's own favorited timeline assets. The backend rejects `isFavorite` when combined with `withPartners` or `withSharedSpaces`, and this design preserves that server contract instead of redefining cross-owner favorite semantics. Concrete shared-space scopes using `spaceId` remain supported.
 
+Photos search mode follows the same owner-only rule. When Favorites is selected, Photos smart-search and Photos dependent suggestions should not include `withSharedSpaces`. Map keeps its existing behavior: it may send `withSharedSpaces` with `isFavorite`, and the existing backend map service narrows that combination to owner-only favorites.
+
+Spaces exposes Favorites only in normal view mode. Select-assets and select-cover flows do not show the filter panel today, so they remain unchanged.
+
 ## Architecture
 
 The implementation should reuse the existing filter state model. `FilterState.isFavorite` already exists and is already counted by `getActiveFilterCount()` and included in `buildFilterContext()` when requested.
@@ -49,6 +54,7 @@ The changes are expected in these areas:
 - Album filter configs should include the `favorites` section and pass `isFavorite` to filter suggestions.
 - Photos, Spaces, and Album option builders should pass `isFavorite` through to their timeline or picker requests.
 - Owner-timeline option builders should omit `withPartners` and `withSharedSpaces` when `isFavorite` is selected.
+- Photos search and dependent suggestion builders should omit `withSharedSpaces` when `isFavorite` is selected.
 - `FilterPanel` localStorage hydration should merge newly introduced sections into saved visible and expanded section sets.
 
 Map already includes the `favorites` section and passes `isFavorite` through map marker, time-bucket, and timeline option builders. Its missing behavior comes from the shared active-chip renderer.
@@ -65,7 +71,7 @@ When a user selects Favorites:
 6. `ActiveFiltersBar` renders a `Favorites` chip.
 7. Closing the chip routes through the page's remove-filter handler and clears `isFavorite`.
 
-For search result mode, `SmartSearchResults` already tracks and passes `filters.isFavorite`, so no separate search redesign is needed.
+For search result mode, `SmartSearchResults` already tracks and passes `filters.isFavorite`; the route-level scope passed into it should match the no-query timeline scope.
 
 ## Persistence
 
@@ -81,6 +87,7 @@ Add or update focused tests for:
 - Photos, Spaces, Album, and Map filter configs include `favorites` in the expected order.
 - Photos, Spaces, and Album option builders include `isFavorite: true` when selected.
 - Photos and Album picker option builders omit partner/shared-space inclusion when `isFavorite` is selected.
+- Photos search and dependent suggestions omit shared-space inclusion when `isFavorite` is selected.
 - Photos and Spaces remove-filter handlers clear favorites.
 - Album suggestions include `isFavorite` for detail and picker configs.
 - `FilterPanel` visible and expanded section hydration merges newly introduced sections into saved section sets.

--- a/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
+++ b/docs/superpowers/specs/2026-04-27-favorites-filter-parity-design.md
@@ -1,0 +1,85 @@
+# Favorites Filter Parity Design
+
+## Context
+
+GitHub issue #443 reports two gaps in the new Favorites filter:
+
+- In Map, selecting Favorites does not create an active filter chip, so the active state is invisible in the results view.
+- Favorites is available in Map but missing from Timeline and Spaces.
+
+During review, we expanded the scope to include Albums because album assets already support favorite state and the album search/timeline APIs already accept `isFavorite`. The dedicated Favorites page stays unchanged because it is intrinsically scoped to favorites-only.
+
+## Goals
+
+- Show a `Favorites` active filter chip whenever `filters.isFavorite === true`.
+- Make the Favorites filter available in Photos, Spaces, Album detail view, and Album asset picker.
+- Preserve existing Map behavior while fixing the shared active-chip omission.
+- Ensure Favorites narrows final results, dependent suggestions, and any route-level time-bucket requests that use the shared filter state.
+- Preserve user section visibility preferences while making newly introduced sections visible and expanded by default.
+
+## Non-Goals
+
+- Do not change backend favorite semantics for personal assets, shared spaces, or albums.
+- Do not add a redundant Favorites filter to the dedicated `/favorites` page.
+- Do not broaden localization cleanup beyond the newly added Favorites labels.
+- Do not add a Map route-level regression; shared component and utility coverage is sufficient for the reported Map chip gap.
+
+## Behavior
+
+Favorites remains a two-state control everywhere it appears:
+
+- `All` maps to `filters.isFavorite === undefined`.
+- `Favorites` maps to `filters.isFavorite === true`.
+
+The active filter bar renders one chip labeled with the existing `favorites` i18n key. Closing that chip resets `isFavorite` to `undefined`, returning the control to `All`. The chip appears after media type chips and before timeline chips.
+
+Favorites appears after `Media Type` in the filter section order for Map, Photos, Spaces, Album detail view, and Album asset picker.
+
+## Architecture
+
+The implementation should reuse the existing filter state model. `FilterState.isFavorite` already exists and is already counted by `getActiveFilterCount()` and included in `buildFilterContext()` when requested.
+
+The changes are expected in these areas:
+
+- `ActiveFiltersBar` should add a chip when `filters.isFavorite === true`.
+- `handlePhotosRemoveFilter()` and `handleSpaceRemoveFilter()` should clear `isFavorite` for `favorites` and `isFavorite` removal types.
+- Photos and Spaces filter panel configs should include the `favorites` section.
+- Album filter configs should include the `favorites` section and pass `isFavorite` to filter suggestions.
+- Photos, Spaces, and Album option builders should pass `isFavorite` through to their timeline or picker requests.
+- `FilterPanel` localStorage hydration should merge newly introduced sections into saved visible and expanded section sets.
+
+Map already includes the `favorites` section and passes `isFavorite` through map marker, time-bucket, and timeline option builders. Its missing behavior comes from the shared active-chip renderer.
+
+## Data Flow
+
+When a user selects Favorites:
+
+1. `FavoritesFilter` sets `filters.isFavorite` to `true`.
+2. `FilterPanel` emits the bound filter state to the owning route.
+3. The route's option builder includes `isFavorite: true` in the timeline, picker, marker, time-bucket, or search request used by that surface.
+4. The route's suggestions provider includes `isFavorite: true`, so dependent filter options narrow to the favorites subset.
+5. `ActiveFiltersBar` renders a `Favorites` chip.
+6. Closing the chip routes through the page's remove-filter handler and clears `isFavorite`.
+
+For search result mode, `SmartSearchResults` already tracks and passes `filters.isFavorite`, so no separate search redesign is needed.
+
+## Persistence
+
+Existing users may have saved visible or expanded section arrays in localStorage. If `favorites` is simply added to a route config, those old saved arrays would omit the new section and make the fix look absent.
+
+`FilterPanel` should handle this generically by merging any sections present in the current config but missing from the saved set into the hydrated visible and expanded sets. This keeps old user preferences for existing sections while showing new first-class sections by default. Users can still hide or collapse Favorites afterward.
+
+## Testing
+
+Add or update focused tests for:
+
+- `ActiveFiltersBar` renders and removes a Favorites chip.
+- Photos, Spaces, Album, and Map filter configs include `favorites` in the expected order.
+- Photos, Spaces, and Album option builders include `isFavorite: true` when selected.
+- Photos and Spaces remove-filter handlers clear favorites.
+- Album suggestions include `isFavorite` for detail and picker configs.
+- `FilterPanel` visible and expanded section hydration merges newly introduced sections into saved section sets.
+- Album route regression covers Favorites in both album detail mode and asset picker mode.
+- Lightweight Photos and Spaces route regressions verify Favorites wiring without full UI interaction scaffolding.
+
+Run the focused web suite covering filter-panel components, filter option utilities, and affected route specs. If time allows, run the broader web type checks after the targeted suite passes.

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -131,7 +131,7 @@ describe('ActiveFiltersBar', () => {
     const { getByTestId } = render(ActiveFiltersBar, {
       props: {
         filters,
-        onRemoveFilter: (type) => {
+        onRemoveFilter: (type: string) => {
           removedType = type;
         },
         onClearAll: () => {},

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -108,6 +108,54 @@ describe('ActiveFiltersBar', () => {
     expect(chips[0].textContent).toContain('Videos only');
   });
 
+  it('should render chip for favorites filter', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('Favorites');
+  });
+
+  it('should remove favorites filter on chip close', async () => {
+    let removedType: string | undefined;
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    const { getByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: (type) => {
+          removedType = type;
+        },
+        onClearAll: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('chip-close'));
+    expect(removedType).toBe('favorites');
+  });
+
+  it('should not render a favorites chip for isFavorite false', () => {
+    const filters = { ...createFilterState(), isFavorite: false };
+
+    const { queryAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    expect(queryAllByTestId('active-chip')).toHaveLength(0);
+  });
+
   it('should render no chips when no filters active', () => {
     const filters = createFilterState();
 

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -349,6 +349,14 @@ describe('Section Selector', () => {
     }
   });
 
+  it('should keep favorites section toggle label distinct from asset favorite action', () => {
+    renderPanel(['favorites']);
+
+    const favoritesToggle = screen.getByTestId('section-toggle-favorites');
+    expect(favoritesToggle).toHaveAttribute('aria-label', 'Starred filter section');
+    expect(favoritesToggle).toHaveAttribute('title', 'Favorites');
+  });
+
   // Test 2
   it('should not render toggle icons for unconfigured sections', () => {
     renderPanel(['people', 'rating']);

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -531,9 +531,9 @@ describe('Section Selector', () => {
   it('should write updated visibility to localStorage when section is toggled', async () => {
     renderPanel(['people', 'rating']);
     await fireEvent.click(screen.getByTestId('section-toggle-people'));
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as string[];
-    expect(stored).toContain('rating');
-    expect(stored).not.toContain('people');
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as { selected: string[] };
+    expect(stored.selected).toContain('rating');
+    expect(stored.selected).not.toContain('people');
   });
 
   // Test 22
@@ -542,6 +542,53 @@ describe('Section Selector', () => {
     renderPanel(['people', 'rating']);
     expect(screen.queryByTestId('filter-section-people')).toBeNull();
     expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
+  });
+
+  it('should add favorites to legacy visible-section preferences without unhiding known hidden sections', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['people']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+  });
+
+  it('should add favorites to empty legacy visible-section preferences without unhiding all known sections', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+    expect(screen.queryByTestId('filter-section-people')).toBeNull();
+    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+  });
+
+  it('should fall back to all visible when legacy visible-section preferences only contain unknown sections', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['obsolete-section']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-rating')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+  });
+
+  it('should add sections missing from stored known-section metadata without unhiding known hidden sections', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        selected: ['people'],
+        known: ['people', 'rating', 'favorites'],
+      }),
+    );
+
+    renderPanel(['people', 'rating', 'favorites', 'media']);
+
+    expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+    expect(screen.getByTestId('filter-section-media')).toBeTruthy();
+    expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+    expect(screen.queryByTestId('filter-section-favorites')).toBeNull();
   });
 
   // Test 23
@@ -643,9 +690,9 @@ describe('Section Accordion Persistence', () => {
     renderPanel(['people', 'rating']);
     const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
     await fireEvent.click(peopleHeader);
-    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
-    expect(stored).not.toContain('people');
-    expect(stored).toContain('rating');
+    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '{}') as { selected: string[] };
+    expect(stored.selected).not.toContain('people');
+    expect(stored.selected).toContain('rating');
   });
 
   it('should restore collapsed sections from localStorage on mount', () => {
@@ -655,6 +702,54 @@ describe('Section Accordion Persistence', () => {
     const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
     expect(peopleContent).toBeNull();
     expect(ratingContent).toBeTruthy();
+  });
+
+  it('should expand favorites for legacy expanded-section preferences without expanding known collapsed sections', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['people']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+
+    expect(peopleContent).toBeTruthy();
+    expect(favoritesContent).toBeTruthy();
+    expect(ratingContent).toBeNull();
+  });
+
+  it('should fall back to all expanded when legacy expanded-section preferences only contain unknown sections', () => {
+    localStorage.setItem(EXPANDED_KEY, JSON.stringify(['obsolete-section']));
+
+    renderPanel(['people', 'rating', 'favorites']);
+
+    const peopleContent = screen.getByTestId('filter-section-people').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+
+    expect(peopleContent).toBeTruthy();
+    expect(ratingContent).toBeTruthy();
+    expect(favoritesContent).toBeTruthy();
+  });
+
+  it('should expand newly introduced sections from stored known-section metadata', () => {
+    localStorage.setItem(
+      EXPANDED_KEY,
+      JSON.stringify({
+        selected: ['people'],
+        known: ['people', 'rating', 'favorites'],
+      }),
+    );
+
+    renderPanel(['people', 'rating', 'favorites', 'media']);
+
+    const mediaContent = screen.getByTestId('filter-section-media').querySelector('.filter-section-content');
+    const ratingContent = screen.getByTestId('filter-section-rating').querySelector('.filter-section-content');
+    const favoritesContent = screen.getByTestId('filter-section-favorites').querySelector('.filter-section-content');
+
+    expect(mediaContent).toBeTruthy();
+    expect(ratingContent).toBeNull();
+    expect(favoritesContent).toBeNull();
   });
 
   it('should keep all sections collapsed when localStorage has empty array', () => {
@@ -687,8 +782,8 @@ describe('Section Accordion Persistence', () => {
     renderPanel(['people', 'rating']);
     const peopleHeader = screen.getByTestId('filter-section-people').querySelector('button')!;
     await fireEvent.click(peopleHeader);
-    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '[]') as string[];
-    expect(stored).toContain('people');
-    expect(stored).toContain('rating');
+    const stored = JSON.parse(localStorage.getItem(EXPANDED_KEY) ?? '{}') as { selected: string[] };
+    expect(stored.selected).toContain('people');
+    expect(stored.selected).toContain('rating');
   });
 });

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -308,12 +308,18 @@ describe('hidden prop', () => {
 
 describe('Section Selector', () => {
   const STORAGE_KEY = 'gallery-filter-visible-sections';
-  const allSections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'] as const;
+  const allSections: FilterSection[] = [
+    'timeline',
+    'people',
+    'location',
+    'camera',
+    'tags',
+    'rating',
+    'media',
+    'favorites',
+  ];
 
-  function renderPanel(
-    sections: Array<(typeof allSections)[number]> = [...allSections],
-    filters?: ReturnType<typeof createFilterState>,
-  ) {
+  function renderPanel(sections: FilterSection[] = [...allSections], filters?: ReturnType<typeof createFilterState>) {
     return render(FilterPanel, {
       props: {
         config: { sections: [...sections], providers: {} },

--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -94,6 +94,11 @@
       result.push({ type: 'mediaType', label: 'Videos only' });
     }
 
+    // Favorites chip
+    if (filters.isFavorite === true) {
+      result.push({ type: 'favorites', label: 'Favorites' });
+    }
+
     // Timeline chip
     const customDateLabel = buildCustomDateLabel(filters.dateAfter, filters.dateBefore);
     if (customDateLabel) {

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -338,6 +338,12 @@
     favorites: 'Favorites',
   };
 
+  const sectionToggleLabels: Record<string, string> = {
+    ...sectionTitles,
+    // Avoid colliding with asset action buttons labeled "Favorite" in browser automation.
+    favorites: 'Starred filter section',
+  };
+
   type StoredSectionSet = string[] | { selected?: string[]; known?: string[] };
 
   const LEGACY_INTRODUCED_SECTIONS = new Set<FilterSectionType>(['favorites']);
@@ -679,7 +685,7 @@
               ? 'bg-primary/10 text-primary'
               : 'text-gray-400 hover:bg-subtle hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400'}"
             onclick={() => toggleSection(section)}
-            aria-label={sectionTitles[section]}
+            aria-label={sectionToggleLabels[section]}
             aria-pressed={visibleSections.has(section)}
             title={sectionTitles[section]}
             data-testid="section-toggle-{section}"

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -338,20 +338,89 @@
     favorites: 'Favorites',
   };
 
+  type StoredSectionSet = string[] | { selected?: string[]; known?: string[] };
+
+  const LEGACY_INTRODUCED_SECTIONS = new Set<FilterSectionType>(['favorites']);
+
+  function isFilterSection(value: string, configSections: FilterSectionType[]): value is FilterSectionType {
+    return configSections.includes(value as FilterSectionType);
+  }
+
+  function getValidSections(values: unknown, configSections: FilterSectionType[]): FilterSectionType[] {
+    if (!Array.isArray(values)) {
+      return [];
+    }
+    return values.filter((value): value is FilterSectionType => {
+      return typeof value === 'string' && isFilterSection(value, configSections);
+    });
+  }
+
+  function getLegacyKnownSections(
+    selected: FilterSectionType[],
+    configSections: FilterSectionType[],
+  ): FilterSectionType[] {
+    const selectedSections = new Set(selected);
+    return configSections.filter(
+      (section) => selectedSections.has(section) || !LEGACY_INTRODUCED_SECTIONS.has(section),
+    );
+  }
+
+  function getLegacySections(
+    values: unknown,
+    configSections: FilterSectionType[],
+    fallback: () => SvelteSet<FilterSectionType>,
+  ): SvelteSet<FilterSectionType> {
+    if (!Array.isArray(values)) {
+      return fallback();
+    }
+
+    const selected = getValidSections(values, configSections);
+    if (values.length > 0 && selected.length === 0) {
+      return fallback();
+    }
+
+    const known = getLegacyKnownSections(selected, configSections);
+    const knownSet = new Set(known);
+    const introduced = configSections.filter((section) => !knownSet.has(section));
+    return new SvelteSet([...selected, ...introduced]);
+  }
+
+  function hydrateSectionSet(
+    configSections: FilterSectionType[],
+    raw: string | null,
+    fallback: () => SvelteSet<FilterSectionType>,
+  ): SvelteSet<FilterSectionType> {
+    if (raw === null) {
+      return fallback();
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as StoredSectionSet;
+      if (Array.isArray(parsed)) {
+        return getLegacySections(parsed, configSections, fallback);
+      }
+
+      const selected = getValidSections(parsed?.selected, configSections);
+      const known = getValidSections(parsed?.known, configSections);
+      const knownSet = new Set(known);
+      const introduced = configSections.filter((section) => !knownSet.has(section));
+
+      return new SvelteSet([...selected, ...introduced]);
+    } catch {
+      return fallback();
+    }
+  }
+
+  function serializeSectionSet(sections: SvelteSet<FilterSectionType>, configSections: FilterSectionType[]): string {
+    return JSON.stringify({
+      selected: [...sections],
+      known: [...configSections],
+    });
+  }
+
   function loadVisibleSections(configSections: FilterSectionType[], key: string): SvelteSet<FilterSectionType> {
     if (browser) {
-      try {
-        const raw = localStorage.getItem(key);
-        if (raw) {
-          const parsed = JSON.parse(raw) as string[];
-          const valid = parsed.filter((s): s is FilterSectionType => configSections.includes(s as FilterSectionType));
-          if (valid.length > 0) {
-            return new SvelteSet(valid);
-          }
-        }
-      } catch {
-        /* corrupted JSON or localStorage unavailable — fall through to default */
-      }
+      return hydrateSectionSet(configSections, localStorage.getItem(key), () => new SvelteSet(configSections));
     }
     return new SvelteSet(configSections);
   }
@@ -362,19 +431,11 @@
 
   function loadExpandedSections(configSections: FilterSectionType[]): SvelteSet<FilterSectionType> {
     if (browser) {
-      try {
-        const raw = localStorage.getItem(EXPANDED_SECTIONS_KEY);
-        if (raw !== null) {
-          const parsed = JSON.parse(raw) as string[];
-          const valid = parsed.filter((s): s is FilterSectionType => configSections.includes(s as FilterSectionType));
-          // Return the validated set even if empty — an empty array means the user
-          // explicitly collapsed all sections. Only fall through to default when
-          // there's no localStorage entry at all (raw === null).
-          return new SvelteSet(valid);
-        }
-      } catch {
-        /* corrupted JSON — fall through to default */
-      }
+      return hydrateSectionSet(
+        configSections,
+        localStorage.getItem(EXPANDED_SECTIONS_KEY),
+        () => new SvelteSet(configSections),
+      );
     }
     return new SvelteSet(configSections);
   }
@@ -408,7 +469,7 @@
   $effect(() => {
     if (browser) {
       try {
-        localStorage.setItem(storageKey, JSON.stringify([...visibleSections]));
+        localStorage.setItem(storageKey, serializeSectionSet(visibleSections, config.sections));
       } catch {
         /* localStorage unavailable */
       }
@@ -428,7 +489,7 @@
   $effect(() => {
     if (browser) {
       try {
-        localStorage.setItem(EXPANDED_SECTIONS_KEY, JSON.stringify([...expandedSections]));
+        localStorage.setItem(EXPANDED_SECTIONS_KEY, serializeSectionSet(expandedSections, config.sections));
       } catch {
         /* localStorage unavailable */
       }

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -27,7 +27,16 @@ beforeEach(() => {
 describe('buildAlbumDetailFilterConfig', () => {
   it('keeps the album filter sections in plan order', () => {
     const config = buildAlbumDetailFilterConfig('album-1');
-    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media']);
+    expect(config.sections).toEqual([
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+    ]);
   });
 
   it('passes albumId to filter suggestions, maps suggestions, and scopes dependent providers', async () => {
@@ -97,12 +106,30 @@ describe('buildAlbumDetailFilterConfig', () => {
       }),
     );
   });
+
+  it('passes isFavorite to album detail filter suggestions', async () => {
+    const config = buildAlbumDetailFilterConfig('album-1');
+    await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ albumId: 'album-1', isFavorite: true }),
+    );
+  });
 });
 
 describe('buildAlbumAssetPickerFilterConfig', () => {
   it('keeps the picker filter sections in plan order', () => {
     const config = buildAlbumAssetPickerFilterConfig();
-    expect(config.sections).toEqual(['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media']);
+    expect(config.sections).toEqual([
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+    ]);
   });
 
   it('does not send albumId or withSharedSpaces', async () => {
@@ -132,5 +159,12 @@ describe('buildAlbumAssetPickerFilterConfig', () => {
         takenBefore: '2025-01-01T00:00:00.000Z',
       }),
     );
+  });
+
+  it('passes isFavorite to album asset picker filter suggestions', async () => {
+    const config = buildAlbumAssetPickerFilterConfig();
+    await config.suggestionsProvider!({ ...createFilterState(), isFavorite: true });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
   });
 });

--- a/web/src/lib/utils/__tests__/album-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-options.spec.ts
@@ -46,6 +46,17 @@ describe('buildAlbumTimelineOptions', () => {
       }),
     );
   });
+
+  it('maps favorites for album timeline options', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, filters)).toEqual(
+      expect.objectContaining({
+        albumId: 'album-1',
+        isFavorite: true,
+      }),
+    );
+  });
 });
 
 describe('buildAlbumAssetPickerOptions', () => {
@@ -76,5 +87,18 @@ describe('buildAlbumAssetPickerOptions', () => {
     expect(buildAlbumAssetPickerOptions('album-1', filters)).toEqual(
       expect.objectContaining({ takenAfter: '2024-01-01T00:00:00.000Z' }),
     );
+  });
+
+  it('maps favorites and omits partners for album asset picker options', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+    const options = buildAlbumAssetPickerOptions('album-1', filters);
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        timelineAlbumId: 'album-1',
+        isFavorite: true,
+      }),
+    );
+    expect(options).not.toHaveProperty('withPartners');
   });
 });

--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -113,4 +113,54 @@ describe('buildMapTimelineOptions', () => {
       spacePersonIds: ['space-person-1'],
     });
   });
+
+  it('omits partners when favorites filter is selected for global map cluster timelines', () => {
+    const filters = {
+      ...createFilterState(),
+      isFavorite: true,
+    };
+    const selectedClusterIds = new Set(['asset-1']);
+
+    const options = buildMapTimelineOptions(filters, '1,2,3,4', selectedClusterIds, undefined, {
+      withPartners: true,
+    });
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        isFavorite: true,
+      }),
+    );
+    expect(options).not.toHaveProperty('withPartners');
+  });
+
+  it('omits partners when map favorites setting is enabled for global map cluster timelines', () => {
+    const selectedClusterIds = new Set(['asset-1']);
+
+    const options = buildMapTimelineOptions(createFilterState(), '1,2,3,4', selectedClusterIds, undefined, {
+      onlyFavorites: true,
+      withPartners: true,
+    });
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        isFavorite: true,
+      }),
+    );
+    expect(options).not.toHaveProperty('withPartners');
+  });
+
+  it('keeps partners when global map cluster timelines are not narrowed to favorites', () => {
+    const selectedClusterIds = new Set(['asset-1']);
+
+    const options = buildMapTimelineOptions(createFilterState(), '1,2,3,4', selectedClusterIds, undefined, {
+      withPartners: true,
+    });
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        withPartners: true,
+      }),
+    );
+    expect(options).not.toHaveProperty('isFavorite');
+  });
 });

--- a/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
@@ -119,6 +119,15 @@ describe('buildPhotosTimelineOptions', () => {
     expect(options.withSharedSpaces).toBe(true);
   });
 
+  it('should include isFavorite and omit shared timeline inclusions when favorites is selected', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+    const options = buildPhotosTimelineOptions(filters);
+
+    expect(options.isFavorite).toBe(true);
+    expect(options).not.toHaveProperty('withPartners');
+    expect(options).not.toHaveProperty('withSharedSpaces');
+  });
+
   it('should handle multiple simultaneous filters', () => {
     const filters = {
       ...createFilterState(),
@@ -209,6 +218,13 @@ describe('handlePhotosRemoveFilter', () => {
     const filters = { ...createFilterState(), mediaType: 'image' as const };
     const result = handlePhotosRemoveFilter(filters, 'mediaType');
     expect(result.mediaType).toBe('all');
+  });
+
+  it('should clear favorites filter', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(handlePhotosRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
+    expect(handlePhotosRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
   });
 
   it('should preserve sortOrder when removing filters', () => {

--- a/web/src/lib/utils/__tests__/space-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/space-filter-options.spec.ts
@@ -69,6 +69,17 @@ describe('buildSpaceTimelineOptions', () => {
       }),
     );
   });
+
+  it('preserves favorites in spaces timeline options', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        spaceId: 'space-1',
+        isFavorite: true,
+      }),
+    );
+  });
 });
 
 describe('handleSpaceRemoveFilter', () => {
@@ -86,5 +97,12 @@ describe('handleSpaceRemoveFilter', () => {
     expect(result.dateBefore).toBeUndefined();
     expect(result.selectedYear).toBeUndefined();
     expect(result.selectedMonth).toBeUndefined();
+  });
+
+  it('clears favorites when removing favorites filter', () => {
+    const filters = { ...createFilterState(), isFavorite: true };
+
+    expect(handleSpaceRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
+    expect(handleSpaceRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
   });
 });

--- a/web/src/lib/utils/album-filter-config.ts
+++ b/web/src/lib/utils/album-filter-config.ts
@@ -6,7 +6,7 @@ import {
 import { createUrl } from '$lib/utils';
 import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
 
-const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'] as const;
+const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
 
 function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>) {
   return {
@@ -34,6 +34,7 @@ function toSuggestionRequest(filters: FilterState) {
     model: filters.model,
     tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
     rating: filters.rating,
+    isFavorite: filters.isFavorite,
     mediaType:
       filters.mediaType === 'all'
         ? undefined

--- a/web/src/lib/utils/album-filter-options.ts
+++ b/web/src/lib/utils/album-filter-options.ts
@@ -23,6 +23,9 @@ function applyCommonFilterFields(base: Record<string, unknown>, filters: FilterS
   if (filters.rating !== undefined) {
     base.rating = filters.rating;
   }
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
+  }
   if (filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
@@ -48,7 +51,7 @@ export function buildAlbumAssetPickerOptions(albumId: string, filters: FilterSta
   return applyCommonFilterFields(
     {
       visibility: AssetVisibility.Timeline,
-      withPartners: true,
+      ...(filters.isFavorite === undefined ? { withPartners: true } : {}),
       timelineAlbumId: albumId,
     },
     filters,

--- a/web/src/lib/utils/map-filter-options.ts
+++ b/web/src/lib/utils/map-filter-options.ts
@@ -97,8 +97,14 @@ export function buildMapTimelineOptions(
   }
 
   if (!spaceId) {
-    base.isFavorite = filters?.isFavorite ?? (settings.onlyFavorites || undefined);
-    base.withPartners = settings.withPartners || undefined;
+    const isFavorite = filters?.isFavorite ?? (settings.onlyFavorites || undefined);
+
+    if (isFavorite !== undefined) {
+      base.isFavorite = isFavorite;
+    }
+    if (isFavorite === undefined && settings.withPartners) {
+      base.withPartners = true;
+    }
   }
 
   if (filters?.mediaType && filters.mediaType !== 'all') {

--- a/web/src/lib/utils/photos-filter-options.ts
+++ b/web/src/lib/utils/photos-filter-options.ts
@@ -3,11 +3,11 @@ import { buildFilterContext } from '$lib/components/filter-panel/filter-panel';
 import { AssetOrder, AssetTypeEnum, AssetVisibility } from '@immich/sdk';
 
 export function buildPhotosTimelineOptions(filters: FilterState): Record<string, unknown> {
+  const includeSharedTimelineAssets = filters.isFavorite === undefined;
   const base: Record<string, unknown> = {
     visibility: AssetVisibility.Timeline,
     withStacked: true,
-    withPartners: true,
-    withSharedSpaces: true,
+    ...(includeSharedTimelineAssets ? { withPartners: true, withSharedSpaces: true } : {}),
   };
 
   if (filters.personIds.length > 0) {
@@ -30,6 +30,9 @@ export function buildPhotosTimelineOptions(filters: FilterState): Record<string,
   }
   if (filters.rating !== undefined) {
     base.rating = filters.rating;
+  }
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
   }
   if (filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
@@ -69,6 +72,10 @@ export function handlePhotosRemoveFilter(filters: FilterState, type: string, id?
     case 'media':
     case 'mediaType': {
       return { ...filters, mediaType: 'all' };
+    }
+    case 'favorites':
+    case 'isFavorite': {
+      return { ...filters, isFavorite: undefined };
     }
     case 'timeline': {
       return {

--- a/web/src/lib/utils/space-filter-options.ts
+++ b/web/src/lib/utils/space-filter-options.ts
@@ -25,6 +25,9 @@ export function buildSpaceTimelineOptions(spaceId: string, filters: FilterState)
   if (filters.rating !== undefined) {
     base.rating = filters.rating;
   }
+  if (filters.isFavorite !== undefined) {
+    base.isFavorite = filters.isFavorite;
+  }
   if (filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
@@ -61,6 +64,10 @@ export function handleSpaceRemoveFilter(filters: FilterState, type: string, id?:
     case 'media':
     case 'mediaType': {
       return { ...filters, mediaType: 'all' };
+    }
+    case 'favorites':
+    case 'isFavorite': {
+      return { ...filters, isFavorite: undefined };
     }
     case 'timeline': {
       return {

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
@@ -156,6 +156,28 @@ describe('album detail filter panel route', () => {
     expect(screen.getByTestId('active-chip')).toHaveTextContent('Album Person');
   });
 
+  it('applies favorites independently in album view and picker modes', async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
+    await user.click(screen.getByTestId('favorites-only'));
+
+    expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
+    expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
+
+    await fireEvent.click(screen.getByLabelText('add_photos'));
+    await waitFor(() => expect(screen.getByTestId('favorites-only')).toBeInTheDocument());
+    expect(screen.queryByTestId('active-chip')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('favorites-only'));
+
+    expect(screen.getByTestId('active-chip')).toHaveTextContent('Favorites');
+    expect(screen.getByTestId('timeline-options').textContent).toContain('"timelineAlbumId":"');
+    expect(screen.getByTestId('timeline-options').textContent).toContain('"isFavorite":true');
+    expect(screen.getByTestId('timeline-options').textContent).not.toContain('"withPartners":true');
+  });
+
   it('keeps timelineAlbumId in picker options after filters change and shows filtered empty state', async () => {
     renderPage();
     const user = userEvent.setup();

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -76,7 +76,7 @@
   let tagNames = new SvelteMap<string, string>();
 
   const filterConfig: FilterPanelConfig = {
-    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'],
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'],
     suggestionsProvider: async (filters: FilterState) => {
       const context = buildFilterContext(filters);
       const response = await getFilterSuggestions({
@@ -96,7 +96,7 @@
         isFavorite: filters.isFavorite,
         takenAfter: context?.takenAfter,
         takenBefore: context?.takenBefore,
-        withSharedSpaces: true,
+        ...(filters.isFavorite === undefined ? { withSharedSpaces: true } : {}),
       });
       const mappedPeople = response.people.map((p) => ({
         id: p.id,
@@ -124,15 +124,15 @@
         getSearchSuggestions({
           $type: SearchSuggestionType.City,
           country,
-          withSharedSpaces: true,
           ...context,
+          ...(context?.isFavorite === undefined ? { withSharedSpaces: true } : {}),
         }),
       cameraModels: (make, context) =>
         getSearchSuggestions({
           $type: SearchSuggestionType.CameraModel,
           make,
-          withSharedSpaces: true,
           ...context,
+          ...(context?.isFavorite === undefined ? { withSharedSpaces: true } : {}),
         }),
     },
   };
@@ -249,7 +249,7 @@
           searchQuery={committedQuery}
           {filters}
           isShared={false}
-          withSharedSpaces={true}
+          withSharedSpaces={filters.isFavorite === undefined}
         />
       {:else}
         <Timeline

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -1,6 +1,8 @@
 import TestWrapper from '$lib/components/TestWrapper.svelte';
+import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+import { getSearchSuggestions } from '@immich/sdk';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import PhotosPage from './+page.svelte';
 
@@ -43,7 +45,7 @@ vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
 });
 
 vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/filter-panel-favorites.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -235,5 +237,57 @@ describe('Photos page search URL state', () => {
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'nature');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
+  });
+
+  it('exposes favorites in the photos filter panel', () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites',
+    );
+  });
+
+  it('passes favorites into photos timeline options when selected', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    await waitFor(() => {
+      expect(buildPhotosTimelineOptions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
+    });
+  });
+
+  it('narrows search results to favorites without shared spaces when selected', async () => {
+    renderPage();
+
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-with-shared-spaces', 'false');
+    });
+  });
+
+  it('narrows dependent suggestions to favorites without shared spaces when selected', async () => {
+    renderPage();
+
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+    await fireEvent.click(screen.getByTestId('load-city-suggestions'));
+    await fireEvent.click(screen.getByTestId('load-camera-model-suggestions'));
+
+    await waitFor(() => {
+      expect(getSearchSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ country: 'Germany', isFavorite: true }),
+      );
+      expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ make: 'Sony', isFavorite: true }));
+    });
+
+    for (const [request] of vi.mocked(getSearchSuggestions).mock.calls) {
+      expect(request).not.toHaveProperty('withSharedSpaces');
+    }
   });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -177,7 +177,7 @@
   });
 
   const filterConfig: FilterPanelConfig = {
-    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'],
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'],
     suggestionsProvider: async (filters: FilterState) => {
       const context = buildFilterContext(filters);
       const response = await getFilterSuggestions({

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -3,7 +3,7 @@ import TestWrapper from '$lib/components/TestWrapper.svelte';
 import type { SharedSpaceMemberResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
 import { SharedSpaceRole } from '@immich/sdk';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import SpacesPage from './+page.svelte';
 
@@ -44,7 +44,7 @@ vi.mock('$lib/components/OnEvents.svelte', async () => {
 });
 
 vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/bindable-filter-panel.stub.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/filter-panel-favorites.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -183,5 +183,26 @@ describe('Spaces page search URL state', () => {
     expect(screen.queryByTestId('sort-toggle')).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
+  });
+
+  it('exposes favorites in the spaces filter panel', () => {
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites',
+    );
+  });
+
+  it('narrows space search results to favorites within the space when selected', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-is-favorite', 'true');
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-space-id', 'space-1');
+    });
   });
 });

--- a/web/src/test-data/mocks/filter-panel-favorites.stub.svelte
+++ b/web/src/test-data/mocks/filter-panel-favorites.stub.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import {
+    buildFilterContext,
+    createFilterState,
+    type FilterPanelConfig,
+    type FilterState,
+  } from '$lib/components/filter-panel/filter-panel';
+
+  interface Props {
+    filters?: FilterState;
+    config?: FilterPanelConfig;
+    [key: string]: unknown;
+  }
+
+  let { filters = $bindable(createFilterState()), config, ...rest }: Props = $props();
+
+  function selectFavorites() {
+    filters = { ...filters, isFavorite: true };
+  }
+
+  function loadCitySuggestions() {
+    void config?.providers?.cities?.('Germany', buildFilterContext(filters, ['country', 'city']));
+  }
+
+  function loadCameraModelSuggestions() {
+    void config?.providers?.cameraModels?.('Sony', buildFilterContext(filters, ['make', 'model']));
+  }
+</script>
+
+<div
+  {...rest}
+  data-testid="filter-panel-stub"
+  data-sections={config?.sections.join(',') ?? ''}
+  data-is-favorite={String(filters?.isFavorite)}
+>
+  <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
+  <button type="button" data-testid="load-city-suggestions" onclick={loadCitySuggestions}>Load cities</button>
+  <button type="button" data-testid="load-camera-model-suggestions" onclick={loadCameraModelSuggestions}>
+    Load camera models
+  </button>
+</div>

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -5,10 +5,12 @@
     isLoading?: boolean;
     searchQuery?: string;
     filters?: FilterState;
+    withSharedSpaces?: boolean;
+    spaceId?: string;
     [key: string]: unknown;
   }
 
-  let { isLoading = $bindable(false), searchQuery = '', filters, ...rest }: Props = $props();
+  let { isLoading = $bindable(false), searchQuery = '', filters, withSharedSpaces, spaceId, ...rest }: Props = $props();
 </script>
 
 <div
@@ -17,4 +19,7 @@
   data-loading={String(isLoading)}
   data-search-query={searchQuery}
   data-sort-order={filters?.sortOrder ?? ''}
+  data-is-favorite={String(filters?.isFavorite)}
+  data-with-shared-spaces={String(withSharedSpaces)}
+  data-space-id={spaceId ?? ''}
 ></div>


### PR DESCRIPTION
## Summary
- Shows the Favorites active chip and preserves section preference migrations when Favorites is introduced.
- Wires Favorites filtering through Photos, Spaces, Album detail, and Album asset picker request builders/config.
- Adds route and utility regressions for Favorites narrowing, including owner timeline shared-scope exclusions.

## Manual Testing
- In Photos/Timeline, open the filter panel, expand the Favorites section, select Favorites, and confirm the active chip is labeled exactly Favorites; use the chip close button and confirm it resets back to All.
- In Map, select Favorites from the filter panel and confirm map markers/clusters narrow to favorite assets; open a cluster timeline and confirm it loads without request errors, then close the Favorites chip and confirm the map returns to All.
- In Spaces, use a space with favorite and non-favorite assets, select Favorites, and confirm the space asset grid narrows to favorites; close the Favorites chip and confirm it resets to All.
- In Albums, repeat the Favorites filter on an album detail page and in the album asset picker; confirm both narrow to favorite assets and the active chip reset returns to All.
- Refresh after opening filter sections and confirm the newly introduced Favorites section appears without hiding existing section preferences.

## Test Plan
- [x] pnpm --dir web exec vitest --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/components/filter-panel/__tests__/filter-panel.spec.ts src/lib/components/filter-panel/__tests__/favorites-filter.spec.ts src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/album-filter-options.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/space-search.spec.ts \"src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts\" \"src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts\" \"src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts\"
- [x] pnpm --dir web run check:svelte
- [x] pnpm --dir web run check:typescript
- [x] pnpm --dir web exec prettier --check touched files
- [x] PR CI: 25 successful, 15 skipped, 0 failing, 0 pending
Closes #443 