### PR TITLE
fix(mobile): refresh snapshot views after remote updates

### DIFF
--- a/mobile/lib/presentation/pages/search/paginated_search.provider.dart
+++ b/mobile/lib/presentation/pages/search/paginated_search.provider.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/services/search.service.dart';
 import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 
 final searchPreFilterProvider = NotifierProvider<SearchFilterProvider, SearchFilter?>(SearchFilterProvider.new);
 
@@ -31,13 +32,20 @@ class SearchState {
   const SearchState({this.assets = const [], this.nextPage = 1, this.isLoading = false});
 }
 
-final paginatedSearchProvider = StateNotifierProvider<PaginatedSearchNotifier, SearchState>(
-  (ref) => PaginatedSearchNotifier(ref.watch(searchServiceProvider)),
-);
+final paginatedSearchProvider = StateNotifierProvider<PaginatedSearchNotifier, SearchState>((ref) {
+  final notifier = PaginatedSearchNotifier(ref.watch(searchServiceProvider));
+  ref.listen<int>(syncStatusProvider.select((state) => state.remoteContentChangedCount), (previous, next) {
+    if (previous != null && next != previous) {
+      unawaited(notifier.refreshActiveSearch());
+    }
+  });
+  return notifier;
+});
 
 class PaginatedSearchNotifier extends StateNotifier<SearchState> {
   final SearchService _searchService;
   final _assetCountController = StreamController<int>.broadcast();
+  SearchFilter? _activeFilter;
 
   PaginatedSearchNotifier(this._searchService) : super(const SearchState());
 
@@ -45,6 +53,7 @@ class PaginatedSearchNotifier extends StateNotifier<SearchState> {
 
   Future<void> search(SearchFilter filter) async {
     if (state.nextPage == null || state.isLoading) return;
+    _activeFilter = filter;
 
     state = SearchState(assets: state.assets, nextPage: state.nextPage, isLoading: true);
 
@@ -61,7 +70,19 @@ class PaginatedSearchNotifier extends StateNotifier<SearchState> {
     _assetCountController.add(assets.length);
   }
 
+  Future<void> refreshActiveSearch() async {
+    final filter = _activeFilter;
+    if (filter == null || state.isLoading) {
+      return;
+    }
+
+    state = const SearchState();
+    _assetCountController.add(0);
+    await search(filter);
+  }
+
   void clear() {
+    _activeFilter = null;
     state = const SearchState();
     _assetCountController.add(0);
   }

--- a/mobile/lib/presentation/widgets/map/map.state.dart
+++ b/mobile/lib/presentation/widgets/map/map.state.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/infrastructure/repositories/timeline.repository.da
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/map.provider.dart';
 import 'package:immich_mobile/providers/map/map_state.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
@@ -121,6 +122,8 @@ class MapStateNotifier extends Notifier<MapState> {
 // This provider watches the markers from the map service and serves the markers.
 // It should be used only after the map service provider is overridden
 final mapMarkerProvider = FutureProvider.family<Map<String, dynamic>, LatLngBounds?>((ref, bounds) async {
+  ref.watch(syncStatusProvider.select((state) => state.remoteContentChangedCount));
+
   final mapService = ref.watch(mapServiceProvider);
   final markers = await mapService.getMarkers(bounds);
   final features = List.filled(markers.length, const <String, dynamic>{});

--- a/mobile/lib/presentation/widgets/map/map.widget.dart
+++ b/mobile/lib/presentation/widgets/map/map.widget.dart
@@ -15,6 +15,7 @@ import 'package:immich_mobile/presentation/widgets/bottom_sheet/map_bottom_sheet
 import 'package:immich_mobile/presentation/widgets/map/map.state.dart';
 import 'package:immich_mobile/presentation/widgets/map/map_utils.dart';
 import 'package:immich_mobile/providers/routes.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/async_mutex.dart';
 import 'package:immich_mobile/utils/debounce.dart';
@@ -59,6 +60,11 @@ class _DriftMapState extends ConsumerState<DriftMap> {
   void initState() {
     super.initState();
     _eventSubscription = EventStream.shared.listen<MapMarkerReloadEvent>(_onEvent);
+    ref.listenManual<int>(syncStatusProvider.select((state) => state.remoteContentChangedCount), (previous, next) {
+      if (previous != null && next != previous) {
+        _debouncer.run(() => setBounds(forceReload: true));
+      }
+    });
   }
 
   @override
@@ -140,6 +146,9 @@ class _DriftMapState extends ConsumerState<DriftMap> {
     unawaited(
       _reloadMutex.run(() async {
         if (mounted && (ref.read(mapStateProvider.notifier).setBounds(bounds) || forceReload)) {
+          if (forceReload) {
+            ref.invalidate(mapMarkerProvider(bounds));
+          }
           final markers = await ref.read(mapMarkerProvider(bounds).future);
           await reloadMarkers(markers);
         }

--- a/mobile/lib/providers/folder.provider.dart
+++ b/mobile/lib/providers/folder.provider.dart
@@ -1,17 +1,22 @@
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/models/folder/root_folder.model.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/services/folder.service.dart';
 import 'package:logging/logging.dart';
 
 class FolderStructureNotifier extends StateNotifier<AsyncValue<RootFolder>> {
   final FolderService _folderService;
   final Logger _log = Logger("FolderStructureNotifier");
+  SortOrder? _lastOrder;
 
   FolderStructureNotifier(this._folderService) : super(const AsyncLoading());
 
   Future<void> fetchFolders(SortOrder order) async {
+    _lastOrder = order;
     try {
       final folders = await _folderService.getFolderStructure(order);
       state = AsyncData(folders);
@@ -20,20 +25,36 @@ class FolderStructureNotifier extends StateNotifier<AsyncValue<RootFolder>> {
       state = AsyncError(e, stack);
     }
   }
+
+  Future<void> refresh() async {
+    final order = _lastOrder;
+    if (order == null) {
+      return;
+    }
+    await fetchFolders(order);
+  }
 }
 
 final folderStructureProvider = StateNotifierProvider<FolderStructureNotifier, AsyncValue<RootFolder>>((ref) {
-  return FolderStructureNotifier(ref.watch(folderServiceProvider));
+  final notifier = FolderStructureNotifier(ref.watch(folderServiceProvider));
+  ref.listen<int>(syncStatusProvider.select((state) => state.remoteContentChangedCount), (previous, next) {
+    if (previous != null && next != previous) {
+      unawaited(notifier.refresh());
+    }
+  });
+  return notifier;
 });
 
 class FolderRenderListNotifier extends StateNotifier<AsyncValue<List<RemoteAssetExif>>> {
   final FolderService _folderService;
   final RootFolder _folder;
   final Logger _log = Logger("FolderAssetsNotifier");
+  SortOrder? _lastOrder;
 
   FolderRenderListNotifier(this._folderService, this._folder) : super(const AsyncLoading());
 
   Future<void> fetchAssets(SortOrder order) async {
+    _lastOrder = order;
     try {
       final assets = await _folderService.getFolderAssets(_folder, order);
       state = AsyncData(assets);
@@ -42,6 +63,14 @@ class FolderRenderListNotifier extends StateNotifier<AsyncValue<List<RemoteAsset
       state = AsyncError(e, stack);
     }
   }
+
+  Future<void> refresh() async {
+    final order = _lastOrder;
+    if (order == null) {
+      return;
+    }
+    await fetchAssets(order);
+  }
 }
 
 final folderRenderListProvider =
@@ -49,5 +78,11 @@ final folderRenderListProvider =
       ref,
       folder,
     ) {
-      return FolderRenderListNotifier(ref.watch(folderServiceProvider), folder);
+      final notifier = FolderRenderListNotifier(ref.watch(folderServiceProvider), folder);
+      ref.listen<int>(syncStatusProvider.select((state) => state.remoteContentChangedCount), (previous, next) {
+        if (previous != null && next != previous) {
+          unawaited(notifier.refresh());
+        }
+      });
+      return notifier;
     });

--- a/mobile/lib/providers/infrastructure/asset.provider.dart
+++ b/mobile/lib/providers/infrastructure/asset.provider.dart
@@ -4,6 +4,7 @@ import 'package:immich_mobile/infrastructure/repositories/local_asset.repository
 import 'package:immich_mobile/infrastructure/repositories/remote_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/trashed_local_asset.repository.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 
 final localAssetRepository = Provider<DriftLocalAssetRepository>(
@@ -26,6 +27,8 @@ final assetServiceProvider = Provider(
 );
 
 final placesProvider = FutureProvider<List<(String, String)>>((ref) {
+  ref.watch(syncStatusProvider.select((state) => state.remoteContentChangedCount));
+
   final assetService = ref.watch(assetServiceProvider);
   final auth = ref.watch(currentUserProvider);
 

--- a/mobile/lib/providers/photos_filter/timeline_query.provider.dart
+++ b/mobile/lib/providers/photos_filter/timeline_query.provider.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_debounce.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 
 final photosTimelineQueryProvider = Provider<TimelineService>((ref) {
@@ -23,6 +24,8 @@ final photosTimelineQueryProvider = Provider<TimelineService>((ref) {
     ref.onDispose(svc.dispose);
     return svc;
   }
+
+  ref.watch(syncStatusProvider.select((state) => state.remoteContentChangedCount));
 
   final search = ref.watch(searchServiceProvider);
   final svc = buildPhotosFilterSearchTimeline(factory: factory, search: search, filter: filter);

--- a/mobile/lib/providers/sync_status.provider.dart
+++ b/mobile/lib/providers/sync_status.provider.dart
@@ -22,6 +22,7 @@ class SyncStatusState {
   final SyncStatus localSyncStatus;
   final SyncStatus hashJobStatus;
   final SyncStatus cloudIdSyncStatus;
+  final int remoteContentChangedCount;
 
   final String? errorMessage;
 
@@ -30,6 +31,7 @@ class SyncStatusState {
     this.localSyncStatus = SyncStatus.idle,
     this.hashJobStatus = SyncStatus.idle,
     this.cloudIdSyncStatus = SyncStatus.idle,
+    this.remoteContentChangedCount = 0,
     this.errorMessage,
   });
 
@@ -38,6 +40,7 @@ class SyncStatusState {
     SyncStatus? localSyncStatus,
     SyncStatus? hashJobStatus,
     SyncStatus? cloudIdSyncStatus,
+    int? remoteContentChangedCount,
     String? errorMessage,
   }) {
     return SyncStatusState(
@@ -45,6 +48,7 @@ class SyncStatusState {
       localSyncStatus: localSyncStatus ?? this.localSyncStatus,
       hashJobStatus: hashJobStatus ?? this.hashJobStatus,
       cloudIdSyncStatus: cloudIdSyncStatus ?? this.cloudIdSyncStatus,
+      remoteContentChangedCount: remoteContentChangedCount ?? this.remoteContentChangedCount,
       errorMessage: errorMessage ?? this.errorMessage,
     );
   }
@@ -62,11 +66,19 @@ class SyncStatusState {
         other.localSyncStatus == localSyncStatus &&
         other.hashJobStatus == hashJobStatus &&
         other.cloudIdSyncStatus == cloudIdSyncStatus &&
+        other.remoteContentChangedCount == remoteContentChangedCount &&
         other.errorMessage == errorMessage;
   }
 
   @override
-  int get hashCode => Object.hash(remoteSyncStatus, localSyncStatus, hashJobStatus, cloudIdSyncStatus, errorMessage);
+  int get hashCode => Object.hash(
+    remoteSyncStatus,
+    localSyncStatus,
+    hashJobStatus,
+    cloudIdSyncStatus,
+    remoteContentChangedCount,
+    errorMessage,
+  );
 }
 
 class SyncStatusNotifier extends Notifier<SyncStatusState> {
@@ -90,7 +102,13 @@ class SyncStatusNotifier extends Notifier<SyncStatusState> {
   }
 
   void startRemoteSync() => setRemoteSyncStatus(SyncStatus.syncing);
-  void completeRemoteSync() => setRemoteSyncStatus(SyncStatus.success);
+  void markRemoteContentChanged() =>
+      state = state.copyWith(remoteContentChangedCount: state.remoteContentChangedCount + 1);
+  void completeRemoteSync() => state = state.copyWith(
+    remoteSyncStatus: SyncStatus.success,
+    remoteContentChangedCount: state.remoteContentChangedCount + 1,
+    errorMessage: null,
+  );
   void errorRemoteSync(String error) => setRemoteSyncStatus(SyncStatus.error, error);
 
   ///

--- a/mobile/lib/providers/websocket.provider.dart
+++ b/mobile/lib/providers/websocket.provider.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/models/server_info/server_version.model.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/utils/debounce.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:logging/logging.dart';
@@ -169,7 +170,11 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
   }
 
   void _handleSyncAssetEditReady(dynamic data) {
-    unawaited(_ref.read(backgroundSyncProvider).syncWebsocketEdit(data));
+    unawaited(
+      _ref.read(backgroundSyncProvider).syncWebsocketEdit(data).then((_) {
+        _ref.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      }),
+    );
   }
 
   void _processBatchedAssetUploadReady() {
@@ -181,6 +186,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
     try {
       unawaited(
         _ref.read(backgroundSyncProvider).syncWebsocketBatch(_batchedAssetUploadReady.toList()).then((_) {
+          _ref.read(syncStatusProvider.notifier).markRemoteContentChanged();
           if (isSyncAlbumEnabled) {
             _ref.read(backgroundSyncProvider).syncLinkedAlbum();
           }

--- a/mobile/test/presentation/pages/search/paginated_search_provider_test.dart
+++ b/mobile/test/presentation/pages/search/paginated_search_provider_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/search_result.model.dart';
+import 'package:immich_mobile/domain/services/search.service.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
+import 'package:immich_mobile/presentation/pages/search/paginated_search.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSearch extends Mock implements SearchService {}
+
+class _FakeFilter extends Fake implements SearchFilter {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeFilter());
+  });
+
+  group('paginatedSearchProvider', () {
+    test('remote content changes rerun the active search from page 1', () async {
+      final search = _MockSearch();
+      final filter = SearchFilter.empty()..context = 'paris';
+      when(() => search.search(any(), any())).thenAnswer((_) async => const SearchResult(assets: []));
+
+      final container = ProviderContainer(overrides: [searchServiceProvider.overrideWithValue(search)]);
+      addTearDown(container.dispose);
+
+      await container.read(paginatedSearchProvider.notifier).search(filter);
+      verify(() => search.search(filter, 1)).called(1);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      verify(() => search.search(filter, 1)).called(1);
+    });
+  });
+}

--- a/mobile/test/presentation/widgets/map/map_state_provider_test.dart
+++ b/mobile/test/presentation/widgets/map/map_state_provider_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/map.model.dart';
+import 'package:immich_mobile/domain/services/map.service.dart';
+import 'package:immich_mobile/presentation/widgets/map/map.state.dart';
+import 'package:immich_mobile/providers/infrastructure/map.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockMapService extends Mock implements MapService {}
+
+void main() {
+  group('mapMarkerProvider', () {
+    test('remote content changes refetch marker GeoJSON for the active bounds', () async {
+      final service = _MockMapService();
+      final bounds = LatLngBounds(southwest: const LatLng(-10, -10), northeast: const LatLng(10, 10));
+      var calls = 0;
+      when(() => service.getMarkers).thenReturn((_) async {
+        calls++;
+        return [Marker(assetId: 'asset-$calls', location: const LatLng(1, 2))];
+      });
+
+      final container = ProviderContainer(overrides: [mapServiceProvider.overrideWithValue(service)]);
+      addTearDown(container.dispose);
+
+      final first = await container.read(mapMarkerProvider(bounds).future);
+      expect(first['features'], [
+        {
+          'type': 'Feature',
+          'id': 'asset-1',
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [2.0, 1.0],
+          },
+        },
+      ]);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      final second = await container.read(mapMarkerProvider(bounds).future);
+
+      expect(calls, 2);
+      expect((second['features'] as List).single['id'], 'asset-2');
+    });
+  });
+}

--- a/mobile/test/providers/folder_provider_test.dart
+++ b/mobile/test/providers/folder_provider_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/models/folder/recursive_folder.model.dart';
+import 'package:immich_mobile/models/folder/root_folder.model.dart';
+import 'package:immich_mobile/providers/folder.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
+import 'package:immich_mobile/services/folder.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockFolderService extends Mock implements FolderService {}
+
+class _FakeRootFolder extends Fake implements RootFolder {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeRootFolder());
+    registerFallbackValue(SortOrder.asc);
+  });
+
+  group('folder providers', () {
+    test('remote content changes refetch the active folder structure query', () async {
+      final service = _MockFolderService();
+      when(
+        () => service.getFolderStructure(any()),
+      ).thenAnswer((_) async => const RootFolder(subfolders: [], path: '/'));
+
+      final container = ProviderContainer(overrides: [folderServiceProvider.overrideWithValue(service)]);
+      addTearDown(container.dispose);
+
+      await container.read(folderStructureProvider.notifier).fetchFolders(SortOrder.asc);
+      verify(() => service.getFolderStructure(SortOrder.asc)).called(1);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      verify(() => service.getFolderStructure(SortOrder.asc)).called(1);
+    });
+
+    test('remote content changes refetch active folder assets', () async {
+      final service = _MockFolderService();
+      const folder = RecursiveFolder(name: 'Camera', path: '', subfolders: []);
+      when(() => service.getFolderAssets(any(), any())).thenAnswer((_) async => const []);
+
+      final container = ProviderContainer(overrides: [folderServiceProvider.overrideWithValue(service)]);
+      addTearDown(container.dispose);
+
+      await container.read(folderRenderListProvider(folder).notifier).fetchAssets(SortOrder.desc);
+      verify(() => service.getFolderAssets(folder, SortOrder.desc)).called(1);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      verify(() => service.getFolderAssets(folder, SortOrder.desc)).called(1);
+    });
+  });
+}

--- a/mobile/test/providers/infrastructure/asset_provider_test.dart
+++ b/mobile/test/providers/infrastructure/asset_provider_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/asset.service.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
+import 'package:immich_mobile/providers/sync_status.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAssetService extends Mock implements AssetService {}
+
+class _MockUserService extends Mock implements UserService {}
+
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service, UserDto? initial) {
+    state = initial;
+  }
+}
+
+UserDto _user(String id) => UserDto(id: id, email: '$id@example.com', name: id, profileChangedAt: DateTime(2024, 1, 1));
+
+void main() {
+  group('placesProvider', () {
+    test('remote content changes refetch places for the current user', () async {
+      final assetService = _MockAssetService();
+      final userService = _MockUserService();
+      final user = _user('u1');
+      when(() => userService.tryGetMyUser()).thenReturn(user);
+      when(() => userService.watchMyUser()).thenAnswer((_) => const Stream<UserDto?>.empty());
+      when(() => assetService.getPlaces(any())).thenAnswer((_) async => const [('Paris', 'asset-1')]);
+
+      final container = ProviderContainer(
+        overrides: [
+          assetServiceProvider.overrideWithValue(assetService),
+          infra.userServiceProvider.overrideWithValue(userService),
+          currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(placesProvider.future);
+      verify(() => assetService.getPlaces('u1')).called(1);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      await container.read(placesProvider.future);
+
+      verify(() => assetService.getPlaces('u1')).called(1);
+    });
+  });
+}

--- a/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
+++ b/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/timeline_query.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -110,6 +111,29 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 5));
       verify(() => search.search(any(), 1)).called(1);
       verify(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).called(1);
+    });
+
+    test('remote content changes refresh the active search-backed timeline', () async {
+      final factory = _MockFactory();
+      final search = _MockSearch();
+      final fake = _FakeService();
+      when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
+      when(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).thenReturn(fake);
+
+      final container = _container(factory: factory, search: search, user: _user('u1'));
+      await container.read(timelineUsersProvider.future);
+      container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+      addTearDown(container.dispose);
+
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      verify(() => search.search(any(), 1)).called(1);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      verify(() => search.search(any(), 1)).called(1);
     });
 
     test('disposes the created service when the container disposes', () async {

--- a/mobile/test/providers/sync_status_provider_test.dart
+++ b/mobile/test/providers/sync_status_provider_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
+
+void main() {
+  group('syncStatusProvider', () {
+    test('markRemoteContentChanged increments content version without changing sync status', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(syncStatusProvider).remoteContentChangedCount, 0);
+      expect(container.read(syncStatusProvider).remoteSyncStatus, SyncStatus.idle);
+
+      container.read(syncStatusProvider.notifier).markRemoteContentChanged();
+
+      expect(container.read(syncStatusProvider).remoteContentChangedCount, 1);
+      expect(container.read(syncStatusProvider).remoteSyncStatus, SyncStatus.idle);
+    });
+
+    test('completeRemoteSync also marks remote content as changed', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(syncStatusProvider.notifier).startRemoteSync();
+      container.read(syncStatusProvider.notifier).completeRemoteSync();
+
+      expect(container.read(syncStatusProvider).remoteContentChangedCount, 1);
+      expect(container.read(syncStatusProvider).remoteSyncStatus, SyncStatus.success);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared mobile remote-content-change signal for completed remote sync and websocket asset upload/edit handling
- refresh search-backed timelines, old paginated search, folders, Places, and map marker GeoJSON when remote content changes
- add focused regression tests for each stale snapshot path found during the mobile deep dive

## Context
Follow-up to discussion #340. The original Not in album behavior was one instance of a broader stale snapshot pattern: several mobile views used one-shot API/search results and did not refresh when web uploads or remote sync changed server-backed content.

## Manual Testing
Use the same account/server in web and mobile. Keep the mobile app foregrounded on the screen being tested, make the content change from web or another server sync source, then wait for the websocket upload/edit batch to process. No mobile restart, route reopen, filter toggle, or map pan should be required.

1. Photos filter / Not in album
- On mobile, open Photos and apply a non-empty filter, for example Display > Not in album or a text search that should match a new upload.
- On web, upload a photo that matches the active mobile filter and is not in an album.
- Expected: the active filtered mobile timeline refreshes and includes the new result after remote content sync completes.

2. Legacy Search tab
- On mobile, open the Search tab and run a text or display-option search.
- On web, upload or edit a photo so it now matches that active search.
- Expected: the mobile search results rerun from page 1 and update without manually clearing/reapplying the search.

3. Folders
- On mobile, open Library > Folders, then open a folder whose contents can change from a remote sync source.
- Add or remove a server asset that belongs to that folder path, then let mobile receive the remote update.
- Expected: both the folder structure and the open folder asset list refresh without leaving and reopening the folder page.

4. Places
- On mobile, open Places.
- On web, upload or edit a geotagged photo in a city that should appear in Places.
- Expected: the Places list refreshes and shows the updated place/thumbnail data without restarting mobile.

5. Map markers
- On mobile, open Map and leave it on bounds that include the location of a new geotagged asset.
- On web, upload or edit a geotagged photo in those bounds.
- Expected: the map marker source reloads and the new marker appears without panning/zooming/reopening the map. The map bottom-sheet timeline should continue to update from the Drift-backed timeline.

6. Manual remote sync fallback
- With any of the above mobile screens open, trigger a remote sync from mobile settings/backup sync.
- Expected: when remote sync completes, the same screens refresh from the shared remote-content-change signal.

## Verification
- `flutter test test/providers/sync_status_provider_test.dart test/providers/photos_filter/timeline_query_provider_test.dart test/domain/services/photos_filter_search_timeline_test.dart test/presentation/pages/search/paginated_search_provider_test.dart test/providers/folder_provider_test.dart test/providers/infrastructure/asset_provider_test.dart test/presentation/widgets/map/map_state_provider_test.dart`
- `flutter analyze lib/providers/sync_status.provider.dart lib/providers/photos_filter/timeline_query.provider.dart lib/presentation/pages/search/paginated_search.provider.dart lib/providers/websocket.provider.dart lib/providers/folder.provider.dart lib/providers/infrastructure/asset.provider.dart lib/presentation/widgets/map/map.state.dart lib/presentation/widgets/map/map.widget.dart test/providers/photos_filter/timeline_query_provider_test.dart test/domain/services/photos_filter_search_timeline_test.dart test/presentation/pages/search/paginated_search_provider_test.dart test/providers/sync_status_provider_test.dart test/providers/folder_provider_test.dart test/providers/infrastructure/asset_provider_test.dart test/presentation/widgets/map/map_state_provider_test.dart`
- `git diff --check`
- PR CI after rebase: 20 passing, 0 failing, 0 pending, 19 skipped
