### PR TITLE
feat: add face exclusion rules to auto-classification

### DIFF
--- a/docs/docs/features/auto-classification.md
+++ b/docs/docs/features/auto-classification.md
@@ -42,6 +42,7 @@ classification:
         - 'a screenshot of a chat conversation'
       similarity: 0.28
       action: tag
+      faceExclusion: off
       enabled: true
     - name: Receipts
       prompts:
@@ -50,6 +51,7 @@ classification:
         - 'a restaurant bill'
       similarity: 0.28
       action: tag_and_archive
+      faceExclusion: off
       enabled: true
 ```
 
@@ -68,13 +70,14 @@ curl -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json
 
 ### Category Fields
 
-| Field        | Type     | Required | Description                                                          |
-| ------------ | -------- | -------- | -------------------------------------------------------------------- |
-| `name`       | string   | Yes      | Category name. Must be unique. Used as the tag name (`Auto/{name}`). |
-| `prompts`    | string[] | Yes      | At least one text prompt describing photos to match.                 |
-| `similarity` | number   | Yes      | Threshold 0-1. Higher = stricter matching. Default: 0.28.            |
-| `action`     | string   | Yes      | `tag` (tag only) or `tag_and_archive` (tag and move to archive).     |
-| `enabled`    | boolean  | Yes      | Whether this category is active. Disabled categories are skipped.    |
+| Field           | Type     | Required | Description                                                                                               |
+| --------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `name`          | string   | Yes      | Category name. Must be unique. Used as the tag name (`Auto/{name}`).                                      |
+| `prompts`       | string[] | Yes      | At least one text prompt describing photos to match.                                                      |
+| `similarity`    | number   | Yes      | Threshold 0-1. Higher = stricter matching. Default: 0.28.                                                 |
+| `action`        | string   | Yes      | `tag` (tag only) or `tag_and_archive` (tag and move to archive).                                          |
+| `faceExclusion` | string   | No       | Face exclusion mode: `off`, `any_assigned_face`, `named_people`, or `named_visible_people`. Default: off. |
+| `enabled`       | boolean  | Yes      | Whether this category is active. Disabled categories are skipped.                                         |
 
 ### Writing Good Prompts
 

--- a/docs/docs/features/auto-classification.md
+++ b/docs/docs/features/auto-classification.md
@@ -107,6 +107,25 @@ The default is **0.28** (Normal). Start there and adjust based on results.
 - **Tag only** (`tag`) — Matching photos get an `Auto/{category name}` tag. They stay on your timeline.
 - **Tag and archive** (`tag_and_archive`) — Matching photos get tagged AND moved to the Archive. Useful for screenshots or receipts you want organized but not on your timeline.
 
+### Face exclusion
+
+Each category can optionally skip assets that contain known human faces. This is useful when a category should classify non-personal images, such as receipts, nature photos, or screenshots, without tagging genuine photos of people.
+
+The **Face exclusion** setting has four modes:
+
+| Mode                  | Behavior                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| Off                   | Classifies assets as usual.                                                                        |
+| Any assigned face     | Skips the category when the asset has a visible face assigned to a person cluster.                 |
+| Named people          | Skips the category when the asset has a visible face assigned to a named person.                   |
+| Named, visible people | Skips the category when the asset has a visible face assigned to a named person who is not hidden. |
+
+Unassigned detected faces do not count as known faces, and pets do not count as human faces for this filter.
+
+Face-aware categories require facial recognition. If facial recognition is disabled, Gallery skips those categories instead of treating the asset as safe to classify. Categories set to **Off** continue to run normally.
+
+Face exclusion is future-only. Changing the setting does not remove existing `Auto/...` tags, and later face recognition, person naming, hiding, or merging does not clean up old tags automatically. Run **Scan All Libraries** after changing rules if you want assets to be evaluated again under the new settings; a forced scan can add new matches, but it still does not remove old `Auto/...` tags that are now excluded.
+
 ## Scanning Your Library
 
 New uploads are classified automatically. To classify your existing library:

--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -268,6 +268,7 @@ The `classification` section configures [Auto-Classification](/features/auto-cla
       "prompts": ["a landscape photo of mountains", "a photo of a forest", "a sunset over water"],
       "similarity": 0.28,
       "action": "tag",
+      "faceExclusion": "off",
       "enabled": true
     },
     {
@@ -275,13 +276,27 @@ The `classification` section configures [Auto-Classification](/features/auto-cla
       "prompts": ["a screenshot of a phone screen", "a screenshot of a website"],
       "similarity": 0.25,
       "action": "tag_and_archive",
+      "faceExclusion": "off",
       "enabled": true
     }
   ]
 }
 ```
 
-The first category tags matching photos as `Auto/Nature`. The second tags and archives screenshots so they don't clutter your timeline. See the [Auto-Classification docs](/features/auto-classification) for the full field reference and prompt writing tips.
+The first category tags matching photos as `Auto/Nature`. The second tags and archives screenshots so they don't clutter your timeline.
+
+`faceExclusion` controls whether the category skips assets with known human faces. Valid values are:
+
+- `off`
+- `any_assigned_face`
+- `named_people`
+- `named_visible_people`
+
+Unassigned detected faces and pets are not counted as known human faces.
+
+Face-aware categories require facial recognition. When facial recognition is disabled, categories with a non-`off` `faceExclusion` value are skipped.
+
+See the [Auto-Classification docs](/features/auto-classification) for the full field reference and prompt writing tips.
 :::
 
 ### Step 2 - Specify the file location

--- a/docs/superpowers/plans/2026-04-27-known-face-auto-classification-filter.md
+++ b/docs/superpowers/plans/2026-04-27-known-face-auto-classification-filter.md
@@ -262,6 +262,21 @@ Add this `describe` block before `removeAutoTagAssignments`:
       });
     });
 
+    it('should treat assigned unnamed people as assigned but not named', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: '   ', isHidden: false, type: 'person' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: true,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+    });
+
     it('should ignore invisible deleted and pet rows', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
@@ -314,14 +329,15 @@ Add this method to `ClassificationRepository`:
       .innerJoin('person', 'person.id', 'asset_face.personId')
       .select([
         sql<boolean>`count(*) > 0`.as('hasAssignedFace'),
-        sql<boolean>`count(*) filter (where btrim(person.name) != '') > 0`.as('hasNamedPerson'),
-        sql<boolean>`count(*) filter (where btrim(person.name) != '' and person."isHidden" is false) > 0`.as(
+        sql<boolean>`count(*) filter (where btrim("person"."name") != '') > 0`.as('hasNamedPerson'),
+        sql<boolean>`count(*) filter (where btrim("person"."name") != '' and "person"."isHidden" is false) > 0`.as(
           'hasNamedVisiblePerson',
         ),
       ])
       .where('asset_face.assetId', '=', assetId)
       .where('asset_face.deletedAt', 'is', null)
       .where('asset_face.isVisible', 'is', true)
+      .where('asset_face.personId', 'is not', null)
       .where('person.type', '=', 'person')
       .executeTakeFirst();
 
@@ -440,7 +456,7 @@ describe(JobRepository.name, () => {
     const { sut, queue } = setup([{ ...emptyCounts(), waiting: 1 }, emptyCounts()]);
 
     const promise = sut.waitForQueueCompletion(QueueName.FaceDetection);
-    await vi.waitFor(() => expect(queue.getJobCounts).toHaveBeenCalledTimes(1));
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1000);
     await promise;
 
@@ -451,7 +467,7 @@ describe(JobRepository.name, () => {
     const { sut, queue } = setup([{ ...emptyCounts(), delayed: 1 }, emptyCounts()]);
 
     const promise = sut.waitForQueueCompletion(QueueName.FacialRecognition);
-    await vi.waitFor(() => expect(queue.getJobCounts).toHaveBeenCalledTimes(1));
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1000);
     await promise;
 
@@ -605,6 +621,9 @@ In `server/src/services/classification.service.spec.ts`, add these tests inside 
       await sut.handleClassify({ id: 'asset-1' });
 
       expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(QueueName.FaceDetection, QueueName.FacialRecognition);
+      expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.classification.getFaceSummary.mock.invocationCallOrder[0],
+      );
       expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
       expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
     });
@@ -641,6 +660,38 @@ In `server/src/services/classification.service.spec.ts`, add these tests inside 
       expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
     });
 
+    it('should skip named_people category when a named person exists', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: true,
+      });
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_people',
+          },
+        ]),
+      );
+
+      const result = await sut.handleClassify({ id: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+      expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
+      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+    });
+
     it('should ignore hidden named people for named_visible_people', async () => {
       mocks.asset.getById.mockResolvedValue({
         id: 'asset-1',
@@ -670,6 +721,38 @@ In `server/src/services/classification.service.spec.ts`, add these tests inside 
       await sut.handleClassify({ id: 'asset-1' });
 
       expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+    });
+
+    it('should skip named_visible_people category when a visible named person exists', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: true,
+      });
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_visible_people',
+          },
+        ]),
+      );
+
+      const result = await sut.handleClassify({ id: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+      expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
+      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
     });
 
     it('should skip face-aware categories when facial recognition is disabled and still classify off categories', async () => {
@@ -739,7 +822,7 @@ In `server/src/services/classification.service.spec.ts`, add these tests inside 
     });
 ```
 
-Add this test inside `describe('handleClassifyQueueAll', () => { ... })`:
+Add these tests inside `describe('handleClassifyQueueAll', () => { ... })`:
 
 ```ts
     it('should queue face work before forced classification when enabled categories are face-aware', async () => {
@@ -770,6 +853,66 @@ Add this test inside `describe('handleClassifyQueueAll', () => { ... })`:
         { name: JobName.AssetClassify, data: { id: 'asset-1' } },
       ]);
     });
+
+    it('should not queue face work before forced classification when facial recognition is disabled', async () => {
+      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig(
+          [
+            {
+              name: 'People',
+              prompts: ['a portrait'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'named_people',
+            },
+          ],
+          true,
+          false,
+        ),
+      );
+
+      await sut.handleClassifyQueueAll({ force: true });
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.AssetDetectFacesQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetClassify, data: { id: 'asset-1' } },
+      ]);
+    });
+```
+
+Add this regression test inside `describe('onConfigUpdate', () => { ... })` to lock in the future-only rule:
+
+```ts
+    it('should not clean up tags when only face exclusion changes', async () => {
+      const oldConfig = makeClassificationConfig([
+        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.28, action: 'tag', faceExclusion: 'off' },
+      ]);
+      const newConfig = makeClassificationConfig([
+        {
+          name: 'Screenshots',
+          prompts: ['screenshot'],
+          similarity: 0.28,
+          action: 'tag',
+          faceExclusion: 'named_people',
+        },
+      ]);
+
+      await sut.onConfigUpdate({ oldConfig, newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
+        SystemMetadataKey.ClassificationConfigState,
+        newConfig.classification,
+      );
+    });
 ```
 
 Add `QueueName` to the enum import at the top of the spec:
@@ -794,16 +937,20 @@ Expected: FAIL because `getFaceSummary` is not used and face queue waiting is no
 In `server/src/services/classification.service.ts`, update imports:
 
 ```ts
-import { ClassificationFaceExclusion, SystemConfig } from 'src/config';
-import { ClassificationFaceSummary } from 'src/repositories/classification.repository';
+import { type ClassificationFaceExclusion, type SystemConfig } from 'src/config';
+import { type ClassificationFaceSummary } from 'src/repositories/classification.repository';
 import { isFacialRecognitionEnabled } from 'src/utils/misc';
 ```
 
 Add these helper methods inside `ClassificationService` before `parseEmbedding`:
 
 ```ts
+  private getFaceExclusion(category: ClassificationConfig['categories'][number]): ClassificationFaceExclusion {
+    return category.faceExclusion ?? 'off';
+  }
+
   private isFaceAwareCategory(category: ClassificationConfig['categories'][number]) {
-    return category.faceExclusion !== 'off';
+    return this.getFaceExclusion(category) !== 'off';
   }
 
   private matchesFaceExclusion(rule: ClassificationFaceExclusion, summary: ClassificationFaceSummary) {
@@ -840,7 +987,7 @@ Add these helper methods inside `ClassificationService` before `parseEmbedding`:
     await this.jobRepository.waitForQueueCompletion(QueueName.FaceDetection, QueueName.FacialRecognition);
     const faceSummary = await this.classificationRepository.getFaceSummary(assetId);
 
-    return categories.filter((category) => !this.matchesFaceExclusion(category.faceExclusion, faceSummary));
+    return categories.filter((category) => !this.matchesFaceExclusion(this.getFaceExclusion(category), faceSummary));
   }
 ```
 
@@ -884,27 +1031,30 @@ with:
 
 - [ ] **Step 5: Queue face work during forced scans**
 
-In `handleClassifyQueueAll`, after the `force` reset block and before streaming unclassified assets, add:
+In `handleClassifyQueueAll`, change the first config read from:
+
+```ts
+    const { classification } = await this.getConfig({ withCache: true });
+```
+
+to:
+
+```ts
+    const { classification, machineLearning } = await this.getConfig({ withCache: true });
+```
+
+Then, after the `force` reset block and before streaming unclassified assets, add:
 
 ```ts
     const faceAwareCategories = classification.categories.filter(
       (category) => category.enabled && this.isFaceAwareCategory(category),
     );
 
-    const { machineLearning } = await this.getConfig({ withCache: true });
     if (force && faceAwareCategories.length > 0 && isFacialRecognitionEnabled(machineLearning)) {
       await this.jobRepository.queue({ name: JobName.AssetDetectFacesQueueAll, data: { force: true } });
       await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
     }
 ```
-
-If the method currently reads only `{ classification }`, change that first config read to:
-
-```ts
-    const { classification, machineLearning } = await this.getConfig({ withCache: true });
-```
-
-and do not add a second `getConfig` call.
 
 - [ ] **Step 6: Run the focused service tests**
 
@@ -963,7 +1113,7 @@ Run:
 
 ```bash
 git status --short
-git diff -- open-api | sed -n '1,220p'
+git diff -- open-api mobile/openapi | sed -n '1,220p'
 ```
 
 Expected: generated files show the new `faceExclusion` schema/property and no unrelated hand edits.
@@ -973,7 +1123,7 @@ Expected: generated files show the new `faceExclusion` schema/property and no un
 Run:
 
 ```bash
-git add open-api
+git add open-api mobile/openapi
 git commit -m "chore(openapi): regenerate classification face exclusion clients"
 ```
 
@@ -1217,7 +1367,7 @@ The **Face exclusion** setting has four modes:
 
 Face-aware categories require facial recognition. If facial recognition is disabled, Gallery skips those categories instead of treating the asset as safe to classify. Categories set to **Off** continue to run normally.
 
-Face exclusion is future-only. Changing the setting does not remove existing `Auto/...` tags, and later face recognition, person naming, hiding, or merging does not clean up old tags automatically. Run **Scan All Libraries** after changing rules if you want assets to be classified again under the new settings.
+Face exclusion is future-only. Changing the setting does not remove existing `Auto/...` tags, and later face recognition, person naming, hiding, or merging does not clean up old tags automatically. Run **Scan All Libraries** after changing rules if you want assets to be evaluated again under the new settings; a forced scan can add new matches, but it still does not remove old `Auto/...` tags that are now excluded.
 ```
 
 - [ ] **Step 2: Update config-file docs**

--- a/docs/superpowers/plans/2026-04-27-known-face-auto-classification-filter.md
+++ b/docs/superpowers/plans/2026-04-27-known-face-auto-classification-filter.md
@@ -30,6 +30,7 @@
 ### Task 1: Add Config And DTO Support
 
 **Files:**
+
 - Modify: `server/src/config.ts`
 - Modify: `server/src/dtos/system-config.dto.ts`
 - Test: `server/src/services/system-config.service.spec.ts`
@@ -46,66 +47,66 @@ import { SystemConfigSchema } from 'src/dtos/system-config.dto';
 Add these tests near the existing classification config tests in `server/src/services/system-config.service.spec.ts`:
 
 ```ts
-  it('should default missing classification faceExclusion to off', () => {
-    const result = SystemConfigSchema.parse({
-      ...defaults,
-      classification: {
-        enabled: true,
-        categories: [
-          {
-            name: 'Nature',
-            prompts: ['a landscape photo'],
-            similarity: 0.28,
-            action: 'tag',
-            enabled: true,
-          },
-        ],
-      },
-    });
-
-    expect(result.classification.categories[0].faceExclusion).toBe('off');
+it('should default missing classification faceExclusion to off', () => {
+  const result = SystemConfigSchema.parse({
+    ...defaults,
+    classification: {
+      enabled: true,
+      categories: [
+        {
+          name: 'Nature',
+          prompts: ['a landscape photo'],
+          similarity: 0.28,
+          action: 'tag',
+          enabled: true,
+        },
+      ],
+    },
   });
 
-  it('should accept all classification faceExclusion modes', () => {
-    const result = SystemConfigSchema.parse({
-      ...defaults,
-      classification: {
-        enabled: true,
-        categories: [
-          {
-            name: 'Any Assigned Face',
-            prompts: ['a test prompt'],
-            similarity: 0.28,
-            action: 'tag',
-            enabled: true,
-            faceExclusion: 'any_assigned_face',
-          },
-          {
-            name: 'Named People',
-            prompts: ['a test prompt'],
-            similarity: 0.28,
-            action: 'tag',
-            enabled: true,
-            faceExclusion: 'named_people',
-          },
-          {
-            name: 'Named Visible People',
-            prompts: ['a test prompt'],
-            similarity: 0.28,
-            action: 'tag',
-            enabled: true,
-            faceExclusion: 'named_visible_people',
-          },
-        ],
-      },
-    });
+  expect(result.classification.categories[0].faceExclusion).toBe('off');
+});
 
-    expect(result.classification.categories.map((category) => category.faceExclusion)).toEqual([
-      'any_assigned_face',
-      'named_people',
-      'named_visible_people',
-    ]);
+it('should accept all classification faceExclusion modes', () => {
+  const result = SystemConfigSchema.parse({
+    ...defaults,
+    classification: {
+      enabled: true,
+      categories: [
+        {
+          name: 'Any Assigned Face',
+          prompts: ['a test prompt'],
+          similarity: 0.28,
+          action: 'tag',
+          enabled: true,
+          faceExclusion: 'any_assigned_face',
+        },
+        {
+          name: 'Named People',
+          prompts: ['a test prompt'],
+          similarity: 0.28,
+          action: 'tag',
+          enabled: true,
+          faceExclusion: 'named_people',
+        },
+        {
+          name: 'Named Visible People',
+          prompts: ['a test prompt'],
+          similarity: 0.28,
+          action: 'tag',
+          enabled: true,
+          faceExclusion: 'named_visible_people',
+        },
+      ],
+    },
   });
+
+  expect(result.classification.categories.map((category) => category.faceExclusion)).toEqual([
+    'any_assigned_face',
+    'named_people',
+    'named_visible_people',
+  ]);
+});
 ```
 
 Update the local helper in `server/src/services/classification.service.spec.ts` so later tests can use the new field:
@@ -157,7 +158,7 @@ export type ClassificationFaceExclusion = 'off' | 'any_assigned_face' | 'named_p
 In the `SystemConfig['classification']['categories']` item type, add:
 
 ```ts
-      faceExclusion: ClassificationFaceExclusion;
+faceExclusion: ClassificationFaceExclusion;
 ```
 
 - [ ] **Step 4: Add the DTO schema default**
@@ -203,6 +204,7 @@ git commit -m "feat(server): add classification face exclusion config"
 ### Task 2: Add Asset Face Summary Query
 
 **Files:**
+
 - Modify: `server/src/repositories/classification.repository.ts`
 - Test: `server/test/medium/specs/repositories/classification.repository.spec.ts`
 
@@ -217,84 +219,84 @@ import { AssetVisibility, SourceType } from 'src/enum';
 Add this `describe` block before `removeAutoTagAssignments`:
 
 ```ts
-  describe('getFaceSummary', () => {
-    it('should return false booleans for an asset without assigned faces', async () => {
-      const { ctx, sut } = setup();
-      const { user } = await ctx.newUser();
-      const { asset } = await ctx.newAsset({ ownerId: user.id });
+describe('getFaceSummary', () => {
+  it('should return false booleans for an asset without assigned faces', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
 
-      await ctx.newAssetFace({ assetId: asset.id, personId: null });
+    await ctx.newAssetFace({ assetId: asset.id, personId: null });
 
-      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
-        hasAssignedFace: false,
-        hasNamedPerson: false,
-        hasNamedVisiblePerson: false,
-      });
-    });
-
-    it('should detect assigned, named, and visible named human faces', async () => {
-      const { ctx, sut } = setup();
-      const { user } = await ctx.newUser();
-      const { asset } = await ctx.newAsset({ ownerId: user.id });
-      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: false, type: 'person' });
-
-      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-
-      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
-        hasAssignedFace: true,
-        hasNamedPerson: true,
-        hasNamedVisiblePerson: true,
-      });
-    });
-
-    it('should detect hidden named people but exclude them from visible named people', async () => {
-      const { ctx, sut } = setup();
-      const { user } = await ctx.newUser();
-      const { asset } = await ctx.newAsset({ ownerId: user.id });
-      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: true, type: 'person' });
-
-      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-
-      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
-        hasAssignedFace: true,
-        hasNamedPerson: true,
-        hasNamedVisiblePerson: false,
-      });
-    });
-
-    it('should treat assigned unnamed people as assigned but not named', async () => {
-      const { ctx, sut } = setup();
-      const { user } = await ctx.newUser();
-      const { asset } = await ctx.newAsset({ ownerId: user.id });
-      const { person } = await ctx.newPerson({ ownerId: user.id, name: '   ', isHidden: false, type: 'person' });
-
-      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-
-      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
-        hasAssignedFace: true,
-        hasNamedPerson: false,
-        hasNamedVisiblePerson: false,
-      });
-    });
-
-    it('should ignore invisible deleted and pet rows', async () => {
-      const { ctx, sut } = setup();
-      const { user } = await ctx.newUser();
-      const { asset } = await ctx.newAsset({ ownerId: user.id });
-      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', type: 'person' });
-      const { person: pet } = await ctx.newPerson({ ownerId: user.id, name: 'Spot', type: 'pet', species: 'dog' });
-
-      await ctx.newAssetFace({ assetId: asset.id, personId: person.id, isVisible: false });
-      await ctx.newAssetFace({ assetId: asset.id, personId: person.id, deletedAt: new Date() });
-      await ctx.newAssetFace({ assetId: asset.id, personId: pet.id, sourceType: SourceType.MachineLearning });
-
-      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
-        hasAssignedFace: false,
-        hasNamedPerson: false,
-        hasNamedVisiblePerson: false,
-      });
+    await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+      hasAssignedFace: false,
+      hasNamedPerson: false,
+      hasNamedVisiblePerson: false,
     });
   });
+
+  it('should detect assigned, named, and visible named human faces', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: false, type: 'person' });
+
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+    await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+      hasAssignedFace: true,
+      hasNamedPerson: true,
+      hasNamedVisiblePerson: true,
+    });
+  });
+
+  it('should detect hidden named people but exclude them from visible named people', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: true, type: 'person' });
+
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+    await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+      hasAssignedFace: true,
+      hasNamedPerson: true,
+      hasNamedVisiblePerson: false,
+    });
+  });
+
+  it('should treat assigned unnamed people as assigned but not named', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: '   ', isHidden: false, type: 'person' });
+
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+    await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+      hasAssignedFace: true,
+      hasNamedPerson: false,
+      hasNamedVisiblePerson: false,
+    });
+  });
+
+  it('should ignore invisible deleted and pet rows', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', type: 'person' });
+    const { person: pet } = await ctx.newPerson({ ownerId: user.id, name: 'Spot', type: 'pet', species: 'dog' });
+
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id, isVisible: false });
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id, deletedAt: new Date() });
+    await ctx.newAssetFace({ assetId: asset.id, personId: pet.id, sourceType: SourceType.MachineLearning });
+
+    await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+      hasAssignedFace: false,
+      hasNamedPerson: false,
+      hasNamedVisiblePerson: false,
+    });
+  });
+});
 ```
 
 - [ ] **Step 2: Run the medium test to verify it fails**
@@ -380,6 +382,7 @@ git commit -m "feat(server): summarize faces for classification"
 ### Task 3: Make Queue Waiting Use Pending Counts
 
 **Files:**
+
 - Modify: `server/src/repositories/job.repository.ts`
 - Create: `server/src/repositories/job.repository.spec.ts`
 - Test: `server/src/services/person.service.spec.ts`
@@ -425,12 +428,7 @@ const setup = (counts: JobCounts[]) => {
     warn: vi.fn(),
   } as unknown as LoggingRepository;
 
-  const sut = new JobRepository(
-    moduleRef,
-    {} as ConfigRepository,
-    {} as EventRepository,
-    logger,
-  );
+  const sut = new JobRepository(moduleRef, {} as ConfigRepository, {} as EventRepository, logger);
 
   return { sut, queue, logger };
 };
@@ -550,6 +548,7 @@ git commit -m "fix(server): wait for pending queue jobs"
 ### Task 4: Apply Face Exclusion In Classification Service
 
 **Files:**
+
 - Modify: `server/src/services/classification.service.ts`
 - Modify: `server/src/services/classification.service.spec.ts`
 - Test: `server/src/services/classification.service.spec.ts`
@@ -559,360 +558,356 @@ git commit -m "fix(server): wait for pending queue jobs"
 In `server/src/services/classification.service.spec.ts`, add these tests inside `describe('handleClassify', () => { ... })` after the disabled category tests:
 
 ```ts
-    it('should not wait for face queues or load face summary when all enabled categories are face exclusion off', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
-      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Sunsets' } as any);
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'Sunsets',
-            prompts: ['sunset sky'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'off',
-          },
-        ]),
-      );
+it('should not wait for face queues or load face summary when all enabled categories are face exclusion off', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+  mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Sunsets' } as any);
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'Sunsets',
+        prompts: ['sunset sky'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'off',
+      },
+    ]),
+  );
 
-      await sut.handleClassify({ id: 'asset-1' });
+  await sut.handleClassify({ id: 'asset-1' });
 
-      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
-      expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
-    });
+  expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+  expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
+});
 
-    it('should skip any_assigned_face category when the asset has an assigned face', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
-      mocks.classification.getFaceSummary.mockResolvedValue({
-        hasAssignedFace: true,
-        hasNamedPerson: false,
-        hasNamedVisiblePerson: false,
-      });
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'any_assigned_face',
-          },
-          {
-            name: 'Screenshots',
-            prompts: ['a screenshot'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'off',
-          },
-        ]),
-      );
+it('should skip any_assigned_face category when the asset has an assigned face', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+  mocks.classification.getFaceSummary.mockResolvedValue({
+    hasAssignedFace: true,
+    hasNamedPerson: false,
+    hasNamedVisiblePerson: false,
+  });
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'People',
+        prompts: ['a portrait'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'any_assigned_face',
+      },
+      {
+        name: 'Screenshots',
+        prompts: ['a screenshot'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'off',
+      },
+    ]),
+  );
 
-      await sut.handleClassify({ id: 'asset-1' });
+  await sut.handleClassify({ id: 'asset-1' });
 
-      expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(QueueName.FaceDetection, QueueName.FacialRecognition);
-      expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
-        mocks.classification.getFaceSummary.mock.invocationCallOrder[0],
-      );
-      expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
-      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
-    });
+  expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(QueueName.FaceDetection, QueueName.FacialRecognition);
+  expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.classification.getFaceSummary.mock.invocationCallOrder[0],
+  );
+  expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
+  expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
+});
 
-    it('should skip named_people category only when a named person exists', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
-      mocks.classification.getFaceSummary.mockResolvedValue({
-        hasAssignedFace: true,
-        hasNamedPerson: false,
-        hasNamedVisiblePerson: false,
-      });
-      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'named_people',
-          },
-        ]),
-      );
+it('should skip named_people category only when a named person exists', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+  mocks.classification.getFaceSummary.mockResolvedValue({
+    hasAssignedFace: true,
+    hasNamedPerson: false,
+    hasNamedVisiblePerson: false,
+  });
+  mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'People',
+        prompts: ['a portrait'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'named_people',
+      },
+    ]),
+  );
 
-      await sut.handleClassify({ id: 'asset-1' });
+  await sut.handleClassify({ id: 'asset-1' });
 
-      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a portrait', { modelName: 'test-model' });
-      expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
-    });
+  expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a portrait', { modelName: 'test-model' });
+  expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+});
 
-    it('should skip named_people category when a named person exists', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.classification.getFaceSummary.mockResolvedValue({
-        hasAssignedFace: true,
-        hasNamedPerson: true,
-        hasNamedVisiblePerson: true,
-      });
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'named_people',
-          },
-        ]),
-      );
+it('should skip named_people category when a named person exists', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.classification.getFaceSummary.mockResolvedValue({
+    hasAssignedFace: true,
+    hasNamedPerson: true,
+    hasNamedVisiblePerson: true,
+  });
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'People',
+        prompts: ['a portrait'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'named_people',
+      },
+    ]),
+  );
 
-      const result = await sut.handleClassify({ id: 'asset-1' });
+  const result = await sut.handleClassify({ id: 'asset-1' });
 
-      expect(result).toBe(JobStatus.Skipped);
-      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
-      expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
-      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
-    });
+  expect(result).toBe(JobStatus.Skipped);
+  expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+  expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
+  expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+});
 
-    it('should ignore hidden named people for named_visible_people', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
-      mocks.classification.getFaceSummary.mockResolvedValue({
-        hasAssignedFace: true,
-        hasNamedPerson: true,
-        hasNamedVisiblePerson: false,
-      });
-      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'named_visible_people',
-          },
-        ]),
-      );
+it('should ignore hidden named people for named_visible_people', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+  mocks.classification.getFaceSummary.mockResolvedValue({
+    hasAssignedFace: true,
+    hasNamedPerson: true,
+    hasNamedVisiblePerson: false,
+  });
+  mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'People',
+        prompts: ['a portrait'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'named_visible_people',
+      },
+    ]),
+  );
 
-      await sut.handleClassify({ id: 'asset-1' });
+  await sut.handleClassify({ id: 'asset-1' });
 
-      expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
-    });
+  expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+});
 
-    it('should skip named_visible_people category when a visible named person exists', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.classification.getFaceSummary.mockResolvedValue({
-        hasAssignedFace: true,
-        hasNamedPerson: true,
-        hasNamedVisiblePerson: true,
-      });
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'named_visible_people',
-          },
-        ]),
-      );
+it('should skip named_visible_people category when a visible named person exists', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.classification.getFaceSummary.mockResolvedValue({
+    hasAssignedFace: true,
+    hasNamedPerson: true,
+    hasNamedVisiblePerson: true,
+  });
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'People',
+        prompts: ['a portrait'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'named_visible_people',
+      },
+    ]),
+  );
 
-      const result = await sut.handleClassify({ id: 'asset-1' });
+  const result = await sut.handleClassify({ id: 'asset-1' });
 
-      expect(result).toBe(JobStatus.Skipped);
-      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
-      expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
-      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
-    });
+  expect(result).toBe(JobStatus.Skipped);
+  expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+  expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
+  expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+});
 
-    it('should skip face-aware categories when facial recognition is disabled and still classify off categories', async () => {
-      mocks.asset.getById.mockResolvedValue({
-        id: 'asset-1',
-        ownerId: 'user-1',
-        visibility: AssetVisibility.Timeline,
-      } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
-      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Screenshots' } as any);
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig(
-          [
-            {
-              name: 'People',
-              prompts: ['a portrait'],
-              similarity: 0.8,
-              action: 'tag',
-              faceExclusion: 'named_people',
-            },
-            {
-              name: 'Screenshots',
-              prompts: ['a screenshot'],
-              similarity: 0.8,
-              action: 'tag',
-              faceExclusion: 'off',
-            },
-          ],
-          true,
-          false,
-        ),
-      );
+it('should skip face-aware categories when facial recognition is disabled and still classify off categories', async () => {
+  mocks.asset.getById.mockResolvedValue({
+    id: 'asset-1',
+    ownerId: 'user-1',
+    visibility: AssetVisibility.Timeline,
+  } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+  mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Screenshots' } as any);
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig(
+      [
+        {
+          name: 'People',
+          prompts: ['a portrait'],
+          similarity: 0.8,
+          action: 'tag',
+          faceExclusion: 'named_people',
+        },
+        {
+          name: 'Screenshots',
+          prompts: ['a screenshot'],
+          similarity: 0.8,
+          action: 'tag',
+          faceExclusion: 'off',
+        },
+      ],
+      true,
+      false,
+    ),
+  );
 
-      await sut.handleClassify({ id: 'asset-1' });
+  await sut.handleClassify({ id: 'asset-1' });
 
-      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
-      expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
-      expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
-      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
-    });
+  expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+  expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
+  expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
+  expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
+});
 
-    it('should mark classified when all enabled categories require disabled facial recognition', async () => {
-      mocks.asset.getById.mockResolvedValue({ id: 'asset-1', ownerId: 'user-1' } as any);
-      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig(
-          [
-            {
-              name: 'People',
-              prompts: ['a portrait'],
-              similarity: 0.8,
-              action: 'tag',
-              faceExclusion: 'named_people',
-            },
-          ],
-          true,
-          false,
-        ),
-      );
+it('should mark classified when all enabled categories require disabled facial recognition', async () => {
+  mocks.asset.getById.mockResolvedValue({ id: 'asset-1', ownerId: 'user-1' } as any);
+  mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig(
+      [
+        {
+          name: 'People',
+          prompts: ['a portrait'],
+          similarity: 0.8,
+          action: 'tag',
+          faceExclusion: 'named_people',
+        },
+      ],
+      true,
+      false,
+    ),
+  );
 
-      const result = await sut.handleClassify({ id: 'asset-1' });
+  const result = await sut.handleClassify({ id: 'asset-1' });
 
-      expect(result).toBe(JobStatus.Skipped);
-      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
-      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
-    });
+  expect(result).toBe(JobStatus.Skipped);
+  expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+  expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+});
 ```
 
 Add these tests inside `describe('handleClassifyQueueAll', () => { ... })`:
 
 ```ts
-    it('should queue face work before forced classification when enabled categories are face-aware', async () => {
-      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'named_people',
-          },
-        ]),
-      );
+it('should queue face work before forced classification when enabled categories are face-aware', async () => {
+  mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig([
+      {
+        name: 'People',
+        prompts: ['a portrait'],
+        similarity: 0.8,
+        action: 'tag',
+        faceExclusion: 'named_people',
+      },
+    ]),
+  );
 
-      await sut.handleClassifyQueueAll({ force: true });
+  await sut.handleClassifyQueueAll({ force: true });
 
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.AssetDetectFacesQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.FacialRecognitionQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        { name: JobName.AssetClassify, data: { id: 'asset-1' } },
-      ]);
-    });
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.AssetDetectFacesQueueAll,
+    data: { force: true },
+  });
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FacialRecognitionQueueAll,
+    data: { force: true },
+  });
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: 'asset-1' } }]);
+});
 
-    it('should not queue face work before forced classification when facial recognition is disabled', async () => {
-      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig(
-          [
-            {
-              name: 'People',
-              prompts: ['a portrait'],
-              similarity: 0.8,
-              action: 'tag',
-              faceExclusion: 'named_people',
-            },
-          ],
-          true,
-          false,
-        ),
-      );
+it('should not queue face work before forced classification when facial recognition is disabled', async () => {
+  mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
+  sut['getConfig'] = vi.fn().mockResolvedValue(
+    makeClassificationConfig(
+      [
+        {
+          name: 'People',
+          prompts: ['a portrait'],
+          similarity: 0.8,
+          action: 'tag',
+          faceExclusion: 'named_people',
+        },
+      ],
+      true,
+      false,
+    ),
+  );
 
-      await sut.handleClassifyQueueAll({ force: true });
+  await sut.handleClassifyQueueAll({ force: true });
 
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.AssetDetectFacesQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.FacialRecognitionQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        { name: JobName.AssetClassify, data: { id: 'asset-1' } },
-      ]);
-    });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.AssetDetectFacesQueueAll,
+    data: { force: true },
+  });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.FacialRecognitionQueueAll,
+    data: { force: true },
+  });
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: 'asset-1' } }]);
+});
 ```
 
 Add this regression test inside `describe('onConfigUpdate', () => { ... })` to lock in the future-only rule:
 
 ```ts
-    it('should not clean up tags when only face exclusion changes', async () => {
-      const oldConfig = makeClassificationConfig([
-        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.28, action: 'tag', faceExclusion: 'off' },
-      ]);
-      const newConfig = makeClassificationConfig([
-        {
-          name: 'Screenshots',
-          prompts: ['screenshot'],
-          similarity: 0.28,
-          action: 'tag',
-          faceExclusion: 'named_people',
-        },
-      ]);
+it('should not clean up tags when only face exclusion changes', async () => {
+  const oldConfig = makeClassificationConfig([
+    { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.28, action: 'tag', faceExclusion: 'off' },
+  ]);
+  const newConfig = makeClassificationConfig([
+    {
+      name: 'Screenshots',
+      prompts: ['screenshot'],
+      similarity: 0.28,
+      action: 'tag',
+      faceExclusion: 'named_people',
+    },
+  ]);
 
-      await sut.onConfigUpdate({ oldConfig, newConfig } as any);
+  await sut.onConfigUpdate({ oldConfig, newConfig } as any);
 
-      expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
-      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
-        SystemMetadataKey.ClassificationConfigState,
-        newConfig.classification,
-      );
-    });
+  expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+  expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
+    SystemMetadataKey.ClassificationConfigState,
+    newConfig.classification,
+  );
+});
 ```
 
 Add `QueueName` to the enum import at the top of the spec:
@@ -1034,26 +1029,26 @@ with:
 In `handleClassifyQueueAll`, change the first config read from:
 
 ```ts
-    const { classification } = await this.getConfig({ withCache: true });
+const { classification } = await this.getConfig({ withCache: true });
 ```
 
 to:
 
 ```ts
-    const { classification, machineLearning } = await this.getConfig({ withCache: true });
+const { classification, machineLearning } = await this.getConfig({ withCache: true });
 ```
 
 Then, after the `force` reset block and before streaming unclassified assets, add:
 
 ```ts
-    const faceAwareCategories = classification.categories.filter(
-      (category) => category.enabled && this.isFaceAwareCategory(category),
-    );
+const faceAwareCategories = classification.categories.filter(
+  (category) => category.enabled && this.isFaceAwareCategory(category),
+);
 
-    if (force && faceAwareCategories.length > 0 && isFacialRecognitionEnabled(machineLearning)) {
-      await this.jobRepository.queue({ name: JobName.AssetDetectFacesQueueAll, data: { force: true } });
-      await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
-    }
+if (force && faceAwareCategories.length > 0 && isFacialRecognitionEnabled(machineLearning)) {
+  await this.jobRepository.queue({ name: JobName.AssetDetectFacesQueueAll, data: { force: true } });
+  await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+}
 ```
 
 - [ ] **Step 6: Run the focused service tests**
@@ -1081,6 +1076,7 @@ git commit -m "feat(server): apply classification face exclusion"
 ### Task 5: Regenerate OpenAPI And SDK
 
 **Files:**
+
 - Modify: `open-api/immich-openapi-specs.json`
 - Modify: `open-api/typescript-sdk/src/fetch-client.ts`
 - Modify: `mobile/openapi/lib/model/system_config_classification_category_dto.dart`
@@ -1132,6 +1128,7 @@ git commit -m "chore(openapi): regenerate classification face exclusion clients"
 ### Task 6: Add Web Face Exclusion Control
 
 **Files:**
+
 - Modify: `web/src/routes/admin/system-settings/ClassificationSettings.svelte`
 - Modify: `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`
 - Test: `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`
@@ -1147,77 +1144,77 @@ In `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`, update
 Add these tests before the config-file disabled test:
 
 ```ts
-  it('should show face exclusion dropdown when creating a category', async () => {
-    render(ClassificationSettings);
-    await waitFor(() => {
-      expect(screen.getByText('Add Category')).toBeInTheDocument();
-    });
-
-    await fireEvent.click(screen.getByText('Add Category'));
-
-    expect(screen.getByLabelText('Face exclusion')).toBeInTheDocument();
-    expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+it('should show face exclusion dropdown when creating a category', async () => {
+  render(ClassificationSettings);
+  await waitFor(() => {
+    expect(screen.getByText('Add Category')).toBeInTheDocument();
   });
 
-  it('should save selected face exclusion for a new category', async () => {
-    render(ClassificationSettings);
-    await waitFor(() => {
-      expect(screen.getByText('Add Category')).toBeInTheDocument();
-    });
+  await fireEvent.click(screen.getByText('Add Category'));
 
-    await fireEvent.click(screen.getByText('Add Category'));
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Nature' } });
-    await fireEvent.input(screen.getByLabelText('Prompts (one per line)'), { target: { value: 'a landscape photo' } });
-    await fireEvent.change(screen.getByLabelText('Face exclusion'), { target: { value: 'named_visible_people' } });
-    await fireEvent.click(screen.getByText('Save'));
+  expect(screen.getByLabelText('Face exclusion')).toBeInTheDocument();
+  expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+});
 
-    await waitFor(() => {
-      expect(updateConfig).toHaveBeenCalledWith({
-        systemConfigDto: expect.objectContaining({
-          classification: expect.objectContaining({
-            categories: [
-              expect.objectContaining({
-                name: 'Nature',
-                faceExclusion: 'named_visible_people',
-              }),
-            ],
-          }),
+it('should save selected face exclusion for a new category', async () => {
+  render(ClassificationSettings);
+  await waitFor(() => {
+    expect(screen.getByText('Add Category')).toBeInTheDocument();
+  });
+
+  await fireEvent.click(screen.getByText('Add Category'));
+  await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Nature' } });
+  await fireEvent.input(screen.getByLabelText('Prompts (one per line)'), { target: { value: 'a landscape photo' } });
+  await fireEvent.change(screen.getByLabelText('Face exclusion'), { target: { value: 'named_visible_people' } });
+  await fireEvent.click(screen.getByText('Save'));
+
+  await waitFor(() => {
+    expect(updateConfig).toHaveBeenCalledWith({
+      systemConfigDto: expect.objectContaining({
+        classification: expect.objectContaining({
+          categories: [
+            expect.objectContaining({
+              name: 'Nature',
+              faceExclusion: 'named_visible_people',
+            }),
+          ],
         }),
-      });
+      }),
     });
   });
+});
 
-  it('should default old categories without faceExclusion to Off in the editor', async () => {
-    vi.mocked(getConfig).mockResolvedValue(
-      makeConfig([
-        {
-          name: 'Legacy',
-          prompts: ['legacy prompt'],
-          similarity: 0.28,
-          action: Action.Tag,
-          enabled: true,
-        } as SystemConfigDto['classification']['categories'][number],
-      ]),
-    );
+it('should default old categories without faceExclusion to Off in the editor', async () => {
+  vi.mocked(getConfig).mockResolvedValue(
+    makeConfig([
+      {
+        name: 'Legacy',
+        prompts: ['legacy prompt'],
+        similarity: 0.28,
+        action: Action.Tag,
+        enabled: true,
+      } as SystemConfigDto['classification']['categories'][number],
+    ]),
+  );
 
-    render(ClassificationSettings);
-    await waitFor(() => {
-      expect(screen.getByText('Legacy')).toBeInTheDocument();
-    });
-
-    await fireEvent.click(screen.getByLabelText('Edit'));
-
-    expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+  render(ClassificationSettings);
+  await waitFor(() => {
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
   });
 
-  it('should show non-Off face exclusion in the category summary', async () => {
-    vi.mocked(getConfig).mockResolvedValue(makeConfig([makeCategory({ faceExclusion: 'named_people' })]));
+  await fireEvent.click(screen.getByLabelText('Edit'));
 
-    render(ClassificationSettings);
-    await waitFor(() => {
-      expect(screen.getByText('Named people')).toBeInTheDocument();
-    });
+  expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+});
+
+it('should show non-Off face exclusion in the category summary', async () => {
+  vi.mocked(getConfig).mockResolvedValue(makeConfig([makeCategory({ faceExclusion: 'named_people' })]));
+
+  render(ClassificationSettings);
+  await waitFor(() => {
+    expect(screen.getByText('Named people')).toBeInTheDocument();
   });
+});
 ```
 
 - [ ] **Step 2: Run the web spec to verify it fails**
@@ -1236,30 +1233,30 @@ Expected: FAIL because the Face exclusion control and summary are not rendered.
 In `web/src/routes/admin/system-settings/ClassificationSettings.svelte`, add:
 
 ```ts
-  type FaceExclusion = NonNullable<Category['faceExclusion']>;
+type FaceExclusion = NonNullable<Category['faceExclusion']>;
 ```
 
 Add state next to the other form state:
 
 ```ts
-  let formFaceExclusion: FaceExclusion = $state('off');
+let formFaceExclusion: FaceExclusion = $state('off');
 ```
 
 Add labels after `actionLabels`:
 
 ```ts
-  const faceExclusionLabels: Record<FaceExclusion, string> = {
-    off: 'Off',
-    any_assigned_face: 'Any assigned face',
-    named_people: 'Named people',
-    named_visible_people: 'Named, visible people',
-  };
+const faceExclusionLabels: Record<FaceExclusion, string> = {
+  off: 'Off',
+  any_assigned_face: 'Any assigned face',
+  named_people: 'Named people',
+  named_visible_people: 'Named, visible people',
+};
 ```
 
 Add a normalizer helper:
 
 ```ts
-  const getFaceExclusion = (category: Partial<Category>): FaceExclusion => category.faceExclusion ?? 'off';
+const getFaceExclusion = (category: Partial<Category>): FaceExclusion => category.faceExclusion ?? 'off';
 ```
 
 - [ ] **Step 4: Wire form create/edit/save state**
@@ -1267,13 +1264,13 @@ Add a normalizer helper:
 In `startCreate`, add:
 
 ```ts
-    formFaceExclusion = 'off';
+formFaceExclusion = 'off';
 ```
 
 In `startEdit`, add:
 
 ```ts
-    formFaceExclusion = getFaceExclusion(category);
+formFaceExclusion = getFaceExclusion(category);
 ```
 
 In the `category` object inside `handleSave`, add:
@@ -1344,6 +1341,7 @@ git commit -m "feat(web): add classification face exclusion setting"
 ### Task 7: Update Docs
 
 **Files:**
+
 - Modify: `docs/docs/features/auto-classification.md`
 - Modify: `docs/docs/install/config-file.md`
 
@@ -1358,12 +1356,12 @@ Each category can optionally skip assets that contain known human faces. This is
 
 The **Face exclusion** setting has four modes:
 
-| Mode                   | Behavior                                                                 |
-| ---------------------- | ------------------------------------------------------------------------ |
-| Off                    | Classifies assets as usual.                                              |
-| Any assigned face      | Skips the category when the asset has a visible face assigned to a person cluster. |
-| Named people           | Skips the category when the asset has a visible face assigned to a named person. |
-| Named, visible people  | Skips the category when the asset has a visible face assigned to a named person who is not hidden. |
+| Mode                  | Behavior                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| Off                   | Classifies assets as usual.                                                                        |
+| Any assigned face     | Skips the category when the asset has a visible face assigned to a person cluster.                 |
+| Named people          | Skips the category when the asset has a visible face assigned to a named person.                   |
+| Named, visible people | Skips the category when the asset has a visible face assigned to a named person who is not hidden. |
 
 Face-aware categories require facial recognition. If facial recognition is disabled, Gallery skips those categories instead of treating the asset as safe to classify. Categories set to **Off** continue to run normally.
 
@@ -1415,6 +1413,7 @@ git commit -m "docs: explain classification face exclusion"
 ### Task 8: Final Verification
 
 **Files:**
+
 - No planned source edits unless verification exposes a defect.
 
 - [ ] **Step 1: Run server unit tests touched by the feature**

--- a/docs/superpowers/plans/2026-04-27-known-face-auto-classification-filter.md
+++ b/docs/superpowers/plans/2026-04-27-known-face-auto-classification-filter.md
@@ -1,0 +1,1334 @@
+# Known-Face Auto-Classification Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-category face exclusion rules to auto-classification so selected categories skip assets containing known human faces after facial recognition has completed.
+
+**Architecture:** Store `faceExclusion` on each classification category in system config, defaulting old categories to `off`. Classification keeps one pass per asset: when any enabled category is face-aware, it waits for face detection and facial recognition queues to drain, loads one face summary for the asset, and skips only the categories whose rule matches. Existing auto-tags remain future-only.
+
+**Tech Stack:** NestJS 11, TypeScript, Kysely, Zod DTO schemas, BullMQ queues, Vitest, Svelte 5, generated `@immich/sdk`, Docusaurus docs.
+
+---
+
+## File Structure
+
+- Modify `server/src/config.ts`: add the classification face exclusion type and category field.
+- Modify `server/src/dtos/system-config.dto.ts`: add Zod enum/default for `faceExclusion`.
+- Modify `server/src/repositories/classification.repository.ts`: add the asset face summary query.
+- Modify `server/src/repositories/job.repository.ts`: make `waitForQueueCompletion` wait on active, waiting, and delayed jobs.
+- Create `server/src/repositories/job.repository.spec.ts`: unit-test queue wait semantics.
+- Modify `server/src/services/classification.service.ts`: evaluate face-aware category eligibility, queue face work on forced scans, and keep current tag/archive behavior.
+- Modify `server/src/services/classification.service.spec.ts`: cover face rules and wait behavior.
+- Modify `server/test/medium/specs/repositories/classification.repository.spec.ts`: cover face summary booleans against real DB rows.
+- Modify `open-api/immich-openapi-specs.json`, `open-api/typescript-sdk/src/fetch-client.ts`, `mobile/openapi/lib/model/system_config_classification_category_dto.dart`, and `mobile/openapi/lib/api.dart` after the schema change.
+- Modify `web/src/routes/admin/system-settings/ClassificationSettings.svelte`: add the category face exclusion control and summary badge.
+- Modify `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`: cover UI persistence and default display.
+- Modify `docs/docs/features/auto-classification.md` and `docs/docs/install/config-file.md`: document the new field and future-only behavior.
+
+---
+
+### Task 1: Add Config And DTO Support
+
+**Files:**
+- Modify: `server/src/config.ts`
+- Modify: `server/src/dtos/system-config.dto.ts`
+- Test: `server/src/services/system-config.service.spec.ts`
+- Test: `server/src/services/classification.service.spec.ts`
+
+- [ ] **Step 1: Write the failing DTO/default tests**
+
+Add this import in `server/src/services/system-config.service.spec.ts` if it is not already present:
+
+```ts
+import { SystemConfigSchema } from 'src/dtos/system-config.dto';
+```
+
+Add these tests near the existing classification config tests in `server/src/services/system-config.service.spec.ts`:
+
+```ts
+  it('should default missing classification faceExclusion to off', () => {
+    const result = SystemConfigSchema.parse({
+      ...defaults,
+      classification: {
+        enabled: true,
+        categories: [
+          {
+            name: 'Nature',
+            prompts: ['a landscape photo'],
+            similarity: 0.28,
+            action: 'tag',
+            enabled: true,
+          },
+        ],
+      },
+    });
+
+    expect(result.classification.categories[0].faceExclusion).toBe('off');
+  });
+
+  it('should accept all classification faceExclusion modes', () => {
+    const result = SystemConfigSchema.parse({
+      ...defaults,
+      classification: {
+        enabled: true,
+        categories: [
+          {
+            name: 'Any Assigned Face',
+            prompts: ['a test prompt'],
+            similarity: 0.28,
+            action: 'tag',
+            enabled: true,
+            faceExclusion: 'any_assigned_face',
+          },
+          {
+            name: 'Named People',
+            prompts: ['a test prompt'],
+            similarity: 0.28,
+            action: 'tag',
+            enabled: true,
+            faceExclusion: 'named_people',
+          },
+          {
+            name: 'Named Visible People',
+            prompts: ['a test prompt'],
+            similarity: 0.28,
+            action: 'tag',
+            enabled: true,
+            faceExclusion: 'named_visible_people',
+          },
+        ],
+      },
+    });
+
+    expect(result.classification.categories.map((category) => category.faceExclusion)).toEqual([
+      'any_assigned_face',
+      'named_people',
+      'named_visible_people',
+    ]);
+  });
+```
+
+Update the local helper in `server/src/services/classification.service.spec.ts` so later tests can use the new field:
+
+```ts
+const makeClassificationConfig = (
+  categories: Array<{
+    name: string;
+    prompts: string[];
+    similarity: number;
+    action: string;
+    enabled?: boolean;
+    faceExclusion?: 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
+  }> = [],
+  enabled = true,
+  facialRecognitionEnabled = true,
+) => ({
+  classification: {
+    enabled,
+    categories: categories.map((c) => ({ ...c, enabled: c.enabled ?? true, faceExclusion: c.faceExclusion ?? 'off' })),
+  },
+  machineLearning: {
+    enabled: true,
+    clip: { modelName: 'test-model' },
+    facialRecognition: { enabled: facialRecognitionEnabled },
+  },
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/services/system-config.service.spec.ts src/services/classification.service.spec.ts
+```
+
+Expected: `system-config.service.spec.ts` fails because `faceExclusion` is not present on parsed categories.
+
+- [ ] **Step 3: Add the config type**
+
+In `server/src/config.ts`, add this exported type near the other config types:
+
+```ts
+export type ClassificationFaceExclusion = 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
+```
+
+In the `SystemConfig['classification']['categories']` item type, add:
+
+```ts
+      faceExclusion: ClassificationFaceExclusion;
+```
+
+- [ ] **Step 4: Add the DTO schema default**
+
+In `server/src/dtos/system-config.dto.ts`, add this schema immediately before `SystemConfigClassificationCategorySchema`:
+
+```ts
+const ClassificationFaceExclusionSchema = z
+  .enum(['off', 'any_assigned_face', 'named_people', 'named_visible_people'])
+  .default('off')
+  .describe('Face exclusion rule for this classification category')
+  .meta({ id: 'ClassificationFaceExclusion' });
+```
+
+Then add this field to `SystemConfigClassificationCategorySchema`:
+
+```ts
+    faceExclusion: ClassificationFaceExclusionSchema,
+```
+
+- [ ] **Step 5: Run the focused tests**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/services/system-config.service.spec.ts src/services/classification.service.spec.ts
+```
+
+Expected: both files pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add server/src/config.ts server/src/dtos/system-config.dto.ts server/src/services/system-config.service.spec.ts server/src/services/classification.service.spec.ts
+git commit -m "feat(server): add classification face exclusion config"
+```
+
+---
+
+### Task 2: Add Asset Face Summary Query
+
+**Files:**
+- Modify: `server/src/repositories/classification.repository.ts`
+- Test: `server/test/medium/specs/repositories/classification.repository.spec.ts`
+
+- [ ] **Step 1: Write the failing medium tests**
+
+Add `SourceType` to the enum import in `server/test/medium/specs/repositories/classification.repository.spec.ts`:
+
+```ts
+import { AssetVisibility, SourceType } from 'src/enum';
+```
+
+Add this `describe` block before `removeAutoTagAssignments`:
+
+```ts
+  describe('getFaceSummary', () => {
+    it('should return false booleans for an asset without assigned faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: null });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: false,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+    });
+
+    it('should detect assigned, named, and visible named human faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: false, type: 'person' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: true,
+      });
+    });
+
+    it('should detect hidden named people but exclude them from visible named people', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: true, type: 'person' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: false,
+      });
+    });
+
+    it('should ignore invisible deleted and pet rows', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', type: 'person' });
+      const { person: pet } = await ctx.newPerson({ ownerId: user.id, name: 'Spot', type: 'pet', species: 'dog' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id, isVisible: false });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id, deletedAt: new Date() });
+      await ctx.newAssetFace({ assetId: asset.id, personId: pet.id, sourceType: SourceType.MachineLearning });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: false,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+    });
+  });
+```
+
+- [ ] **Step 2: Run the medium test to verify it fails**
+
+Run:
+
+```bash
+cd server
+pnpm test:medium -- --run test/medium/specs/repositories/classification.repository.spec.ts
+```
+
+Expected: FAIL with `sut.getFaceSummary is not a function`.
+
+- [ ] **Step 3: Add the repository method**
+
+In `server/src/repositories/classification.repository.ts`, add this exported interface above the class:
+
+```ts
+export interface ClassificationFaceSummary {
+  hasAssignedFace: boolean;
+  hasNamedPerson: boolean;
+  hasNamedVisiblePerson: boolean;
+}
+```
+
+Add this method to `ClassificationRepository`:
+
+```ts
+  async getFaceSummary(assetId: string): Promise<ClassificationFaceSummary> {
+    const row = await this.db
+      .selectFrom('asset_face')
+      .innerJoin('person', 'person.id', 'asset_face.personId')
+      .select([
+        sql<boolean>`count(*) > 0`.as('hasAssignedFace'),
+        sql<boolean>`count(*) filter (where btrim(person.name) != '') > 0`.as('hasNamedPerson'),
+        sql<boolean>`count(*) filter (where btrim(person.name) != '' and person."isHidden" is false) > 0`.as(
+          'hasNamedVisiblePerson',
+        ),
+      ])
+      .where('asset_face.assetId', '=', assetId)
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', 'is', true)
+      .where('person.type', '=', 'person')
+      .executeTakeFirst();
+
+    return {
+      hasAssignedFace: row?.hasAssignedFace ?? false,
+      hasNamedPerson: row?.hasNamedPerson ?? false,
+      hasNamedVisiblePerson: row?.hasNamedVisiblePerson ?? false,
+    };
+  }
+```
+
+The file already imports `sql` from Kysely. If it does not after rebasing, use:
+
+```ts
+import { Kysely, sql } from 'kysely';
+```
+
+- [ ] **Step 4: Run the medium test**
+
+Run:
+
+```bash
+cd server
+pnpm test:medium -- --run test/medium/specs/repositories/classification.repository.spec.ts
+```
+
+Expected: PASS for `classification.repository.spec.ts`.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add server/src/repositories/classification.repository.ts server/test/medium/specs/repositories/classification.repository.spec.ts
+git commit -m "feat(server): summarize faces for classification"
+```
+
+---
+
+### Task 3: Make Queue Waiting Use Pending Counts
+
+**Files:**
+- Modify: `server/src/repositories/job.repository.ts`
+- Create: `server/src/repositories/job.repository.spec.ts`
+- Test: `server/src/services/person.service.spec.ts`
+- Test: `server/src/repositories/job.repository.spec.ts`
+
+- [ ] **Step 1: Write the failing JobRepository unit tests**
+
+Create `server/src/repositories/job.repository.spec.ts`:
+
+```ts
+import { ModuleRef } from '@nestjs/core';
+import { QueueName } from 'src/enum';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { EventRepository } from 'src/repositories/event.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { JobCounts } from 'src/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const emptyCounts = (): JobCounts => ({
+  active: 0,
+  completed: 0,
+  failed: 0,
+  delayed: 0,
+  waiting: 0,
+  paused: 0,
+});
+
+const setup = (counts: JobCounts[]) => {
+  const queue = {
+    getJobCounts: vi.fn().mockResolvedValue(emptyCounts()),
+    isPaused: vi.fn().mockResolvedValue(false),
+  };
+
+  for (const value of counts) {
+    queue.getJobCounts.mockResolvedValueOnce(value);
+  }
+
+  const moduleRef = { get: vi.fn().mockReturnValue(queue) } as unknown as ModuleRef;
+  const logger = {
+    setContext: vi.fn(),
+    verbose: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggingRepository;
+
+  const sut = new JobRepository(
+    moduleRef,
+    {} as ConfigRepository,
+    {} as EventRepository,
+    logger,
+  );
+
+  return { sut, queue, logger };
+};
+
+describe(JobRepository.name, () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return immediately when queues have no active waiting or delayed jobs', async () => {
+    const { sut, queue } = setup([emptyCounts()]);
+
+    await sut.waitForQueueCompletion(QueueName.FaceDetection);
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(1);
+  });
+
+  it('should wait while a queue has waiting jobs', async () => {
+    const { sut, queue } = setup([{ ...emptyCounts(), waiting: 1 }, emptyCounts()]);
+
+    const promise = sut.waitForQueueCompletion(QueueName.FaceDetection);
+    await vi.waitFor(() => expect(queue.getJobCounts).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(2);
+  });
+
+  it('should wait while a queue has delayed jobs', async () => {
+    const { sut, queue } = setup([{ ...emptyCounts(), delayed: 1 }, emptyCounts()]);
+
+    const promise = sut.waitForQueueCompletion(QueueName.FacialRecognition);
+    await vi.waitFor(() => expect(queue.getJobCounts).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the repository test to verify it fails**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/repositories/job.repository.spec.ts
+```
+
+Expected: FAIL because the current helper checks only active jobs and does not wait on waiting or delayed jobs.
+
+- [ ] **Step 3: Update `waitForQueueCompletion`**
+
+In `server/src/repositories/job.repository.ts`, replace the current `waitForQueueCompletion` method with:
+
+```ts
+  async waitForQueueCompletion(...queues: QueueName[]): Promise<void> {
+    const getPending = async () => {
+      const results = await Promise.all(
+        queues.map(async (name) => {
+          const [counts, paused] = await Promise.all([this.getJobCounts(name), this.isPaused(name)]);
+          const pending = counts.active + counts.waiting + counts.delayed;
+          return { counts, name, paused, pending };
+        }),
+      );
+
+      return results.filter(({ pending }) => pending > 0);
+    };
+
+    let pending = await getPending();
+
+    while (pending.length > 0) {
+      const blocked = pending[0];
+      const message =
+        `Waiting for ${blocked.name} queue to finish ` +
+        `(${blocked.counts.active} active, ${blocked.counts.waiting} waiting, ${blocked.counts.delayed} delayed)`;
+
+      if (blocked.paused) {
+        this.logger.warn(`${message}; queue is paused`);
+      } else {
+        this.logger.verbose(`${message}...`);
+      }
+
+      await setTimeout(1000);
+      pending = await getPending();
+    }
+  }
+```
+
+- [ ] **Step 4: Run the focused tests**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/repositories/job.repository.spec.ts src/services/person.service.spec.ts
+```
+
+Expected: both files pass.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts
+git commit -m "fix(server): wait for pending queue jobs"
+```
+
+---
+
+### Task 4: Apply Face Exclusion In Classification Service
+
+**Files:**
+- Modify: `server/src/services/classification.service.ts`
+- Modify: `server/src/services/classification.service.spec.ts`
+- Test: `server/src/services/classification.service.spec.ts`
+
+- [ ] **Step 1: Write failing service tests**
+
+In `server/src/services/classification.service.spec.ts`, add these tests inside `describe('handleClassify', () => { ... })` after the disabled category tests:
+
+```ts
+    it('should not wait for face queues or load face summary when all enabled categories are face exclusion off', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Sunsets' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'Sunsets',
+            prompts: ['sunset sky'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'off',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
+    });
+
+    it('should skip any_assigned_face category when the asset has an assigned face', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'any_assigned_face',
+          },
+          {
+            name: 'Screenshots',
+            prompts: ['a screenshot'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'off',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(QueueName.FaceDetection, QueueName.FacialRecognition);
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
+    });
+
+    it('should skip named_people category only when a named person exists', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_people',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a portrait', { modelName: 'test-model' });
+      expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+    });
+
+    it('should ignore hidden named people for named_visible_people', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: false,
+      });
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_visible_people',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+    });
+
+    it('should skip face-aware categories when facial recognition is disabled and still classify off categories', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Screenshots' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig(
+          [
+            {
+              name: 'People',
+              prompts: ['a portrait'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'named_people',
+            },
+            {
+              name: 'Screenshots',
+              prompts: ['a screenshot'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'off',
+            },
+          ],
+          true,
+          false,
+        ),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
+    });
+
+    it('should mark classified when all enabled categories require disabled facial recognition', async () => {
+      mocks.asset.getById.mockResolvedValue({ id: 'asset-1', ownerId: 'user-1' } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig(
+          [
+            {
+              name: 'People',
+              prompts: ['a portrait'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'named_people',
+            },
+          ],
+          true,
+          false,
+        ),
+      );
+
+      const result = await sut.handleClassify({ id: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+    });
+```
+
+Add this test inside `describe('handleClassifyQueueAll', () => { ... })`:
+
+```ts
+    it('should queue face work before forced classification when enabled categories are face-aware', async () => {
+      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_people',
+          },
+        ]),
+      );
+
+      await sut.handleClassifyQueueAll({ force: true });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetDetectFacesQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetClassify, data: { id: 'asset-1' } },
+      ]);
+    });
+```
+
+Add `QueueName` to the enum import at the top of the spec:
+
+```ts
+import { AssetVisibility, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
+```
+
+- [ ] **Step 2: Run the classification service spec to verify failures**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/services/classification.service.spec.ts
+```
+
+Expected: FAIL because `getFaceSummary` is not used and face queue waiting is not implemented.
+
+- [ ] **Step 3: Add imports and helpers to ClassificationService**
+
+In `server/src/services/classification.service.ts`, update imports:
+
+```ts
+import { ClassificationFaceExclusion, SystemConfig } from 'src/config';
+import { ClassificationFaceSummary } from 'src/repositories/classification.repository';
+import { isFacialRecognitionEnabled } from 'src/utils/misc';
+```
+
+Add these helper methods inside `ClassificationService` before `parseEmbedding`:
+
+```ts
+  private isFaceAwareCategory(category: ClassificationConfig['categories'][number]) {
+    return category.faceExclusion !== 'off';
+  }
+
+  private matchesFaceExclusion(rule: ClassificationFaceExclusion, summary: ClassificationFaceSummary) {
+    switch (rule) {
+      case 'any_assigned_face': {
+        return summary.hasAssignedFace;
+      }
+      case 'named_people': {
+        return summary.hasNamedPerson;
+      }
+      case 'named_visible_people': {
+        return summary.hasNamedVisiblePerson;
+      }
+      case 'off': {
+        return false;
+      }
+    }
+  }
+
+  private async getEligibleCategories(
+    categories: ClassificationConfig['categories'],
+    machineLearning: SystemConfig['machineLearning'],
+    assetId: string,
+  ) {
+    const faceAwareCategories = categories.filter((category) => this.isFaceAwareCategory(category));
+    if (faceAwareCategories.length === 0) {
+      return categories;
+    }
+
+    if (!isFacialRecognitionEnabled(machineLearning)) {
+      return categories.filter((category) => !this.isFaceAwareCategory(category));
+    }
+
+    await this.jobRepository.waitForQueueCompletion(QueueName.FaceDetection, QueueName.FacialRecognition);
+    const faceSummary = await this.classificationRepository.getFaceSummary(assetId);
+
+    return categories.filter((category) => !this.matchesFaceExclusion(category.faceExclusion, faceSummary));
+  }
+```
+
+- [ ] **Step 4: Use eligible categories in `handleClassify`**
+
+In `handleClassify`, replace:
+
+```ts
+    const enabledCategories = classification.categories.filter((c) => c.enabled);
+    if (enabledCategories.length === 0) {
+      await this.classificationRepository.setClassifiedAt(id);
+      return JobStatus.Skipped;
+    }
+
+    const assetEmbedding = this.parseEmbedding(embedding);
+    let shouldArchive = false;
+
+    for (const category of enabledCategories) {
+```
+
+with:
+
+```ts
+    const enabledCategories = classification.categories.filter((c) => c.enabled);
+    if (enabledCategories.length === 0) {
+      await this.classificationRepository.setClassifiedAt(id);
+      return JobStatus.Skipped;
+    }
+
+    const eligibleCategories = await this.getEligibleCategories(enabledCategories, machineLearning, id);
+    if (eligibleCategories.length === 0) {
+      await this.classificationRepository.setClassifiedAt(id);
+      return JobStatus.Skipped;
+    }
+
+    const assetEmbedding = this.parseEmbedding(embedding);
+    let shouldArchive = false;
+
+    for (const category of eligibleCategories) {
+```
+
+- [ ] **Step 5: Queue face work during forced scans**
+
+In `handleClassifyQueueAll`, after the `force` reset block and before streaming unclassified assets, add:
+
+```ts
+    const faceAwareCategories = classification.categories.filter(
+      (category) => category.enabled && this.isFaceAwareCategory(category),
+    );
+
+    const { machineLearning } = await this.getConfig({ withCache: true });
+    if (force && faceAwareCategories.length > 0 && isFacialRecognitionEnabled(machineLearning)) {
+      await this.jobRepository.queue({ name: JobName.AssetDetectFacesQueueAll, data: { force: true } });
+      await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+    }
+```
+
+If the method currently reads only `{ classification }`, change that first config read to:
+
+```ts
+    const { classification, machineLearning } = await this.getConfig({ withCache: true });
+```
+
+and do not add a second `getConfig` call.
+
+- [ ] **Step 6: Run the focused service tests**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/services/classification.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add server/src/services/classification.service.ts server/src/services/classification.service.spec.ts
+git commit -m "feat(server): apply classification face exclusion"
+```
+
+---
+
+### Task 5: Regenerate OpenAPI And SDK
+
+**Files:**
+- Modify: `open-api/immich-openapi-specs.json`
+- Modify: `open-api/typescript-sdk/src/fetch-client.ts`
+- Modify: `mobile/openapi/lib/model/system_config_classification_category_dto.dart`
+- Modify: `mobile/openapi/lib/api.dart`
+- Test: generated TypeScript SDK build
+
+- [ ] **Step 1: Regenerate OpenAPI clients**
+
+Run:
+
+```bash
+make open-api
+```
+
+Expected: OpenAPI generation completes without errors and generated schemas include `faceExclusion`.
+
+- [ ] **Step 2: Build the TypeScript SDK**
+
+Run:
+
+```bash
+make build-sdk
+```
+
+Expected: `@immich/sdk` builds successfully.
+
+- [ ] **Step 3: Inspect generated changes**
+
+Run:
+
+```bash
+git status --short
+git diff -- open-api | sed -n '1,220p'
+```
+
+Expected: generated files show the new `faceExclusion` schema/property and no unrelated hand edits.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add open-api
+git commit -m "chore(openapi): regenerate classification face exclusion clients"
+```
+
+---
+
+### Task 6: Add Web Face Exclusion Control
+
+**Files:**
+- Modify: `web/src/routes/admin/system-settings/ClassificationSettings.svelte`
+- Modify: `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`
+- Test: `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`
+
+- [ ] **Step 1: Write failing web tests**
+
+In `web/src/routes/admin/system-settings/ClassificationSettings.spec.ts`, update `makeCategory` so old test data has the generated field:
+
+```ts
+  faceExclusion: 'off',
+```
+
+Add these tests before the config-file disabled test:
+
+```ts
+  it('should show face exclusion dropdown when creating a category', async () => {
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Add Category')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByText('Add Category'));
+
+    expect(screen.getByLabelText('Face exclusion')).toBeInTheDocument();
+    expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+  });
+
+  it('should save selected face exclusion for a new category', async () => {
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Add Category')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByText('Add Category'));
+    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Nature' } });
+    await fireEvent.input(screen.getByLabelText('Prompts (one per line)'), { target: { value: 'a landscape photo' } });
+    await fireEvent.change(screen.getByLabelText('Face exclusion'), { target: { value: 'named_visible_people' } });
+    await fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith({
+        systemConfigDto: expect.objectContaining({
+          classification: expect.objectContaining({
+            categories: [
+              expect.objectContaining({
+                name: 'Nature',
+                faceExclusion: 'named_visible_people',
+              }),
+            ],
+          }),
+        }),
+      });
+    });
+  });
+
+  it('should default old categories without faceExclusion to Off in the editor', async () => {
+    vi.mocked(getConfig).mockResolvedValue(
+      makeConfig([
+        {
+          name: 'Legacy',
+          prompts: ['legacy prompt'],
+          similarity: 0.28,
+          action: Action.Tag,
+          enabled: true,
+        } as SystemConfigDto['classification']['categories'][number],
+      ]),
+    );
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Legacy')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByLabelText('Edit'));
+
+    expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+  });
+
+  it('should show non-Off face exclusion in the category summary', async () => {
+    vi.mocked(getConfig).mockResolvedValue(makeConfig([makeCategory({ faceExclusion: 'named_people' })]));
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Named people')).toBeInTheDocument();
+    });
+  });
+```
+
+- [ ] **Step 2: Run the web spec to verify it fails**
+
+Run:
+
+```bash
+cd web
+pnpm exec vitest run src/routes/admin/system-settings/ClassificationSettings.spec.ts
+```
+
+Expected: FAIL because the Face exclusion control and summary are not rendered.
+
+- [ ] **Step 3: Add component state and labels**
+
+In `web/src/routes/admin/system-settings/ClassificationSettings.svelte`, add:
+
+```ts
+  type FaceExclusion = NonNullable<Category['faceExclusion']>;
+```
+
+Add state next to the other form state:
+
+```ts
+  let formFaceExclusion: FaceExclusion = $state('off');
+```
+
+Add labels after `actionLabels`:
+
+```ts
+  const faceExclusionLabels: Record<FaceExclusion, string> = {
+    off: 'Off',
+    any_assigned_face: 'Any assigned face',
+    named_people: 'Named people',
+    named_visible_people: 'Named, visible people',
+  };
+```
+
+Add a normalizer helper:
+
+```ts
+  const getFaceExclusion = (category: Partial<Category>): FaceExclusion => category.faceExclusion ?? 'off';
+```
+
+- [ ] **Step 4: Wire form create/edit/save state**
+
+In `startCreate`, add:
+
+```ts
+    formFaceExclusion = 'off';
+```
+
+In `startEdit`, add:
+
+```ts
+    formFaceExclusion = getFaceExclusion(category);
+```
+
+In the `category` object inside `handleSave`, add:
+
+```ts
+        faceExclusion: formFaceExclusion,
+```
+
+- [ ] **Step 5: Render the dropdown**
+
+In the form markup, place this block after the Action `<select>` block:
+
+```svelte
+        <div>
+          <label for="category-face-exclusion" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Face exclusion
+          </label>
+          <select
+            id="category-face-exclusion"
+            bind:value={formFaceExclusion}
+            {disabled}
+            class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-immich-primary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <option value="off">{faceExclusionLabels.off}</option>
+            <option value="any_assigned_face">{faceExclusionLabels.any_assigned_face}</option>
+            <option value="named_people">{faceExclusionLabels.named_people}</option>
+            <option value="named_visible_people">{faceExclusionLabels.named_visible_people}</option>
+          </select>
+        </div>
+```
+
+- [ ] **Step 6: Render the summary badge**
+
+In the category summary row, after the action badge, add:
+
+```svelte
+                {#if getFaceExclusion(category) !== 'off'}
+                  <span
+                    class="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200"
+                  >
+                    {faceExclusionLabels[getFaceExclusion(category)]}
+                  </span>
+                {/if}
+```
+
+- [ ] **Step 7: Run the web spec**
+
+Run:
+
+```bash
+cd web
+pnpm exec vitest run src/routes/admin/system-settings/ClassificationSettings.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add web/src/routes/admin/system-settings/ClassificationSettings.svelte web/src/routes/admin/system-settings/ClassificationSettings.spec.ts
+git commit -m "feat(web): add classification face exclusion setting"
+```
+
+---
+
+### Task 7: Update Docs
+
+**Files:**
+- Modify: `docs/docs/features/auto-classification.md`
+- Modify: `docs/docs/install/config-file.md`
+
+- [ ] **Step 1: Update auto-classification feature docs**
+
+In `docs/docs/features/auto-classification.md`, add this section after the category action explanation:
+
+```md
+### Face exclusion
+
+Each category can optionally skip assets that contain known human faces. This is useful when a category should classify non-personal images, such as receipts, nature photos, or screenshots, without tagging genuine photos of people.
+
+The **Face exclusion** setting has four modes:
+
+| Mode                   | Behavior                                                                 |
+| ---------------------- | ------------------------------------------------------------------------ |
+| Off                    | Classifies assets as usual.                                              |
+| Any assigned face      | Skips the category when the asset has a visible face assigned to a person cluster. |
+| Named people           | Skips the category when the asset has a visible face assigned to a named person. |
+| Named, visible people  | Skips the category when the asset has a visible face assigned to a named person who is not hidden. |
+
+Face-aware categories require facial recognition. If facial recognition is disabled, Gallery skips those categories instead of treating the asset as safe to classify. Categories set to **Off** continue to run normally.
+
+Face exclusion is future-only. Changing the setting does not remove existing `Auto/...` tags, and later face recognition, person naming, hiding, or merging does not clean up old tags automatically. Run **Scan All Libraries** after changing rules if you want assets to be classified again under the new settings.
+```
+
+- [ ] **Step 2: Update config-file docs**
+
+In `docs/docs/install/config-file.md`, update the classification category example to include:
+
+```json
+"faceExclusion": "off"
+```
+
+Add this field reference near the classification config explanation:
+
+```md
+`faceExclusion` controls whether the category skips assets with known human faces. Valid values are:
+
+- `off`
+- `any_assigned_face`
+- `named_people`
+- `named_visible_people`
+
+Face-aware categories require facial recognition. When facial recognition is disabled, categories with a non-`off` `faceExclusion` value are skipped.
+```
+
+- [ ] **Step 3: Format docs**
+
+Run:
+
+```bash
+pnpm --filter documentation run format:fix
+```
+
+Expected: Prettier completes and only docs formatting changes remain.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add docs/docs/features/auto-classification.md docs/docs/install/config-file.md
+git commit -m "docs: explain classification face exclusion"
+```
+
+---
+
+### Task 8: Final Verification
+
+**Files:**
+- No planned source edits unless verification exposes a defect.
+
+- [ ] **Step 1: Run server unit tests touched by the feature**
+
+Run:
+
+```bash
+cd server
+pnpm test -- --run src/services/classification.service.spec.ts src/services/system-config.service.spec.ts src/repositories/job.repository.spec.ts src/services/person.service.spec.ts
+```
+
+Expected: all selected server unit test files pass.
+
+- [ ] **Step 2: Run classification repository medium test**
+
+Run:
+
+```bash
+cd server
+pnpm test:medium -- --run test/medium/specs/repositories/classification.repository.spec.ts
+```
+
+Expected: the medium repository spec passes.
+
+- [ ] **Step 3: Run web classification settings test**
+
+Run:
+
+```bash
+cd web
+pnpm exec vitest run src/routes/admin/system-settings/ClassificationSettings.spec.ts
+```
+
+Expected: the web spec passes.
+
+- [ ] **Step 4: Run type checks for changed packages**
+
+Run:
+
+```bash
+make check-server
+make check-web
+```
+
+Expected: both checks complete successfully.
+
+- [ ] **Step 5: Inspect the branch**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate -8
+```
+
+Expected: working tree is clean, and the task commits are visible on `discussion-321-known-face-filter`.
+
+- [ ] **Step 6: Final commit only if verification fixes were needed**
+
+If Step 1 through Step 4 exposed fixes, commit them:
+
+```bash
+git add server/src/config.ts server/src/dtos/system-config.dto.ts server/src/repositories/classification.repository.ts server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts server/src/services/classification.service.ts server/src/services/classification.service.spec.ts server/src/services/system-config.service.spec.ts server/test/medium/specs/repositories/classification.repository.spec.ts web/src/routes/admin/system-settings/ClassificationSettings.svelte web/src/routes/admin/system-settings/ClassificationSettings.spec.ts docs/docs/features/auto-classification.md docs/docs/install/config-file.md open-api mobile/openapi
+git commit -m "fix: stabilize classification face exclusion"
+```
+
+If no fixes were needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-04-27-known-face-auto-classification-filter-design.md
+++ b/docs/superpowers/specs/2026-04-27-known-face-auto-classification-filter-design.md
@@ -1,0 +1,191 @@
+# Known-Face Auto-Classification Filter Design
+
+## Context
+
+GitHub discussion: https://github.com/open-noodle/gallery/discussions/321
+
+Auto-classification currently evaluates every eligible asset with a CLIP embedding against every enabled classification category. The requested enhancement is an opt-in way to avoid applying selected auto-classification categories to personal photos that contain known faces.
+
+Gallery already stores auto-classification categories in system config and tracks one `classifiedAt` timestamp per asset in `asset_job_status`. Facial recognition data is stored through `asset_face` rows linked to `person` rows, with `facesRecognizedAt` currently written after face detection queues recognition jobs. That timestamp does not prove all face recognition jobs have completed.
+
+## Goals
+
+- Let each classification category define its own face exclusion behavior.
+- Preserve current behavior for existing categories and installs.
+- Treat face-aware classification as dependent on completed facial recognition, not only completed face detection.
+- Keep the implementation compatible with the existing single `classifiedAt` model.
+- Avoid automatic cleanup of existing auto-tags when face rules or face metadata change.
+
+## Non-Goals
+
+- Do not remove existing `Auto/...` tag assignments when a face rule is added or when a person is later named.
+- Do not add per-category classification history.
+- Do not classify face-free categories in one phase and face-aware categories in a later phase.
+- Do not treat unassigned detected faces as known faces.
+- Do not include pet/person-like pet detection rows in the human face exclusion checks.
+
+## Product Behavior
+
+Each classification category gets a **Face exclusion** setting:
+
+- `Off` - category behaves exactly as it does today.
+- `Any assigned face` - skip this category when the asset has at least one visible human face linked to a person cluster.
+- `Named people` - skip this category when the asset has at least one visible human face linked to a person with a non-empty name.
+- `Named, visible people` - skip this category when the asset has at least one visible human face linked to a non-hidden person with a non-empty name.
+
+The setting is per category. For example, an admin can allow a `Screenshots` category to classify images that contain faces while configuring a `Nature` category to skip assets with known people.
+
+The behavior is future-only. The rule is evaluated when an asset is classified. Existing `Auto/...` tags are not removed because a category rule changes, because face recognition later assigns a face, or because a person is later named or hidden.
+
+## Configuration Model
+
+Add `faceExclusion` to each classification category:
+
+```ts
+type ClassificationFaceExclusion = 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
+```
+
+Existing categories default to `off`. Config loading and DTO validation must accept existing persisted config entries that do not have the field yet.
+
+No database migration is needed because classification categories are persisted inside system configuration. The compatibility work belongs in the config schema/defaulting path and generated OpenAPI/SDK types.
+
+Example config:
+
+```json
+{
+  "classification": {
+    "enabled": true,
+    "categories": [
+      {
+        "name": "Nature",
+        "prompts": ["a landscape photo", "a nature scene"],
+        "similarity": 0.28,
+        "action": "tag",
+        "enabled": true,
+        "faceExclusion": "named_visible_people"
+      }
+    ]
+  }
+}
+```
+
+## Server Design
+
+Classification keeps one pass per asset. The handler loads enabled categories, determines whether any enabled category has `faceExclusion !== 'off'`, and only evaluates face state in that case.
+
+Classification flow:
+
+1. Load the asset and config.
+2. If classification is disabled, return `Skipped`.
+3. Load the smart-search embedding. If absent, return `Skipped`.
+4. Build the enabled category list.
+5. If no categories are enabled, set `classifiedAt` and return `Skipped`.
+6. If any enabled category is face-aware:
+   - If facial recognition is disabled, exclude all face-aware categories from this run.
+   - If facial recognition is enabled, wait for face detection and facial recognition queues to finish, then load a face summary for this asset.
+7. Evaluate CLIP similarity for eligible categories.
+8. Apply matching `Auto/{category}` tags and archive the asset if any matched eligible category uses `tag_and_archive`.
+9. Set `classifiedAt`.
+
+If facial recognition is disabled and every enabled category is face-aware, the asset is still marked classified for that run. This avoids retrying the same asset forever. Enabling facial recognition later requires the admin to run a forced classification scan, which already resets `classifiedAt`.
+
+### Waiting For Recognition
+
+The current `facesRecognizedAt` field is not sufficient as a completion signal because it is written by face detection after recognition jobs are queued. To honor "wait for actual facial recognition completion", classification should wait on queue state before evaluating face-aware categories.
+
+The existing job wait helper should be extended or replaced for this use case so it considers pending work, not only active work. Pending should include active, waiting, and delayed jobs. If a required queue is paused while it still has pending jobs, classification should keep waiting and log that the face-aware classification job is blocked by the paused queue. Classification should wait for both:
+
+- `QueueName.FaceDetection`
+- `QueueName.FacialRecognition`
+
+The wait should live in the classification path only when face-aware categories are enabled. Installations that keep all categories at `off` should not wait on face queues.
+
+### Queue-All Behavior
+
+`handleClassifyQueueAll({ force: true })` already resets `classifiedAt` and streams assets for classification. For face-aware categories, a forced scan should also ensure facial recognition work is queued before classification jobs are queued. The classify handler still performs the queue wait, so this ordering does not need to be perfect, but queueing face work first avoids avoidable blocking per asset.
+
+When facial recognition is disabled, queue-all does not need to queue face work. Face-aware categories are skipped by the classify handler.
+
+## Repository Design
+
+Add a classification repository method that returns a compact face summary for one asset:
+
+```ts
+interface ClassificationFaceSummary {
+  hasAssignedFace: boolean;
+  hasNamedPerson: boolean;
+  hasNamedVisiblePerson: boolean;
+}
+```
+
+The query should consider only:
+
+- `asset_face.assetId = assetId`
+- `asset_face.deletedAt IS NULL`
+- `asset_face.isVisible IS TRUE`
+- `asset_face.personId IS NOT NULL`
+- joined `person.type = 'person'`
+
+Rule mapping:
+
+- `any_assigned_face` -> `hasAssignedFace`
+- `named_people` -> `hasNamedPerson`
+- `named_visible_people` -> `hasNamedVisiblePerson`
+
+Names should be treated as present only when `person.name` is not an empty string after trimming.
+
+## Web Design
+
+The existing admin classification category editor gets a **Face exclusion** dropdown. It appears alongside the current category settings and is disabled when config-file mode makes system config read-only.
+
+The category summary row should show the selected rule when it is not `Off`, so admins can scan which categories are face-aware without opening each category. Existing categories with no explicit field display `Off`.
+
+The UI should use the generated SDK enum/type after OpenAPI regeneration. Until then, local component tests can use the literal values through the generated type shape.
+
+## Documentation
+
+Update:
+
+- `docs/docs/features/auto-classification.md`
+- `docs/docs/install/config-file.md`
+
+Docs should explain:
+
+- The setting is per category.
+- `Off` preserves existing behavior.
+- Face-aware rules require facial recognition.
+- When facial recognition is disabled, face-aware categories are skipped.
+- The behavior is future-only; existing auto-tags are not removed automatically.
+- Unassigned detected faces do not count as known faces.
+
+## Testing
+
+Server unit tests:
+
+- Config/DTO accepts `faceExclusion` and defaults old categories to `off`.
+- `handleClassify` does not load face data or wait for face queues when all enabled categories use `off`.
+- `any_assigned_face` skips only the matching category when an assigned visible human face exists.
+- `named_people` skips only when a linked person has a non-empty name.
+- `named_visible_people` ignores hidden named people.
+- Face-aware categories are skipped when facial recognition is disabled, while `off` categories still run.
+- When face-aware categories exist and facial recognition is enabled, classification waits for face detection and facial recognition queue completion before evaluating.
+- `handleClassifyQueueAll({ force: true })` queues or ensures face recognition work before classification when needed.
+
+Repository or medium tests:
+
+- The face-summary query returns the expected booleans for assigned, named, hidden, unassigned, deleted, invisible, and pet rows.
+
+Web tests:
+
+- Category editor shows the Face exclusion dropdown.
+- Existing categories with no explicit field show `Off`.
+- Saving a category persists the selected rule.
+- Category summary shows the selected non-`Off` rule.
+
+## Open Questions Resolved
+
+- Face exclusion is per category, not global.
+- Existing tags are future-only and are not cleaned up automatically.
+- Face-aware classification waits for actual recognition completion.
+- If any enabled category uses face exclusion, the asset's single classification pass waits; face-free categories do not run earlier in a separate phase.
+- When facial recognition is disabled, face-aware categories are skipped.

--- a/e2e/src/specs/server/api/classification.e2e-spec.ts
+++ b/e2e/src/specs/server/api/classification.e2e-spec.ts
@@ -210,8 +210,22 @@ describe('/classification', () => {
     describe('round-trip', () => {
       it('preserves a custom categories array across PUT/GET', async () => {
         const customCategories = [
-          { name: 'Pets', prompts: ['a cat', 'a dog'], similarity: 0.55, action: 'tag', enabled: true },
-          { name: 'Food', prompts: ['food'], similarity: 0.6, action: 'tag_and_archive', enabled: false },
+          {
+            name: 'Pets',
+            prompts: ['a cat', 'a dog'],
+            similarity: 0.55,
+            action: 'tag',
+            faceExclusion: 'off',
+            enabled: true,
+          },
+          {
+            name: 'Food',
+            prompts: ['food'],
+            similarity: 0.6,
+            action: 'tag_and_archive',
+            faceExclusion: 'off',
+            enabled: false,
+          },
         ];
         const update = {
           ...baseConfig,

--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -2,6 +2,20 @@ import type { LoginResponseDto } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
 import { utils } from 'src/utils';
 
+async function selectPageSort(page: import('@playwright/test').Page, label: 'Newest first' | 'Oldest first') {
+  const sortButton = page.locator('[data-testid="search-sort-btn"]');
+  await expect(sortButton).toBeVisible();
+
+  if ((await sortButton.getAttribute('aria-label')) === label) {
+    return sortButton;
+  }
+
+  await sortButton.click();
+  await page.locator('[data-testid="search-sort-container"] div.absolute button').filter({ hasText: label }).click();
+
+  return sortButton;
+}
+
 test.describe('Spaces FilterPanel', () => {
   let admin: LoginResponseDto;
 
@@ -21,26 +35,6 @@ test.describe('Spaces FilterPanel', () => {
     await page.goto(`/spaces/${spaceId}`);
     // Wait for the timeline container to be present (always rendered, even for empty spaces)
     await page.waitForSelector('[data-testid="discovery-timeline"]');
-  }
-
-  async function selectPageSort(
-    page: import('@playwright/test').Page,
-    label: 'Newest first' | 'Oldest first',
-  ) {
-    const sortButton = page.locator('[data-testid="search-sort-btn"]');
-    await expect(sortButton).toBeVisible();
-
-    if ((await sortButton.getAttribute('aria-label')) === label) {
-      return sortButton;
-    }
-
-    await sortButton.click();
-    await page
-      .locator('[data-testid="search-sort-container"] div.absolute button')
-      .filter({ hasText: label })
-      .click();
-
-    return sortButton;
   }
 
   // ─── Helper: create a space with diverse test data ───
@@ -1141,7 +1135,7 @@ test.describe('Spaces FilterPanel', () => {
 
       // Sort should remain ascending
       await expect(sortButton).toHaveAttribute('aria-label', 'Oldest first');
-      await expect(page).toHaveURL(new RegExp(`/spaces/${space.id}\\?sort=asc`));
+      await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}\?sort=asc`));
     });
   });
 

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -439,6 +439,7 @@ Class | Method | HTTP request | Description
  - [CastResponse](doc//CastResponse.md)
  - [CastUpdate](doc//CastUpdate.md)
  - [ChangePasswordDto](doc//ChangePasswordDto.md)
+ - [ClassificationFaceExclusion](doc//ClassificationFaceExclusion.md)
  - [Colorspace](doc//Colorspace.md)
  - [ContributorCountResponseDto](doc//ContributorCountResponseDto.md)
  - [CreateAlbumDto](doc//CreateAlbumDto.md)

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -148,6 +148,7 @@ part 'model/cq_mode.dart';
 part 'model/cast_response.dart';
 part 'model/cast_update.dart';
 part 'model/change_password_dto.dart';
+part 'model/classification_face_exclusion.dart';
 part 'model/colorspace.dart';
 part 'model/contributor_count_response_dto.dart';
 part 'model/create_album_dto.dart';

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -332,6 +332,8 @@ class ApiClient {
           return CastUpdate.fromJson(value);
         case 'ChangePasswordDto':
           return ChangePasswordDto.fromJson(value);
+        case 'ClassificationFaceExclusion':
+          return ClassificationFaceExclusionTypeTransformer().decode(value);
         case 'Colorspace':
           return ColorspaceTypeTransformer().decode(value);
         case 'ContributorCountResponseDto':

--- a/mobile/openapi/lib/api_helper.dart
+++ b/mobile/openapi/lib/api_helper.dart
@@ -97,6 +97,9 @@ String parameterToString(dynamic value) {
   if (value is CQMode) {
     return CQModeTypeTransformer().encode(value).toString();
   }
+  if (value is ClassificationFaceExclusion) {
+    return ClassificationFaceExclusionTypeTransformer().encode(value).toString();
+  }
   if (value is Colorspace) {
     return ColorspaceTypeTransformer().encode(value).toString();
   }

--- a/mobile/openapi/lib/model/classification_face_exclusion.dart
+++ b/mobile/openapi/lib/model/classification_face_exclusion.dart
@@ -1,0 +1,91 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+/// Face exclusion rule for this classification category
+class ClassificationFaceExclusion {
+  /// Instantiate a new enum with the provided [value].
+  const ClassificationFaceExclusion._(this.value);
+
+  /// The underlying value of this enum member.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  String toJson() => value;
+
+  static const off = ClassificationFaceExclusion._(r'off');
+  static const anyAssignedFace = ClassificationFaceExclusion._(r'any_assigned_face');
+  static const namedPeople = ClassificationFaceExclusion._(r'named_people');
+  static const namedVisiblePeople = ClassificationFaceExclusion._(r'named_visible_people');
+
+  /// List of all possible values in this [enum][ClassificationFaceExclusion].
+  static const values = <ClassificationFaceExclusion>[
+    off,
+    anyAssignedFace,
+    namedPeople,
+    namedVisiblePeople,
+  ];
+
+  static ClassificationFaceExclusion? fromJson(dynamic value) => ClassificationFaceExclusionTypeTransformer().decode(value);
+
+  static List<ClassificationFaceExclusion> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <ClassificationFaceExclusion>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = ClassificationFaceExclusion.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+}
+
+/// Transformation class that can [encode] an instance of [ClassificationFaceExclusion] to String,
+/// and [decode] dynamic data back to [ClassificationFaceExclusion].
+class ClassificationFaceExclusionTypeTransformer {
+  factory ClassificationFaceExclusionTypeTransformer() => _instance ??= const ClassificationFaceExclusionTypeTransformer._();
+
+  const ClassificationFaceExclusionTypeTransformer._();
+
+  String encode(ClassificationFaceExclusion data) => data.value;
+
+  /// Decodes a [dynamic value][data] to a ClassificationFaceExclusion.
+  ///
+  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
+  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
+  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
+  ///
+  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
+  /// and users are still using an old app with the old code.
+  ClassificationFaceExclusion? decode(dynamic data, {bool allowNull = true}) {
+    if (data != null) {
+      switch (data) {
+        case r'off': return ClassificationFaceExclusion.off;
+        case r'any_assigned_face': return ClassificationFaceExclusion.anyAssignedFace;
+        case r'named_people': return ClassificationFaceExclusion.namedPeople;
+        case r'named_visible_people': return ClassificationFaceExclusion.namedVisiblePeople;
+        default:
+          if (!allowNull) {
+            throw ArgumentError('Unknown enum value to decode: $data');
+          }
+      }
+    }
+    return null;
+  }
+
+  /// Singleton [ClassificationFaceExclusionTypeTransformer] instance.
+  static ClassificationFaceExclusionTypeTransformer? _instance;
+}
+

--- a/mobile/openapi/lib/model/system_config_classification_category_dto.dart
+++ b/mobile/openapi/lib/model/system_config_classification_category_dto.dart
@@ -15,6 +15,7 @@ class SystemConfigClassificationCategoryDto {
   SystemConfigClassificationCategoryDto({
     required this.action,
     required this.enabled,
+    this.faceExclusion,
     required this.name,
     this.prompts = const [],
     required this.similarity,
@@ -25,6 +26,14 @@ class SystemConfigClassificationCategoryDto {
 
   /// Whether this category is enabled
   bool enabled;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  ClassificationFaceExclusion? faceExclusion;
 
   /// Category name
   String name;
@@ -42,6 +51,7 @@ class SystemConfigClassificationCategoryDto {
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigClassificationCategoryDto &&
     other.action == action &&
     other.enabled == enabled &&
+    other.faceExclusion == faceExclusion &&
     other.name == name &&
     _deepEquality.equals(other.prompts, prompts) &&
     other.similarity == similarity;
@@ -51,17 +61,23 @@ class SystemConfigClassificationCategoryDto {
     // ignore: unnecessary_parenthesis
     (action.hashCode) +
     (enabled.hashCode) +
+    (faceExclusion == null ? 0 : faceExclusion!.hashCode) +
     (name.hashCode) +
     (prompts.hashCode) +
     (similarity.hashCode);
 
   @override
-  String toString() => 'SystemConfigClassificationCategoryDto[action=$action, enabled=$enabled, name=$name, prompts=$prompts, similarity=$similarity]';
+  String toString() => 'SystemConfigClassificationCategoryDto[action=$action, enabled=$enabled, faceExclusion=$faceExclusion, name=$name, prompts=$prompts, similarity=$similarity]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'action'] = this.action;
       json[r'enabled'] = this.enabled;
+    if (this.faceExclusion != null) {
+      json[r'faceExclusion'] = this.faceExclusion;
+    } else {
+    //  json[r'faceExclusion'] = null;
+    }
       json[r'name'] = this.name;
       json[r'prompts'] = this.prompts;
       json[r'similarity'] = this.similarity;
@@ -79,6 +95,7 @@ class SystemConfigClassificationCategoryDto {
       return SystemConfigClassificationCategoryDto(
         action: SystemConfigClassificationCategoryDtoActionEnum.fromJson(json[r'action'])!,
         enabled: mapValueOfType<bool>(json, r'enabled')!,
+        faceExclusion: ClassificationFaceExclusion.fromJson(json[r'faceExclusion']),
         name: mapValueOfType<String>(json, r'name')!,
         prompts: json[r'prompts'] is Iterable
             ? (json[r'prompts'] as Iterable).cast<String>().toList(growable: false)

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -20429,6 +20429,17 @@
         ],
         "type": "object"
       },
+      "ClassificationFaceExclusion": {
+        "default": "off",
+        "description": "Face exclusion rule for this classification category",
+        "enum": [
+          "off",
+          "any_assigned_face",
+          "named_people",
+          "named_visible_people"
+        ],
+        "type": "string"
+      },
       "Colorspace": {
         "description": "Colorspace",
         "enum": [
@@ -28325,6 +28336,9 @@
           "enabled": {
             "description": "Whether this category is enabled",
             "type": "boolean"
+          },
+          "faceExclusion": {
+            "$ref": "#/components/schemas/ClassificationFaceExclusion"
           },
           "name": {
             "description": "Category name",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2637,6 +2637,7 @@ export type SystemConfigClassificationCategoryDto = {
     action: Action;
     /** Whether this category is enabled */
     enabled: boolean;
+    faceExclusion?: ClassificationFaceExclusion;
     /** Category name */
     name: string;
     /** CLIP text prompts for this category */
@@ -8466,6 +8467,12 @@ export enum SyncRequestType {
 export enum Action {
     Tag = "tag",
     TagAndArchive = "tag_and_archive"
+}
+export enum ClassificationFaceExclusion {
+    Off = "off",
+    AnyAssignedFace = "any_assigned_face",
+    NamedPeople = "named_people",
+    NamedVisiblePeople = "named_visible_people"
 }
 export enum TranscodeHWAccel {
     Nvenc = "nvenc",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -15,6 +15,8 @@ import {
 } from 'src/enum';
 import { ConcurrentQueueName, FullsizeImageOptions, ImageOptions } from 'src/types';
 
+export type ClassificationFaceExclusion = 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
+
 export type SystemConfig = {
   backup: {
     database: {
@@ -201,6 +203,7 @@ export type SystemConfig = {
       similarity: number;
       action: 'tag' | 'tag_and_archive';
       enabled: boolean;
+      faceExclusion: ClassificationFaceExclusion;
     }>;
   };
   user: {

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -152,6 +152,12 @@ const SystemConfigMachineLearningSchema = z
   })
   .meta({ id: 'SystemConfigMachineLearningDto' });
 
+const ClassificationFaceExclusionSchema = z
+  .enum(['off', 'any_assigned_face', 'named_people', 'named_visible_people'])
+  .default('off')
+  .describe('Face exclusion rule for this classification category')
+  .meta({ id: 'ClassificationFaceExclusion' });
+
 const SystemConfigClassificationCategorySchema = z
   .object({
     name: z.string().describe('Category name'),
@@ -164,6 +170,7 @@ const SystemConfigClassificationCategorySchema = z
       .describe('Cosine similarity threshold for matching this category'),
     action: z.enum(['tag', 'tag_and_archive']).describe('Action to take when an asset matches'),
     enabled: z.boolean().describe('Whether this category is enabled'),
+    faceExclusion: ClassificationFaceExclusionSchema,
   })
   .meta({ id: 'SystemConfigClassificationCategoryDto' });
 

--- a/server/src/repositories/classification.repository.ts
+++ b/server/src/repositories/classification.repository.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { Kysely } from 'kysely';
+import { Kysely, sql } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { AssetVisibility } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
+
+export interface ClassificationFaceSummary {
+  hasAssignedFace: boolean;
+  hasNamedPerson: boolean;
+  hasNamedVisiblePerson: boolean;
+}
 
 @Injectable()
 export class ClassificationRepository {
@@ -59,6 +65,31 @@ export class ClassificationRepository {
       .set({ classifiedAt: new Date().toISOString() })
       .where('assetId', '=', assetId)
       .execute();
+  }
+
+  async getFaceSummary(assetId: string): Promise<ClassificationFaceSummary> {
+    const row = await this.db
+      .selectFrom('asset_face')
+      .innerJoin('person', 'person.id', 'asset_face.personId')
+      .select([
+        sql<boolean>`count(*) > 0`.as('hasAssignedFace'),
+        sql<boolean>`count(*) filter (where btrim("person"."name") != '') > 0`.as('hasNamedPerson'),
+        sql<boolean>`count(*) filter (where btrim("person"."name") != '' and "person"."isHidden" is false) > 0`.as(
+          'hasNamedVisiblePerson',
+        ),
+      ])
+      .where('asset_face.assetId', '=', assetId)
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', 'is', true)
+      .where('asset_face.personId', 'is not', null)
+      .where('person.type', '=', 'person')
+      .executeTakeFirst();
+
+    return {
+      hasAssignedFace: row?.hasAssignedFace ?? false,
+      hasNamedPerson: row?.hasNamedPerson ?? false,
+      hasNamedVisiblePerson: row?.hasNamedVisiblePerson ?? false,
+    };
   }
 
   streamUnclassifiedAssets() {

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -1,0 +1,104 @@
+import { ModuleRef } from '@nestjs/core';
+import { setTimeout } from 'node:timers/promises';
+import { QueueName } from 'src/enum';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { EventRepository } from 'src/repositories/event.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { JobCounts } from 'src/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:timers/promises', () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
+const setTimeoutMock = vi.mocked(setTimeout);
+
+const emptyCounts = (): JobCounts => ({
+  active: 0,
+  completed: 0,
+  failed: 0,
+  delayed: 0,
+  waiting: 0,
+  paused: 0,
+});
+
+const setup = (counts: JobCounts[]) => {
+  const queue = {
+    getJobCounts: vi.fn().mockResolvedValue(emptyCounts()),
+    isPaused: vi.fn().mockResolvedValue(false),
+  };
+
+  for (const value of counts) {
+    queue.getJobCounts.mockResolvedValueOnce(value);
+  }
+
+  const moduleRef = { get: vi.fn().mockReturnValue(queue) } as unknown as ModuleRef;
+  const logger = {
+    setContext: vi.fn(),
+    verbose: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggingRepository;
+
+  const sut = new JobRepository(
+    moduleRef,
+    {} as ConfigRepository,
+    {} as EventRepository,
+    logger,
+  );
+
+  return { sut, queue, logger };
+};
+
+describe(JobRepository.name, () => {
+  beforeEach(() => {
+    setTimeoutMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return immediately when queues have no active waiting delayed or paused jobs', async () => {
+    const { sut, queue } = setup([emptyCounts()]);
+
+    await sut.waitForQueueCompletion(QueueName.FaceDetection);
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(1);
+    expect(setTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it('should wait while a queue has waiting jobs', async () => {
+    const { sut, queue } = setup([{ ...emptyCounts(), waiting: 1 }, emptyCounts()]);
+
+    await sut.waitForQueueCompletion(QueueName.FaceDetection);
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(2);
+    expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(setTimeoutMock).toHaveBeenCalledWith(1000);
+  });
+
+  it('should wait while a queue has delayed jobs', async () => {
+    const { sut, queue } = setup([{ ...emptyCounts(), delayed: 1 }, emptyCounts()]);
+
+    await sut.waitForQueueCompletion(QueueName.FacialRecognition);
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(2);
+    expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(setTimeoutMock).toHaveBeenCalledWith(1000);
+  });
+
+  it('should wait and warn while a paused queue has paused jobs', async () => {
+    const { sut, queue, logger } = setup([{ ...emptyCounts(), paused: 1 }, emptyCounts()]);
+    queue.isPaused.mockResolvedValueOnce(true);
+
+    await sut.waitForQueueCompletion(QueueName.FaceDetection);
+
+    expect(queue.getJobCounts).toHaveBeenCalledTimes(2);
+    expect(setTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(setTimeoutMock).toHaveBeenCalledWith(1000);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `Waiting for ${QueueName.FaceDetection} queue to finish (0 active, 0 waiting, 0 delayed, 1 paused); queue is paused`,
+    );
+  });
+});

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -9,7 +9,7 @@ import { JobCounts } from 'src/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('node:timers/promises', () => ({
-  setTimeout: vi.fn().mockResolvedValue(undefined),
+  setTimeout: vi.fn().mockResolvedValue(void 0),
 }));
 
 const setTimeoutMock = vi.mocked(setTimeout);
@@ -40,12 +40,7 @@ const setup = (counts: JobCounts[]) => {
     warn: vi.fn(),
   } as unknown as LoggingRepository;
 
-  const sut = new JobRepository(
-    moduleRef,
-    {} as ConfigRepository,
-    {} as EventRepository,
-    logger,
-  );
+  const sut = new JobRepository(moduleRef, {} as ConfigRepository, {} as EventRepository, logger);
 
   return { sut, queue, logger };
 };

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -194,14 +194,32 @@ export class JobRepository {
 
   async waitForQueueCompletion(...queues: QueueName[]): Promise<void> {
     const getPending = async () => {
-      const results = await Promise.all(queues.map(async (name) => ({ pending: await this.isActive(name), name })));
-      return results.filter(({ pending }) => pending).map(({ name }) => name);
+      const results = await Promise.all(
+        queues.map(async (name) => {
+          const [counts, paused] = await Promise.all([this.getJobCounts(name), this.isPaused(name)]);
+          const pending = counts.active + counts.waiting + counts.delayed + counts.paused;
+          return { counts, name, paused, pending };
+        }),
+      );
+
+      return results.filter(({ pending }) => pending > 0);
     };
 
     let pending = await getPending();
 
     while (pending.length > 0) {
-      this.logger.verbose(`Waiting for ${pending[0]} queue to stop...`);
+      const blocked = pending[0];
+      const message =
+        `Waiting for ${blocked.name} queue to finish ` +
+        `(${blocked.counts.active} active, ${blocked.counts.waiting} waiting, ` +
+        `${blocked.counts.delayed} delayed, ${blocked.counts.paused} paused)`;
+
+      if (blocked.paused) {
+        this.logger.warn(`${message}; queue is paused`);
+      } else {
+        this.logger.verbose(`${message}...`);
+      }
+
       await setTimeout(1000);
       pending = await getPending();
     }

--- a/server/src/services/classification.service.spec.ts
+++ b/server/src/services/classification.service.spec.ts
@@ -1,4 +1,4 @@
-import { AssetVisibility, JobName, JobStatus, SystemMetadataKey } from 'src/enum';
+import { AssetVisibility, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
 import { ClassificationService } from 'src/services/classification.service';
 import { authStub } from 'test/fixtures/auth.stub';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
@@ -89,6 +89,272 @@ describe(ClassificationService.name, () => {
 
       expect(result).toBe(JobStatus.Skipped);
       expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+    });
+
+    it('should not wait for face queues or load face summary when all enabled categories are face exclusion off', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Sunsets' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'Sunsets',
+            prompts: ['sunset sky'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'off',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
+    });
+
+    it('should skip any_assigned_face category when the asset has an assigned face', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Screenshots' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'any_assigned_face',
+          },
+          {
+            name: 'Screenshots',
+            prompts: ['a screenshot'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'off',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(
+        QueueName.FaceDetection,
+        QueueName.FacialRecognition,
+      );
+      expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.classification.getFaceSummary.mock.invocationCallOrder[0],
+      );
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
+    });
+
+    it('should skip named_people category only when a named person exists', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_people',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a portrait', { modelName: 'test-model' });
+      expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+    });
+
+    it('should skip named_people category when a named person exists', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: true,
+      });
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_people',
+          },
+        ]),
+      );
+
+      const result = await sut.handleClassify({ id: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+      expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
+      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+    });
+
+    it('should ignore hidden named people for named_visible_people', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: false,
+      });
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/People' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_visible_people',
+          },
+        ]),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.tag.upsertAssetIds).toHaveBeenCalledWith([{ tagId: 'tag-id', assetId: 'asset-1' }]);
+    });
+
+    it('should skip named_visible_people category when a visible named person exists', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.classification.getFaceSummary.mockResolvedValue({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: true,
+      });
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_visible_people',
+          },
+        ]),
+      );
+
+      const result = await sut.handleClassify({ id: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
+      expect(mocks.tag.upsertAssetIds).not.toHaveBeenCalled();
+      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+    });
+
+    it('should skip face-aware categories when facial recognition is disabled and still classify off categories', async () => {
+      mocks.asset.getById.mockResolvedValue({
+        id: 'asset-1',
+        ownerId: 'user-1',
+        visibility: AssetVisibility.Timeline,
+      } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      mocks.machineLearning.encodeText.mockResolvedValue('[1,0,0]');
+      mocks.tag.upsertValue.mockResolvedValue({ id: 'tag-id', value: 'Auto/Screenshots' } as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig(
+          [
+            {
+              name: 'People',
+              prompts: ['a portrait'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'named_people',
+            },
+            {
+              name: 'Screenshots',
+              prompts: ['a screenshot'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'off',
+            },
+          ],
+          true,
+          false,
+        ),
+      );
+
+      await sut.handleClassify({ id: 'asset-1' });
+
+      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(mocks.classification.getFaceSummary).not.toHaveBeenCalled();
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledTimes(1);
+      expect(mocks.machineLearning.encodeText).toHaveBeenCalledWith('a screenshot', { modelName: 'test-model' });
+    });
+
+    it('should mark classified when all enabled categories require disabled facial recognition', async () => {
+      mocks.asset.getById.mockResolvedValue({ id: 'asset-1', ownerId: 'user-1' } as any);
+      mocks.search.getEmbedding.mockResolvedValue('[1,0,0]' as any);
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig(
+          [
+            {
+              name: 'People',
+              prompts: ['a portrait'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'named_people',
+            },
+          ],
+          true,
+          false,
+        ),
+      );
+
+      const result = await sut.handleClassify({ id: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.classification.setClassifiedAt).toHaveBeenCalledWith('asset-1');
+      expect(mocks.machineLearning.encodeText).not.toHaveBeenCalled();
     });
 
     it('should tag asset when similarity exceeds threshold', async () => {
@@ -538,6 +804,64 @@ describe(ClassificationService.name, () => {
       expect(mocks.classification.resetClassifiedAt).not.toHaveBeenCalled();
       expect(mocks.classification.streamUnclassifiedAssets).not.toHaveBeenCalled();
     });
+
+    it('should queue face work before forced classification when enabled categories are face-aware', async () => {
+      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig([
+          {
+            name: 'People',
+            prompts: ['a portrait'],
+            similarity: 0.8,
+            action: 'tag',
+            faceExclusion: 'named_people',
+          },
+        ]),
+      );
+
+      await sut.handleClassifyQueueAll({ force: true });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetDetectFacesQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: 'asset-1' } }]);
+    });
+
+    it('should not queue face work before forced classification when facial recognition is disabled', async () => {
+      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
+      sut['getConfig'] = vi.fn().mockResolvedValue(
+        makeClassificationConfig(
+          [
+            {
+              name: 'People',
+              prompts: ['a portrait'],
+              similarity: 0.8,
+              action: 'tag',
+              faceExclusion: 'named_people',
+            },
+          ],
+          true,
+          false,
+        ),
+      );
+
+      await sut.handleClassifyQueueAll({ force: true });
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.AssetDetectFacesQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: 'asset-1' } }]);
+    });
   });
 
   describe('scanLibrary', () => {
@@ -724,6 +1048,29 @@ describe(ClassificationService.name, () => {
       await sut.onConfigUpdate({ oldConfig, newConfig } as any);
 
       expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+    });
+
+    it('should not clean up tags when only face exclusion changes', async () => {
+      const oldConfig = makeClassificationConfig([
+        { name: 'Screenshots', prompts: ['screenshot'], similarity: 0.28, action: 'tag', faceExclusion: 'off' },
+      ]);
+      const newConfig = makeClassificationConfig([
+        {
+          name: 'Screenshots',
+          prompts: ['screenshot'],
+          similarity: 0.28,
+          action: 'tag',
+          faceExclusion: 'named_people',
+        },
+      ]);
+
+      await sut.onConfigUpdate({ oldConfig, newConfig } as any);
+
+      expect(mocks.classification.removeAutoTagAssignments).not.toHaveBeenCalled();
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(
+        SystemMetadataKey.ClassificationConfigState,
+        newConfig.classification,
+      );
     });
 
     it('should write classification snapshot to system metadata after diff', async () => {

--- a/server/src/services/classification.service.spec.ts
+++ b/server/src/services/classification.service.spec.ts
@@ -5,11 +5,26 @@ import { makeStream, newTestService, ServiceMocks } from 'test/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const makeClassificationConfig = (
-  categories: Array<{ name: string; prompts: string[]; similarity: number; action: string; enabled?: boolean }> = [],
+  categories: Array<{
+    name: string;
+    prompts: string[];
+    similarity: number;
+    action: string;
+    enabled?: boolean;
+    faceExclusion?: 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
+  }> = [],
   enabled = true,
+  facialRecognitionEnabled = true,
 ) => ({
-  classification: { enabled, categories: categories.map((c) => ({ ...c, enabled: c.enabled ?? true })) },
-  machineLearning: { clip: { modelName: 'test-model' } },
+  classification: {
+    enabled,
+    categories: categories.map((c) => ({ ...c, enabled: c.enabled ?? true, faceExclusion: c.faceExclusion ?? 'off' })),
+  },
+  machineLearning: {
+    enabled: true,
+    clip: { modelName: 'test-model' },
+    facialRecognition: { enabled: facialRecognitionEnabled },
+  },
 });
 
 describe(ClassificationService.name, () => {

--- a/server/src/services/classification.service.ts
+++ b/server/src/services/classification.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@nestjs/common';
-import { SystemConfig } from 'src/config';
+import { type ClassificationFaceExclusion, type SystemConfig } from 'src/config';
 import { OnEvent, OnJob } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetVisibility, ImmichWorker, JobName, JobStatus, QueueName, SystemMetadataKey } from 'src/enum';
+import { type ClassificationFaceSummary } from 'src/repositories/classification.repository';
 import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { JobOf } from 'src/types';
+import { isFacialRecognitionEnabled } from 'src/utils/misc';
 import { upsertTags } from 'src/utils/tag';
 
 type ClassificationConfig = SystemConfig['classification'];
@@ -105,7 +107,7 @@ export class ClassificationService extends BaseService {
 
   @OnJob({ name: JobName.AssetClassifyQueueAll, queue: QueueName.Classification })
   async handleClassifyQueueAll({ force }: JobOf<JobName.AssetClassifyQueueAll>): Promise<JobStatus> {
-    const { classification } = await this.getConfig({ withCache: true });
+    const { classification, machineLearning } = await this.getConfig({ withCache: true });
 
     if (!classification.enabled) {
       return JobStatus.Skipped;
@@ -113,6 +115,15 @@ export class ClassificationService extends BaseService {
 
     if (force) {
       await this.classificationRepository.resetClassifiedAt();
+    }
+
+    const faceAwareCategories = classification.categories.filter(
+      (category) => category.enabled && this.isFaceAwareCategory(category),
+    );
+
+    if (force && faceAwareCategories.length > 0 && isFacialRecognitionEnabled(machineLearning)) {
+      await this.jobRepository.queue({ name: JobName.AssetDetectFacesQueueAll, data: { force: true } });
+      await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
     }
 
     const stream = this.classificationRepository.streamUnclassifiedAssets();
@@ -154,10 +165,16 @@ export class ClassificationService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    const eligibleCategories = await this.getEligibleCategories(enabledCategories, machineLearning, id);
+    if (eligibleCategories.length === 0) {
+      await this.classificationRepository.setClassifiedAt(id);
+      return JobStatus.Skipped;
+    }
+
     const assetEmbedding = this.parseEmbedding(embedding);
     let shouldArchive = false;
 
-    for (const category of enabledCategories) {
+    for (const category of eligibleCategories) {
       let bestSimilarity = -1;
       for (const prompt of category.prompts) {
         const promptEmbedding = await this.getOrEncodePrompt(prompt, machineLearning.clip.modelName);
@@ -187,6 +204,51 @@ export class ClassificationService extends BaseService {
 
     await this.classificationRepository.setClassifiedAt(id);
     return JobStatus.Success;
+  }
+
+  private getFaceExclusion(category: ClassificationConfig['categories'][number]): ClassificationFaceExclusion {
+    return category.faceExclusion ?? 'off';
+  }
+
+  private isFaceAwareCategory(category: ClassificationConfig['categories'][number]) {
+    return this.getFaceExclusion(category) !== 'off';
+  }
+
+  private matchesFaceExclusion(rule: ClassificationFaceExclusion, summary: ClassificationFaceSummary) {
+    switch (rule) {
+      case 'any_assigned_face': {
+        return summary.hasAssignedFace;
+      }
+      case 'named_people': {
+        return summary.hasNamedPerson;
+      }
+      case 'named_visible_people': {
+        return summary.hasNamedVisiblePerson;
+      }
+      case 'off': {
+        return false;
+      }
+    }
+  }
+
+  private async getEligibleCategories(
+    categories: ClassificationConfig['categories'],
+    machineLearning: SystemConfig['machineLearning'],
+    assetId: string,
+  ) {
+    const faceAwareCategories = categories.filter((category) => this.isFaceAwareCategory(category));
+    if (faceAwareCategories.length === 0) {
+      return categories;
+    }
+
+    if (!isFacialRecognitionEnabled(machineLearning)) {
+      return categories.filter((category) => !this.isFaceAwareCategory(category));
+    }
+
+    await this.jobRepository.waitForQueueCompletion(QueueName.FaceDetection, QueueName.FacialRecognition);
+    const faceSummary = await this.classificationRepository.getFaceSummary(assetId);
+
+    return categories.filter((category) => !this.matchesFaceExclusion(this.getFaceExclusion(category), faceSummary));
   }
 
   private parseEmbedding(raw: string): number[] {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { defaults, SystemConfig } from 'src/config';
+import { SystemConfigSchema } from 'src/dtos/system-config.dto';
 import {
   AudioCodec,
   Colorspace,
@@ -277,6 +278,67 @@ describe(SystemConfigService.name, () => {
       });
 
       await expect(sut.getSystemConfig()).resolves.toEqual(updatedConfig);
+    });
+
+    it('should default missing classification faceExclusion to off', () => {
+      const result = SystemConfigSchema.parse({
+        ...defaults,
+        classification: {
+          enabled: true,
+          categories: [
+            {
+              name: 'Nature',
+              prompts: ['a landscape photo'],
+              similarity: 0.28,
+              action: 'tag',
+              enabled: true,
+            },
+          ],
+        },
+      });
+
+      expect(result.classification.categories[0].faceExclusion).toBe('off');
+    });
+
+    it('should accept all classification faceExclusion modes', () => {
+      const result = SystemConfigSchema.parse({
+        ...defaults,
+        classification: {
+          enabled: true,
+          categories: [
+            {
+              name: 'Any Assigned Face',
+              prompts: ['a test prompt'],
+              similarity: 0.28,
+              action: 'tag',
+              enabled: true,
+              faceExclusion: 'any_assigned_face',
+            },
+            {
+              name: 'Named People',
+              prompts: ['a test prompt'],
+              similarity: 0.28,
+              action: 'tag',
+              enabled: true,
+              faceExclusion: 'named_people',
+            },
+            {
+              name: 'Named Visible People',
+              prompts: ['a test prompt'],
+              similarity: 0.28,
+              action: 'tag',
+              enabled: true,
+              faceExclusion: 'named_visible_people',
+            },
+          ],
+        },
+      });
+
+      expect(result.classification.categories.map((category) => category.faceExclusion)).toEqual([
+        'any_assigned_face',
+        'named_people',
+        'named_visible_people',
+      ]);
     });
 
     it('should load the config from a json file', async () => {

--- a/server/test/medium/specs/repositories/classification.repository.spec.ts
+++ b/server/test/medium/specs/repositories/classification.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { AssetVisibility } from 'src/enum';
+import { AssetVisibility, SourceType } from 'src/enum';
 import { ClassificationRepository } from 'src/repositories/classification.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { TagRepository } from 'src/repositories/tag.repository';
@@ -114,6 +114,85 @@ describe(ClassificationRepository.name, () => {
         .executeTakeFirstOrThrow();
 
       expect(status.classifiedAt).not.toBeNull();
+    });
+  });
+
+  describe('getFaceSummary', () => {
+    it('should return false booleans for an asset without assigned faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: null });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: false,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+    });
+
+    it('should detect assigned, named, and visible named human faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: false, type: 'person' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: true,
+      });
+    });
+
+    it('should detect hidden named people but exclude them from visible named people', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', isHidden: true, type: 'person' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: true,
+        hasNamedPerson: true,
+        hasNamedVisiblePerson: false,
+      });
+    });
+
+    it('should treat assigned unnamed people as assigned but not named', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: '   ', isHidden: false, type: 'person' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: true,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
+    });
+
+    it('should ignore invisible deleted and pet rows', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice', type: 'person' });
+      const { person: pet } = await ctx.newPerson({ ownerId: user.id, name: 'Spot', type: 'pet', species: 'dog' });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id, isVisible: false });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id, deletedAt: new Date() });
+      await ctx.newAssetFace({ assetId: asset.id, personId: pet.id, sourceType: SourceType.MachineLearning });
+
+      await expect(sut.getFaceSummary(asset.id)).resolves.toEqual({
+        hasAssignedFace: false,
+        hasNamedPerson: false,
+        hasNamedVisiblePerson: false,
+      });
     });
   });
 

--- a/web/src/routes/admin/system-settings/ClassificationSettings.spec.ts
+++ b/web/src/routes/admin/system-settings/ClassificationSettings.spec.ts
@@ -1,7 +1,15 @@
-import { Action, getConfig, scanClassification, updateConfig, type SystemConfigDto } from '@immich/sdk';
+import {
+  Action,
+  ClassificationFaceExclusion,
+  getConfig,
+  scanClassification,
+  updateConfig,
+  type SystemConfigDto,
+} from '@immich/sdk';
 import { modalManager, toastManager } from '@immich/ui';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ClassificationSettings from './ClassificationSettings.svelte';
 
@@ -10,6 +18,12 @@ vi.mock('@immich/sdk', () => ({
   updateConfig: vi.fn(),
   scanClassification: vi.fn(),
   Action: { Tag: 'tag', TagAndArchive: 'tag_and_archive' },
+  ClassificationFaceExclusion: {
+    Off: 'off',
+    AnyAssignedFace: 'any_assigned_face',
+    NamedPeople: 'named_people',
+    NamedVisiblePeople: 'named_visible_people',
+  },
 }));
 
 const mockFeatureFlags = { configFile: false, smartSearch: true, trash: true };
@@ -46,6 +60,7 @@ const makeCategory = (
   prompts: ['a screenshot'],
   similarity: 0.28,
   action: Action.Tag,
+  faceExclusion: ClassificationFaceExclusion.Off,
   enabled: true,
   ...overrides,
 });
@@ -227,6 +242,122 @@ describe('ClassificationSettings', () => {
     });
 
     expect(scanClassification).not.toHaveBeenCalled();
+  });
+
+  it('should show face exclusion dropdown when creating a category', async () => {
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Add Category')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByText('Add Category'));
+
+    expect(screen.getByLabelText('Face exclusion')).toBeInTheDocument();
+    expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+  });
+
+  it('should save selected face exclusion for a new category', async () => {
+    const user = userEvent.setup();
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Add Category')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByText('Add Category'));
+    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Nature' } });
+    await fireEvent.input(screen.getByLabelText('Prompts (one per line)'), { target: { value: 'a landscape photo' } });
+    const faceExclusionSelect = screen.getByLabelText('Face exclusion') as HTMLSelectElement;
+    // Svelte's select binding reads `:checked`; mirror browser behavior because happy-dom does not match it.
+    const querySelectedOption = vi.spyOn(faceExclusionSelect, 'querySelector');
+    querySelectedOption.mockImplementation((selector: string) => {
+      if (selector === ':checked') {
+        return faceExclusionSelect.selectedOptions.item(0);
+      }
+      return Element.prototype.querySelector.call(faceExclusionSelect, selector);
+    });
+
+    try {
+      await user.selectOptions(faceExclusionSelect, ClassificationFaceExclusion.NamedVisiblePeople);
+      await fireEvent.click(screen.getByText('Save'));
+    } finally {
+      querySelectedOption.mockRestore();
+    }
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith({
+        systemConfigDto: expect.objectContaining({
+          classification: expect.objectContaining({
+            categories: [
+              expect.objectContaining({
+                name: 'Nature',
+                faceExclusion: ClassificationFaceExclusion.NamedVisiblePeople,
+              }),
+            ],
+          }),
+        }),
+      });
+    });
+  });
+
+  it('should default old categories without faceExclusion to Off in the editor', async () => {
+    vi.mocked(getConfig).mockResolvedValue(
+      makeConfig([
+        {
+          name: 'Legacy',
+          prompts: ['legacy prompt'],
+          similarity: 0.28,
+          action: Action.Tag,
+          enabled: true,
+        } as SystemConfigDto['classification']['categories'][number],
+      ]),
+    );
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Legacy')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByLabelText('Edit'));
+
+    expect(screen.getByLabelText('Face exclusion')).toHaveValue('off');
+  });
+
+  it('should show non-Off face exclusion in the category summary', async () => {
+    vi.mocked(getConfig).mockResolvedValue(
+      makeConfig([makeCategory({ faceExclusion: ClassificationFaceExclusion.NamedPeople })]),
+    );
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Named people')).toBeInTheDocument();
+    });
+  });
+
+  it('should render summary badges in a separate wrapping row under the category name', async () => {
+    const categoryName = 'Very long category name that should not collide with controls';
+    vi.mocked(getConfig).mockResolvedValue(
+      makeConfig([
+        makeCategory({
+          name: categoryName,
+          action: Action.TagAndArchive,
+          faceExclusion: ClassificationFaceExclusion.NamedVisiblePeople,
+        }),
+      ]),
+    );
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText(categoryName)).toBeInTheDocument();
+    });
+
+    const nameRow = screen.getByText(categoryName).closest('.min-w-0');
+    expect(nameRow).toBeInTheDocument();
+    expect(nameRow).not.toHaveTextContent('Tag and archive');
+    expect(nameRow).not.toHaveTextContent('Named, visible people');
+
+    const metadataRow = screen.getByText('Tag and archive').parentElement;
+    expect(metadataRow).toContainElement(screen.getByText('Named, visible people'));
+    expect(metadataRow).toHaveClass('flex', 'flex-wrap', 'gap-2');
   });
 
   it('should disable controls when config file is active', async () => {

--- a/web/src/routes/admin/system-settings/ClassificationSettings.svelte
+++ b/web/src/routes/admin/system-settings/ClassificationSettings.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { handleError } from '$lib/utils/handle-error';
-  import { Action, getConfig, scanClassification, updateConfig, type SystemConfigDto } from '@immich/sdk';
+  import {
+    Action,
+    ClassificationFaceExclusion,
+    getConfig,
+    scanClassification,
+    updateConfig,
+    type SystemConfigDto,
+  } from '@immich/sdk';
   import { Button, IconButton, modalManager, Switch, Text, toastManager } from '@immich/ui';
   import { mdiContentSave, mdiDelete, mdiPencil, mdiPlus, mdiUndoVariant } from '@mdi/js';
   import { onMount } from 'svelte';
 
   type Category = SystemConfigDto['classification']['categories'][number];
+  type FaceExclusion = NonNullable<Category['faceExclusion']>;
 
   const disabled = $derived(featureFlagsManager.value.configFile);
 
@@ -21,12 +29,23 @@
   let formPrompts = $state('');
   let formSimilarity = $state(0.28);
   let formAction: Action = $state(Action.Tag);
+  let formFaceExclusion: FaceExclusion = $state(ClassificationFaceExclusion.Off);
   let formEnabled = $state(true);
 
   const actionLabels: Record<string, string> = {
     tag: 'Tag only',
     tag_and_archive: 'Tag and archive',
   };
+
+  const faceExclusionLabels: Record<FaceExclusion, string> = {
+    [ClassificationFaceExclusion.Off]: 'Off',
+    [ClassificationFaceExclusion.AnyAssignedFace]: 'Any assigned face',
+    [ClassificationFaceExclusion.NamedPeople]: 'Named people',
+    [ClassificationFaceExclusion.NamedVisiblePeople]: 'Named, visible people',
+  };
+
+  const getFaceExclusion = (category: Partial<Category>): FaceExclusion =>
+    category.faceExclusion ?? ClassificationFaceExclusion.Off;
 
   const getSimilarityLabel = (value: number): string => {
     if (value < 0.22) {
@@ -58,6 +77,7 @@
     formPrompts = '';
     formSimilarity = 0.28;
     formAction = Action.Tag;
+    formFaceExclusion = ClassificationFaceExclusion.Off;
     formEnabled = true;
   };
 
@@ -69,6 +89,7 @@
     formPrompts = category.prompts.join('\n');
     formSimilarity = category.similarity;
     formAction = category.action;
+    formFaceExclusion = getFaceExclusion(category);
     formEnabled = category.enabled;
   };
 
@@ -100,6 +121,7 @@
         prompts,
         similarity: formSimilarity,
         action: formAction,
+        faceExclusion: formFaceExclusion,
         enabled: formEnabled,
       };
 
@@ -245,6 +267,31 @@
           </select>
         </div>
 
+        <div>
+          <label for="category-face-exclusion" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Face exclusion
+          </label>
+          <select
+            id="category-face-exclusion"
+            bind:value={formFaceExclusion}
+            {disabled}
+            class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-immich-primary focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <option value={ClassificationFaceExclusion.Off}>
+              {faceExclusionLabels[ClassificationFaceExclusion.Off]}
+            </option>
+            <option value={ClassificationFaceExclusion.AnyAssignedFace}>
+              {faceExclusionLabels[ClassificationFaceExclusion.AnyAssignedFace]}
+            </option>
+            <option value={ClassificationFaceExclusion.NamedPeople}>
+              {faceExclusionLabels[ClassificationFaceExclusion.NamedPeople]}
+            </option>
+            <option value={ClassificationFaceExclusion.NamedVisiblePeople}>
+              {faceExclusionLabels[ClassificationFaceExclusion.NamedVisiblePeople]}
+            </option>
+          </select>
+        </div>
+
         {#if editingIndex !== null}
           <div class="flex items-center gap-2">
             <Switch bind:checked={formEnabled} {disabled} />
@@ -276,19 +323,28 @@
         class="rounded-2xl border border-gray-200 dark:border-gray-800 mt-4 bg-slate-50 dark:bg-gray-900 p-4"
         class:opacity-50={!category.enabled}
       >
-        <div class="flex items-center justify-between">
+        <div class="flex items-center justify-between gap-3">
           <div class="flex items-center gap-3 flex-1 min-w-0">
             <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <Text fontWeight="medium">{category.name}</Text>
+              <div class="min-w-0">
+                <Text fontWeight="medium" class="block truncate break-words">{category.name}</Text>
+              </div>
+              <div class="mt-1 flex flex-wrap gap-2">
                 <span
-                  class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                  class="inline-flex max-w-full items-center rounded-full px-2 py-0.5 text-xs font-medium break-words whitespace-normal
                     {category.action === 'tag_and_archive'
                     ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
                     : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'}"
                 >
                   {actionLabels[category.action] ?? category.action}
                 </span>
+                {#if getFaceExclusion(category) !== ClassificationFaceExclusion.Off}
+                  <span
+                    class="inline-flex max-w-full items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800 break-words whitespace-normal dark:bg-emerald-900 dark:text-emerald-200"
+                  >
+                    {faceExclusionLabels[getFaceExclusion(category)]}
+                  </span>
+                {/if}
               </div>
               <Text size="tiny" color="muted">
                 {category.prompts.length} prompt{category.prompts.length === 1 ? '' : 's'} &middot; {getSimilarityLabel(
@@ -299,7 +355,7 @@
             </div>
           </div>
 
-          <div class="flex items-center gap-2">
+          <div class="flex shrink-0 items-center gap-2">
             <Switch checked={category.enabled} onCheckedChange={() => handleToggleEnabled(index)} {disabled} />
             <IconButton
               shape="round"


### PR DESCRIPTION
## Summary
- add per-category `faceExclusion` config/DTO support and generated clients
- skip configured classification categories when assets contain assigned/named/visible named human faces
- wait for face detection and facial recognition queues before face-aware classification
- add web settings control plus feature/config-file docs

Closes discussion #321.

## Manual Testing
1. In Admin settings, enable smart search/CLIP, facial recognition, and auto-classification.
2. Open the Classification settings page and create two enabled categories:
   - `Screenshots`: prompt `a screenshot`, action `Tag only`, Face exclusion `Off`.
   - `People guarded`: prompt that should match a known face test photo, action `Tag only`, Face exclusion `Named people`.
3. Confirm the category list shows the `Named people` badge only for the guarded category, then edit the category and confirm the dropdown value persists.
4. Use a test asset with a visible face assigned to a named person. Run face detection/facial recognition if needed, then run a classification scan.
5. Verify the named-person asset is skipped for `Auto/People guarded`, while categories with Face exclusion `Off` can still tag matching assets.
6. Use a similar asset with no assigned/named person and rerun classification. Verify the guarded category can tag it when the prompt threshold matches.
7. Future-only check: tag a named-person asset with a category while Face exclusion is `Off`, then change that category to `Named people`. Verify the existing `Auto/...` tag remains until manually changed or a separate cleanup-worthy config change is made.
8. Optional disabled-FR check: disable facial recognition, keep one face-aware category and one `Off` category, then run classification. Verify the face-aware category is skipped and the `Off` category still runs.

## Verification
- server unit suite: 121 passed | 1 skipped, 3975 passed | 9 skipped
- `pnpm test:medium --run test/medium/specs/repositories/classification.repository.spec.ts`: 11 passed
- `pnpm exec vitest run src/routes/admin/system-settings/ClassificationSettings.spec.ts`: 17 passed
- `make check-server`
- `make check-web`
- `git diff --check`
