### PR TITLE
fix(ml): pass OCR model root to RapidOCR

### DIFF
--- a/machine-learning/immich_ml/models/ocr/recognition.py
+++ b/machine-learning/immich_ml/models/ocr/recognition.py
@@ -61,6 +61,7 @@ class TextRecognizer(InferenceModel):
         self.model = RapidTextRecognizer(
             OcrOptions(
                 session=session.session,
+                model_root_dir=self.model_path.parent,
                 rec_batch_num=max_batch_size if max_batch_size else 6,
                 rec_img_shape=(3, 48, 320),
                 lang_type=self.language,

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -926,8 +926,26 @@ class TestOcr:
         text_recognizer.load()
 
         rapid_recognizer.assert_called_once_with(
-            OcrOptions(session=ort_session.return_value, rec_batch_num=6, rec_img_shape=(3, 48, 320))
+            OcrOptions(
+                session=ort_session.return_value,
+                model_root_dir=text_recognizer.model_path.parent,
+                rec_batch_num=6,
+                rec_img_shape=(3, 48, 320),
+            )
         )
+
+    def test_passes_model_root_dir_to_rapidocr(
+        self, ort_session: mock.Mock, path: mock.Mock, mocker: MockerFixture
+    ) -> None:
+        path.return_value.__truediv__.return_value.__truediv__.return_value.suffix = ".onnx"
+        mocker.patch("immich_ml.models.base.InferenceModel.download")
+        rapid_recognizer = mocker.patch("immich_ml.models.ocr.recognition.RapidTextRecognizer")
+
+        text_recognizer = TextRecognizer("PP-OCRv5_mobile", cache_dir="test_cache")
+        text_recognizer.load()
+
+        options = rapid_recognizer.call_args.args[0]
+        assert options["model_root_dir"] == text_recognizer.model_path.parent
 
     def test_set_custom_max_batch_size(self, ort_session: mock.Mock, path: mock.Mock, mocker: MockerFixture) -> None:
         path.return_value.__truediv__.return_value.__truediv__.return_value.suffix = ".onnx"
@@ -939,7 +957,12 @@ class TestOcr:
         text_recognizer.load()
 
         rapid_recognizer.assert_called_once_with(
-            OcrOptions(session=ort_session.return_value, rec_batch_num=4, rec_img_shape=(3, 48, 320))
+            OcrOptions(
+                session=ort_session.return_value,
+                model_root_dir=text_recognizer.model_path.parent,
+                rec_batch_num=4,
+                rec_img_shape=(3, 48, 320),
+            )
         )
 
     def test_ignore_other_custom_max_batch_size(
@@ -954,7 +977,12 @@ class TestOcr:
         text_recognizer.load()
 
         rapid_recognizer.assert_called_once_with(
-            OcrOptions(session=ort_session.return_value, rec_batch_num=6, rec_img_shape=(3, 48, 320))
+            OcrOptions(
+                session=ort_session.return_value,
+                model_root_dir=text_recognizer.model_path.parent,
+                rec_batch_num=6,
+                rec_img_shape=(3, 48, 320),
+            )
         )
 
 


### PR DESCRIPTION
## Summary
- pass `model_root_dir` to RapidOCR when constructing the OCR recognizer
- add a regression test for the RapidOCR 3.8.1 config requirement

## Verification
- `uv run --extra cpu pytest test_main.py::TestOcr::test_passes_model_root_dir_to_rapidocr -q`
- `uv run --extra cpu pytest test_main.py::TestOcr -q`
- `uv run --extra cpu pytest test_main.py -q`
- built and pushed `ghcr.io/open-noodle/gallery-ml:fix-ml-ocr-model-root-rc1`
- pinned personal `gallery-ml` to the RC image and verified `/predict` OCR returns text without the previous RapidOCR `TypeError`