### PR TITLE
refactor(takeout): load zip media on demand

### DIFF
--- a/docs/superpowers/plans/2026-04-29-google-takeout-zip-on-demand-files.md
+++ b/docs/superpowers/plans/2026-04-29-google-takeout-zip-on-demand-files.md
@@ -71,6 +71,7 @@ Tests       37 passed (37)
 ### Task 1: Zip Items Expose Lazy Files
 
 **Files:**
+
 - Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts`
 - Modify: `web/src/lib/utils/google-takeout-parser.ts`
 - Modify: `web/src/lib/utils/google-takeout-scanner.ts`
@@ -80,98 +81,98 @@ Tests       37 passed (37)
 In `web/src/lib/utils/google-takeout-scanner.spec.ts`, update the first zip scan test body to assert the new metadata fields and `getFile()` result:
 
 ```ts
-  it('should scan a zip and expose media bytes lazily with metadata', async () => {
-    const zipBlob = await createZipBlob([
-      { path: 'Takeout/Google Photos/Trip/IMG_001.jpg', content: 'fake-image-data' },
-      { path: 'Takeout/Google Photos/Trip/IMG_001.jpg.json', content: makeSidecar() },
-    ]);
+it('should scan a zip and expose media bytes lazily with metadata', async () => {
+  const zipBlob = await createZipBlob([
+    { path: 'Takeout/Google Photos/Trip/IMG_001.jpg', content: 'fake-image-data' },
+    { path: 'Takeout/Google Photos/Trip/IMG_001.jpg.json', content: makeSidecar() },
+  ]);
 
-    const result: ScanResult = await scanTakeoutFiles({
-      files: [blobToFile(zipBlob, 'takeout-001.zip')],
-    });
-
-    expect(result.items).toHaveLength(1);
-    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
-    expect(result.items[0].name).toBe('IMG_001.jpg');
-    expect(result.items[0].size).toBe('fake-image-data'.length);
-    expect(result.items[0].lastModified).toBeGreaterThan(0);
-
-    const file = await result.items[0].getFile();
-    expect(file.name).toBe('IMG_001.jpg');
-    expect(file.size).toBe('fake-image-data'.length);
-    expect(await file.text()).toBe('fake-image-data');
-
-    const secondFile = await result.items[0].getFile();
-    expect(secondFile).not.toBe(file);
-    expect(secondFile.name).toBe('IMG_001.jpg');
-    expect(await secondFile.text()).toBe('fake-image-data');
-
-    expect(result.items[0].metadata).toBeDefined();
-    expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
-    expect(result.items[0].metadata!.latitude).toBe(48.8566);
-    expect(result.items[0].metadata!.isFavorite).toBe(true);
-    expect(result.stats.totalMedia).toBe(1);
-    expect(result.stats.withLocation).toBe(1);
-    expect(result.stats.withDate).toBe(1);
-    expect(result.stats.favorites).toBe(1);
-    expect(result.stats.archived).toBe(0);
+  const result: ScanResult = await scanTakeoutFiles({
+    files: [blobToFile(zipBlob, 'takeout-001.zip')],
   });
+
+  expect(result.items).toHaveLength(1);
+  expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
+  expect(result.items[0].name).toBe('IMG_001.jpg');
+  expect(result.items[0].size).toBe('fake-image-data'.length);
+  expect(result.items[0].lastModified).toBeGreaterThan(0);
+
+  const file = await result.items[0].getFile();
+  expect(file.name).toBe('IMG_001.jpg');
+  expect(file.size).toBe('fake-image-data'.length);
+  expect(await file.text()).toBe('fake-image-data');
+
+  const secondFile = await result.items[0].getFile();
+  expect(secondFile).not.toBe(file);
+  expect(secondFile.name).toBe('IMG_001.jpg');
+  expect(await secondFile.text()).toBe('fake-image-data');
+
+  expect(result.items[0].metadata).toBeDefined();
+  expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
+  expect(result.items[0].metadata!.latitude).toBe(48.8566);
+  expect(result.items[0].metadata!.isFavorite).toBe(true);
+  expect(result.stats.totalMedia).toBe(1);
+  expect(result.stats.withLocation).toBe(1);
+  expect(result.stats.withDate).toBe(1);
+  expect(result.stats.favorites).toBe(1);
+  expect(result.stats.archived).toBe(0);
+});
 ```
 
 Also add this test inside `describe('scanTakeoutFiles', ...)` to prove scan does not extract media:
 
 ```ts
-  it('does not extract media entries while scanning a zip', async () => {
+it('does not extract media entries while scanning a zip', async () => {
+  vi.resetModules();
+
+  const mediaArrayBuffer = vi.fn(async () => new TextEncoder().encode('media-bytes').buffer);
+  const sidecarArrayBuffer = vi.fn(async () => new TextEncoder().encode(makeSidecar()).buffer);
+  const close = vi.fn(async () => undefined);
+
+  vi.doMock('@zip.js/zip.js', () => ({
+    BlobReader: vi.fn(),
+    configure: vi.fn(),
+    ZipReader: vi.fn().mockImplementation(() => ({
+      close,
+      getEntries: vi.fn(async () => [
+        {
+          filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+          directory: false,
+          uncompressedSize: 'media-bytes'.length,
+          lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+          arrayBuffer: mediaArrayBuffer,
+        },
+        {
+          filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
+          directory: false,
+          uncompressedSize: 10,
+          lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+          arrayBuffer: sidecarArrayBuffer,
+        },
+      ]),
+    })),
+  }));
+
+  try {
+    const { scanTakeoutFiles } = await import('$lib/utils/google-takeout-scanner');
+    const result = await scanTakeoutFiles({
+      files: [new File(['zip-placeholder'], 'takeout.zip', { type: 'application/zip' })],
+    });
+
+    expect(sidecarArrayBuffer).toHaveBeenCalledOnce();
+    expect(mediaArrayBuffer).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+
+    const file = await result.items[0].getFile();
+    expect(mediaArrayBuffer).toHaveBeenCalledOnce();
+    expect(await file.text()).toBe('media-bytes');
+  } finally {
+    vi.doUnmock('@zip.js/zip.js');
     vi.resetModules();
-
-    const mediaArrayBuffer = vi.fn(async () => new TextEncoder().encode('media-bytes').buffer);
-    const sidecarArrayBuffer = vi.fn(async () => new TextEncoder().encode(makeSidecar()).buffer);
-    const close = vi.fn(async () => undefined);
-
-    vi.doMock('@zip.js/zip.js', () => ({
-      BlobReader: vi.fn(),
-      configure: vi.fn(),
-      ZipReader: vi.fn().mockImplementation(() => ({
-        close,
-        getEntries: vi.fn(async () => [
-          {
-            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
-            directory: false,
-            uncompressedSize: 'media-bytes'.length,
-            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
-            arrayBuffer: mediaArrayBuffer,
-          },
-          {
-            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
-            directory: false,
-            uncompressedSize: 10,
-            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
-            arrayBuffer: sidecarArrayBuffer,
-          },
-        ]),
-      })),
-    }));
-
-    try {
-      const { scanTakeoutFiles } = await import('$lib/utils/google-takeout-scanner');
-      const result = await scanTakeoutFiles({
-        files: [new File(['zip-placeholder'], 'takeout.zip', { type: 'application/zip' })],
-      });
-
-      expect(sidecarArrayBuffer).toHaveBeenCalledOnce();
-      expect(mediaArrayBuffer).not.toHaveBeenCalled();
-      expect(close).toHaveBeenCalledOnce();
-
-      const file = await result.items[0].getFile();
-      expect(mediaArrayBuffer).toHaveBeenCalledOnce();
-      expect(await file.text()).toBe('media-bytes');
-    } finally {
-      vi.doUnmock('@zip.js/zip.js');
-      vi.resetModules();
-      const mod = await import('$lib/utils/google-takeout-scanner');
-      scanTakeoutFiles = mod.scanTakeoutFiles;
-    }
-  });
+    const mod = await import('$lib/utils/google-takeout-scanner');
+    scanTakeoutFiles = mod.scanTakeoutFiles;
+  }
+});
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -248,9 +249,9 @@ async function getZipEntryFile(entry: ZipEntry, name: string, lastModified: numb
 In `web/src/lib/utils/google-takeout-scanner.ts`, inside `scanZipFile`, replace the `mediaBlobs` map with descriptors:
 
 ```ts
-  const mediaPaths: string[] = [];
-  const mediaDescriptors = new Map<string, ZipMediaDescriptor>();
-  const sidecarTexts = new Map<string, string>();
+const mediaPaths: string[] = [];
+const mediaDescriptors = new Map<string, ZipMediaDescriptor>();
+const sidecarTexts = new Map<string, string>();
 ```
 
 Then replace the media branch in the entry loop with:
@@ -285,33 +286,33 @@ Keep the existing sidecar extraction block after `else if`.
 In `web/src/lib/utils/google-takeout-scanner.ts`, replace the `for (const [path, blob] of mediaBlobs)` block with:
 
 ```ts
-  for (const descriptor of mediaDescriptors.values()) {
-    const metadata = metadataMap.get(descriptor.path);
+for (const descriptor of mediaDescriptors.values()) {
+  const metadata = metadataMap.get(descriptor.path);
 
-    if (metadata?.latitude !== undefined && metadata?.longitude !== undefined) {
-      progress.withLocation++;
-    }
-    if (metadata?.dateTaken) {
-      progress.withDate++;
-    }
-    if (metadata?.isFavorite) {
-      progress.favorites++;
-    }
-    if (metadata?.isArchived) {
-      progress.archived++;
-    }
-
-    allItems.push({
-      path: descriptor.path,
-      name: descriptor.name,
-      size: descriptor.size,
-      lastModified: descriptor.lastModified,
-      getFile: () => getZipEntryFile(descriptor.entry, descriptor.name, descriptor.lastModified),
-      metadata,
-      albumName: undefined,
-    });
-    onProgress?.(progress);
+  if (metadata?.latitude !== undefined && metadata?.longitude !== undefined) {
+    progress.withLocation++;
   }
+  if (metadata?.dateTaken) {
+    progress.withDate++;
+  }
+  if (metadata?.isFavorite) {
+    progress.favorites++;
+  }
+  if (metadata?.isArchived) {
+    progress.archived++;
+  }
+
+  allItems.push({
+    path: descriptor.path,
+    name: descriptor.name,
+    size: descriptor.size,
+    lastModified: descriptor.lastModified,
+    getFile: () => getZipEntryFile(descriptor.entry, descriptor.name, descriptor.lastModified),
+    metadata,
+    albumName: undefined,
+  });
+  onProgress?.(progress);
+}
 ```
 
 - [ ] **Step 7: Run the focused tests to verify they pass**
@@ -336,6 +337,7 @@ git commit -m "refactor(takeout): expose zip files on demand"
 ### Task 2: Update Existing Zip Scanner Edge Cases
 
 **Files:**
+
 - Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts`
 - Modify: `web/src/lib/utils/google-takeout-scanner.ts` only if these tests reveal a regression
 
@@ -344,13 +346,13 @@ git commit -m "refactor(takeout): expose zip files on demand"
 In `web/src/lib/utils/google-takeout-scanner.spec.ts`, update `should handle items without sidecar`:
 
 ```ts
-    expect(result.items).toHaveLength(1);
-    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_002.jpg');
-    expect(result.items[0].name).toBe('IMG_002.jpg');
-    expect(await result.items[0].getFile()).toBeInstanceOf(File);
-    expect(result.items[0].metadata).toBeUndefined();
-    expect(result.stats.withLocation).toBe(0);
-    expect(result.stats.withDate).toBe(0);
+expect(result.items).toHaveLength(1);
+expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_002.jpg');
+expect(result.items[0].name).toBe('IMG_002.jpg');
+expect(await result.items[0].getFile()).toBeInstanceOf(File);
+expect(result.items[0].metadata).toBeUndefined();
+expect(result.stats.withLocation).toBe(0);
+expect(result.stats.withDate).toBe(0);
 ```
 
 - [ ] **Step 2: Run the no-sidecar test**
@@ -385,6 +387,7 @@ git commit -m "test(takeout): update zip scanner edge cases"
 ### Task 3: Folder Imports Use The Same Item Contract
 
 **Files:**
+
 - Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts`
 - Modify: `web/src/lib/utils/google-takeout-scanner.ts`
 
@@ -393,24 +396,24 @@ git commit -m "test(takeout): update zip scanner edge cases"
 In `web/src/lib/utils/google-takeout-scanner.spec.ts`, update `should scan folder files with webkitRelativePath`:
 
 ```ts
-    expect(result.items).toHaveLength(1);
-    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
-    expect(result.items[0].name).toBe('IMG_001.jpg');
-    expect(result.items[0].size).toBe('fake-image'.length);
-    expect(result.items[0].lastModified).toBeGreaterThan(0);
-    expect(await result.items[0].getFile()).toBe(files[0]);
-    expect(result.items[0].metadata).toBeDefined();
-    expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
-    expect(result.items[0].metadata!.latitude).toBe(48.8566);
-    expect(result.stats.totalMedia).toBe(1);
-    expect(result.stats.withLocation).toBe(1);
+expect(result.items).toHaveLength(1);
+expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
+expect(result.items[0].name).toBe('IMG_001.jpg');
+expect(result.items[0].size).toBe('fake-image'.length);
+expect(result.items[0].lastModified).toBeGreaterThan(0);
+expect(await result.items[0].getFile()).toBe(files[0]);
+expect(result.items[0].metadata).toBeDefined();
+expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
+expect(result.items[0].metadata!.latitude).toBe(48.8566);
+expect(result.stats.totalMedia).toBe(1);
+expect(result.stats.withLocation).toBe(1);
 ```
 
 Update the sidecar matching test assertion:
 
 ```ts
-    expect(itemWithout!.name).toBe('IMG_002.jpg');
-    expect(await itemWithout!.getFile()).toBe(files[2]);
+expect(itemWithout!.name).toBe('IMG_002.jpg');
+expect(await itemWithout!.getFile()).toBe(files[2]);
 ```
 
 - [ ] **Step 2: Run the folder tests to verify they fail**
@@ -428,15 +431,15 @@ Expected: FAIL because folder items still use `file` and do not define `name`, `
 In `web/src/lib/utils/google-takeout-scanner.ts`, replace the folder item object with:
 
 ```ts
-    const item: TakeoutMediaItem = {
-      path: filePath,
-      name: file.name,
-      size: file.size,
-      lastModified: file.lastModified,
-      getFile: async () => file,
-      metadata,
-      albumName: undefined,
-    };
+const item: TakeoutMediaItem = {
+  path: filePath,
+  name: file.name,
+  size: file.size,
+  lastModified: file.lastModified,
+  getFile: async () => file,
+  metadata,
+  albumName: undefined,
+};
 ```
 
 - [ ] **Step 4: Run scanner specs**
@@ -461,6 +464,7 @@ git commit -m "refactor(takeout): adapt folder imports to lazy files"
 ### Task 4: Uploader Loads Bytes Only At Upload Time
 
 **Files:**
+
 - Modify: `web/src/lib/utils/google-takeout-uploader.spec.ts`
 - Modify: `web/src/lib/utils/google-takeout-uploader.ts`
 
@@ -497,95 +501,95 @@ function makeItem(overrides: Partial<TakeoutMediaItem> = {}): TakeoutMediaItem {
 In `describe('uploadTakeoutItem', ...)`, add:
 
 ```ts
-  it('loads the file through getFile once during upload', async () => {
-    utilsMock.uploadRequest.mockResolvedValue({
-      data: { id: 'asset-1', status: 'created' },
-      status: 201,
-    });
-
-    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
-    const item = makeItem({ getFile, size: 'lazy-bytes'.length });
-
-    await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
-
-    expect(getFile).toHaveBeenCalledOnce();
-    const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
-    const uploadedFile = formData.get('assetData') as File;
-    expect(uploadedFile.name).toBe('IMG_001.jpg');
-    expect(await uploadedFile.text()).toBe('lazy-bytes');
+it('loads the file through getFile once during upload', async () => {
+  utilsMock.uploadRequest.mockResolvedValue({
+    data: { id: 'asset-1', status: 'created' },
+    status: 201,
   });
 
-  it('hashes lazy file bytes for duplicate checks at upload time', async () => {
-    vi.mocked(sdkMock.checkBulkUpload).mockResolvedValue({
-      results: [
-        {
-          id: 'IMG_001.jpg',
-          assetId: 'existing-asset-1',
-          action: AssetUploadAction.Reject,
-          reason: AssetRejectReason.Duplicate,
-        },
-      ],
-    });
+  const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+  const item = makeItem({ getFile, size: 'lazy-bytes'.length });
 
-    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
-    const item = makeItem({ getFile, size: 'lazy-bytes'.length });
+  await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
 
-    const result = await uploadTakeoutItem(item, defaultOptions());
+  expect(getFile).toHaveBeenCalledOnce();
+  const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
+  const uploadedFile = formData.get('assetData') as File;
+  expect(uploadedFile.name).toBe('IMG_001.jpg');
+  expect(await uploadedFile.text()).toBe('lazy-bytes');
+});
 
-    expect(getFile).toHaveBeenCalledOnce();
-    expect(sdkMock.checkBulkUpload).toHaveBeenCalledWith({
-      assetBulkUploadCheckDto: {
-        assets: [{ id: 'IMG_001.jpg', checksum: 'b2953b8e364061cea5600e64ec5049d63f08efbe' }],
+it('hashes lazy file bytes for duplicate checks at upload time', async () => {
+  vi.mocked(sdkMock.checkBulkUpload).mockResolvedValue({
+    results: [
+      {
+        id: 'IMG_001.jpg',
+        assetId: 'existing-asset-1',
+        action: AssetUploadAction.Reject,
+        reason: AssetRejectReason.Duplicate,
       },
-    });
-    expect(result).toEqual({ assetId: 'existing-asset-1', status: 'duplicate' });
-    expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+    ],
   });
 
-  it('uses item name and lastModified metadata instead of file metadata', async () => {
-    utilsMock.uploadRequest.mockResolvedValue({
-      data: { id: 'asset-1', status: 'created' },
-      status: 201,
-    });
+  const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+  const item = makeItem({ getFile, size: 'lazy-bytes'.length });
 
-    const file = new File(['bytes'], 'WRONG_NAME.jpg', { lastModified: 946_684_800_000 });
-    const item = makeItem({
-      name: 'IMG_FROM_ITEM.jpg',
-      lastModified: 1_609_459_200_000,
-      getFile: vi.fn(async () => file),
-      metadata: {
-        title: 'IMG_FROM_ITEM.jpg',
-        description: undefined,
-        dateTaken: undefined,
-        latitude: undefined,
-        longitude: undefined,
-        isFavorite: false,
-        isArchived: false,
-      },
-    });
+  const result = await uploadTakeoutItem(item, defaultOptions());
 
-    await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+  expect(getFile).toHaveBeenCalledOnce();
+  expect(sdkMock.checkBulkUpload).toHaveBeenCalledWith({
+    assetBulkUploadCheckDto: {
+      assets: [{ id: 'IMG_001.jpg', checksum: 'b2953b8e364061cea5600e64ec5049d63f08efbe' }],
+    },
+  });
+  expect(result).toEqual({ assetId: 'existing-asset-1', status: 'duplicate' });
+  expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+});
 
-    const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
-    const uploadedFile = formData.get('assetData') as File;
-    expect(formData.get('deviceAssetId')).toBe('takeout-IMG_FROM_ITEM.jpg-1609459200000');
-    expect(formData.get('fileCreatedAt')).toBe('2021-01-01T00:00:00.000Z');
-    expect(uploadedFile.name).toBe('IMG_FROM_ITEM.jpg');
+it('uses item name and lastModified metadata instead of file metadata', async () => {
+  utilsMock.uploadRequest.mockResolvedValue({
+    data: { id: 'asset-1', status: 'created' },
+    status: 201,
   });
 
-  it('returns an item error when lazy file loading fails', async () => {
-    const item = makeItem({
-      getFile: vi.fn(async () => {
-        throw new Error('Cannot extract zip entry');
-      }),
-    });
-
-    const result = await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
-
-    expect(result.status).toBe('error');
-    expect(result.error).toContain('Cannot extract zip entry');
-    expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+  const file = new File(['bytes'], 'WRONG_NAME.jpg', { lastModified: 946_684_800_000 });
+  const item = makeItem({
+    name: 'IMG_FROM_ITEM.jpg',
+    lastModified: 1_609_459_200_000,
+    getFile: vi.fn(async () => file),
+    metadata: {
+      title: 'IMG_FROM_ITEM.jpg',
+      description: undefined,
+      dateTaken: undefined,
+      latitude: undefined,
+      longitude: undefined,
+      isFavorite: false,
+      isArchived: false,
+    },
   });
+
+  await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+  const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
+  const uploadedFile = formData.get('assetData') as File;
+  expect(formData.get('deviceAssetId')).toBe('takeout-IMG_FROM_ITEM.jpg-1609459200000');
+  expect(formData.get('fileCreatedAt')).toBe('2021-01-01T00:00:00.000Z');
+  expect(uploadedFile.name).toBe('IMG_FROM_ITEM.jpg');
+});
+
+it('returns an item error when lazy file loading fails', async () => {
+  const item = makeItem({
+    getFile: vi.fn(async () => {
+      throw new Error('Cannot extract zip entry');
+    }),
+  });
+
+  const result = await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+  expect(result.status).toBe('error');
+  expect(result.error).toContain('Cannot extract zip entry');
+  expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+});
 ```
 
 - [ ] **Step 3: Run uploader tests to verify they fail**
@@ -660,6 +664,7 @@ git commit -m "refactor(takeout): load upload files on demand"
 ### Task 5: Update UI And Test-Only Item Fixtures
 
 **Files:**
+
 - Modify: `web/src/lib/components/import/import-wizard.svelte`
 - Modify: `web/src/lib/components/import/__tests__/import-wizard.spec.ts`
 - Modify: `web/src/lib/components/import/__tests__/import-review-step.spec.ts`
@@ -693,53 +698,53 @@ import ImportWizard from '../import-wizard.svelte';
 Add this test inside `describe('ImportWizard', ...)`:
 
 ```ts
-  it('imports name-only Takeout items without reading item.file', async () => {
-    const user = userEvent.setup();
-    const file = new File(['bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 });
-    const item: TakeoutMediaItem = {
-      path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
-      name: 'IMG_001.jpg',
-      size: file.size,
-      lastModified: file.lastModified,
-      getFile: async () => file,
-      metadata: undefined,
-      albumName: undefined,
-    };
-    Object.defineProperty(item, 'file', {
-      get() {
-        throw new Error('item.file should not be read');
-      },
-    });
-
-    vi.mocked(scanTakeoutFiles).mockResolvedValue({
-      items: [item],
-      albums: [],
-      stats: {
-        totalMedia: 1,
-        withLocation: 0,
-        withDate: 0,
-        favorites: 0,
-        archived: 0,
-        dateRange: undefined,
-      },
-    });
-    vi.mocked(uploadTakeoutItem).mockResolvedValue({ assetId: 'asset-1', status: 'imported' });
-
-    const { container, getByText, getByTestId } = render(ImportWizard);
-
-    await user.click(getByText('next'));
-
-    const zipInput = container.querySelector('input[type="file"][accept=".zip"]') as HTMLInputElement;
-    await fireEvent.change(zipInput, {
-      target: { files: [new File(['zip'], 'takeout.zip', { type: 'application/zip' })] },
-    });
-    await user.click(getByTestId('next-button'));
-
-    await waitFor(() => expect(getByTestId('import-button')).toBeInTheDocument());
-    await user.click(getByTestId('import-button'));
-
-    await waitFor(() => expect(uploadTakeoutItem).toHaveBeenCalledWith(item, expect.any(Object)));
+it('imports name-only Takeout items without reading item.file', async () => {
+  const user = userEvent.setup();
+  const file = new File(['bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 });
+  const item: TakeoutMediaItem = {
+    path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+    name: 'IMG_001.jpg',
+    size: file.size,
+    lastModified: file.lastModified,
+    getFile: async () => file,
+    metadata: undefined,
+    albumName: undefined,
+  };
+  Object.defineProperty(item, 'file', {
+    get() {
+      throw new Error('item.file should not be read');
+    },
   });
+
+  vi.mocked(scanTakeoutFiles).mockResolvedValue({
+    items: [item],
+    albums: [],
+    stats: {
+      totalMedia: 1,
+      withLocation: 0,
+      withDate: 0,
+      favorites: 0,
+      archived: 0,
+      dateRange: undefined,
+    },
+  });
+  vi.mocked(uploadTakeoutItem).mockResolvedValue({ assetId: 'asset-1', status: 'imported' });
+
+  const { container, getByText, getByTestId } = render(ImportWizard);
+
+  await user.click(getByText('next'));
+
+  const zipInput = container.querySelector('input[type="file"][accept=".zip"]') as HTMLInputElement;
+  await fireEvent.change(zipInput, {
+    target: { files: [new File(['zip'], 'takeout.zip', { type: 'application/zip' })] },
+  });
+  await user.click(getByTestId('next-button'));
+
+  await waitFor(() => expect(getByTestId('import-button')).toBeInTheDocument());
+  await user.click(getByTestId('import-button'));
+
+  await waitFor(() => expect(uploadTakeoutItem).toHaveBeenCalledWith(item, expect.any(Object)));
+});
 ```
 
 - [ ] **Step 3: Run the import wizard test to verify it fails**
@@ -769,13 +774,13 @@ with:
 Replace:
 
 ```ts
-        manager.trackError(item.file.name, result.error ?? 'Unknown error');
+manager.trackError(item.file.name, result.error ?? 'Unknown error');
 ```
 
 with:
 
 ```ts
-        manager.trackError(item.name, result.error ?? 'Unknown error');
+manager.trackError(item.name, result.error ?? 'Unknown error');
 ```
 
 - [ ] **Step 5: Add a parser spec fixture helper**
@@ -806,13 +811,13 @@ Replace old literals shaped like:
 with:
 
 ```ts
-makeMediaItem('Takeout/Google Photos/A/img.jpg', { metadata: validMeta })
+makeMediaItem('Takeout/Google Photos/A/img.jpg', { metadata: validMeta });
 ```
 
 For old literals with `albumName`, use:
 
 ```ts
-makeMediaItem('Takeout/YouTube/playlists/playlist.json', { albumName: 'playlists' })
+makeMediaItem('Takeout/YouTube/playlists/playlist.json', { albumName: 'playlists' });
 ```
 
 - [ ] **Step 6: Update import review fixture helper**
@@ -874,6 +879,7 @@ git commit -m "refactor(takeout): update media item consumers"
 ### Task 6: Worker Configuration And Full Verification
 
 **Files:**
+
 - Modify: `web/src/lib/utils/google-takeout-scanner.ts` only if worker configuration is changed
 
 - [ ] **Step 1: Try enabling zip.js workers for the scanner path**
@@ -881,14 +887,14 @@ git commit -m "refactor(takeout): update media item consumers"
 In `web/src/lib/utils/google-takeout-scanner.ts`, replace:
 
 ```ts
-  // Disable web workers to avoid stream lifecycle issues during SvelteKit navigation
-  configure({ useWebWorkers: false });
+// Disable web workers to avoid stream lifecycle issues during SvelteKit navigation
+configure({ useWebWorkers: false });
 ```
 
 with:
 
 ```ts
-  configure({ useWebWorkers: true });
+configure({ useWebWorkers: true });
 ```
 
 - [ ] **Step 2: Run scanner and uploader specs**

--- a/docs/superpowers/plans/2026-04-29-google-takeout-zip-on-demand-files.md
+++ b/docs/superpowers/plans/2026-04-29-google-takeout-zip-on-demand-files.md
@@ -1,0 +1,838 @@
+# Google Takeout Zip On-Demand Files Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor browser Google Takeout zip scanning so media bytes are loaded only when an item is uploaded, not during scan/review.
+
+**Architecture:** `TakeoutMediaItem` becomes a metadata object with `getFile()`. Folder imports return the original selected `File`; zip imports keep zip entry metadata and a cached `FileEntry` closure that extracts one media file on demand. Upload uses cheap metadata until it needs bytes, then calls `getFile()` once per item.
+
+**Tech Stack:** SvelteKit web app, TypeScript, Vitest, zip.js `ZipReader`/`FileEntry`, browser `File`/`Blob`/`FormData`.
+
+---
+
+## File Structure
+
+- Modify `web/src/lib/utils/google-takeout-parser.ts`: update `TakeoutMediaItem` interface only; album/root helpers continue using `path`, `metadata`, and `albumName`.
+- Modify `web/src/lib/utils/google-takeout-scanner.ts`: replace eager zip media extraction with metadata descriptors and on-demand `getFile()` closures; update folder items to new shape.
+- Modify `web/src/lib/utils/google-takeout-uploader.ts`: replace `item.file` reads with `item.name`, `item.lastModified`, and a local `await item.getFile()`.
+- Modify `web/src/lib/components/import/import-wizard.svelte`: use `item.name` for current file and error reporting.
+- Modify `web/src/lib/utils/google-takeout-scanner.spec.ts`: add red tests for lazy zip extraction and update assertions to the new item shape.
+- Modify `web/src/lib/utils/google-takeout-uploader.spec.ts`: update fixture helper and add red tests for upload-time `getFile()` behavior.
+- Modify `web/src/lib/utils/google-takeout-parser.spec.ts`: update test-only `TakeoutMediaItem` literals to the new shape.
+- Modify `web/src/lib/components/import/__tests__/import-review-step.spec.ts`: update test fixture helper to the new shape.
+
+## Setup
+
+- [ ] **Step 1: Confirm clean worktree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected output:
+
+```text
+## refactor/takeout-zip-on-demand-files
+```
+
+- [ ] **Step 2: Build the local SDK for web tests**
+
+Run:
+
+```bash
+pnpm --dir open-api/typescript-sdk build
+```
+
+Expected output includes:
+
+```text
+> @immich/sdk@2.7.5 build
+> tsc
+```
+
+- [ ] **Step 3: Confirm focused baseline**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts src/lib/utils/google-takeout-uploader.spec.ts
+```
+
+Expected output:
+
+```text
+Test Files  2 passed (2)
+Tests       37 passed (37)
+```
+
+### Task 1: Zip Items Expose Lazy Files
+
+**Files:**
+- Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts`
+- Modify: `web/src/lib/utils/google-takeout-parser.ts`
+- Modify: `web/src/lib/utils/google-takeout-scanner.ts`
+
+- [ ] **Step 1: Write the failing scanner tests**
+
+In `web/src/lib/utils/google-takeout-scanner.spec.ts`, update the first zip scan test body to assert the new metadata fields and `getFile()` result:
+
+```ts
+  it('should scan a zip and expose media bytes lazily with metadata', async () => {
+    const zipBlob = await createZipBlob([
+      { path: 'Takeout/Google Photos/Trip/IMG_001.jpg', content: 'fake-image-data' },
+      { path: 'Takeout/Google Photos/Trip/IMG_001.jpg.json', content: makeSidecar() },
+    ]);
+
+    const result: ScanResult = await scanTakeoutFiles({
+      files: [blobToFile(zipBlob, 'takeout-001.zip')],
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
+    expect(result.items[0].name).toBe('IMG_001.jpg');
+    expect(result.items[0].size).toBe('fake-image-data'.length);
+    expect(result.items[0].lastModified).toBeGreaterThan(0);
+
+    const file = await result.items[0].getFile();
+    expect(file.name).toBe('IMG_001.jpg');
+    expect(file.size).toBe('fake-image-data'.length);
+    expect(await file.text()).toBe('fake-image-data');
+
+    const secondFile = await result.items[0].getFile();
+    expect(secondFile).not.toBe(file);
+    expect(secondFile.name).toBe('IMG_001.jpg');
+    expect(await secondFile.text()).toBe('fake-image-data');
+
+    expect(result.items[0].metadata).toBeDefined();
+    expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
+    expect(result.items[0].metadata!.latitude).toBe(48.8566);
+    expect(result.items[0].metadata!.isFavorite).toBe(true);
+    expect(result.stats.totalMedia).toBe(1);
+    expect(result.stats.withLocation).toBe(1);
+    expect(result.stats.withDate).toBe(1);
+    expect(result.stats.favorites).toBe(1);
+    expect(result.stats.archived).toBe(0);
+  });
+```
+
+Also add this test inside `describe('scanTakeoutFiles', ...)` to prove scan does not extract media:
+
+```ts
+  it('does not extract media entries while scanning a zip', async () => {
+    vi.resetModules();
+
+    const mediaArrayBuffer = vi.fn(async () => new TextEncoder().encode('media-bytes').buffer);
+    const sidecarArrayBuffer = vi.fn(async () => new TextEncoder().encode(makeSidecar()).buffer);
+    const close = vi.fn(async () => undefined);
+
+    vi.doMock('@zip.js/zip.js', () => ({
+      BlobReader: vi.fn(),
+      configure: vi.fn(),
+      ZipReader: vi.fn().mockImplementation(() => ({
+        close,
+        getEntries: vi.fn(async () => [
+          {
+            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+            directory: false,
+            uncompressedSize: 'media-bytes'.length,
+            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+            arrayBuffer: mediaArrayBuffer,
+          },
+          {
+            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
+            directory: false,
+            uncompressedSize: 10,
+            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+            arrayBuffer: sidecarArrayBuffer,
+          },
+        ]),
+      })),
+    }));
+
+    try {
+      const { scanTakeoutFiles } = await import('$lib/utils/google-takeout-scanner');
+      const result = await scanTakeoutFiles({
+        files: [new File(['zip-placeholder'], 'takeout.zip', { type: 'application/zip' })],
+      });
+
+      expect(sidecarArrayBuffer).toHaveBeenCalledOnce();
+      expect(mediaArrayBuffer).not.toHaveBeenCalled();
+      expect(close).toHaveBeenCalledOnce();
+
+      const file = await result.items[0].getFile();
+      expect(mediaArrayBuffer).toHaveBeenCalledOnce();
+      expect(await file.text()).toBe('media-bytes');
+    } finally {
+      vi.doUnmock('@zip.js/zip.js');
+      vi.resetModules();
+      const mod = await import('$lib/utils/google-takeout-scanner');
+      scanTakeoutFiles = mod.scanTakeoutFiles;
+    }
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts -t "should scan a zip and expose media bytes lazily with metadata|does not extract media entries while scanning a zip"
+```
+
+Expected: FAIL. The first test fails because `result.items[0].name`, `size`, `lastModified`, and `getFile` do not exist yet. The second test fails because the current scanner calls `mediaArrayBuffer` during scan.
+
+- [ ] **Step 3: Update the `TakeoutMediaItem` interface**
+
+In `web/src/lib/utils/google-takeout-parser.ts`, replace the interface at lines 60-65 with:
+
+```ts
+export interface TakeoutMediaItem {
+  path: string;
+  name: string;
+  size: number;
+  lastModified: number;
+  getFile: () => Promise<File>;
+  metadata?: TakeoutMetadata;
+  albumName?: string;
+}
+```
+
+- [ ] **Step 4: Add zip entry metadata support**
+
+In `web/src/lib/utils/google-takeout-scanner.ts`, replace the local `ZipEntry` interface with:
+
+```ts
+interface ZipEntry {
+  filename: string;
+  directory?: boolean;
+  uncompressedSize?: number;
+  lastModDate?: Date;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getData?: (...args: any[]) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  arrayBuffer?: (options?: any) => Promise<ArrayBuffer>;
+}
+
+interface ZipMediaDescriptor {
+  path: string;
+  name: string;
+  size: number;
+  lastModified: number;
+  entry: ZipEntry;
+}
+
+function basename(path: string): string {
+  return path.slice(Math.max(0, path.lastIndexOf('/') + 1));
+}
+
+async function getZipEntryFile(entry: ZipEntry, name: string, lastModified: number): Promise<File> {
+  if (entry.arrayBuffer) {
+    const buffer = await entry.arrayBuffer();
+    return new File([buffer], name, { lastModified });
+  }
+
+  if (entry.getData) {
+    const blob = (await entry.getData(new WritableStream())) as Blob;
+    return new File([blob], name, { type: blob.type || 'application/octet-stream', lastModified });
+  }
+
+  throw new Error(`Zip entry "${entry.filename}" cannot be extracted`);
+}
+```
+
+- [ ] **Step 5: Replace eager zip media extraction with descriptors**
+
+In `web/src/lib/utils/google-takeout-scanner.ts`, inside `scanZipFile`, replace the `mediaBlobs` map with descriptors:
+
+```ts
+  const mediaPaths: string[] = [];
+  const mediaDescriptors = new Map<string, ZipMediaDescriptor>();
+  const sidecarTexts = new Map<string, string>();
+```
+
+Then replace the media branch in the entry loop with:
+
+```ts
+        if (isMediaFile(entry.filename)) {
+          const name = basename(entry.filename);
+          const lastModified = entry.lastModDate?.getTime() ?? zipFile.lastModified;
+
+          mediaPaths.push(entry.filename);
+          mediaDescriptors.set(entry.filename, {
+            path: entry.filename,
+            name,
+            size: entry.uncompressedSize ?? 0,
+            lastModified,
+            entry,
+          });
+
+          progress.mediaCount++;
+          const parts = entry.filename.split('/');
+          if (parts[0] === 'Takeout' && parts.length >= 4) {
+            progress.albumNames.add(parts[2]);
+          }
+          onProgress?.(progress);
+        } else if (isSidecarFile(entry.filename)) {
+```
+
+Keep the existing sidecar extraction block after `else if`.
+
+- [ ] **Step 6: Build zip items from descriptors**
+
+In `web/src/lib/utils/google-takeout-scanner.ts`, replace the `for (const [path, blob] of mediaBlobs)` block with:
+
+```ts
+  for (const descriptor of mediaDescriptors.values()) {
+    const metadata = metadataMap.get(descriptor.path);
+
+    if (metadata?.latitude !== undefined && metadata?.longitude !== undefined) {
+      progress.withLocation++;
+    }
+    if (metadata?.dateTaken) {
+      progress.withDate++;
+    }
+    if (metadata?.isFavorite) {
+      progress.favorites++;
+    }
+    if (metadata?.isArchived) {
+      progress.archived++;
+    }
+
+    allItems.push({
+      path: descriptor.path,
+      name: descriptor.name,
+      size: descriptor.size,
+      lastModified: descriptor.lastModified,
+      getFile: () => getZipEntryFile(descriptor.entry, descriptor.name, descriptor.lastModified),
+      metadata,
+      albumName: undefined,
+    });
+    onProgress?.(progress);
+  }
+```
+
+- [ ] **Step 7: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts -t "should scan a zip and expose media bytes lazily with metadata|does not extract media entries while scanning a zip"
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 8: Commit Task 1**
+
+Run:
+
+```bash
+git add web/src/lib/utils/google-takeout-parser.ts web/src/lib/utils/google-takeout-scanner.ts web/src/lib/utils/google-takeout-scanner.spec.ts
+git commit -m "refactor(takeout): expose zip files on demand"
+```
+
+### Task 2: Update Existing Zip Scanner Edge Cases
+
+**Files:**
+- Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts`
+- Modify: `web/src/lib/utils/google-takeout-scanner.ts` only if these tests reveal a regression
+
+- [ ] **Step 1: Update the no-sidecar zip test to use the new item contract**
+
+In `web/src/lib/utils/google-takeout-scanner.spec.ts`, update `should handle items without sidecar`:
+
+```ts
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_002.jpg');
+    expect(result.items[0].name).toBe('IMG_002.jpg');
+    expect(await result.items[0].getFile()).toBeInstanceOf(File);
+    expect(result.items[0].metadata).toBeUndefined();
+    expect(result.stats.withLocation).toBe(0);
+    expect(result.stats.withDate).toBe(0);
+```
+
+- [ ] **Step 2: Run the no-sidecar test**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts -t "should handle items without sidecar"
+```
+
+Expected: PASS after Task 1. If it fails, fix the descriptor path for media entries without metadata before continuing.
+
+- [ ] **Step 3: Run the updated zip edge tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts -t "should scan a zip and expose media bytes lazily with metadata|does not extract media entries while scanning a zip|should handle items without sidecar"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 4: Commit Task 2**
+
+Run:
+
+```bash
+git add web/src/lib/utils/google-takeout-scanner.spec.ts web/src/lib/utils/google-takeout-scanner.ts
+git commit -m "test(takeout): update zip scanner edge cases"
+```
+
+### Task 3: Folder Imports Use The Same Item Contract
+
+**Files:**
+- Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts`
+- Modify: `web/src/lib/utils/google-takeout-scanner.ts`
+
+- [ ] **Step 1: Write or update the failing folder test**
+
+In `web/src/lib/utils/google-takeout-scanner.spec.ts`, update `should scan folder files with webkitRelativePath`:
+
+```ts
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
+    expect(result.items[0].name).toBe('IMG_001.jpg');
+    expect(result.items[0].size).toBe('fake-image'.length);
+    expect(result.items[0].lastModified).toBeGreaterThan(0);
+    expect(await result.items[0].getFile()).toBe(files[0]);
+    expect(result.items[0].metadata).toBeDefined();
+    expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
+    expect(result.items[0].metadata!.latitude).toBe(48.8566);
+    expect(result.stats.totalMedia).toBe(1);
+    expect(result.stats.withLocation).toBe(1);
+```
+
+Update the sidecar matching test assertion:
+
+```ts
+    expect(itemWithout!.name).toBe('IMG_002.jpg');
+    expect(await itemWithout!.getFile()).toBe(files[2]);
+```
+
+- [ ] **Step 2: Run the folder tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts -t "folder"
+```
+
+Expected: FAIL because folder items still use `file` and do not define `name`, `size`, `lastModified`, or `getFile`.
+
+- [ ] **Step 3: Update folder item creation**
+
+In `web/src/lib/utils/google-takeout-scanner.ts`, replace the folder item object with:
+
+```ts
+    const item: TakeoutMediaItem = {
+      path: filePath,
+      name: file.name,
+      size: file.size,
+      lastModified: file.lastModified,
+      getFile: async () => file,
+      metadata,
+      albumName: undefined,
+    };
+```
+
+- [ ] **Step 4: Run scanner specs**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts
+```
+
+Expected: scanner specs pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add web/src/lib/utils/google-takeout-scanner.ts web/src/lib/utils/google-takeout-scanner.spec.ts
+git commit -m "refactor(takeout): adapt folder imports to lazy files"
+```
+
+### Task 4: Uploader Loads Bytes Only At Upload Time
+
+**Files:**
+- Modify: `web/src/lib/utils/google-takeout-uploader.spec.ts`
+- Modify: `web/src/lib/utils/google-takeout-uploader.ts`
+
+- [ ] **Step 1: Update the uploader test fixture first**
+
+In `web/src/lib/utils/google-takeout-uploader.spec.ts`, replace `makeItem()` with:
+
+```ts
+function makeItem(overrides: Partial<TakeoutMediaItem> = {}): TakeoutMediaItem {
+  const file = new File(['fake-image-data'], 'IMG_001.jpg', { type: 'image/jpeg', lastModified: 1_609_459_200_000 });
+  return {
+    path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+    name: 'IMG_001.jpg',
+    size: file.size,
+    lastModified: 1_609_459_200_000,
+    getFile: vi.fn(async () => file),
+    metadata: {
+      title: 'IMG_001.jpg',
+      description: 'A nice photo',
+      dateTaken: new Date('2021-01-01T00:00:00.000Z'),
+      latitude: 48.8566,
+      longitude: 2.3522,
+      isFavorite: true,
+      isArchived: false,
+    },
+    albumName: 'Trip',
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 2: Add failing uploader tests**
+
+In `describe('uploadTakeoutItem', ...)`, add:
+
+```ts
+  it('loads the file through getFile once during upload', async () => {
+    utilsMock.uploadRequest.mockResolvedValue({
+      data: { id: 'asset-1', status: 'created' },
+      status: 201,
+    });
+
+    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+    const item = makeItem({ getFile, size: 'lazy-bytes'.length });
+
+    await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+    expect(getFile).toHaveBeenCalledOnce();
+    const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
+    const uploadedFile = formData.get('assetData') as File;
+    expect(uploadedFile.name).toBe('IMG_001.jpg');
+    expect(await uploadedFile.text()).toBe('lazy-bytes');
+  });
+
+  it('returns an item error when lazy file loading fails', async () => {
+    const item = makeItem({
+      getFile: vi.fn(async () => {
+        throw new Error('Cannot extract zip entry');
+      }),
+    });
+
+    const result = await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Cannot extract zip entry');
+    expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 3: Run uploader tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-uploader.spec.ts -t "getFile|lazy file loading"
+```
+
+Expected: FAIL because `uploadTakeoutItem()` still reads `item.file`.
+
+- [ ] **Step 4: Update uploader implementation**
+
+In `web/src/lib/utils/google-takeout-uploader.ts`, replace the top of `uploadTakeoutItem()` through `assetData` append with:
+
+```ts
+  try {
+    const deviceAssetId = 'takeout-' + item.name + '-' + item.lastModified;
+    const fileCreatedAt = item.metadata?.dateTaken
+      ? item.metadata.dateTaken.toISOString()
+      : new Date(item.lastModified).toISOString();
+    const file = await item.getFile();
+
+    // Duplicate check
+    if (options.skipDuplicates && crypto?.subtle) {
+      try {
+        const checksum = await computeSha1(file);
+        const {
+          results: [checkResult],
+        } = await checkBulkUpload({
+          assetBulkUploadCheckDto: { assets: [{ id: item.name, checksum }] },
+        });
+        if (checkResult.action === AssetUploadAction.Reject && checkResult.assetId) {
+          return { assetId: checkResult.assetId, status: 'duplicate' };
+        }
+      } catch (error) {
+        console.error('Error checking duplicate', error);
+      }
+    }
+
+    // Build FormData
+    const formData = new FormData();
+    formData.append('deviceAssetId', deviceAssetId);
+    formData.append('deviceId', 'WEB_IMPORT');
+    formData.append('fileCreatedAt', fileCreatedAt);
+    formData.append('fileModifiedAt', fileCreatedAt);
+    formData.append('isFavorite', String(options.importFavorites && item.metadata?.isFavorite === true));
+    formData.append('duration', '0:00:00.000000');
+    formData.append('assetData', new File([file], item.name, { lastModified: item.lastModified }));
+```
+
+- [ ] **Step 5: Run uploader specs**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-uploader.spec.ts
+```
+
+Expected: all uploader tests pass.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add web/src/lib/utils/google-takeout-uploader.ts web/src/lib/utils/google-takeout-uploader.spec.ts
+git commit -m "refactor(takeout): load upload files on demand"
+```
+
+### Task 5: Update UI And Test-Only Item Fixtures
+
+**Files:**
+- Modify: `web/src/lib/components/import/import-wizard.svelte`
+- Modify: `web/src/lib/components/import/__tests__/import-review-step.spec.ts`
+- Modify: `web/src/lib/utils/google-takeout-parser.spec.ts`
+- Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts` if any old `file` assertion remains
+
+- [ ] **Step 1: Write or confirm typecheck failure**
+
+Run:
+
+```bash
+pnpm --dir web run check:typescript
+```
+
+Expected before this task: FAIL with `Property 'file' does not exist on type 'TakeoutMediaItem'` in import wizard and/or specs.
+
+- [ ] **Step 2: Update import wizard runtime reads**
+
+In `web/src/lib/components/import/import-wizard.svelte`, replace:
+
+```ts
+        currentFile: item.file.name,
+```
+
+with:
+
+```ts
+        currentFile: item.name,
+```
+
+Replace:
+
+```ts
+        manager.trackError(item.file.name, result.error ?? 'Unknown error');
+```
+
+with:
+
+```ts
+        manager.trackError(item.name, result.error ?? 'Unknown error');
+```
+
+- [ ] **Step 3: Add a parser spec fixture helper**
+
+In `web/src/lib/utils/google-takeout-parser.spec.ts`, near the `validMeta` constant, add:
+
+```ts
+function makeMediaItem(path: string, overrides: Partial<TakeoutMediaItem> = {}): TakeoutMediaItem {
+  const name = path.slice(Math.max(0, path.lastIndexOf('/') + 1));
+  const file = new File([], name);
+  return {
+    path,
+    name,
+    size: file.size,
+    lastModified: file.lastModified,
+    getFile: async () => file,
+    ...overrides,
+  };
+}
+```
+
+Replace old literals shaped like:
+
+```ts
+{ path: 'Takeout/Google Photos/A/img.jpg', file: new File([], 'img.jpg'), metadata: validMeta }
+```
+
+with:
+
+```ts
+makeMediaItem('Takeout/Google Photos/A/img.jpg', { metadata: validMeta })
+```
+
+For old literals with `albumName`, use:
+
+```ts
+makeMediaItem('Takeout/YouTube/playlists/playlist.json', { albumName: 'playlists' })
+```
+
+- [ ] **Step 4: Update import review fixture helper**
+
+In `web/src/lib/components/import/__tests__/import-review-step.spec.ts`, replace `makeItem()` with:
+
+```ts
+function makeItem(overrides?: Partial<TakeoutMediaItem>): TakeoutMediaItem {
+  const file = new File(['x'], 'IMG_1234.jpg');
+  return {
+    path: 'Takeout/Google Photos/Vacation/IMG_1234.jpg',
+    name: 'IMG_1234.jpg',
+    size: file.size,
+    lastModified: file.lastModified,
+    getFile: async () => file,
+    metadata: undefined,
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 5: Remove remaining stale `item.file` references**
+
+Run:
+
+```bash
+rg -n 'item\.file|\.file\.name|file: new File' web/src/lib/utils web/src/lib/components/import
+```
+
+Expected remaining matches may include unrelated upload utilities outside Takeout. There must be no matches in:
+
+```text
+web/src/lib/utils/google-takeout-*.ts
+web/src/lib/utils/google-takeout-*.spec.ts
+web/src/lib/components/import/*.svelte
+web/src/lib/components/import/__tests__/*.spec.ts
+```
+
+- [ ] **Step 6: Run typecheck and focused component/parser tests**
+
+Run:
+
+```bash
+pnpm --dir web run check:typescript
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-parser.spec.ts src/lib/components/import/__tests__/import-review-step.spec.ts
+```
+
+Expected: both commands pass. If `check:typescript` surfaces unrelated baseline failures, document them and run the focused Vitest command.
+
+- [ ] **Step 7: Commit Task 5**
+
+Run:
+
+```bash
+git add web/src/lib/components/import/import-wizard.svelte web/src/lib/components/import/__tests__/import-review-step.spec.ts web/src/lib/utils/google-takeout-parser.spec.ts web/src/lib/utils/google-takeout-scanner.spec.ts
+git commit -m "refactor(takeout): update media item consumers"
+```
+
+### Task 6: Worker Configuration And Full Verification
+
+**Files:**
+- Modify: `web/src/lib/utils/google-takeout-scanner.ts` only if worker configuration is changed
+
+- [ ] **Step 1: Try enabling zip.js workers for the scanner path**
+
+In `web/src/lib/utils/google-takeout-scanner.ts`, replace:
+
+```ts
+  // Disable web workers to avoid stream lifecycle issues during SvelteKit navigation
+  configure({ useWebWorkers: false });
+```
+
+with:
+
+```ts
+  configure({ useWebWorkers: true });
+```
+
+- [ ] **Step 2: Run scanner and uploader specs**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts src/lib/utils/google-takeout-uploader.spec.ts
+```
+
+Expected: all tests pass. If zip.js worker setup fails in Vitest or reproduces stream lifecycle errors, revert only this worker configuration change and keep the on-demand file refactor.
+
+- [ ] **Step 3: Run all Takeout-related tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-parser.spec.ts src/lib/utils/google-takeout-scanner.spec.ts src/lib/utils/google-takeout-uploader.spec.ts src/lib/components/import/__tests__/import-review-step.spec.ts
+```
+
+Expected: all listed test files pass.
+
+- [ ] **Step 4: Run lint and type checks**
+
+Run:
+
+```bash
+pnpm --dir web run lint
+pnpm --dir web run check:typescript
+pnpm --dir web run check:svelte
+```
+
+Expected: all pass. If there are unrelated baseline failures, capture exact failing files and messages in the final summary.
+
+- [ ] **Step 5: Run broader test command**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run
+```
+
+Expected: pass. If this is too broad for the environment, document the exact failure or timeout and keep the focused Takeout test results from Step 3.
+
+- [ ] **Step 6: Final stale-reference audit**
+
+Run:
+
+```bash
+rg -n 'mediaBlobs|item\.file|TakeoutMediaItem.*file|file: new File' web/src/lib/utils/google-takeout-* web/src/lib/components/import
+```
+
+Expected: no stale eager-media implementation references. Test fixture helpers may contain local `const file = new File(...)`, but `TakeoutMediaItem` objects must use `name`, `size`, `lastModified`, and `getFile`.
+
+- [ ] **Step 7: Commit Task 6**
+
+Run:
+
+```bash
+git add web/src/lib/utils/google-takeout-scanner.ts
+git commit -m "chore(takeout): verify lazy zip import"
+```
+
+If no files changed in this task, do not create an empty commit.
+
+## Manual Verification
+
+- [ ] Select a small Google Takeout zip in the browser import flow.
+- [ ] Confirm scan completes and review counts still match the fixture contents.
+- [ ] Confirm import uploads files with correct names.
+- [ ] Confirm sidecar date, favorite, archive, GPS, and description behavior is unchanged.
+- [ ] Confirm album creation still maps uploaded asset IDs to selected album names.
+- [ ] Confirm browser memory does not grow by the sum of decompressed media bytes during scan.
+
+## Completion Criteria
+
+- `TakeoutMediaItem` no longer has `file`.
+- Zip scan does not extract media entries during scan.
+- Zip `getFile()` returns the correct file bytes on demand.
+- Folder `getFile()` returns the original selected `File`.
+- Upload calls `getFile()` once per item and does not retain the file beyond the function scope.
+- Focused Takeout tests pass.
+- Lint, TypeScript, Svelte checks, and broad Vitest verification pass or blockers are documented with exact output.

--- a/docs/superpowers/plans/2026-04-29-google-takeout-zip-on-demand-files.md
+++ b/docs/superpowers/plans/2026-04-29-google-takeout-zip-on-demand-files.md
@@ -18,6 +18,7 @@
 - Modify `web/src/lib/components/import/import-wizard.svelte`: use `item.name` for current file and error reporting.
 - Modify `web/src/lib/utils/google-takeout-scanner.spec.ts`: add red tests for lazy zip extraction and update assertions to the new item shape.
 - Modify `web/src/lib/utils/google-takeout-uploader.spec.ts`: update fixture helper and add red tests for upload-time `getFile()` behavior.
+- Modify `web/src/lib/components/import/__tests__/import-wizard.spec.ts`: add a red interaction test proving the import loop uses `item.name`, not `item.file.name`.
 - Modify `web/src/lib/utils/google-takeout-parser.spec.ts`: update test-only `TakeoutMediaItem` literals to the new shape.
 - Modify `web/src/lib/components/import/__tests__/import-review-step.spec.ts`: update test fixture helper to the new shape.
 
@@ -514,6 +515,64 @@ In `describe('uploadTakeoutItem', ...)`, add:
     expect(await uploadedFile.text()).toBe('lazy-bytes');
   });
 
+  it('hashes lazy file bytes for duplicate checks at upload time', async () => {
+    vi.mocked(sdkMock.checkBulkUpload).mockResolvedValue({
+      results: [
+        {
+          id: 'IMG_001.jpg',
+          assetId: 'existing-asset-1',
+          action: AssetUploadAction.Reject,
+          reason: AssetRejectReason.Duplicate,
+        },
+      ],
+    });
+
+    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+    const item = makeItem({ getFile, size: 'lazy-bytes'.length });
+
+    const result = await uploadTakeoutItem(item, defaultOptions());
+
+    expect(getFile).toHaveBeenCalledOnce();
+    expect(sdkMock.checkBulkUpload).toHaveBeenCalledWith({
+      assetBulkUploadCheckDto: {
+        assets: [{ id: 'IMG_001.jpg', checksum: 'b2953b8e364061cea5600e64ec5049d63f08efbe' }],
+      },
+    });
+    expect(result).toEqual({ assetId: 'existing-asset-1', status: 'duplicate' });
+    expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+  });
+
+  it('uses item name and lastModified metadata instead of file metadata', async () => {
+    utilsMock.uploadRequest.mockResolvedValue({
+      data: { id: 'asset-1', status: 'created' },
+      status: 201,
+    });
+
+    const file = new File(['bytes'], 'WRONG_NAME.jpg', { lastModified: 946_684_800_000 });
+    const item = makeItem({
+      name: 'IMG_FROM_ITEM.jpg',
+      lastModified: 1_609_459_200_000,
+      getFile: vi.fn(async () => file),
+      metadata: {
+        title: 'IMG_FROM_ITEM.jpg',
+        description: undefined,
+        dateTaken: undefined,
+        latitude: undefined,
+        longitude: undefined,
+        isFavorite: false,
+        isArchived: false,
+      },
+    });
+
+    await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+    const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
+    const uploadedFile = formData.get('assetData') as File;
+    expect(formData.get('deviceAssetId')).toBe('takeout-IMG_FROM_ITEM.jpg-1609459200000');
+    expect(formData.get('fileCreatedAt')).toBe('2021-01-01T00:00:00.000Z');
+    expect(uploadedFile.name).toBe('IMG_FROM_ITEM.jpg');
+  });
+
   it('returns an item error when lazy file loading fails', async () => {
     const item = makeItem({
       getFile: vi.fn(async () => {
@@ -534,7 +593,7 @@ In `describe('uploadTakeoutItem', ...)`, add:
 Run:
 
 ```bash
-pnpm --dir web exec vitest run src/lib/utils/google-takeout-uploader.spec.ts -t "getFile|lazy file loading"
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-uploader.spec.ts -t "getFile|lazy file loading|lazy file bytes|file metadata"
 ```
 
 Expected: FAIL because `uploadTakeoutItem()` still reads `item.file`.
@@ -602,6 +661,7 @@ git commit -m "refactor(takeout): load upload files on demand"
 
 **Files:**
 - Modify: `web/src/lib/components/import/import-wizard.svelte`
+- Modify: `web/src/lib/components/import/__tests__/import-wizard.spec.ts`
 - Modify: `web/src/lib/components/import/__tests__/import-review-step.spec.ts`
 - Modify: `web/src/lib/utils/google-takeout-parser.spec.ts`
 - Modify: `web/src/lib/utils/google-takeout-scanner.spec.ts` if any old `file` assertion remains
@@ -616,7 +676,83 @@ pnpm --dir web run check:typescript
 
 Expected before this task: FAIL with `Property 'file' does not exist on type 'TakeoutMediaItem'` in import wizard and/or specs.
 
-- [ ] **Step 2: Update import wizard runtime reads**
+- [ ] **Step 2: Add the failing import wizard interaction test**
+
+In `web/src/lib/components/import/__tests__/import-wizard.spec.ts`, replace the imports with:
+
+```ts
+import type { TakeoutMediaItem } from '$lib/utils/google-takeout-parser';
+import { scanTakeoutFiles } from '$lib/utils/google-takeout-scanner';
+import { uploadTakeoutItem } from '$lib/utils/google-takeout-uploader';
+import '@testing-library/jest-dom';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import ImportWizard from '../import-wizard.svelte';
+```
+
+Add this test inside `describe('ImportWizard', ...)`:
+
+```ts
+  it('imports name-only Takeout items without reading item.file', async () => {
+    const user = userEvent.setup();
+    const file = new File(['bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 });
+    const item: TakeoutMediaItem = {
+      path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+      name: 'IMG_001.jpg',
+      size: file.size,
+      lastModified: file.lastModified,
+      getFile: async () => file,
+      metadata: undefined,
+      albumName: undefined,
+    };
+    Object.defineProperty(item, 'file', {
+      get() {
+        throw new Error('item.file should not be read');
+      },
+    });
+
+    vi.mocked(scanTakeoutFiles).mockResolvedValue({
+      items: [item],
+      albums: [],
+      stats: {
+        totalMedia: 1,
+        withLocation: 0,
+        withDate: 0,
+        favorites: 0,
+        archived: 0,
+        dateRange: undefined,
+      },
+    });
+    vi.mocked(uploadTakeoutItem).mockResolvedValue({ assetId: 'asset-1', status: 'imported' });
+
+    const { container, getByText, getByTestId } = render(ImportWizard);
+
+    await user.click(getByText('next'));
+
+    const zipInput = container.querySelector('input[type="file"][accept=".zip"]') as HTMLInputElement;
+    await fireEvent.change(zipInput, {
+      target: { files: [new File(['zip'], 'takeout.zip', { type: 'application/zip' })] },
+    });
+    await user.click(getByTestId('next-button'));
+
+    await waitFor(() => expect(getByTestId('import-button')).toBeInTheDocument());
+    await user.click(getByTestId('import-button'));
+
+    await waitFor(() => expect(uploadTakeoutItem).toHaveBeenCalledWith(item, expect.any(Object)));
+  });
+```
+
+- [ ] **Step 3: Run the import wizard test to verify it fails**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest run src/lib/components/import/__tests__/import-wizard.spec.ts -t "imports name-only Takeout items without reading item.file"
+```
+
+Expected: FAIL because `import-wizard.svelte` reads `item.file.name`.
+
+- [ ] **Step 4: Update import wizard runtime reads**
 
 In `web/src/lib/components/import/import-wizard.svelte`, replace:
 
@@ -642,7 +778,7 @@ with:
         manager.trackError(item.name, result.error ?? 'Unknown error');
 ```
 
-- [ ] **Step 3: Add a parser spec fixture helper**
+- [ ] **Step 5: Add a parser spec fixture helper**
 
 In `web/src/lib/utils/google-takeout-parser.spec.ts`, near the `validMeta` constant, add:
 
@@ -679,7 +815,7 @@ For old literals with `albumName`, use:
 makeMediaItem('Takeout/YouTube/playlists/playlist.json', { albumName: 'playlists' })
 ```
 
-- [ ] **Step 4: Update import review fixture helper**
+- [ ] **Step 6: Update import review fixture helper**
 
 In `web/src/lib/components/import/__tests__/import-review-step.spec.ts`, replace `makeItem()` with:
 
@@ -698,7 +834,7 @@ function makeItem(overrides?: Partial<TakeoutMediaItem>): TakeoutMediaItem {
 }
 ```
 
-- [ ] **Step 5: Remove remaining stale `item.file` references**
+- [ ] **Step 7: Remove remaining stale `item.file` references**
 
 Run:
 
@@ -715,23 +851,23 @@ web/src/lib/components/import/*.svelte
 web/src/lib/components/import/__tests__/*.spec.ts
 ```
 
-- [ ] **Step 6: Run typecheck and focused component/parser tests**
+- [ ] **Step 8: Run typecheck and focused component/parser tests**
 
 Run:
 
 ```bash
 pnpm --dir web run check:typescript
-pnpm --dir web exec vitest run src/lib/utils/google-takeout-parser.spec.ts src/lib/components/import/__tests__/import-review-step.spec.ts
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-parser.spec.ts src/lib/components/import/__tests__/import-review-step.spec.ts src/lib/components/import/__tests__/import-wizard.spec.ts
 ```
 
 Expected: both commands pass. If `check:typescript` surfaces unrelated baseline failures, document them and run the focused Vitest command.
 
-- [ ] **Step 7: Commit Task 5**
+- [ ] **Step 9: Commit Task 5**
 
 Run:
 
 ```bash
-git add web/src/lib/components/import/import-wizard.svelte web/src/lib/components/import/__tests__/import-review-step.spec.ts web/src/lib/utils/google-takeout-parser.spec.ts web/src/lib/utils/google-takeout-scanner.spec.ts
+git add web/src/lib/components/import/import-wizard.svelte web/src/lib/components/import/__tests__/import-wizard.spec.ts web/src/lib/components/import/__tests__/import-review-step.spec.ts web/src/lib/utils/google-takeout-parser.spec.ts web/src/lib/utils/google-takeout-scanner.spec.ts
 git commit -m "refactor(takeout): update media item consumers"
 ```
 

--- a/docs/superpowers/specs/2026-04-29-google-takeout-zip-on-demand-files-design.md
+++ b/docs/superpowers/specs/2026-04-29-google-takeout-zip-on-demand-files-design.md
@@ -45,7 +45,7 @@ export interface TakeoutMediaItem {
 }
 ```
 
-Folder imports keep the original selected `File` and implement `getFile` as a closure returning that file. Zip imports populate `name`, `size`, and `lastModified` from zip entry metadata and implement `getFile` as a closure that extracts only that entry.
+Folder imports keep the original selected `File` and implement `getFile` as a closure returning that file. Zip imports populate `name`, `size`, and `lastModified` from zip entry metadata (`filename`, `uncompressedSize`, and `lastModDate`) and implement `getFile` as a closure that extracts only that entry.
 
 ## Zip Scan Design
 
@@ -60,7 +60,9 @@ Folder imports keep the original selected `File` and implement `getFile` as a cl
 
 The primary implementation should use a per-zip central-directory cache so uploads do not reparse every zip entry for every item. The cache may retain zip entry metadata and the source zip `File`, but it must not retain extracted media blobs.
 
-Because zip.js reader and entry lifetimes can be subtle, the implementation must verify whether entries remain extractable after `reader.close()`. If they do not, the extractor should reopen a `ZipReader` as needed and cache only the resulting entry map, closing readers after extraction. The invariant is more important than the exact lifecycle: scan must not extract media, and upload must extract only the requested media file.
+The expected lifecycle is: call `getEntries()`, cache `FileEntry` references for media, close the `ZipReader` after scan, and let each `getFile()` call invoke `entry.arrayBuffer()` on the cached entry. A small zip.js probe in the worktree confirmed this works after `reader.close()` in the local test environment. Add regression coverage so this assumption is protected by tests. If browser validation shows closed-reader extraction is unsafe, change only the extractor internals to reopen a reader and rebuild the entry map on demand; keep the public `TakeoutMediaItem` contract unchanged.
+
+Extraction failures for encrypted, corrupt, or missing entries should surface as upload errors for that item through the existing `uploadTakeoutItem()` error result path. Scan should continue to skip entries that lack a usable extractor, matching current behavior.
 
 ## Worker Configuration
 
@@ -82,6 +84,20 @@ Name and timestamp-only values should use `item.name` and `item.lastModified` so
 
 `import-wizard.svelte` will replace `item.file.name` with `item.name` for progress and error reporting. `import-review-step.svelte` does not need runtime changes unless TypeScript fixtures or props require the new shape in tests.
 
+## TDD Execution
+
+Implementation must use red-green-refactor. Do not write production code for a behavior until its failing test has been added and run.
+
+Recommended test-first order:
+
+1. Add a scanner test proving zip scan returns item metadata and `getFile()` returns the expected bytes. Run it and confirm it fails because `getFile` does not exist yet.
+2. Add a scanner test proving media entries are not extracted during scan. Use a zip.js mock or spy that distinguishes sidecar extraction from media extraction, and confirm the test fails against the current eager scanner.
+3. Add a folder-source scanner test proving `getFile()` returns the original selected `File`, including `name`, `size`, and `lastModified`.
+4. Add uploader tests proving name/timestamp metadata is read without extraction where possible, `getFile()` is called during upload, and duplicate hashing still reads bytes at upload time.
+5. Update parser and import component fixtures only after the tests define the new `TakeoutMediaItem` shape.
+
+After each red test fails for the expected reason, implement the minimal production change to make it pass, then rerun the focused specs before moving to the next behavior.
+
 ## Testing
 
 Update the scanner, parser, uploader, and import component specs to construct `TakeoutMediaItem` with `name`, `size`, `lastModified`, and `getFile`.
@@ -99,6 +115,19 @@ Add uploader coverage that:
 - verifies `uploadTakeoutItem()` calls `getFile()` during upload,
 - verifies duplicate checks still hash the file bytes at upload time,
 - verifies name and last-modified metadata are preserved.
+
+Edge cases to cover or preserve:
+
+| Edge Case | Expected Behavior |
+| --- | --- |
+| Zip entry has no sidecar | Item is listed with undefined metadata and `getFile()` still works. |
+| Sidecar exists before or after media in zip order | Matching remains order-independent. |
+| Localized Google Photos root | Album detection still works for roots such as `Google Fotos` and `Google フォト`. |
+| Non-Photos Takeout media path | Progress reconciliation still drops tentative non-Photos album names. |
+| Mixed zip and folder selection | Both item sources use the same `TakeoutMediaItem` contract. |
+| Abort during scan | Scan stops before building or extracting further entries. |
+| Extraction failure during upload | The item returns upload status `error`; other imports can continue through the existing wizard loop. |
+| Repeated `getFile()` call | Each call returns a fresh usable `File` without retaining prior extracted bytes. |
 
 Baseline verification in the worktree after setup:
 

--- a/docs/superpowers/specs/2026-04-29-google-takeout-zip-on-demand-files-design.md
+++ b/docs/superpowers/specs/2026-04-29-google-takeout-zip-on-demand-files-design.md
@@ -1,0 +1,124 @@
+# Google Takeout Zip On-Demand Files Design
+
+Date: 2026-04-29
+
+## Context
+
+The in-browser Google Photos Takeout scanner currently materializes every media entry from a selected zip during scan. `scanZipFile()` calls `entry.arrayBuffer()` for each media file, stores the decompressed bytes in `mediaBlobs`, then builds `File` objects for every item before upload starts. For large Takeout archives this can retain many gigabytes of media in browser heap and makes scan run heavy decompression work on the main thread.
+
+Runtime consumers do not need media bytes during review. The audit found that:
+
+- `import-wizard.svelte` needs the current item name for progress and errors.
+- `google-takeout-uploader.ts` needs name and last-modified metadata before upload, then bytes only when hashing and appending to `FormData`.
+- `import-review-step.svelte` reads `item.path` for extension-derived counts and does not read bytes.
+
+Additional `TakeoutMediaItem.file` references are test fixtures or assertions that must be updated to the new shape.
+
+## Goals
+
+- Scanning a multi-gigabyte zip must not decompress and retain all media files.
+- The review flow must keep using cheap metadata: path, name, size, last modified, metadata, and album name.
+- Upload must preserve current behavior for zip and folder imports.
+- Sidecar JSON may still be extracted during scan because sidecars are small and needed for metadata matching.
+- The implementation should be testable with the existing Vitest scanner and uploader specs.
+
+## Non-Goals
+
+- No server-side changes.
+- No size warning UI changes.
+- No broader import wizard redesign.
+- No attempt to stream directly into the upload request in this change.
+
+## Data Model
+
+`TakeoutMediaItem` changes from an eager file object to metadata plus an on-demand file loader:
+
+```ts
+export interface TakeoutMediaItem {
+  path: string;
+  name: string;
+  size: number;
+  lastModified: number;
+  getFile: () => Promise<File>;
+  metadata?: TakeoutMetadata;
+  albumName?: string;
+}
+```
+
+Folder imports keep the original selected `File` and implement `getFile` as a closure returning that file. Zip imports populate `name`, `size`, and `lastModified` from zip entry metadata and implement `getFile` as a closure that extracts only that entry.
+
+## Zip Scan Design
+
+`scanZipFile()` will:
+
+1. Open the zip with zip.js and read the central directory with `getEntries()`.
+2. Build a per-zip entry map keyed by entry filename.
+3. For media entries, record only metadata and the filename. Do not call `entry.arrayBuffer()` or `entry.getData()` during scan.
+4. For sidecar entries, extract text during scan and keep it in `sidecarTexts`.
+5. Match sidecars to media paths after the entry loop, as today.
+6. Build `TakeoutMediaItem` objects from recorded media descriptors, metadata matches, and on-demand `getFile` closures.
+
+The primary implementation should use a per-zip central-directory cache so uploads do not reparse every zip entry for every item. The cache may retain zip entry metadata and the source zip `File`, but it must not retain extracted media blobs.
+
+Because zip.js reader and entry lifetimes can be subtle, the implementation must verify whether entries remain extractable after `reader.close()`. If they do not, the extractor should reopen a `ZipReader` as needed and cache only the resulting entry map, closing readers after extraction. The invariant is more important than the exact lifecycle: scan must not extract media, and upload must extract only the requested media file.
+
+## Worker Configuration
+
+The existing scanner disables zip.js web workers because prior eager extraction hit stream lifecycle issues during SvelteKit navigation. After media extraction moves out of the scan loop, scan only reads the central directory and sidecar JSON. The implementation should try `configure({ useWebWorkers: true })` for the scanner path if tests and manual validation show no lifecycle regression.
+
+If worker use still causes stream lifecycle errors with the on-demand extractor, keep workers disabled for this change. The memory fix does not depend on workers.
+
+## Upload Design
+
+`uploadTakeoutItem()` will call `const file = await item.getFile()` once per item and use that local `File` for:
+
+- checksum calculation when duplicate skipping is enabled,
+- `assetData` in `FormData`,
+- any upload code that requires a `File` object.
+
+Name and timestamp-only values should use `item.name` and `item.lastModified` so they remain cheap and do not force extraction. The local `file` must not be stored beyond the upload function, allowing the browser to reclaim the extracted media bytes after the upload finishes.
+
+## UI Changes
+
+`import-wizard.svelte` will replace `item.file.name` with `item.name` for progress and error reporting. `import-review-step.svelte` does not need runtime changes unless TypeScript fixtures or props require the new shape in tests.
+
+## Testing
+
+Update the scanner, parser, uploader, and import component specs to construct `TakeoutMediaItem` with `name`, `size`, `lastModified`, and `getFile`.
+
+Add scanner coverage that:
+
+- scans a small zip and verifies media `getFile()` returns the expected bytes,
+- verifies scanning does not extract media entries,
+- verifies media extraction happens only when `getFile()` or upload is called,
+- keeps folder-source behavior unchanged by returning the original file through `getFile`,
+- keeps sidecar matching, album detection, progress reconciliation, and mixed zip/folder behavior intact.
+
+Add uploader coverage that:
+
+- verifies `uploadTakeoutItem()` calls `getFile()` during upload,
+- verifies duplicate checks still hash the file bytes at upload time,
+- verifies name and last-modified metadata are preserved.
+
+Baseline verification in the worktree after setup:
+
+```text
+pnpm --dir web exec vitest run src/lib/utils/google-takeout-scanner.spec.ts src/lib/utils/google-takeout-uploader.spec.ts
+Test Files  2 passed
+Tests       37 passed
+```
+
+The local SDK package must be built in a fresh worktree before these tests can resolve `@immich/sdk`:
+
+```text
+pnpm --dir open-api/typescript-sdk build
+```
+
+## Acceptance Criteria
+
+- Scan does not call media entry extraction APIs for media entries.
+- Scan memory growth is proportional to zip metadata, sidecar JSON, and `TakeoutMediaItem` metadata, not decompressed media bytes.
+- Upload still works for small zip imports and folder-source imports.
+- Media names, last-modified timestamps, sidecar metadata, album names, and duplicate handling are preserved.
+- Focused scanner and uploader tests pass.
+- Full `pnpm test` and `pnpm lint` are run before completion, or any pre-existing blocker is documented.

--- a/docs/superpowers/specs/2026-04-29-google-takeout-zip-on-demand-files-design.md
+++ b/docs/superpowers/specs/2026-04-29-google-takeout-zip-on-demand-files-design.md
@@ -118,16 +118,16 @@ Add uploader coverage that:
 
 Edge cases to cover or preserve:
 
-| Edge Case | Expected Behavior |
-| --- | --- |
-| Zip entry has no sidecar | Item is listed with undefined metadata and `getFile()` still works. |
-| Sidecar exists before or after media in zip order | Matching remains order-independent. |
-| Localized Google Photos root | Album detection still works for roots such as `Google Fotos` and `Google フォト`. |
-| Non-Photos Takeout media path | Progress reconciliation still drops tentative non-Photos album names. |
-| Mixed zip and folder selection | Both item sources use the same `TakeoutMediaItem` contract. |
-| Abort during scan | Scan stops before building or extracting further entries. |
-| Extraction failure during upload | The item returns upload status `error`; other imports can continue through the existing wizard loop. |
-| Repeated `getFile()` call | Each call returns a fresh usable `File` without retaining prior extracted bytes. |
+| Edge Case                                         | Expected Behavior                                                                                    |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Zip entry has no sidecar                          | Item is listed with undefined metadata and `getFile()` still works.                                  |
+| Sidecar exists before or after media in zip order | Matching remains order-independent.                                                                  |
+| Localized Google Photos root                      | Album detection still works for roots such as `Google Fotos` and `Google フォト`.                    |
+| Non-Photos Takeout media path                     | Progress reconciliation still drops tentative non-Photos album names.                                |
+| Mixed zip and folder selection                    | Both item sources use the same `TakeoutMediaItem` contract.                                          |
+| Abort during scan                                 | Scan stops before building or extracting further entries.                                            |
+| Extraction failure during upload                  | The item returns upload status `error`; other imports can continue through the existing wizard loop. |
+| Repeated `getFile()` call                         | Each call returns a fresh usable `File` without retaining prior extracted bytes.                     |
 
 Baseline verification in the worktree after setup:
 

--- a/web/src/lib/components/import/__tests__/import-review-step.spec.ts
+++ b/web/src/lib/components/import/__tests__/import-review-step.spec.ts
@@ -6,9 +6,13 @@ import userEvent from '@testing-library/user-event';
 import ImportReviewStep from '../import-review-step.svelte';
 
 function makeItem(overrides?: Partial<TakeoutMediaItem>): TakeoutMediaItem {
+  const file = new File(['x'], 'IMG_1234.jpg');
   return {
     path: 'Takeout/Google Photos/Vacation/IMG_1234.jpg',
-    file: new File(['x'], 'IMG_1234.jpg'),
+    name: file.name,
+    size: file.size,
+    lastModified: file.lastModified,
+    getFile: async () => file,
     metadata: undefined,
     ...overrides,
   };

--- a/web/src/lib/components/import/__tests__/import-review-step.spec.ts
+++ b/web/src/lib/components/import/__tests__/import-review-step.spec.ts
@@ -12,7 +12,7 @@ function makeItem(overrides?: Partial<TakeoutMediaItem>): TakeoutMediaItem {
     name: file.name,
     size: file.size,
     lastModified: file.lastModified,
-    getFile: async () => file,
+    getFile: () => Promise.resolve(file),
     metadata: undefined,
     ...overrides,
   };

--- a/web/src/lib/components/import/__tests__/import-wizard.spec.ts
+++ b/web/src/lib/components/import/__tests__/import-wizard.spec.ts
@@ -1,5 +1,8 @@
+import type { TakeoutMediaItem } from '$lib/utils/google-takeout-parser';
+import { scanTakeoutFiles } from '$lib/utils/google-takeout-scanner';
+import { uploadTakeoutItem } from '$lib/utils/google-takeout-uploader';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import ImportWizard from '../import-wizard.svelte';
 
@@ -39,5 +42,53 @@ describe('ImportWizard', () => {
 
     // Should now show files step (drop zone)
     expect(getByTestId('drop-zone')).toBeInTheDocument();
+  });
+
+  it('imports name-only Takeout items', async () => {
+    const user = userEvent.setup();
+    const file = new File(['bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 });
+    const item: TakeoutMediaItem = {
+      path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+      name: 'IMG_001.jpg',
+      size: file.size,
+      lastModified: file.lastModified,
+      getFile: async () => file,
+      metadata: undefined,
+      albumName: undefined,
+    };
+    vi.mocked(scanTakeoutFiles).mockResolvedValue({
+      items: [item],
+      albums: [],
+      stats: {
+        totalMedia: 1,
+        withLocation: 0,
+        withDate: 0,
+        favorites: 0,
+        archived: 0,
+        dateRange: undefined,
+      },
+    });
+    vi.mocked(uploadTakeoutItem).mockResolvedValue({ assetId: 'asset-1', status: 'imported' });
+
+    const { container, getByText, getByTestId } = render(ImportWizard);
+
+    await user.click(getByText('next'));
+
+    const zipInput = container.querySelector('input[type="file"][accept=".zip"]') as HTMLInputElement;
+    await fireEvent.change(zipInput, {
+      target: { files: [new File(['zip'], 'takeout.zip', { type: 'application/zip' })] },
+    });
+    await user.click(getByTestId('next-button'));
+
+    await waitFor(() => expect(getByTestId('import-button')).toBeInTheDocument());
+    await user.click(getByTestId('import-button'));
+
+    await waitFor(() => expect(uploadTakeoutItem).toHaveBeenCalledOnce());
+    expect(vi.mocked(uploadTakeoutItem).mock.calls[0][0]).toMatchObject({
+      path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+      name: 'IMG_001.jpg',
+      size: file.size,
+      lastModified: file.lastModified,
+    });
   });
 });

--- a/web/src/lib/components/import/__tests__/import-wizard.spec.ts
+++ b/web/src/lib/components/import/__tests__/import-wizard.spec.ts
@@ -52,7 +52,7 @@ describe('ImportWizard', () => {
       name: 'IMG_001.jpg',
       size: file.size,
       lastModified: file.lastModified,
-      getFile: async () => file,
+      getFile: () => Promise.resolve(file),
       metadata: undefined,
       albumName: undefined,
     };

--- a/web/src/lib/components/import/import-wizard.svelte
+++ b/web/src/lib/components/import/import-wizard.svelte
@@ -79,7 +79,7 @@
 
       manager.importProgress = {
         ...manager.importProgress,
-        currentFile: item.file.name,
+        currentFile: item.name,
       };
 
       const result = await uploadTakeoutItem(item, manager.options);
@@ -93,7 +93,7 @@
           assetIdMap.set(item.path, result.assetId);
         }
       } else {
-        manager.trackError(item.file.name, result.error ?? 'Unknown error');
+        manager.trackError(item.name, result.error ?? 'Unknown error');
       }
     }
 

--- a/web/src/lib/utils/google-takeout-parser.spec.ts
+++ b/web/src/lib/utils/google-takeout-parser.spec.ts
@@ -14,6 +14,20 @@ import {
   type TakeoutMediaItem,
 } from '$lib/utils/google-takeout-parser';
 
+function makeMediaItem(path: string, overrides: Partial<TakeoutMediaItem> = {}): TakeoutMediaItem {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  const file = new File([], name);
+
+  return {
+    path,
+    name,
+    size: file.size,
+    lastModified: file.lastModified,
+    getFile: async () => file,
+    ...overrides,
+  };
+}
+
 describe('parseGoogleTakeoutSidecar', () => {
   it('should parse a complete sidecar with all fields', () => {
     const json = JSON.stringify({
@@ -397,22 +411,22 @@ describe('derivePhotoRoots', () => {
 
   it('collects parts[1] from items with metadata under Takeout/', () => {
     const items = [
-      { path: 'Takeout/Google Photos/A/img.jpg', file: new File([], 'img.jpg'), metadata: validMeta },
-      { path: 'Takeout/Google Fotos/B/img.jpg', file: new File([], 'img.jpg'), metadata: validMeta },
+      makeMediaItem('Takeout/Google Photos/A/img.jpg', { metadata: validMeta }),
+      makeMediaItem('Takeout/Google Fotos/B/img.jpg', { metadata: validMeta }),
     ];
     expect(derivePhotoRoots(items)).toEqual(new Set(['Google Photos', 'Google Fotos']));
   });
 
   it('ignores items without metadata', () => {
     const items = [
-      { path: 'Takeout/Google Photos/A/img.jpg', file: new File([], 'img.jpg'), metadata: undefined },
-      { path: 'Takeout/Google Fotos/B/img.jpg', file: new File([], 'img.jpg'), metadata: validMeta },
+      makeMediaItem('Takeout/Google Photos/A/img.jpg', { metadata: undefined }),
+      makeMediaItem('Takeout/Google Fotos/B/img.jpg', { metadata: validMeta }),
     ];
     expect(derivePhotoRoots(items)).toEqual(new Set(['Google Fotos']));
   });
 
   it('ignores items not under Takeout/', () => {
-    const items = [{ path: 'Other/Google Photos/A/img.jpg', file: new File([], 'img.jpg'), metadata: validMeta }];
+    const items = [makeMediaItem('Other/Google Photos/A/img.jpg', { metadata: validMeta })];
     expect(derivePhotoRoots(items)).toEqual(new Set());
   });
 });
@@ -420,9 +434,9 @@ describe('derivePhotoRoots', () => {
 describe('detectAlbums', () => {
   it('should extract albums from folder structure', () => {
     const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/Google Photos/Summer Trip/IMG_001.jpg', file: new File([], 'IMG_001.jpg') },
-      { path: 'Takeout/Google Photos/Summer Trip/IMG_002.jpg', file: new File([], 'IMG_002.jpg') },
-      { path: 'Takeout/Google Photos/Birthday/IMG_003.jpg', file: new File([], 'IMG_003.jpg') },
+      makeMediaItem('Takeout/Google Photos/Summer Trip/IMG_001.jpg'),
+      makeMediaItem('Takeout/Google Photos/Summer Trip/IMG_002.jpg'),
+      makeMediaItem('Takeout/Google Photos/Birthday/IMG_003.jpg'),
     ];
 
     const albums = detectAlbums(items, new Set(['Google Photos']));
@@ -443,9 +457,7 @@ describe('detectAlbums', () => {
   });
 
   it('should mark auto-generated albums', () => {
-    const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/Google Photos/Photos from 2023/IMG_001.jpg', file: new File([], 'IMG_001.jpg') },
-    ];
+    const items: TakeoutMediaItem[] = [makeMediaItem('Takeout/Google Photos/Photos from 2023/IMG_001.jpg')];
 
     const albums = detectAlbums(items, new Set(['Google Photos']));
 
@@ -455,7 +467,7 @@ describe('detectAlbums', () => {
   });
 
   it('should return empty array for flat files', () => {
-    const items: TakeoutMediaItem[] = [{ path: 'IMG_001.jpg', file: new File([], 'IMG_001.jpg') }];
+    const items: TakeoutMediaItem[] = [makeMediaItem('IMG_001.jpg')];
 
     const albums = detectAlbums(items, new Set(['Google Photos']));
 
@@ -464,8 +476,8 @@ describe('detectAlbums', () => {
 
   it('detects albums under a localized Photos root', () => {
     const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/Google Fotos/Sommer/IMG_001.jpg', file: new File([], 'IMG_001.jpg') },
-      { path: 'Takeout/Google Fotos/Sommer/IMG_002.jpg', file: new File([], 'IMG_002.jpg') },
+      makeMediaItem('Takeout/Google Fotos/Sommer/IMG_001.jpg'),
+      makeMediaItem('Takeout/Google Fotos/Sommer/IMG_002.jpg'),
     ];
     const albums = detectAlbums(items, new Set(['Google Fotos']));
     expect(albums).toHaveLength(1);
@@ -474,8 +486,8 @@ describe('detectAlbums', () => {
 
   it('handles multiple Photos roots in one scan', () => {
     const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/Google Photos/A/img.jpg', file: new File([], 'img.jpg') },
-      { path: 'Takeout/Google Fotos/B/img.jpg', file: new File([], 'img.jpg') },
+      makeMediaItem('Takeout/Google Photos/A/img.jpg'),
+      makeMediaItem('Takeout/Google Fotos/B/img.jpg'),
     ];
     const albums = detectAlbums(items, new Set(['Google Photos', 'Google Fotos']));
     expect(albums.map((a) => a.name).sort()).toEqual(['A', 'B']);
@@ -483,8 +495,8 @@ describe('detectAlbums', () => {
 
   it('ignores items under paths NOT in photoRoots', () => {
     const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/YouTube/playlists/playlist.json', file: new File([], 'x.json') },
-      { path: 'Takeout/Google Fotos/Album/img.jpg', file: new File([], 'img.jpg') },
+      makeMediaItem('Takeout/YouTube/playlists/playlist.json'),
+      makeMediaItem('Takeout/Google Fotos/Album/img.jpg'),
     ];
     const albums = detectAlbums(items, new Set(['Google Fotos']));
     expect(albums).toHaveLength(1);
@@ -494,14 +506,14 @@ describe('detectAlbums', () => {
 
 describe('finalizeItemAlbumNames', () => {
   it('sets albumName from parts[2] when item is under a photo root', () => {
-    const items: TakeoutMediaItem[] = [{ path: 'Takeout/Google Fotos/Sommer/img.jpg', file: new File([], 'img.jpg') }];
+    const items: TakeoutMediaItem[] = [makeMediaItem('Takeout/Google Fotos/Sommer/img.jpg')];
     finalizeItemAlbumNames(items, new Set(['Google Fotos']));
     expect(items[0].albumName).toBe('Sommer');
   });
 
   it('forces albumName to undefined when item is NOT under a photo root', () => {
     const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/YouTube/playlists/playlist.json', file: new File([], 'x.json'), albumName: 'playlists' },
+      makeMediaItem('Takeout/YouTube/playlists/playlist.json', { albumName: 'playlists' }),
     ];
     finalizeItemAlbumNames(items, new Set(['Google Photos']));
     expect(items[0].albumName).toBeUndefined();
@@ -509,7 +521,7 @@ describe('finalizeItemAlbumNames', () => {
 
   it('leaves albumName undefined for items loose in the Photos root (no album subfolder)', () => {
     const items: TakeoutMediaItem[] = [
-      { path: 'Takeout/Google Fotos/img.jpg', file: new File([], 'img.jpg'), albumName: 'whatever' },
+      makeMediaItem('Takeout/Google Fotos/img.jpg', { albumName: 'whatever' }),
     ];
     finalizeItemAlbumNames(items, new Set(['Google Fotos']));
     expect(items[0].albumName).toBeUndefined();

--- a/web/src/lib/utils/google-takeout-parser.spec.ts
+++ b/web/src/lib/utils/google-takeout-parser.spec.ts
@@ -23,7 +23,7 @@ function makeMediaItem(path: string, overrides: Partial<TakeoutMediaItem> = {}):
     name,
     size: file.size,
     lastModified: file.lastModified,
-    getFile: async () => file,
+    getFile: () => Promise.resolve(file),
     ...overrides,
   };
 }

--- a/web/src/lib/utils/google-takeout-parser.spec.ts
+++ b/web/src/lib/utils/google-takeout-parser.spec.ts
@@ -520,9 +520,7 @@ describe('finalizeItemAlbumNames', () => {
   });
 
   it('leaves albumName undefined for items loose in the Photos root (no album subfolder)', () => {
-    const items: TakeoutMediaItem[] = [
-      makeMediaItem('Takeout/Google Fotos/img.jpg', { albumName: 'whatever' }),
-    ];
+    const items: TakeoutMediaItem[] = [makeMediaItem('Takeout/Google Fotos/img.jpg', { albumName: 'whatever' })];
     finalizeItemAlbumNames(items, new Set(['Google Fotos']));
     expect(items[0].albumName).toBeUndefined();
   });

--- a/web/src/lib/utils/google-takeout-parser.ts
+++ b/web/src/lib/utils/google-takeout-parser.ts
@@ -59,7 +59,10 @@ export interface TakeoutMetadata {
 
 export interface TakeoutMediaItem {
   path: string;
-  file: File;
+  name: string;
+  size: number;
+  lastModified: number;
+  getFile: () => Promise<File>;
   metadata?: TakeoutMetadata;
   albumName?: string;
 }

--- a/web/src/lib/utils/google-takeout-scanner.spec.ts
+++ b/web/src/lib/utils/google-takeout-scanner.spec.ts
@@ -90,22 +90,24 @@ describe('scanTakeoutFiles', () => {
     const zipReader = vi.fn(function ZipReader() {
       return {
         close,
-        getEntries: vi.fn(() => Promise.resolve([
-          {
-            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
-            directory: false,
-            uncompressedSize: 'media-bytes'.length,
-            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
-            arrayBuffer: mediaArrayBuffer,
-          },
-          {
-            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
-            directory: false,
-            uncompressedSize: 10,
-            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
-            arrayBuffer: sidecarArrayBuffer,
-          },
-        ])),
+        getEntries: vi.fn(() =>
+          Promise.resolve([
+            {
+              filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+              directory: false,
+              uncompressedSize: 'media-bytes'.length,
+              lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+              arrayBuffer: mediaArrayBuffer,
+            },
+            {
+              filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
+              directory: false,
+              uncompressedSize: 10,
+              lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+              arrayBuffer: sidecarArrayBuffer,
+            },
+          ]),
+        ),
       };
     });
 

--- a/web/src/lib/utils/google-takeout-scanner.spec.ts
+++ b/web/src/lib/utils/google-takeout-scanner.spec.ts
@@ -163,6 +163,8 @@ describe('scanTakeoutFiles', () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_002.jpg');
+    expect(result.items[0].name).toBe('IMG_002.jpg');
+    expect(await result.items[0].getFile()).toBeInstanceOf(File);
     expect(result.items[0].metadata).toBeUndefined();
     expect(result.stats.withLocation).toBe(0);
     expect(result.stats.withDate).toBe(0);

--- a/web/src/lib/utils/google-takeout-scanner.spec.ts
+++ b/web/src/lib/utils/google-takeout-scanner.spec.ts
@@ -300,7 +300,11 @@ describe('scanTakeoutFiles — folder support', () => {
     const result: ScanResult = await scanTakeoutFiles({ files });
 
     expect(result.items).toHaveLength(1);
-    expect(result.items[0].file.name).toBe('IMG_001.jpg');
+    expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
+    expect(result.items[0].name).toBe('IMG_001.jpg');
+    expect(result.items[0].size).toBe('fake-image'.length);
+    expect(result.items[0].lastModified).toBeGreaterThan(0);
+    expect(await result.items[0].getFile()).toBe(files[0]);
     expect(result.items[0].metadata).toBeDefined();
     expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
     expect(result.items[0].metadata!.latitude).toBe(48.8566);
@@ -329,7 +333,8 @@ describe('scanTakeoutFiles — folder support', () => {
     expect(itemWithMeta).toBeDefined();
     expect(itemWithMeta!.metadata!.isFavorite).toBe(true);
     expect(itemWithout).toBeDefined();
-    expect(itemWithout!.file.name).toBe('IMG_002.jpg');
+    expect(itemWithout!.name).toBe('IMG_002.jpg');
+    expect(await itemWithout!.getFile()).toBe(files[2]);
   });
 
   it('should detect albums from folder hierarchy', async () => {

--- a/web/src/lib/utils/google-takeout-scanner.spec.ts
+++ b/web/src/lib/utils/google-takeout-scanner.spec.ts
@@ -85,31 +85,34 @@ describe('scanTakeoutFiles', () => {
     const mediaArrayBuffer = vi.fn(async () => new TextEncoder().encode('media-bytes').buffer);
     const sidecarArrayBuffer = vi.fn(async () => new TextEncoder().encode(makeSidecar()).buffer);
     const close = vi.fn(async () => undefined);
+    const blobReader = vi.fn(function BlobReader() {});
+    const configure = vi.fn();
+    const zipReader = vi.fn(function ZipReader() {
+      return {
+        close,
+        getEntries: vi.fn(async () => [
+          {
+            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+            directory: false,
+            uncompressedSize: 'media-bytes'.length,
+            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+            arrayBuffer: mediaArrayBuffer,
+          },
+          {
+            filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
+            directory: false,
+            uncompressedSize: 10,
+            lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+            arrayBuffer: sidecarArrayBuffer,
+          },
+        ]),
+      };
+    });
 
     vi.doMock('@zip.js/zip.js', () => ({
-      BlobReader: vi.fn(function BlobReader() {}),
-      configure: vi.fn(),
-      ZipReader: vi.fn(function ZipReader() {
-        return {
-          close,
-          getEntries: vi.fn(async () => [
-            {
-              filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
-              directory: false,
-              uncompressedSize: 'media-bytes'.length,
-              lastModDate: new Date('2021-01-01T00:00:00.000Z'),
-              arrayBuffer: mediaArrayBuffer,
-            },
-            {
-              filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
-              directory: false,
-              uncompressedSize: 10,
-              lastModDate: new Date('2021-01-01T00:00:00.000Z'),
-              arrayBuffer: sidecarArrayBuffer,
-            },
-          ]),
-        };
-      }),
+      BlobReader: blobReader,
+      configure,
+      ZipReader: zipReader,
     }));
 
     try {
@@ -121,10 +124,16 @@ describe('scanTakeoutFiles', () => {
       expect(sidecarArrayBuffer).toHaveBeenCalledOnce();
       expect(mediaArrayBuffer).not.toHaveBeenCalled();
       expect(close).toHaveBeenCalledOnce();
+      expect(configure).toHaveBeenCalledWith({ useWebWorkers: true });
+      expect(blobReader).toHaveBeenCalledOnce();
+      expect(zipReader).toHaveBeenCalledOnce();
 
       const file = await result.items[0].getFile();
       expect(mediaArrayBuffer).toHaveBeenCalledOnce();
       expect(await file.text()).toBe('media-bytes');
+      expect(blobReader).toHaveBeenCalledTimes(2);
+      expect(zipReader).toHaveBeenCalledTimes(2);
+      expect(close).toHaveBeenCalledTimes(2);
     } finally {
       vi.doUnmock('@zip.js/zip.js');
       vi.resetModules();

--- a/web/src/lib/utils/google-takeout-scanner.spec.ts
+++ b/web/src/lib/utils/google-takeout-scanner.spec.ts
@@ -82,15 +82,15 @@ describe('scanTakeoutFiles', () => {
   it('does not extract media entries while scanning a zip', async () => {
     vi.resetModules();
 
-    const mediaArrayBuffer = vi.fn(async () => new TextEncoder().encode('media-bytes').buffer);
-    const sidecarArrayBuffer = vi.fn(async () => new TextEncoder().encode(makeSidecar()).buffer);
-    const close = vi.fn(async () => undefined);
+    const mediaArrayBuffer = vi.fn(() => Promise.resolve(new TextEncoder().encode('media-bytes').buffer));
+    const sidecarArrayBuffer = vi.fn(() => Promise.resolve(new TextEncoder().encode(makeSidecar()).buffer));
+    const close = vi.fn(() => Promise.resolve(undefined));
     const blobReader = vi.fn(function BlobReader() {});
     const configure = vi.fn();
     const zipReader = vi.fn(function ZipReader() {
       return {
         close,
-        getEntries: vi.fn(async () => [
+        getEntries: vi.fn(() => Promise.resolve([
           {
             filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
             directory: false,
@@ -105,7 +105,7 @@ describe('scanTakeoutFiles', () => {
             lastModDate: new Date('2021-01-01T00:00:00.000Z'),
             arrayBuffer: sidecarArrayBuffer,
           },
-        ]),
+        ])),
       };
     });
 

--- a/web/src/lib/utils/google-takeout-scanner.spec.ts
+++ b/web/src/lib/utils/google-takeout-scanner.spec.ts
@@ -42,7 +42,7 @@ describe('scanTakeoutFiles', () => {
     scanTakeoutFiles = mod.scanTakeoutFiles;
   });
 
-  it('should scan a zip and extract media with metadata', async () => {
+  it('should scan a zip and expose media bytes lazily with metadata', async () => {
     const zipBlob = await createZipBlob([
       { path: 'Takeout/Google Photos/Trip/IMG_001.jpg', content: 'fake-image-data' },
       { path: 'Takeout/Google Photos/Trip/IMG_001.jpg.json', content: makeSidecar() },
@@ -54,6 +54,20 @@ describe('scanTakeoutFiles', () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].path).toBe('Takeout/Google Photos/Trip/IMG_001.jpg');
+    expect(result.items[0].name).toBe('IMG_001.jpg');
+    expect(result.items[0].size).toBe('fake-image-data'.length);
+    expect(result.items[0].lastModified).toBeGreaterThan(0);
+
+    const file = await result.items[0].getFile();
+    expect(file.name).toBe('IMG_001.jpg');
+    expect(file.size).toBe('fake-image-data'.length);
+    expect(await file.text()).toBe('fake-image-data');
+
+    const secondFile = await result.items[0].getFile();
+    expect(secondFile).not.toBe(file);
+    expect(secondFile.name).toBe('IMG_001.jpg');
+    expect(await secondFile.text()).toBe('fake-image-data');
+
     expect(result.items[0].metadata).toBeDefined();
     expect(result.items[0].metadata!.title).toBe('IMG_001.jpg');
     expect(result.items[0].metadata!.latitude).toBe(48.8566);
@@ -63,6 +77,60 @@ describe('scanTakeoutFiles', () => {
     expect(result.stats.withDate).toBe(1);
     expect(result.stats.favorites).toBe(1);
     expect(result.stats.archived).toBe(0);
+  });
+
+  it('does not extract media entries while scanning a zip', async () => {
+    vi.resetModules();
+
+    const mediaArrayBuffer = vi.fn(async () => new TextEncoder().encode('media-bytes').buffer);
+    const sidecarArrayBuffer = vi.fn(async () => new TextEncoder().encode(makeSidecar()).buffer);
+    const close = vi.fn(async () => undefined);
+
+    vi.doMock('@zip.js/zip.js', () => ({
+      BlobReader: vi.fn(function BlobReader() {}),
+      configure: vi.fn(),
+      ZipReader: vi.fn(function ZipReader() {
+        return {
+          close,
+          getEntries: vi.fn(async () => [
+            {
+              filename: 'Takeout/Google Photos/Trip/IMG_001.jpg',
+              directory: false,
+              uncompressedSize: 'media-bytes'.length,
+              lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+              arrayBuffer: mediaArrayBuffer,
+            },
+            {
+              filename: 'Takeout/Google Photos/Trip/IMG_001.jpg.json',
+              directory: false,
+              uncompressedSize: 10,
+              lastModDate: new Date('2021-01-01T00:00:00.000Z'),
+              arrayBuffer: sidecarArrayBuffer,
+            },
+          ]),
+        };
+      }),
+    }));
+
+    try {
+      const { scanTakeoutFiles } = await import('$lib/utils/google-takeout-scanner');
+      const result = await scanTakeoutFiles({
+        files: [new File(['zip-placeholder'], 'takeout.zip', { type: 'application/zip' })],
+      });
+
+      expect(sidecarArrayBuffer).toHaveBeenCalledOnce();
+      expect(mediaArrayBuffer).not.toHaveBeenCalled();
+      expect(close).toHaveBeenCalledOnce();
+
+      const file = await result.items[0].getFile();
+      expect(mediaArrayBuffer).toHaveBeenCalledOnce();
+      expect(await file.text()).toBe('media-bytes');
+    } finally {
+      vi.doUnmock('@zip.js/zip.js');
+      vi.resetModules();
+      const mod = await import('$lib/utils/google-takeout-scanner');
+      scanTakeoutFiles = mod.scanTakeoutFiles;
+    }
   });
 
   it('should report progress via callback', async () => {

--- a/web/src/lib/utils/google-takeout-scanner.ts
+++ b/web/src/lib/utils/google-takeout-scanner.ts
@@ -72,10 +72,21 @@ function checkAbort(signal?: AbortSignal): void {
 
 interface ZipEntry {
   filename: string;
+  directory?: boolean;
+  uncompressedSize?: number;
+  lastModDate?: Date;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getData?: (...args: any[]) => Promise<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   arrayBuffer?: (options?: any) => Promise<ArrayBuffer>;
+}
+
+interface ZipMediaDescriptor {
+  path: string;
+  name: string;
+  size: number;
+  lastModified: number;
+  entry: ZipEntry;
 }
 
 function isZipFile(file: File): boolean {
@@ -89,6 +100,24 @@ function isZipFile(file: File): boolean {
 function getFilePath(file: File): string {
   // Use webkitRelativePath if available (folder selection), otherwise just the name
   return (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
+}
+
+function basename(path: string): string {
+  return path.slice(Math.max(0, path.lastIndexOf('/') + 1));
+}
+
+async function getZipEntryFile(entry: ZipEntry, name: string, lastModified: number): Promise<File> {
+  if (entry.arrayBuffer) {
+    const buffer = await entry.arrayBuffer();
+    return new File([buffer], name, { lastModified });
+  }
+
+  if (entry.getData) {
+    const blob = (await entry.getData(new WritableStream())) as Blob;
+    return new File([blob], name, { type: blob.type || 'application/octet-stream', lastModified });
+  }
+
+  throw new Error(`Zip entry "${entry.filename}" cannot be extracted`);
 }
 
 function trackItemStats(
@@ -140,7 +169,7 @@ async function scanZipFile(
   // Single pass: read all entries once to avoid stream reuse errors.
   // Wrap in try/finally to ensure reader is always closed.
   const mediaPaths: string[] = [];
-  const mediaBlobs = new Map<string, Blob>();
+  const mediaDescriptors = new Map<string, ZipMediaDescriptor>();
   const sidecarTexts = new Map<string, string>();
 
   try {
@@ -165,9 +194,19 @@ async function scanZipFile(
 
       try {
         if (isMediaFile(entry.filename)) {
-          mediaPaths.push(entry.filename);
+          const name = basename(entry.filename);
+          const lastModified = entry.lastModDate?.getTime() ?? zipFile.lastModified;
 
-          // Update progress counters during extraction so the UI shows activity
+          mediaPaths.push(entry.filename);
+          mediaDescriptors.set(entry.filename, {
+            path: entry.filename,
+            name,
+            size: entry.uncompressedSize ?? 0,
+            lastModified,
+            entry,
+          });
+
+          // Update progress counters while scanning so the UI shows activity.
           progress.mediaCount++;
           const parts = entry.filename.split('/');
           if (parts[0] === 'Takeout' && parts.length >= 4) {
@@ -175,15 +214,6 @@ async function scanZipFile(
           }
           onProgress?.(progress);
 
-          // arrayBuffer() creates a fresh TransformStream per call, avoiding
-          // the BlobWriter stream lifecycle issues in browsers.
-          if (entry.arrayBuffer) {
-            const buffer = await entry.arrayBuffer();
-            mediaBlobs.set(entry.filename, new Blob([buffer]));
-          } else {
-            const blob = (await entry.getData!(new WritableStream())) as Blob;
-            mediaBlobs.set(entry.filename, blob);
-          }
         } else if (isSidecarFile(entry.filename)) {
           if (entry.arrayBuffer) {
             const buffer = await entry.arrayBuffer();
@@ -217,13 +247,11 @@ async function scanZipFile(
     }
   }
 
-  // Build items from extracted blobs.
-  // mediaCount and albumNames were already updated during extraction,
+  // Build items from media descriptors.
+  // mediaCount and albumNames were already updated during scanning,
   // so only track metadata-dependent stats here (location, date, favorites, archived).
-  for (const [path, blob] of mediaBlobs) {
-    const basename = path.slice(Math.max(0, path.lastIndexOf('/') + 1));
-    const file = new File([blob], basename, { type: blob.type || 'application/octet-stream' });
-    const metadata = metadataMap.get(path);
+  for (const descriptor of mediaDescriptors.values()) {
+    const metadata = metadataMap.get(descriptor.path);
 
     // Track metadata-dependent stats
     if (metadata?.latitude !== undefined && metadata?.longitude !== undefined) {
@@ -239,7 +267,15 @@ async function scanZipFile(
       progress.archived++;
     }
 
-    allItems.push({ path, file, metadata, albumName: undefined });
+    allItems.push({
+      path: descriptor.path,
+      name: descriptor.name,
+      size: descriptor.size,
+      lastModified: descriptor.lastModified,
+      getFile: () => getZipEntryFile(descriptor.entry, descriptor.name, descriptor.lastModified),
+      metadata,
+      albumName: undefined,
+    });
     onProgress?.(progress);
   }
 }

--- a/web/src/lib/utils/google-takeout-scanner.ts
+++ b/web/src/lib/utils/google-takeout-scanner.ts
@@ -227,7 +227,6 @@ async function scanZipFile(
             progress.albumNames.add(parts[2]);
           }
           onProgress?.(progress);
-
         } else if (isSidecarFile(entry.filename)) {
           if (entry.arrayBuffer) {
             const buffer = await entry.arrayBuffer();

--- a/web/src/lib/utils/google-takeout-scanner.ts
+++ b/web/src/lib/utils/google-takeout-scanner.ts
@@ -338,7 +338,10 @@ async function scanFolderFiles(
 
     const item: TakeoutMediaItem = {
       path: filePath,
-      file,
+      name: file.name,
+      size: file.size,
+      lastModified: file.lastModified,
+      getFile: async () => file,
       metadata,
       albumName: undefined,
     };

--- a/web/src/lib/utils/google-takeout-scanner.ts
+++ b/web/src/lib/utils/google-takeout-scanner.ts
@@ -355,7 +355,7 @@ async function scanFolderFiles(
       name: file.name,
       size: file.size,
       lastModified: file.lastModified,
-      getFile: async () => file,
+      getFile: () => Promise.resolve(file),
       metadata,
       albumName: undefined,
     };

--- a/web/src/lib/utils/google-takeout-scanner.ts
+++ b/web/src/lib/utils/google-takeout-scanner.ts
@@ -86,7 +86,6 @@ interface ZipMediaDescriptor {
   name: string;
   size: number;
   lastModified: number;
-  entry: ZipEntry;
 }
 
 function isZipFile(file: File): boolean {
@@ -106,7 +105,7 @@ function basename(path: string): string {
   return path.slice(Math.max(0, path.lastIndexOf('/') + 1));
 }
 
-async function getZipEntryFile(entry: ZipEntry, name: string, lastModified: number): Promise<File> {
+async function extractZipEntryFile(entry: ZipEntry, name: string, lastModified: number): Promise<File> {
   if (entry.arrayBuffer) {
     const buffer = await entry.arrayBuffer();
     return new File([buffer], name, { lastModified });
@@ -118,6 +117,23 @@ async function getZipEntryFile(entry: ZipEntry, name: string, lastModified: numb
   }
 
   throw new Error(`Zip entry "${entry.filename}" cannot be extracted`);
+}
+
+async function getZipEntryFile(zipFile: File, entryPath: string, name: string, lastModified: number): Promise<File> {
+  const { BlobReader, ZipReader } = await import('@zip.js/zip.js');
+  const reader = new ZipReader(new BlobReader(zipFile));
+
+  try {
+    const entries: ZipEntry[] = await reader.getEntries();
+    const entry = entries.find((entry) => entry.filename === entryPath);
+    if (!entry) {
+      throw new Error(`Zip entry "${entryPath}" not found`);
+    }
+
+    return await extractZipEntryFile(entry, name, lastModified);
+  } finally {
+    await reader.close();
+  }
 }
 
 function trackItemStats(
@@ -161,8 +177,7 @@ async function scanZipFile(
 ): Promise<void> {
   const { BlobReader, ZipReader, configure } = await import('@zip.js/zip.js');
 
-  // Disable web workers to avoid stream lifecycle issues during SvelteKit navigation
-  configure({ useWebWorkers: false });
+  configure({ useWebWorkers: true });
 
   const reader = new ZipReader(new BlobReader(zipFile));
 
@@ -203,7 +218,6 @@ async function scanZipFile(
             name,
             size: entry.uncompressedSize ?? 0,
             lastModified,
-            entry,
           });
 
           // Update progress counters while scanning so the UI shows activity.
@@ -272,7 +286,7 @@ async function scanZipFile(
       name: descriptor.name,
       size: descriptor.size,
       lastModified: descriptor.lastModified,
-      getFile: () => getZipEntryFile(descriptor.entry, descriptor.name, descriptor.lastModified),
+      getFile: () => getZipEntryFile(zipFile, descriptor.path, descriptor.name, descriptor.lastModified),
       metadata,
       albumName: undefined,
     });

--- a/web/src/lib/utils/google-takeout-uploader.spec.ts
+++ b/web/src/lib/utils/google-takeout-uploader.spec.ts
@@ -21,11 +21,16 @@ vi.mock('$lib/utils/album-utils', () => ({
 }));
 
 function makeItem(overrides: Partial<TakeoutMediaItem> = {}): TakeoutMediaItem {
-  const file = new File(['fake-image-data'], 'IMG_001.jpg', { type: 'image/jpeg' });
-  Object.defineProperty(file, 'lastModified', { value: 1_609_459_200_000 });
+  const file = new File(['fake-image-data'], 'IMG_001.jpg', {
+    type: 'image/jpeg',
+    lastModified: 1_609_459_200_000,
+  });
   return {
     path: 'Takeout/Google Photos/Trip/IMG_001.jpg',
-    file,
+    name: 'IMG_001.jpg',
+    size: file.size,
+    lastModified: 1_609_459_200_000,
+    getFile: vi.fn(async () => file),
     metadata: {
       title: 'IMG_001.jpg',
       description: 'A nice photo',
@@ -113,6 +118,82 @@ describe('uploadTakeoutItem', () => {
     const callArgs = utilsMock.uploadRequest.mock.calls[0][0];
     const formData = callArgs.data as FormData;
     expect(formData.get('isFavorite')).toBe('false');
+  });
+
+  it('loads the file through getFile once during upload', async () => {
+    utilsMock.uploadRequest.mockResolvedValue({
+      data: { id: 'asset-1', status: 'created' },
+      status: 201,
+    });
+
+    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+    const item = makeItem({ getFile, size: 'lazy-bytes'.length });
+
+    await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+    expect(getFile).toHaveBeenCalledOnce();
+    const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
+    const uploadedFile = formData.get('assetData') as File;
+    expect(uploadedFile.name).toBe('IMG_001.jpg');
+    expect(await uploadedFile.text()).toBe('lazy-bytes');
+  });
+
+  it('hashes lazy file bytes for duplicate checks at upload time', async () => {
+    vi.mocked(sdkMock.checkBulkUpload).mockResolvedValue({
+      results: [
+        {
+          id: 'IMG_001.jpg',
+          assetId: 'existing-asset-1',
+          action: AssetUploadAction.Reject,
+          reason: AssetRejectReason.Duplicate,
+        },
+      ],
+    });
+
+    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+    const item = makeItem({ getFile, size: 'lazy-bytes'.length });
+
+    const result = await uploadTakeoutItem(item, defaultOptions());
+
+    expect(getFile).toHaveBeenCalledOnce();
+    expect(sdkMock.checkBulkUpload).toHaveBeenCalledWith({
+      assetBulkUploadCheckDto: {
+        assets: [{ id: 'IMG_001.jpg', checksum: 'b2953b8e364061cea5600e64ec5049d63f08efbe' }],
+      },
+    });
+    expect(result).toEqual({ assetId: 'existing-asset-1', status: 'duplicate' });
+    expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
+  });
+
+  it('uses item name and lastModified metadata instead of file metadata', async () => {
+    utilsMock.uploadRequest.mockResolvedValue({
+      data: { id: 'asset-1', status: 'created' },
+      status: 201,
+    });
+
+    const file = new File(['bytes'], 'WRONG_NAME.jpg', { lastModified: 946_684_800_000 });
+    const item = makeItem({
+      name: 'IMG_FROM_ITEM.jpg',
+      lastModified: 1_609_459_200_000,
+      getFile: vi.fn(async () => file),
+      metadata: {
+        title: 'IMG_FROM_ITEM.jpg',
+        description: undefined,
+        dateTaken: undefined,
+        latitude: undefined,
+        longitude: undefined,
+        isFavorite: false,
+        isArchived: false,
+      },
+    });
+
+    await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+    const formData = utilsMock.uploadRequest.mock.calls[0][0].data as FormData;
+    const uploadedFile = formData.get('assetData') as File;
+    expect(formData.get('deviceAssetId')).toBe('takeout-IMG_FROM_ITEM.jpg-1609459200000');
+    expect(formData.get('fileCreatedAt')).toBe('2021-01-01T00:00:00.000Z');
+    expect(uploadedFile.name).toBe('IMG_FROM_ITEM.jpg');
   });
 
   it('calls updateAsset with GPS coordinates after upload', async () => {
@@ -234,6 +315,20 @@ describe('uploadTakeoutItem', () => {
 
     expect(result.status).toBe('error');
     expect(result.error).toContain('Network error');
+  });
+
+  it('returns an item error when lazy file loading fails', async () => {
+    const item = makeItem({
+      getFile: vi.fn(async () => {
+        throw new Error('Cannot extract zip entry');
+      }),
+    });
+
+    const result = await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Cannot extract zip entry');
+    expect(utilsMock.uploadRequest).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/lib/utils/google-takeout-uploader.spec.ts
+++ b/web/src/lib/utils/google-takeout-uploader.spec.ts
@@ -30,7 +30,7 @@ function makeItem(overrides: Partial<TakeoutMediaItem> = {}): TakeoutMediaItem {
     name: 'IMG_001.jpg',
     size: file.size,
     lastModified: 1_609_459_200_000,
-    getFile: vi.fn(async () => file),
+    getFile: vi.fn(() => Promise.resolve(file)),
     metadata: {
       title: 'IMG_001.jpg',
       description: 'A nice photo',
@@ -126,7 +126,9 @@ describe('uploadTakeoutItem', () => {
       status: 201,
     });
 
-    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+    const getFile = vi.fn(() =>
+      Promise.resolve(new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 })),
+    );
     const item = makeItem({ getFile, size: 'lazy-bytes'.length });
 
     await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });
@@ -150,7 +152,9 @@ describe('uploadTakeoutItem', () => {
       ],
     });
 
-    const getFile = vi.fn(async () => new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 }));
+    const getFile = vi.fn(() =>
+      Promise.resolve(new File(['lazy-bytes'], 'IMG_001.jpg', { lastModified: 1_609_459_200_000 })),
+    );
     const item = makeItem({ getFile, size: 'lazy-bytes'.length });
 
     const result = await uploadTakeoutItem(item, defaultOptions());
@@ -175,7 +179,7 @@ describe('uploadTakeoutItem', () => {
     const item = makeItem({
       name: 'IMG_FROM_ITEM.jpg',
       lastModified: 1_609_459_200_000,
-      getFile: vi.fn(async () => file),
+      getFile: vi.fn(() => Promise.resolve(file)),
       metadata: {
         title: 'IMG_FROM_ITEM.jpg',
         description: undefined,
@@ -319,9 +323,7 @@ describe('uploadTakeoutItem', () => {
 
   it('returns an item error when lazy file loading fails', async () => {
     const item = makeItem({
-      getFile: vi.fn(async () => {
-        throw new Error('Cannot extract zip entry');
-      }),
+      getFile: vi.fn(() => Promise.reject(new Error('Cannot extract zip entry'))),
     });
 
     const result = await uploadTakeoutItem(item, { ...defaultOptions(), skipDuplicates: false });

--- a/web/src/lib/utils/google-takeout-uploader.ts
+++ b/web/src/lib/utils/google-takeout-uploader.ts
@@ -28,19 +28,20 @@ async function computeSha1(file: File): Promise<string> {
 
 export async function uploadTakeoutItem(item: TakeoutMediaItem, options: ImportOptions): Promise<UploadResult> {
   try {
-    const deviceAssetId = 'takeout-' + item.file.name + '-' + item.file.lastModified;
+    const deviceAssetId = 'takeout-' + item.name + '-' + item.lastModified;
     const fileCreatedAt = item.metadata?.dateTaken
       ? item.metadata.dateTaken.toISOString()
-      : new Date(item.file.lastModified).toISOString();
+      : new Date(item.lastModified).toISOString();
+    const file = await item.getFile();
 
     // Duplicate check
     if (options.skipDuplicates && crypto?.subtle) {
       try {
-        const checksum = await computeSha1(item.file);
+        const checksum = await computeSha1(file);
         const {
           results: [checkResult],
         } = await checkBulkUpload({
-          assetBulkUploadCheckDto: { assets: [{ id: item.file.name, checksum }] },
+          assetBulkUploadCheckDto: { assets: [{ id: item.name, checksum }] },
         });
         if (checkResult.action === AssetUploadAction.Reject && checkResult.assetId) {
           return { assetId: checkResult.assetId, status: 'duplicate' };
@@ -58,7 +59,7 @@ export async function uploadTakeoutItem(item: TakeoutMediaItem, options: ImportO
     formData.append('fileModifiedAt', fileCreatedAt);
     formData.append('isFavorite', String(options.importFavorites && item.metadata?.isFavorite === true));
     formData.append('duration', '0:00:00.000000');
-    formData.append('assetData', new File([item.file], item.file.name));
+    formData.append('assetData', new File([file], item.name, { lastModified: item.lastModified }));
 
     // Upload
     const response = await uploadRequest<AssetMediaResponseDto>({


### PR DESCRIPTION
## Summary
- Refactor Google Takeout media items to store cheap metadata and load file bytes through `getFile()` only at upload time.
- Make zip scanning metadata-first: media entries are not decompressed during scan, sidecars remain extracted, and on-demand zip reads reopen a fresh `ZipReader` for the requested entry.
- Update folder imports, upload flow, import UI consumers, and tests for the lazy media item shape; enable zip.js web workers for scanning.

## Test Plan
- [x] `pnpm --dir web run lint`
- [x] `pnpm --dir web run check:typescript`
- [x] `pnpm --dir web run check:svelte`
- [x] `pnpm --dir web exec vitest run`
- [x] stale reference scan for `mediaBlobs`, `item.file`, old `TakeoutMediaItem` file shape

## Manual Testing
- [ ] Select a small Google Takeout zip in the import wizard.
- [ ] Scan, review, and upload the import.
- [ ] Confirm uploaded assets have expected names and sidecar metadata.
- [ ] Confirm albums are created for selected album folders.
