### PR TITLE
feat(web): improve location filter city search

### DIFF
--- a/docs/plans/2026-04-29-location-filter-city-search-design.md
+++ b/docs/plans/2026-04-29-location-filter-city-search-design.md
@@ -1,0 +1,111 @@
+# Location Filter City Search Design
+
+## Problem
+
+The filter panel location section currently caps and searches the country list, but selecting a country renders every city returned for that country. Countries with many cities, such as Germany, can make the filter panel extremely long and hard to scan. The current search input also does not help once the user needs a city inside an expanded country.
+
+## Goals
+
+- Keep the current country-to-city hierarchy.
+- Prevent expanded countries from rendering an unbounded city list.
+- Make the existing location search input search city names as well as country names.
+- Let users find and select a city without scrolling through all cities in a large country.
+- Preserve existing selection behavior: selecting a country filters by country, selecting a city filters by city and its country.
+- Keep route-level provider APIs unchanged unless implementation proves that impossible.
+
+## Non-Goals
+
+- Replacing the hierarchy with a flat location list.
+- Adding a second city-specific input.
+- Changing the smart facet API or backend search behavior.
+- Virtualizing the filter panel list.
+
+## User Experience
+
+The location filter continues to show countries first, with the existing `Search locations...` input. When no query is entered, the country list is capped as it is today. Opening a country fetches its cities, but only the first city batch is rendered. A `Show N more` action appears under that country when more cities are available.
+
+When the user types into the search input, the query matches both countries and cities. A country should remain visible when either the country name matches or one of its fetched city names matches. Matching cities should appear under their country so a query like `ber` can surface `Berlin` under `Germany`.
+
+Selected locations remain visible even when they fall outside the current cap or search result. Orphaned country behavior remains intact for selected countries that are no longer returned by contextual suggestions.
+
+## Component Design
+
+Changes are centered in `web/src/lib/components/filter-panel/location-filter.svelte`.
+
+The component should introduce a city display cap, separate from the existing country cap. A starting cap of 10 cities matches the existing country behavior and keeps the panel bounded. The city `Show N more` state should be tracked per country so expanding one country does not expand every country.
+
+The component currently stores one expanded country and one city result list. That can remain the default browsing model. For city search, the implementation should cache fetched city lists by country. When the search query is non-empty, it should fetch uncached city lists across the current country suggestions so city search is complete, not limited to the first visible country batch. The first implementation should avoid changing `FilterPanelConfig.providers.cities`; it can call the existing `onCityFetch(country, context)` callback as needed.
+
+The displayed country list should be derived from:
+
+- country name matches,
+- countries with city matches,
+- the selected country,
+- any orphaned selected country.
+
+The displayed city list for a country should be derived from:
+
+- the fetched city cache for that country,
+- the active search query,
+- the selected city,
+- that country's per-country city cap.
+
+## Data Flow
+
+`FilterPanel` continues to pass `countries`, `selectedCountry`, `selectedCity`, `context`, `onCityFetch`, and `onSelectionChange` to `LocationFilter`.
+
+`LocationFilter` handles all view-local search, city caching, caps, and show-more state. Selecting a country calls `onSelectionChange(country, undefined)`. Selecting a city calls `onSelectionChange(country, city)`.
+
+Contextual refetch behavior should remain compatible with temporal and other contextual filters. When `countries` or `context` changes, stale city cache entries should not cause incorrect city results. The implementation should clear or invalidate city cache entries when the country list changes or when context changes.
+
+Async city fetches should be guarded so older responses cannot overwrite newer results after the search query, expanded country, or context changes. A later fetch for the same country/context should win over earlier in-flight requests.
+
+## Error Handling
+
+If a city fetch fails, the component should stop loading for that country and keep the panel usable. Existing behavior does not surface an inline error, so the scoped change can continue logging or silently keeping previous city results. Failed city searches should not clear the selected country or city.
+
+## TDD Workflow
+
+Implementation must follow red-green-refactor:
+
+1. Add or update one focused `LocationFilter` test for the next behavior.
+2. Run the targeted test command and confirm the new test fails for the expected reason.
+3. Make the smallest component change that passes that test.
+4. Rerun the targeted test and confirm it passes.
+5. Refactor only after the behavior is green, then rerun the same tests.
+
+Do not write production code for this feature before a failing test exists. The first failing test should cover the core bug: expanding a country with more than the city cap does not render every city.
+
+## Testing
+
+Add focused tests to the existing `LocationFilter` tests in `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`.
+
+Cover:
+
+- expanded city lists are capped and show `Show N more`;
+- clicking the city-level show-more reveals hidden cities for only that country;
+- the location search matches city names and displays matching cities under the country;
+- city search finds a matching city in a country beyond the initial 10-country visible cap;
+- selecting a city from a city search still calls `onSelectionChange(country, city)`;
+- selected city remains visible even if it is outside the initial city cap;
+- selected country-only behavior still works: clicking an already-selected country with no city clears the location;
+- selected city behavior still works: clicking an already-selected city clears the city but keeps the country;
+- countries with zero cities do not show a city-level `Show more`;
+- no-results state waits for relevant city fetches during city search so a matching city is not hidden behind a premature `No matching locations` message;
+- city fetch failures leave the panel usable and do not clear the active selection;
+- city cache is refreshed or invalidated when countries/context changes;
+- stale in-flight city fetches do not overwrite newer search/context results.
+
+Run `pnpm --filter @immich/sdk build` in fresh worktrees before web tests if `@immich/sdk` has not been built yet. Use `pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts` for the targeted test file. After implementation, run that targeted file and the broader web check that is practical for the change.
+
+## Implementation Notes
+
+The preferred implementation keeps this as a component-local enhancement. Avoid backend changes and avoid changing route provider signatures unless the current API cannot support city search without excessive requests.
+
+Because city search across all countries can cause multiple provider calls, the implementation should limit repeated work with caching, context invalidation, and debounce/cancellation around the active query. The current country suggestion set is the search boundary.
+
+- continue fetching cities immediately for the expanded or selected country;
+- during search, fetch city lists for current countries that have not been cached for the active context;
+- show country-name matches immediately while city matches populate as fetches resolve.
+
+This keeps network/API work bounded by the current country facet list and preserves complete city search within the active filter context.

--- a/docs/plans/2026-04-29-location-filter-city-search-plan.md
+++ b/docs/plans/2026-04-29-location-filter-city-search-plan.md
@@ -46,6 +46,7 @@ pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests
 ## Task 0: Commit Reviewed Design And Plan
 
 **Files:**
+
 - Add: `docs/plans/2026-04-29-location-filter-city-search-design.md`
 - Add: `docs/plans/2026-04-29-location-filter-city-search-plan.md`
 
@@ -78,6 +79,7 @@ Expected: one docs commit on `feat/location-filter-city-search`.
 ## Task 1: Red Test For Capped City Lists
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 
 - [ ] **Step 1: Add tests before production code**
@@ -85,75 +87,75 @@ Expected: one docs commit on `feat/location-filter-city-search`.
 Add these tests inside `describe('LocationFilter', () => { ... })`, after `should show cities when country is expanded`. The first test is the required RED test for the core bug. The other two lock edge behavior before any production code is written.
 
 ```ts
-  it('should cap expanded city lists and expand cities with city-level show more', async () => {
-    const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+it('should cap expanded city lists and expand cities with city-level show more', async () => {
+  const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: ['Germany'],
-        onCityFetch: () => Promise.resolve(cities),
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
-
-    await waitFor(() => {
-      expect(queryByTestId('location-city-City 1')).toBeTruthy();
-      expect(queryByTestId('location-city-City 10')).toBeTruthy();
-      expect(queryByTestId('location-city-City 11')).toBeNull();
-      expect(queryByTestId('location-city-City 12')).toBeNull();
-      expect(getByTestId('location-city-show-more-Germany').textContent).toContain('Show 2 more');
-    });
-
-    await fireEvent.click(getByTestId('location-city-show-more-Germany'));
-
-    expect(queryByTestId('location-city-City 11')).toBeTruthy();
-    expect(queryByTestId('location-city-City 12')).toBeTruthy();
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: ['Germany'],
+      onCityFetch: () => Promise.resolve(cities),
+      onSelectionChange: () => {},
+    },
   });
 
-  it('should expand hidden cities only for the selected country city list', async () => {
-    const cityMap: Record<string, string[]> = {
-      Germany: Array.from({ length: 12 }, (_, index) => `German City ${index + 1}`),
-      France: Array.from({ length: 12 }, (_, index) => `French City ${index + 1}`),
-    };
+  await fireEvent.click(getByTestId('location-country-Germany'));
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: ['Germany', 'France'],
-        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
-    await waitFor(() => expect(queryByTestId('location-city-German City 11')).toBeNull());
-
-    await fireEvent.click(getByTestId('location-city-show-more-Germany'));
-    expect(queryByTestId('location-city-German City 11')).toBeTruthy();
-
-    await fireEvent.click(getByTestId('location-country-France'));
-    await waitFor(() => {
-      expect(queryByTestId('location-city-French City 10')).toBeTruthy();
-      expect(queryByTestId('location-city-French City 11')).toBeNull();
-    });
+  await waitFor(() => {
+    expect(queryByTestId('location-city-City 1')).toBeTruthy();
+    expect(queryByTestId('location-city-City 10')).toBeTruthy();
+    expect(queryByTestId('location-city-City 11')).toBeNull();
+    expect(queryByTestId('location-city-City 12')).toBeNull();
+    expect(getByTestId('location-city-show-more-Germany').textContent).toContain('Show 2 more');
   });
 
-  it('should not show city-level show more for countries with no cities', async () => {
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: ['Germany'],
-        onCityFetch: () => Promise.resolve([]),
-        onSelectionChange: () => {},
-      },
-    });
+  await fireEvent.click(getByTestId('location-city-show-more-Germany'));
 
-    await fireEvent.click(getByTestId('location-country-Germany'));
+  expect(queryByTestId('location-city-City 11')).toBeTruthy();
+  expect(queryByTestId('location-city-City 12')).toBeTruthy();
+});
 
-    await waitFor(() => {
-      expect(queryByTestId('location-city-show-more-Germany')).toBeNull();
-    });
+it('should expand hidden cities only for the selected country city list', async () => {
+  const cityMap: Record<string, string[]> = {
+    Germany: Array.from({ length: 12 }, (_, index) => `German City ${index + 1}`),
+    France: Array.from({ length: 12 }, (_, index) => `French City ${index + 1}`),
+  };
+
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: ['Germany', 'France'],
+      onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+      onSelectionChange: () => {},
+    },
   });
+
+  await fireEvent.click(getByTestId('location-country-Germany'));
+  await waitFor(() => expect(queryByTestId('location-city-German City 11')).toBeNull());
+
+  await fireEvent.click(getByTestId('location-city-show-more-Germany'));
+  expect(queryByTestId('location-city-German City 11')).toBeTruthy();
+
+  await fireEvent.click(getByTestId('location-country-France'));
+  await waitFor(() => {
+    expect(queryByTestId('location-city-French City 10')).toBeTruthy();
+    expect(queryByTestId('location-city-French City 11')).toBeNull();
+  });
+});
+
+it('should not show city-level show more for countries with no cities', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: ['Germany'],
+      onCityFetch: () => Promise.resolve([]),
+      onSelectionChange: () => {},
+    },
+  });
+
+  await fireEvent.click(getByTestId('location-country-Germany'));
+
+  await waitFor(() => {
+    expect(queryByTestId('location-city-show-more-Germany')).toBeNull();
+  });
+});
 ```
 
 - [ ] **Step 2: Run the targeted test and verify RED**
@@ -171,65 +173,65 @@ Expected: FAIL because `location-city-City 11` is currently rendered and `locati
 In `web/src/lib/components/filter-panel/location-filter.svelte`, replace:
 
 ```ts
-  let showAll = $state(false);
+let showAll = $state(false);
 
-  const INITIAL_SHOW_COUNT = 10;
+const INITIAL_SHOW_COUNT = 10;
 ```
 
 with:
 
 ```ts
-  let showAll = $state(false);
-  let expandedCityLists = $state<Record<string, boolean>>({});
+let showAll = $state(false);
+let expandedCityLists = $state<Record<string, boolean>>({});
 
-  const COUNTRY_SHOW_COUNT = 10;
-  const CITY_SHOW_COUNT = 10;
+const COUNTRY_SHOW_COUNT = 10;
+const CITY_SHOW_COUNT = 10;
 ```
 
 Replace current uses of `INITIAL_SHOW_COUNT` for country display with `COUNTRY_SHOW_COUNT`:
 
 ```ts
-  let visibleCountries = $derived(
-    searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, COUNTRY_SHOW_COUNT),
-  );
+let visibleCountries = $derived(
+  searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, COUNTRY_SHOW_COUNT),
+);
 
-  let remainingCount = $derived(Math.max(0, filteredCountries.length - COUNTRY_SHOW_COUNT));
+let remainingCount = $derived(Math.max(0, filteredCountries.length - COUNTRY_SHOW_COUNT));
 ```
 
 Add these helpers before `handleCountryClick`:
 
 ```ts
-  function getFilteredCities(country: string): string[] {
-    return cities;
-  }
+function getFilteredCities(country: string): string[] {
+  return cities;
+}
 
-  function getVisibleCities(country: string): string[] {
-    const filtered = getFilteredCities(country);
-    return expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
-  }
+function getVisibleCities(country: string): string[] {
+  const filtered = getFilteredCities(country);
+  return expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
+}
 
-  function getRemainingCityCount(country: string): number {
-    return Math.max(0, getFilteredCities(country).length - CITY_SHOW_COUNT);
-  }
+function getRemainingCityCount(country: string): number {
+  return Math.max(0, getFilteredCities(country).length - CITY_SHOW_COUNT);
+}
 
-  function showAllCities(country: string) {
-    expandedCityLists = { ...expandedCityLists, [country]: true };
-  }
+function showAllCities(country: string) {
+  expandedCityLists = { ...expandedCityLists, [country]: true };
+}
 ```
 
 Reset collapsed city state when opening a country by replacing `handleCountryClick` with:
 
 ```ts
-  function handleCountryClick(country: string) {
-    if (selectedCountry === country && !selectedCity) {
-      expandedCountry = undefined;
-      onSelectionChange(undefined, undefined);
-    } else {
-      expandedCountry = country;
-      expandedCityLists = { ...expandedCityLists, [country]: false };
-      onSelectionChange(country, undefined);
-    }
+function handleCountryClick(country: string) {
+  if (selectedCountry === country && !selectedCity) {
+    expandedCountry = undefined;
+    onSelectionChange(undefined, undefined);
+  } else {
+    expandedCountry = country;
+    expandedCityLists = { ...expandedCityLists, [country]: false };
+    onSelectionChange(country, undefined);
   }
+}
 ```
 
 Replace the city `#each` block:
@@ -279,6 +281,7 @@ git commit -m "feat: cap location city lists"
 ## Task 2: Complete City Search Across Current Country Suggestions
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 - Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
 
@@ -287,66 +290,66 @@ git commit -m "feat: cap location city lists"
 Add these tests inside the `LocationFilter` describe block:
 
 ```ts
-  it('should search city names and show matching cities under their country', async () => {
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: mockCountries,
-        onCityFetch: mockCityFetch,
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
-
-    await waitFor(() => {
-      expect(queryByTestId('location-country-Germany')).toBeTruthy();
-      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
-      expect(queryByTestId('location-country-Italy')).toBeNull();
-      expect(queryByTestId('location-city-Munich')).toBeNull();
-    });
+it('should search city names and show matching cities under their country', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
   });
 
-  it('should find a city in a country beyond the initial country cap', async () => {
-    const cityMap: Record<string, string[]> = {
-      Mexico: ['Merida'],
-    };
+  await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: manyCountries,
-        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
-        onSelectionChange: () => {},
-      },
-    });
+  await waitFor(() => {
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+    expect(queryByTestId('location-country-Italy')).toBeNull();
+    expect(queryByTestId('location-city-Munich')).toBeNull();
+  });
+});
 
-    expect(queryByTestId('location-country-Mexico')).toBeNull();
+it('should find a city in a country beyond the initial country cap', async () => {
+  const cityMap: Record<string, string[]> = {
+    Mexico: ['Merida'],
+  };
 
-    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'meri' } });
-
-    await waitFor(() => {
-      expect(queryByTestId('location-country-Mexico')).toBeTruthy();
-      expect(queryByTestId('location-city-Merida')).toBeTruthy();
-    });
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: manyCountries,
+      onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+      onSelectionChange: () => {},
+    },
   });
 
-  it('should select a city from city search results', async () => {
-    const onSelectionChange = vi.fn();
+  expect(queryByTestId('location-country-Mexico')).toBeNull();
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: mockCountries,
-        onCityFetch: mockCityFetch,
-        onSelectionChange,
-      },
-    });
+  await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'meri' } });
 
-    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
-
-    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
-    await fireEvent.click(getByTestId('location-city-Berlin'));
-
-    expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', 'Berlin');
+  await waitFor(() => {
+    expect(queryByTestId('location-country-Mexico')).toBeTruthy();
+    expect(queryByTestId('location-city-Merida')).toBeTruthy();
   });
+});
+
+it('should select a city from city search results', async () => {
+  const onSelectionChange = vi.fn();
+
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      onCityFetch: mockCityFetch,
+      onSelectionChange,
+    },
+  });
+
+  await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+  await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+  await fireEvent.click(getByTestId('location-city-Berlin'));
+
+  expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', 'Berlin');
+});
 ```
 
 - [ ] **Step 2: Run and verify RED**
@@ -364,134 +367,134 @@ Expected: FAIL because city search currently only filters countries and does not
 In `location-filter.svelte`, add a normalized query and cache state after `expandedCityLists`:
 
 ```ts
-  let cityCache = $state<Record<string, string[]>>({});
-  let loadingCitiesByCountry = $state<Record<string, boolean>>({});
-  let cityFetchErrors = $state<Record<string, boolean>>({});
-  let latestCityFetchIds = $state<Record<string, number>>({});
-  let cityFetchSequence = 0;
+let cityCache = $state<Record<string, string[]>>({});
+let loadingCitiesByCountry = $state<Record<string, boolean>>({});
+let cityFetchErrors = $state<Record<string, boolean>>({});
+let latestCityFetchIds = $state<Record<string, number>>({});
+let cityFetchSequence = 0;
 
-  let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
-  let cityCacheKey = $state('');
+let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
+let cityCacheKey = $state('');
 ```
 
 Add cache invalidation after the existing country-length reset effect:
 
 ```ts
-  $effect(() => {
-    const nextKey = JSON.stringify({ countries, context });
-    if (cityCacheKey && nextKey !== cityCacheKey) {
-      cityCache = {};
-      loadingCitiesByCountry = {};
-      cityFetchErrors = {};
-      latestCityFetchIds = {};
-      expandedCityLists = {};
-      cities = [];
-    }
-    cityCacheKey = nextKey;
-  });
+$effect(() => {
+  const nextKey = JSON.stringify({ countries, context });
+  if (cityCacheKey && nextKey !== cityCacheKey) {
+    cityCache = {};
+    loadingCitiesByCountry = {};
+    cityFetchErrors = {};
+    latestCityFetchIds = {};
+    expandedCityLists = {};
+    cities = [];
+  }
+  cityCacheKey = nextKey;
+});
 ```
 
 Add `ensureCities` before the existing city-fetching effect:
 
 ```ts
-  function ensureCities(country: string) {
-    if (cityCache[country] || loadingCitiesByCountry[country]) {
-      return;
-    }
-
-    const fetchId = ++cityFetchSequence;
-    const requestContext = context;
-    latestCityFetchIds = { ...latestCityFetchIds, [country]: fetchId };
-    loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: true };
-    cityFetchErrors = { ...cityFetchErrors, [country]: false };
-
-    void onCityFetch(country, requestContext)
-      .then((result) => {
-        if (latestCityFetchIds[country] !== fetchId) {
-          return;
-        }
-
-        cityCache = { ...cityCache, [country]: result };
-        loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: false };
-
-        if (selectedCountry === country && selectedCity && result.length > 0 && !result.includes(selectedCity)) {
-          onSelectionChange(country, undefined);
-        }
-      })
-      .catch((error) => {
-        console.error('Failed to fetch cities:', error);
-        if (latestCityFetchIds[country] !== fetchId) {
-          return;
-        }
-
-        loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: false };
-        cityFetchErrors = { ...cityFetchErrors, [country]: true };
-      });
+function ensureCities(country: string) {
+  if (cityCache[country] || loadingCitiesByCountry[country]) {
+    return;
   }
+
+  const fetchId = ++cityFetchSequence;
+  const requestContext = context;
+  latestCityFetchIds = { ...latestCityFetchIds, [country]: fetchId };
+  loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: true };
+  cityFetchErrors = { ...cityFetchErrors, [country]: false };
+
+  void onCityFetch(country, requestContext)
+    .then((result) => {
+      if (latestCityFetchIds[country] !== fetchId) {
+        return;
+      }
+
+      cityCache = { ...cityCache, [country]: result };
+      loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: false };
+
+      if (selectedCountry === country && selectedCity && result.length > 0 && !result.includes(selectedCity)) {
+        onSelectionChange(country, undefined);
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to fetch cities:', error);
+      if (latestCityFetchIds[country] !== fetchId) {
+        return;
+      }
+
+      loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: false };
+      cityFetchErrors = { ...cityFetchErrors, [country]: true };
+    });
+}
 ```
 
 Replace the existing `$effect` that directly calls `onCityFetch(expandedCountry, _context)` with:
 
 ```ts
-  $effect(() => {
-    if (expandedCountry) {
-      ensureCities(expandedCountry);
-      cities = cityCache[expandedCountry] ?? [];
-    } else {
-      cities = [];
+$effect(() => {
+  if (expandedCountry) {
+    ensureCities(expandedCountry);
+    cities = cityCache[expandedCountry] ?? [];
+  } else {
+    cities = [];
+  }
+});
+
+$effect(() => {
+  if (!selectedCountry) {
+    return;
+  }
+
+  ensureCities(selectedCountry);
+});
+
+$effect(() => {
+  if (!normalizedSearchQuery) {
+    return;
+  }
+
+  const timer = setTimeout(() => {
+    for (const country of countries) {
+      ensureCities(country);
     }
-  });
+  }, 150);
 
-  $effect(() => {
-    if (!selectedCountry) {
-      return;
-    }
-
-    ensureCities(selectedCountry);
-  });
-
-  $effect(() => {
-    if (!normalizedSearchQuery) {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      for (const country of countries) {
-        ensureCities(country);
-      }
-    }, 150);
-
-    return () => clearTimeout(timer);
-  });
+  return () => clearTimeout(timer);
+});
 ```
 
 Replace `filteredCountries` with:
 
 ```ts
-  let filteredCountries = $derived.by(() => {
-    if (!normalizedSearchQuery) {
-      return countries;
-    }
+let filteredCountries = $derived.by(() => {
+  if (!normalizedSearchQuery) {
+    return countries;
+  }
 
-    return countries.filter((country) => {
-      const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
-      const cityMatches = (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
-      return countryMatches || cityMatches || selectedCountry === country;
-    });
+  return countries.filter((country) => {
+    const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
+    const cityMatches = (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
+    return countryMatches || cityMatches || selectedCountry === country;
   });
+});
 ```
 
 Replace `getFilteredCities` with:
 
 ```ts
-  function getFilteredCities(country: string): string[] {
-    const cachedCities = cityCache[country] ?? (expandedCountry === country ? cities : []);
-    if (!normalizedSearchQuery) {
-      return cachedCities;
-    }
-
-    return cachedCities.filter((city) => city.toLowerCase().includes(normalizedSearchQuery));
+function getFilteredCities(country: string): string[] {
+  const cachedCities = cityCache[country] ?? (expandedCountry === country ? cities : []);
+  if (!normalizedSearchQuery) {
+    return cachedCities;
   }
+
+  return cachedCities.filter((city) => city.toLowerCase().includes(normalizedSearchQuery));
+}
 ```
 
 Change the city section condition:
@@ -520,6 +523,7 @@ git commit -m "feat: search location cities"
 ## Task 3: Selection Visibility And Toggle Edge Cases
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 - Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
 
@@ -528,82 +532,82 @@ git commit -m "feat: search location cities"
 Replace the existing `should preserve selected country across search/clear cycle` test with:
 
 ```ts
-  it('should keep selected country visible during search even when it does not match', async () => {
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: mockCountries,
-        selectedCountry: 'Germany',
-        onCityFetch: mockCityFetch,
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'Italy' } });
-
-    expect(queryByTestId('location-country-Germany')).toBeTruthy();
-    expect(queryByTestId('location-country-Italy')).toBeTruthy();
+it('should keep selected country visible during search even when it does not match', async () => {
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      selectedCountry: 'Germany',
+      onCityFetch: mockCityFetch,
+      onSelectionChange: () => {},
+    },
   });
+
+  await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'Italy' } });
+
+  expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  expect(queryByTestId('location-country-Italy')).toBeTruthy();
+});
 ```
 
 Add these tests inside the `LocationFilter` describe block:
 
 ```ts
-  it('should keep selected city visible when it is outside the initial city cap', async () => {
-    const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+it('should keep selected city visible when it is outside the initial city cap', async () => {
+  const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: ['Germany'],
-        selectedCountry: 'Germany',
-        selectedCity: 'City 12',
-        onCityFetch: () => Promise.resolve(cities),
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
-
-    await waitFor(() => {
-      expect(queryByTestId('location-city-City 12')).toBeTruthy();
-    });
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: ['Germany'],
+      selectedCountry: 'Germany',
+      selectedCity: 'City 12',
+      onCityFetch: () => Promise.resolve(cities),
+      onSelectionChange: () => {},
+    },
   });
 
-  it('should clear country selection when clicking an already-selected country with no selected city', async () => {
-    const onSelectionChange = vi.fn();
+  await fireEvent.click(getByTestId('location-country-Germany'));
 
-    const { getByTestId } = render(LocationFilter, {
-      props: {
-        countries: mockCountries,
-        selectedCountry: 'Germany',
-        onCityFetch: mockCityFetch,
-        onSelectionChange,
-      },
-    });
+  await waitFor(() => {
+    expect(queryByTestId('location-city-City 12')).toBeTruthy();
+  });
+});
 
-    await fireEvent.click(getByTestId('location-country-Germany'));
+it('should clear country selection when clicking an already-selected country with no selected city', async () => {
+  const onSelectionChange = vi.fn();
 
-    expect(onSelectionChange).toHaveBeenLastCalledWith(undefined, undefined);
+  const { getByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      selectedCountry: 'Germany',
+      onCityFetch: mockCityFetch,
+      onSelectionChange,
+    },
   });
 
-  it('should clear city selection but keep country when clicking an already-selected city', async () => {
-    const onSelectionChange = vi.fn();
+  await fireEvent.click(getByTestId('location-country-Germany'));
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: mockCountries,
-        selectedCountry: 'Germany',
-        selectedCity: 'Berlin',
-        onCityFetch: mockCityFetch,
-        onSelectionChange,
-      },
-    });
+  expect(onSelectionChange).toHaveBeenLastCalledWith(undefined, undefined);
+});
 
-    await fireEvent.click(getByTestId('location-country-Germany'));
-    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
-    await fireEvent.click(getByTestId('location-city-Berlin'));
+it('should clear city selection but keep country when clicking an already-selected city', async () => {
+  const onSelectionChange = vi.fn();
 
-    expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', undefined);
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: mockCountries,
+      selectedCountry: 'Germany',
+      selectedCity: 'Berlin',
+      onCityFetch: mockCityFetch,
+      onSelectionChange,
+    },
   });
+
+  await fireEvent.click(getByTestId('location-country-Germany'));
+  await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+  await fireEvent.click(getByTestId('location-city-Berlin'));
+
+  expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', undefined);
+});
 ```
 
 - [ ] **Step 2: Run and verify RED**
@@ -621,27 +625,27 @@ Expected: FAIL because selected city `City 12` is outside the initial city cap a
 Replace `getVisibleCities` with:
 
 ```ts
-  function getVisibleCities(country: string): string[] {
-    const filtered = getFilteredCities(country);
-    const visible = expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
+function getVisibleCities(country: string): string[] {
+  const filtered = getFilteredCities(country);
+  const visible = expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
 
-    if (
-      selectedCountry === country &&
-      selectedCity &&
-      (cityCache[country] ?? []).includes(selectedCity) &&
-      !visible.includes(selectedCity)
-    ) {
-      return [...visible, selectedCity];
-    }
-
-    return visible;
+  if (
+    selectedCountry === country &&
+    selectedCity &&
+    (cityCache[country] ?? []).includes(selectedCity) &&
+    !visible.includes(selectedCity)
+  ) {
+    return [...visible, selectedCity];
   }
+
+  return visible;
+}
 ```
 
 Verify the `filteredCountries` return expression is exactly:
 
 ```ts
-      return countryMatches || cityMatches || selectedCountry === country;
+return countryMatches || cityMatches || selectedCountry === country;
 ```
 
 - [ ] **Step 4: Run and verify GREEN**
@@ -664,6 +668,7 @@ git commit -m "fix: preserve selected location visibility"
 ## Task 4: Async Failures, Loading, And Stale Fetches
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 - Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
 
@@ -672,94 +677,95 @@ git commit -m "fix: preserve selected location visibility"
 Add these tests inside the `LocationFilter` describe block:
 
 ```ts
-  it('should not show no-results while city search fetches are still pending', async () => {
-    let resolveCities!: (cities: string[]) => void;
-    const pendingCities = new Promise<string[]>((resolve) => {
-      resolveCities = resolve;
-    });
-
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: ['Germany'],
-        onCityFetch: () => pendingCities,
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
-
-    expect(queryByTestId('location-no-results')).toBeNull();
-
-    resolveCities(['Berlin']);
-
-    await waitFor(() => {
-      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
-      expect(queryByTestId('location-no-results')).toBeNull();
-    });
+it('should not show no-results while city search fetches are still pending', async () => {
+  let resolveCities!: (cities: string[]) => void;
+  const pendingCities = new Promise<string[]>((resolve) => {
+    resolveCities = resolve;
   });
 
-  it('should keep the panel usable when a city fetch fails', async () => {
-    const onSelectionChange = vi.fn();
-
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
-      props: {
-        countries: ['Germany', 'France'],
-        selectedCountry: 'Germany',
-        onCityFetch: (country) => (country === 'Germany' ? Promise.reject(new Error('failed')) : Promise.resolve(['Paris'])),
-        onSelectionChange,
-      },
-    });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
-
-    await waitFor(() => {
-      expect(queryByTestId('location-country-Germany')).toBeTruthy();
-    });
-
-    await fireEvent.click(getByTestId('location-country-France'));
-    expect(onSelectionChange).toHaveBeenLastCalledWith('France', undefined);
-  });
-
-  it('should ignore stale city fetch responses after context changes', async () => {
-    let resolveFirst!: (cities: string[]) => void;
-    let resolveSecond!: (cities: string[]) => void;
-    const first = new Promise<string[]>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const second = new Promise<string[]>((resolve) => {
-      resolveSecond = resolve;
-    });
-    const cityFetch = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
-
-    const { getByTestId, queryByTestId, rerender } = render(LocationFilter, {
-      props: {
-        countries: ['Germany'],
-        context: { isFavorite: true },
-        onCityFetch: cityFetch,
-        onSelectionChange: () => {},
-      },
-    });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
-
-    await rerender({
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
       countries: ['Germany'],
-      context: { isFavorite: false },
+      onCityFetch: () => pendingCities,
+      onSelectionChange: () => {},
+    },
+  });
+
+  await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+  expect(queryByTestId('location-no-results')).toBeNull();
+
+  resolveCities(['Berlin']);
+
+  await waitFor(() => {
+    expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+    expect(queryByTestId('location-no-results')).toBeNull();
+  });
+});
+
+it('should keep the panel usable when a city fetch fails', async () => {
+  const onSelectionChange = vi.fn();
+
+  const { getByTestId, queryByTestId } = render(LocationFilter, {
+    props: {
+      countries: ['Germany', 'France'],
+      selectedCountry: 'Germany',
+      onCityFetch: (country) =>
+        country === 'Germany' ? Promise.reject(new Error('failed')) : Promise.resolve(['Paris']),
+      onSelectionChange,
+    },
+  });
+
+  await fireEvent.click(getByTestId('location-country-Germany'));
+
+  await waitFor(() => {
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+  });
+
+  await fireEvent.click(getByTestId('location-country-France'));
+  expect(onSelectionChange).toHaveBeenLastCalledWith('France', undefined);
+});
+
+it('should ignore stale city fetch responses after context changes', async () => {
+  let resolveFirst!: (cities: string[]) => void;
+  let resolveSecond!: (cities: string[]) => void;
+  const first = new Promise<string[]>((resolve) => {
+    resolveFirst = resolve;
+  });
+  const second = new Promise<string[]>((resolve) => {
+    resolveSecond = resolve;
+  });
+  const cityFetch = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+  const { getByTestId, queryByTestId, rerender } = render(LocationFilter, {
+    props: {
+      countries: ['Germany'],
+      context: { isFavorite: true },
       onCityFetch: cityFetch,
       onSelectionChange: () => {},
-    });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
-
-    resolveSecond(['Berlin']);
-    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
-
-    resolveFirst(['Munich']);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(queryByTestId('location-city-Berlin')).toBeTruthy();
-    expect(queryByTestId('location-city-Munich')).toBeNull();
+    },
   });
+
+  await fireEvent.click(getByTestId('location-country-Germany'));
+
+  await rerender({
+    countries: ['Germany'],
+    context: { isFavorite: false },
+    onCityFetch: cityFetch,
+    onSelectionChange: () => {},
+  });
+
+  await fireEvent.click(getByTestId('location-country-Germany'));
+
+  resolveSecond(['Berlin']);
+  await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+
+  resolveFirst(['Munich']);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+  expect(queryByTestId('location-city-Munich')).toBeNull();
+});
 ```
 
 - [ ] **Step 2: Run and verify RED**
@@ -777,15 +783,15 @@ Expected: FAIL because `location-no-results` appears before delayed city fetches
 Add this derived value near `filteredCountries`:
 
 ```ts
-  let hasPendingCitySearch = $derived.by(() => {
-    if (!normalizedSearchQuery) {
-      return false;
-    }
+let hasPendingCitySearch = $derived.by(() => {
+  if (!normalizedSearchQuery) {
+    return false;
+  }
 
-    return countries.some(
-      (country) => loadingCitiesByCountry[country] || (!cityCache[country] && !cityFetchErrors[country]),
-    );
-  });
+  return countries.some(
+    (country) => loadingCitiesByCountry[country] || (!cityCache[country] && !cityFetchErrors[country]),
+  );
+});
 ```
 
 Update the no-results condition:
@@ -799,19 +805,19 @@ Update the no-results condition:
 In the cache invalidation effect from Task 2, increment `cityFetchSequence` before clearing request IDs:
 
 ```ts
-      cityFetchSequence += 1;
+cityFetchSequence += 1;
 ```
 
 The invalidation effect should contain this exact block:
 
 ```ts
-      cityFetchSequence += 1;
-      cityCache = {};
-      loadingCitiesByCountry = {};
-      cityFetchErrors = {};
-      latestCityFetchIds = {};
-      expandedCityLists = {};
-      cities = [];
+cityFetchSequence += 1;
+cityCache = {};
+loadingCitiesByCountry = {};
+cityFetchErrors = {};
+latestCityFetchIds = {};
+expandedCityLists = {};
+cities = [];
 ```
 
 - [ ] **Step 4: Run and verify GREEN**
@@ -834,6 +840,7 @@ git commit -m "fix: handle location city fetch edge cases"
 ## Task 5: Final Refactor And Verification
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
 - Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
 
@@ -842,22 +849,22 @@ git commit -m "fix: handle location city fetch edge cases"
 In `location-filter.svelte`, keep the final state names clear:
 
 ```ts
-  const COUNTRY_SHOW_COUNT = 10;
-  const CITY_SHOW_COUNT = 10;
+const COUNTRY_SHOW_COUNT = 10;
+const CITY_SHOW_COUNT = 10;
 
-  let searchQuery = $state('');
-  let showAll = $state(false);
-  let expandedCityLists = $state<Record<string, boolean>>({});
-  let cityCache = $state<Record<string, string[]>>({});
-  let loadingCitiesByCountry = $state<Record<string, boolean>>({});
-  let cityFetchErrors = $state<Record<string, boolean>>({});
-  let latestCityFetchIds = $state<Record<string, number>>({});
+let searchQuery = $state('');
+let showAll = $state(false);
+let expandedCityLists = $state<Record<string, boolean>>({});
+let cityCache = $state<Record<string, string[]>>({});
+let loadingCitiesByCountry = $state<Record<string, boolean>>({});
+let cityFetchErrors = $state<Record<string, boolean>>({});
+let latestCityFetchIds = $state<Record<string, number>>({});
 ```
 
 Delete the old single-purpose loading state:
 
 ```ts
-  let loadingCities = $state(false);
+let loadingCities = $state(false);
 ```
 
 Replace any remaining `!loadingCities` template checks with:
@@ -869,7 +876,7 @@ Replace any remaining `!loadingCities` template checks with:
 Keep `cities` only as the expanded-country mirror used by the Task 2 effect:
 
 ```ts
-      cities = cityCache[expandedCountry] ?? [];
+cities = cityCache[expandedCountry] ?? [];
 ```
 
 - [ ] **Step 2: Run targeted tests**
@@ -901,6 +908,7 @@ git diff -- web/src/lib/components/filter-panel/location-filter.svelte web/src/l
 ```
 
 Verify these points manually from the diff:
+
 - no backend/API files changed;
 - `FilterPanelConfig.providers.cities` signature is unchanged;
 - city search is complete across `countries`, not only visible countries;

--- a/docs/plans/2026-04-29-location-filter-city-search-plan.md
+++ b/docs/plans/2026-04-29-location-filter-city-search-plan.md
@@ -1,0 +1,926 @@
+# Location Filter City Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the location filter searchable by city while keeping expanded country city lists bounded.
+
+**Architecture:** Keep the change local to `LocationFilter`. Add component-local city caching keyed by country, invalidate it when country suggestions or filter context changes, and derive displayed countries/cities from search query, selection, cached city matches, and per-country caps. Keep `FilterPanelConfig.providers.cities` unchanged.
+
+**Tech Stack:** Svelte 5, `@testing-library/svelte`, Vitest, existing `FilterPanel` provider callbacks.
+
+---
+
+## File Structure
+
+- Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
+  - Owns location search state, country cap, city cache, city cap, city fetch lifecycle, and selection callbacks.
+  - Do not add backend/API changes.
+  - Do not introduce plain `Map` or `Set` in the Svelte component. Use records or Svelte reactive collections.
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+  - Extend the existing `LocationFilter` describe block.
+  - Update existing expectations that conflict with the new design, especially selected location visibility during search.
+- Create: `docs/plans/2026-04-29-location-filter-city-search-plan.md`
+  - This implementation plan.
+
+## Commands
+
+Run once in a fresh worktree before web tests if the SDK has not already been built:
+
+```bash
+pnpm --filter @immich/sdk build
+```
+
+Targeted test command:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Broader practical verification after implementation:
+
+```bash
+pnpm --filter immich-web run check:svelte
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+## Task 0: Commit Reviewed Design And Plan
+
+**Files:**
+- Add: `docs/plans/2026-04-29-location-filter-city-search-design.md`
+- Add: `docs/plans/2026-04-29-location-filter-city-search-plan.md`
+
+- [ ] **Step 1: Verify the docs are the only untracked planned files**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected output includes:
+
+```text
+?? docs/plans/2026-04-29-location-filter-city-search-design.md
+?? docs/plans/2026-04-29-location-filter-city-search-plan.md
+```
+
+- [ ] **Step 2: Commit the reviewed docs**
+
+Run:
+
+```bash
+git add docs/plans/2026-04-29-location-filter-city-search-design.md docs/plans/2026-04-29-location-filter-city-search-plan.md
+git commit -m "docs: plan location city search"
+```
+
+Expected: one docs commit on `feat/location-filter-city-search`.
+
+## Task 1: Red Test For Capped City Lists
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+
+- [ ] **Step 1: Add tests before production code**
+
+Add these tests inside `describe('LocationFilter', () => { ... })`, after `should show cities when country is expanded`. The first test is the required RED test for the core bug. The other two lock edge behavior before any production code is written.
+
+```ts
+  it('should cap expanded city lists and expand cities with city-level show more', async () => {
+    const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        onCityFetch: () => Promise.resolve(cities),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-City 1')).toBeTruthy();
+      expect(queryByTestId('location-city-City 10')).toBeTruthy();
+      expect(queryByTestId('location-city-City 11')).toBeNull();
+      expect(queryByTestId('location-city-City 12')).toBeNull();
+      expect(getByTestId('location-city-show-more-Germany').textContent).toContain('Show 2 more');
+    });
+
+    await fireEvent.click(getByTestId('location-city-show-more-Germany'));
+
+    expect(queryByTestId('location-city-City 11')).toBeTruthy();
+    expect(queryByTestId('location-city-City 12')).toBeTruthy();
+  });
+
+  it('should expand hidden cities only for the selected country city list', async () => {
+    const cityMap: Record<string, string[]> = {
+      Germany: Array.from({ length: 12 }, (_, index) => `German City ${index + 1}`),
+      France: Array.from({ length: 12 }, (_, index) => `French City ${index + 1}`),
+    };
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'France'],
+        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(queryByTestId('location-city-German City 11')).toBeNull());
+
+    await fireEvent.click(getByTestId('location-city-show-more-Germany'));
+    expect(queryByTestId('location-city-German City 11')).toBeTruthy();
+
+    await fireEvent.click(getByTestId('location-country-France'));
+    await waitFor(() => {
+      expect(queryByTestId('location-city-French City 10')).toBeTruthy();
+      expect(queryByTestId('location-city-French City 11')).toBeNull();
+    });
+  });
+
+  it('should not show city-level show more for countries with no cities', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        onCityFetch: () => Promise.resolve([]),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-show-more-Germany')).toBeNull();
+    });
+  });
+```
+
+- [ ] **Step 2: Run the targeted test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: FAIL because `location-city-City 11` is currently rendered and `location-city-show-more-Germany` does not exist. Do not proceed unless the first new test fails for that reason.
+
+- [ ] **Step 3: Implement the minimal city cap**
+
+In `web/src/lib/components/filter-panel/location-filter.svelte`, replace:
+
+```ts
+  let showAll = $state(false);
+
+  const INITIAL_SHOW_COUNT = 10;
+```
+
+with:
+
+```ts
+  let showAll = $state(false);
+  let expandedCityLists = $state<Record<string, boolean>>({});
+
+  const COUNTRY_SHOW_COUNT = 10;
+  const CITY_SHOW_COUNT = 10;
+```
+
+Replace current uses of `INITIAL_SHOW_COUNT` for country display with `COUNTRY_SHOW_COUNT`:
+
+```ts
+  let visibleCountries = $derived(
+    searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, COUNTRY_SHOW_COUNT),
+  );
+
+  let remainingCount = $derived(Math.max(0, filteredCountries.length - COUNTRY_SHOW_COUNT));
+```
+
+Add these helpers before `handleCountryClick`:
+
+```ts
+  function getFilteredCities(country: string): string[] {
+    return cities;
+  }
+
+  function getVisibleCities(country: string): string[] {
+    const filtered = getFilteredCities(country);
+    return expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
+  }
+
+  function getRemainingCityCount(country: string): number {
+    return Math.max(0, getFilteredCities(country).length - CITY_SHOW_COUNT);
+  }
+
+  function showAllCities(country: string) {
+    expandedCityLists = { ...expandedCityLists, [country]: true };
+  }
+```
+
+Reset collapsed city state when opening a country by replacing `handleCountryClick` with:
+
+```ts
+  function handleCountryClick(country: string) {
+    if (selectedCountry === country && !selectedCity) {
+      expandedCountry = undefined;
+      onSelectionChange(undefined, undefined);
+    } else {
+      expandedCountry = country;
+      expandedCityLists = { ...expandedCityLists, [country]: false };
+      onSelectionChange(country, undefined);
+    }
+  }
+```
+
+Replace the city `#each` block:
+
+```svelte
+        {#each cities as city (city)}
+```
+
+with:
+
+```svelte
+        {#each getVisibleCities(country) as city (city)}
+```
+
+Add this immediately after the city `#each` block and still inside `expandedCountry === country && !loadingCities`:
+
+```svelte
+        {#if !expandedCityLists[country] && getRemainingCityCount(country) > 0}
+          <button
+            type="button"
+            class="ml-5 py-1 text-xs font-medium text-immich-primary dark:text-immich-dark-primary"
+            onclick={() => showAllCities(country)}
+            data-testid="location-city-show-more-{country}"
+          >
+            Show {getRemainingCityCount(country)} more
+          </button>
+        {/if}
+```
+
+- [ ] **Step 4: Run the targeted test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: PASS for the new cap test and all existing `LocationFilter` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/location-filter.svelte web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+git commit -m "feat: cap location city lists"
+```
+
+## Task 2: Complete City Search Across Current Country Suggestions
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+- Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
+
+- [ ] **Step 1: Add failing city-search tests**
+
+Add these tests inside the `LocationFilter` describe block:
+
+```ts
+  it('should search city names and show matching cities under their country', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Germany')).toBeTruthy();
+      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+      expect(queryByTestId('location-country-Italy')).toBeNull();
+      expect(queryByTestId('location-city-Munich')).toBeNull();
+    });
+  });
+
+  it('should find a city in a country beyond the initial country cap', async () => {
+    const cityMap: Record<string, string[]> = {
+      Mexico: ['Merida'],
+    };
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onSelectionChange: () => {},
+      },
+    });
+
+    expect(queryByTestId('location-country-Mexico')).toBeNull();
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'meri' } });
+
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Mexico')).toBeTruthy();
+      expect(queryByTestId('location-city-Merida')).toBeTruthy();
+    });
+  });
+
+  it('should select a city from city search results', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+    await fireEvent.click(getByTestId('location-city-Berlin'));
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', 'Berlin');
+  });
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: FAIL because city search currently only filters countries and does not fetch/search cities.
+
+- [ ] **Step 3: Add city cache and search fetching**
+
+In `location-filter.svelte`, add a normalized query and cache state after `expandedCityLists`:
+
+```ts
+  let cityCache = $state<Record<string, string[]>>({});
+  let loadingCitiesByCountry = $state<Record<string, boolean>>({});
+  let cityFetchErrors = $state<Record<string, boolean>>({});
+  let latestCityFetchIds = $state<Record<string, number>>({});
+  let cityFetchSequence = 0;
+
+  let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
+  let cityCacheKey = $state('');
+```
+
+Add cache invalidation after the existing country-length reset effect:
+
+```ts
+  $effect(() => {
+    const nextKey = JSON.stringify({ countries, context });
+    if (cityCacheKey && nextKey !== cityCacheKey) {
+      cityCache = {};
+      loadingCitiesByCountry = {};
+      cityFetchErrors = {};
+      latestCityFetchIds = {};
+      expandedCityLists = {};
+      cities = [];
+    }
+    cityCacheKey = nextKey;
+  });
+```
+
+Add `ensureCities` before the existing city-fetching effect:
+
+```ts
+  function ensureCities(country: string) {
+    if (cityCache[country] || loadingCitiesByCountry[country]) {
+      return;
+    }
+
+    const fetchId = ++cityFetchSequence;
+    const requestContext = context;
+    latestCityFetchIds = { ...latestCityFetchIds, [country]: fetchId };
+    loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: true };
+    cityFetchErrors = { ...cityFetchErrors, [country]: false };
+
+    void onCityFetch(country, requestContext)
+      .then((result) => {
+        if (latestCityFetchIds[country] !== fetchId) {
+          return;
+        }
+
+        cityCache = { ...cityCache, [country]: result };
+        loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: false };
+
+        if (selectedCountry === country && selectedCity && result.length > 0 && !result.includes(selectedCity)) {
+          onSelectionChange(country, undefined);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to fetch cities:', error);
+        if (latestCityFetchIds[country] !== fetchId) {
+          return;
+        }
+
+        loadingCitiesByCountry = { ...loadingCitiesByCountry, [country]: false };
+        cityFetchErrors = { ...cityFetchErrors, [country]: true };
+      });
+  }
+```
+
+Replace the existing `$effect` that directly calls `onCityFetch(expandedCountry, _context)` with:
+
+```ts
+  $effect(() => {
+    if (expandedCountry) {
+      ensureCities(expandedCountry);
+      cities = cityCache[expandedCountry] ?? [];
+    } else {
+      cities = [];
+    }
+  });
+
+  $effect(() => {
+    if (!selectedCountry) {
+      return;
+    }
+
+    ensureCities(selectedCountry);
+  });
+
+  $effect(() => {
+    if (!normalizedSearchQuery) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      for (const country of countries) {
+        ensureCities(country);
+      }
+    }, 150);
+
+    return () => clearTimeout(timer);
+  });
+```
+
+Replace `filteredCountries` with:
+
+```ts
+  let filteredCountries = $derived.by(() => {
+    if (!normalizedSearchQuery) {
+      return countries;
+    }
+
+    return countries.filter((country) => {
+      const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
+      const cityMatches = (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
+      return countryMatches || cityMatches || selectedCountry === country;
+    });
+  });
+```
+
+Replace `getFilteredCities` with:
+
+```ts
+  function getFilteredCities(country: string): string[] {
+    const cachedCities = cityCache[country] ?? (expandedCountry === country ? cities : []);
+    if (!normalizedSearchQuery) {
+      return cachedCities;
+    }
+
+    return cachedCities.filter((city) => city.toLowerCase().includes(normalizedSearchQuery));
+  }
+```
+
+Change the city section condition:
+
+```svelte
+      {#if (expandedCountry === country || (normalizedSearchQuery && (cityCache[country] ?? []).length > 0)) && !loadingCitiesByCountry[country]}
+```
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: PASS for the three city-search tests and existing country search tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/location-filter.svelte web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+git commit -m "feat: search location cities"
+```
+
+## Task 3: Selection Visibility And Toggle Edge Cases
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+- Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
+
+- [ ] **Step 1: Update/add failing selection tests**
+
+Replace the existing `should preserve selected country across search/clear cycle` test with:
+
+```ts
+  it('should keep selected country visible during search even when it does not match', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        selectedCountry: 'Germany',
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'Italy' } });
+
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    expect(queryByTestId('location-country-Italy')).toBeTruthy();
+  });
+```
+
+Add these tests inside the `LocationFilter` describe block:
+
+```ts
+  it('should keep selected city visible when it is outside the initial city cap', async () => {
+    const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        selectedCountry: 'Germany',
+        selectedCity: 'City 12',
+        onCityFetch: () => Promise.resolve(cities),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-City 12')).toBeTruthy();
+    });
+  });
+
+  it('should clear country selection when clicking an already-selected country with no selected city', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        selectedCountry: 'Germany',
+        onCityFetch: mockCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(undefined, undefined);
+  });
+
+  it('should clear city selection but keep country when clicking an already-selected city', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        selectedCountry: 'Germany',
+        selectedCity: 'Berlin',
+        onCityFetch: mockCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+    await fireEvent.click(getByTestId('location-city-Berlin'));
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', undefined);
+  });
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: FAIL because selected city `City 12` is outside the initial city cap and is not rendered.
+
+- [ ] **Step 3: Preserve selected country/city in derived lists**
+
+Replace `getVisibleCities` with:
+
+```ts
+  function getVisibleCities(country: string): string[] {
+    const filtered = getFilteredCities(country);
+    const visible = expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
+
+    if (
+      selectedCountry === country &&
+      selectedCity &&
+      (cityCache[country] ?? []).includes(selectedCity) &&
+      !visible.includes(selectedCity)
+    ) {
+      return [...visible, selectedCity];
+    }
+
+    return visible;
+  }
+```
+
+Verify the `filteredCountries` return expression is exactly:
+
+```ts
+      return countryMatches || cityMatches || selectedCountry === country;
+```
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/location-filter.svelte web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+git commit -m "fix: preserve selected location visibility"
+```
+
+## Task 4: Async Failures, Loading, And Stale Fetches
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+- Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
+
+- [ ] **Step 1: Add failing async edge-case tests**
+
+Add these tests inside the `LocationFilter` describe block:
+
+```ts
+  it('should not show no-results while city search fetches are still pending', async () => {
+    let resolveCities!: (cities: string[]) => void;
+    const pendingCities = new Promise<string[]>((resolve) => {
+      resolveCities = resolve;
+    });
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        onCityFetch: () => pendingCities,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+    expect(queryByTestId('location-no-results')).toBeNull();
+
+    resolveCities(['Berlin']);
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+      expect(queryByTestId('location-no-results')).toBeNull();
+    });
+  });
+
+  it('should keep the panel usable when a city fetch fails', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'France'],
+        selectedCountry: 'Germany',
+        onCityFetch: (country) => (country === 'Germany' ? Promise.reject(new Error('failed')) : Promise.resolve(['Paris'])),
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    });
+
+    await fireEvent.click(getByTestId('location-country-France'));
+    expect(onSelectionChange).toHaveBeenLastCalledWith('France', undefined);
+  });
+
+  it('should ignore stale city fetch responses after context changes', async () => {
+    let resolveFirst!: (cities: string[]) => void;
+    let resolveSecond!: (cities: string[]) => void;
+    const first = new Promise<string[]>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<string[]>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const cityFetch = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+    const { getByTestId, queryByTestId, rerender } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        context: { isFavorite: true },
+        onCityFetch: cityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await rerender({
+      countries: ['Germany'],
+      context: { isFavorite: false },
+      onCityFetch: cityFetch,
+      onSelectionChange: () => {},
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    resolveSecond(['Berlin']);
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+
+    resolveFirst(['Munich']);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+    expect(queryByTestId('location-city-Munich')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: FAIL because `location-no-results` appears before delayed city fetches have resolved, and stale in-flight city responses are not fully invalidated across context changes.
+
+- [ ] **Step 3: Add loading/no-results and stale guards**
+
+Add this derived value near `filteredCountries`:
+
+```ts
+  let hasPendingCitySearch = $derived.by(() => {
+    if (!normalizedSearchQuery) {
+      return false;
+    }
+
+    return countries.some(
+      (country) => loadingCitiesByCountry[country] || (!cityCache[country] && !cityFetchErrors[country]),
+    );
+  });
+```
+
+Update the no-results condition:
+
+```svelte
+    {#if filteredCountries.length === 0 && searchQuery.trim() && !hasPendingCitySearch}
+      <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-no-results">No matching locations</p>
+    {/if}
+```
+
+In the cache invalidation effect from Task 2, increment `cityFetchSequence` before clearing request IDs:
+
+```ts
+      cityFetchSequence += 1;
+```
+
+The invalidation effect should contain this exact block:
+
+```ts
+      cityFetchSequence += 1;
+      cityCache = {};
+      loadingCitiesByCountry = {};
+      cityFetchErrors = {};
+      latestCityFetchIds = {};
+      expandedCityLists = {};
+      cities = [];
+```
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/location-filter.svelte web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+git commit -m "fix: handle location city fetch edge cases"
+```
+
+## Task 5: Final Refactor And Verification
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/location-filter.svelte`
+- Modify: `web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts`
+
+- [ ] **Step 1: Refactor names and remove dead state**
+
+In `location-filter.svelte`, keep the final state names clear:
+
+```ts
+  const COUNTRY_SHOW_COUNT = 10;
+  const CITY_SHOW_COUNT = 10;
+
+  let searchQuery = $state('');
+  let showAll = $state(false);
+  let expandedCityLists = $state<Record<string, boolean>>({});
+  let cityCache = $state<Record<string, string[]>>({});
+  let loadingCitiesByCountry = $state<Record<string, boolean>>({});
+  let cityFetchErrors = $state<Record<string, boolean>>({});
+  let latestCityFetchIds = $state<Record<string, number>>({});
+```
+
+Delete the old single-purpose loading state:
+
+```ts
+  let loadingCities = $state(false);
+```
+
+Replace any remaining `!loadingCities` template checks with:
+
+```svelte
+!loadingCitiesByCountry[country]
+```
+
+Keep `cities` only as the expanded-country mirror used by the Task 2 effect:
+
+```ts
+      cities = cityCache[expandedCountry] ?? [];
+```
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Svelte check**
+
+Run:
+
+```bash
+pnpm --filter immich-web run check:svelte
+```
+
+Expected: PASS. Existing `state_referenced_locally` warnings in unrelated files are acceptable only if the command exits 0; do not add new warnings in `location-filter.svelte`.
+
+- [ ] **Step 4: Review diff**
+
+Run:
+
+```bash
+git diff -- web/src/lib/components/filter-panel/location-filter.svelte web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts docs/plans/2026-04-29-location-filter-city-search-design.md docs/plans/2026-04-29-location-filter-city-search-plan.md
+```
+
+Verify these points manually from the diff:
+- no backend/API files changed;
+- `FilterPanelConfig.providers.cities` signature is unchanged;
+- city search is complete across `countries`, not only visible countries;
+- selected country and selected city remain visible;
+- stale fetches are guarded;
+- no broad unrelated refactors are present.
+
+- [ ] **Step 5: Commit final refactor**
+
+```bash
+git add web/src/lib/components/filter-panel/location-filter.svelte web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+git commit -m "refactor: clean up location city search"
+```
+
+- [ ] **Step 6: Verify branch status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output.

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -318,6 +318,76 @@ describe('LocationFilter', () => {
     });
   });
 
+  it('should cap expanded city lists and expand cities with city-level show more', async () => {
+    const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        onCityFetch: () => Promise.resolve(cities),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-City 1')).toBeTruthy();
+      expect(queryByTestId('location-city-City 10')).toBeTruthy();
+      expect(queryByTestId('location-city-City 11')).toBeNull();
+      expect(queryByTestId('location-city-City 12')).toBeNull();
+      expect(getByTestId('location-city-show-more-Germany').textContent).toContain('Show 2 more');
+    });
+
+    await fireEvent.click(getByTestId('location-city-show-more-Germany'));
+
+    expect(queryByTestId('location-city-City 11')).toBeTruthy();
+    expect(queryByTestId('location-city-City 12')).toBeTruthy();
+  });
+
+  it('should expand hidden cities only for the selected country city list', async () => {
+    const cityMap: Record<string, string[]> = {
+      Germany: Array.from({ length: 12 }, (_, index) => `German City ${index + 1}`),
+      France: Array.from({ length: 12 }, (_, index) => `French City ${index + 1}`),
+    };
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'France'],
+        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(queryByTestId('location-city-German City 11')).toBeNull());
+
+    await fireEvent.click(getByTestId('location-city-show-more-Germany'));
+    expect(queryByTestId('location-city-German City 11')).toBeTruthy();
+
+    await fireEvent.click(getByTestId('location-country-France'));
+    await waitFor(() => {
+      expect(queryByTestId('location-city-French City 10')).toBeTruthy();
+      expect(queryByTestId('location-city-French City 11')).toBeNull();
+    });
+  });
+
+  it('should not show city-level show more for countries with no cities', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        onCityFetch: () => Promise.resolve([]),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-show-more-Germany')).toBeNull();
+    });
+  });
+
   it('should auto-fill country when city is selected', async () => {
     let lastCountry: string | undefined;
     let lastCity: string | undefined;

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -347,18 +347,17 @@ describe('LocationFilter', () => {
 
   it('should keep a selected city visible when it is outside the initial city cap', async () => {
     const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+    const onSelectionChange = vi.fn();
 
-    const { getByTestId, queryByTestId } = render(LocationFilter, {
+    const { queryByTestId } = render(LocationFilter, {
       props: {
         countries: ['Germany'],
         selectedCountry: 'Germany',
         selectedCity: 'City 11',
         onCityFetch: () => Promise.resolve(cities),
-        onSelectionChange: () => {},
+        onSelectionChange,
       },
     });
-
-    await fireEvent.click(getByTestId('location-country-Germany'));
 
     await waitFor(() => {
       expect(queryByTestId('location-city-City 10')).toBeTruthy();
@@ -366,6 +365,7 @@ describe('LocationFilter', () => {
       expect(queryByTestId('location-city-City 12')).toBeNull();
       expect(queryByTestId('location-city-show-more-Germany')).toBeTruthy();
     });
+    expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
   it('should expand hidden cities only for the selected country city list', async () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -833,7 +833,7 @@ describe('LocationFilter', () => {
     expect(queryByTestId('location-country-Germany')).toBeNull();
   });
 
-  it('should preserve selected country across search/clear cycle', async () => {
+  it('should keep selected country visible during search', async () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
         countries: mockCountries,
@@ -845,11 +845,10 @@ describe('LocationFilter', () => {
 
     const searchInput = getByTestId('location-search-input');
 
-    // Search hides Germany
     await fireEvent.input(searchInput, { target: { value: 'Italy' } });
-    expect(queryByTestId('location-country-Germany')).toBeNull();
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    expect(queryByTestId('location-country-Italy')).toBeTruthy();
 
-    // Clear search — Germany reappears
     await fireEvent.input(searchInput, { target: { value: '' } });
     expect(queryByTestId('location-country-Germany')).toBeTruthy();
   });

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -489,6 +489,43 @@ describe('LocationFilter', () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
+  it('should recover when a city fetch rejects and another country is selected', async () => {
+    let rejectGermany!: (error: Error) => void;
+    let resolveFrance!: (cities: string[]) => void;
+    const germanyPromise = new Promise<string[]>((_, reject) => {
+      rejectGermany = reject;
+    });
+    const francePromise = new Promise<string[]>((resolve) => {
+      resolveFrance = resolve;
+    });
+    const onCityFetch = vi.fn((country: string) => (country === 'Germany' ? germanyPromise : francePromise));
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'France'],
+        onCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('Germany', undefined));
+
+    rejectGermany(new Error('city fetch failed'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await fireEvent.click(getByTestId('location-country-France'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('France', undefined));
+
+    resolveFrance(['Paris']);
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Paris')).toBeTruthy();
+      expect(queryByTestId('location-city-Munich')).toBeNull();
+    });
+    expect(onSelectionChange).toHaveBeenCalledWith('France', undefined);
+  });
+
   it('should not show city-level show more for countries with no cities', async () => {
     const fetchPromise = Promise.resolve([]);
     const onCityFetch = vi.fn(() => fetchPromise);

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -662,6 +662,67 @@ describe('LocationFilter', () => {
     expect(queryByTestId('location-country-Italy')).toBeNull();
   });
 
+  it('should search city names and show matching cities under their country', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Germany')).toBeTruthy();
+      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+      expect(queryByTestId('location-country-Italy')).toBeNull();
+      expect(queryByTestId('location-city-Munich')).toBeNull();
+    });
+  });
+
+  it('should find a city in a country beyond the initial country cap', async () => {
+    const cityMap: Record<string, string[]> = {
+      Mexico: ['Merida'],
+    };
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onSelectionChange: () => {},
+      },
+    });
+
+    expect(queryByTestId('location-country-Mexico')).toBeNull();
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'meri' } });
+
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Mexico')).toBeTruthy();
+      expect(queryByTestId('location-city-Merida')).toBeTruthy();
+    });
+  });
+
+  it('should select a city from city search results', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: mockCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ber' } });
+
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+    await fireEvent.click(getByTestId('location-city-Berlin'));
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith('Germany', 'Berlin');
+  });
+
   it('should search case-insensitively', async () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -360,7 +360,8 @@ describe('LocationFilter', () => {
     });
 
     await waitFor(() => {
-      expect(queryByTestId('location-city-City 10')).toBeTruthy();
+      expect(queryByTestId('location-city-City 9')).toBeTruthy();
+      expect(queryByTestId('location-city-City 10')).toBeNull();
       expect(queryByTestId('location-city-City 11')).toBeTruthy();
       expect(queryByTestId('location-city-City 12')).toBeNull();
       expect(queryByTestId('location-city-show-more-Germany')).toBeTruthy();

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -721,6 +721,35 @@ describe('LocationFilter', () => {
     });
   });
 
+  it('should not show no-results while city search fetches are pending', async () => {
+    let resolveSwitzerland!: (cities: string[]) => void;
+    const switzerlandPromise = new Promise<string[]>((resolve) => {
+      resolveSwitzerland = resolve;
+    });
+    const onCityFetch = vi.fn((country: string) => (country === 'Switzerland' ? switzerlandPromise : Promise.resolve([])));
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'Switzerland'],
+        onCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'gene' } });
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('Switzerland', undefined));
+
+    expect(queryByTestId('location-no-results')).toBeNull();
+
+    resolveSwitzerland(['Geneva']);
+
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Switzerland')).toBeTruthy();
+      expect(queryByTestId('location-city-Geneva')).toBeTruthy();
+      expect(queryByTestId('location-no-results')).toBeNull();
+    });
+  });
+
   it('should find a city in a country beyond the initial country cap', async () => {
     const cityMap: Record<string, string[]> = {
       Mexico: ['Merida'],

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -369,6 +369,29 @@ describe('LocationFilter', () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
+  it('should keep a selected city visible when it does not match the active search', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'Italy'],
+        selectedCountry: 'Germany',
+        selectedCity: 'Berlin',
+        onCityFetch: () => Promise.resolve(['Berlin', 'Munich']),
+        onSelectionChange,
+      },
+    });
+
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'Italy' } });
+
+    expect(queryByTestId('location-country-Germany')).toBeTruthy();
+    expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+    expect(queryByTestId('location-country-Italy')).toBeTruthy();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
   it('should expand hidden cities only for the selected country city list', async () => {
     const cityMap: Record<string, string[]> = {
       Germany: Array.from({ length: 12 }, (_, index) => `German City ${index + 1}`),
@@ -677,6 +700,25 @@ describe('LocationFilter', () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
 
     expect(onCityFetch).not.toHaveBeenCalled();
+  });
+
+  it('should not use cached city matches for one-character searches', async () => {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        onCityFetch: () => Promise.resolve(['Berlin']),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'b' } });
+
+    expect(queryByTestId('location-country-Germany')).toBeNull();
+    expect(queryByTestId('location-city-Berlin')).toBeNull();
+    expect(getByTestId('location-no-results').textContent).toBe('No matching locations');
   });
 
   it('should search matching city names when the query also matches a country name', async () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -441,6 +441,54 @@ describe('LocationFilter', () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
+  it('should ignore stale same-country city fetch responses after context changes', async () => {
+    let resolveFirstGermany!: (cities: string[]) => void;
+    let resolveSecondGermany!: (cities: string[]) => void;
+    const firstGermanyPromise = new Promise<string[]>((resolve) => {
+      resolveFirstGermany = resolve;
+    });
+    const secondGermanyPromise = new Promise<string[]>((resolve) => {
+      resolveSecondGermany = resolve;
+    });
+    const germanyRequests = [firstGermanyPromise, secondGermanyPromise];
+    const onCityFetch = vi.fn(() => germanyRequests.shift() ?? Promise.resolve([]));
+    const onSelectionChange = vi.fn();
+
+    const { queryByTestId, rerender } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        selectedCountry: 'Germany',
+        selectedCity: 'Berlin',
+        context: { takenAfter: '2026-01-01' },
+        onCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledTimes(1));
+    await rerender({
+      countries: ['Germany'],
+      selectedCountry: 'Germany',
+      selectedCity: 'Berlin',
+      context: { takenAfter: '2026-02-01' },
+      onCityFetch,
+      onSelectionChange,
+    });
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledTimes(2));
+
+    resolveSecondGermany(['Berlin']);
+    await waitFor(() => expect(queryByTestId('location-city-Berlin')).toBeTruthy());
+    onSelectionChange.mockClear();
+
+    resolveFirstGermany(['Munich']);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Berlin')).toBeTruthy();
+      expect(queryByTestId('location-city-Munich')).toBeNull();
+    });
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
   it('should not show city-level show more for countries with no cities', async () => {
     const fetchPromise = Promise.resolve([]);
     const onCityFetch = vi.fn(() => fetchPromise);

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -679,21 +679,27 @@ describe('LocationFilter', () => {
     expect(onCityFetch).not.toHaveBeenCalled();
   });
 
-  it('should not fetch all country cities when search already matches a country name', async () => {
-    const onCityFetch = vi.fn(() => Promise.resolve([]));
+  it('should search matching city names when the query also matches a country name', async () => {
+    const cityMap: Record<string, string[]> = {
+      Germany: [],
+      Switzerland: ['Geneva'],
+    };
 
-    const { getByTestId } = render(LocationFilter, {
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
-        countries: manyCountries,
-        onCityFetch,
+        countries: ['Germany', 'Switzerland'],
+        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
         onSelectionChange: () => {},
       },
     });
 
-    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'Germany' } });
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'ge' } });
 
-    expect(onCityFetch).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Germany')).toBeTruthy();
+      expect(queryByTestId('location-country-Switzerland')).toBeTruthy();
+      expect(queryByTestId('location-city-Geneva')).toBeTruthy();
+    });
   });
 
   it('should search city names and show matching cities under their country', async () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -384,7 +384,7 @@ describe('LocationFilter', () => {
     });
 
     await fireEvent.click(getByTestId('location-country-Germany'));
-    await waitFor(() => expect(queryByTestId('location-city-German City 11')).toBeNull());
+    await waitFor(() => expect(queryByTestId('location-city-show-more-Germany')).toBeTruthy());
 
     await fireEvent.click(getByTestId('location-city-show-more-Germany'));
     expect(queryByTestId('location-city-German City 11')).toBeTruthy();
@@ -765,6 +765,43 @@ describe('LocationFilter', () => {
 
     expect(onCityFetch).not.toHaveBeenCalled();
     expect(queryByTestId('location-no-results')).toBeNull();
+  });
+
+  it('should refetch city search results when context changes with the same active query', async () => {
+    const countries = ['Germany', 'Switzerland'];
+    const onCityFetch = vi.fn((country: string, context?: { takenAfter?: string }) => {
+      if (country === 'Switzerland' && context?.takenAfter === '2026-02-01') {
+        return Promise.resolve(['Geneva']);
+      }
+
+      return Promise.resolve([]);
+    });
+
+    const { getByTestId, queryByTestId, rerender } = render(LocationFilter, {
+      props: {
+        countries,
+        context: { takenAfter: '2026-01-01' },
+        onCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'gene' } });
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('Switzerland', { takenAfter: '2026-01-01' }));
+    await waitFor(() => expect(queryByTestId('location-no-results')).toBeTruthy());
+
+    await rerender({
+      countries,
+      context: { takenAfter: '2026-02-01' },
+      onCityFetch,
+      onSelectionChange: () => {},
+    });
+
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('Switzerland', { takenAfter: '2026-02-01' }));
+    await waitFor(() => {
+      expect(queryByTestId('location-country-Switzerland')).toBeTruthy();
+      expect(queryByTestId('location-city-Geneva')).toBeTruthy();
+    });
   });
 
   it('should find a city in a country beyond the initial country cap', async () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -345,6 +345,29 @@ describe('LocationFilter', () => {
     expect(queryByTestId('location-city-City 12')).toBeTruthy();
   });
 
+  it('should keep a selected city visible when it is outside the initial city cap', async () => {
+    const cities = Array.from({ length: 12 }, (_, index) => `City ${index + 1}`);
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany'],
+        selectedCountry: 'Germany',
+        selectedCity: 'City 11',
+        onCityFetch: () => Promise.resolve(cities),
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-City 10')).toBeTruthy();
+      expect(queryByTestId('location-city-City 11')).toBeTruthy();
+      expect(queryByTestId('location-city-City 12')).toBeNull();
+      expect(queryByTestId('location-city-show-more-Germany')).toBeTruthy();
+    });
+  });
+
   it('should expand hidden cities only for the selected country city list', async () => {
     const cityMap: Record<string, string[]> = {
       Germany: Array.from({ length: 12 }, (_, index) => `German City ${index + 1}`),
@@ -373,15 +396,20 @@ describe('LocationFilter', () => {
   });
 
   it('should not show city-level show more for countries with no cities', async () => {
+    const fetchPromise = Promise.resolve([]);
+    const onCityFetch = vi.fn(() => fetchPromise);
+
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
         countries: ['Germany'],
-        onCityFetch: () => Promise.resolve([]),
+        onCityFetch,
         onSelectionChange: () => {},
       },
     });
 
     await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledTimes(1));
+    await fetchPromise;
 
     await waitFor(() => {
       expect(queryByTestId('location-city-show-more-Germany')).toBeNull();

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -768,7 +768,9 @@ describe('LocationFilter', () => {
     const switzerlandPromise = new Promise<string[]>((resolve) => {
       resolveSwitzerland = resolve;
     });
-    const onCityFetch = vi.fn((country: string) => (country === 'Switzerland' ? switzerlandPromise : Promise.resolve([])));
+    const onCityFetch = vi.fn((country: string) =>
+      country === 'Switzerland' ? switzerlandPromise : Promise.resolve([]),
+    );
 
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -401,7 +401,7 @@ describe('LocationFilter', () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
         countries: ['Germany', 'France'],
-        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onCityFetch: (country: string) => Promise.resolve(cityMap[country] ?? []),
         onSelectionChange: () => {},
       },
     });
@@ -730,7 +730,7 @@ describe('LocationFilter', () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
         countries: ['Germany', 'Switzerland'],
-        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onCityFetch: (country: string) => Promise.resolve(cityMap[country] ?? []),
         onSelectionChange: () => {},
       },
     });
@@ -854,7 +854,7 @@ describe('LocationFilter', () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {
         countries: manyCountries,
-        onCityFetch: (country) => Promise.resolve(cityMap[country] ?? []),
+        onCityFetch: (country: string) => Promise.resolve(cityMap[country] ?? []),
         onSelectionChange: () => {},
       },
     });

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -526,6 +526,46 @@ describe('LocationFilter', () => {
     expect(onSelectionChange).toHaveBeenCalledWith('France', undefined);
   });
 
+  it('should not render prior country cities when the next country fetch rejects', async () => {
+    let resolveGermany!: (cities: string[]) => void;
+    let rejectFrance!: (error: Error) => void;
+    const germanyPromise = new Promise<string[]>((resolve) => {
+      resolveGermany = resolve;
+    });
+    const francePromise = new Promise<string[]>((_, reject) => {
+      rejectFrance = reject;
+    });
+    const onCityFetch = vi.fn((country: string) => (country === 'Germany' ? germanyPromise : francePromise));
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'France'],
+        onCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('Germany', undefined));
+
+    resolveGermany(['Munich']);
+    await waitFor(() => expect(queryByTestId('location-city-Munich')).toBeTruthy());
+
+    await fireEvent.click(getByTestId('location-country-France'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('France', undefined));
+    onSelectionChange.mockClear();
+
+    rejectFrance(new Error('city fetch failed'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await waitFor(() => {
+      expect(queryByTestId('location-city-Munich')).toBeNull();
+      expect(getByTestId('location-country-France')).toBeTruthy();
+    });
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
   it('should not show city-level show more for countries with no cities', async () => {
     const fetchPromise = Promise.resolve([]);
     const onCityFetch = vi.fn(() => fetchPromise);

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -750,6 +750,23 @@ describe('LocationFilter', () => {
     });
   });
 
+  it('should not show no-results before debounced city search fetches start', async () => {
+    const onCityFetch = vi.fn(() => Promise.resolve([]));
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'Switzerland'],
+        onCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'gene' } });
+
+    expect(onCityFetch).not.toHaveBeenCalled();
+    expect(queryByTestId('location-no-results')).toBeNull();
+  });
+
   it('should find a city in a country beyond the initial country cap', async () => {
     const cityMap: Record<string, string[]> = {
       Mexico: ['Merida'],
@@ -877,6 +894,21 @@ describe('LocationFilter', () => {
 
     const searchInput = getByTestId('location-search-input');
     await fireEvent.input(searchInput, { target: { value: 'zzzzz' } });
+
+    await waitFor(() => expect(getByTestId('location-no-results').textContent).toBe('No matching locations'));
+  });
+
+  it('should show "No matching locations" immediately for one-character empty search results', async () => {
+    const { getByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch: mockCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    const searchInput = getByTestId('location-search-input');
+    await fireEvent.input(searchInput, { target: { value: 'q' } });
 
     expect(getByTestId('location-no-results').textContent).toBe('No matching locations');
   });

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -662,6 +662,40 @@ describe('LocationFilter', () => {
     expect(queryByTestId('location-country-Italy')).toBeNull();
   });
 
+  it('should not fetch all country cities for one-character searches', async () => {
+    const onCityFetch = vi.fn(() => Promise.resolve([]));
+
+    const { getByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'a' } });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(onCityFetch).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch all country cities when search already matches a country name', async () => {
+    const onCityFetch = vi.fn(() => Promise.resolve([]));
+
+    const { getByTestId } = render(LocationFilter, {
+      props: {
+        countries: manyCountries,
+        onCityFetch,
+        onSelectionChange: () => {},
+      },
+    });
+
+    await fireEvent.input(getByTestId('location-search-input'), { target: { value: 'Germany' } });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(onCityFetch).not.toHaveBeenCalled();
+  });
+
   it('should search city names and show matching cities under their country', async () => {
     const { getByTestId, queryByTestId } = render(LocationFilter, {
       props: {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -395,6 +395,52 @@ describe('LocationFilter', () => {
     });
   });
 
+  it('should ignore stale city fetch responses after expanding another country', async () => {
+    let resolveGermany!: (cities: string[]) => void;
+    let resolveFrance!: (cities: string[]) => void;
+    const germanyPromise = new Promise<string[]>((resolve) => {
+      resolveGermany = resolve;
+    });
+    const francePromise = new Promise<string[]>((resolve) => {
+      resolveFrance = resolve;
+    });
+    const onSelectionChange = vi.fn();
+    const onCityFetch = vi.fn((country: string) => (country === 'Germany' ? germanyPromise : francePromise));
+
+    const { getByTestId, queryByTestId, rerender } = render(LocationFilter, {
+      props: {
+        countries: ['Germany', 'France'],
+        onCityFetch,
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-Germany'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('Germany', undefined));
+    await fireEvent.click(getByTestId('location-country-France'));
+    await waitFor(() => expect(onCityFetch).toHaveBeenCalledWith('France', undefined));
+    await waitFor(() => expect(queryByTestId('location-city-French City 1')).toBeNull());
+
+    resolveFrance(['French City 1']);
+    await waitFor(() => expect(queryByTestId('location-city-French City 1')).toBeTruthy());
+    await rerender({
+      countries: ['Germany', 'France'],
+      selectedCountry: 'France',
+      selectedCity: 'French City 1',
+      onCityFetch,
+      onSelectionChange,
+    });
+    onSelectionChange.mockClear();
+
+    resolveGermany(['German City 1']);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(() => {
+      expect(queryByTestId('location-city-French City 1')).toBeTruthy();
+      expect(queryByTestId('location-city-German City 1')).toBeNull();
+    });
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
   it('should not show city-level show more for countries with no cities', async () => {
     const fetchPromise = Promise.resolve([]);
     const onCityFetch = vi.fn(() => fetchPromise);

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -37,8 +37,16 @@
 
   const COUNTRY_SHOW_COUNT = 10;
   const CITY_SHOW_COUNT = 10;
+  const MIN_CITY_SEARCH_LENGTH = 2;
 
   let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
+  let shouldFetchCitiesForSearch = $derived.by(() => {
+    if (normalizedSearchQuery.length < MIN_CITY_SEARCH_LENGTH) {
+      return false;
+    }
+
+    return !countries.some((country) => country.toLowerCase().includes(normalizedSearchQuery));
+  });
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
   let previousCountriesLength = 0;
@@ -160,7 +168,7 @@
   });
 
   $effect(() => {
-    if (!normalizedSearchQuery) {
+    if (!shouldFetchCitiesForSearch) {
       return;
     }
 

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -169,12 +169,10 @@
   });
 
   $effect(() => {
-    if (!shouldFetchCitiesForSearch) {
+    if (!shouldFetchCitiesForSearch || !cityCacheKey) {
       return;
     }
 
-    const searchCacheKey = cityCacheKey;
-    void searchCacheKey;
     const currentCountries = countries;
     const timeout = setTimeout(() => {
       untrack(() => {

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -41,9 +41,13 @@
 
   let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
   let shouldFetchCitiesForSearch = $derived(normalizedSearchQuery.length >= MIN_CITY_SEARCH_LENGTH);
-  let hasPendingCitySearchFetches = $derived.by(
-    () => shouldFetchCitiesForSearch && countries.some((country) => loadingCitiesByCountry[country]),
-  );
+  let hasPendingCitySearchFetches = $derived.by(() => {
+    if (!shouldFetchCitiesForSearch) {
+      return false;
+    }
+
+    return countries.some((country) => loadingCitiesByCountry[country] || (!(country in cityCache) && !cityFetchErrors[country]));
+  });
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
   let previousCountriesLength = 0;

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -57,6 +57,7 @@
   let expandedCountry = $state<string | undefined>(undefined);
   let cities = $state<string[]>([]);
   let loadingCities = $state(false);
+  let cityFetchRequestId = 0;
 
   // Orphaned country: selected but not in current results
   let orphanedCountry = $derived(selectedCountry && !countries.includes(selectedCountry) ? selectedCountry : undefined);
@@ -72,12 +73,10 @@
     if (expandedCountry) {
       const requestedCountry = expandedCountry;
       const _context = context;
+      const requestId = ++cityFetchRequestId;
       loadingCities = true;
       void onCityFetch(requestedCountry, _context).then((result) => {
-        if (expandedCountry !== requestedCountry) {
-          if (!expandedCountry) {
-            loadingCities = false;
-          }
+        if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {
           return;
         }
 
@@ -90,6 +89,7 @@
         }
       });
     } else {
+      cityFetchRequestId++;
       cities = [];
       loadingCities = false;
     }

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -85,11 +85,25 @@
 
   function getVisibleCities(country: string): string[] {
     const filtered = getFilteredCities(country);
-    return expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
+    if (expandedCityLists[country]) {
+      return filtered;
+    }
+
+    const visible = filtered.slice(0, CITY_SHOW_COUNT);
+    if (
+      selectedCountry === country &&
+      selectedCity &&
+      filtered.includes(selectedCity) &&
+      !visible.includes(selectedCity)
+    ) {
+      return [...visible, selectedCity];
+    }
+
+    return visible;
   }
 
   function getRemainingCityCount(country: string): number {
-    return Math.max(0, getFilteredCities(country).length - CITY_SHOW_COUNT);
+    return Math.max(0, getFilteredCities(country).length - getVisibleCities(country).length);
   }
 
   function showAllCities(country: string) {

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -3,6 +3,7 @@
 
   import { Icon } from '@immich/ui';
   import { mdiMagnify } from '@mdi/js';
+  import { untrack } from 'svelte';
 
   interface Props {
     countries: string[];
@@ -27,9 +28,17 @@
   let searchQuery = $state('');
   let showAll = $state(false);
   let expandedCityLists = $state<Record<string, boolean>>({});
+  let cityCache = $state<Record<string, string[]>>({});
+  let loadingCitiesByCountry = $state<Record<string, boolean>>({});
+  let cityFetchErrors = $state<Record<string, boolean>>({});
+  let latestCityFetchIds = $state<Record<string, number>>({});
+  let cityFetchSequence = 0;
+  let cityCacheKey = $state('');
 
   const COUNTRY_SHOW_COUNT = 10;
   const CITY_SHOW_COUNT = 10;
+
+  let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
   let previousCountriesLength = 0;
@@ -42,11 +51,31 @@
     previousCountriesLength = currentLength;
   });
 
-  let filteredCountries = $derived(
-    searchQuery.trim()
-      ? countries.filter((c) => c.toLowerCase().includes(searchQuery.trim().toLowerCase()))
-      : countries,
-  );
+  $effect(() => {
+    const nextKey = JSON.stringify({ countries, context });
+    if (cityCacheKey && nextKey !== cityCacheKey) {
+      cityFetchSequence += 1;
+      cityCache = {};
+      loadingCitiesByCountry = {};
+      cityFetchErrors = {};
+      latestCityFetchIds = {};
+      expandedCityLists = {};
+      cities = [];
+    }
+    cityCacheKey = nextKey;
+  });
+
+  let filteredCountries = $derived.by(() => {
+    if (!normalizedSearchQuery) {
+      return countries;
+    }
+
+    return countries.filter((country) => {
+      const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
+      const cityMatches = (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
+      return countryMatches || cityMatches;
+    });
+  });
 
   let visibleCountries = $derived(
     searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, COUNTRY_SHOW_COUNT),
@@ -56,8 +85,6 @@
 
   let expandedCountry = $state<string | undefined>(undefined);
   let cities = $state<string[]>([]);
-  let loadingCities = $state(false);
-  let cityFetchRequestId = 0;
 
   // Orphaned country: selected but not in current results
   let orphanedCountry = $derived(selectedCountry && !countries.includes(selectedCountry) ? selectedCountry : undefined);
@@ -69,47 +96,97 @@
     }
   });
 
+  function ensureCities(country: string) {
+    if (country in cityCache || loadingCitiesByCountry[country]) {
+      return;
+    }
+
+    const requestedCountry = country;
+    const _context = context;
+    const requestId = ++cityFetchSequence;
+
+    latestCityFetchIds = { ...latestCityFetchIds, [requestedCountry]: requestId };
+    loadingCitiesByCountry = { ...loadingCitiesByCountry, [requestedCountry]: true };
+    cityFetchErrors = { ...cityFetchErrors, [requestedCountry]: false };
+    if (expandedCountry === requestedCountry) {
+      cities = [];
+    }
+
+    void onCityFetch(requestedCountry, _context)
+      .then((result) => {
+        if (latestCityFetchIds[requestedCountry] !== requestId) {
+          return;
+        }
+
+        cityCache = { ...cityCache, [requestedCountry]: result };
+        loadingCitiesByCountry = { ...loadingCitiesByCountry, [requestedCountry]: false };
+        cityFetchErrors = { ...cityFetchErrors, [requestedCountry]: false };
+
+        if (expandedCountry === requestedCountry) {
+          cities = result;
+        }
+
+        // Cascade child auto-clear: if selected city is not in new results, clear it
+        if (selectedCountry === requestedCountry && selectedCity && result.length > 0 && !result.includes(selectedCity)) {
+          onSelectionChange(requestedCountry, undefined);
+        }
+      })
+      .catch(() => {
+        if (latestCityFetchIds[requestedCountry] !== requestId) {
+          return;
+        }
+
+        loadingCitiesByCountry = { ...loadingCitiesByCountry, [requestedCountry]: false };
+        cityFetchErrors = { ...cityFetchErrors, [requestedCountry]: true };
+        if (expandedCountry === requestedCountry) {
+          cities = [];
+        }
+      });
+  }
+
   $effect(() => {
     if (expandedCountry) {
-      const requestedCountry = expandedCountry;
-      const _context = context;
-      const requestId = ++cityFetchRequestId;
-      loadingCities = true;
-      cities = [];
-      void onCityFetch(requestedCountry, _context)
-        .then((result) => {
-          if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {
-            return;
-          }
-
-          cities = result;
-          loadingCities = false;
-
-          // Cascade child auto-clear: if selected city is not in new results, clear it
-          if (selectedCity && result.length > 0 && !result.includes(selectedCity)) {
-            onSelectionChange(requestedCountry, undefined);
-          }
-        })
-        .catch(() => {
-          if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {
-            return;
-          }
-
-          loadingCities = false;
-        });
+      cities = cityCache[expandedCountry] ?? [];
+      untrack(() => ensureCities(expandedCountry!));
     } else {
-      cityFetchRequestId++;
       cities = [];
-      loadingCities = false;
     }
   });
 
-  function getFilteredCities(): string[] {
-    return cities;
+  $effect(() => {
+    if (selectedCountry) {
+      untrack(() => ensureCities(selectedCountry));
+    }
+  });
+
+  $effect(() => {
+    if (!normalizedSearchQuery) {
+      return;
+    }
+
+    const currentCountries = countries;
+    const timeout = setTimeout(() => {
+      untrack(() => {
+        for (const country of currentCountries) {
+          ensureCities(country);
+        }
+      });
+    }, 150);
+
+    return () => clearTimeout(timeout);
+  });
+
+  function getFilteredCities(country: string): string[] {
+    const cachedCities = cityCache[country] ?? (expandedCountry === country ? cities : []);
+    if (!normalizedSearchQuery || country.toLowerCase().includes(normalizedSearchQuery)) {
+      return cachedCities;
+    }
+
+    return cachedCities.filter((city) => city.toLowerCase().includes(normalizedSearchQuery));
   }
 
   function getVisibleCities(country: string): string[] {
-    const filtered = getFilteredCities();
+    const filtered = getFilteredCities(country);
     if (expandedCityLists[country]) {
       return filtered;
     }
@@ -128,7 +205,7 @@
   }
 
   function getRemainingCityCount(country: string): number {
-    return Math.max(0, getFilteredCities().length - getVisibleCities(country).length);
+    return Math.max(0, getFilteredCities(country).length - getVisibleCities(country).length);
   }
 
   function showAllCities(country: string) {
@@ -235,7 +312,7 @@
       </button>
 
       <!-- Cities (indented when country is expanded) -->
-      {#if expandedCountry === country && !loadingCities}
+      {#if (expandedCountry === country || (normalizedSearchQuery && (cityCache[country] ?? []).length > 0)) && !loadingCitiesByCountry[country]}
         {#each getVisibleCities(country) as city (city)}
           {@const isCitySelected = selectedCity === city && selectedCountry === country}
           <button

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -40,13 +40,7 @@
   const MIN_CITY_SEARCH_LENGTH = 2;
 
   let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
-  let shouldFetchCitiesForSearch = $derived.by(() => {
-    if (normalizedSearchQuery.length < MIN_CITY_SEARCH_LENGTH) {
-      return false;
-    }
-
-    return !countries.some((country) => country.toLowerCase().includes(normalizedSearchQuery));
-  });
+  let shouldFetchCitiesForSearch = $derived(normalizedSearchQuery.length >= MIN_CITY_SEARCH_LENGTH);
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
   let previousCountriesLength = 0;

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -46,7 +46,9 @@
       return false;
     }
 
-    return countries.some((country) => loadingCitiesByCountry[country] || (!(country in cityCache) && !cityFetchErrors[country]));
+    return countries.some(
+      (country) => loadingCitiesByCountry[country] || (!(country in cityCache) && !cityFetchErrors[country]),
+    );
   });
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
@@ -138,7 +140,12 @@
         }
 
         // Cascade child auto-clear: if selected city is not in new results, clear it
-        if (selectedCountry === requestedCountry && selectedCity && result.length > 0 && !result.includes(selectedCity)) {
+        if (
+          selectedCountry === requestedCountry &&
+          selectedCity &&
+          result.length > 0 &&
+          !result.includes(selectedCity)
+        ) {
           onSelectionChange(requestedCountry, undefined);
         }
       })

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -121,7 +121,7 @@
       filtered.includes(selectedCity) &&
       !visible.includes(selectedCity)
     ) {
-      return [...visible, selectedCity];
+      return [...visible.slice(0, CITY_SHOW_COUNT - 1), selectedCity];
     }
 
     return visible;

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -75,19 +75,27 @@
       const _context = context;
       const requestId = ++cityFetchRequestId;
       loadingCities = true;
-      void onCityFetch(requestedCountry, _context).then((result) => {
-        if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {
-          return;
-        }
+      void onCityFetch(requestedCountry, _context)
+        .then((result) => {
+          if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {
+            return;
+          }
 
-        cities = result;
-        loadingCities = false;
+          cities = result;
+          loadingCities = false;
 
-        // Cascade child auto-clear: if selected city is not in new results, clear it
-        if (selectedCity && result.length > 0 && !result.includes(selectedCity)) {
-          onSelectionChange(requestedCountry, undefined);
-        }
-      });
+          // Cascade child auto-clear: if selected city is not in new results, clear it
+          if (selectedCity && result.length > 0 && !result.includes(selectedCity)) {
+            onSelectionChange(requestedCountry, undefined);
+          }
+        })
+        .catch(() => {
+          if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {
+            return;
+          }
+
+          loadingCities = false;
+        });
     } else {
       cityFetchRequestId++;
       cities = [];
@@ -95,12 +103,12 @@
     }
   });
 
-  function getFilteredCities(country: string): string[] {
+  function getFilteredCities(): string[] {
     return cities;
   }
 
   function getVisibleCities(country: string): string[] {
-    const filtered = getFilteredCities(country);
+    const filtered = getFilteredCities();
     if (expandedCityLists[country]) {
       return filtered;
     }
@@ -119,7 +127,7 @@
   }
 
   function getRemainingCityCount(country: string): number {
-    return Math.max(0, getFilteredCities(country).length - getVisibleCities(country).length);
+    return Math.max(0, getFilteredCities().length - getVisibleCities(country).length);
   }
 
   function showAllCities(country: string) {

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -62,6 +62,13 @@
   let orphanedCountry = $derived(selectedCountry && !countries.includes(selectedCountry) ? selectedCountry : undefined);
 
   $effect(() => {
+    if (selectedCountry && selectedCity && expandedCountry !== selectedCountry) {
+      expandedCountry = selectedCountry;
+      expandedCityLists = { ...expandedCityLists, [selectedCountry]: false };
+    }
+  });
+
+  $effect(() => {
     if (expandedCountry) {
       const _context = context;
       loadingCities = true;

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -73,7 +73,7 @@
     return countries.filter((country) => {
       const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
       const cityMatches = (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
-      return countryMatches || cityMatches;
+      return countryMatches || cityMatches || selectedCountry === country;
     });
   });
 

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -75,6 +75,7 @@
       const _context = context;
       const requestId = ++cityFetchRequestId;
       loadingCities = true;
+      cities = [];
       void onCityFetch(requestedCountry, _context)
         .then((result) => {
           if (requestId !== cityFetchRequestId || expandedCountry !== requestedCountry) {

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -81,7 +81,9 @@
 
     return countries.filter((country) => {
       const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
-      const cityMatches = (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
+      const cityMatches =
+        shouldFetchCitiesForSearch &&
+        (cityCache[country] ?? []).some((city) => city.toLowerCase().includes(normalizedSearchQuery));
       return countryMatches || cityMatches || selectedCountry === country;
     });
   });
@@ -187,11 +189,23 @@
 
   function getFilteredCities(country: string): string[] {
     const cachedCities = cityCache[country] ?? (expandedCountry === country ? cities : []);
-    if (!normalizedSearchQuery || country.toLowerCase().includes(normalizedSearchQuery)) {
+    if (!normalizedSearchQuery) {
       return cachedCities;
     }
 
-    return cachedCities.filter((city) => city.toLowerCase().includes(normalizedSearchQuery));
+    const countryMatches = country.toLowerCase().includes(normalizedSearchQuery);
+    const filtered =
+      expandedCountry === country && countryMatches
+        ? cachedCities
+        : shouldFetchCitiesForSearch
+          ? cachedCities.filter((city) => city.toLowerCase().includes(normalizedSearchQuery))
+          : [];
+
+    if (selectedCountry === country && selectedCity && !filtered.includes(selectedCity)) {
+      return [...filtered, selectedCity];
+    }
+
+    return filtered;
   }
 
   function getVisibleCities(country: string): string[] {
@@ -295,6 +309,7 @@
 
     {#each visibleCountries as country (country)}
       {@const isCountrySelected = selectedCountry === country}
+      {@const visibleCities = getVisibleCities(country)}
       <!-- Country row -->
       <button
         type="button"
@@ -321,8 +336,8 @@
       </button>
 
       <!-- Cities (indented when country is expanded) -->
-      {#if (expandedCountry === country || (normalizedSearchQuery && (cityCache[country] ?? []).length > 0)) && !loadingCitiesByCountry[country]}
-        {#each getVisibleCities(country) as city (city)}
+      {#if (expandedCountry === country || (normalizedSearchQuery && visibleCities.length > 0)) && !loadingCitiesByCountry[country]}
+        {#each visibleCities as city (city)}
           {@const isCitySelected = selectedCity === city && selectedCountry === country}
           <button
             type="button"

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -26,8 +26,10 @@
 
   let searchQuery = $state('');
   let showAll = $state(false);
+  let expandedCityLists = $state<Record<string, boolean>>({});
 
-  const INITIAL_SHOW_COUNT = 10;
+  const COUNTRY_SHOW_COUNT = 10;
+  const CITY_SHOW_COUNT = 10;
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
   let previousCountriesLength = 0;
@@ -47,10 +49,10 @@
   );
 
   let visibleCountries = $derived(
-    searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, INITIAL_SHOW_COUNT),
+    searchQuery.trim() || showAll ? filteredCountries : filteredCountries.slice(0, COUNTRY_SHOW_COUNT),
   );
 
-  let remainingCount = $derived(Math.max(0, filteredCountries.length - INITIAL_SHOW_COUNT));
+  let remainingCount = $derived(Math.max(0, filteredCountries.length - COUNTRY_SHOW_COUNT));
 
   let expandedCountry = $state<string | undefined>(undefined);
   let cities = $state<string[]>([]);
@@ -77,14 +79,30 @@
     }
   });
 
+  function getFilteredCities(country: string): string[] {
+    return cities;
+  }
+
+  function getVisibleCities(country: string): string[] {
+    const filtered = getFilteredCities(country);
+    return expandedCityLists[country] ? filtered : filtered.slice(0, CITY_SHOW_COUNT);
+  }
+
+  function getRemainingCityCount(country: string): number {
+    return Math.max(0, getFilteredCities(country).length - CITY_SHOW_COUNT);
+  }
+
+  function showAllCities(country: string) {
+    expandedCityLists = { ...expandedCityLists, [country]: true };
+  }
+
   function handleCountryClick(country: string) {
     if (selectedCountry === country && !selectedCity) {
-      // Deselect country
       expandedCountry = undefined;
       onSelectionChange(undefined, undefined);
     } else {
-      // Select country
       expandedCountry = country;
+      expandedCityLists = { ...expandedCityLists, [country]: false };
       onSelectionChange(country, undefined);
     }
   }
@@ -179,7 +197,7 @@
 
       <!-- Cities (indented when country is expanded) -->
       {#if expandedCountry === country && !loadingCities}
-        {#each cities as city (city)}
+        {#each getVisibleCities(country) as city (city)}
           {@const isCitySelected = selectedCity === city && selectedCountry === country}
           <button
             type="button"
@@ -204,6 +222,16 @@
             <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left">{city}</span>
           </button>
         {/each}
+        {#if !expandedCityLists[country] && getRemainingCityCount(country) > 0}
+          <button
+            type="button"
+            class="ml-5 py-1 text-xs font-medium text-immich-primary dark:text-immich-dark-primary"
+            onclick={() => showAllCities(country)}
+            data-testid="location-city-show-more-{country}"
+          >
+            Show {getRemainingCityCount(country)} more
+          </button>
+        {/if}
       {/if}
     {/each}
 

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -70,19 +70,28 @@
 
   $effect(() => {
     if (expandedCountry) {
+      const requestedCountry = expandedCountry;
       const _context = context;
       loadingCities = true;
-      void onCityFetch(expandedCountry, _context).then((result) => {
+      void onCityFetch(requestedCountry, _context).then((result) => {
+        if (expandedCountry !== requestedCountry) {
+          if (!expandedCountry) {
+            loadingCities = false;
+          }
+          return;
+        }
+
         cities = result;
         loadingCities = false;
 
         // Cascade child auto-clear: if selected city is not in new results, clear it
         if (selectedCity && result.length > 0 && !result.includes(selectedCity)) {
-          onSelectionChange(expandedCountry, undefined);
+          onSelectionChange(requestedCountry, undefined);
         }
       });
     } else {
       cities = [];
+      loadingCities = false;
     }
   });
 

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -173,6 +173,8 @@
       return;
     }
 
+    const searchCacheKey = cityCacheKey;
+    void searchCacheKey;
     const currentCountries = countries;
     const timeout = setTimeout(() => {
       untrack(() => {

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -41,6 +41,9 @@
 
   let normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
   let shouldFetchCitiesForSearch = $derived(normalizedSearchQuery.length >= MIN_CITY_SEARCH_LENGTH);
+  let hasPendingCitySearchFetches = $derived.by(
+    () => shouldFetchCitiesForSearch && countries.some((country) => loadingCitiesByCountry[country]),
+  );
 
   // Clear search when countries list changes (e.g. temporal filter refetch)
   let previousCountriesLength = 0;
@@ -282,7 +285,7 @@
     {/if}
 
     <!-- Empty search results -->
-    {#if filteredCountries.length === 0 && searchQuery.trim()}
+    {#if filteredCountries.length === 0 && searchQuery.trim() && !hasPendingCitySearchFetches}
       <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="location-no-results">No matching locations</p>
     {/if}
 


### PR DESCRIPTION
## Summary
- cap expanded location city lists with per-country show-more controls
- make location search find matching city names across current country suggestions
- cache and invalidate city fetches by filter context with stale-response guards
- keep selected country/city visible through search, caps, pending fetches, and context changes

## Tests
- pnpm --filter immich-web exec vitest run src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
- pnpm --filter immich-web run check:svelte

## Plan
- docs/plans/2026-04-29-location-filter-city-search-design.md
- docs/plans/2026-04-29-location-filter-city-search-plan.md