### PR TITLE
fix: allow hiding space people from details

### DIFF
--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -31,7 +31,13 @@
     type SharedSpacePersonResponseDto,
   } from '@immich/sdk';
   import { ContextMenuButton, modalManager, toastManager, type ActionItem } from '@immich/ui';
-  import { mdiAccountMultipleCheckOutline, mdiArrowLeft, mdiCalendarEditOutline, mdiDotsVertical } from '@mdi/js';
+  import {
+    mdiAccountMultipleCheckOutline,
+    mdiArrowLeft,
+    mdiCalendarEditOutline,
+    mdiDotsVertical,
+    mdiEyeOffOutline,
+  } from '@mdi/js';
   import { DateTime } from 'luxon';
   import { tick } from 'svelte';
   import { t } from 'svelte-i18n';
@@ -195,6 +201,20 @@
     });
   }
 
+  async function handleHidePerson() {
+    try {
+      await updateSpacePerson({
+        id: space.id,
+        personId: person.id,
+        sharedSpacePersonUpdateDto: { isHidden: true },
+      });
+      toastManager.primary($t('changed_visibility_successfully'));
+      await goto(`/spaces/${space.id}/people`);
+    } catch (error) {
+      handleError(error, $t('errors.unable_to_hide_person'));
+    }
+  }
+
   const actionItems = $derived.by(() => {
     const items: ActionItem[] = [];
 
@@ -204,6 +224,12 @@
           title: $t('set_date_of_birth'),
           icon: mdiCalendarEditOutline,
           onAction: () => void openBirthDateModal(),
+        },
+        {
+          title: $t('hide_person'),
+          icon: mdiEyeOffOutline,
+          $if: () => !person.isHidden,
+          onAction: () => void handleHidePerson(),
         },
         {
           title: $t('merge_people'),

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -44,7 +44,7 @@ vi.mock('@immich/ui', async (importOriginal) => {
     ...original,
     ContextMenuButton: MockContextMenuButton,
     modalManager: { show: vi.fn(), showDialog: vi.fn() },
-    toastManager: { success: vi.fn() },
+    toastManager: { primary: vi.fn(), success: vi.fn() },
   };
 });
 
@@ -235,5 +235,20 @@ describe('Spaces person detail page', () => {
       birthDate: string | null;
     };
     expect(reopenedModalProps.birthDate).toBe('1990-06-15');
+  });
+
+  it('hides a space person from the detail page action menu', async () => {
+    const person = makePerson({ isHidden: false });
+    sdkMock.updateSpacePerson.mockResolvedValue({ ...person, isHidden: true });
+    renderPage({ person });
+
+    await userEvent.click(screen.getByText('hide_person'));
+
+    expect(sdkMock.updateSpacePerson).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'person-1',
+      sharedSpacePersonUpdateDto: { isHidden: true },
+    });
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/people');
   });
 });


### PR DESCRIPTION
## Summary
- add a hide action to the shared-space person detail menu for editors
- call the existing shared-space person visibility API and return to the people list after hiding
- cover the detail-page hide action with a regression test

## Tests
- pnpm exec vitest run 'src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts'
- pnpm exec vitest run 'src/lib/components/spaces/space-people-page.spec.ts'
- pnpm run check:svelte
- pnpm run check:typescript
- pnpm exec prettier --check 'src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' 'src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts'