### PR TITLE
fix(mobile): update app store links

### DIFF
--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -45,8 +45,8 @@ const List<(String, String)> kWidgetNames = [
 
 const int kMinMonthsToEnableScrubberSnap = 12;
 
-const String kImmichAppStoreLink = "https://apps.apple.com/app/immich/id1613945652";
-const String kImmichPlayStoreLink = "https://play.google.com/store/apps/details?id=app.alextran.immich";
+const String kImmichAppStoreLink = "https://apps.apple.com/app/id6761776289";
+const String kImmichPlayStoreLink = "https://play.google.com/store/apps/details?id=de.opennoodle.gallery";
 const String kImmichLatestRelease = "https://github.com/immich-app/immich/releases/latest";
 
 const int kPhotoTabIndex = 0;

--- a/mobile/test/constants/app_store_links_test.dart
+++ b/mobile/test/constants/app_store_links_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/constants/constants.dart';
+
+void main() {
+  test('iOS client update link points to the Noodle Gallery App Store listing', () {
+    expect(kImmichAppStoreLink, 'https://apps.apple.com/app/id6761776289');
+  });
+
+  test('Android client update link points to the Noodle Gallery Play Store listing', () {
+    expect(kImmichPlayStoreLink, 'https://play.google.com/store/apps/details?id=de.opennoodle.gallery');
+  });
+}


### PR DESCRIPTION
## Summary
- update the iOS client update link to the Noodle Gallery App Store listing
- update the Android client update link to the Noodle Gallery Play Store listing
- add regression coverage for both mobile store links

Fixes #472

## Tests
- /home/pierre/.local/share/mise/installs/flutter/3.41.7/bin/dart analyze lib/constants/constants.dart test/constants/app_store_links_test.dart
- /home/pierre/.local/share/mise/installs/flutter/3.41.7/bin/flutter test test/constants/app_store_links_test.dart test/modules/utils/version_compatibility_test.dart