### PR TITLE
fix(server): sort space people alphabetically within tied photo counts

### DIFF
--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -421,6 +421,10 @@ order by
     ELSE 1
   END,
   "shared_space_person"."assetCount" desc,
+  COALESCE(
+    NULLIF(shared_space_person.name, ''),
+    NULLIF(person.name, '')
+  ) asc nulls last,
   "shared_space_person"."id"
 limit
   $3

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -582,6 +582,9 @@ export class SharedSpaceRepository {
              ELSE 1 END`,
       )
       .orderBy('shared_space_person.assetCount', 'desc')
+      .orderBy(sql`COALESCE(NULLIF(shared_space_person.name, ''), NULLIF(person.name, ''))`, (om) =>
+        om.asc().nullsLast(),
+      )
       .orderBy('shared_space_person.id')
       .$if(!!options.limit, (qb) => qb.limit(options.limit!))
       .$if(!!options.offset, (qb) => qb.offset(options.offset!))

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1052,6 +1052,74 @@ describe(SharedSpaceRepository.name, () => {
       expect(result[0].personalName).toBe('Global Name');
       expect(result[0].personalThumbnailPath).toBe('/path/to/thumbnail.jpg');
     });
+
+    it('should sort space persons tied on assetCount alphabetically by name', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+
+      const charlie = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Charlie',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 5,
+      });
+      const alice = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Alice',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 5,
+      });
+      const bob = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Bob',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 5,
+      });
+
+      const result = await sut.getPersonsBySpaceId(space.id, {});
+
+      expect(result.map((p) => p.id)).toEqual([alice.id, bob.id, charlie.id]);
+    });
+
+    it('should fall back to global person name when sorting tied space persons', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      const { result: globalBob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+      const { assetFace: bobFace } = await ctx.newAssetFace({ assetId: asset.id, personId: globalBob.id });
+
+      const charlie = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Charlie',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 5,
+      });
+      const bob = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: bobFace.id,
+        type: 'person',
+        assetCount: 5,
+      });
+      const alice = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Alice',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 5,
+      });
+
+      const result = await sut.getPersonsBySpaceId(space.id, {});
+
+      expect(result.map((p) => p.id)).toEqual([alice.id, bob.id, charlie.id]);
+    });
   });
 
   describe('getFilteredMapMarkers — space filter interaction', () => {


### PR DESCRIPTION
## Summary

Fixes #476 — People in a shared space appeared in random order. The server query ordered by `(named-flag, assetCount DESC, id)`, so any people that tied on photo count fell back to UUID-ordering, looking unsorted to users with many low-count people.

Adds an alphabetical tiebreak (mirroring the global People view at `person.repository.ts:209-212`), with a `COALESCE(NULLIF(shared_space_person.name, ''), NULLIF(person.name, ''))` so it works whether the name lives on the space-person row or is inherited from the joined global person:

```sql
ORDER BY
  CASE WHEN named THEN 0 ELSE 1 END,
  shared_space_person.assetCount DESC,
  COALESCE(NULLIF(shared_space_person.name, ''), NULLIF(person.name, '')) ASC NULLS LAST,  -- new
  shared_space_person.id
```

## Test plan
- [x] Two new medium tests in `shared-space.repository.spec.ts` covering tied-count alphabetical sort, including the personalName fallback case
- [x] All 64 tests in the shared-space repo medium spec pass
- [x] All 4023 server unit tests pass
- [x] `tsc --noEmit` clean
- [x] SQL snapshot regenerated via `pnpm sync:sql`
- [x] Manual: 30 test people across 5 photo-count tiers in a dev space — render alphabetical within each tier