### PR TITLE
chore: ignore .codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ vite.config.js.timestamp-*
 *.tsbuildinfo
 *.tsbuildInfo
 .worktrees
+.codex


### PR DESCRIPTION
## Summary
- Add `.codex` to `.gitignore` to exclude local Codex tooling state.