### PR TITLE
fix(server): persist space people birthdays globally

### DIFF
--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -1882,7 +1882,7 @@ describe('/shared-spaces', () => {
 
         it('updates, persists, lists, and clears birthDate', async () => {
           const scratch = await utils.createSpacePerson(spaceId, 'BirthDatePerson', owner.userId, spaceAssetId);
-          const expectedBirthDate = '1984-05-09T00:00:00.000Z';
+          const expectedBirthDate = '1984-05-09';
 
           const putRes = await request(app)
             .put(`/shared-spaces/${spaceId}/people/${scratch.spacePersonId}`)
@@ -1890,6 +1890,12 @@ describe('/shared-spaces', () => {
             .send({ birthDate: '1984-05-09' });
           expect(putRes.status).toBe(200);
           expect((putRes.body as { birthDate: string | null }).birthDate).toBe(expectedBirthDate);
+
+          const globalPerson = await request(app)
+            .get(`/people/${scratch.globalPersonId}`)
+            .set('Authorization', `Bearer ${owner.accessToken}`);
+          expect(globalPerson.status).toBe(200);
+          expect((globalPerson.body as { birthDate: string | null }).birthDate).toBe(expectedBirthDate);
 
           const direct = await request(app)
             .get(`/shared-spaces/${spaceId}/people/${scratch.spacePersonId}`)
@@ -1918,6 +1924,12 @@ describe('/shared-spaces', () => {
             .set('Authorization', `Bearer ${owner.accessToken}`);
           expect(directAfterClear.status).toBe(200);
           expect((directAfterClear.body as { birthDate: string | null }).birthDate).toBeNull();
+
+          const globalPersonAfterClear = await request(app)
+            .get(`/people/${scratch.globalPersonId}`)
+            .set('Authorization', `Bearer ${owner.accessToken}`);
+          expect(globalPersonAfterClear.status).toBe(200);
+          expect((globalPersonAfterClear.body as { birthDate: string | null }).birthDate).toBeNull();
         });
 
         it('non-existent personId returns 400', async () => {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -381,8 +381,10 @@ export type SharedSpacePerson = {
   updatedAt: Date;
   updateId: string;
   // Populated via LEFT JOIN to asset_face → person in repository queries
+  personalPersonId: string | null;
   personalName: string | null;
   personalThumbnailPath: string | null;
+  personalBirthDate: Date | null;
 };
 
 export type SharedSpacePersonFace = {

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -404,8 +404,10 @@ where
 -- SharedSpaceRepository.getPersonsBySpaceId
 select
   "shared_space_person".*,
+  "person"."id" as "personalPersonId",
   "person"."name" as "personalName",
-  "person"."thumbnailPath" as "personalThumbnailPath"
+  "person"."thumbnailPath" as "personalThumbnailPath",
+  "person"."birthDate" as "personalBirthDate"
 from
   "shared_space_person"
   left join "asset_face" on "asset_face"."id" = "shared_space_person"."representativeFaceId"
@@ -432,8 +434,10 @@ limit
 -- SharedSpaceRepository.getPersonById
 select
   "shared_space_person".*,
+  "person"."id" as "personalPersonId",
   "person"."name" as "personalName",
-  "person"."thumbnailPath" as "personalThumbnailPath"
+  "person"."thumbnailPath" as "personalThumbnailPath",
+  "person"."birthDate" as "personalBirthDate"
 from
   "shared_space_person"
   left join "asset_face" on "asset_face"."id" = "shared_space_person"."representativeFaceId"

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -558,7 +558,12 @@ export class SharedSpaceRepository {
       .leftJoin('asset_face', 'asset_face.id', 'shared_space_person.representativeFaceId')
       .leftJoin('person', 'person.id', 'asset_face.personId')
       .selectAll('shared_space_person')
-      .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
+      .select([
+        'person.id as personalPersonId',
+        'person.name as personalName',
+        'person.thumbnailPath as personalThumbnailPath',
+        'person.birthDate as personalBirthDate',
+      ])
       .where('shared_space_person.spaceId', '=', spaceId)
       .$if(!options.withHidden, (qb) => qb.where('shared_space_person.isHidden', '=', false))
       .$if(!options.petsEnabled, (qb) => qb.where('shared_space_person.type', '!=', 'pet'))
@@ -611,7 +616,12 @@ export class SharedSpaceRepository {
       .leftJoin('asset_face', 'asset_face.id', 'shared_space_person.representativeFaceId')
       .leftJoin('person', 'person.id', 'asset_face.personId')
       .selectAll('shared_space_person')
-      .select(['person.name as personalName', 'person.thumbnailPath as personalThumbnailPath'])
+      .select([
+        'person.id as personalPersonId',
+        'person.name as personalName',
+        'person.thumbnailPath as personalThumbnailPath',
+        'person.birthDate as personalBirthDate',
+      ])
       .where('shared_space_person.id', '=', id)
       .executeTakeFirst();
   }

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3391,6 +3391,28 @@ describe(SharedSpaceService.name, () => {
       expect(result.name).toBe('Bob');
     });
 
+    it('should return birth date from linked personal person', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const birthDate = '1984-05-09';
+      const person = factory.sharedSpacePerson({ id: personId, spaceId, birthDate: null });
+      const space = factory.sharedSpace({ id: spaceId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+      mocks.sharedSpace.getPersonById.mockResolvedValue({
+        ...person,
+        personalPersonId: newUuid(),
+        personalBirthDate: new Date(birthDate),
+      });
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAlias.mockResolvedValue(void 0);
+
+      const result = await sut.getSpacePerson(auth, spaceId, personId);
+
+      expect(result.birthDate).toBe(birthDate);
+    });
+
     it('should read counts from person row without separate queries', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
@@ -3544,26 +3566,33 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(personId, { name: 'New Name' });
     });
 
-    it('should update person birth date', async () => {
+    it('should update linked personal person birth date', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
       const personId = newUuid();
+      const personalPersonId = newUuid();
       const birthDate = '1984-05-09';
       const person = factory.sharedSpacePerson({ id: personId, spaceId });
       const updatedPerson = factory.sharedSpacePerson({ id: personId, spaceId, birthDate });
 
       mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Editor }));
-      mocks.sharedSpace.getPersonById
-        .mockResolvedValueOnce(person)
-        .mockResolvedValueOnce({ ...updatedPerson, personalName: null, personalThumbnailPath: null });
-      mocks.sharedSpace.updatePerson.mockResolvedValue(updatedPerson);
+      mocks.sharedSpace.getPersonById.mockResolvedValueOnce({ ...person, personalPersonId }).mockResolvedValueOnce({
+        ...updatedPerson,
+        birthDate: null,
+        personalPersonId,
+        personalBirthDate: new Date(birthDate),
+        personalName: null,
+        personalThumbnailPath: null,
+      });
+      mocks.person.update.mockResolvedValue(factory.person({ id: personalPersonId, birthDate: new Date(birthDate) }));
       mocks.sharedSpace.getAlias.mockResolvedValue(void 0);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
 
       const result = await sut.updateSpacePerson(auth, spaceId, personId, { birthDate });
 
       expect(result.birthDate).toBe(birthDate);
-      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(personId, { birthDate });
+      expect(mocks.person.update).toHaveBeenCalledWith({ id: personalPersonId, birthDate });
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
     });
 
     it('should reject representativeFaceId that does not belong to an asset in the space', async () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -42,6 +42,7 @@ import {
 } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
 import { JobOf } from 'src/types';
+import { asBirthDateString } from 'src/utils/date';
 import { ImmichMediaResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
 
@@ -727,12 +728,31 @@ export class SharedSpaceService extends BaseService {
       }
     }
 
-    await this.sharedSpaceRepository.updatePerson(personId, {
+    const sharedPersonUpdates = {
       name: dto.name,
       isHidden: dto.isHidden,
-      birthDate: dto.birthDate,
       representativeFaceId: dto.representativeFaceId,
-    });
+    };
+
+    const hasSharedPersonUpdates = Object.values(sharedPersonUpdates).some((value) => value !== undefined);
+    if (hasSharedPersonUpdates) {
+      await this.sharedSpaceRepository.updatePerson(personId, sharedPersonUpdates);
+    }
+
+    let birthDatePerson = person;
+    if (dto.birthDate !== undefined) {
+      if (dto.representativeFaceId !== undefined && hasSharedPersonUpdates) {
+        const refreshed = await this.sharedSpaceRepository.getPersonById(personId);
+        if (!refreshed) {
+          throw new BadRequestException('Person not found');
+        }
+        birthDatePerson = refreshed;
+      }
+
+      await (birthDatePerson.personalPersonId
+        ? this.personRepository.update({ id: birthDatePerson.personalPersonId, birthDate: dto.birthDate })
+        : this.sharedSpaceRepository.updatePerson(personId, { birthDate: dto.birthDate }));
+    }
 
     const alias = await this.sharedSpaceRepository.getAlias(personId, auth.user.id);
 
@@ -1321,7 +1341,7 @@ export class SharedSpaceService extends BaseService {
       name: person.name || person.personalName || '',
       thumbnailPath: person.personalThumbnailPath || '',
       isHidden: person.isHidden,
-      birthDate: person.birthDate,
+      birthDate: person.personalPersonId ? asBirthDateString(person.personalBirthDate) : person.birthDate,
       representativeFaceId: person.representativeFaceId,
       faceCount: person.faceCount,
       assetCount: person.assetCount,

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -444,8 +444,10 @@ const sharedSpacePersonFactory = (data: Partial<SharedSpacePerson> = {}): Shared
   createdAt: newDate(),
   updatedAt: newDate(),
   updateId: newUuidV7(),
+  personalPersonId: null,
   personalName: null,
   personalThumbnailPath: null,
+  personalBirthDate: null,
   ...data,
 });
 


### PR DESCRIPTION
## Summary
- read Space People birth dates from the linked global person when available
- persist Space People birth date updates to the linked global person record
- add regression coverage for displaying and saving linked person birth dates

Fixes #474

## Testing
- pnpm --dir server test src/services/shared-space.service.spec.ts
- pnpm --dir server check
- pnpm --dir server format
- pnpm --dir server lint
- git diff --check