### PR TITLE
fix: hide future scheduled memories

### DIFF
--- a/server/src/queries/memory.repository.sql
+++ b/server/src/queries/memory.repository.sql
@@ -6,8 +6,12 @@ select
 from
   "memory"
 where
-  "deletedAt" is null
-  and "ownerId" = $1
+  (
+    "showAt" is null
+    or "showAt" <= $1
+  )
+  and "deletedAt" is null
+  and "ownerId" = $2
 
 -- MemoryRepository.statistics (date filter)
 select
@@ -50,8 +54,12 @@ select
 from
   "memory"
 where
-  "deletedAt" is null
-  and "ownerId" = $1
+  (
+    "showAt" is null
+    or "showAt" <= $1
+  )
+  and "deletedAt" is null
+  and "ownerId" = $2
 order by
   "memoryAt" desc
 

--- a/server/src/repositories/memory.repository.spec.ts
+++ b/server/src/repositories/memory.repository.spec.ts
@@ -1,0 +1,52 @@
+import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } from 'kysely';
+import { DateTime } from 'luxon';
+import { MemoryRepository } from 'src/repositories/memory.repository';
+import type { DB } from 'src/schema';
+
+const offlineKysely = () =>
+  new Kysely<DB>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+describe(MemoryRepository.name, () => {
+  const sut = new MemoryRepository(offlineKysely());
+
+  describe('searchBuilder', () => {
+    it('excludes future scheduled memories when no date filter is provided', () => {
+      const now = vi.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2026-04-30T12:00:00Z') as DateTime<true>);
+
+      try {
+        const query = sut.searchBuilder('00000000-0000-0000-0000-000000000000', {}).selectAll('memory').compile();
+
+        expect(query.sql).toContain('("showAt" is null or "showAt" <= $1)');
+        expect(query.sql).not.toContain('"hideAt"');
+        expect(query.parameters).toEqual([
+          new Date('2026-04-30T12:00:00.000Z'),
+          '00000000-0000-0000-0000-000000000000',
+        ]);
+      } finally {
+        now.mockRestore();
+      }
+    });
+
+    it('filters by the full visibility window when a date filter is provided', () => {
+      const query = sut
+        .searchBuilder('00000000-0000-0000-0000-000000000000', { for: new Date('2026-04-30T12:00:00.000Z') })
+        .selectAll('memory')
+        .compile();
+
+      expect(query.sql).toContain('("showAt" is null or "showAt" <= $1)');
+      expect(query.sql).toContain('("hideAt" is null or "hideAt" >= $2)');
+      expect(query.parameters).toEqual([
+        new Date('2026-04-30T12:00:00.000Z'),
+        new Date('2026-04-30T12:00:00.000Z'),
+        '00000000-0000-0000-0000-000000000000',
+      ]);
+    });
+  });
+});

--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -38,14 +38,15 @@ export class MemoryRepository implements IBulkAsset {
   }
 
   private baseSearchBuilder(dto: MemorySearchDto) {
+    const visibleAt = dto.for ?? DateTime.now().toJSDate();
+
     return this.db
       .selectFrom('memory')
       .$if(dto.isSaved !== undefined, (qb) => qb.where('isSaved', '=', dto.isSaved!))
       .$if(dto.type !== undefined, (qb) => qb.where('type', '=', dto.type!))
+      .where((where) => where.or([where('showAt', 'is', null), where('showAt', '<=', visibleAt)]))
       .$if(dto.for !== undefined, (qb) =>
-        qb
-          .where((where) => where.or([where('showAt', 'is', null), where('showAt', '<=', dto.for!)]))
-          .where((where) => where.or([where('hideAt', 'is', null), where('hideAt', '>=', dto.for!)])),
+        qb.where((where) => where.or([where('hideAt', 'is', null), where('hideAt', '>=', dto.for!)])),
       )
       .where('deletedAt', dto.isTrashed ? 'is not' : 'is', null);
   }

--- a/server/test/medium/specs/services/memory.service.spec.ts
+++ b/server/test/medium/specs/services/memory.service.spec.ts
@@ -252,12 +252,15 @@ describe(MemoryService.name, () => {
       vi.setSystemTime(now.toJSDate());
       await sut.onMemoriesCreate();
 
-      const memories = await memoryRepo.search(user.id, {});
+      const defaultMemories = await memoryRepo.search(user.id, {});
+      expect(defaultMemories.length).toBe(0);
+
+      const memories = await memoryRepo.search(user.id, { for: now.plus({ days: 3 }).toJSDate() });
       expect(memories.length).toBe(1);
 
       await sut.onMemoriesCreate();
 
-      const memoriesAfter = await memoryRepo.search(user.id, {});
+      const memoriesAfter = await memoryRepo.search(user.id, { for: now.plus({ days: 3 }).toJSDate() });
       expect(memoriesAfter.length).toBe(1);
     });
 


### PR DESCRIPTION
## Summary
- hide memories whose showAt date is still in the future from default memory searches
- preserve explicit for-date visibility checks using both showAt and hideAt
- add repository coverage for default and explicit memory visibility query behavior

Fixes #471.

## Test plan
- pnpm exec vitest --config test/vitest.config.mjs src/repositories/memory.repository.spec.ts --run
- pnpm exec vitest --config test/vitest.config.mjs src/services/memory.service.spec.ts --run
- pnpm --filter immich check
- pnpm --filter immich lint
- pnpm exec vitest --config test/vitest.config.mjs --run