### PR TITLE
fix(server): allow shared-space person thumbnails

### DIFF
--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -316,6 +316,46 @@ where
   "person"."id" in ($1)
   and "person"."ownerId" = $2
 
+-- AccessRepository.person.checkSharedSpaceAccess
+select
+  "person"."id"
+from
+  "person"
+where
+  "person"."id" in ($1)
+  and exists (
+    select
+    from
+      "asset_face"
+      inner join "asset" on "asset"."id" = "asset_face"."assetId"
+      and "asset"."deletedAt" is null
+      and "asset"."visibility" = $2
+    where
+      "asset_face"."personId" = "person"."id"
+      and "asset_face"."deletedAt" is null
+      and "asset_face"."isVisible" is true
+      and (
+        exists (
+          select
+          from
+            "shared_space_asset"
+            inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
+          where
+            "shared_space_asset"."assetId" = "asset"."id"
+            and "shared_space_member"."userId" = $3
+        )
+        or exists (
+          select
+          from
+            "shared_space_library"
+            inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
+          where
+            "shared_space_library"."libraryId" = "asset"."libraryId"
+            and "shared_space_member"."userId" = $4
+        )
+      )
+  )
+
 -- AccessRepository.person.checkFaceOwnerAccess
 select
   "asset_face"."id"

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -594,6 +594,54 @@ class PersonAccess {
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID_SET] })
   @ChunkedSet({ paramIndex: 1 })
+  async checkSharedSpaceAccess(userId: string, personIds: Set<string>) {
+    if (personIds.size === 0) {
+      return new Set<string>();
+    }
+
+    return this.db
+      .selectFrom('person')
+      .select('person.id')
+      .where('person.id', 'in', [...personIds])
+      .where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom('asset_face')
+            .innerJoin('asset', (join) =>
+              join
+                .onRef('asset.id', '=', 'asset_face.assetId')
+                .on('asset.deletedAt', 'is', null)
+                .on('asset.visibility', '=', AssetVisibility.Timeline),
+            )
+            .whereRef('asset_face.personId', '=', 'person.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where((eb) =>
+              eb.or([
+                eb.exists(
+                  eb
+                    .selectFrom('shared_space_asset')
+                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                    .where('shared_space_member.userId', '=', userId),
+                ),
+                eb.exists(
+                  eb
+                    .selectFrom('shared_space_library')
+                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                    .where('shared_space_member.userId', '=', userId),
+                ),
+              ]),
+            ),
+        ),
+      )
+      .execute()
+      .then((persons) => new Set(persons.map((person) => person.id)));
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID_SET] })
+  @ChunkedSet({ paramIndex: 1 })
   async checkFaceOwnerAccess(userId: string, assetFaceIds: Set<string>) {
     if (assetFaceIds.size === 0) {
       return new Set<string>();

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -179,6 +179,25 @@ describe(PersonService.name, () => {
       );
       expect(mocks.access.person.checkOwnerAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
     });
+
+    it('should serve the thumbnail when the person is visible through a shared space', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.person.checkSharedSpaceAccess.mockResolvedValue(new Set([person.id]));
+
+      await expect(sut.getThumbnail(auth, person.id)).resolves.toEqual(
+        new ImmichFileResponse({
+          path: person.thumbnailPath,
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithoutCache,
+        }),
+      );
+      expect(mocks.access.person.checkOwnerAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
+      expect(mocks.access.person.checkSharedSpaceAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
+    });
   });
 
   describe('update', () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -164,7 +164,7 @@ export class PersonService extends BaseService {
   }
 
   async getThumbnail(auth: AuthDto, id: string): Promise<ImmichMediaResponse> {
-    await this.requireAccess({ auth, permission: Permission.PersonRead, ids: [id] });
+    await this.requireThumbnailAccess(auth, id);
     const person = await this.personRepository.getById(id);
     if (!person || !person.thumbnailPath) {
       throw new NotFoundException();
@@ -175,6 +175,19 @@ export class PersonService extends BaseService {
       mimeTypes.lookup(person.thumbnailPath),
       CacheControl.PrivateWithoutCache,
     );
+  }
+
+  private async requireThumbnailAccess(auth: AuthDto, id: string) {
+    const ids = new Set([id]);
+    const isOwner = await this.accessRepository.person.checkOwnerAccess(auth.user.id, ids);
+    if (isOwner.has(id)) {
+      return;
+    }
+
+    const isShared = await this.accessRepository.person.checkSharedSpaceAccess(auth.user.id, ids);
+    if (!isShared.has(id)) {
+      throw new BadRequestException('Not found or no person.read access');
+    }
   }
 
   async create(auth: AuthDto, dto: PersonCreateDto): Promise<PersonResponseDto> {

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -51,6 +51,7 @@ export const newAccessRepositoryMock = (): IAccessRepositoryMock => {
     person: {
       checkFaceOwnerAccess: vitest.fn().mockResolvedValue(new Set()),
       checkOwnerAccess: vitest.fn().mockResolvedValue(new Set()),
+      checkSharedSpaceAccess: vitest.fn().mockResolvedValue(new Set()),
     },
 
     partner: {


### PR DESCRIPTION
## Summary
- Allow `/people/:id/thumbnail` to serve person thumbnails when the viewer can access a visible face through a shared space.
- Keep owner access as the first path and add a shared-space fallback scoped to timeline assets.
- Add a regression test for non-owner shared-space person thumbnail access.

## Test Plan
- [x] `pnpm --dir server test person.service.spec.ts --pool=forks --poolOptions.forks.singleFork=true`
- [x] Manual API check: reader in shared space receives `200 image/jpeg` for seeded shared person thumbnail
- [x] Manual API check: outsider receives `400 application/json` for the same thumbnail

Fixes #480