### PR TITLE
fix: show memories to users with asset access

### DIFF
--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -34,6 +34,10 @@ export class MemoryRepository implements IBulkAsset {
   }
 
   searchBuilder(ownerId: string, dto: MemorySearchDto) {
+    return this.baseSearchBuilder(dto).where('ownerId', '=', ownerId);
+  }
+
+  private baseSearchBuilder(dto: MemorySearchDto) {
     return this.db
       .selectFrom('memory')
       .$if(dto.isSaved !== undefined, (qb) => qb.where('isSaved', '=', dto.isSaved!))
@@ -43,8 +47,53 @@ export class MemoryRepository implements IBulkAsset {
           .where((where) => where.or([where('showAt', 'is', null), where('showAt', '<=', dto.for!)]))
           .where((where) => where.or([where('hideAt', 'is', null), where('hideAt', '>=', dto.for!)])),
       )
-      .where('deletedAt', dto.isTrashed ? 'is not' : 'is', null)
-      .where('ownerId', '=', ownerId);
+      .where('deletedAt', dto.isTrashed ? 'is not' : 'is', null);
+  }
+
+  private accessibleSearchBuilder(userId: string, dto: MemorySearchDto) {
+    return this.baseSearchBuilder(dto).where((eb) =>
+      eb.or([
+        eb('memory.ownerId', '=', userId),
+        eb.exists(
+          eb
+            .selectFrom('memory_asset')
+            .innerJoin('asset', 'asset.id', 'memory_asset.assetId')
+            .select('memory_asset.assetId')
+            .whereRef('memory_asset.memoriesId', '=', 'memory.id')
+            .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+            .where('asset.deletedAt', 'is', null)
+            .where((eb) =>
+              eb.or([
+                eb('asset.ownerId', '=', userId),
+                eb.exists(
+                  eb
+                    .selectFrom('partner')
+                    .select('partner.sharedById')
+                    .where('partner.sharedWithId', '=', userId)
+                    .whereRef('partner.sharedById', '=', 'asset.ownerId'),
+                ),
+                eb.exists(
+                  eb
+                    .selectFrom('shared_space_asset')
+                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+                    .select('shared_space_asset.assetId')
+                    .where('shared_space_member.userId', '=', userId)
+                    .whereRef('shared_space_asset.assetId', '=', 'asset.id'),
+                ),
+                eb.exists(
+                  eb
+                    .selectFrom('shared_space_library')
+                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+                    .select('shared_space_library.libraryId')
+                    .where('shared_space_member.userId', '=', userId)
+                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                    .where('asset.isOffline', '=', false),
+                ),
+              ]),
+            ),
+        ),
+      ]),
+    );
   }
 
   @GenerateSql(
@@ -57,12 +106,42 @@ export class MemoryRepository implements IBulkAsset {
       .executeTakeFirstOrThrow();
   }
 
+  statisticsAccessible(userId: string, dto: MemorySearchDto) {
+    return this.accessibleSearchBuilder(userId, dto)
+      .select((qb) => qb.fn.countAll<number>().as('total'))
+      .executeTakeFirstOrThrow();
+  }
+
   @GenerateSql(
     { params: [DummyValue.UUID, {}] },
     { name: 'date filter', params: [DummyValue.UUID, { for: DummyValue.DATE }] },
   )
   search(ownerId: string, dto: MemorySearchDto) {
     return this.searchBuilder(ownerId, dto)
+      .select((eb) =>
+        jsonArrayFrom(
+          eb
+            .selectFrom('asset')
+            .selectAll('asset')
+            .innerJoin('memory_asset', 'asset.id', 'memory_asset.assetId')
+            .whereRef('memory_asset.memoriesId', '=', 'memory.id')
+            .orderBy('asset.localDateTime', 'asc')
+            .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+            .where('asset.deletedAt', 'is', null),
+        ).as('assets'),
+      )
+      .selectAll('memory')
+      .$call((qb) =>
+        dto.order === AssetOrderWithRandom.Random
+          ? qb.orderBy(sql`RANDOM()`)
+          : qb.orderBy('memoryAt', (dto.order?.toLowerCase() || 'desc') as OrderByDirection),
+      )
+      .$if(dto.size !== undefined, (qb) => qb.limit(dto.size!))
+      .execute();
+  }
+
+  searchAccessible(userId: string, dto: MemorySearchDto) {
+    return this.accessibleSearchBuilder(userId, dto)
       .select((eb) =>
         jsonArrayFrom(
           eb

--- a/server/src/services/memory.service.spec.ts
+++ b/server/src/services/memory.service.spec.ts
@@ -17,6 +17,7 @@ describe(MemoryService.name, () => {
   beforeEach(() => {
     ({ sut, mocks } = newTestService(MemoryService));
     mocks.memory.search.mockResolvedValue([]);
+    mocks.memory.searchAccessible.mockResolvedValue([]);
   });
 
   it('should be defined', () => {
@@ -497,7 +498,8 @@ describe(MemoryService.name, () => {
       const memory1 = MemoryFactory.from({ ownerId: userId }).asset(asset).build();
       const memory2 = MemoryFactory.create({ ownerId: userId });
 
-      mocks.memory.search.mockResolvedValue([getForMemory(memory1), getForMemory(memory2)]);
+      mocks.memory.searchAccessible.mockResolvedValue([getForMemory(memory1), getForMemory(memory2)]);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
 
       await expect(sut.search(factory.auth({ user: { id: userId } }), {})).resolves.toEqual(
         expect.arrayContaining([
@@ -508,7 +510,7 @@ describe(MemoryService.name, () => {
     });
 
     it('should map ', async () => {
-      mocks.memory.search.mockResolvedValue([]);
+      mocks.memory.searchAccessible.mockResolvedValue([]);
 
       await expect(sut.search(factory.auth(), {})).resolves.toEqual([]);
     });
@@ -516,11 +518,27 @@ describe(MemoryService.name, () => {
     it('should pass search dto to repository', async () => {
       const auth = factory.auth();
       const dto = { type: MemoryType.OnThisDay, isSaved: true };
-      mocks.memory.search.mockResolvedValue([]);
+      mocks.memory.searchAccessible.mockResolvedValue([]);
 
       await sut.search(auth, dto);
 
-      expect(mocks.memory.search).toHaveBeenCalledWith(auth.user.id, dto);
+      expect(mocks.memory.searchAccessible).toHaveBeenCalledWith(auth.user.id, dto);
+    });
+
+    it('should only return assets the user can access', async () => {
+      const [userId] = newUuids();
+      const visibleAsset = AssetFactory.create();
+      const hiddenAsset = AssetFactory.create();
+      const memory = MemoryFactory.from({ ownerId: userId }).asset(visibleAsset).asset(hiddenAsset).build();
+      mocks.memory.searchAccessible.mockResolvedValue([getForMemory(memory)]);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([visibleAsset.id]));
+
+      await expect(sut.search(factory.auth({ user: { id: userId } }), {})).resolves.toEqual([
+        expect.objectContaining({
+          id: memory.id,
+          assets: [expect.objectContaining({ id: visibleAsset.id })],
+        }),
+      ]);
     });
 
     it('should expose server-owned title and subtitle for rule memories', async () => {
@@ -536,7 +554,7 @@ describe(MemoryService.name, () => {
         } satisfies RuleMemoryData,
       });
 
-      mocks.memory.search.mockResolvedValue([getForMemory(memory)]);
+      mocks.memory.searchAccessible.mockResolvedValue([getForMemory(memory)]);
 
       await expect(sut.search(factory.auth({ user: { id: userId } }), {})).resolves.toEqual([
         expect.objectContaining({
@@ -554,12 +572,12 @@ describe(MemoryService.name, () => {
       const auth = factory.auth();
       const dto = { type: MemoryType.OnThisDay };
       const stats = { total: 5 };
-      mocks.memory.statistics.mockResolvedValue(stats as any);
+      mocks.memory.statisticsAccessible.mockResolvedValue(stats as any);
 
       const result = await sut.statistics(auth, dto);
 
       expect(result).toEqual(stats);
-      expect(mocks.memory.statistics).toHaveBeenCalledWith(auth.user.id, dto);
+      expect(mocks.memory.statisticsAccessible).toHaveBeenCalledWith(auth.user.id, dto);
     });
   });
 

--- a/server/src/services/memory.service.ts
+++ b/server/src/services/memory.service.ts
@@ -183,12 +183,23 @@ export class MemoryService extends BaseService {
   }
 
   async search(auth: AuthDto, dto: MemorySearchDto) {
-    const memories = await this.memoryRepository.search(auth.user.id, dto);
-    return memories.map((memory) => mapMemory(memory, auth));
+    const memories = await this.memoryRepository.searchAccessible(auth.user.id, dto);
+    const assetIds = memories.flatMap((memory) => memory.assets.map((asset) => asset.id));
+    const allowedAssetIds = await this.checkAccess({ auth, permission: Permission.AssetView, ids: assetIds });
+
+    return memories.map((memory) =>
+      mapMemory(
+        {
+          ...memory,
+          assets: memory.assets.filter((asset) => allowedAssetIds.has(asset.id)),
+        },
+        auth,
+      ),
+    );
   }
 
   statistics(auth: AuthDto, dto: MemorySearchDto) {
-    return this.memoryRepository.statistics(auth.user.id, dto);
+    return this.memoryRepository.statisticsAccessible(auth.user.id, dto);
   }
 
   async get(auth: AuthDto, id: string): Promise<MemoryResponseDto> {

--- a/server/test/medium/specs/services/memory.service.spec.ts
+++ b/server/test/medium/specs/services/memory.service.spec.ts
@@ -111,6 +111,27 @@ describe(MemoryService.name, () => {
     });
   });
 
+  describe('search', () => {
+    it('should return memories containing assets visible through a shared space', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { memory } = await ctx.newMemory({ ownerId: owner.id });
+      await ctx.newMemoryAsset({ memoryId: memory.id, assetId: asset.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id });
+
+      await expect(sut.search(factory.auth({ user: member }), {})).resolves.toEqual([
+        expect.objectContaining({
+          id: memory.id,
+          assets: [expect.objectContaining({ id: asset.id })],
+        }),
+      ]);
+    });
+  });
+
   describe('onMemoryCreate', () => {
     it('should work on an empty database', async () => {
       const { sut } = setup();


### PR DESCRIPTION
## Summary
- make memory search/statistics include memories containing assets visible through owner, partner, or shared-space access
- filter returned memory assets through existing asset access checks
- add unit and medium regressions for non-owner memory visibility and asset filtering

Fixes #467

## Testing
- pnpm --dir server check
- pnpm --dir server exec vitest --config test/vitest.config.mjs --run src/services/memory.service.spec.ts
- pnpm --dir server exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/services/memory.service.spec.ts
- pnpm --filter immich test -- --run