### PR TITLE
fix: use space people in asset details

### DIFF
--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -904,18 +904,32 @@ limit
 -- SharedSpaceRepository.findSpacePersonsByLinkedPersonIds
 select
   "shared_space_person"."id",
+  "shared_space_person"."name",
   "shared_space_person"."isHidden",
+  "shared_space_person"."birthDate",
+  "shared_space_person"."updatedAt",
+  "shared_space_person"."type",
+  "person"."name" as "personalName",
+  "person"."thumbnailPath" as "personalThumbnailPath",
   "asset_face"."personId"
 from
   "shared_space_person"
   inner join "shared_space_person_face" on "shared_space_person_face"."personId" = "shared_space_person"."id"
   inner join "asset_face" on "asset_face"."id" = "shared_space_person_face"."assetFaceId"
+  left join "asset_face" as "representative_face" on "representative_face"."id" = "shared_space_person"."representativeFaceId"
+  left join "person" on "person"."id" = "representative_face"."personId"
 where
   "shared_space_person"."spaceId" = $1
   and "asset_face"."personId" in ($2)
 group by
   "shared_space_person"."id",
+  "shared_space_person"."name",
   "shared_space_person"."isHidden",
+  "shared_space_person"."birthDate",
+  "shared_space_person"."updatedAt",
+  "shared_space_person"."type",
+  "person"."name",
+  "person"."thumbnailPath",
   "asset_face"."personId"
 
 -- SharedSpaceRepository.findSpaceForAssetAndUser

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -15,6 +15,17 @@ import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.ta
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 import { searchAssetBuilder } from 'src/utils/database';
 
+export type LinkedSpacePerson = {
+  id: string;
+  isHidden: boolean;
+  name?: string | null;
+  personalName?: string | null;
+  personalThumbnailPath?: string | null;
+  birthDate?: string | null;
+  updatedAt?: Date | string;
+  type?: string;
+};
+
 @Injectable()
 export class SharedSpaceRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
@@ -1140,23 +1151,58 @@ export class SharedSpaceRepository {
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
   async findSpacePersonsByLinkedPersonIds(spaceId: string, personIds: string[]) {
     if (personIds.length === 0) {
-      return new Map<string, { id: string; isHidden: boolean }>();
+      return new Map<string, LinkedSpacePerson>();
     }
 
     const results = await this.db
       .selectFrom('shared_space_person')
       .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
       .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
-      .select(['shared_space_person.id', 'shared_space_person.isHidden', 'asset_face.personId'])
+      .leftJoin(
+        'asset_face as representative_face',
+        'representative_face.id',
+        'shared_space_person.representativeFaceId',
+      )
+      .leftJoin('person', 'person.id', 'representative_face.personId')
+      .select([
+        'shared_space_person.id',
+        'shared_space_person.name',
+        'shared_space_person.isHidden',
+        'shared_space_person.birthDate',
+        'shared_space_person.updatedAt',
+        'shared_space_person.type',
+        'person.name as personalName',
+        'person.thumbnailPath as personalThumbnailPath',
+        'asset_face.personId',
+      ])
       .where('shared_space_person.spaceId', '=', spaceId)
       .where('asset_face.personId', 'in', personIds)
-      .groupBy(['shared_space_person.id', 'shared_space_person.isHidden', 'asset_face.personId'])
+      .groupBy([
+        'shared_space_person.id',
+        'shared_space_person.name',
+        'shared_space_person.isHidden',
+        'shared_space_person.birthDate',
+        'shared_space_person.updatedAt',
+        'shared_space_person.type',
+        'person.name',
+        'person.thumbnailPath',
+        'asset_face.personId',
+      ])
       .execute();
 
-    const map = new Map<string, { id: string; isHidden: boolean }>();
+    const map = new Map<string, LinkedSpacePerson>();
     for (const row of results) {
       if (row.personId) {
-        map.set(row.personId, { id: row.id, isHidden: row.isHidden });
+        map.set(row.personId, {
+          id: row.id,
+          isHidden: row.isHidden,
+          name: row.name,
+          personalName: row.personalName,
+          personalThumbnailPath: row.personalThumbnailPath,
+          birthDate: row.birthDate,
+          updatedAt: row.updatedAt,
+          type: row.type,
+        });
       }
     }
     return map;

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -205,6 +205,55 @@ describe(AssetService.name, () => {
       expect((result as any).people[0].spacePersonId).toBe('space-person-1');
     });
 
+    it('should expose space person fields for people in explicit space context', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) =>
+          f.person({
+            id: 'person-1',
+            name: 'Global Person',
+            thumbnailPath: '/global-person-thumb.jpg',
+            birthDate: '1980-01-01' as any,
+          }),
+        )
+        .build();
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.getMember.mockResolvedValue({ userId: authStub.admin.user.id } as any);
+      mocks.access.asset.checkSpaceAccessForSpace.mockResolvedValue(new Set([asset.id]));
+      mocks.sharedSpace.findSpacePersonsByLinkedPersonIds.mockResolvedValue(
+        new Map([
+          [
+            'person-1',
+            {
+              id: 'space-person-1',
+              isHidden: false,
+              name: 'Space Person',
+              personalName: 'Global Person',
+              personalThumbnailPath: '/linked-person-thumb.jpg',
+              birthDate: '1990-02-03',
+              updatedAt: new Date('2026-01-02T03:04:05.000Z'),
+              type: 'person',
+            },
+          ],
+        ]) as any,
+      );
+
+      const result = await sut.get(authStub.admin, asset.id, 'space-id');
+
+      expect((result as any).people[0]).toEqual(
+        expect.objectContaining({
+          id: 'person-1',
+          spacePersonId: 'space-person-1',
+          name: 'Space Person',
+          thumbnailPath: '/linked-person-thumb.jpg',
+          birthDate: '1990-02-03',
+          updatedAt: '2026-01-02T03:04:05.000Z',
+          type: 'person',
+        }),
+      );
+    });
+
     it('should map spacePersonId for asset owner in shared space context', async () => {
       const asset = AssetFactory.from({ ownerId: authStub.user1.user.id })
         .exif()

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -41,6 +41,7 @@ import {
   Permission,
   QueueName,
 } from 'src/enum';
+import type { LinkedSpacePerson } from 'src/repositories/shared-space.repository';
 import { BaseService } from 'src/services/base.service';
 import { StorageService } from 'src/services/storage.service';
 import { JobItem, JobOf } from 'src/types';
@@ -54,7 +55,7 @@ import {
   onBeforeUnlink,
 } from 'src/utils/asset.util';
 import { updateLockedColumns } from 'src/utils/database';
-import { extractTimeZone } from 'src/utils/date';
+import { asDateString, extractTimeZone } from 'src/utils/date';
 import { formatSecondsToDuration, parseDurationToSeconds } from 'src/utils/duration';
 import { transformOcrBoundingBox } from 'src/utils/transform';
 
@@ -121,12 +122,7 @@ export class AssetService extends BaseService {
           spaceId,
           globalPersonIds,
         );
-        for (const person of data.people) {
-          const spacePerson = spacePersonMap.get(person.id);
-          if (spacePerson) {
-            person.spacePersonId = spacePerson.id;
-          }
-        }
+        this.applySpacePeople(data, spacePersonMap);
         data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
       }
     } else if (data.ownerId !== auth.user.id) {
@@ -140,12 +136,7 @@ export class AssetService extends BaseService {
           spaceForAsset.spaceId,
           globalPersonIds,
         );
-        for (const person of data.people || []) {
-          const spacePerson = spacePersonMap.get(person.id);
-          if (spacePerson) {
-            person.spacePersonId = spacePerson.id;
-          }
-        }
+        this.applySpacePeople(data, spacePersonMap);
         data.people = (data.people || []).filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
         data.resolvedSpaceId = spaceForAsset.spaceId;
       } else {
@@ -154,6 +145,39 @@ export class AssetService extends BaseService {
     }
 
     return data;
+  }
+
+  private applySpacePeople(data: AssetResponseDto, spacePersonMap: Map<string, LinkedSpacePerson>) {
+    for (const person of data.people || []) {
+      const spacePerson = spacePersonMap.get(person.id);
+      if (!spacePerson) {
+        continue;
+      }
+
+      person.spacePersonId = spacePerson.id;
+      person.isHidden = spacePerson.isHidden;
+
+      const name = spacePerson.name || spacePerson.personalName;
+      if (name !== undefined) {
+        person.name = name ?? '';
+      }
+
+      if (spacePerson.personalThumbnailPath !== undefined) {
+        person.thumbnailPath = spacePerson.personalThumbnailPath || '';
+      }
+
+      if (spacePerson.birthDate !== undefined) {
+        person.birthDate = spacePerson.birthDate ?? null;
+      }
+
+      if (spacePerson.updatedAt !== undefined) {
+        person.updatedAt = asDateString(spacePerson.updatedAt);
+      }
+
+      if (spacePerson.type) {
+        person.type = spacePerson.type;
+      }
+    }
   }
 
   async update(auth: AuthDto, id: string, dto: UpdateAssetDto): Promise<AssetResponseDto> {

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.test-wrapper.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.test-wrapper.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { Action } from '$lib/components/asset-viewer/actions/action';
+  import { AssetAction } from '$lib/constants';
+  import type { AssetResponseDto, PersonResponseDto } from '@immich/sdk';
+
+  interface Props {
+    asset: AssetResponseDto;
+    onAction?: (action: Action) => void;
+  }
+
+  let { asset, onAction }: Props = $props();
+
+  const person: PersonResponseDto = {
+    id: 'person-1',
+    name: 'Person',
+    birthDate: null,
+    thumbnailPath: '',
+    isHidden: false,
+    isFavorite: false,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    type: 'person',
+    species: null,
+  };
+</script>
+
+<button
+  type="button"
+  aria-label="set featured photo"
+  onclick={() => onAction?.({ type: AssetAction.SET_PERSON_FEATURED_PHOTO, asset, person })}
+>
+  Set featured photo
+</button>

--- a/web/src/lib/components/asset-viewer/asset-viewer-space-context.spec.ts
+++ b/web/src/lib/components/asset-viewer/asset-viewer-space-context.spec.ts
@@ -1,0 +1,68 @@
+import { getAnimateMock } from '$lib/__mocks__/animate.mock';
+import { getResizeObserverMock } from '$lib/__mocks__/resize-observer.mock';
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { authManager } from '$lib/managers/auth-manager.svelte';
+import { renderWithTooltips } from '$tests/helpers';
+import { assetFactory } from '@test-data/factories/asset-factory';
+import { preferencesFactory } from '@test-data/factories/preferences-factory';
+import { userAdminFactory } from '@test-data/factories/user-factory';
+import { fireEvent, screen, waitFor } from '@testing-library/svelte';
+import AssetViewer from './asset-viewer.svelte';
+
+vi.mock('$lib/components/asset-viewer/asset-viewer-nav-bar.svelte', async () => {
+  const { default: MockAssetViewerNavBar } = await import('./asset-viewer-nav-bar.test-wrapper.svelte');
+  return { default: MockAssetViewerNavBar };
+});
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: {
+    init: vi.fn(),
+    loadFeatureFlags: vi.fn(),
+    value: { smartSearch: true, trash: true },
+  } as never,
+}));
+
+vi.mock('$lib/stores/ocr.svelte', () => ({
+  ocrManager: {
+    clear: vi.fn(),
+    getAssetOcr: vi.fn(),
+    hasOcrData: false,
+    showOverlay: false,
+  },
+}));
+
+describe('AssetViewer space context', () => {
+  beforeAll(() => {
+    Element.prototype.animate = getAnimateMock();
+    vi.stubGlobal('ResizeObserver', getResizeObserverMock());
+  });
+
+  afterEach(() => {
+    authManager.reset();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('refreshes person updates with the current spaceId', async () => {
+    const ownerId = 'owner-id';
+    const asset = assetFactory.build({ ownerId });
+    const refreshedAsset = assetFactory.build({ id: asset.id, ownerId, people: [] });
+
+    authManager.setUser(userAdminFactory.build({ id: ownerId }));
+    authManager.setPreferences(preferencesFactory.build({ cast: { gCastEnabled: false } }));
+    sdkMock.getAssetInfo.mockResolvedValue(refreshedAsset);
+
+    renderWithTooltips(AssetViewer, {
+      cursor: { current: asset },
+      showNavigation: false,
+      spaceId: 'space-1',
+    });
+
+    await fireEvent.click(screen.getByLabelText('set featured photo'));
+
+    await waitFor(() => expect(sdkMock.getAssetInfo).toHaveBeenCalledWith({ id: asset.id, spaceId: 'space-1' }));
+  });
+});

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -186,7 +186,7 @@
 
   const closeEditor = async () => {
     if (editManager.hasAppliedEdits) {
-      const refreshedAsset = await getAssetInfo({ id: asset.id });
+      const refreshedAsset = await getAssetInfo({ id: asset.id, spaceId });
       onAssetChange?.(refreshedAsset);
       assetViewerManager.setAsset(refreshedAsset);
     }
@@ -315,7 +315,7 @@
         break;
       }
       case AssetAction.SET_PERSON_FEATURED_PHOTO: {
-        const assetInfo = await getAssetInfo({ id: asset.id });
+        const assetInfo = await getAssetInfo({ id: asset.id, spaceId });
         cursor.current = { ...asset, people: assetInfo.people };
         break;
       }

--- a/web/src/lib/components/asset-viewer/detail-panel.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel.spec.ts
@@ -6,9 +6,10 @@ import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/svelte';
 import DetailPanel from './detail-panel.svelte';
 
-const { getAllAlbumsMock, getAssetInfoMock } = vi.hoisted(() => ({
+const { getAllAlbumsMock, getAssetInfoMock, zoomImageToBase64Mock } = vi.hoisted(() => ({
   getAllAlbumsMock: vi.fn(),
   getAssetInfoMock: vi.fn(),
+  zoomImageToBase64Mock: vi.fn(),
 }));
 
 vi.mock('@immich/sdk', async (importOriginal) => {
@@ -21,6 +22,10 @@ vi.mock('@immich/sdk', async (importOriginal) => {
 });
 
 vi.mock('$app/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('$lib/utils/people-utils', () => ({
+  zoomImageToBase64: zoomImageToBase64Mock,
+}));
 
 vi.mock('$lib/managers/auth-manager.svelte', () => ({
   authManager: {
@@ -116,9 +121,12 @@ describe('DetailPanel', () => {
     vi.clearAllMocks();
     getAllAlbumsMock.mockResolvedValue([]);
     getAssetInfoMock.mockResolvedValue(undefined);
+    zoomImageToBase64Mock.mockResolvedValue(null);
   });
 
-  it('uses the shared-space person thumbnail URL when spacePersonId is present', () => {
+  it('uses the detected face crop instead of the shared-space person thumbnail when spacePersonId is present', async () => {
+    zoomImageToBase64Mock.mockResolvedValue('data:image/jpeg;base64,current-face');
+
     const asset: AssetResponseDto = {
       id: 'asset-1',
       ownerId: 'owner-1',
@@ -153,7 +161,17 @@ describe('DetailPanel', () => {
           isHidden: false,
           birthDate: null,
           type: 'person',
-          faces: [],
+          faces: [
+            {
+              id: 'face-1',
+              imageWidth: 1000,
+              imageHeight: 800,
+              boundingBoxX1: 100,
+              boundingBoxY1: 200,
+              boundingBoxX2: 300,
+              boundingBoxY2: 400,
+            },
+          ],
           spacePersonId: 'space-person-1',
         },
       ],
@@ -166,8 +184,105 @@ describe('DetailPanel', () => {
       spaceId: 'space-1',
     });
 
-    const image = container.querySelector('img[src*="/shared-spaces/space-1/people/space-person-1/thumbnail"]');
-    expect(image).toBeTruthy();
+    await waitFor(() =>
+      expect(zoomImageToBase64Mock).toHaveBeenCalledWith(asset.people![0].faces[0], asset.id, asset.type, undefined),
+    );
+
+    const croppedFace = container.querySelector('img[src="data:image/jpeg;base64,current-face"]');
+    expect(croppedFace).toBeTruthy();
+    expect(container.querySelector('img[src*="/shared-spaces/space-1/people/space-person-1/thumbnail"]')).toBeNull();
+  });
+
+  it('renders distinct detected face crops when multiple people resolve to the same space person', async () => {
+    zoomImageToBase64Mock
+      .mockResolvedValueOnce('data:image/jpeg;base64,first-face')
+      .mockResolvedValueOnce('data:image/jpeg;base64,second-face');
+
+    const asset: AssetResponseDto = {
+      id: 'asset-1',
+      ownerId: 'owner-1',
+      libraryId: 'library-1',
+      type: AssetTypeEnum.Image,
+      originalPath: '/library/asset-1.jpg',
+      originalFileName: 'asset-1.jpg',
+      originalMimeType: 'image/jpeg',
+      thumbhash: 'thumbhash',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      fileCreatedAt: '2026-01-01T00:00:00.000Z',
+      fileModifiedAt: '2026-01-01T00:00:00.000Z',
+      localDateTime: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      isFavorite: false,
+      isArchived: false,
+      isTrashed: false,
+      duration: null,
+      checksum: 'checksum',
+      isOffline: false,
+      hasMetadata: false,
+      visibility: AssetVisibility.Timeline,
+      width: 1000,
+      height: 800,
+      isEdited: false,
+      people: [
+        {
+          id: 'global-person-1',
+          name: 'Alice',
+          thumbnailPath: '/ignored-1.jpg',
+          updatedAt: '2026-01-02T00:00:00.000Z',
+          isHidden: false,
+          birthDate: null,
+          type: 'person',
+          faces: [
+            {
+              id: 'face-1',
+              imageWidth: 1000,
+              imageHeight: 800,
+              boundingBoxX1: 100,
+              boundingBoxY1: 200,
+              boundingBoxX2: 300,
+              boundingBoxY2: 400,
+            },
+          ],
+          spacePersonId: 'space-person-1',
+        },
+        {
+          id: 'global-person-2',
+          name: 'Bob',
+          thumbnailPath: '/ignored-2.jpg',
+          updatedAt: '2026-01-03T00:00:00.000Z',
+          isHidden: false,
+          birthDate: null,
+          type: 'person',
+          faces: [
+            {
+              id: 'face-2',
+              imageWidth: 1000,
+              imageHeight: 800,
+              boundingBoxX1: 500,
+              boundingBoxY1: 200,
+              boundingBoxX2: 700,
+              boundingBoxY2: 400,
+            },
+          ],
+          spacePersonId: 'space-person-1',
+        },
+      ],
+      unassignedFaces: [],
+    };
+
+    const { container } = renderWithTooltips(DetailPanel, {
+      asset,
+      currentAlbum: null,
+      spaceId: 'space-1',
+    });
+
+    await waitFor(() => expect(zoomImageToBase64Mock).toHaveBeenCalledTimes(2));
+
+    expect(container.querySelector('img[src="data:image/jpeg;base64,first-face"]')).toBeTruthy();
+    expect(container.querySelector('img[src="data:image/jpeg;base64,second-face"]')).toBeTruthy();
+    expect(
+      container.querySelectorAll('img[src*="/shared-spaces/space-1/people/space-person-1/thumbnail"]'),
+    ).toHaveLength(0);
   });
 
   it('renders Google, Apple, and OpenStreetMap links in the image info panel map popup', async () => {

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -14,6 +14,7 @@
   import { locale } from '$lib/stores/preferences.store';
   import { createUrl, getAssetMediaUrl, getPeopleThumbnailUrl } from '$lib/utils';
   import { delay, getDimensions } from '$lib/utils/asset-utils';
+  import { zoomImageToBase64 } from '$lib/utils/people-utils';
   import { getParentPath } from '$lib/utils/tree-utils';
   import { getByteUnitString } from '$lib/utils/byte-units';
   import { getMapProviderLinks } from '$lib/utils/exif-utils';
@@ -116,6 +117,13 @@
 
   const getAssetFolderHref = (asset: AssetResponseDto) => Route.folders({ path: getParentPath(asset.originalPath) });
 
+  const getPersonFallbackThumbnailUrl = (person: AssetResponseDto['people'][number]) =>
+    effectiveSpaceId && person.spacePersonId
+      ? createUrl(`/shared-spaces/${effectiveSpaceId}/people/${person.spacePersonId}/thumbnail`, {
+          updatedAt: person.updatedAt,
+        })
+      : getPeopleThumbnailUrl(person);
+
   onDestroy(() => {
     assetViewerManager.closeEditFacesPanel();
   });
@@ -208,6 +216,7 @@
           {#each people as person, index (person.id)}
             {#if showingHiddenPeople || !person.isHidden}
               {@const isHighlighted = people[index].faces.some((f) => $boundingBoxesArray.some((b) => b.id === f.id))}
+              {@const fallbackThumbnailUrl = getPersonFallbackThumbnailUrl(person)}
               <a
                 class="group w-22 outline-none"
                 href={effectiveSpaceId && person.spacePersonId
@@ -219,22 +228,48 @@
                 onmouseleave={() => ($boundingBoxesArray = [])}
               >
                 <div class="relative">
-                  <ImageThumbnail
-                    curve
-                    shadow
-                    url={effectiveSpaceId && person.spacePersonId
-                      ? createUrl(`/shared-spaces/${effectiveSpaceId}/people/${person.spacePersonId}/thumbnail`, {
-                          updatedAt: person.updatedAt,
-                        })
-                      : getPeopleThumbnailUrl(person)}
-                    altText={person.name}
-                    title={person.name}
-                    widthStyle="90px"
-                    heightStyle="90px"
-                    hidden={person.isHidden}
-                    highlighted={isHighlighted}
-                    class="group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary"
-                  />
+                  {#if person.faces[0]}
+                    {#await zoomImageToBase64(person.faces[0], asset.id, asset.type, assetViewerManager.imgRef)}
+                      <ImageThumbnail
+                        curve
+                        shadow
+                        url={fallbackThumbnailUrl}
+                        altText={person.name}
+                        title={person.name}
+                        widthStyle="90px"
+                        heightStyle="90px"
+                        hidden={person.isHidden}
+                        highlighted={isHighlighted}
+                        class="group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary"
+                      />
+                    {:then faceThumbnailUrl}
+                      <ImageThumbnail
+                        curve
+                        shadow
+                        url={faceThumbnailUrl ?? fallbackThumbnailUrl}
+                        altText={person.name}
+                        title={person.name}
+                        widthStyle="90px"
+                        heightStyle="90px"
+                        hidden={person.isHidden}
+                        highlighted={isHighlighted}
+                        class="group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary"
+                      />
+                    {/await}
+                  {:else}
+                    <ImageThumbnail
+                      curve
+                      shadow
+                      url={fallbackThumbnailUrl}
+                      altText={person.name}
+                      title={person.name}
+                      widthStyle="90px"
+                      heightStyle="90px"
+                      hidden={person.isHidden}
+                      highlighted={isHighlighted}
+                      class="group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-immich-primary dark:group-focus-visible:outline-immich-dark-primary"
+                    />
+                  {/if}
                 </div>
                 <p class="mt-1 truncate font-medium" title={person.name}>{person.name}</p>
                 {#if person.birthDate}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -117,7 +117,9 @@
 
   const getAssetFolderHref = (asset: AssetResponseDto) => Route.folders({ path: getParentPath(asset.originalPath) });
 
-  const getPersonFallbackThumbnailUrl = (person: AssetResponseDto['people'][number]) =>
+  type AssetPerson = NonNullable<AssetResponseDto['people']>[number];
+
+  const getPersonFallbackThumbnailUrl = (person: AssetPerson) =>
     effectiveSpaceId && person.spacePersonId
       ? createUrl(`/shared-spaces/${effectiveSpaceId}/people/${person.spacePersonId}/thumbnail`, {
           updatedAt: person.updatedAt,

--- a/web/src/lib/utils/navigation.spec.ts
+++ b/web/src/lib/utils/navigation.spec.ts
@@ -1,0 +1,41 @@
+import { assetCacheManager } from '$lib/managers/AssetCacheManager.svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getAssetInfoFromParam } from './navigation';
+
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('$app/stores', () => ({
+  page: {
+    subscribe: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/managers/AssetCacheManager.svelte', () => ({
+  assetCacheManager: {
+    getAsset: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('getAssetInfoFromParam', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes spaceId through when preloading an asset from a space route', async () => {
+    await getAssetInfoFromParam({ assetId: 'asset-1', spaceId: 'space-1' });
+
+    expect(assetCacheManager.getAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'asset-1', spaceId: 'space-1' }),
+      false,
+    );
+  });
+
+  it('does not fetch when assetId is absent', () => {
+    const result = getAssetInfoFromParam({ spaceId: 'space-1' });
+
+    expect(result).toBeUndefined();
+    expect(assetCacheManager.getAsset).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/utils/navigation.ts
+++ b/web/src/lib/utils/navigation.ts
@@ -25,8 +25,18 @@ export const isAssetViewerRoute = (
   target?: { route?: { id?: RouteId | null }; params?: Record<string, string> | null } | null,
 ) => !!(target?.route?.id?.endsWith('/[[assetId=id]]') && 'assetId' in (target?.params || {}));
 
-export function getAssetInfoFromParam({ assetId, slug, key }: { assetId?: string; key?: string; slug?: string }) {
-  return assetId ? assetCacheManager.getAsset({ id: assetId, slug, key }, false) : undefined;
+export function getAssetInfoFromParam({
+  assetId,
+  slug,
+  key,
+  spaceId,
+}: {
+  assetId?: string;
+  key?: string;
+  slug?: string;
+  spaceId?: string;
+}) {
+  return assetId ? assetCacheManager.getAsset({ id: assetId, slug, key, spaceId }, false) : undefined;
 }
 
 function currentUrlWithoutAsset() {

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -1,7 +1,7 @@
 import type { Faces } from '$lib/stores/people.store';
 import { getAssetMediaUrl } from '$lib/utils';
 import { mapNormalizedRectToContent, type Rect, type Size } from '$lib/utils/container-utils';
-import { AssetTypeEnum, type AssetFaceResponseDto } from '@immich/sdk';
+import { AssetTypeEnum } from '@immich/sdk';
 
 export type BoundingBox = Rect & { id: string };
 
@@ -22,7 +22,7 @@ export const getBoundingBox = (faces: Faces[], imageSize: Size): BoundingBox[] =
 };
 
 export const zoomImageToBase64 = async (
-  face: AssetFaceResponseDto,
+  face: Faces,
   assetId: string,
   assetType: AssetTypeEnum,
   photoViewer: HTMLImageElement | undefined,


### PR DESCRIPTION
## Summary
- show linked space person fields in asset detail people responses
- preserve spaceId when preloading and refreshing assets in space photo routes
- render detected face crops in the detail panel instead of repeated representative thumbnails

## Test Plan
- pnpm -C web exec vitest run src/lib/utils/navigation.spec.ts src/lib/components/asset-viewer/asset-viewer-space-context.spec.ts src/lib/components/asset-viewer/detail-panel.spec.ts src/lib/utils/people-utils.spec.ts
- pnpm -C server exec vitest --config test/vitest.config.mjs run src/services/asset.service.spec.ts src/dtos/asset-response.dto.spec.ts
- pnpm -C web run check:typescript
- pnpm -C web run check:svelte
- pnpm -C server exec tsc --noEmit --tsBuildInfoFile /tmp/gallery-server-issue-469.tsbuildinfo