### PR TITLE
feat(web): anchor global search dropdown

### DIFF
--- a/e2e/src/specs/web/global-search.e2e-spec.ts
+++ b/e2e/src/specs/web/global-search.e2e-spec.ts
@@ -1,6 +1,15 @@
 import type { LoginResponseDto } from '@immich/sdk';
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import { utils } from 'src/utils';
+
+async function openGlobalSearchDropdown(page: Page) {
+  const trigger = page.getByTestId('cmdk-input-trigger');
+  await trigger.click();
+  const panel = page.locator('[data-cmdk-dropdown-panel]');
+  await expect(panel).toBeVisible();
+  await expect(page.getByRole('dialog')).toBeHidden();
+  return { trigger, panel, input: trigger.getByRole('combobox') };
+}
 
 test.describe('global search palette', () => {
   let admin: LoginResponseDto;
@@ -57,15 +66,20 @@ test.describe('global search palette', () => {
     await expect(page.getByRole('dialog')).toBeHidden();
   });
 
-  test('clicking the trigger opens the palette', async ({ page }) => {
-    await page.getByTestId('cmdk-input-trigger').click();
-    await expect(page.getByRole('dialog')).toBeVisible();
+  test('clicking the trigger opens the anchored dropdown', async ({ page }) => {
+    const { input } = await openGlobalSearchDropdown(page);
+    await expect(input).toBeFocused();
   });
 
-  test('desktop input trigger opens the palette', async ({ page }) => {
-    await expect(page.getByTestId('cmdk-input-trigger')).toBeVisible();
-    await page.getByTestId('cmdk-input-trigger').click();
-    await expect(page.getByRole('dialog')).toBeVisible();
+  test('desktop input trigger keeps typed text in the navbar field', async ({ page }) => {
+    const trigger = page.getByTestId('cmdk-input-trigger');
+    await expect(trigger).toBeVisible();
+    const input = trigger.getByRole('combobox');
+    await input.fill('beach');
+
+    await expect(page.locator('[data-cmdk-dropdown-panel]')).toBeVisible();
+    await expect(input).toHaveValue('beach');
+    await expect(page.getByRole('dialog')).toBeHidden();
   });
 
   test('maxlength on input is 256', async ({ page }) => {
@@ -75,9 +89,9 @@ test.describe('global search palette', () => {
   });
 
   test('focus returns to the trigger after the palette closes', async ({ page }) => {
-    const trigger = page.getByTestId('cmdk-input-trigger');
-    await trigger.focus();
-    await expect(trigger).toBeFocused();
+    const triggerInput = page.getByTestId('cmdk-input-trigger').getByRole('combobox');
+    await triggerInput.focus();
+    await expect(triggerInput).toBeFocused();
     await page.keyboard.press('Control+k');
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
@@ -86,7 +100,7 @@ test.describe('global search palette', () => {
     await expect(dialog).toBeHidden();
     // @immich/ui Modal / bits-ui Dialog restores focus to the element that had it
     // before the dialog opened. If this regresses, it's a keyboard-a11y issue.
-    await expect(trigger).toBeFocused();
+    await expect(triggerInput).toBeFocused();
   });
 
   test('Ctrl+/ cycles search mode via footer', async ({ page }) => {
@@ -183,7 +197,7 @@ test.describe('global search palette', () => {
   });
 
   test('query recents replay on /photos', async ({ page }) => {
-    await page.getByTestId('cmdk-input-trigger').click();
+    await page.keyboard.press('Control+k');
     let dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
     await dialog.getByRole('combobox').fill('beach');
@@ -192,7 +206,7 @@ test.describe('global search palette', () => {
 
     await page.goto('/photos');
     await page.getByTestId('cmdk-input-trigger').waitFor({ state: 'visible' });
-    await page.getByTestId('cmdk-input-trigger').click();
+    await page.keyboard.press('Control+k');
     dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
     const recentGroup = dialog.getByRole('group', { name: /^recent$/i });

--- a/e2e/src/specs/web/photos-search.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-search.e2e-spec.ts
@@ -75,6 +75,7 @@ test.describe('Photos Search', () => {
     });
 
     const trigger = page.getByTestId('cmdk-input-trigger');
+    await expect(trigger.getByRole('combobox')).toHaveValue('mountain');
     await trigger.click();
     await expect(page.locator('[data-cmdk-dropdown-panel]')).toBeVisible();
     await expect(trigger.getByRole('combobox')).toHaveValue('mountain');

--- a/e2e/src/specs/web/photos-search.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-search.e2e-spec.ts
@@ -4,7 +4,7 @@ import { utils } from 'src/utils';
 
 async function submitGlobalSearch(page: import('@playwright/test').Page, query: string) {
   const mobileSearchButton = page.locator('#search-button');
-  await ((await mobileSearchButton.isVisible()) ? mobileSearchButton : page.getByTestId('cmdk-input-trigger')).click();
+  await ((await mobileSearchButton.isVisible()) ? mobileSearchButton.click() : page.keyboard.press('Control+k'));
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
   const combobox = dialog.getByRole('combobox');
@@ -51,6 +51,11 @@ test.describe('Photos Search', () => {
     await gotoPhotos(context, page);
     await submitGlobalSearch(page, 'beach');
     await expect(page).toHaveURL(/\/photos\?q=beach/, { timeout: 10_000 });
+
+    await page.keyboard.press('Control+k');
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('combobox')).toHaveValue('');
   });
 
   test('navigating directly to /photos?q=... hides the timeline and shows search results area', async ({
@@ -69,8 +74,10 @@ test.describe('Photos Search', () => {
       timeout: 15_000,
     });
 
-    await page.getByTestId('cmdk-input-trigger').click();
-    await expect(page.getByRole('dialog').getByRole('combobox')).toHaveValue('mountain');
+    const trigger = page.getByTestId('cmdk-input-trigger');
+    await trigger.click();
+    await expect(page.locator('[data-cmdk-dropdown-panel]')).toBeVisible();
+    await expect(trigger.getByRole('combobox')).toHaveValue('mountain');
   });
 
   test('clearing the search via the X button returns to the timeline', async ({ context, page }) => {
@@ -177,7 +184,7 @@ test.describe('Photos Search', () => {
     await gotoPhotos(context, page);
 
     await expect(page.locator('#asset-grid img').first()).toBeVisible({ timeout: 15_000 });
-    await page.getByTestId('cmdk-input-trigger').click();
+    await page.keyboard.press('Control+k');
     const dialog = page.getByRole('dialog');
     const combobox = dialog.getByRole('combobox');
     await expect(combobox).toBeVisible();

--- a/e2e/src/specs/web/photos-search.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-search.e2e-spec.ts
@@ -56,6 +56,24 @@ test.describe('Photos Search', () => {
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
     await expect(dialog.getByRole('combobox')).toHaveValue('');
+    await dialog.getByRole('combobox').press('Enter');
+    await expect(page).toHaveURL(/\/photos(?!\?q=)/, { timeout: 10_000 });
+  });
+
+  test('clearing the top search field and pressing Enter removes q=', async ({ context, page }) => {
+    await gotoPhotos(context, page, '/photos?q=mountain');
+
+    const trigger = page.getByTestId('cmdk-input-trigger');
+    const input = trigger.getByRole('combobox');
+    await expect(input).toHaveValue('mountain');
+
+    await trigger.click();
+    await expect(page.locator('[data-cmdk-dropdown-panel]')).toBeVisible();
+    await input.fill('');
+    await input.press('Enter');
+
+    await expect(page).toHaveURL(/\/photos(?!\?q=)/, { timeout: 10_000 });
+    await expect(page.getByTestId('search-chip')).not.toBeVisible();
   });
 
   test('navigating directly to /photos?q=... hides the timeline and shows search results area', async ({

--- a/e2e/src/specs/web/spaces-search.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-search.e2e-spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { utils } from 'src/utils';
 
 async function submitGlobalSearch(page: import('@playwright/test').Page, query: string) {
-  await page.getByTestId('cmdk-input-trigger').click();
+  await page.keyboard.press('Control+k');
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
   const combobox = dialog.getByRole('combobox');
@@ -64,8 +64,10 @@ test.describe('Spaces Search', () => {
     await page.goBack();
 
     await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/photos\?q=sunset$`));
-    await page.getByTestId('cmdk-input-trigger').click();
-    await expect(page.getByRole('dialog').getByRole('combobox')).toHaveValue('sunset');
+    const trigger = page.getByTestId('cmdk-input-trigger');
+    await trigger.click();
+    await expect(page.locator('[data-cmdk-dropdown-panel]')).toBeVisible();
+    await expect(trigger.getByRole('combobox')).toHaveValue('sunset');
   });
 
   test('clearing search via X removes q and returns to the timeline', async ({ context, page }) => {

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -51,6 +51,15 @@ describe('global-search-input-trigger', () => {
     expect(globalSearchManager.presentation).toBe('dropdown');
   });
 
+  it('shows the committed page query while the search field is closed', () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountains');
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByRole('combobox', { name: 'cmdk_placeholder' })).toHaveValue('mountains');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
   it('closes the dropdown on outside click', async () => {
     const user = userEvent.setup();
 

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -17,30 +17,75 @@ vi.mock('$app/state', () => ({ page: mockPage }));
 describe('global-search-input-trigger', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    globalSearchManager.close();
     mockPage.url = new URL('https://gallery.test/photos');
     mockPage.route.id = null;
     mockPage.params = {};
   });
 
-  it('opens cmdk on click and keyboard activation', async () => {
-    const openSpy = vi.spyOn(globalSearchManager, 'open').mockImplementation(() => {});
+  it('opens a dropdown from an editable search field', async () => {
+    const openSpy = vi.spyOn(globalSearchManager, 'open');
     const user = userEvent.setup();
 
     render(GlobalSearchInputTrigger);
 
-    const button = screen.getByTestId('cmdk-input-trigger');
-    await user.click(button);
-    button.focus();
-    await user.keyboard('{Enter}');
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.click(input);
+    await user.type(input, 'mountain');
 
-    expect(openSpy).toHaveBeenCalledTimes(2);
+    expect(openSpy).toHaveBeenCalledWith('dropdown');
+    expect(input).toHaveValue('mountain');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+  });
+
+  it('keeps the dropdown panel closed until the search field receives focus', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+
+    await user.click(screen.getByRole('combobox', { name: 'cmdk_placeholder' }));
+
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+    expect(globalSearchManager.presentation).toBe('dropdown');
+  });
+
+  it('closes the dropdown on outside click', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    await user.click(screen.getByRole('combobox', { name: 'cmdk_placeholder' }));
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+
+    await user.click(document.body);
+
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+    expect(globalSearchManager.isOpen).toBe(false);
+  });
+
+  it('switches from dropdown to modal presentation on the keyboard launcher shortcut', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.click(input);
+    expect(globalSearchManager.presentation).toBe('dropdown');
+
+    await user.keyboard('{Control>}k{/Control}');
+
+    expect(globalSearchManager.isOpen).toBe(true);
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
   });
 
   it('renders the placeholder and hotkey hint', () => {
     render(GlobalSearchInputTrigger);
 
     expect(screen.getByTestId('cmdk-input-trigger')).toBeInTheDocument();
-    expect(screen.getByText('cmdk_placeholder')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'cmdk_placeholder' })).toBeInTheDocument();
     expect(screen.getByText(/^(⌘K|Ctrl\+K)$/)).toBeInTheDocument();
   });
 

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -65,6 +65,18 @@ describe('global-search-input-trigger', () => {
     expect(globalSearchManager.isOpen).toBe(false);
   });
 
+  it('does not let the dropdown outside-click listener close the modal presentation', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    globalSearchManager.open('modal');
+    await user.click(document.body);
+
+    expect(globalSearchManager.isOpen).toBe(true);
+    expect(globalSearchManager.presentation).toBe('modal');
+  });
+
   it('switches from dropdown to modal presentation on the keyboard launcher shortcut', async () => {
     const user = userEvent.setup();
 

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -60,6 +60,23 @@ describe('global-search-input-trigger', () => {
     expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
   });
 
+  it('pressing Enter after clearing the top search field clears the committed search', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountains');
+    const activateSearchSpy = vi.spyOn(globalSearchManager, 'activateSearch').mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    expect(input).toHaveValue('mountains');
+
+    await user.click(input);
+    await user.clear(input);
+    await user.keyboard('{Enter}');
+
+    expect(activateSearchSpy).toHaveBeenCalledWith('');
+  });
+
   it('closes the dropdown on outside click', async () => {
     const user = userEvent.setup();
 

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -519,6 +519,22 @@ describe('global-search root', () => {
     expect(activateSearchSpy).toHaveBeenCalledWith('beach');
   });
 
+  it('pressing Enter after clearing the modal input clears the committed search', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountain');
+    const m = new GlobalSearchManager();
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    m.open('modal');
+    render(GlobalSearch, { props: { manager: m } });
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('mountain');
+
+    await user.clear(input);
+    await user.keyboard('{Enter}');
+
+    expect(activateSearchSpy).toHaveBeenCalledWith('');
+  });
+
   it('pressing Enter on an almost-exact command query activates the promoted command instead of search', async () => {
     const m = new GlobalSearchManager();
     const activateSpy = vi.spyOn(m, 'activate').mockImplementation(() => {});

--- a/web/src/lib/components/global-search/global-search-input-trigger.svelte
+++ b/web/src/lib/components/global-search/global-search-input-trigger.svelte
@@ -1,40 +1,17 @@
 <script lang="ts">
   import { page } from '$app/state';
   import SearchSortDropdown from '$lib/components/filter-panel/search-sort-dropdown.svelte';
+  import GlobalSearch from '$lib/components/global-search/global-search.svelte';
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
   import { getSearchablePageState } from '$lib/utils/searchable-page-search';
-  import { Icon } from '@immich/ui';
-  import { mdiMagnify } from '@mdi/js';
-  import { t } from 'svelte-i18n';
 
-  const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform);
-  const hotkeyLabel = isMac ? '⌘K' : 'Ctrl+K';
   const searchablePageState = $derived(getSearchablePageState(page.url));
   const showSearchSortControl = $derived(searchablePageState.isSearchable);
 </script>
 
 <div class="flex items-center gap-2">
-  <button
-    type="button"
-    data-testid="cmdk-input-trigger"
-    aria-label={$t('cmdk_placeholder')}
-    onclick={() => globalSearchManager.open()}
-    class="flex h-10 min-w-0 flex-1 items-center justify-between gap-4 rounded-2xl border border-gray-300/80 bg-gray-100/90 px-3 text-left text-sm shadow-sm transition-all duration-150 hover:border-primary/50 hover:bg-white hover:shadow md:h-11 dark:border-immich-dark-gray dark:bg-immich-dark-gray/70 dark:hover:border-primary/40 dark:hover:bg-immich-dark-gray"
-  >
-    <span class="flex min-w-0 items-center gap-3 text-gray-500 dark:text-gray-300">
-      <span
-        class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/80 text-gray-500 shadow-sm dark:bg-immich-dark-bg dark:text-gray-300"
-      >
-        <Icon icon={mdiMagnify} size="1.05em" aria-hidden />
-      </span>
-      <span class="truncate">{$t('cmdk_placeholder')}</span>
-    </span>
-    <kbd
-      class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
-      >{hotkeyLabel}</kbd
-    >
-  </button>
+  <GlobalSearch manager={globalSearchManager} variant="dropdown" />
 
   {#if showSearchSortControl}
     <div class="shrink-0">

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -25,6 +25,8 @@
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { NAVIGATION_ITEMS, type NavigationItem } from '$lib/managers/navigation-items';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
+  import { page } from '$app/state';
+  import { getSearchablePageState } from '$lib/utils/searchable-page-search';
 
   interface Props {
     manager: GlobalSearchManager;
@@ -42,9 +44,16 @@
   // `$state` + `$effect` is flagged by svelte/prefer-writable-derived. The cleanest
   // Svelte 5 shape for a bi-directional mirror is to keep $state and push changes in
   // both directions via $effect. The rule's preferred pattern doesn't fit this case.
-  // eslint-disable-next-line svelte/prefer-writable-derived
   let inputValue = $state('');
+  const showDropdownPanel = $derived(manager.isOpen && manager.presentation === 'dropdown');
+  const closedDropdownSearchState = $derived.by(() =>
+    variant === 'dropdown' ? getSearchablePageState(page.url) : null,
+  );
   $effect(() => {
+    if (variant === 'dropdown' && !showDropdownPanel) {
+      inputValue = closedDropdownSearchState?.query ?? '';
+      return;
+    }
     inputValue = manager.query;
   });
   let selectedValue = $state<string>('');
@@ -63,6 +72,9 @@
   }
 
   $effect(() => {
+    if (variant === 'dropdown' && !showDropdownPanel) {
+      return;
+    }
     manager.setQuery(inputValue);
   });
 
@@ -243,8 +255,6 @@
     return { status: 'ok' as const, items, total: items.length };
   });
   const showPreview = $derived(mediaQueryManager.minLg);
-  const showDropdownPanel = $derived(manager.isOpen && manager.presentation === 'dropdown');
-
   // Progress stripe: only show after a 200ms grace window. A clean setTimeout
   // pattern — the effect fires on every batchInFlight transition and the cleanup
   // cancels any pending stripe when the batch settles before the 200ms mark.

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -3,6 +3,7 @@
   import { mdiClose, mdiMagnify } from '@mdi/js';
   import { Command } from 'bits-ui';
   import { t } from 'svelte-i18n';
+  import { clickOutside } from '$lib/actions/click-outside';
   import type { GlobalSearchManager, SearchMode } from '$lib/managers/global-search-manager.svelte';
   import GlobalSearchSection from './global-search-section.svelte';
   import GlobalSearchNavigationSections from './global-search-navigation-sections.svelte';
@@ -27,8 +28,12 @@
 
   interface Props {
     manager: GlobalSearchManager;
+    variant?: 'modal' | 'dropdown';
   }
-  let { manager }: Props = $props();
+  let { manager, variant = 'modal' }: Props = $props();
+
+  const isApplePlatform = typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+  const hotkeyLabel = isApplePlatform ? '⌘K' : 'Ctrl+K';
 
   // Two-way sync with manager.query: the user types into the Command.Input (writes to
   // inputValue), and the manager can also update its own query internally (e.g. when
@@ -238,6 +243,7 @@
     return { status: 'ok' as const, items, total: items.length };
   });
   const showPreview = $derived(mediaQueryManager.minLg);
+  const showDropdownPanel = $derived(manager.isOpen && manager.presentation === 'dropdown');
 
   // Progress stripe: only show after a 200ms grace window. A clean setTimeout
   // pattern — the effect fires on every batchInFlight transition and the cleanup
@@ -290,6 +296,16 @@
     return true;
   }
 
+  function isModalLauncherShortcut(e: KeyboardEvent) {
+    return e.key.toLowerCase() === 'k' && (isApplePlatform ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey);
+  }
+
+  function openDropdown() {
+    if (!showDropdownPanel) {
+      manager.open('dropdown');
+    }
+  }
+
   function onKeyDown(e: KeyboardEvent) {
     // Bare `?` opens the app-wide keyboard shortcuts modal. No modifiers — Ctrl/Alt/Meta
     // fall through so browser chords (e.g. a custom user-agent binding) still work.
@@ -313,8 +329,8 @@
       e.preventDefault();
       return;
     }
-    if (e.ctrlKey && e.key === 'k') {
-      manager.close();
+    if (isModalLauncherShortcut(e)) {
+      manager.toggle('modal');
       e.preventDefault();
       return;
     }
@@ -372,72 +388,61 @@
   }
 </script>
 
-<Modal
-  size="large"
-  closeOnEsc={false}
-  closeOnBackdropClick={true}
-  onClose={() => manager.close()}
-  class="motion-reduce:transition-none motion-reduce:transform-none !p-0"
->
-  <ModalBody class="!p-0">
-    <span class="sr-only" id="global-search-label">{$t('global_search')}</span>
+{#if variant === 'dropdown'}
+  <div
+    class="relative min-w-0 flex-1"
+    use:clickOutside={{
+      onOutclick: () => manager.close(),
+      onEscape: () => manager.close(),
+    }}
+  >
+    <span class="sr-only" id="global-search-dropdown-label">{$t('global_search')}</span>
     <Command.Root
       shouldFilter={false}
       vimBindings={false}
       loop
+      label={$t('cmdk_placeholder')}
       bind:value={() => selectedValue, syncSelectedValueFromBits}
-      aria-labelledby="global-search-label"
+      aria-labelledby="global-search-dropdown-label"
       onkeydown={onKeyDown}
-      class="flex h-full min-h-0 flex-col"
+      class="min-w-0"
     >
-      <div class="flex items-center border-b border-gray-200 dark:border-gray-700">
+      <div
+        data-testid="cmdk-input-trigger"
+        class="flex h-10 min-w-0 flex-1 items-center gap-3 rounded-2xl border border-gray-300/80 bg-gray-100/90 px-3 text-left text-sm shadow-sm transition-all duration-150 focus-within:border-primary/50 focus-within:bg-white focus-within:shadow hover:border-primary/50 hover:bg-white hover:shadow md:h-11 dark:border-immich-dark-gray dark:bg-immich-dark-gray/70 dark:focus-within:border-primary/40 dark:focus-within:bg-immich-dark-gray dark:hover:border-primary/40 dark:hover:bg-immich-dark-gray"
+      >
+        <span
+          class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/80 text-gray-500 shadow-sm dark:bg-immich-dark-bg dark:text-gray-300"
+        >
+          <Icon icon={mdiMagnify} size="1.05em" aria-hidden />
+        </span>
         <Command.Input
           bind:value={inputValue}
-          autofocus
+          aria-label={$t('cmdk_placeholder')}
           placeholder={$t('cmdk_placeholder')}
           maxlength={256}
+          onfocus={openDropdown}
           oninput={() => inputEditRevision++}
-          class="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm focus:outline-none"
+          class="min-w-0 flex-1 bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none dark:text-gray-100 dark:placeholder:text-gray-300"
         />
-        <IconButton
-          icon={mdiClose}
-          size="small"
-          variant="ghost"
-          shape="round"
-          color="secondary"
-          class="me-2"
-          onclick={clearOrClose}
-          aria-label={inputValue === '' ? $t('close') : $t('clear')}
-        />
-      </div>
-      {#if showProgressStripe}
-        <div
-          aria-hidden="true"
-          data-cmdk-progress
-          class="h-0.5 bg-gradient-to-r from-transparent via-primary to-transparent bg-[length:200%_100%] animate-cmdk-shimmer motion-reduce:animate-none"
-        ></div>
-      {/if}
-
-      <!-- Mobile (<sm): grow into the full-height Modal Card via flex-1 + min-h-0
-               so the palette fills the screen instead of leaving dead space below
-               the footer. The chain is Modal h-full → CardBody h-full → Command.Root
-               h-full → this row flex-1.
-           Desktop (sm+): Modal collapses to sm:h-min, so flex-1 has no basis.
-               Switch to a fixed `sm:h-[520px]` (with `sm:max-h-[80vh]` clamp for
-               short viewports) to give Command.List + the preview pane a definite
-               height so internal `overflow-y-auto` actually scrolls. -->
-      <!-- `min-w-0` on the left column is critical: flex children default to
-               `min-width: auto` (= content size), so without it the column refuses
-               to shrink below the widest row (long filenames) and the whole row
-               grows wider than the modal/viewport — pushing the fixed-width preview
-               pane off-screen. With min-w-0, flex-1 can shrink below content width
-               and the rows' `truncate` class ellipsizes long text. -->
-      <div class="flex flex-1 min-h-0 sm:h-[520px] sm:max-h-[80vh] sm:flex-none">
-        <div
-          class="flex min-h-0 min-w-0 flex-1 flex-col {showPreview
-            ? 'border-e border-gray-200 dark:border-gray-700'
-            : ''}"
+        <kbd
+          class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
+          >{hotkeyLabel}</kbd
         >
+      </div>
+
+      {#if showDropdownPanel}
+        <div
+          data-cmdk-dropdown-panel
+          class="absolute start-0 top-full z-50 mt-2 w-full overflow-hidden rounded-xl border border-gray-200/90 bg-white/95 shadow-[0_18px_48px_rgba(15,23,42,0.18)] backdrop-blur-md dark:border-gray-700/90 dark:bg-immich-dark-bg/95"
+        >
+          {#if showProgressStripe}
+            <div
+              aria-hidden="true"
+              data-cmdk-progress
+              class="h-0.5 bg-gradient-to-r from-transparent via-primary to-transparent bg-[length:200%_100%] animate-cmdk-shimmer motion-reduce:animate-none"
+            ></div>
+          {/if}
           {#if manager.mode === 'smart' && !manager.mlHealthy && inputValue.trim() !== '' && manager.scope === 'all'}
             <div class="mx-3 mt-3 rounded-md bg-subtle/60 px-3 py-2 text-xs">
               {$t('cmdk_smart_unavailable')}
@@ -450,7 +455,7 @@
               </button>
             </div>
           {/if}
-          <Command.List class="flex-1 overflow-y-auto py-2">
+          <Command.List class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto py-2">
             {#if inputValue.trim() === ''}
               {#if recentEntries.length > 0}
                 <Command.Group>
@@ -461,36 +466,14 @@
                   </Command.GroupHeading>
                   <Command.GroupItems>
                     {#each recentEntries as entry (entry.id)}
-                      <Command.Item
-                        value={entry.id}
-                        onSelect={() => manager.activateRecent(entry)}
-                        class="group relative"
-                      >
+                      <Command.Item value={entry.id} onSelect={() => manager.activateRecent(entry)} class="group">
                         <RecentRow {entry} />
-                        <!-- Per-row remove affordance. Hidden by default, surfaced on
-                             hover OR when the row is keyboard-selected (data-selected
-                             from bits-ui) so both input modes have a visible target.
-                             stopPropagation is load-bearing: without it, the surrounding
-                             Command.Item treats the click as a selection and triggers
-                             activateRecent, which would navigate before the removal UI
-                             update could render. -->
-                        <button
-                          type="button"
-                          aria-label={$t('cmdk_remove_from_recents')}
-                          class="absolute end-3 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-gray-500 opacity-0 transition-opacity duration-[80ms] ease-out hover:bg-black/10 hover:text-gray-900 group-hover:opacity-100 group-data-[selected]:opacity-100 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-100"
-                          onclick={(e) => {
-                            e.stopPropagation();
-                            manager.removeRecent(entry.id);
-                          }}
-                        >
-                          <Icon icon={mdiClose} size="1em" aria-hidden />
-                        </button>
                       </Command.Item>
                     {/each}
                   </Command.GroupItems>
                 </Command.Group>
               {:else if quickLinks.length > 0}
-                <Command.Group class="mb-4">
+                <Command.Group class="mb-2">
                   <Command.GroupHeading
                     class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                   >
@@ -511,7 +494,7 @@
               {/if}
             {:else if manager.scope === 'all'}
               {#if manager.topSearchMatch}
-                <Command.Group class="mb-4" data-cmdk-top-result-search>
+                <Command.Group class="mb-2" data-cmdk-top-result-search>
                   <Command.GroupHeading
                     class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                   >
@@ -533,7 +516,7 @@
                 </Command.Group>
               {/if}
               {#if manager.topCommandMatch}
-                <Command.Group class="mb-4" data-cmdk-top-result-commands>
+                <Command.Group class="mb-2" data-cmdk-top-result-commands>
                   <Command.GroupHeading
                     class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                   >
@@ -553,7 +536,7 @@
                   </Command.GroupItems>
                 </Command.Group>
               {:else if manager.topNavigationMatch}
-                <Command.Group class="mb-4" data-cmdk-top-result-navigation>
+                <Command.Group class="mb-2" data-cmdk-top-result-navigation>
                   <Command.GroupHeading
                     class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                   >
@@ -586,11 +569,6 @@
                   <PhotoRow item={item as never} />
                 {/snippet}
               </GlobalSearchSection>
-              <!-- Albums + Spaces sit between Photos and People per the v1.1 plan's
-                     declared section sequence. Headings use `cmdk_section_albums` /
-                     `cmdk_section_spaces` (Task 24). `isPending` wiring reads
-                     `manager.pendingActivation` so the row spinner affordance appears for
-                     the exact key being activated. -->
               <GlobalSearchSection
                 heading={$t('cmdk_section_albums')}
                 status={manager.sections.albums}
@@ -658,10 +636,6 @@
                 onActivate={(item) => manager.activate('nav', item)}
               />
             {:else if manager.scope === 'people'}
-              <!-- Scope `@` — only the People section. Other sections force-idled in
-                   runBatch so they wouldn't render anyway, but gating the render
-                   branch keeps the DOM free of other sections' headings and gives
-                   a11y a single contiguous result set. -->
               <GlobalSearchSection
                 heading={$t('cmdk_people_heading')}
                 status={manager.sections.people}
@@ -673,7 +647,6 @@
                 {/snippet}
               </GlobalSearchSection>
             {:else if manager.scope === 'tags'}
-              <!-- Scope `#` — only the Tags section. -->
               <GlobalSearchSection
                 heading={$t('cmdk_tags_heading')}
                 status={manager.sections.tags}
@@ -685,8 +658,6 @@
                 {/snippet}
               </GlobalSearchSection>
             {:else if manager.scope === 'collections'}
-              <!-- Scope `/` — Albums + Spaces. Matches the `ENTITY_KEYS_BY_SCOPE.collections`
-                   tuple order so the cursor-reconcile order stays aligned with DOM order. -->
               <GlobalSearchSection
                 heading={$t('cmdk_section_albums')}
                 status={manager.sections.albums}
@@ -714,9 +685,6 @@
                 {/snippet}
               </GlobalSearchSection>
             {:else if manager.scope === 'nav'}
-              <!-- Scope `>` — only NavigationSections. The navigation provider runs
-                   synchronously in setQuery (no debounce); under `>` it surfaces the
-                   whole catalog for bare `>` or filtered matches for `>foo`. -->
               <GlobalSearchCommandsSection
                 status={manager.sections.commands}
                 onActivate={(item) => manager.activate('command', item)}
@@ -727,16 +695,380 @@
               />
             {/if}
           </Command.List>
+          <div aria-live="polite" aria-atomic="true" class="sr-only">{manager.announcementText}</div>
         </div>
-        {#if showPreview}
-          <div data-cmdk-preview class="w-[280px] shrink-0 overflow-y-auto min-h-0">
-            <GlobalSearchPreview activeItem={manager.getActiveItem()} />
-          </div>
-        {/if}
-      </div>
-
-      <div aria-live="polite" aria-atomic="true" class="sr-only">{manager.announcementText}</div>
-      <GlobalSearchFooter {manager} />
+      {/if}
     </Command.Root>
-  </ModalBody>
-</Modal>
+  </div>
+{:else}
+  <Modal
+    size="large"
+    closeOnEsc={false}
+    closeOnBackdropClick={true}
+    onClose={() => manager.close()}
+    class="motion-reduce:transition-none motion-reduce:transform-none !p-0"
+  >
+    <ModalBody class="!p-0">
+      <span class="sr-only" id="global-search-label">{$t('global_search')}</span>
+      <Command.Root
+        shouldFilter={false}
+        vimBindings={false}
+        loop
+        label={$t('cmdk_placeholder')}
+        bind:value={() => selectedValue, syncSelectedValueFromBits}
+        aria-labelledby="global-search-label"
+        onkeydown={onKeyDown}
+        class="flex h-full min-h-0 flex-col"
+      >
+        <div class="flex items-center border-b border-gray-200 dark:border-gray-700">
+          <Command.Input
+            bind:value={inputValue}
+            autofocus
+            placeholder={$t('cmdk_placeholder')}
+            maxlength={256}
+            oninput={() => inputEditRevision++}
+            class="min-w-0 flex-1 bg-transparent px-4 py-3 text-sm focus:outline-none"
+          />
+          <IconButton
+            icon={mdiClose}
+            size="small"
+            variant="ghost"
+            shape="round"
+            color="secondary"
+            class="me-2"
+            onclick={clearOrClose}
+            aria-label={inputValue === '' ? $t('close') : $t('clear')}
+          />
+        </div>
+        {#if showProgressStripe}
+          <div
+            aria-hidden="true"
+            data-cmdk-progress
+            class="h-0.5 bg-gradient-to-r from-transparent via-primary to-transparent bg-[length:200%_100%] animate-cmdk-shimmer motion-reduce:animate-none"
+          ></div>
+        {/if}
+
+        <!-- Mobile (<sm): grow into the full-height Modal Card via flex-1 + min-h-0
+               so the palette fills the screen instead of leaving dead space below
+               the footer. The chain is Modal h-full → CardBody h-full → Command.Root
+               h-full → this row flex-1.
+           Desktop (sm+): Modal collapses to sm:h-min, so flex-1 has no basis.
+               Switch to a fixed `sm:h-[520px]` (with `sm:max-h-[80vh]` clamp for
+               short viewports) to give Command.List + the preview pane a definite
+               height so internal `overflow-y-auto` actually scrolls. -->
+        <!-- `min-w-0` on the left column is critical: flex children default to
+               `min-width: auto` (= content size), so without it the column refuses
+               to shrink below the widest row (long filenames) and the whole row
+               grows wider than the modal/viewport — pushing the fixed-width preview
+               pane off-screen. With min-w-0, flex-1 can shrink below content width
+               and the rows' `truncate` class ellipsizes long text. -->
+        <div class="flex flex-1 min-h-0 sm:h-[520px] sm:max-h-[80vh] sm:flex-none">
+          <div
+            class="flex min-h-0 min-w-0 flex-1 flex-col {showPreview
+              ? 'border-e border-gray-200 dark:border-gray-700'
+              : ''}"
+          >
+            {#if manager.mode === 'smart' && !manager.mlHealthy && inputValue.trim() !== '' && manager.scope === 'all'}
+              <div class="mx-3 mt-3 rounded-md bg-subtle/60 px-3 py-2 text-xs">
+                {$t('cmdk_smart_unavailable')}
+                <button
+                  type="button"
+                  onclick={() => manager.setMode('metadata')}
+                  class="ml-2 text-primary transition-colors duration-[80ms] ease-out"
+                >
+                  {$t('cmdk_try_filename')}
+                </button>
+              </div>
+            {/if}
+            <Command.List class="flex-1 overflow-y-auto py-2">
+              {#if inputValue.trim() === ''}
+                {#if recentEntries.length > 0}
+                  <Command.Group>
+                    <Command.GroupHeading
+                      class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                    >
+                      {$t('cmdk_recent_heading')}
+                    </Command.GroupHeading>
+                    <Command.GroupItems>
+                      {#each recentEntries as entry (entry.id)}
+                        <Command.Item
+                          value={entry.id}
+                          onSelect={() => manager.activateRecent(entry)}
+                          class="group relative"
+                        >
+                          <RecentRow {entry} />
+                          <!-- Per-row remove affordance. Hidden by default, surfaced on
+                             hover OR when the row is keyboard-selected (data-selected
+                             from bits-ui) so both input modes have a visible target.
+                             stopPropagation is load-bearing: without it, the surrounding
+                             Command.Item treats the click as a selection and triggers
+                             activateRecent, which would navigate before the removal UI
+                             update could render. -->
+                          <button
+                            type="button"
+                            aria-label={$t('cmdk_remove_from_recents')}
+                            class="absolute end-3 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-gray-500 opacity-0 transition-opacity duration-[80ms] ease-out hover:bg-black/10 hover:text-gray-900 group-hover:opacity-100 group-data-[selected]:opacity-100 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-100"
+                            onclick={(e) => {
+                              e.stopPropagation();
+                              manager.removeRecent(entry.id);
+                            }}
+                          >
+                            <Icon icon={mdiClose} size="1em" aria-hidden />
+                          </button>
+                        </Command.Item>
+                      {/each}
+                    </Command.GroupItems>
+                  </Command.Group>
+                {:else if quickLinks.length > 0}
+                  <Command.Group class="mb-4">
+                    <Command.GroupHeading
+                      class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                    >
+                      {$t('cmdk_quick_links')}
+                    </Command.GroupHeading>
+                    <Command.GroupItems>
+                      {#each quickLinks as item (item.id)}
+                        <Command.Item value={item.id} onSelect={() => manager.activate('nav', item)} class="group">
+                          <NavigationRow {item} />
+                        </Command.Item>
+                      {/each}
+                    </Command.GroupItems>
+                  </Command.Group>
+                {:else}
+                  <div class="p-6 text-center text-[13px] font-normal text-gray-500 dark:text-gray-400">
+                    {$t('cmdk_helper')}
+                  </div>
+                {/if}
+              {:else if manager.scope === 'all'}
+                {#if manager.topSearchMatch}
+                  <Command.Group class="mb-4" data-cmdk-top-result-search>
+                    <Command.GroupHeading
+                      class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                    >
+                      {$t('cmdk_top_result')}
+                    </Command.GroupHeading>
+                    <div class="px-1">
+                      <button
+                        type="button"
+                        onclick={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
+                        class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId ===
+                        manager.topSearchMatch.id
+                          ? 'bg-primary/10'
+                          : ''}"
+                      >
+                        <Icon icon={mdiMagnify} />
+                        <span>{$t('cmdk_top_search_label', { values: { query: manager.topSearchMatch.query } })}</span>
+                      </button>
+                    </div>
+                  </Command.Group>
+                {/if}
+                {#if manager.topCommandMatch}
+                  <Command.Group class="mb-4" data-cmdk-top-result-commands>
+                    <Command.GroupHeading
+                      class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                    >
+                      {$t('cmdk_top_result')}
+                    </Command.GroupHeading>
+                    <Command.GroupItems>
+                      <Command.Item
+                        value={manager.topCommandMatch.id}
+                        onSelect={() => manager.topCommandMatch && manager.activate('command', manager.topCommandMatch)}
+                        class="group"
+                      >
+                        <CommandRow
+                          item={manager.topCommandMatch}
+                          pending={manager.topCommandMatch.id === manager.pendingConfirmId}
+                        />
+                      </Command.Item>
+                    </Command.GroupItems>
+                  </Command.Group>
+                {:else if manager.topNavigationMatch}
+                  <Command.Group class="mb-4" data-cmdk-top-result-navigation>
+                    <Command.GroupHeading
+                      class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                    >
+                      {$t('cmdk_top_result')}
+                    </Command.GroupHeading>
+                    <Command.GroupItems>
+                      <Command.Item
+                        value={manager.topNavigationMatch.id}
+                        onSelect={() =>
+                          manager.topNavigationMatch && manager.activate('nav', manager.topNavigationMatch)}
+                        class="group"
+                      >
+                        <NavigationRow item={manager.topNavigationMatch} />
+                      </Command.Item>
+                    </Command.GroupItems>
+                  </Command.Group>
+                {/if}
+                {#if manager.topCommandMatch}
+                  <GlobalSearchCommandsSection
+                    status={manager.sections.commands}
+                    onActivate={(item) => manager.activate('command', item)}
+                  />
+                {/if}
+                <GlobalSearchSection
+                  heading={$t('cmdk_photos_heading')}
+                  status={manager.sections.photos}
+                  idPrefix="photo"
+                  onActivate={(item) => manager.activate('photo', item)}
+                >
+                  {#snippet renderRow(item)}
+                    <PhotoRow item={item as never} />
+                  {/snippet}
+                </GlobalSearchSection>
+                <!-- Albums + Spaces sit between Photos and People per the v1.1 plan's
+                     declared section sequence. Headings use `cmdk_section_albums` /
+                     `cmdk_section_spaces` (Task 24). `isPending` wiring reads
+                     `manager.pendingActivation` so the row spinner affordance appears for
+                     the exact key being activated. -->
+                <GlobalSearchSection
+                  heading={$t('cmdk_section_albums')}
+                  status={manager.sections.albums}
+                  idPrefix="album"
+                  onActivate={(item) => void manager.activateAlbum((item as { id: string }).id)}
+                >
+                  {#snippet renderRow(item)}
+                    <AlbumRow
+                      item={item as never}
+                      isPending={manager.pendingActivation === `album:${(item as { id: string }).id}`}
+                    />
+                  {/snippet}
+                </GlobalSearchSection>
+                <GlobalSearchSection
+                  heading={$t('cmdk_section_spaces')}
+                  status={manager.sections.spaces}
+                  idPrefix="space"
+                  onActivate={(item) => void manager.activateSpace((item as { id: string }).id)}
+                >
+                  {#snippet renderRow(item)}
+                    <SpaceRow
+                      item={item as never}
+                      isPending={manager.pendingActivation === `space:${(item as { id: string }).id}`}
+                    />
+                  {/snippet}
+                </GlobalSearchSection>
+                <GlobalSearchSection
+                  heading={$t('cmdk_people_heading')}
+                  status={manager.sections.people}
+                  idPrefix="person"
+                  onActivate={(item) => manager.activate('person', item)}
+                >
+                  {#snippet renderRow(item)}
+                    <PersonRow item={item as never} />
+                  {/snippet}
+                </GlobalSearchSection>
+                <GlobalSearchSection
+                  heading={$t('cmdk_places_heading')}
+                  status={manager.sections.places}
+                  idPrefix="place"
+                  onActivate={(item) => manager.activate('place', item)}
+                >
+                  {#snippet renderRow(item)}
+                    <PlaceRow item={item as never} />
+                  {/snippet}
+                </GlobalSearchSection>
+                <GlobalSearchSection
+                  heading={$t('cmdk_tags_heading')}
+                  status={manager.sections.tags}
+                  idPrefix="tag"
+                  onActivate={(item) => manager.activate('tag', item)}
+                >
+                  {#snippet renderRow(item)}
+                    <TagRow item={item as never} />
+                  {/snippet}
+                </GlobalSearchSection>
+                {#if !manager.topCommandMatch}
+                  <GlobalSearchCommandsSection
+                    status={manager.sections.commands}
+                    onActivate={(item) => manager.activate('command', item)}
+                  />
+                {/if}
+                <GlobalSearchNavigationSections
+                  status={dedupedNavigationStatus}
+                  onActivate={(item) => manager.activate('nav', item)}
+                />
+              {:else if manager.scope === 'people'}
+                <!-- Scope `@` — only the People section. Other sections force-idled in
+                   runBatch so they wouldn't render anyway, but gating the render
+                   branch keeps the DOM free of other sections' headings and gives
+                   a11y a single contiguous result set. -->
+                <GlobalSearchSection
+                  heading={$t('cmdk_people_heading')}
+                  status={manager.sections.people}
+                  idPrefix="person"
+                  onActivate={(item) => manager.activate('person', item)}
+                >
+                  {#snippet renderRow(item)}
+                    <PersonRow item={item as never} />
+                  {/snippet}
+                </GlobalSearchSection>
+              {:else if manager.scope === 'tags'}
+                <!-- Scope `#` — only the Tags section. -->
+                <GlobalSearchSection
+                  heading={$t('cmdk_tags_heading')}
+                  status={manager.sections.tags}
+                  idPrefix="tag"
+                  onActivate={(item) => manager.activate('tag', item)}
+                >
+                  {#snippet renderRow(item)}
+                    <TagRow item={item as never} />
+                  {/snippet}
+                </GlobalSearchSection>
+              {:else if manager.scope === 'collections'}
+                <!-- Scope `/` — Albums + Spaces. Matches the `ENTITY_KEYS_BY_SCOPE.collections`
+                   tuple order so the cursor-reconcile order stays aligned with DOM order. -->
+                <GlobalSearchSection
+                  heading={$t('cmdk_section_albums')}
+                  status={manager.sections.albums}
+                  idPrefix="album"
+                  onActivate={(item) => void manager.activateAlbum((item as { id: string }).id)}
+                >
+                  {#snippet renderRow(item)}
+                    <AlbumRow
+                      item={item as never}
+                      isPending={manager.pendingActivation === `album:${(item as { id: string }).id}`}
+                    />
+                  {/snippet}
+                </GlobalSearchSection>
+                <GlobalSearchSection
+                  heading={$t('cmdk_section_spaces')}
+                  status={manager.sections.spaces}
+                  idPrefix="space"
+                  onActivate={(item) => void manager.activateSpace((item as { id: string }).id)}
+                >
+                  {#snippet renderRow(item)}
+                    <SpaceRow
+                      item={item as never}
+                      isPending={manager.pendingActivation === `space:${(item as { id: string }).id}`}
+                    />
+                  {/snippet}
+                </GlobalSearchSection>
+              {:else if manager.scope === 'nav'}
+                <!-- Scope `>` — only NavigationSections. The navigation provider runs
+                   synchronously in setQuery (no debounce); under `>` it surfaces the
+                   whole catalog for bare `>` or filtered matches for `>foo`. -->
+                <GlobalSearchCommandsSection
+                  status={manager.sections.commands}
+                  onActivate={(item) => manager.activate('command', item)}
+                />
+                <GlobalSearchNavigationSections
+                  status={manager.sections.navigation}
+                  onActivate={(item) => manager.activate('nav', item)}
+                />
+              {/if}
+            </Command.List>
+          </div>
+          {#if showPreview}
+            <div data-cmdk-preview class="w-[280px] shrink-0 overflow-y-auto min-h-0">
+              <GlobalSearchPreview activeItem={manager.getActiveItem()} />
+            </div>
+          {/if}
+        </div>
+
+        <div aria-live="polite" aria-atomic="true" class="sr-only">{manager.announcementText}</div>
+        <GlobalSearchFooter {manager} />
+      </Command.Root>
+    </ModalBody>
+  </Modal>
+{/if}

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -366,6 +366,11 @@
       e.preventDefault();
       return;
     }
+    if (e.key === 'Enter' && inputValue.trim() === '' && getSearchablePageState(page.url).query !== '') {
+      manager.activateSearch('');
+      e.preventDefault();
+      return;
+    }
     if (e.key === 'Enter' && manager.topSearchMatch && manager.activeItemId === manager.topSearchMatch.id) {
       manager.activateSearch(manager.topSearchMatch.query);
       e.preventDefault();

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -392,8 +392,16 @@
   <div
     class="relative min-w-0 flex-1"
     use:clickOutside={{
-      onOutclick: () => manager.close(),
-      onEscape: () => manager.close(),
+      onOutclick: () => {
+        if (manager.presentation === 'dropdown') {
+          manager.close();
+        }
+      },
+      onEscape: () => {
+        if (manager.presentation === 'dropdown') {
+          manager.close();
+        }
+      },
     }}
   >
     <span class="sr-only" id="global-search-dropdown-label">{$t('global_search')}</span>

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -244,6 +244,36 @@ describe('GlobalSearchManager (skeleton)', () => {
     expect(manager.searchSortOrder).toBe('asc');
   });
 
+  it('open() clears the modal query once after activating a text search', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    m.open('modal');
+    m.activateSearch('beach');
+    m.close();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
+
+    m.open('modal');
+
+    expect(m.query).toBe('');
+    expect(m.searchSortOrder).toBe('relevance');
+  });
+
+  it('open() still hydrates the dropdown query after activating a text search', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    m.open('modal');
+    m.activateSearch('beach');
+    m.close();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
+
+    m.open('dropdown');
+
+    expect(m.query).toBe('beach');
+    expect(m.searchSortOrder).toBe('asc');
+  });
+
   it('open() resets the search draft sort to relevance when the current searchable page has no query', () => {
     mockPage.url = new URL('https://gallery.test/photos');
     manager.open();

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1322,6 +1322,16 @@ describe('activate("command")', () => {
     expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach&sort=asc');
   });
 
+  it('activateSearch with empty text clears the committed searchable-page query', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?q=mountain&sort=asc&view=grid');
+
+    m.activateSearch('');
+
+    expect(goto).toHaveBeenCalledWith('/photos?view=grid');
+    expect(getEntries()).toEqual([]);
+  });
+
   it('activateSearch falls back to /photos and drops unrelated params', () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/albums?view=list');

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -204,6 +204,37 @@ describe('GlobalSearchManager (skeleton)', () => {
     expect(manager.isOpen).toBe(true);
   });
 
+  it('open() records the requested presentation', () => {
+    manager.open('dropdown');
+
+    expect(manager.isOpen).toBe(true);
+    expect(manager.presentation).toBe('dropdown');
+
+    manager.open('modal');
+    expect(manager.presentation).toBe('modal');
+  });
+
+  it('toggle() swaps presentation instead of closing when another surface is open', () => {
+    manager.open('dropdown');
+
+    manager.toggle('modal');
+
+    expect(manager.isOpen).toBe(true);
+    expect(manager.presentation).toBe('modal');
+
+    manager.toggle('modal');
+    expect(manager.isOpen).toBe(false);
+  });
+
+  it('close() resets presentation back to modal', () => {
+    manager.open('dropdown');
+
+    manager.close();
+
+    expect(manager.isOpen).toBe(false);
+    expect(manager.presentation).toBe('modal');
+  });
+
   it('open() hydrates the current searchable page query and sort', () => {
     mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
     manager.open();

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -39,6 +39,7 @@ import { COMMAND_ITEMS, isAlmostExactCommandMatch, type CommandItem } from './co
 import { isAlmostExactNavMatch, NAVIGATION_ITEMS, type NavigationItem } from './navigation-items';
 
 export type SearchMode = 'smart' | 'metadata' | 'description' | 'ocr';
+export type SearchPresentation = 'modal' | 'dropdown';
 
 export type ProviderStatus<T = unknown> =
   | { status: 'idle' }
@@ -208,6 +209,7 @@ function loadSearchQueryType(): SearchMode {
 
 export class GlobalSearchManager {
   isOpen = $state(false);
+  presentation = $state<SearchPresentation>('modal');
   query = $state('');
   searchSortOrder = $state<SearchablePageSortOrder>('relevance');
   mode = $state<SearchMode>(loadSearchQueryType());
@@ -574,8 +576,9 @@ export class GlobalSearchManager {
     return { status: 'ok', items: filtered.slice(0, topN), total: filtered.length };
   }
 
-  open() {
+  open(presentation: SearchPresentation = 'modal') {
     this.isOpen = true;
+    this.presentation = presentation;
     const currentPageSearchState = getSearchablePageState(page.url);
     if (currentPageSearchState.isSearchable) {
       this.query = currentPageSearchState.query;
@@ -923,6 +926,7 @@ export class GlobalSearchManager {
   close() {
     this.cancelConfirm();
     this.isOpen = false;
+    this.presentation = 'modal';
     this.keepOpenOnNextNavigate = false;
     this.closeController.abort();
     if (this.debounceTimer !== null) {
@@ -963,11 +967,11 @@ export class GlobalSearchManager {
     return shouldKeepOpen;
   }
 
-  toggle() {
-    if (this.isOpen) {
+  toggle(presentation: SearchPresentation = 'modal') {
+    if (this.isOpen && this.presentation === presentation) {
       this.close();
     } else {
-      this.open();
+      this.open(presentation);
     }
   }
 

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1251,6 +1251,13 @@ export class GlobalSearchManager {
   activateSearch(text: string): void {
     const trimmed = text.trim();
     if (!trimmed) {
+      const searchablePageUrl = buildSearchablePageUrl(page.url, '');
+      if (searchablePageUrl && searchablePageUrl !== page.url.pathname + page.url.search) {
+        this.query = '';
+        this.searchSortOrder = 'relevance';
+        this.clearQueryOnNextModalOpen = false;
+        void goto(searchablePageUrl);
+      }
       return;
     }
 

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -260,6 +260,8 @@ export class GlobalSearchManager {
    */
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   private commandInFlight: Set<string> = new Set();
+
+  private clearQueryOnNextModalOpen = false;
   /**
    * Id of the row currently showing the 200 ms "pending" affordance (subtle spinner
    * on the row) while its activation handler is resolving. Null when no activation is
@@ -580,7 +582,11 @@ export class GlobalSearchManager {
     this.isOpen = true;
     this.presentation = presentation;
     const currentPageSearchState = getSearchablePageState(page.url);
-    if (currentPageSearchState.isSearchable) {
+    if (presentation === 'modal' && this.clearQueryOnNextModalOpen) {
+      this.query = '';
+      this.searchSortOrder = 'relevance';
+      this.clearQueryOnNextModalOpen = false;
+    } else if (currentPageSearchState.isSearchable) {
       this.query = currentPageSearchState.query;
       this.searchSortOrder = currentPageSearchState.query ? currentPageSearchState.sortOrder : 'relevance';
     } else {
@@ -1254,6 +1260,7 @@ export class GlobalSearchManager {
       text: trimmed,
       lastUsed: Date.now(),
     });
+    this.clearQueryOnNextModalOpen = true;
     void goto(this.buildSearchDestination(trimmed));
   }
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -143,6 +143,16 @@
       }
     }
   };
+
+  const isApplePlatform = typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+
+  const openModalSearch = () => {
+    // Use valueOrUndefined so the shortcut never throws if it fires before
+    // feature flags have loaded (SSR→hydration race).
+    if (featureFlagsManager.valueOrUndefined?.search) {
+      globalSearchManager.toggle('modal');
+    }
+  };
 </script>
 
 <OnEvents {onWebsocketConnect} />
@@ -201,10 +211,16 @@
     {
       shortcut: { ctrl: true, key: 'k' },
       onShortcut: () => {
-        // Use valueOrUndefined so the shortcut never throws if it fires before
-        // feature flags have loaded (SSR→hydration race).
-        if (featureFlagsManager.valueOrUndefined?.search) {
-          globalSearchManager.toggle();
+        if (!isApplePlatform) {
+          openModalSearch();
+        }
+      },
+    },
+    {
+      shortcut: { meta: true, key: 'k' },
+      onShortcut: () => {
+        if (isApplePlatform) {
+          openModalSearch();
         }
       },
     },
@@ -236,7 +252,7 @@
 
   <DownloadPanel />
   <UploadPanel />
-  {#if globalSearchManager.isOpen}
+  {#if globalSearchManager.isOpen && globalSearchManager.presentation === 'modal'}
     <GlobalSearch manager={globalSearchManager} />
   {/if}
 </TooltipProvider>


### PR DESCRIPTION
## Summary
- turn the navbar global search trigger into an editable dropdown search field
- keep the centered global search modal for Ctrl+K on Windows/Linux and Cmd+K on macOS
- add coverage for dropdown open/close, presentation switching, and manager presentation reset

## Tests
- pnpm --filter immich-web test --run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts
- pnpm --filter immich-web test --run src/lib/components/global-search/__tests__/global-search.spec.ts src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts
- pnpm --filter immich-web check:svelte
- pnpm --filter immich-web check:typescript
- pnpm exec eslint src/lib/components/global-search/global-search.svelte src/lib/components/global-search/global-search-input-trigger.svelte src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts src/lib/managers/global-search-manager.svelte.ts src/lib/managers/global-search-manager.svelte.spec.ts src/routes/+layout.svelte --max-warnings 0 --concurrency 4