### PR TITLE
fix(server): count physical storage in quota sync

### DIFF
--- a/server/src/backends/disk-storage.backend.spec.ts
+++ b/server/src/backends/disk-storage.backend.spec.ts
@@ -130,4 +130,19 @@ describe('DiskStorageBackend', () => {
       expect(existsSync(join(testDir, 'thumbs/user-a/thumb.webp'))).toBe(true);
     });
   });
+
+  describe('getPrefixUsage', () => {
+    it('should sum files recursively under the prefix', async () => {
+      await mkdir(join(testDir, 'thumbs/user-a/aa'), { recursive: true });
+      await writeFile(join(testDir, 'thumbs/user-a/aa/one.webp'), 'one');
+      await mkdir(join(testDir, 'thumbs/user-a/bb'), { recursive: true });
+      await writeFile(join(testDir, 'thumbs/user-a/bb/two.webp'), 'two!!');
+
+      await expect(backend.getPrefixUsage('thumbs/user-a/')).resolves.toBe(8);
+    });
+
+    it('should return zero for a missing prefix', async () => {
+      await expect(backend.getPrefixUsage('thumbs/ghost/')).resolves.toBe(0);
+    });
+  });
 });

--- a/server/src/backends/disk-storage.backend.ts
+++ b/server/src/backends/disk-storage.backend.ts
@@ -1,5 +1,5 @@
 import { createReadStream, createWriteStream } from 'node:fs';
-import { access, mkdir, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { access, mkdir, opendir, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -54,6 +54,10 @@ export class DiskStorageBackend implements StorageBackend {
     await rm(this.resolvePath(prefix), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 
+  async getPrefixUsage(prefix: string): Promise<number> {
+    return this.getFolderSize(this.resolvePath(prefix));
+  }
+
   getServeStrategy(key: string, _contentType: string): Promise<ServeStrategy> {
     return Promise.resolve({ type: 'file', path: this.resolvePath(key) });
   }
@@ -63,5 +67,30 @@ export class DiskStorageBackend implements StorageBackend {
       tempPath: this.resolvePath(key),
       cleanup: () => Promise.resolve(),
     });
+  }
+
+  private async getFolderSize(folder: string): Promise<number> {
+    let total = 0;
+    let dir;
+    try {
+      dir = await opendir(folder);
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return 0;
+      }
+      throw error;
+    }
+
+    for await (const entry of dir) {
+      const entryPath = join(folder, entry.name);
+      if (entry.isDirectory()) {
+        total += await this.getFolderSize(entryPath);
+      } else if (entry.isFile()) {
+        const entryStat = await stat(entryPath);
+        total += entryStat.size;
+      }
+    }
+
+    return total;
   }
 }

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -246,4 +246,39 @@ describe('S3StorageBackend', () => {
       expect(mockSend.mock.calls.filter(([cmd]) => cmd._type === 'DeleteObjectsCommand')).toEqual([]);
     });
   });
+
+  describe('getPrefixUsage', () => {
+    it('should sum object sizes across all pages', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Contents: [{ Size: 10 }, { Size: 20 }],
+          IsTruncated: true,
+          NextContinuationToken: 'token-page-2',
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Size: 30 }, {}],
+          IsTruncated: false,
+        });
+
+      await expect(backend.getPrefixUsage('thumbs/user-a/')).resolves.toBe(60);
+
+      const listInputs = mockSend.mock.calls
+        .filter(([cmd]) => cmd._type === 'ListObjectsV2Command')
+        .map(([cmd]) => cmd.input);
+      expect(listInputs).toEqual([
+        expect.objectContaining({ Bucket: 'test-bucket', Prefix: 'thumbs/user-a/' }),
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          Prefix: 'thumbs/user-a/',
+          ContinuationToken: 'token-page-2',
+        }),
+      ]);
+    });
+
+    it('should return zero when the prefix matches nothing', async () => {
+      mockSend.mockResolvedValueOnce({ Contents: undefined, IsTruncated: false });
+
+      await expect(backend.getPrefixUsage('profile/ghost/')).resolves.toBe(0);
+    });
+  });
 });

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -112,6 +112,22 @@ export class S3StorageBackend implements StorageBackend {
     } while (continuationToken);
   }
 
+  async getPrefixUsage(prefix: string): Promise<number> {
+    let total = 0;
+    let continuationToken: string | undefined;
+    do {
+      const page = await this.client.send(
+        new ListObjectsV2Command({ Bucket: this.bucket, Prefix: prefix, ContinuationToken: continuationToken }),
+      );
+      for (const object of page.Contents ?? []) {
+        total += object.Size ?? 0;
+      }
+      continuationToken = page.IsTruncated ? page.NextContinuationToken : undefined;
+    } while (continuationToken);
+
+    return total;
+  }
+
   async getServeStrategy(key: string, contentType: string): Promise<ServeStrategy> {
     if (this.serveMode === 'proxy') {
       const { stream, length } = await this.get(key);

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -21,6 +21,9 @@ export interface StorageBackend {
   /** Delete all objects/files under the given key prefix. Idempotent. No-op if nothing matches. */
   deletePrefix(prefix: string): Promise<void>;
 
+  /** Return the total size in bytes for all objects/files under the given key prefix. */
+  getPrefixUsage(prefix: string): Promise<number>;
+
   /** Determine how to serve this file to a client */
   getServeStrategy(key: string, contentType: string): Promise<ServeStrategy>;
 

--- a/server/src/queries/user.repository.sql
+++ b/server/src/queries/user.repository.sql
@@ -380,20 +380,11 @@ where
   "id" = $3::uuid
   and "user"."deletedAt" is null
 
--- UserRepository.syncUsage
+-- UserRepository.setUsage
 update "user"
 set
-  "quotaUsageInBytes" = (
-    select
-      coalesce(sum("asset_exif"."fileSizeInByte"), 0) as "usage"
-    from
-      "asset"
-      left join "asset_exif" on "asset_exif"."assetId" = "asset"."id"
-    where
-      "asset"."libraryId" is null
-      and "asset"."ownerId" = "user"."id"
-  ),
-  "updatedAt" = $1
+  "quotaUsageInBytes" = $1,
+  "updatedAt" = $2
 where
-  "user"."deletedAt" is null
-  and "user"."id" = $2::uuid
+  "id" = $3::uuid
+  and "user"."deletedAt" is null

--- a/server/src/repositories/storage.repository.spec.ts
+++ b/server/src/repositories/storage.repository.spec.ts
@@ -1,4 +1,7 @@
 import mockfs from 'mock-fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { CrawlOptionsDto } from 'src/dtos/library.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
@@ -205,6 +208,30 @@ describe(StorageRepository.name, () => {
         expect(actual.toSorted()).toEqual(expected.toSorted());
       });
     }
+  });
+
+  describe('getFolderSize', () => {
+    it('sums nested file sizes recursively', async () => {
+      mockfs.restore();
+      const testDir = join(tmpdir(), `immich-storage-repo-${Date.now()}`);
+      try {
+        await mkdir(join(testDir, 'aa'), { recursive: true });
+        await writeFile(join(testDir, 'aa/one.jpg'), 'one');
+        await mkdir(join(testDir, 'bb'), { recursive: true });
+        await writeFile(join(testDir, 'bb/two.jpg'), 'two!!');
+        await mkdir(join(testDir, 'empty'), { recursive: true });
+
+        await expect(sut.getFolderSize(testDir)).resolves.toBe(8);
+      } finally {
+        await rm(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns zero when the folder does not exist', async () => {
+      mockfs({});
+
+      await expect(sut.getFolderSize('/data/upload/missing')).resolves.toBe(0);
+    });
   });
 
   describe('createZipStream', () => {

--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -243,6 +243,31 @@ export class StorageRepository {
     };
   }
 
+  async getFolderSize(folder: string): Promise<number> {
+    let total = 0;
+    let dir;
+    try {
+      dir = await fs.opendir(folder);
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        return 0;
+      }
+      throw error;
+    }
+
+    for await (const entry of dir) {
+      const entryPath = path.join(folder, entry.name);
+      if (entry.isDirectory()) {
+        total += await this.getFolderSize(entryPath);
+      } else if (entry.isFile()) {
+        const entryStat = await fs.stat(entryPath);
+        total += entryStat.size;
+      }
+    }
+
+    return total;
+  }
+
   crawl(crawlOptions: CrawlOptionsDto): Promise<string[]> {
     const { pathsToCrawl, exclusionPatterns, includeHidden } = crawlOptions;
     if (pathsToCrawl.length === 0) {

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -306,23 +306,14 @@ export class UserRepository {
       .execute();
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  async syncUsage(id?: string) {
-    const query = this.db
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.NUMBER] })
+  async setUsage(id: string, usage: number): Promise<void> {
+    await this.db
       .updateTable('user')
-      .set({
-        quotaUsageInBytes: (eb) =>
-          eb
-            .selectFrom('asset')
-            .leftJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
-            .select((eb) => eb.fn.coalesce(eb.fn.sum<number>('asset_exif.fileSizeInByte'), eb.lit(0)).as('usage'))
-            .where('asset.libraryId', 'is', null)
-            .where('asset.ownerId', '=', eb.ref('user.id')),
-        updatedAt: new Date(),
-      })
+      .set({ quotaUsageInBytes: usage, updatedAt: new Date() })
+      .where('id', '=', asUuid(id))
       .where('user.deletedAt', 'is', null)
-      .$if(id != undefined, (eb) => eb.where('user.id', '=', asUuid(id!)));
-
-    await query.execute();
+      .execute();
   }
+
 }

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -315,5 +315,4 @@ export class UserRepository {
       .where('user.deletedAt', 'is', null)
       .execute();
   }
-
 }

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -6,7 +6,7 @@ import { SystemConfig } from 'src/config';
 import { SALT_ROUNDS } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
 import { UserAdmin } from 'src/database';
-import { CacheControl } from 'src/enum';
+import { CacheControl, StorageFolder } from 'src/enum';
 import { ServeStrategy } from 'src/interfaces/storage-backend.interface';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { ActivityRepository } from 'src/repositories/activity.repository';
@@ -286,6 +286,48 @@ export class BaseService {
     const backend = StorageService.resolveBackendForKey(filePath);
     const { tempPath, cleanup } = await backend.downloadToTemp(filePath);
     return { localPath: tempPath, cleanup };
+  }
+
+  protected async syncUsage(id?: string): Promise<void> {
+    const users = id
+      ? [await this.userRepository.get(id, { withDeleted: false })].filter((user): user is UserAdmin => !!user)
+      : await this.userRepository.getList({ withDeleted: false });
+
+    for (const user of users) {
+      await this.userRepository.setUsage(user.id, await this.getPhysicalUsage(user));
+    }
+  }
+
+  private async getPhysicalUsage(user: Pick<UserAdmin, 'id' | 'storageLabel'>): Promise<number> {
+    let total = await this.getDiskUsage(user);
+
+    // lazy import to avoid circular dependency (StorageService extends BaseService)
+    const { StorageService } = await import('./storage.service.js');
+    const s3 = StorageService.getS3Backend();
+    if (s3) {
+      const prefixes = [
+        StorageFolder.Upload,
+        StorageFolder.Profile,
+        StorageFolder.Thumbnails,
+        StorageFolder.EncodedVideo,
+      ].map((folder) => `${folder}/${user.id}/`);
+      const usage = await Promise.all(prefixes.map((prefix) => s3.getPrefixUsage(prefix)));
+      total += usage.reduce((total, value) => total + value, 0);
+    }
+
+    return total;
+  }
+
+  private async getDiskUsage(user: Pick<UserAdmin, 'id' | 'storageLabel'>): Promise<number> {
+    const folders = [
+      StorageCore.getLibraryFolder(user),
+      StorageCore.getFolderLocation(StorageFolder.Upload, user.id),
+      StorageCore.getFolderLocation(StorageFolder.Profile, user.id),
+      StorageCore.getFolderLocation(StorageFolder.Thumbnails, user.id),
+      StorageCore.getFolderLocation(StorageFolder.EncodedVideo, user.id),
+    ];
+    const usage = await Promise.all(folders.map((folder) => this.storageRepository.getFolderSize(folder)));
+    return usage.reduce((total, value) => total + value, 0);
   }
 
   async createUser(dto: Insertable<UserTable> & { email: string }): Promise<UserAdmin> {

--- a/server/src/services/user-admin.service.spec.ts
+++ b/server/src/services/user-admin.service.spec.ts
@@ -224,20 +224,23 @@ describe(UserAdminService.name, () => {
 
     it('should sync usage when quota size changes', async () => {
       mocks.user.update.mockResolvedValue({ ...userStub.user1, quotaSizeInBytes: 1024 } as any);
+      (mocks.user as any).setUsage = vi.fn().mockResolvedValue(void 0);
+      mocks.storage.getFolderSize.mockResolvedValue(0);
 
       await sut.update(authStub.admin, userStub.user1.id, { quotaSizeInBytes: 1024 });
 
-      expect(mocks.user.syncUsage).toHaveBeenCalledWith(userStub.user1.id);
+      expect((mocks.user as any).setUsage).toHaveBeenCalledWith(userStub.user1.id, 0);
     });
 
     it('should not sync usage when quota size does not change', async () => {
       const user = factory.userAdmin({ quotaSizeInBytes: 1024 });
+      (mocks.user as any).setUsage = vi.fn().mockResolvedValue(void 0);
       mocks.user.get.mockResolvedValue(user);
       mocks.user.update.mockResolvedValue(user);
 
       await sut.update(authStub.admin, user.id, { quotaSizeInBytes: 1024 });
 
-      expect(mocks.user.syncUsage).not.toHaveBeenCalled();
+      expect((mocks.user as any).setUsage).not.toHaveBeenCalled();
     });
 
     it('should hash password when provided', async () => {

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -58,7 +58,7 @@ export class UserAdminService extends BaseService {
     }
 
     if (dto.quotaSizeInBytes && user.quotaSizeInBytes !== dto.quotaSizeInBytes) {
-      await this.userRepository.syncUsage(id);
+      await this.syncUsage(id);
     }
 
     if (dto.email) {

--- a/server/src/services/user.service.spec.ts
+++ b/server/src/services/user.service.spec.ts
@@ -885,13 +885,75 @@ describe(UserService.name, () => {
   });
 
   describe('handleUserSyncUsage', () => {
-    it('should sync usage', async () => {
+    afterEach(() => {
+      (StorageService as any).s3Backend = undefined;
+    });
+
+    it('should sync usage from S3 prefixes and existing disk folders', async () => {
+      const user = factory.userAdmin({ id: 'user-id', storageLabel: 'storage-label' });
+      const s3Backend = {
+        getPrefixUsage: vi
+          .fn()
+          .mockResolvedValueOnce(100)
+          .mockResolvedValueOnce(200)
+          .mockResolvedValueOnce(300)
+          .mockResolvedValueOnce(400),
+      };
+      (StorageService as any).s3Backend = s3Backend;
+      (mocks.user as any).setUsage = vi.fn().mockResolvedValue(void 0);
+      mocks.user.getList.mockResolvedValue([user]);
+      mocks.storage.getFolderSize
+        .mockResolvedValueOnce(10)
+        .mockResolvedValueOnce(20)
+        .mockResolvedValueOnce(30)
+        .mockResolvedValueOnce(40)
+        .mockResolvedValueOnce(50);
+
       await sut.handleUserSyncUsage();
 
-      expect(mocks.user.syncUsage).toHaveBeenCalledTimes(1);
+      expect(mocks.storage.getFolderSize.mock.calls).toEqual([
+        ['/data/library/storage-label'],
+        ['/data/upload/user-id'],
+        ['/data/profile/user-id'],
+        ['/data/thumbs/user-id'],
+        ['/data/encoded-video/user-id'],
+      ]);
+      expect(s3Backend.getPrefixUsage.mock.calls).toEqual([
+        ['upload/user-id/'],
+        ['profile/user-id/'],
+        ['thumbs/user-id/'],
+        ['encoded-video/user-id/'],
+      ]);
+      expect((mocks.user as any).setUsage).toHaveBeenCalledWith(user.id, 1150);
+    });
+
+    it('should sync disk usage from all managed user folders', async () => {
+      const user = factory.userAdmin({ id: 'user-id', storageLabel: 'storage-label' });
+      (mocks.user as any).setUsage = vi.fn().mockResolvedValue(void 0);
+      mocks.user.getList.mockResolvedValue([user]);
+      mocks.storage.getFolderSize
+        .mockResolvedValueOnce(100)
+        .mockResolvedValueOnce(200)
+        .mockResolvedValueOnce(300)
+        .mockResolvedValueOnce(400)
+        .mockResolvedValueOnce(500);
+
+      await sut.handleUserSyncUsage();
+
+      expect(mocks.storage.getFolderSize.mock.calls).toEqual([
+        ['/data/library/storage-label'],
+        ['/data/upload/user-id'],
+        ['/data/profile/user-id'],
+        ['/data/thumbs/user-id'],
+        ['/data/encoded-video/user-id'],
+      ]);
+      expect((mocks.user as any).setUsage).toHaveBeenCalledWith(user.id, 1500);
     });
 
     it('should return JobStatus.Success', async () => {
+      (mocks.user as any).setUsage = vi.fn().mockResolvedValue(void 0);
+      mocks.user.getList.mockResolvedValue([]);
+
       const result = await sut.handleUserSyncUsage();
 
       expect(result).toBe(JobStatus.Success);

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -245,7 +245,7 @@ export class UserService extends BaseService {
 
   @OnJob({ name: JobName.UserSyncUsage, queue: QueueName.BackgroundTask })
   async handleUserSyncUsage(): Promise<JobStatus> {
-    await this.userRepository.syncUsage();
+    await this.syncUsage();
     return JobStatus.Success;
   }
 

--- a/server/test/repositories/storage.repository.mock.ts
+++ b/server/test/repositories/storage.repository.mock.ts
@@ -65,6 +65,7 @@ export const newStorageRepositoryMock = (): Mocked<RepositoryInterface<StorageRe
     checkFileExists: vitest.fn(),
     mkdirSync: vitest.fn(),
     checkDiskUsage: vitest.fn(),
+    getFolderSize: vitest.fn(),
     readdir: vitest.fn(),
     realpath: vitest.fn().mockImplementation((filepath: string) => Promise.resolve(filepath)),
     stat: vitest.fn(),


### PR DESCRIPTION
## Summary
- change quota sync to persist physical storage usage instead of original-only EXIF file sizes
- count managed disk folders plus S3 user prefixes for mixed disk/S3 deployments
- add recursive disk folder sizing and paginated S3 prefix usage helpers
- remove the stale original-only UserRepository.syncUsage path

## Review notes
- Covered S3 + existing disk mixed storage, disk-only storage, empty/missing prefixes/folders, recursive folder sizing, and paginated S3 listings.
- Left user-facing quota display unchanged; it now receives the recalculated physical usage through the existing quotaUsageInBytes field.
- Existing incremental upload/delete quota deltas remain original-size based until the scheduled/manual sync runs; this PR fixes the authoritative sync path used to reconcile usage.

## Testing
- pnpm --dir server lint
- pnpm --dir server check
- pnpm --dir server test -- user.service.spec.ts user-admin.service.spec.ts s3-storage.backend.spec.ts disk-storage.backend.spec.ts storage.repository.spec.ts -t "handleUserSyncUsage|sync usage when quota size changes|not sync usage when quota size does not change|getPrefixUsage|getFolderSize"