### PR TITLE
fix: handle client aborts before proxy stream creation

### DIFF
--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -38,6 +38,14 @@ const flushPromises = async () => {
   }
 };
 
+const readStreamText = async (stream: Readable) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString();
+};
+
 describe('S3StorageBackend', () => {
   let backend: S3StorageBackend;
   let mockSend: ReturnType<typeof vi.fn>;
@@ -250,6 +258,48 @@ describe('S3StorageBackend', () => {
 
       expect(second.type).toBe('stream');
       expect(proxyClient.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('should release small thumbnail proxy reads before the returned stream is consumed', async () => {
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+        proxyReadConcurrency: 1,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      proxyClient.send
+        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('first')]), ContentLength: 5 })
+        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
+
+      const first = await proxyBackend.getServeStrategy('thumbs/user1/ab/cd/first_thumbnail.webp', 'image/webp');
+      const secondPromise = proxyBackend.getServeStrategy('thumbs/user1/ab/cd/second_thumbnail.webp', 'image/webp');
+
+      let assertionError: unknown;
+      try {
+        await flushPromises();
+        expect(proxyClient.send).toHaveBeenCalledTimes(2);
+      } catch (error) {
+        assertionError = error;
+      } finally {
+        if (proxyClient.send.mock.calls.length < 2 && first.type === 'stream') {
+          first.stream.destroy();
+        }
+        await secondPromise.catch(() => {});
+      }
+
+      if (assertionError) {
+        throw assertionError;
+      }
+
+      const second = await secondPromise;
+      expect(first.type).toBe('stream');
+      expect(second.type).toBe('stream');
+      if (first.type === 'stream' && second.type === 'stream') {
+        await expect(readStreamText(first.stream)).resolves.toBe('first');
+        await expect(readStreamText(second.stream)).resolves.toBe('second');
+      }
     });
 
     it('should remove an aborted queued proxy read without starting an S3 request', async () => {

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -217,6 +217,54 @@ describe('S3StorageBackend', () => {
       expect(proxyClient.send).toHaveBeenCalledTimes(2);
     });
 
+    it('should remove an aborted queued proxy read without starting an S3 request', async () => {
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+        proxyReadConcurrency: 1,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      const firstStream = new Readable({
+        read() {
+          // keep the first slot occupied until the queued request is aborted
+        },
+      });
+      proxyClient.send
+        .mockResolvedValueOnce({ Body: firstStream, ContentLength: 5 })
+        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('third')]), ContentLength: 5 });
+
+      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
+      const abortController = new AbortController();
+      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg', abortController.signal);
+      await flushPromises();
+      expect(proxyClient.send).toHaveBeenCalledTimes(1);
+
+      abortController.abort();
+      await flushPromises();
+
+      await expect(
+        Promise.race([
+          secondPromise.then(
+            () => 'resolved',
+            (error) => error.name,
+          ),
+          new Promise((resolve) => setTimeout(() => resolve('pending'), 0)),
+        ]),
+      ).resolves.toBe('AbortError');
+      expect(proxyClient.send).toHaveBeenCalledTimes(1);
+
+      if (first.type === 'stream') {
+        first.stream.destroy();
+      }
+      await flushPromises();
+      const third = await proxyBackend.getServeStrategy('third.jpg', 'image/jpeg');
+
+      expect(third.type).toBe('stream');
+      expect(proxyClient.send).toHaveBeenCalledTimes(2);
+    });
+
     it('should release a proxy read slot when stream creation fails', async () => {
       const proxyBackend = new S3StorageBackend({
         bucket: 'test-bucket',

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -1,3 +1,4 @@
+import { once } from 'node:events';
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Readable } from 'node:stream';
@@ -153,6 +154,40 @@ describe('S3StorageBackend', () => {
 
       const strategy = await proxyBackend.getServeStrategy('key.jpg', 'image/jpeg');
       expect(strategy.type).toBe('stream');
+    });
+
+    it('should emit diagnostic logs when proxy debug logging is enabled', async () => {
+      const logger = { log: vi.fn(), warn: vi.fn() } as any;
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+        proxyDebugLogs: true,
+        logger,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      proxyClient.send.mockResolvedValueOnce({
+        Body: Readable.from([Buffer.from('proxied')]),
+        ContentLength: 7,
+      });
+
+      const strategy = await proxyBackend.getServeStrategy('key.jpg', 'image/jpeg');
+      expect(strategy.type).toBe('stream');
+      if (strategy.type === 'stream') {
+        strategy.stream.resume();
+        await once(strategy.stream, 'end');
+      }
+
+      expect(logger.log.mock.calls.map(([message]: [string]) => message)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('[S3ProxyTrace:1] request'),
+          expect.stringContaining('[S3ProxyTrace:1] acquired'),
+          expect.stringContaining('[S3ProxyTrace:1] s3-response'),
+          expect.stringContaining('[S3ProxyTrace:1] first-byte'),
+          expect.stringContaining('[S3ProxyTrace:1] release reason=end'),
+        ]),
+      );
     });
 
     it('should limit concurrent proxied S3 reads', async () => {

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -20,15 +20,53 @@ import { ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.in
 const DEFAULT_PROXY_READ_CONCURRENCY = 32;
 const DEFAULT_PROXY_READ_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
+const createAbortError = () => Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+
+type QueueEntry = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+};
+
 class AsyncLimiter {
   private active = 0;
-  private readonly queue: Array<() => void> = [];
+  private readonly queue: QueueEntry[] = [];
 
   constructor(private readonly max: number) {}
 
-  async acquire(): Promise<() => void> {
+  async acquire(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
+
     if (this.active >= this.max) {
-      await new Promise<void>((resolve) => this.queue.push(resolve));
+      await new Promise<void>((resolve, reject) => {
+        const entry: QueueEntry = {
+          resolve: () => {
+            if (entry.onAbort) {
+              signal?.removeEventListener('abort', entry.onAbort);
+            }
+            resolve();
+          },
+          reject,
+          signal,
+        };
+        entry.onAbort = () => {
+          const index = this.queue.indexOf(entry);
+          if (index !== -1) {
+            this.queue.splice(index, 1);
+          }
+          reject(createAbortError());
+        };
+        signal?.addEventListener('abort', entry.onAbort, { once: true });
+        this.queue.push(entry);
+      });
+    }
+
+    if (signal?.aborted) {
+      this.releaseQueuedWaiter();
+      throw createAbortError();
     }
 
     this.active++;
@@ -39,8 +77,23 @@ class AsyncLimiter {
       }
       released = true;
       this.active--;
-      this.queue.shift()?.();
+      this.releaseQueuedWaiter();
     };
+  }
+
+  private releaseQueuedWaiter() {
+    while (this.queue.length > 0) {
+      const entry = this.queue.shift()!;
+      if (entry.onAbort) {
+        entry.signal?.removeEventListener('abort', entry.onAbort);
+      }
+      if (entry.signal?.aborted) {
+        entry.reject(createAbortError());
+        continue;
+      }
+      entry.resolve();
+      return;
+    }
   }
 }
 
@@ -99,8 +152,11 @@ export class S3StorageBackend implements StorageBackend {
     await upload.done();
   }
 
-  async get(key: string): Promise<{ stream: Readable; contentType?: string; length?: number }> {
-    const response = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+  async get(key: string, signal?: AbortSignal): Promise<{ stream: Readable; contentType?: string; length?: number }> {
+    const command = new GetObjectCommand({ Bucket: this.bucket, Key: key });
+    const response = signal
+      ? await this.client.send(command, { abortSignal: signal })
+      : await this.client.send(command);
 
     return {
       stream: response.Body as Readable,
@@ -161,7 +217,7 @@ export class S3StorageBackend implements StorageBackend {
     return total;
   }
 
-  private releaseWhenStreamCloses(stream: Readable, release: () => void) {
+  private releaseWhenStreamCloses(stream: Readable, release: () => void, signal?: AbortSignal) {
     let released = false;
     let idleTimeout: ReturnType<typeof setTimeout> | undefined;
     const originalEmit = stream.emit;
@@ -179,8 +235,19 @@ export class S3StorageBackend implements StorageBackend {
       }
       released = true;
       clearIdleTimeout();
+      if (signal) {
+        signal.removeEventListener('abort', abortStream);
+      }
       stream.emit = originalEmit;
       release();
+    };
+
+    const abortStream = () => {
+      try {
+        stream.destroy(createAbortError());
+      } finally {
+        releaseOnce();
+      }
     };
 
     const resetIdleTimeout = () => {
@@ -210,16 +277,21 @@ export class S3StorageBackend implements StorageBackend {
     stream.once('end', releaseOnce);
     stream.once('error', releaseOnce);
     stream.once('close', releaseOnce);
+    if (signal?.aborted) {
+      abortStream();
+    } else {
+      signal?.addEventListener('abort', abortStream, { once: true });
+    }
     resetIdleTimeout();
     return stream;
   }
 
-  async getServeStrategy(key: string, contentType: string): Promise<ServeStrategy> {
+  async getServeStrategy(key: string, contentType: string, signal?: AbortSignal): Promise<ServeStrategy> {
     if (this.serveMode === 'proxy') {
-      const release = await this.proxyReadLimiter.acquire();
+      const release = await this.proxyReadLimiter.acquire(signal);
       try {
-        const { stream, length } = await this.get(key);
-        return { type: 'stream', stream: this.releaseWhenStreamCloses(stream, release), length };
+        const { stream, length } = await this.get(key, signal);
+        return { type: 'stream', stream: this.releaseWhenStreamCloses(stream, release, signal), length };
       } catch (error) {
         release();
         throw error;

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
+import { LoggingRepository } from 'src/repositories/logging.repository';
 
 const DEFAULT_PROXY_READ_CONCURRENCY = 32;
 const DEFAULT_PROXY_READ_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
@@ -95,6 +96,14 @@ class AsyncLimiter {
       return;
     }
   }
+
+  getStats() {
+    return {
+      active: this.active,
+      queued: this.queue.length,
+      max: this.max,
+    };
+  }
 }
 
 export interface S3StorageConfig {
@@ -107,6 +116,8 @@ export interface S3StorageConfig {
   serveMode: 'redirect' | 'proxy';
   proxyReadConcurrency?: number;
   proxyReadIdleTimeoutMs?: number;
+  proxyDebugLogs?: boolean;
+  logger?: LoggingRepository;
 }
 
 export class S3StorageBackend implements StorageBackend {
@@ -116,6 +127,9 @@ export class S3StorageBackend implements StorageBackend {
   private serveMode: 'redirect' | 'proxy';
   private proxyReadLimiter: AsyncLimiter;
   private proxyReadIdleTimeoutMs: number;
+  private proxyDebugLogs: boolean;
+  private proxyReadSequence = 0;
+  private logger?: LoggingRepository;
 
   constructor(config: S3StorageConfig) {
     this.bucket = config.bucket;
@@ -123,6 +137,8 @@ export class S3StorageBackend implements StorageBackend {
     this.serveMode = config.serveMode;
     this.proxyReadLimiter = new AsyncLimiter(config.proxyReadConcurrency ?? DEFAULT_PROXY_READ_CONCURRENCY);
     this.proxyReadIdleTimeoutMs = Math.max(0, config.proxyReadIdleTimeoutMs ?? DEFAULT_PROXY_READ_IDLE_TIMEOUT_MS);
+    this.proxyDebugLogs = !!config.proxyDebugLogs;
+    this.logger = config.logger;
 
     this.client = new S3Client({
       region: config.region,
@@ -217,9 +233,24 @@ export class S3StorageBackend implements StorageBackend {
     return total;
   }
 
-  private releaseWhenStreamCloses(stream: Readable, release: () => void, signal?: AbortSignal) {
+  private traceProxyRead(level: 'log' | 'warn', readId: number, message: string) {
+    if (!this.proxyDebugLogs || !this.logger) {
+      return;
+    }
+
+    this.logger[level](`[S3ProxyTrace:${readId}] ${message}`);
+  }
+
+  private releaseWhenStreamCloses(
+    stream: Readable,
+    release: () => void,
+    context: { readId: number; key: string; startedAt: number; s3StartedAt: number; length?: number },
+    signal?: AbortSignal,
+  ) {
     let released = false;
     let idleTimeout: ReturnType<typeof setTimeout> | undefined;
+    let bytesRead = 0;
+    let firstByteAt: number | undefined;
     const originalEmit = stream.emit;
 
     const clearIdleTimeout = () => {
@@ -229,7 +260,7 @@ export class S3StorageBackend implements StorageBackend {
       }
     };
 
-    const releaseOnce = () => {
+    const releaseOnce = (reason: string) => {
       if (released) {
         return;
       }
@@ -240,13 +271,23 @@ export class S3StorageBackend implements StorageBackend {
       }
       stream.emit = originalEmit;
       release();
+      const stats = this.proxyReadLimiter.getStats();
+      this.traceProxyRead(
+        'log',
+        context.readId,
+        `release reason=${reason} totalMs=${Date.now() - context.startedAt} streamMs=${
+          Date.now() - context.s3StartedAt
+        } firstByteMs=${firstByteAt === undefined ? 'none' : firstByteAt - context.s3StartedAt} bytes=${bytesRead} length=${
+          context.length ?? 'unknown'
+        } active=${stats.active} queued=${stats.queued} key=${context.key}`,
+      );
     };
 
     const abortStream = () => {
       try {
         stream.destroy(createAbortError());
       } finally {
-        releaseOnce();
+        releaseOnce('abort');
       }
     };
 
@@ -258,25 +299,46 @@ export class S3StorageBackend implements StorageBackend {
       clearIdleTimeout();
       idleTimeout = setTimeout(() => {
         try {
+          this.traceProxyRead(
+            'warn',
+            context.readId,
+            `idle-timeout timeoutMs=${this.proxyReadIdleTimeoutMs} bytes=${bytesRead} key=${context.key}`,
+          );
           stream.destroy(new Error(`S3 proxy read timed out after ${this.proxyReadIdleTimeoutMs}ms of inactivity`));
         } finally {
-          releaseOnce();
+          releaseOnce('idle-timeout');
         }
       }, this.proxyReadIdleTimeoutMs);
+    };
+
+    const traceFirstByte = (timestamp: number) => {
+      this.traceProxyRead(
+        'log',
+        context.readId,
+        `first-byte firstByteMs=${timestamp - context.s3StartedAt} key=${context.key}`,
+      );
     };
 
     // Observe data activity without adding a "data" listener, which would switch the stream into flowing mode
     // before the HTTP response pipe is attached.
     stream.emit = function (this: Readable, eventName: string | symbol, ...args: any[]) {
-      if (eventName === 'data' || eventName === 'readable') {
+      if (eventName === 'data') {
+        if (firstByteAt === undefined) {
+          firstByteAt = Date.now();
+          traceFirstByte(firstByteAt);
+        }
+        const chunk = args[0];
+        bytesRead += typeof chunk?.length === 'number' ? chunk.length : 0;
+        resetIdleTimeout();
+      } else if (eventName === 'readable') {
         resetIdleTimeout();
       }
       return originalEmit.call(this, eventName, ...args);
     } as typeof stream.emit;
 
-    stream.once('end', releaseOnce);
-    stream.once('error', releaseOnce);
-    stream.once('close', releaseOnce);
+    stream.once('end', () => releaseOnce('end'));
+    stream.once('error', (error) => releaseOnce(`error:${error instanceof Error ? error.message : String(error)}`));
+    stream.once('close', () => releaseOnce('close'));
     if (signal?.aborted) {
       abortStream();
     } else {
@@ -288,12 +350,51 @@ export class S3StorageBackend implements StorageBackend {
 
   async getServeStrategy(key: string, contentType: string, signal?: AbortSignal): Promise<ServeStrategy> {
     if (this.serveMode === 'proxy') {
-      const release = await this.proxyReadLimiter.acquire(signal);
+      const readId = ++this.proxyReadSequence;
+      const startedAt = Date.now();
+      const queuedStats = this.proxyReadLimiter.getStats();
+      this.traceProxyRead(
+        'log',
+        readId,
+        `request contentType=${contentType} active=${queuedStats.active} queued=${queuedStats.queued} max=${queuedStats.max} key=${key}`,
+      );
+      let release: (() => void) | undefined;
       try {
+        release = await this.proxyReadLimiter.acquire(signal);
+        const acquiredAt = Date.now();
+        const acquiredStats = this.proxyReadLimiter.getStats();
+        this.traceProxyRead(
+          'log',
+          readId,
+          `acquired waitMs=${acquiredAt - startedAt} active=${acquiredStats.active} queued=${acquiredStats.queued} key=${key}`,
+        );
+        const s3StartedAt = Date.now();
         const { stream, length } = await this.get(key, signal);
-        return { type: 'stream', stream: this.releaseWhenStreamCloses(stream, release, signal), length };
+        this.traceProxyRead(
+          'log',
+          readId,
+          `s3-response s3Ms=${Date.now() - s3StartedAt} length=${length ?? 'unknown'} key=${key}`,
+        );
+        return {
+          type: 'stream',
+          stream: this.releaseWhenStreamCloses(
+            stream,
+            release,
+            { readId, key, startedAt, s3StartedAt, length },
+            signal,
+          ),
+          length,
+        };
       } catch (error) {
-        release();
+        release?.();
+        const stats = this.proxyReadLimiter.getStats();
+        this.traceProxyRead(
+          'warn',
+          readId,
+          `failed totalMs=${Date.now() - startedAt} active=${stats.active} queued=${stats.queued} error=${
+            error instanceof Error ? error.message : String(error)
+          } key=${key}`,
+        );
         throw error;
       }
     }

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -20,6 +20,7 @@ import { LoggingRepository } from 'src/repositories/logging.repository';
 
 const DEFAULT_PROXY_READ_CONCURRENCY = 32;
 const DEFAULT_PROXY_READ_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_PROXY_THUMBNAIL_BUFFER_MAX_BYTES = 2 * 1024 * 1024;
 
 const createAbortError = () => Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
 
@@ -241,6 +242,15 @@ export class S3StorageBackend implements StorageBackend {
     this.logger[level](`[S3ProxyTrace:${readId}] ${message}`);
   }
 
+  private shouldBufferProxyRead(key: string, contentType: string, length?: number) {
+    return (
+      key.startsWith('thumbs/') &&
+      contentType.startsWith('image/') &&
+      length !== undefined &&
+      length <= DEFAULT_PROXY_THUMBNAIL_BUFFER_MAX_BYTES
+    );
+  }
+
   private releaseWhenStreamCloses(
     stream: Readable,
     release: () => void,
@@ -348,6 +358,31 @@ export class S3StorageBackend implements StorageBackend {
     return stream;
   }
 
+  private async bufferProxyRead(
+    stream: Readable,
+    release: () => void,
+    context: { readId: number; key: string; startedAt: number; s3StartedAt: number; length?: number },
+    signal?: AbortSignal,
+  ) {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    const trackedStream = this.releaseWhenStreamCloses(stream, release, context, signal);
+
+    for await (const chunk of trackedStream) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.length;
+      if (totalBytes > DEFAULT_PROXY_THUMBNAIL_BUFFER_MAX_BYTES) {
+        trackedStream.destroy(
+          new Error(`S3 proxy thumbnail buffer exceeded ${DEFAULT_PROXY_THUMBNAIL_BUFFER_MAX_BYTES} bytes`),
+        );
+        throw new Error(`S3 proxy thumbnail buffer exceeded ${DEFAULT_PROXY_THUMBNAIL_BUFFER_MAX_BYTES} bytes`);
+      }
+      chunks.push(buffer);
+    }
+
+    return Buffer.concat(chunks, totalBytes);
+  }
+
   async getServeStrategy(key: string, contentType: string, signal?: AbortSignal): Promise<ServeStrategy> {
     if (this.serveMode === 'proxy') {
       const readId = ++this.proxyReadSequence;
@@ -375,14 +410,19 @@ export class S3StorageBackend implements StorageBackend {
           readId,
           `s3-response s3Ms=${Date.now() - s3StartedAt} length=${length ?? 'unknown'} key=${key}`,
         );
+        const context = { readId, key, startedAt, s3StartedAt, length };
+        if (this.shouldBufferProxyRead(key, contentType, length)) {
+          const buffer = await this.bufferProxyRead(stream, release, context, signal);
+          return {
+            type: 'stream',
+            stream: Readable.from([buffer]),
+            length,
+          };
+        }
+
         return {
           type: 'stream',
-          stream: this.releaseWhenStreamCloses(
-            stream,
-            release,
-            { readId, key, startedAt, s3StartedAt, length },
-            signal,
-          ),
+          stream: this.releaseWhenStreamCloses(stream, release, context, signal),
           length,
         };
       } catch (error) {

--- a/server/src/controllers/asset-media.controller.spec.ts
+++ b/server/src/controllers/asset-media.controller.spec.ts
@@ -1,8 +1,12 @@
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 import { AssetMediaController } from 'src/controllers/asset-media.controller';
 import { AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
-import { AssetMetadataKey } from 'src/enum';
+import { AssetMediaSize } from 'src/dtos/asset-media.dto';
+import { AssetMetadataKey, CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { AssetMediaService } from 'src/services/asset-media.service';
+import { ImmichStreamResponse } from 'src/utils/file';
 import request from 'supertest';
 import { factory } from 'test/small.factory';
 import { automock, ControllerContext, controllerSetup, mockBaseService } from 'test/utils';
@@ -150,6 +154,57 @@ describe(AssetMediaController.name, () => {
       it('should redirect if size=original is requested', async () => {
         const { status } = await request(ctx.getHttpServer()).get(`/assets/${factory.uuid()}/thumbnail?size=original`);
         expect(status).toBe(302);
+      });
+
+      it('should abort pending thumbnail work when the response closes before the thumbnail is ready', async () => {
+        const logger = automock(LoggingRepository, { strict: false });
+        const controller = new AssetMediaController(logger, service);
+        let capturedSignal: AbortSignal | undefined;
+        let resolveThumbnail!: (response: ImmichStreamResponse) => void;
+        service.viewThumbnail.mockImplementation((_auth, _id, _dto, signal?: AbortSignal) => {
+          capturedSignal = signal;
+          return new Promise((resolve) => {
+            resolveThumbnail = resolve;
+          });
+        });
+        const res = Object.assign(new EventEmitter(), {
+          set: vi.fn(),
+          header: vi.fn(),
+          headersSent: false,
+          writableEnded: false,
+        }) as any;
+        const next = vi.fn();
+        const stream = new Readable({
+          read() {
+            // keep the stream open so cleanup is observable
+          },
+        });
+        stream.pipe = vi.fn().mockReturnValue(res);
+
+        const sendPromise = controller.viewAsset(
+          {} as any,
+          { id: factory.uuid() },
+          { size: AssetMediaSize.THUMBNAIL },
+          { url: '/assets/id/thumbnail?size=thumbnail' } as any,
+          res,
+          next,
+        );
+        await Promise.resolve();
+
+        expect(capturedSignal).toBeInstanceOf(AbortSignal);
+        res.emit('close');
+        expect(capturedSignal?.aborted).toBe(true);
+
+        resolveThumbnail(
+          new ImmichStreamResponse({
+            stream,
+            contentType: 'image/webp',
+            cacheControl: CacheControl.PrivateWithCache,
+          }),
+        );
+        await sendPromise;
+
+        expect(stream.pipe).not.toHaveBeenCalled();
       });
     });
   });

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -104,7 +104,7 @@ export class AssetMediaController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
-    await sendFile(res, next, () => this.service.downloadOriginal(auth, id, dto), this.logger);
+    await sendFile(res, next, (signal) => this.service.downloadOriginal(auth, id, dto, signal), this.logger);
   }
 
   @Get(':id/thumbnail')
@@ -134,34 +134,43 @@ export class AssetMediaController {
       return res.redirect('original' + '?' + redirSearchParams.toString());
     }
 
-    const viewThumbnailRes = await this.service.viewThumbnail(auth, id, dto);
+    await sendFile(
+      res,
+      next,
+      async (signal) => {
+        const viewThumbnailRes = await this.service.viewThumbnail(auth, id, dto, signal);
 
-    if (
-      viewThumbnailRes instanceof ImmichFileResponse ||
-      viewThumbnailRes instanceof ImmichRedirectResponse ||
-      viewThumbnailRes instanceof ImmichStreamResponse
-    ) {
-      await sendFile(res, next, () => Promise.resolve(viewThumbnailRes), this.logger);
-    } else {
-      // viewThumbnailRes is a AssetMediaRedirectResponse
-      // which redirects to the original asset or a specific size to make better use of caching
-      const { targetSize } = viewThumbnailRes;
-      const [reqPath, reqSearch] = req.url.split('?');
-      let redirPath: string;
-      const redirSearchParams = new URLSearchParams(reqSearch);
-      if (targetSize === 'original') {
-        // relative path to this.downloadAsset
-        redirPath = 'original';
-        redirSearchParams.delete('size');
-      } else if (Object.values(AssetMediaSize).includes(targetSize)) {
-        redirPath = reqPath;
-        redirSearchParams.set('size', targetSize);
-      } else {
-        throw new Error('Invalid targetSize: ' + targetSize);
-      }
-      const finalRedirPath = redirPath + '?' + redirSearchParams.toString();
-      return res.redirect(finalRedirPath);
-    }
+        if (
+          viewThumbnailRes instanceof ImmichFileResponse ||
+          viewThumbnailRes instanceof ImmichRedirectResponse ||
+          viewThumbnailRes instanceof ImmichStreamResponse
+        ) {
+          return viewThumbnailRes;
+        }
+
+        if (signal.aborted) {
+          return;
+        }
+
+        const { targetSize } = viewThumbnailRes;
+        const [reqPath, reqSearch] = req.url.split('?');
+        let redirPath: string;
+        const redirSearchParams = new URLSearchParams(reqSearch);
+        if (targetSize === 'original') {
+          // relative path to this.downloadAsset
+          redirPath = 'original';
+          redirSearchParams.delete('size');
+        } else if (Object.values(AssetMediaSize).includes(targetSize)) {
+          redirPath = reqPath;
+          redirSearchParams.set('size', targetSize);
+        } else {
+          throw new Error('Invalid targetSize: ' + targetSize);
+        }
+        const finalRedirPath = redirPath + '?' + redirSearchParams.toString();
+        res.redirect(finalRedirPath);
+      },
+      this.logger,
+    );
   }
 
   @Get(':id/video/playback')
@@ -178,7 +187,7 @@ export class AssetMediaController {
     @Res() res: Response,
     @Next() next: NextFunction,
   ) {
-    await sendFile(res, next, () => this.service.playbackVideo(auth, id), this.logger);
+    await sendFile(res, next, (signal) => this.service.playbackVideo(auth, id, signal), this.logger);
   }
 
   @Post('bulk-upload-check')

--- a/server/src/controllers/person.controller.ts
+++ b/server/src/controllers/person.controller.ts
@@ -153,7 +153,7 @@ export class PersonController {
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,
   ) {
-    await sendFile(res, next, () => this.service.getThumbnail(auth, id), this.logger);
+    await sendFile(res, next, (signal) => this.service.getThumbnail(auth, id, signal), this.logger);
   }
 
   @Put(':id/reassign')

--- a/server/src/controllers/shared-space.controller.ts
+++ b/server/src/controllers/shared-space.controller.ts
@@ -316,7 +316,12 @@ export class SharedSpaceController {
     @Param('id') id: string,
     @Param('personId') personId: string,
   ) {
-    await sendFile(res, next, () => this.service.getSpacePersonThumbnail(auth, id, personId), this.logger);
+    await sendFile(
+      res,
+      next,
+      (signal) => this.service.getSpacePersonThumbnail(auth, id, personId, signal),
+      this.logger,
+    );
   }
 
   @Put(':id/people/:personId')

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -213,6 +213,6 @@ export class UserController {
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
   async getProfileImage(@Res() res: Response, @Next() next: NextFunction, @Param() { id }: UUIDParamDto) {
-    await sendFile(res, next, () => this.service.getProfileImage(id), this.logger);
+    await sendFile(res, next, (signal) => this.service.getProfileImage(id, signal), this.logger);
   }
 }

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -59,6 +59,7 @@ export const EnvSchema = z
     IMMICH_S3_PRESIGNED_URL_EXPIRY: z.coerce.number().int().optional(),
     IMMICH_S3_SERVE_MODE: z.enum(['redirect', 'proxy']).optional(),
     IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),
+    IMMICH_S3_PROXY_DEBUG_LOGS: stringBool.optional(),
     IMMICH_MICROSERVICES_METRICS_PORT: z.coerce.number().int().optional(),
     IMMICH_ALLOW_EXTERNAL_PLUGINS: stringBool.optional(),
     IMMICH_PLUGINS_INSTALL_FOLDER: absolutePath,

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -10,7 +10,7 @@ export interface StorageBackend {
   put(key: string, source: Readable | Buffer, metadata?: { contentType?: string }): Promise<void>;
 
   /** Get a readable stream for the given key */
-  get(key: string): Promise<{ stream: Readable; contentType?: string; length?: number }>;
+  get(key: string, signal?: AbortSignal): Promise<{ stream: Readable; contentType?: string; length?: number }>;
 
   /** Check if a key exists */
   exists(key: string): Promise<boolean>;
@@ -25,7 +25,7 @@ export interface StorageBackend {
   getPrefixUsage(prefix: string): Promise<number>;
 
   /** Determine how to serve this file to a client */
-  getServeStrategy(key: string, contentType: string): Promise<ServeStrategy>;
+  getServeStrategy(key: string, contentType: string, signal?: AbortSignal): Promise<ServeStrategy>;
 
   /**
    * Download content to a local temp file for processing by tools

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -49,6 +49,7 @@ const resetEnv = () => {
     'IMMICH_S3_PRESIGNED_URL_EXPIRY',
     'IMMICH_S3_SERVE_MODE',
     'IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS',
+    'IMMICH_S3_PROXY_DEBUG_LOGS',
   ]) {
     delete process.env[env];
   }
@@ -364,6 +365,7 @@ describe('getEnv', () => {
       process.env.IMMICH_S3_PRESIGNED_URL_EXPIRY = '7200';
       process.env.IMMICH_S3_SERVE_MODE = 'proxy';
       process.env.IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS = '120000';
+      process.env.IMMICH_S3_PROXY_DEBUG_LOGS = 'true';
 
       const { storage } = getEnv();
 
@@ -377,6 +379,7 @@ describe('getEnv', () => {
         presignedUrlExpiry: 7200,
         serveMode: 'proxy',
         proxyReadIdleTimeoutMs: 120_000,
+        proxyDebugLogs: true,
       });
     });
 
@@ -395,6 +398,7 @@ describe('getEnv', () => {
         presignedUrlExpiry: 3600,
         serveMode: 'redirect',
         proxyReadIdleTimeoutMs: 300_000,
+        proxyDebugLogs: false,
       });
     });
   });

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -124,6 +124,7 @@ export interface EnvData {
       presignedUrlExpiry: number;
       serveMode: 'redirect' | 'proxy';
       proxyReadIdleTimeoutMs: number;
+      proxyDebugLogs: boolean;
     };
   };
 
@@ -387,6 +388,7 @@ const getEnv = (): EnvData => {
         presignedUrlExpiry: dto.IMMICH_S3_PRESIGNED_URL_EXPIRY || 3600,
         serveMode: (dto.IMMICH_S3_SERVE_MODE as 'redirect' | 'proxy') || 'redirect',
         proxyReadIdleTimeoutMs: dto.IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS ?? 300_000,
+        proxyDebugLogs: !!dto.IMMICH_S3_PROXY_DEBUG_LOGS,
       },
     },
 

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -163,7 +163,12 @@ export class AssetMediaService extends BaseService {
     }
   }
 
-  async downloadOriginal(auth: AuthDto, id: string, dto: AssetDownloadOriginalDto): Promise<ImmichMediaResponse> {
+  async downloadOriginal(
+    auth: AuthDto,
+    id: string,
+    dto: AssetDownloadOriginalDto,
+    signal?: AbortSignal,
+  ): Promise<ImmichMediaResponse> {
     await this.requireAccess({ auth, permission: Permission.AssetDownload, ids: [id] });
 
     if (auth.sharedLink) {
@@ -182,6 +187,7 @@ export class AssetMediaService extends BaseService {
       mimeTypes.lookup(path),
       CacheControl.PrivateWithCache,
       getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
+      signal,
     );
   }
 
@@ -189,6 +195,7 @@ export class AssetMediaService extends BaseService {
     auth: AuthDto,
     id: string,
     dto: AssetMediaOptionsDto,
+    signal?: AbortSignal,
   ): Promise<ImmichMediaResponse | AssetMediaRedirectResponse> {
     await this.requireAccess({ auth, permission: Permission.AssetView, ids: [id] });
 
@@ -226,10 +233,10 @@ export class AssetMediaService extends BaseService {
       auth.sharedLink && !auth.sharedLink.showExif ? id : getFileNameWithoutExtension(originalFileName);
     const fileName = `${fileNameBase}_${size}${getFilenameExtension(path)}`;
 
-    return this.serveFromBackend(path, mimeTypes.lookup(path), CacheControl.PrivateWithCache, fileName);
+    return this.serveFromBackend(path, mimeTypes.lookup(path), CacheControl.PrivateWithCache, fileName, signal);
   }
 
-  async playbackVideo(auth: AuthDto, id: string): Promise<ImmichMediaResponse> {
+  async playbackVideo(auth: AuthDto, id: string, signal?: AbortSignal): Promise<ImmichMediaResponse> {
     await this.requireAccess({ auth, permission: Permission.AssetView, ids: [id] });
 
     const asset = await this.assetRepository.getForVideo(id);
@@ -240,7 +247,13 @@ export class AssetMediaService extends BaseService {
 
     const filepath = asset.encodedVideoPath || asset.originalPath;
 
-    return this.serveFromBackend(filepath, mimeTypes.lookup(filepath), CacheControl.PrivateWithCache);
+    return this.serveFromBackend(
+      filepath,
+      mimeTypes.lookup(filepath),
+      CacheControl.PrivateWithCache,
+      undefined,
+      signal,
+    );
   }
 
   async bulkUploadCheck(auth: AuthDto, dto: AssetBulkUploadCheckDto): Promise<AssetBulkUploadCheckResponseDto> {

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -233,11 +233,12 @@ export class BaseService {
     contentType: string,
     cacheControl: CacheControl,
     fileName?: string,
+    signal?: AbortSignal,
   ): Promise<ImmichMediaResponse> {
     // lazy import to avoid circular dependency (StorageService extends BaseService)
     const { StorageService } = await import('./storage.service.js');
     const backend = StorageService.resolveBackendForKey(filePath);
-    const strategy: ServeStrategy = await backend.getServeStrategy(filePath, contentType);
+    const strategy: ServeStrategy = await backend.getServeStrategy(filePath, contentType, signal);
 
     switch (strategy.type) {
       case 'file': {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -163,7 +163,7 @@ export class PersonService extends BaseService {
     return this.personRepository.getStatistics(id);
   }
 
-  async getThumbnail(auth: AuthDto, id: string): Promise<ImmichMediaResponse> {
+  async getThumbnail(auth: AuthDto, id: string, signal?: AbortSignal): Promise<ImmichMediaResponse> {
     await this.requireThumbnailAccess(auth, id);
     const person = await this.personRepository.getById(id);
     if (!person || !person.thumbnailPath) {
@@ -174,6 +174,8 @@ export class PersonService extends BaseService {
       person.thumbnailPath,
       mimeTypes.lookup(person.thumbnailPath),
       CacheControl.PrivateWithoutCache,
+      undefined,
+      signal,
     );
   }
 

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -695,7 +695,12 @@ export class SharedSpaceService extends BaseService {
     return this.mapSpacePerson(person, alias?.alias ?? null);
   }
 
-  async getSpacePersonThumbnail(auth: AuthDto, spaceId: string, personId: string): Promise<ImmichMediaResponse> {
+  async getSpacePersonThumbnail(
+    auth: AuthDto,
+    spaceId: string,
+    personId: string,
+    signal?: AbortSignal,
+  ): Promise<ImmichMediaResponse> {
     await this.requireMembership(auth, spaceId);
 
     const person = await this.sharedSpaceRepository.getPersonById(personId);
@@ -708,7 +713,13 @@ export class SharedSpaceService extends BaseService {
       throw new NotFoundException();
     }
 
-    return this.serveFromBackend(thumbnailPath, mimeTypes.lookup(thumbnailPath), CacheControl.PrivateWithoutCache);
+    return this.serveFromBackend(
+      thumbnailPath,
+      mimeTypes.lookup(thumbnailPath),
+      CacheControl.PrivateWithoutCache,
+      undefined,
+      signal,
+    );
   }
 
   async updateSpacePerson(

--- a/server/src/services/storage.service.spec.ts
+++ b/server/src/services/storage.service.spec.ts
@@ -455,6 +455,7 @@ describe(StorageService.name, () => {
               presignedUrlExpiry: 3600,
               serveMode: 'redirect',
               proxyReadIdleTimeoutMs: 300_000,
+              proxyDebugLogs: false,
             },
           },
         }),

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -83,8 +83,11 @@ export class StorageService extends BaseService {
     StorageService.writeBackendType = envData.storage.backend;
 
     if (envData.storage.s3.bucket) {
-      StorageService.s3Backend = new S3StorageBackend(envData.storage.s3);
+      StorageService.s3Backend = new S3StorageBackend({ ...envData.storage.s3, logger: this.logger });
       this.logger.log(`S3 storage backend configured (bucket: ${envData.storage.s3.bucket})`);
+      if (envData.storage.s3.proxyDebugLogs) {
+        this.logger.warn('S3 proxy debug logging is enabled');
+      }
     }
 
     if (envData.storage.backend === 's3' && !StorageService.s3Backend) {

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -152,13 +152,19 @@ export class UserService extends BaseService {
     await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [user.profileImagePath] } });
   }
 
-  async getProfileImage(id: string): Promise<ImmichMediaResponse> {
+  async getProfileImage(id: string, signal?: AbortSignal): Promise<ImmichMediaResponse> {
     const user = await this.findOrFail(id, {});
     if (!user.profileImagePath) {
       throw new NotFoundException('User does not have a profile image');
     }
 
-    return this.serveFromBackend(user.profileImagePath, mimeTypes.lookup(user.profileImagePath), CacheControl.None);
+    return this.serveFromBackend(
+      user.profileImagePath,
+      mimeTypes.lookup(user.profileImagePath),
+      CacheControl.None,
+      undefined,
+      signal,
+    );
   }
 
   async getLicense(auth: AuthDto): Promise<LicenseResponseDto> {

--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -153,6 +153,44 @@ describe('sendFile with ImmichMediaResponse', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('should destroy a stream returned after the response already closed', async () => {
+    let resolveHandler!: (response: ImmichStreamResponse) => void;
+    const handlerPromise = new Promise<ImmichStreamResponse>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const res = Object.assign(new EventEmitter(), {
+      set: vi.fn(),
+      header: vi.fn(),
+      headersSent: false,
+      writableEnded: false,
+    }) as any;
+    const next = vi.fn();
+
+    const sendPromise = sendFile(res, next, () => handlerPromise, mockLogger);
+    res.emit('close');
+
+    const stream = new Readable({
+      read() {
+        // keep the stream open so this test observes explicit cleanup
+      },
+    });
+    const destroy = vi.spyOn(stream, 'destroy');
+    stream.pipe = vi.fn().mockReturnValue(res);
+
+    resolveHandler(
+      new ImmichStreamResponse({
+        stream,
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      }),
+    );
+    await sendPromise;
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(stream.pipe).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('should not destroy a stream when the response closes after completion', async () => {
     const stream = new Readable({
       read() {

--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -447,6 +447,21 @@ describe('sendFile with ImmichMediaResponse', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('should silently ignore AbortError from canceled media work', async () => {
+    const error = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      headersSent: false,
+    } as any;
+    const next = vi.fn();
+
+    await sendFile(res, next, () => Promise.reject(error), mockLogger);
+
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('should silently return if headers are already sent', async () => {
     const error = new Error('Something went wrong');
     const res = {

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -57,6 +57,9 @@ export type ImmichMediaResponse = ImmichFileResponse | ImmichRedirectResponse | 
 
 type SendFile = Parameters<Response['sendFile']>;
 type SendFileOptions = SendFile[1];
+type MediaResponseHandler = (
+  signal: AbortSignal,
+) => Promise<ImmichMediaResponse | undefined> | ImmichMediaResponse | undefined;
 
 const cacheControlHeaders: Record<CacheControl, string | null> = {
   [CacheControl.PrivateWithCache]:
@@ -68,7 +71,7 @@ const cacheControlHeaders: Record<CacheControl, string | null> = {
 export const sendFile = async (
   res: Response,
   next: NextFunction,
-  handler: () => Promise<ImmichMediaResponse> | ImmichMediaResponse,
+  handler: MediaResponseHandler,
   logger: LoggingRepository,
 ): Promise<void> => {
   // promisified version of 'res.sendFile' for cleaner async handling
@@ -76,10 +79,14 @@ export const sendFile = async (
     promisify<string, SendFileOptions>(res.sendFile).bind(res)(path, options);
   let responseClosed = false;
   let streamResponse: ImmichStreamResponse | undefined;
+  const abortController = new AbortController();
 
   if (typeof res.once === 'function') {
     res.once('close', () => {
       responseClosed = true;
+      if (!res.writableEnded && !abortController.signal.aborted) {
+        abortController.abort();
+      }
       if (streamResponse && !res.writableEnded && !streamResponse.stream.destroyed) {
         streamResponse.stream.destroy();
       }
@@ -87,7 +94,11 @@ export const sendFile = async (
   }
 
   try {
-    const file = await handler();
+    const file = await handler(abortController.signal);
+
+    if (!file) {
+      return;
+    }
 
     if (file instanceof ImmichRedirectResponse) {
       let parsed: URL;

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -74,6 +74,17 @@ export const sendFile = async (
   // promisified version of 'res.sendFile' for cleaner async handling
   const _sendFile = (path: string, options: SendFileOptions) =>
     promisify<string, SendFileOptions>(res.sendFile).bind(res)(path, options);
+  let responseClosed = false;
+  let streamResponse: ImmichStreamResponse | undefined;
+
+  if (typeof res.once === 'function') {
+    res.once('close', () => {
+      responseClosed = true;
+      if (streamResponse && !res.writableEnded && !streamResponse.stream.destroyed) {
+        streamResponse.stream.destroy();
+      }
+    });
+  }
 
   try {
     const file = await handler();
@@ -99,6 +110,12 @@ export const sendFile = async (
     }
 
     if (file instanceof ImmichStreamResponse) {
+      streamResponse = file;
+      if (responseClosed && !file.stream.destroyed) {
+        file.stream.destroy();
+        return;
+      }
+
       const cacheControlHeader = cacheControlHeaders[file.cacheControl];
       if (cacheControlHeader) {
         res.set('Cache-Control', cacheControlHeader);
@@ -109,13 +126,6 @@ export const sendFile = async (
       }
       if (file.fileName) {
         res.header('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(file.fileName)}`);
-      }
-      if (typeof res.once === 'function') {
-        res.once('close', () => {
-          if (!res.writableEnded && !file.stream.destroyed) {
-            file.stream.destroy();
-          }
-        });
       }
       file.stream.pipe(res);
       return;

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -106,7 +106,8 @@ export const isDuplicateDetectionEnabled = (machineLearning: SystemConfig['machi
   isSmartSearchEnabled(machineLearning) && machineLearning.duplicateDetection.enabled;
 export const isFaceImportEnabled = (metadata: SystemConfig['metadata']) => metadata.faces.import;
 
-export const isConnectionAborted = (error: Error | any) => error.code === 'ECONNABORTED';
+export const isConnectionAborted = (error: Error | any) =>
+  error.code === 'ECONNABORTED' || error.code === 'ABORT_ERR' || error.name === 'AbortError';
 
 export const handlePromiseError = <T>(promise: Promise<T>, logger: LoggingRepository): void => {
   promise.catch((error: Error | any) => logger.error(`Promise error: ${error}`, error?.stack));

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -100,6 +100,7 @@ const envData: EnvData = {
       presignedUrlExpiry: 3600,
       serveMode: 'redirect',
       proxyReadIdleTimeoutMs: 300_000,
+      proxyDebugLogs: false,
     },
   },
 

--- a/web/src/service-worker/request.spec.ts
+++ b/web/src/service-worker/request.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requestUrl = 'https://gallery.example/api/assets/00000000-0000-4000-8000-000000000001/thumbnail';
+
+const loadRequestModule = async () => {
+  vi.resetModules();
+  return await import('./request');
+};
+
+describe('service worker asset request handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the original response for the first request without cloning an unconsumed body', async () => {
+    const { handleFetch } = await loadRequestModule();
+    const response = new Response('thumbnail');
+    const clone = vi.spyOn(response, 'clone');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    await expect(handleFetch(new Request(requestUrl))).resolves.toBe(response);
+
+    expect(clone).not.toHaveBeenCalled();
+  });
+
+  it('starts a fresh fetch after the first response has started instead of reusing its body for five minutes', async () => {
+    const { handleFetch } = await loadRequestModule();
+    const firstResponse = new Response('first');
+    const secondResponse = new Response('second');
+    const fetch = vi.fn().mockResolvedValueOnce(firstResponse).mockResolvedValueOnce(secondResponse);
+    vi.stubGlobal('fetch', fetch);
+
+    await expect(handleFetch(new Request(requestUrl))).resolves.toBe(firstResponse);
+    await expect(handleFetch(new Request(requestUrl))).resolves.toBe(secondResponse);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/service-worker/request.ts
+++ b/web/src/service-worker/request.ts
@@ -5,7 +5,7 @@
 
 type PendingRequest = {
   controller: AbortController;
-  promise: Promise<Response>;
+  responsePromise?: Promise<Response>;
   cleanupTimeout?: ReturnType<typeof setTimeout>;
 };
 
@@ -20,21 +20,20 @@ export const handleFetch = (request: URL | Request): Promise<Response> => {
   const requestKey = getRequestKey(request);
   const existing = pendingRequests.get(requestKey);
 
-  if (existing) {
+  if (existing?.responsePromise) {
     // Clone the response since response bodies can only be read once
     // Each caller gets an independent clone they can consume
-    return existing.promise.then((response) => response.clone());
+    return existing.responsePromise.then((response) => response.clone());
   }
 
   const pendingRequest: PendingRequest = {
     controller: new AbortController(),
-    promise: undefined as unknown as Promise<Response>,
     cleanupTimeout: undefined,
   };
   pendingRequests.set(requestKey, pendingRequest);
 
   // NOTE: fetch returns after headers received, not the body
-  pendingRequest.promise = fetch(request, { signal: pendingRequest.controller.signal })
+  pendingRequest.responsePromise = fetch(request, { signal: pendingRequest.controller.signal })
     .catch((error: unknown) => {
       const standardError = error instanceof Error ? error : new Error(String(error));
       if (standardError.name === 'AbortError' || standardError.message === CANCELATION_MESSAGE) {
@@ -44,15 +43,18 @@ export const handleFetch = (request: URL | Request): Promise<Response> => {
       throw standardError;
     })
     .finally(() => {
-      // Schedule cleanup after timeout to allow response body streaming to complete
+      // Fetch resolves once headers arrive. Do not retain the Response for the body lifetime:
+      // an unconsumed cloned body can keep proxied media streams open until their idle timeout.
+      pendingRequest.responsePromise = undefined;
       const cleanupTimeout = setTimeout(() => {
-        pendingRequests.delete(requestKey);
+        if (pendingRequests.get(requestKey) === pendingRequest) {
+          pendingRequests.delete(requestKey);
+        }
       }, CLEANUP_TIMEOUT_MS);
       pendingRequest.cleanupTimeout = cleanupTimeout;
     });
 
-  // Clone for the first caller to keep the original response unconsumed for future callers
-  return pendingRequest.promise.then((response) => response.clone());
+  return pendingRequest.responsePromise;
 };
 
 export const handleCancel = (url: URL) => {


### PR DESCRIPTION
## Summary
- register the response close listener before awaiting media handlers
- destroy delayed stream responses when the client has already aborted
- add regression coverage for the pre-stream abort case

## Verification
- `pnpm test src/backends/s3-storage.backend.spec.ts src/utils/file.spec.ts`
- `pnpm check`
- RC deployed to pierre.opennoodle.de as `fix-s3-proxy-client-abort-rc1`
- authenticated thumbnail burst: 120/120 HTTP 200, max total 0.553s
- repeated burst: 120/120 HTTP 200, max total 0.439s
- client-abort burst left limiter at active=3, queued=0, max=32 (same stable baseline as before the abort burst)