### PR TITLE
revert: s3 proxy timeout fixes

### DIFF
--- a/docs/docs/features/s3-storage.md
+++ b/docs/docs/features/s3-storage.md
@@ -25,17 +25,16 @@ Gallery supports two modes for serving files from S3:
 
 All S3 variables are set on the `immich-server` container.
 
-| Variable                               | Description                                                                           |   Default   | Required          |
-| :------------------------------------- | :------------------------------------------------------------------------------------ | :---------: | :---------------- |
-| `IMMICH_STORAGE_BACKEND`               | Storage backend for new uploads (`disk` or `s3`)                                      |   `disk`    | Yes (set to `s3`) |
-| `IMMICH_S3_BUCKET`                     | S3 bucket name                                                                        |             | Yes               |
-| `IMMICH_S3_REGION`                     | AWS region (or region of your S3-compatible provider)                                 | `us-east-1` | No                |
-| `IMMICH_S3_ENDPOINT`                   | Custom endpoint URL for S3-compatible services (e.g. MinIO, R2)                       |             | No<sup>\*1</sup>  |
-| `IMMICH_S3_ACCESS_KEY_ID`              | Access key ID                                                                         |             | No<sup>\*2</sup>  |
-| `IMMICH_S3_SECRET_ACCESS_KEY`          | Secret access key                                                                     |             | No<sup>\*2</sup>  |
-| `IMMICH_S3_PRESIGNED_URL_EXPIRY`       | Presigned URL expiration time in seconds (only relevant for `redirect` mode)          |   `3600`    | No                |
-| `IMMICH_S3_SERVE_MODE`                 | How to serve S3 assets: `redirect` (presigned URL) or `proxy` (stream through server) | `redirect`  | No                |
-| `IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS` | Idle timeout for proxied S3 reads in milliseconds; set to `0` to disable              |  `300000`   | No                |
+| Variable                         | Description                                                                           |   Default   | Required          |
+| :------------------------------- | :------------------------------------------------------------------------------------ | :---------: | :---------------- |
+| `IMMICH_STORAGE_BACKEND`         | Storage backend for new uploads (`disk` or `s3`)                                      |   `disk`    | Yes (set to `s3`) |
+| `IMMICH_S3_BUCKET`               | S3 bucket name                                                                        |             | Yes               |
+| `IMMICH_S3_REGION`               | AWS region (or region of your S3-compatible provider)                                 | `us-east-1` | No                |
+| `IMMICH_S3_ENDPOINT`             | Custom endpoint URL for S3-compatible services (e.g. MinIO, R2)                       |             | No<sup>\*1</sup>  |
+| `IMMICH_S3_ACCESS_KEY_ID`        | Access key ID                                                                         |             | No<sup>\*2</sup>  |
+| `IMMICH_S3_SECRET_ACCESS_KEY`    | Secret access key                                                                     |             | No<sup>\*2</sup>  |
+| `IMMICH_S3_PRESIGNED_URL_EXPIRY` | Presigned URL expiration time in seconds (only relevant for `redirect` mode)          |   `3600`    | No                |
+| `IMMICH_S3_SERVE_MODE`           | How to serve S3 assets: `redirect` (presigned URL) or `proxy` (stream through server) | `redirect`  | No                |
 
 \*1: Required for non-AWS S3-compatible services (MinIO, R2, B2, etc.). Omit for AWS S3.
 
@@ -233,7 +232,7 @@ When a client requests an asset, `BaseService.serveFromBackend()` asks the resol
 | S3      | `redirect` | `ImmichRedirectResponse` | HTTP 302 to a presigned URL; client fetches from S3 |
 | S3      | `proxy`    | `ImmichStreamResponse`   | Server streams S3 data through to the client        |
 
-Presigned URLs expire after `IMMICH_S3_PRESIGNED_URL_EXPIRY` seconds (default 3600). In `proxy` mode, inactive S3 reads are destroyed after `IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS` milliseconds (default 300000) so a stuck stream cannot hold a proxy read slot forever. The S3 backend uses `forcePathStyle: true` when a custom endpoint is configured, which is required for MinIO, DigitalOcean Spaces, and similar providers.
+Presigned URLs expire after `IMMICH_S3_PRESIGNED_URL_EXPIRY` seconds (default 3600). The S3 backend uses `forcePathStyle: true` when a custom endpoint is configured, which is required for MinIO, DigitalOcean Spaces, and similar providers.
 
 ### Upload Flow
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -207,17 +207,16 @@ Additional machine learning parameters can be tuned from the admin UI.
 
 ## S3 Storage
 
-| Variable                               | Description                                                                           |   Default   | Containers | Workers            |
-| :------------------------------------- | :------------------------------------------------------------------------------------ | :---------: | :--------- | :----------------- |
-| `IMMICH_STORAGE_BACKEND`               | Storage backend for new uploads (`disk` or `s3`)                                      |   `disk`    | server     | api, microservices |
-| `IMMICH_S3_BUCKET`                     | S3 bucket name                                                                        |             | server     | api, microservices |
-| `IMMICH_S3_REGION`                     | AWS region or S3-compatible provider region                                           | `us-east-1` | server     | api, microservices |
-| `IMMICH_S3_ENDPOINT`                   | Custom endpoint URL for S3-compatible services                                        |             | server     | api, microservices |
-| `IMMICH_S3_ACCESS_KEY_ID`              | Access key ID (falls back to IAM role if omitted)                                     |             | server     | api, microservices |
-| `IMMICH_S3_SECRET_ACCESS_KEY`          | Secret access key (falls back to IAM role if omitted)                                 |             | server     | api, microservices |
-| `IMMICH_S3_PRESIGNED_URL_EXPIRY`       | Presigned URL expiration time in seconds                                              |   `3600`    | server     | api, microservices |
-| `IMMICH_S3_SERVE_MODE`                 | How to serve S3 assets: `redirect` (presigned URL) or `proxy` (stream through server) | `redirect`  | server     | api, microservices |
-| `IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS` | Idle timeout for proxied S3 reads in milliseconds; set to `0` to disable              |  `300000`   | server     | api, microservices |
+| Variable                         | Description                                                                           |   Default   | Containers | Workers            |
+| :------------------------------- | :------------------------------------------------------------------------------------ | :---------: | :--------- | :----------------- |
+| `IMMICH_STORAGE_BACKEND`         | Storage backend for new uploads (`disk` or `s3`)                                      |   `disk`    | server     | api, microservices |
+| `IMMICH_S3_BUCKET`               | S3 bucket name                                                                        |             | server     | api, microservices |
+| `IMMICH_S3_REGION`               | AWS region or S3-compatible provider region                                           | `us-east-1` | server     | api, microservices |
+| `IMMICH_S3_ENDPOINT`             | Custom endpoint URL for S3-compatible services                                        |             | server     | api, microservices |
+| `IMMICH_S3_ACCESS_KEY_ID`        | Access key ID (falls back to IAM role if omitted)                                     |             | server     | api, microservices |
+| `IMMICH_S3_SECRET_ACCESS_KEY`    | Secret access key (falls back to IAM role if omitted)                                 |             | server     | api, microservices |
+| `IMMICH_S3_PRESIGNED_URL_EXPIRY` | Presigned URL expiration time in seconds                                              |   `3600`    | server     | api, microservices |
+| `IMMICH_S3_SERVE_MODE`           | How to serve S3 assets: `redirect` (presigned URL) or `proxy` (stream through server) | `redirect`  | server     | api, microservices |
 
 :::info
 For detailed setup instructions, see the [S3-Compatible Storage](/features/s3-storage) guide.

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -31,12 +31,6 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
 
-const flushPromises = async () => {
-  for (let index = 0; index < 5; index++) {
-    await Promise.resolve();
-  }
-};
-
 describe('S3StorageBackend', () => {
   let backend: S3StorageBackend;
   let mockSend: ReturnType<typeof vi.fn>;
@@ -53,9 +47,7 @@ describe('S3StorageBackend', () => {
   });
 
   afterEach(() => {
-    mockSend?.mockReset();
     vi.clearAllMocks();
-    vi.useRealTimers();
   });
 
   describe('put', () => {
@@ -271,190 +263,6 @@ describe('S3StorageBackend', () => {
 
       expect(second.type).toBe('stream');
       expect(proxyClient.send).toHaveBeenCalledTimes(2);
-    });
-
-    it('should destroy and release an idle proxy read after the configured timeout', async () => {
-      vi.useFakeTimers();
-      const proxyBackend = new S3StorageBackend({
-        bucket: 'test-bucket',
-        region: 'us-east-1',
-        presignedUrlExpiry: 3600,
-        serveMode: 'proxy' as const,
-        proxyReadConcurrency: 1,
-        proxyReadIdleTimeoutMs: 50,
-      });
-      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
-      const idleStream = new Readable({
-        read() {
-          // simulate a stuck S3 body that never emits end/error/close on its own
-        },
-      });
-      const destroy = vi.spyOn(idleStream, 'destroy');
-      proxyClient.send
-        .mockResolvedValueOnce({ Body: idleStream, ContentLength: 5 })
-        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
-
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
-      expect(first.type).toBe('stream');
-      expect(proxyClient.send).toHaveBeenCalledTimes(1);
-
-      await vi.advanceTimersByTimeAsync(49);
-      await expect(Promise.race([secondPromise.then(() => 'resolved'), Promise.resolve('pending')])).resolves.toBe(
-        'pending',
-      );
-
-      await vi.advanceTimersByTimeAsync(1);
-      await flushPromises();
-      expect(destroy).toHaveBeenCalledTimes(1);
-      expect(proxyClient.send).toHaveBeenCalledTimes(2);
-      await expect(secondPromise).resolves.toMatchObject({ type: 'stream' });
-    });
-
-    it('should reset the idle timeout when proxy stream data is emitted', async () => {
-      vi.useFakeTimers();
-      const proxyBackend = new S3StorageBackend({
-        bucket: 'test-bucket',
-        region: 'us-east-1',
-        presignedUrlExpiry: 3600,
-        serveMode: 'proxy' as const,
-        proxyReadConcurrency: 1,
-        proxyReadIdleTimeoutMs: 50,
-      });
-      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
-      const activeStream = new Readable({
-        read() {
-          // activity is emitted manually below to verify watchdog reset behavior
-        },
-      });
-      const destroy = vi.spyOn(activeStream, 'destroy');
-      proxyClient.send
-        .mockResolvedValueOnce({ Body: activeStream, ContentLength: 5 })
-        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
-
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
-      expect(first.type).toBe('stream');
-
-      await vi.advanceTimersByTimeAsync(40);
-      activeStream.emit('data', Buffer.from('still active'));
-      await vi.advanceTimersByTimeAsync(40);
-      await expect(Promise.race([secondPromise.then(() => 'resolved'), Promise.resolve('pending')])).resolves.toBe(
-        'pending',
-      );
-      expect(destroy).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(10);
-      await flushPromises();
-      expect(proxyClient.send).toHaveBeenCalledTimes(2);
-
-      await expect(secondPromise).resolves.toMatchObject({ type: 'stream' });
-      expect(destroy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should clear the idle timeout when a proxy stream ends', async () => {
-      vi.useFakeTimers();
-      const proxyBackend = new S3StorageBackend({
-        bucket: 'test-bucket',
-        region: 'us-east-1',
-        presignedUrlExpiry: 3600,
-        serveMode: 'proxy' as const,
-        proxyReadConcurrency: 1,
-        proxyReadIdleTimeoutMs: 50,
-      });
-      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
-      const endingStream = new Readable({
-        read() {
-          // end is emitted manually below to isolate timeout cleanup
-        },
-      });
-      const destroy = vi.spyOn(endingStream, 'destroy');
-      proxyClient.send
-        .mockResolvedValueOnce({ Body: endingStream, ContentLength: 5 })
-        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
-
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
-      expect(first.type).toBe('stream');
-
-      endingStream.emit('end');
-      await flushPromises();
-      expect(proxyClient.send).toHaveBeenCalledTimes(2);
-
-      await vi.advanceTimersByTimeAsync(50);
-
-      expect(destroy).not.toHaveBeenCalled();
-      await expect(secondPromise).resolves.toMatchObject({ type: 'stream' });
-    });
-
-    it('should release only one queued proxy read when an idle stream times out', async () => {
-      vi.useFakeTimers();
-      const proxyBackend = new S3StorageBackend({
-        bucket: 'test-bucket',
-        region: 'us-east-1',
-        presignedUrlExpiry: 3600,
-        serveMode: 'proxy' as const,
-        proxyReadConcurrency: 1,
-        proxyReadIdleTimeoutMs: 50,
-      });
-      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
-      const idleStream = new Readable({
-        read() {
-          // simulate a stuck S3 body that will be destroyed by the watchdog
-        },
-      });
-      proxyClient.send
-        .mockResolvedValueOnce({ Body: idleStream, ContentLength: 5 })
-        .mockResolvedValueOnce({ Body: new Readable({ read() {} }), ContentLength: 6 })
-        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('third')]), ContentLength: 5 });
-
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
-      const thirdPromise = proxyBackend.getServeStrategy('third.jpg', 'image/jpeg');
-      expect(first.type).toBe('stream');
-      expect(proxyClient.send).toHaveBeenCalledTimes(1);
-
-      await vi.advanceTimersByTimeAsync(50);
-      await flushPromises();
-
-      expect(proxyClient.send).toHaveBeenCalledTimes(2);
-      await expect(secondPromise).resolves.toMatchObject({ type: 'stream' });
-      await expect(Promise.race([thirdPromise.then(() => 'resolved'), Promise.resolve('pending')])).resolves.toBe(
-        'pending',
-      );
-    });
-
-    it('should not arm an idle timeout when proxy read idle timeout is disabled', async () => {
-      vi.useFakeTimers();
-      const proxyBackend = new S3StorageBackend({
-        bucket: 'test-bucket',
-        region: 'us-east-1',
-        presignedUrlExpiry: 3600,
-        serveMode: 'proxy' as const,
-        proxyReadConcurrency: 1,
-        proxyReadIdleTimeoutMs: 0,
-      });
-      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
-      const idleStream = new Readable({
-        read() {
-          // keep the stream open until explicit cleanup
-        },
-      });
-      const destroy = vi.spyOn(idleStream, 'destroy');
-      proxyClient.send
-        .mockResolvedValueOnce({ Body: idleStream, ContentLength: 5 })
-        .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
-
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
-      expect(first.type).toBe('stream');
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      await expect(Promise.race([secondPromise.then(() => 'resolved'), Promise.resolve('pending')])).resolves.toBe(
-        'pending',
-      );
-      expect(destroy).not.toHaveBeenCalled();
     });
 
     it('should not acquire proxy read slots in redirect mode', async () => {

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -17,9 +17,6 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
 
-const DEFAULT_PROXY_READ_CONCURRENCY = 32;
-const DEFAULT_PROXY_READ_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
-
 class AsyncLimiter {
   private active = 0;
   private readonly queue: Array<() => void> = [];
@@ -53,7 +50,6 @@ export interface S3StorageConfig {
   presignedUrlExpiry: number;
   serveMode: 'redirect' | 'proxy';
   proxyReadConcurrency?: number;
-  proxyReadIdleTimeoutMs?: number;
 }
 
 export class S3StorageBackend implements StorageBackend {
@@ -62,14 +58,12 @@ export class S3StorageBackend implements StorageBackend {
   private presignedUrlExpiry: number;
   private serveMode: 'redirect' | 'proxy';
   private proxyReadLimiter: AsyncLimiter;
-  private proxyReadIdleTimeoutMs: number;
 
   constructor(config: S3StorageConfig) {
     this.bucket = config.bucket;
     this.presignedUrlExpiry = config.presignedUrlExpiry;
     this.serveMode = config.serveMode;
-    this.proxyReadLimiter = new AsyncLimiter(config.proxyReadConcurrency ?? DEFAULT_PROXY_READ_CONCURRENCY);
-    this.proxyReadIdleTimeoutMs = Math.max(0, config.proxyReadIdleTimeoutMs ?? DEFAULT_PROXY_READ_IDLE_TIMEOUT_MS);
+    this.proxyReadLimiter = new AsyncLimiter(config.proxyReadConcurrency ?? 32);
 
     this.client = new S3Client({
       region: config.region,
@@ -162,55 +156,9 @@ export class S3StorageBackend implements StorageBackend {
   }
 
   private releaseWhenStreamCloses(stream: Readable, release: () => void) {
-    let released = false;
-    let idleTimeout: ReturnType<typeof setTimeout> | undefined;
-    const originalEmit = stream.emit;
-
-    const clearIdleTimeout = () => {
-      if (idleTimeout) {
-        clearTimeout(idleTimeout);
-        idleTimeout = undefined;
-      }
-    };
-
-    const releaseOnce = () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      clearIdleTimeout();
-      stream.emit = originalEmit;
-      release();
-    };
-
-    const resetIdleTimeout = () => {
-      if (this.proxyReadIdleTimeoutMs <= 0 || released) {
-        return;
-      }
-
-      clearIdleTimeout();
-      idleTimeout = setTimeout(() => {
-        try {
-          stream.destroy(new Error(`S3 proxy read timed out after ${this.proxyReadIdleTimeoutMs}ms of inactivity`));
-        } finally {
-          releaseOnce();
-        }
-      }, this.proxyReadIdleTimeoutMs);
-    };
-
-    // Observe data activity without adding a "data" listener, which would switch the stream into flowing mode
-    // before the HTTP response pipe is attached.
-    stream.emit = function (this: Readable, eventName: string | symbol, ...args: any[]) {
-      if (eventName === 'data' || eventName === 'readable') {
-        resetIdleTimeout();
-      }
-      return originalEmit.call(this, eventName, ...args);
-    } as typeof stream.emit;
-
-    stream.once('end', releaseOnce);
-    stream.once('error', releaseOnce);
-    stream.once('close', releaseOnce);
-    resetIdleTimeout();
+    stream.once('end', release);
+    stream.once('error', release);
+    stream.once('close', release);
     return stream;
   }
 

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -58,7 +58,6 @@ export const EnvSchema = z
     IMMICH_S3_SECRET_ACCESS_KEY: z.string().optional(),
     IMMICH_S3_PRESIGNED_URL_EXPIRY: z.coerce.number().int().optional(),
     IMMICH_S3_SERVE_MODE: z.enum(['redirect', 'proxy']).optional(),
-    IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS: z.coerce.number().int().min(0).optional(),
     IMMICH_MICROSERVICES_METRICS_PORT: z.coerce.number().int().optional(),
     IMMICH_ALLOW_EXTERNAL_PLUGINS: stringBool.optional(),
     IMMICH_PLUGINS_INSTALL_FOLDER: absolutePath,

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -48,7 +48,6 @@ const resetEnv = () => {
     'IMMICH_S3_SECRET_ACCESS_KEY',
     'IMMICH_S3_PRESIGNED_URL_EXPIRY',
     'IMMICH_S3_SERVE_MODE',
-    'IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS',
   ]) {
     delete process.env[env];
   }
@@ -363,7 +362,6 @@ describe('getEnv', () => {
       process.env.IMMICH_S3_SECRET_ACCESS_KEY = 'minioadmin';
       process.env.IMMICH_S3_PRESIGNED_URL_EXPIRY = '7200';
       process.env.IMMICH_S3_SERVE_MODE = 'proxy';
-      process.env.IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS = '120000';
 
       const { storage } = getEnv();
 
@@ -376,7 +374,6 @@ describe('getEnv', () => {
         secretAccessKey: 'minioadmin',
         presignedUrlExpiry: 7200,
         serveMode: 'proxy',
-        proxyReadIdleTimeoutMs: 120_000,
       });
     });
 
@@ -394,7 +391,6 @@ describe('getEnv', () => {
         secretAccessKey: undefined,
         presignedUrlExpiry: 3600,
         serveMode: 'redirect',
-        proxyReadIdleTimeoutMs: 300_000,
       });
     });
   });

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -123,7 +123,6 @@ export interface EnvData {
       secretAccessKey?: string;
       presignedUrlExpiry: number;
       serveMode: 'redirect' | 'proxy';
-      proxyReadIdleTimeoutMs: number;
     };
   };
 
@@ -386,7 +385,6 @@ const getEnv = (): EnvData => {
         secretAccessKey: dto.IMMICH_S3_SECRET_ACCESS_KEY,
         presignedUrlExpiry: dto.IMMICH_S3_PRESIGNED_URL_EXPIRY || 3600,
         serveMode: (dto.IMMICH_S3_SERVE_MODE as 'redirect' | 'proxy') || 'redirect',
-        proxyReadIdleTimeoutMs: dto.IMMICH_S3_PROXY_READ_IDLE_TIMEOUT_MS ?? 300_000,
       },
     },
 

--- a/server/src/services/storage.service.spec.ts
+++ b/server/src/services/storage.service.spec.ts
@@ -454,7 +454,6 @@ describe(StorageService.name, () => {
               secretAccessKey: undefined,
               presignedUrlExpiry: 3600,
               serveMode: 'redirect',
-              proxyReadIdleTimeoutMs: 300_000,
             },
           },
         }),

--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -1,5 +1,4 @@
 import { HttpException } from '@nestjs/common';
-import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
@@ -117,74 +116,6 @@ describe('sendFile with ImmichMediaResponse', () => {
     );
 
     expect(res.header).toHaveBeenCalledWith('Content-Disposition', `inline; filename*=UTF-8''photo.jpg`);
-  });
-
-  it('should destroy an unfinished stream when the response closes early', async () => {
-    const stream = new Readable({
-      read() {
-        // keep the stream open until the client aborts
-      },
-    });
-    const destroy = vi.spyOn(stream, 'destroy');
-    const res = Object.assign(new EventEmitter(), {
-      set: vi.fn(),
-      header: vi.fn(),
-      headersSent: false,
-      writableEnded: false,
-    }) as any;
-    stream.pipe = vi.fn().mockReturnValue(res);
-    const next = vi.fn();
-
-    await sendFile(
-      res,
-      next,
-      () =>
-        new ImmichStreamResponse({
-          stream,
-          contentType: 'image/jpeg',
-          cacheControl: CacheControl.PrivateWithCache,
-        }),
-      mockLogger,
-    );
-
-    res.emit('close');
-
-    expect(destroy).toHaveBeenCalledTimes(1);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('should not destroy a stream when the response closes after completion', async () => {
-    const stream = new Readable({
-      read() {
-        // keep the stream open so only response state controls this assertion
-      },
-    });
-    const destroy = vi.spyOn(stream, 'destroy');
-    const res = Object.assign(new EventEmitter(), {
-      set: vi.fn(),
-      header: vi.fn(),
-      headersSent: false,
-      writableEnded: true,
-    }) as any;
-    stream.pipe = vi.fn().mockReturnValue(res);
-    const next = vi.fn();
-
-    await sendFile(
-      res,
-      next,
-      () =>
-        new ImmichStreamResponse({
-          stream,
-          contentType: 'image/jpeg',
-          cacheControl: CacheControl.PrivateWithCache,
-        }),
-      mockLogger,
-    );
-
-    res.emit('close');
-
-    expect(destroy).not.toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
   });
 
   it('should set cache-control for redirect with None', async () => {

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -110,13 +110,6 @@ export const sendFile = async (
       if (file.fileName) {
         res.header('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(file.fileName)}`);
       }
-      if (typeof res.once === 'function') {
-        res.once('close', () => {
-          if (!res.writableEnded && !file.stream.destroyed) {
-            file.stream.destroy();
-          }
-        });
-      }
       file.stream.pipe(res);
       return;
     }

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -99,7 +99,6 @@ const envData: EnvData = {
       secretAccessKey: undefined,
       presignedUrlExpiry: 3600,
       serveMode: 'redirect',
-      proxyReadIdleTimeoutMs: 300_000,
     },
   },
 


### PR DESCRIPTION
## Summary
- Reverts the merged S3 proxy timeout/client-abort fix from #497
- Removes the S3 proxy limiter, idle timeout, abort propagation, and related env/docs/tests added by that change
- Leaves #498 closed rather than layering further fixes on the proxy path

## Verification
- pnpm --filter immich test src/backends/s3-storage.backend.spec.ts src/repositories/config.repository.spec.ts src/services/storage.service.spec.ts src/utils/file.spec.ts --run
- pnpm --filter immich check
- pnpm --filter immich lint
- git diff --check HEAD~1..HEAD