### PR TITLE
feat: support direct S3 media delivery

### DIFF
--- a/docs/docs/features/s3-storage.md
+++ b/docs/docs/features/s3-storage.md
@@ -16,10 +16,10 @@ When S3 storage is enabled:
 
 Gallery supports two modes for serving files from S3:
 
-| Mode       | Behavior                                                                                          |
-| :--------- | :------------------------------------------------------------------------------------------------ |
-| `redirect` | Returns a temporary presigned URL — the client downloads directly from S3. Best for performance.  |
-| `proxy`    | The Gallery server streams the file from S3 to the client. Use when S3 is not directly reachable. |
+| Mode       | Behavior                                                                                                                          |
+| :--------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| `redirect` | Returns a temporary presigned URL. The client downloads directly from S3. Recommended when the browser can reach the S3 endpoint. |
+| `proxy`    | The Gallery server streams the file from S3 to the client. Use only when S3 is not directly reachable by browsers.                |
 
 ## Environment Variables
 
@@ -112,14 +112,44 @@ IMMICH_S3_ENDPOINT=https://your-s3-endpoint.example.com
 
 Pick the mode that fits your setup:
 
-- **`redirect`** (default) — Best for performance. The client is redirected to a presigned URL and downloads directly from S3. Requires the client to be able to reach the S3 endpoint.
-- **`proxy`** — The Gallery server fetches the file from S3 and streams it to the client. Use this if your S3 endpoint is not reachable by clients (e.g. MinIO on an internal network).
+- **`redirect`** (default) — Recommended for browser-readable S3 endpoints. Gallery authorizes the API request and returns a short-lived presigned URL, so media bytes flow directly from S3 to the browser.
+- **`proxy`** — Compatibility mode for private-network S3 endpoints. Gallery streams every media byte through the API process, so it costs more server resources and is not the recommended mode for large scrolling grids.
 
 ```bash title=".env"
 IMMICH_S3_SERVE_MODE=proxy
 ```
 
-### 4. Restart Gallery
+### 4. Configure CORS For Redirect Mode
+
+Redirect mode keeps the bucket private, but browsers need CORS headers when Gallery draws S3 images to canvas for editing, face crops, and copy-to-clipboard.
+
+Use your real Gallery origins in `AllowedOrigins`:
+
+```json
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://gallery.example.com", "http://localhost:3000", "http://localhost:2283"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["Accept-Ranges", "Content-Length", "Content-Range", "Content-Type", "ETag"],
+      "MaxAgeSeconds": 3600
+    }
+  ]
+}
+```
+
+AWS CLI example:
+
+```bash
+aws s3api put-bucket-cors \
+  --bucket my-gallery-storage \
+  --cors-configuration '{"CORSRules":[{"AllowedOrigins":["https://gallery.example.com","http://localhost:3000","http://localhost:2283"],"AllowedMethods":["GET","HEAD"],"AllowedHeaders":["*"],"ExposeHeaders":["Accept-Ranges","Content-Length","Content-Range","Content-Type","ETag"],"MaxAgeSeconds":3600}]}'
+```
+
+Do not use `"*"` for production origins if you introduce credentialed browser requests to S3. Gallery media images use anonymous CORS.
+
+### 5. Restart Gallery
 
 Recreate the containers to apply the new environment variables:
 
@@ -232,7 +262,9 @@ When a client requests an asset, `BaseService.serveFromBackend()` asks the resol
 | S3      | `redirect` | `ImmichRedirectResponse` | HTTP 302 to a presigned URL; client fetches from S3 |
 | S3      | `proxy`    | `ImmichStreamResponse`   | Server streams S3 data through to the client        |
 
-Presigned URLs expire after `IMMICH_S3_PRESIGNED_URL_EXPIRY` seconds (default 3600). The S3 backend uses `forcePathStyle: true` when a custom endpoint is configured, which is required for MinIO, DigitalOcean Spaces, and similar providers.
+Presigned URLs expire after `IMMICH_S3_PRESIGNED_URL_EXPIRY` seconds (default 3600). Gallery sends `Cache-Control: private, no-cache, no-transform` on redirect responses so browsers do not reuse an expired 302. The S3 backend signs content type and filename response overrides when they are available, so inline display and explicit downloads behave consistently after the browser follows the redirect.
+
+The S3 backend uses `forcePathStyle: true` when a custom endpoint is configured, which is required for MinIO, DigitalOcean Spaces, and similar providers.
 
 ### Upload Flow
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -207,16 +207,16 @@ Additional machine learning parameters can be tuned from the admin UI.
 
 ## S3 Storage
 
-| Variable                         | Description                                                                           |   Default   | Containers | Workers            |
-| :------------------------------- | :------------------------------------------------------------------------------------ | :---------: | :--------- | :----------------- |
-| `IMMICH_STORAGE_BACKEND`         | Storage backend for new uploads (`disk` or `s3`)                                      |   `disk`    | server     | api, microservices |
-| `IMMICH_S3_BUCKET`               | S3 bucket name                                                                        |             | server     | api, microservices |
-| `IMMICH_S3_REGION`               | AWS region or S3-compatible provider region                                           | `us-east-1` | server     | api, microservices |
-| `IMMICH_S3_ENDPOINT`             | Custom endpoint URL for S3-compatible services                                        |             | server     | api, microservices |
-| `IMMICH_S3_ACCESS_KEY_ID`        | Access key ID (falls back to IAM role if omitted)                                     |             | server     | api, microservices |
-| `IMMICH_S3_SECRET_ACCESS_KEY`    | Secret access key (falls back to IAM role if omitted)                                 |             | server     | api, microservices |
-| `IMMICH_S3_PRESIGNED_URL_EXPIRY` | Presigned URL expiration time in seconds                                              |   `3600`    | server     | api, microservices |
-| `IMMICH_S3_SERVE_MODE`           | How to serve S3 assets: `redirect` (presigned URL) or `proxy` (stream through server) | `redirect`  | server     | api, microservices |
+| Variable                         | Description                                                                                                      |   Default   | Containers | Workers            |
+| :------------------------------- | :--------------------------------------------------------------------------------------------------------------- | :---------: | :--------- | :----------------- |
+| `IMMICH_STORAGE_BACKEND`         | Storage backend for new uploads (`disk` or `s3`)                                                                 |   `disk`    | server     | api, microservices |
+| `IMMICH_S3_BUCKET`               | S3 bucket name                                                                                                   |             | server     | api, microservices |
+| `IMMICH_S3_REGION`               | AWS region or S3-compatible provider region                                                                      | `us-east-1` | server     | api, microservices |
+| `IMMICH_S3_ENDPOINT`             | Custom endpoint URL for S3-compatible services                                                                   |             | server     | api, microservices |
+| `IMMICH_S3_ACCESS_KEY_ID`        | Access key ID (falls back to IAM role if omitted)                                                                |             | server     | api, microservices |
+| `IMMICH_S3_SECRET_ACCESS_KEY`    | Secret access key (falls back to IAM role if omitted)                                                            |             | server     | api, microservices |
+| `IMMICH_S3_PRESIGNED_URL_EXPIRY` | Presigned URL expiration time in seconds                                                                         |   `3600`    | server     | api, microservices |
+| `IMMICH_S3_SERVE_MODE`           | How to serve S3 assets: `redirect` is recommended when browsers can reach S3; `proxy` streams through the server | `redirect`  | server     | api, microservices |
 
 :::info
 For detailed setup instructions, see the [S3-Compatible Storage](/features/s3-storage) guide.

--- a/docs/plans/2026-05-02-s3-direct-media-delivery-design.md
+++ b/docs/plans/2026-05-02-s3-direct-media-delivery-design.md
@@ -1,0 +1,381 @@
+# S3 Direct Media Delivery Design
+
+## Problem
+
+The production instance repeatedly gets into a state where asset thumbnails, previews, originals, and person thumbnails stay blurred or never complete. The current deployment stores media in OVH S3 with `IMMICH_S3_SERVE_MODE=proxy`, so browser media requests flow through the Gallery API process:
+
+```text
+browser image/video request
+  -> service worker intercept for /api/assets/:id/(thumbnail|original)
+  -> Gallery API authorization
+  -> S3 GetObject stream in the Node process
+  -> Express response stream
+  -> service worker cloned Response body
+  -> browser image/video consumer
+```
+
+The observed production failure matches saturation of this stream chain:
+
+- Direct S3 `HeadObject` and pod-local S3 `GetObject` succeed quickly for affected keys.
+- Authenticated JSON API endpoints keep working.
+- Media endpoints hang with zero response bytes.
+- The API process accumulates many open client media sockets.
+- A stale S3 socket can remain established with unread bytes.
+- Previous attempts to release, abort, idle-timeout, service-worker-retain, and buffer small thumbnail streams still failed under fast-scroll production load and were reverted.
+
+The root issue is architectural: the API and service worker are in the hot byte path for high-cardinality media reads. Every browser scheduling, cancellation, backpressure, service-worker clone, Express close, S3 SDK stream, and limiter interaction must be correct for the system to keep loading photos. That coupling is too brittle for timeline scrolling.
+
+## Goals
+
+- Remove the Gallery API process from the S3 media byte path for normal browser-readable S3 deployments.
+- Remove the service worker from media response bodies.
+- Preserve Gallery authorization semantics before a user can read media.
+- Preserve disk-backed and mixed disk/S3 deployments.
+- Preserve S3 proxy mode as an explicit fallback for S3 endpoints that browsers cannot reach.
+- Keep originals, previews, thumbnails, videos, person thumbnails, profile images, shared-link media, and download filenames working.
+- Add regression coverage that proves fast-scroll media loading does not wedge the API process.
+
+## Non-Goals
+
+- Rewriting upload, thumbnail generation, video transcoding, storage migration, or S3 object layout.
+- Making S3 objects public.
+- Building a CDN integration in this change.
+- Removing S3 proxy mode from the codebase.
+- Fixing unrelated bulk-add or face-recognition queue behavior.
+
+## Decision
+
+Use direct S3 delivery for browser-readable S3 deployments:
+
+```text
+browser image/video request
+  -> Gallery API authorization
+  -> short-lived 302 redirect to a presigned S3 URL
+  -> browser downloads bytes directly from S3
+```
+
+The Gallery server remains the authorization and URL-signing boundary. The browser never receives raw bucket credentials and S3 objects remain private. The server no longer owns the media stream lifetime after it has authorized and signed a request.
+
+This uses the existing `redirect` serve strategy in `S3StorageBackend`, but it must be paired with three supporting changes:
+
+1. Service worker media bypass: do not intercept `/api/assets/:id/thumbnail`, `/api/assets/:id/original`, or video playback media.
+2. Redirect response semantics: do not cache a 302 longer than its presigned URL can remain valid, and include filename/content-type response overrides in signed URLs.
+3. S3 CORS and frontend image attributes: allow canvas workflows to keep working when image bytes come from S3 instead of same-origin API responses.
+
+## Approaches Considered
+
+### Recommended: Presigned Redirects Plus Service-Worker Bypass
+
+The API authorizes the request and returns a short-lived presigned URL. The service worker ignores media routes so the browser owns the final media request directly.
+
+Pros:
+
+- Removes Node streams, Express backpressure, S3 SDK sockets, and service-worker response clones from normal media delivery.
+- Uses an existing backend serve mode.
+- Keeps private buckets through presigned URLs.
+- Scales with S3 and browser connection handling instead of API process sockets.
+- Smallest durable architecture change.
+
+Cons:
+
+- Requires S3 CORS for canvas workflows.
+- Exposes temporary provider URLs to the browser.
+- Requires care around redirect cache headers and presigned expiry.
+
+### Alternative: Batch Signed Media URLs In API DTOs
+
+Asset list endpoints return signed thumbnail/preview URLs directly, avoiding one API redirect per image.
+
+Pros:
+
+- Reduces API round trips for dense grids.
+- Makes direct media delivery explicit in DTOs.
+
+Cons:
+
+- Larger API and web contract change.
+- Signed URLs may expire while asset DTOs remain cached in client state.
+- More places need refresh logic.
+- Does not help disk-backed assets and complicates mixed-mode responses.
+
+This can be a later optimization after redirect delivery is stable.
+
+### Alternative: Dedicated Media Gateway Or CDN
+
+Gallery authorizes media through a separate gateway or CDN that can validate signed cookies/URLs and fetch private S3 objects.
+
+Pros:
+
+- Keeps a stable first-party media hostname.
+- Can add edge caching and range handling.
+- Keeps the application API out of the stream path.
+
+Cons:
+
+- Larger operational footprint.
+- More secrets and routing configuration.
+- Not needed to fix the immediate failure on the production instance.
+
+This is a future infrastructure option if presigned provider URLs become unacceptable.
+
+## Backend Design
+
+### Serve Mode Policy
+
+`IMMICH_S3_SERVE_MODE=redirect` should be the recommended mode for S3 endpoints reachable by browsers. `proxy` remains supported only for private-network S3 endpoints or deployments that intentionally cannot expose S3 URLs to clients.
+
+Documentation should be updated to make the tradeoff explicit:
+
+- `redirect`: normal mode, best for performance and reliability.
+- `proxy`: compatibility fallback, higher API resource cost, vulnerable to browser backpressure and cancellation behavior under large media bursts.
+
+Production GitOps config should switch from `proxy` to `redirect` only after the code changes below are available.
+
+### Proxy Fallback Behavior
+
+Proxy mode remains a supported serve strategy. The design does not remove `ImmichStreamResponse`, `S3StorageBackend.get()`, or streaming through `sendFile()`. A deployment with browser-unreachable S3 can continue using:
+
+```text
+browser media request
+  -> Gallery API authorization
+  -> S3 GetObject stream in the Node process
+  -> Express response stream
+  -> browser media consumer
+```
+
+The service worker media bypass applies to proxy mode too. Even when the API must stream bytes, the browser should receive that stream directly instead of through a service-worker cloned `Response` body. That keeps proxy compatibility while removing one known source of body-retention and cancellation coupling.
+
+Proxy mode should not receive another default idle-timeout, buffering, or abort-propagation stack as part of this work. Those were already tried and reverted after production fast-scroll stalls persisted. The first implementation should only verify that existing proxy behavior still works without service-worker interception. Deeper proxy hardening should be a separate design if someone needs private-network S3 at large timeline scale.
+
+### Presigned URL Response Overrides
+
+`S3StorageBackend.getServeStrategy()` should include response overrides when generating a presigned URL:
+
+- `ResponseContentType`: existing behavior.
+- `ResponseContentDisposition`: include inline or attachment filename when the service provides one.
+- Optional `ResponseCacheControl`: only if we intentionally want the S3 response to carry a cache policy.
+
+The backend interface currently accepts only `(key, contentType)`. It should be extended with a serve options object:
+
+```typescript
+type ServeOptions = {
+  contentType: string;
+  fileName?: string;
+  disposition?: 'inline' | 'attachment';
+  cacheControl: CacheControl;
+};
+
+getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy>;
+```
+
+Disk and proxy responses keep using the existing `ImmichMediaResponse` shape. Redirect responses gain enough metadata to control HTTP 302 cache headers safely.
+
+### Redirect Cache Headers
+
+The 302 redirect response must not be cached longer than the signed URL expiry. The safest default is:
+
+```text
+Cache-Control: private, no-cache, no-transform
+```
+
+That lets the browser cache final S3 object bytes according to the S3 response, but forces revalidation of the API authorization redirect instead of reusing an expired presigned URL.
+
+If we want cacheable redirects later, the max-age must be derived from `IMMICH_S3_PRESIGNED_URL_EXPIRY` with a safety margin, not from the normal 24-hour media cache header.
+
+### Video And Range Requests
+
+S3 must handle range requests directly for video playback. Redirect mode should preserve browser range behavior because the browser follows the redirect and sends `Range` to S3.
+
+The API should not try to proxy or synthesize range responses for S3 redirect mode. The presigned URL used for browser media playback should be generated for `GET`; metadata probes that need content type should use a small GET range request instead of following `HEAD` to a GET-signed S3 URL.
+
+### Shared Links And API Keys
+
+Shared-link and API-key authorization remains on the API route. The API validates the current request, then signs a URL. The signed S3 URL does not encode Gallery auth state; it is valid until expiry.
+
+Recommended expiry remains short, such as the existing default 3600 seconds. If tighter shared-link revocation is needed later, lower the expiry for shared-link requests through per-request serve options.
+
+## Service Worker Design
+
+The service worker should stop intercepting media routes. The current media request deduplication and cancelation layer introduces body ownership that is unsafe for streaming media.
+
+Remove or narrow the `ASSET_REQUEST_REGEX` intercept so these routes are browser-native:
+
+- `/api/assets/:id/thumbnail`
+- `/api/assets/:id/original`
+- `/api/assets/:id/video/playback`
+
+Person and profile thumbnail routes are not currently intercepted, but they also use `sendFile()` and S3 backend resolution. They will benefit from backend redirect mode without service-worker changes.
+
+The frontend can keep `cancelImageUrl()` calls as harmless no-ops for media URLs no longer owned by the service worker. A later cleanup can remove the media cancel protocol if no other route uses it.
+
+## S3 CORS Design
+
+Direct S3 image display through `<img>` can work without CORS, but canvas reads require CORS. Gallery has canvas workflows:
+
+- Face crop helpers.
+- Face editor thumbnail extraction.
+- Copy image to clipboard.
+- Edit/crop/mirror/rotate preview paths.
+
+The S3 bucket needs CORS allowing Gallery origins to read media objects:
+
+```json
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://gallery.example.com", "http://localhost:3000", "http://localhost:2283"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["Accept-Ranges", "Content-Length", "Content-Range", "Content-Type", "ETag"],
+      "MaxAgeSeconds": 3600
+    }
+  ]
+}
+```
+
+The exact origin list should be environment-specific. Production should not use `*` if credentials are ever introduced. Presigned URLs do not need browser credentials, so images should use anonymous CORS.
+
+## Frontend Design
+
+### Image Components
+
+The shared image primitives should support CORS-safe rendering:
+
+- Add `crossorigin="anonymous"` to media images loaded through the shared `Image` component.
+- Add `crossOrigin = 'anonymous'` before assigning `src` in explicit `new Image()` paths that may draw to canvas.
+- Ensure `loadImage()` sets `crossOrigin` before `src` when it creates an off-DOM image.
+
+This must be done before switching production to redirect mode, otherwise direct S3 images can display but canvas operations can fail with tainted-canvas errors.
+
+### Download Links
+
+Single-asset download currently clicks an API media URL. In redirect mode that will follow to S3. To preserve filenames reliably:
+
+- Server-signed URLs should include `ResponseContentDisposition=attachment; filename*=UTF-8''...` for original downloads.
+- Inline display routes should keep `inline`.
+
+The client should not rely on the `<a download>` attribute for cross-origin S3 URLs.
+
+### Cast And Content-Type Probe
+
+Google Cast currently probes the media URL to get content type, then sends the authenticated URL to the cast device. In redirect mode, do not probe with `HEAD`: S3 presigned URLs are method-specific, so a `HEAD` request that follows a redirect to a GET-signed S3 URL can fail signature validation.
+
+- The browser should probe with `GET` plus `Range: bytes=0-0`, which follows the normal GET-signed redirect path and returns headers with a minimal body.
+- The cast device should still receive the authenticated Gallery API media URL with `sessionKey`.
+- The cast device must be able to reach both Gallery and the S3 endpoint, and the generated S3 signature must not expire before playback starts.
+
+This path should be tested manually on a redirect-mode S3 instance. If cast devices do not preserve query parameters, do not follow Gallery's 302, or cannot reach OVH S3, Cast may need a separate short-lived direct media URL endpoint.
+
+## Data Flow
+
+### Thumbnail Or Preview Display
+
+1. Browser requests `/api/assets/:id/thumbnail?size=thumbnail&c=...`.
+2. Gallery authenticates `AssetView`.
+3. Gallery resolves the asset file path and backend.
+4. Disk backend returns `file` and Express sends the local file.
+5. S3 redirect backend returns `redirect` with a presigned S3 URL.
+6. Gallery returns a 302 with safe redirect cache headers.
+7. Browser follows to S3 and downloads bytes directly.
+
+### Original Download
+
+1. Browser requests `/api/assets/:id/original`.
+2. Gallery authenticates `AssetDownload`.
+3. Gallery signs S3 URL with content type and attachment filename response overrides.
+4. Browser follows redirect and downloads from S3.
+
+### Video Playback
+
+1. Browser requests `/api/assets/:id/video/playback`.
+2. Gallery authenticates `AssetView`.
+3. Gallery signs a video object URL.
+4. Browser follows redirect and sends normal range requests to S3.
+
+## Testing Strategy
+
+### Unit Tests
+
+Backend:
+
+- `S3StorageBackend` includes content type and content disposition overrides in presigned `GetObjectCommand`.
+- Redirect responses use `private, no-cache, no-transform` or another expiry-safe policy instead of the normal 24-hour media cache header.
+- Disk backend behavior is unchanged.
+- Proxy backend behavior is unchanged for deployments that still choose `proxy`.
+- `sendFile()` handles redirect metadata without applying stream/file cache behavior blindly.
+
+Service worker:
+
+- `GET /api/assets/:id/thumbnail` is not intercepted.
+- `GET /api/assets/:id/original` is not intercepted.
+- `GET /api/assets/:id/video/playback` is not intercepted.
+- Non-media service-worker behavior remains unchanged.
+
+Frontend:
+
+- Shared `Image` renders `crossorigin="anonymous"` for media images.
+- `loadImage()` and explicit canvas helper image loads set `crossOrigin` before `src`.
+- Download URL generation still points at the API authorization route, not directly at S3.
+
+### Integration Tests
+
+MinIO or S3-compatible integration:
+
+- Redirect-mode thumbnail request returns 302 and the redirected URL returns valid bytes.
+- Original download redirect includes a filename override.
+- Video playback redirect supports `Range` against the final S3 URL.
+- CORS preflight or direct CORS checks confirm image GET/HEAD is allowed from a Gallery origin.
+
+### Browser Regression
+
+Add a Playwright scenario with service worker enabled:
+
+1. Seed enough S3-backed assets to create several hundred timeline thumbnails.
+2. Open `/photos`.
+3. Fast-scroll through multiple viewport heights.
+4. Assert visible thumbnails eventually transition out of blurred preview state.
+5. Assert `/api/users/me` and `/api/server/ping` still respond during/after the scroll.
+6. Assert API media requests do not pile up as long-running proxied streams.
+
+This test should run against a redirect-mode S3-compatible test setup. If CI cannot run MinIO with Playwright, keep the full version as a manual RC smoke script and add lower-level automated coverage for the service-worker and redirect pieces.
+
+## Rollout Plan
+
+1. Land code changes with `proxy` still supported and existing default `redirect` unchanged.
+2. Configure CORS on the production OVH bucket.
+3. Deploy an RC to the production host while still in proxy mode to verify no regressions in disk/proxy behavior.
+4. Change production GitOps `IMMICH_S3_SERVE_MODE` from `proxy` to `redirect`.
+5. Hard refresh or unregister old service workers on the production host.
+6. Fast-scroll `/photos`, people pages, shared spaces, asset viewer, video playback, downloads, face editor, and copy-to-clipboard.
+7. Watch API pod sockets, Traefik 499/5xx rates, and app logs during the smoke.
+8. If stable, update S3 documentation to recommend redirect mode for browser-reachable S3.
+
+## Operational Notes
+
+- Existing browser service workers may continue running old code until updated. The rollout should include a hard refresh or service-worker version bump verification.
+- The production bucket currently has no CORS configuration. Redirect-mode canvas testing should not start until CORS is applied.
+- Presigned URLs may appear in browser devtools and logs. They are temporary credentials and should be treated as sensitive while valid.
+- Proxy mode should not be removed. It remains useful for private MinIO-style deployments, but it should not be used as the normal mode for large browser media grids.
+
+## Success Criteria
+
+- Fast-scrolling `/photos` no longer leaves the instance in a global blurred-media state.
+- Media delivery no longer depends on long-lived S3 streams inside `gallery-server`.
+- API health and auth endpoints stay responsive while hundreds of thumbnails load.
+- Browser image cancellation no longer needs to propagate through service worker, API response, and S3 stream state.
+- Canvas workflows still work against S3-backed images.
+- Single downloads keep correct filenames.
+- Video playback and range requests work through direct S3 delivery.
+
+## Risks
+
+- Some S3-compatible providers may have incomplete CORS or response override behavior. MinIO and OVH should be tested explicitly.
+- Cross-origin redirects can expose provider hostnames in the browser, which should be documented.
+- Cast devices may have different network reachability than the browser. This needs manual verification.
+- Old service workers can mask the fix during RC testing if they keep intercepting media.
+
+## First Implementation Decisions
+
+- Shared-link requests should use the same presigned expiry as normal authenticated requests in the first implementation. Shorter shared-link expiry can be added later if revocation latency becomes a real problem.
+- Redirect responses should use `private, no-cache, no-transform` in the first implementation. Cacheable 302 responses can be reconsidered later after the direct media path is stable.
+- `crossorigin="anonymous"` should be applied in the shared `Image` component and off-DOM image loaders. Same-origin images continue to load, and S3 media becomes canvas-safe when bucket CORS is configured.

--- a/docs/plans/2026-05-02-s3-direct-media-delivery-plan.md
+++ b/docs/plans/2026-05-02-s3-direct-media-delivery-plan.md
@@ -1,0 +1,1466 @@
+# S3 Direct Media Delivery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make S3-backed media load through authorized presigned redirects by default, with proxy mode preserved as a fallback and without the service worker owning media response bodies.
+
+**Architecture:** Keep Gallery API routes as the authorization boundary, then let the storage backend return either a disk file, a proxy stream, or a redirect. S3 redirect mode signs content-type and content-disposition response overrides, API 302 responses use an expiry-safe cache policy, and the web app loads redirected images with anonymous CORS so canvas workflows keep working.
+
+**Tech Stack:** NestJS, Express, AWS SDK v3 S3 presigning, Zod DTOs, Svelte 5, service worker APIs, Vitest, Docusaurus docs.
+
+---
+
+## Design Reference
+
+Read `docs/plans/2026-05-02-s3-direct-media-delivery-design.md` before executing. The implementation below deliberately does not add new S3 proxy idle-timeout, stream buffering, or abort-propagation patches. Those approaches were already tried and did not resolve the production fast-scroll stall.
+
+## File Map
+
+- `server/src/interfaces/storage-backend.interface.ts`: Replace the bare `contentType` serve argument with a `ServeOptions` object.
+- `server/src/utils/file.ts`: Add reusable content-disposition formatting and per-response disposition support for file and stream responses.
+- `server/src/utils/file.spec.ts`: Cover attachment disposition and expiry-safe redirect cache headers.
+- `server/src/backends/disk-storage.backend.ts`: Accept `ServeOptions` while keeping file serving behavior unchanged.
+- `server/src/backends/disk-storage.backend.spec.ts`: Update call sites for the new `getServeStrategy()` signature.
+- `server/src/backends/s3-storage.backend.ts`: Sign `ResponseContentType` and `ResponseContentDisposition` in redirect mode; keep proxy mode streaming unchanged.
+- `server/src/backends/s3-storage.backend.spec.ts`: Cover signed response overrides and proxy compatibility.
+- `server/src/backends/s3-storage.backend.integration.spec.ts`: Update the integration call signature and add a redirect URL smoke assertion for response overrides.
+- `server/src/services/base.service.ts`: Pass `ServeOptions` into backends and force redirect responses to `CacheControl.PrivateWithoutCache`.
+- `server/src/dtos/asset.dto.ts`: Add a `download` query flag to `/api/assets/:id/original`.
+- `server/src/services/asset-media.service.ts`: Use `attachment` only when the explicit download flag is set; viewer originals remain `inline`.
+- `server/src/services/asset-media.service.spec.ts`: Cover inline display, attachment download, and S3 redirect metadata.
+- `web/src/lib/utils.ts`: Add `download?: boolean` to media URL generation and include it only on original media URLs.
+- `web/src/lib/utils.spec.ts`: Cover original download URL generation.
+- `web/src/lib/services/asset.service.ts`: Pass `download: true` for user-initiated single-asset downloads.
+- `web/src/lib/services/asset.service.spec.ts`: Assert single-asset downloads request the API route with `download=true`.
+- `web/src/service-worker/index.ts`: Stop registering a `fetch` handler for asset media.
+- `web/src/service-worker/index.spec.ts`: Verify no service-worker fetch listener is registered.
+- `web/src/lib/components/Image.svelte`: Default shared images to `crossorigin="anonymous"` with caller override support.
+- `web/src/lib/components/Image.spec.ts`: Cover default and overridden CORS attributes.
+- `web/src/lib/actions/image-loader.svelte.ts`: Set `img.crossOrigin` before `img.src`.
+- `web/src/lib/actions/__test__/image-loader.spec.ts`: Cover off-DOM image CORS behavior.
+- `web/src/lib/utils/people-utils.ts`: Set anonymous CORS before assigning `src` for helper images drawn to canvas.
+- `web/src/lib/utils/people-utils.spec.ts`: Cover video face crop helper image CORS behavior.
+- `web/src/lib/managers/edit/transform-manager.svelte.ts`: Set anonymous CORS before loading the editor preview image.
+- `web/src/lib/managers/edit/transform-manager.svelte.spec.ts`: Cover editor preview image CORS behavior.
+- `web/src/lib/utils/cast/gcast-destination.svelte.ts`: Probe media content type with a GET range request instead of HEAD.
+- `web/src/lib/utils/cast/gcast-destination.svelte.spec.ts`: Cover the Cast content-type probe.
+- `docs/docs/features/s3-storage.md`: Document redirect as the preferred browser-readable S3 mode and include CORS configuration.
+- `docs/docs/install/environment-variables.md`: Clarify the `IMMICH_S3_SERVE_MODE` tradeoff.
+
+## Test Coverage And Edge-Case Targets
+
+| Scenario                                                                  | Red/green coverage in this plan                                                                                                                                                                             |
+| :------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Production-like fast-scroll burst against many S3 thumbnails              | Task 1 adds a burst thumbnail service test that currently fails because S3 proxy/stream behavior can remain in the API byte path; it passes only when S3 media resolves to redirect responses.              |
+| Service worker owning/copying media bodies during rapid image load/cancel | Task 3 adds a burst media fetch test that currently fails because the service worker registers `fetch` and calls `respondWith()` for asset media; it passes only after media fetch interception is removed. |
+| Redirect mode accidentally opening S3 `GetObject` streams                 | Task 1 adds high-cardinality S3 redirect tests that assert redirect signing does not call the S3 client's `send()` stream path.                                                                             |
+| Proxy mode regression while redirect becomes preferred                    | Existing S3 proxy limiter/release tests stay in scope, and Task 1 reruns them with the new serve-options signature.                                                                                         |
+| Expired presigned URL cached behind a long-lived 302                      | Task 1 covers redirect `Cache-Control: private, no-cache, no-transform`.                                                                                                                                    |
+| Cross-origin image display works but canvas becomes tainted               | Task 4 covers shared `<Image>`, off-DOM loaders, face crop helpers, and editor preview images setting anonymous CORS before `src`.                                                                          |
+| Cross-origin download ignores `<a download>` filename                     | Task 2 covers explicit `download=true` and attachment content-disposition signing.                                                                                                                          |
+| Cast content-type probe follows `HEAD` to a GET-signed S3 URL             | Task 5 covers switching the probe to `GET` with `Range: bytes=0-0`.                                                                                                                                         |
+| Provider CORS/range behavior differs from unit tests                      | Task 7 includes MinIO integration and RC smoke checks for CORS, attachment filenames, and video ranges.                                                                                                     |
+
+---
+
+### Task 1: Backend Serve Options And Redirect Metadata
+
+**Files:**
+
+- Modify: `server/src/interfaces/storage-backend.interface.ts`
+- Modify: `server/src/utils/file.ts`
+- Modify: `server/src/utils/file.spec.ts`
+- Modify: `server/src/backends/disk-storage.backend.ts`
+- Modify: `server/src/backends/disk-storage.backend.spec.ts`
+- Modify: `server/src/backends/s3-storage.backend.ts`
+- Modify: `server/src/backends/s3-storage.backend.spec.ts`
+- Modify: `server/src/backends/s3-storage.backend.integration.spec.ts`
+- Modify: `server/src/services/base.service.ts`
+- Modify: `server/src/services/asset-media.service.spec.ts`
+
+- [ ] **Step 1: Write failing backend tests**
+
+Add these cases to `server/src/utils/file.spec.ts`:
+
+```ts
+it('should send file response with attachment disposition', async () => {
+  const res = {
+    set: vi.fn(),
+    header: vi.fn(),
+    headersSent: false,
+    sendFile: vi.fn((_path: string, _options: any, cb: (err?: Error) => void) => cb()),
+  } as any;
+  const next = vi.fn();
+
+  await sendFile(
+    res,
+    next,
+    () =>
+      new ImmichFileResponse({
+        path: '/tmp/test-file.jpg',
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+        fileName: 'my photo.jpg',
+        disposition: 'attachment',
+      }),
+    mockLogger,
+  );
+
+  expect(res.header).toHaveBeenCalledWith('Content-Disposition', `attachment; filename*=UTF-8''my%20photo.jpg`);
+});
+
+it('should set expiry-safe cache-control for redirect responses', async () => {
+  const res = {
+    set: vi.fn(),
+    header: vi.fn(),
+    redirect: vi.fn(),
+    headersSent: false,
+  } as any;
+  const next = vi.fn();
+
+  await sendFile(
+    res,
+    next,
+    () =>
+      new ImmichRedirectResponse({
+        url: 'https://s3.example.com/signed-url',
+        cacheControl: CacheControl.PrivateWithoutCache,
+      }),
+    mockLogger,
+  );
+
+  expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache, no-transform');
+  expect(res.redirect).toHaveBeenCalledWith('https://s3.example.com/signed-url');
+});
+```
+
+Update `server/src/backends/s3-storage.backend.spec.ts` imports:
+
+```ts
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { CacheControl } from 'src/enum';
+```
+
+Add this redirect-mode test in `describe('getServeStrategy')`:
+
+```ts
+it('should include response override metadata in redirect presigned URLs', async () => {
+  const strategy = await backend.getServeStrategy('upload/user1/photo.jpg', {
+    contentType: 'image/jpeg',
+    cacheControl: CacheControl.PrivateWithCache,
+    fileName: 'Vacation Photo.jpg',
+    disposition: 'attachment',
+  });
+
+  expect(strategy.type).toBe('redirect');
+  expect(GetObjectCommand).toHaveBeenCalledWith(
+    expect.objectContaining({
+      Bucket: 'test-bucket',
+      Key: 'upload/user1/photo.jpg',
+      ResponseContentType: 'image/jpeg',
+      ResponseContentDisposition: `attachment; filename*=UTF-8''Vacation%20Photo.jpg`,
+    }),
+  );
+});
+```
+
+Add this production-regression burst test in `server/src/backends/s3-storage.backend.spec.ts` in `describe('getServeStrategy')`:
+
+```ts
+it('should sign a high-cardinality redirect burst without opening S3 read streams', async () => {
+  const strategies = await Promise.all(
+    Array.from({ length: 200 }, (_, index) =>
+      backend.getServeStrategy(`thumbs/user1/aa/bb/thumb-${index}.webp`, {
+        contentType: 'image/webp',
+        cacheControl: CacheControl.PrivateWithCache,
+        fileName: `thumb-${index}.webp`,
+        disposition: 'inline',
+      }),
+    ),
+  );
+
+  expect(strategies).toHaveLength(200);
+  expect(strategies.every((strategy) => strategy.type === 'redirect')).toBe(true);
+  expect(mockSend).not.toHaveBeenCalled();
+  expect(getSignedUrl).toHaveBeenCalledTimes(200);
+});
+```
+
+Update the `server/src/services/asset-media.service.spec.ts` file import so redirect responses can be asserted:
+
+```ts
+import { ImmichFileResponse, ImmichRedirectResponse } from 'src/utils/file';
+```
+
+Add these S3 redirect bridge tests to `server/src/services/asset-media.service.spec.ts` in `describe('downloadOriginal')` and `describe('viewThumbnail')`:
+
+```ts
+it('should create a safe redirect response for S3 originals', async () => {
+  const asset = AssetFactory.create({
+    originalPath: 'upload/admin/aa/bb/image.jpg',
+    originalFileName: 'image.jpg',
+  });
+  const s3Backend = {
+    getServeStrategy: vi.fn().mockResolvedValue({
+      type: 'redirect',
+      url: 'https://s3.example.com/image.jpg?X-Amz-Signature=abc',
+    }),
+  };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getForOriginal.mockResolvedValue(asset);
+  const previousS3Backend = (StorageService as any).s3Backend;
+  (StorageService as any).s3Backend = s3Backend;
+
+  try {
+    await expect(sut.downloadOriginal(authStub.admin, asset.id, {})).resolves.toEqual(
+      expect.objectContaining({
+        url: 'https://s3.example.com/image.jpg?X-Amz-Signature=abc',
+        cacheControl: CacheControl.PrivateWithoutCache,
+      }),
+    );
+    expect(s3Backend.getServeStrategy).toHaveBeenCalledWith('upload/admin/aa/bb/image.jpg', {
+      contentType: 'image/jpeg',
+      cacheControl: CacheControl.PrivateWithCache,
+      fileName: 'image.jpg',
+      disposition: 'inline',
+    });
+  } finally {
+    (StorageService as any).s3Backend = previousS3Backend;
+  }
+});
+
+it('should return safe redirects for a burst of S3 thumbnail loads without API streaming', async () => {
+  const asset = AssetFactory.from()
+    .file({ type: AssetFileType.Thumbnail, path: 'thumbs/admin/aa/bb/thumb.jpg' })
+    .build();
+  const path = asset.files[0].path;
+  const s3Backend = {
+    getServeStrategy: vi.fn().mockResolvedValue({
+      type: 'redirect',
+      url: 'https://s3.example.com/thumb.jpg?X-Amz-Signature=abc',
+    }),
+  };
+
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getForThumbnail.mockResolvedValue({ ...asset, path });
+  const previousS3Backend = (StorageService as any).s3Backend;
+  (StorageService as any).s3Backend = s3Backend;
+
+  try {
+    const results = await Promise.all(
+      Array.from({ length: 150 }, () =>
+        sut.viewThumbnail(authStub.admin, asset.id, { size: AssetMediaSize.THUMBNAIL }),
+      ),
+    );
+
+    expect(results).toHaveLength(150);
+    expect(results.every((result) => result instanceof ImmichRedirectResponse)).toBe(true);
+    for (const result of results) {
+      expect(result).toEqual(
+        expect.objectContaining({
+          url: 'https://s3.example.com/thumb.jpg?X-Amz-Signature=abc',
+          cacheControl: CacheControl.PrivateWithoutCache,
+        }),
+      );
+    }
+    expect(s3Backend.getServeStrategy).toHaveBeenCalledTimes(150);
+    expect(s3Backend.getServeStrategy).toHaveBeenNthCalledWith(1, path, {
+      contentType: 'image/jpeg',
+      cacheControl: CacheControl.PrivateWithCache,
+      fileName: `IMG_${asset.id}_thumbnail.jpg`,
+      disposition: 'inline',
+    });
+  } finally {
+    (StorageService as any).s3Backend = previousS3Backend;
+  }
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+pnpm --dir server test src/utils/file.spec.ts src/backends/s3-storage.backend.spec.ts src/services/asset-media.service.spec.ts --run
+```
+
+Expected: FAIL because `disposition` and `ServeOptions` do not exist yet.
+
+- [ ] **Step 3: Add serve option types**
+
+Replace `server/src/interfaces/storage-backend.interface.ts` with this shape:
+
+```ts
+import { Readable } from 'node:stream';
+import { CacheControl } from 'src/enum';
+import type { ContentDisposition } from 'src/utils/file';
+
+export type ServeOptions = {
+  contentType: string;
+  cacheControl: CacheControl;
+  fileName?: string;
+  disposition?: ContentDisposition;
+};
+
+export type ServeStrategy =
+  | { type: 'file'; path: string }
+  | { type: 'redirect'; url: string }
+  | { type: 'stream'; stream: Readable; length?: number };
+
+export interface StorageBackend {
+  put(key: string, source: Buffer | Readable, options?: { contentType?: string }): Promise<void>;
+  get(key: string): Promise<{ stream: Readable; contentType?: string; length?: number }>;
+  exists(key: string): Promise<boolean>;
+  delete(key: string): Promise<void>;
+  deletePrefix(prefix: string): Promise<void>;
+  getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy>;
+  downloadToTemp(key: string): Promise<{ tempPath: string; cleanup: () => Promise<void> }>;
+  getPrefixUsage(prefix: string): Promise<number>;
+}
+```
+
+- [ ] **Step 4: Add response disposition support**
+
+In `server/src/utils/file.ts`, add the type and helper near the response classes:
+
+```ts
+export type ContentDisposition = 'inline' | 'attachment';
+
+export const getContentDispositionHeader = (disposition: ContentDisposition, fileName: string): string => {
+  return `${disposition}; filename*=UTF-8''${encodeURIComponent(fileName)}`;
+};
+```
+
+Add `public readonly disposition?: ContentDisposition;` to `ImmichFileResponse` and `ImmichStreamResponse`.
+
+Replace each inline content-disposition header in `sendFile()` with:
+
+```ts
+res.header('Content-Disposition', getContentDispositionHeader(file.disposition ?? 'inline', file.fileName));
+```
+
+- [ ] **Step 5: Update storage backends**
+
+In `server/src/backends/disk-storage.backend.ts`, change the signature only:
+
+```ts
+async getServeStrategy(key: string, _options: ServeOptions): Promise<ServeStrategy> {
+  return { type: 'file', path: this.resolvePath(key) };
+}
+```
+
+In `server/src/backends/s3-storage.backend.ts`, import the new types and helper:
+
+```ts
+import type { ServeOptions, ServeStrategy } from 'src/interfaces/storage-backend.interface';
+import { getContentDispositionHeader } from 'src/utils/file';
+```
+
+Change `getServeStrategy()` to:
+
+```ts
+async getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy> {
+  if (this.serveMode === 'proxy') {
+    await this.proxyLimiter.acquire();
+    let released = false;
+    const release = () => {
+      if (!released) {
+        released = true;
+        this.proxyLimiter.release();
+      }
+    };
+
+    try {
+      const { stream, length } = await this.get(key);
+      return { type: 'stream', stream: releaseWhenStreamCloses(stream, release), length };
+    } catch (error) {
+      release();
+      throw error;
+    }
+  }
+
+  const commandInput = {
+    Bucket: this.bucket,
+    Key: key,
+    ResponseContentType: options.contentType,
+    ResponseContentDisposition: options.fileName
+      ? getContentDispositionHeader(options.disposition ?? 'inline', options.fileName)
+      : undefined,
+  };
+
+  const command = new GetObjectCommand(commandInput);
+  const url = await getSignedUrl(this.client, command, { expiresIn: this.presignedUrlExpiry });
+  return { type: 'redirect', url };
+}
+```
+
+Use `GetObjectCommandInput` if TypeScript asks for explicit typing:
+
+```ts
+const commandInput: GetObjectCommandInput = {
+  Bucket: this.bucket,
+  Key: key,
+  ResponseContentType: options.contentType,
+};
+if (options.fileName) {
+  commandInput.ResponseContentDisposition = getContentDispositionHeader(
+    options.disposition ?? 'inline',
+    options.fileName,
+  );
+}
+```
+
+- [ ] **Step 6: Update BaseService redirect policy**
+
+In `server/src/services/base.service.ts`, update `serveFromBackend()` to accept disposition and pass `ServeOptions`:
+
+```ts
+protected async serveFromBackend(
+  filePath: string,
+  contentType: string,
+  cacheControl: CacheControl,
+  fileName?: string,
+  disposition: ContentDisposition = 'inline',
+): Promise<ImmichMediaResponse> {
+  const { StorageService } = await import('./storage.service.js');
+  const backend = StorageService.resolveBackendForKey(filePath);
+  const strategy: ServeStrategy = await backend.getServeStrategy(filePath, {
+    contentType,
+    cacheControl,
+    fileName,
+    disposition,
+  });
+  const responseDisposition = disposition === 'inline' ? undefined : disposition;
+
+  switch (strategy.type) {
+    case 'file': {
+      return new ImmichFileResponse({
+        path: strategy.path,
+        contentType,
+        cacheControl,
+        fileName,
+        disposition: responseDisposition,
+      });
+    }
+    case 'redirect': {
+      return new ImmichRedirectResponse({
+        url: strategy.url,
+        cacheControl: CacheControl.PrivateWithoutCache,
+      });
+    }
+    case 'stream': {
+      return new ImmichStreamResponse({
+        stream: strategy.stream,
+        contentType,
+        length: strategy.length,
+        cacheControl,
+        fileName,
+        disposition: responseDisposition,
+      });
+    }
+  }
+}
+```
+
+Add `ContentDisposition` to the `src/utils/file` import.
+
+- [ ] **Step 7: Update backend call sites and tests**
+
+Replace direct test calls like this:
+
+```ts
+await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', 'image/webp');
+```
+
+with:
+
+```ts
+await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', {
+  contentType: 'image/webp',
+  cacheControl: CacheControl.PrivateWithCache,
+});
+```
+
+Apply the same pattern in:
+
+- `server/src/backends/disk-storage.backend.spec.ts`
+- `server/src/backends/s3-storage.backend.spec.ts`
+- `server/src/backends/s3-storage.backend.integration.spec.ts`
+
+- [ ] **Step 8: Run backend tests**
+
+Run:
+
+```bash
+pnpm --dir server test src/utils/file.spec.ts src/backends/disk-storage.backend.spec.ts src/backends/s3-storage.backend.spec.ts src/services/asset-media.service.spec.ts --run
+pnpm --dir server check
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit backend serve metadata**
+
+Run:
+
+```bash
+git add server/src/interfaces/storage-backend.interface.ts server/src/utils/file.ts server/src/utils/file.spec.ts server/src/backends/disk-storage.backend.ts server/src/backends/disk-storage.backend.spec.ts server/src/backends/s3-storage.backend.ts server/src/backends/s3-storage.backend.spec.ts server/src/backends/s3-storage.backend.integration.spec.ts server/src/services/base.service.ts server/src/services/asset-media.service.spec.ts
+git commit -m "feat: sign s3 media response metadata"
+```
+
+---
+
+### Task 2: Explicit Original Download Disposition
+
+**Files:**
+
+- Modify: `server/src/dtos/asset.dto.ts`
+- Modify: `server/src/services/asset-media.service.ts`
+- Modify: `server/src/services/asset-media.service.spec.ts`
+- Modify: `web/src/lib/utils.ts`
+- Modify: `web/src/lib/utils.spec.ts`
+- Modify: `web/src/lib/services/asset.service.ts`
+- Modify: `web/src/lib/services/asset.service.spec.ts`
+
+- [ ] **Step 1: Write failing server tests**
+
+Add this case to `server/src/services/asset-media.service.spec.ts` in `describe('downloadOriginal')`:
+
+```ts
+it('should mark explicit original downloads as attachments', async () => {
+  const asset = AssetFactory.create();
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getForOriginal.mockResolvedValue(asset);
+
+  await expect(sut.downloadOriginal(authStub.admin, asset.id, { download: true })).resolves.toEqual(
+    new ImmichFileResponse({
+      path: asset.originalPath,
+      fileName: asset.originalFileName,
+      contentType: 'image/jpeg',
+      cacheControl: CacheControl.PrivateWithCache,
+      disposition: 'attachment',
+    }),
+  );
+});
+
+it('should keep original viewer requests inline by default', async () => {
+  const asset = AssetFactory.create();
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+  mocks.asset.getForOriginal.mockResolvedValue(asset);
+
+  const response = await sut.downloadOriginal(authStub.admin, asset.id, {});
+  expect(response).toEqual(
+    new ImmichFileResponse({
+      path: asset.originalPath,
+      fileName: asset.originalFileName,
+      contentType: 'image/jpeg',
+      cacheControl: CacheControl.PrivateWithCache,
+    }),
+  );
+  expect(response).not.toHaveProperty('disposition');
+});
+```
+
+- [ ] **Step 2: Write failing web URL tests**
+
+Update the import in `web/src/lib/utils.spec.ts`:
+
+```ts
+import { getAssetMediaUrl, getAssetUrl, getMemoryTitle, getReleaseType } from '$lib/utils';
+import { AssetMediaSize, AssetTypeEnum, MemoryType, type MemoryResponseDto } from '@immich/sdk';
+```
+
+Add these cases under `describe('utils')`:
+
+```ts
+describe(getAssetMediaUrl.name, () => {
+  it('adds download=true to original media URLs when requested', () => {
+    const url = getAssetMediaUrl({
+      id: 'asset-1',
+      size: AssetMediaSize.Original,
+      edited: false,
+      cacheKey: 'cache-1',
+      download: true,
+    });
+
+    expect(url).toContain('/api/assets/asset-1/original');
+    expect(url).toContain('download=true');
+    expect(url).toContain('edited=false');
+    expect(url).toContain('c=cache-1');
+  });
+
+  it('does not add download=true to thumbnail media URLs', () => {
+    const url = getAssetMediaUrl({
+      id: 'asset-1',
+      size: AssetMediaSize.Thumbnail,
+      download: true,
+    });
+
+    expect(url).toContain('/api/assets/asset-1/thumbnail');
+    expect(url).not.toContain('download=true');
+  });
+});
+```
+
+In `web/src/lib/services/asset.service.spec.ts`, add a hoisted mock above the existing mocks:
+
+```ts
+const { downloadUrlMock } = vitest.hoisted(() => ({
+  downloadUrlMock: vitest.fn(),
+}));
+
+vitest.mock('$lib/utils/asset-utils', async () => {
+  const originalModule = await vitest.importActual<typeof import('$lib/utils/asset-utils')>('$lib/utils/asset-utils');
+  return {
+    ...originalModule,
+    downloadUrl: downloadUrlMock,
+  };
+});
+```
+
+Add this case in `describe('handleDownloadAsset')`:
+
+```ts
+it('should request attachment disposition for single-asset downloads', async () => {
+  downloadUrlMock.mockClear();
+  const $t = vitest.fn().mockReturnValue('formatter');
+  vitest.mocked(getFormatter).mockResolvedValue($t);
+  const asset = assetFactory.build({ id: 'asset-1', originalFileName: 'asset.jpg', thumbhash: 'cache-1' });
+
+  await handleDownloadAsset(asset, { edited: false });
+
+  expect(downloadUrlMock).toHaveBeenCalledWith(expect.stringContaining('/api/assets/asset-1/original'), 'asset.jpg');
+  expect(downloadUrlMock.mock.calls[0][0]).toContain('download=true');
+  expect(downloadUrlMock.mock.calls[0][0]).toContain('edited=false');
+  expect(downloadUrlMock.mock.calls[0][0]).toContain('c=cache-1');
+});
+```
+
+- [ ] **Step 3: Run failing tests**
+
+Run:
+
+```bash
+pnpm --dir server test src/services/asset-media.service.spec.ts --run
+pnpm --dir web test src/lib/utils.spec.ts src/lib/services/asset.service.spec.ts --run
+```
+
+Expected: FAIL because the `download` flag is not defined or propagated.
+
+- [ ] **Step 4: Add server download flag**
+
+In `server/src/dtos/asset.dto.ts`, extend `AssetDownloadOriginalSchema`:
+
+```ts
+const AssetDownloadOriginalSchema = z
+  .object({
+    edited: stringToBool.default(false).optional().describe('Return edited asset if available'),
+    download: stringToBool.default(false).optional().describe('Return original asset as an attachment download'),
+  })
+  .meta({ id: 'AssetDownloadOriginalDto' });
+```
+
+In `server/src/services/asset-media.service.ts`, change the final `serveFromBackend()` call in `downloadOriginal()`:
+
+```ts
+return this.serveFromBackend(
+  path,
+  mimeTypes.lookup(path),
+  CacheControl.PrivateWithCache,
+  getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
+  dto.download ? 'attachment' : 'inline',
+);
+```
+
+In `viewThumbnail()`, make the inline behavior explicit:
+
+```ts
+return this.serveFromBackend(path, mimeTypes.lookup(path), CacheControl.PrivateWithCache, fileName, 'inline');
+```
+
+- [ ] **Step 5: Add web download URL propagation**
+
+In `web/src/lib/utils.ts`, update the type and URL builder:
+
+```ts
+type AssetUrlOptions = {
+  id: string;
+  cacheKey?: string | null;
+  edited?: boolean;
+  size?: AssetMediaSize;
+  download?: boolean;
+};
+
+export const getAssetMediaUrl = (options: AssetUrlOptions) => {
+  const { id, size, cacheKey: c, edited = true, download } = options;
+  const isOriginal = size === AssetMediaSize.Original;
+  const path = isOriginal ? getAssetOriginalPath(id) : getAssetThumbnailPath(id);
+  return createUrl(path, {
+    ...authManager.params,
+    size: isOriginal ? undefined : size,
+    c,
+    edited,
+    download: isOriginal ? download : undefined,
+  });
+};
+```
+
+In `web/src/lib/services/asset.service.ts`, update the single-asset download call:
+
+```ts
+downloadUrl(getAssetMediaUrl({ id, size: AssetMediaSize.Original, edited, cacheKey, download: true }), filename);
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+pnpm --dir server test src/services/asset-media.service.spec.ts --run
+pnpm --dir web test src/lib/utils.spec.ts src/lib/services/asset.service.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit explicit download disposition**
+
+Run:
+
+```bash
+git add server/src/dtos/asset.dto.ts server/src/services/asset-media.service.ts server/src/services/asset-media.service.spec.ts web/src/lib/utils.ts web/src/lib/utils.spec.ts web/src/lib/services/asset.service.ts web/src/lib/services/asset.service.spec.ts
+git commit -m "feat: preserve filenames for s3 original downloads"
+```
+
+---
+
+### Task 3: Service Worker Media Bypass
+
+**Files:**
+
+- Modify: `web/src/service-worker/index.ts`
+- Create: `web/src/service-worker/index.spec.ts`
+
+- [ ] **Step 1: Write failing service-worker registration test**
+
+Create `web/src/service-worker/index.spec.ts`:
+
+```ts
+import { installMessageListener } from './messaging';
+
+vi.mock('./messaging', () => ({
+  installMessageListener: vi.fn(),
+}));
+
+describe('service worker index', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('does not register a fetch listener for media requests', async () => {
+    const addEventListener = vi.spyOn(globalThis, 'addEventListener');
+    Object.defineProperty(globalThis, 'clients', {
+      value: { claim: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'skipWaiting', {
+      value: vi.fn().mockResolvedValue(undefined),
+      configurable: true,
+    });
+
+    await import('./index');
+
+    expect(addEventListener).toHaveBeenCalledWith('install', expect.any(Function), { passive: true });
+    expect(addEventListener).toHaveBeenCalledWith('activate', expect.any(Function), { passive: true });
+    expect(addEventListener.mock.calls.some(([eventName]) => eventName === 'fetch')).toBe(false);
+    expect(installMessageListener).toHaveBeenCalledOnce();
+  });
+
+  it('does not take ownership of a burst of asset media fetches', async () => {
+    const listeners = new Map<string, EventListener[]>();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    vi.spyOn(globalThis, 'addEventListener').mockImplementation((eventName, listener) => {
+      const key = String(eventName);
+      listeners.set(key, [...(listeners.get(key) ?? []), listener as EventListener]);
+    });
+    Object.defineProperty(globalThis, 'clients', {
+      value: { claim: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'skipWaiting', {
+      value: vi.fn().mockResolvedValue(undefined),
+      configurable: true,
+    });
+
+    await import('./index');
+
+    const fetchListeners = listeners.get('fetch') ?? [];
+    const respondWith = vi.fn();
+    for (let index = 0; index < 200; index++) {
+      for (const listener of fetchListeners) {
+        listener({
+          request: new Request(
+            `${location.origin}/api/assets/00000000-0000-4000-8000-${String(index).padStart(12, '0')}/thumbnail`,
+          ),
+          respondWith,
+        } as unknown as Event);
+      }
+    }
+
+    expect(fetchListeners).toHaveLength(0);
+    expect(respondWith).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run:
+
+```bash
+pnpm --dir web test src/service-worker/index.spec.ts --run
+```
+
+Expected: FAIL because `index.ts` still registers a `fetch` listener.
+
+- [ ] **Step 3: Remove the media fetch intercept**
+
+In `web/src/service-worker/index.ts`, remove:
+
+```ts
+import { handleFetch as handleAssetFetch } from './request';
+
+const ASSET_REQUEST_REGEX = /^\/api\/assets\/[a-f0-9-]+\/(original|thumbnail)/;
+```
+
+Remove the `handleFetch()` function and this registration:
+
+```ts
+sw.addEventListener('fetch', handleFetch, { passive: true });
+```
+
+The final file should keep install, activate, and message handling:
+
+```ts
+sw.addEventListener('install', handleInstall, { passive: true });
+sw.addEventListener('activate', handleActivate, { passive: true });
+installMessageListener();
+```
+
+Keep `web/src/service-worker/request.ts` and `web/src/service-worker/messaging.ts` in this change. `cancelImageUrl()` remains harmless when no media fetches are owned by the service worker.
+
+- [ ] **Step 4: Run service-worker test**
+
+Run:
+
+```bash
+pnpm --dir web test src/service-worker/index.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit service-worker bypass**
+
+Run:
+
+```bash
+git add web/src/service-worker/index.ts web/src/service-worker/index.spec.ts
+git commit -m "fix: bypass service worker for media requests"
+```
+
+---
+
+### Task 4: CORS-Safe Image Loading
+
+**Files:**
+
+- Modify: `web/src/lib/components/Image.svelte`
+- Modify: `web/src/lib/components/Image.spec.ts`
+- Modify: `web/src/lib/actions/image-loader.svelte.ts`
+- Create: `web/src/lib/actions/__test__/image-loader.spec.ts`
+- Modify: `web/src/lib/utils/people-utils.ts`
+- Modify: `web/src/lib/utils/people-utils.spec.ts`
+- Modify: `web/src/lib/managers/edit/transform-manager.svelte.ts`
+- Create: `web/src/lib/managers/edit/transform-manager.svelte.spec.ts`
+
+- [ ] **Step 1: Write failing image component tests**
+
+Add these cases to `web/src/lib/components/Image.spec.ts`:
+
+```ts
+it('renders anonymous CORS by default', () => {
+  const { baseElement } = render(Image, { src: '/test.jpg', alt: 'test' });
+  const img = baseElement.querySelector('img')!;
+  expect(img).toHaveAttribute('crossorigin', 'anonymous');
+});
+
+it('allows callers to override crossorigin', () => {
+  const { baseElement } = render(Image, { src: '/test.jpg', alt: 'test', crossorigin: 'use-credentials' });
+  const img = baseElement.querySelector('img')!;
+  expect(img).toHaveAttribute('crossorigin', 'use-credentials');
+});
+```
+
+Create `web/src/lib/actions/__test__/image-loader.spec.ts`:
+
+```ts
+import { loadImage } from '$lib/actions/image-loader.svelte';
+
+describe('loadImage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets anonymous CORS before assigning src', () => {
+    const originalCreateElement = document.createElement.bind(document);
+    let imageElement: HTMLImageElement | undefined;
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      const element = originalCreateElement(tagName);
+      if (tagName === 'img') {
+        imageElement = element as HTMLImageElement;
+      }
+      return element;
+    });
+
+    loadImage('/api/assets/asset-1/thumbnail', vi.fn(), vi.fn());
+
+    expect(imageElement).toBeDefined();
+    expect(imageElement!.crossOrigin).toBe('anonymous');
+    expect(imageElement!.src).toContain('/api/assets/asset-1/thumbnail');
+  });
+});
+```
+
+- [ ] **Step 2: Write failing canvas helper tests**
+
+Update `web/src/lib/utils/people-utils.spec.ts` imports:
+
+```ts
+import { AssetTypeEnum } from '@immich/sdk';
+import { getBoundingBox, zoomImageToBase64 } from '$lib/utils/people-utils';
+```
+
+Add this mock near the top:
+
+```ts
+vi.mock('$lib/utils', () => ({
+  getAssetMediaUrl: vi.fn(() => '/api/assets/asset-1/thumbnail'),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+```
+
+Add this case:
+
+```ts
+it('sets anonymous CORS on images used for video face crops', async () => {
+  const originalCreateElement = document.createElement.bind(document);
+  vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+    if (tagName === 'canvas') {
+      return {
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage: vi.fn() }),
+        toDataURL: () => 'data:image/png;base64,face',
+      } as unknown as HTMLCanvasElement;
+    }
+    return originalCreateElement(tagName);
+  });
+
+  class TestImage {
+    crossOrigin = '';
+    naturalWidth = 4000;
+    naturalHeight = 3000;
+    private currentSrc = '';
+
+    set src(value: string) {
+      this.currentSrc = value;
+    }
+
+    get src() {
+      return this.currentSrc;
+    }
+
+    addEventListener(eventName: string, listener: EventListenerOrEventListenerObject) {
+      if (eventName === 'load') {
+        queueMicrotask(() => {
+          if (typeof listener === 'function') {
+            listener(new Event('load'));
+          }
+        });
+      }
+    }
+  }
+
+  const imageMock = vi.fn(() => new TestImage());
+  vi.stubGlobal('Image', imageMock);
+
+  const result = await zoomImageToBase64(makeFace(), 'asset-1', AssetTypeEnum.Video, undefined);
+
+  expect(result).toBe('data:image/png;base64,face');
+  expect(imageMock).toHaveBeenCalledTimes(2);
+  expect(imageMock.mock.results[0].value.crossOrigin).toBe('anonymous');
+  expect(imageMock.mock.results[1].value.crossOrigin).toBe('anonymous');
+});
+```
+
+Create `web/src/lib/managers/edit/transform-manager.svelte.spec.ts`:
+
+```ts
+import { transformManager } from '$lib/managers/edit/transform-manager.svelte';
+import { AssetTypeEnum } from '@immich/sdk';
+import { assetFactory } from '@test-data/factories/asset-factory';
+
+describe('transformManager image loading', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    transformManager.onDeactivate();
+  });
+
+  it('sets anonymous CORS before assigning the editor preview src', async () => {
+    const image = {
+      crossOrigin: '',
+      src: '',
+      style: {},
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as HTMLImageElement;
+    vi.stubGlobal(
+      'Image',
+      vi.fn(() => image),
+    );
+
+    const asset = assetFactory.build({
+      id: 'asset-1',
+      type: AssetTypeEnum.Image,
+      thumbhash: 'cache-1',
+      exifInfo: { exifImageWidth: 4000, exifImageHeight: 3000 } as any,
+    });
+
+    await transformManager.onActivate(asset, []);
+
+    expect(image.crossOrigin).toBe('anonymous');
+    expect(image.src).toContain('/api/assets/asset-1/thumbnail');
+  });
+});
+```
+
+- [ ] **Step 3: Run failing web tests**
+
+Run:
+
+```bash
+pnpm --dir web test src/lib/components/Image.spec.ts src/lib/actions/__test__/image-loader.spec.ts src/lib/utils/people-utils.spec.ts src/lib/managers/edit/transform-manager.svelte.spec.ts --run
+```
+
+Expected: FAIL because anonymous CORS is not set yet.
+
+- [ ] **Step 4: Implement shared image CORS defaults**
+
+In `web/src/lib/components/Image.svelte`, destructure `crossorigin` with a default:
+
+```svelte
+let { src, onStart, onLoad, onError, ref = $bindable(), crossorigin = 'anonymous', ...rest }: Props = $props();
+```
+
+Add the attribute to the `<img>` element before `{...rest}` or after it. Since `crossorigin` is destructured, it will not be duplicated:
+
+```svelte
+<img
+  bind:this={ref}
+  src={capturedSource}
+  crossorigin={crossorigin}
+  {...rest}
+  style:visibility={isFirefox && !loaded ? 'hidden' : undefined}
+  onload={handleLoad}
+  onerror={handleError}
+/>
+```
+
+In `web/src/lib/actions/image-loader.svelte.ts`, set CORS before `src`:
+
+```ts
+const img = document.createElement('img');
+img.crossOrigin = 'anonymous';
+img.addEventListener('load', handleLoad);
+img.addEventListener('error', handleError);
+```
+
+- [ ] **Step 5: Implement explicit canvas image CORS**
+
+In `web/src/lib/utils/people-utils.ts`, set CORS before each `src` assignment:
+
+```ts
+const img: HTMLImageElement = new Image();
+img.crossOrigin = 'anonymous';
+img.src = data;
+```
+
+and:
+
+```ts
+const faceImage = new Image();
+faceImage.crossOrigin = 'anonymous';
+faceImage.src = image.src;
+```
+
+In `web/src/lib/managers/edit/transform-manager.svelte.ts`, set CORS immediately after constructing the image:
+
+```ts
+this.imgElement = new Image();
+this.imgElement.crossOrigin = 'anonymous';
+```
+
+- [ ] **Step 6: Run focused web tests**
+
+Run:
+
+```bash
+pnpm --dir web test src/lib/components/Image.spec.ts src/lib/actions/__test__/image-loader.spec.ts src/lib/utils/people-utils.spec.ts src/lib/managers/edit/transform-manager.svelte.spec.ts --run
+pnpm --dir web check:typescript
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit CORS-safe image loading**
+
+Run:
+
+```bash
+git add web/src/lib/components/Image.svelte web/src/lib/components/Image.spec.ts web/src/lib/actions/image-loader.svelte.ts web/src/lib/actions/__test__/image-loader.spec.ts web/src/lib/utils/people-utils.ts web/src/lib/utils/people-utils.spec.ts web/src/lib/managers/edit/transform-manager.svelte.ts web/src/lib/managers/edit/transform-manager.svelte.spec.ts
+git commit -m "fix: load redirected media with anonymous cors"
+```
+
+---
+
+### Task 5: Cast Content-Type Probe For Redirect Mode
+
+**Files:**
+
+- Modify: `web/src/lib/utils/cast/gcast-destination.svelte.ts`
+- Create: `web/src/lib/utils/cast/gcast-destination.svelte.spec.ts`
+
+- [ ] **Step 1: Write failing Cast probe test**
+
+Create `web/src/lib/utils/cast/gcast-destination.svelte.spec.ts`:
+
+```ts
+import { getMediaContentType } from '$lib/utils/cast/gcast-destination.svelte';
+
+describe('getMediaContentType', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses a GET range probe so redirect-mode S3 keeps the signed GET method', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, {
+        headers: { 'content-type': 'video/mp4' },
+      }),
+    );
+
+    await expect(getMediaContentType('/api/assets/asset-1/video/playback')).resolves.toBe('video/mp4');
+    expect(fetchMock).toHaveBeenCalledWith('/api/assets/asset-1/video/playback', {
+      method: 'GET',
+      headers: { Range: 'bytes=0-0' },
+    });
+  });
+
+  it('returns null when the media response has no content type', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null));
+
+    await expect(getMediaContentType('/api/assets/asset-1/video/playback')).resolves.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run failing Cast probe test**
+
+Run:
+
+```bash
+pnpm --dir web test src/lib/utils/cast/gcast-destination.svelte.spec.ts --run
+```
+
+Expected: FAIL because `getMediaContentType()` does not exist and Cast still uses `HEAD`.
+
+- [ ] **Step 3: Add GET range content-type probe**
+
+In `web/src/lib/utils/cast/gcast-destination.svelte.ts`, add this helper near the imports:
+
+```ts
+export const getMediaContentType = async (mediaUrl: string) => {
+  const response = await fetch(mediaUrl, {
+    method: 'GET',
+    headers: { Range: 'bytes=0-0' },
+  });
+  return response.headers.get('content-type');
+};
+```
+
+Replace the existing `HEAD` probe:
+
+```ts
+const assetHead = await fetch(mediaUrl, { method: 'HEAD' });
+const contentType = assetHead.headers.get('content-type');
+```
+
+with:
+
+```ts
+const contentType = await getMediaContentType(mediaUrl);
+```
+
+Keep the existing error when `contentType` is missing.
+
+- [ ] **Step 4: Run Cast probe test**
+
+Run:
+
+```bash
+pnpm --dir web test src/lib/utils/cast/gcast-destination.svelte.spec.ts --run
+pnpm --dir web check:typescript
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Cast redirect compatibility**
+
+Run:
+
+```bash
+git add web/src/lib/utils/cast/gcast-destination.svelte.ts web/src/lib/utils/cast/gcast-destination.svelte.spec.ts
+git commit -m "fix: probe cast media with get range"
+```
+
+---
+
+### Task 6: S3 Redirect Documentation And CORS Guidance
+
+**Files:**
+
+- Modify: `docs/docs/features/s3-storage.md`
+- Modify: `docs/docs/install/environment-variables.md`
+
+- [ ] **Step 1: Update S3 serve mode guidance**
+
+In `docs/docs/features/s3-storage.md`, replace the serve mode table with:
+
+```md
+| Mode       | Behavior                                                                                                                          |
+| :--------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| `redirect` | Returns a temporary presigned URL. The client downloads directly from S3. Recommended when the browser can reach the S3 endpoint. |
+| `proxy`    | The Gallery server streams the file from S3 to the client. Use only when S3 is not directly reachable by browsers.                |
+```
+
+Replace the "Choose a Serve Mode" bullets with:
+
+```md
+- **`redirect`** (default) - Recommended for browser-readable S3 endpoints. Gallery authorizes the API request and returns a short-lived presigned URL, so media bytes flow directly from S3 to the browser.
+- **`proxy`** - Compatibility mode for private-network S3 endpoints. Gallery streams every media byte through the API process, so it costs more server resources and is not the recommended mode for large scrolling grids.
+```
+
+- [ ] **Step 2: Add CORS section**
+
+Add this section after "Choose a Serve Mode":
+
+````md
+### 4. Configure CORS For Redirect Mode
+
+Redirect mode keeps the bucket private, but browsers need CORS headers when Gallery draws S3 images to canvas for editing, face crops, and copy-to-clipboard.
+
+Use an origin list that matches your deployment:
+
+```json
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://gallery.example.com", "http://localhost:3000", "http://localhost:2283"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["Accept-Ranges", "Content-Length", "Content-Range", "Content-Type", "ETag"],
+      "MaxAgeSeconds": 3600
+    }
+  ]
+}
+```
+
+For S3-compatible providers that support the AWS CLI, apply it with:
+
+```bash
+aws --endpoint-url "$IMMICH_S3_ENDPOINT" s3api put-bucket-cors \
+  --bucket "$IMMICH_S3_BUCKET" \
+  --cors-configuration '{"CORSRules":[{"AllowedOrigins":["https://gallery.example.com","http://localhost:3000","http://localhost:2283"],"AllowedMethods":["GET","HEAD"],"AllowedHeaders":["*"],"ExposeHeaders":["Accept-Ranges","Content-Length","Content-Range","Content-Type","ETag"],"MaxAgeSeconds":3600}]}'
+```
+
+Do not use `"*"` for production origins if you introduce credentialed browser requests to S3. Gallery media images use anonymous CORS.
+````
+
+Renumber the existing restart section from `### 4. Restart Gallery` to `### 5. Restart Gallery`.
+
+- [ ] **Step 3: Update environment variable table wording**
+
+In `docs/docs/install/environment-variables.md`, change the `IMMICH_S3_SERVE_MODE` description to:
+
+```md
+How to serve S3 assets: `redirect` is recommended when browsers can reach S3; `proxy` streams through the server
+```
+
+- [ ] **Step 4: Run docs formatting**
+
+Run:
+
+```bash
+pnpm --dir docs exec prettier --check docs/features/s3-storage.md docs/install/environment-variables.md
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit docs**
+
+Run:
+
+```bash
+git add docs/docs/features/s3-storage.md docs/docs/install/environment-variables.md
+git commit -m "docs: document s3 redirect media delivery"
+```
+
+---
+
+### Task 7: Verification, OpenAPI, And RC Smoke
+
+**Files:**
+
+- May modify generated OpenAPI files if `sync:open-api` reports changes.
+- No code file should be modified by the manual smoke steps.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+pnpm --dir server test src/utils/file.spec.ts src/backends/disk-storage.backend.spec.ts src/backends/s3-storage.backend.spec.ts src/services/asset-media.service.spec.ts --run
+pnpm --dir web test src/lib/utils.spec.ts src/lib/services/asset.service.spec.ts src/service-worker/index.spec.ts src/lib/components/Image.spec.ts src/lib/actions/__test__/image-loader.spec.ts src/lib/utils/people-utils.spec.ts src/lib/managers/edit/transform-manager.svelte.spec.ts src/lib/utils/cast/gcast-destination.svelte.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type and lint checks**
+
+Run:
+
+```bash
+pnpm --dir server check
+pnpm --dir web check:typescript
+pnpm --dir web check:svelte
+pnpm --dir docs exec prettier --check plans/2026-05-02-s3-direct-media-delivery-design.md plans/2026-05-02-s3-direct-media-delivery-plan.md docs/features/s3-storage.md docs/install/environment-variables.md
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Regenerate OpenAPI after DTO change**
+
+Run:
+
+```bash
+pnpm --dir server build
+pnpm --dir server sync:open-api
+git status --short open-api
+```
+
+Expected: `open-api/immich-openapi-specs.json` and TypeScript SDK outputs may change to include `download` on `AssetDownloadOriginalDto`. If files change, include them in the current branch and rerun the web type checks.
+
+- [ ] **Step 4: Run optional MinIO integration tests**
+
+Run this when Docker is available:
+
+```bash
+IMMICH_TEST_DOCKER=true pnpm --dir server test src/backends/s3-storage.backend.integration.spec.ts --run
+```
+
+Expected: PASS. The redirect-mode integration should still return a presigned URL, and proxy mode should still stream object bytes.
+
+- [ ] **Step 5: Smoke redirect behavior locally or on RC**
+
+With a redirect-mode S3 instance, choose one real image asset id and one real video asset id from the browser network panel. Use an API key that has asset view and asset download permissions:
+
+```bash
+IMAGE_ASSET_ID="$GALLERY_SMOKE_IMAGE_ASSET_ID"
+VIDEO_ASSET_ID="$GALLERY_SMOKE_VIDEO_ASSET_ID"
+GALLERY_BASE_URL="$GALLERY_SMOKE_BASE_URL"
+AUTH_HEADER="x-api-key: ${GALLERY_SMOKE_API_KEY}"
+curl -I -H "${AUTH_HEADER}" "${GALLERY_BASE_URL}/api/assets/${IMAGE_ASSET_ID}/thumbnail?size=thumbnail"
+curl -I -H "${AUTH_HEADER}" "${GALLERY_BASE_URL}/api/assets/${IMAGE_ASSET_ID}/original?download=true"
+curl -I -H "${AUTH_HEADER}" "${GALLERY_BASE_URL}/api/assets/${VIDEO_ASSET_ID}/video/playback"
+```
+
+Expected:
+
+- Each API media response is a 302.
+- `Cache-Control` on the 302 is `private, no-cache, no-transform`.
+- The `Location` host is the S3 provider endpoint.
+- Following the thumbnail `Location` returns image bytes and CORS headers for the Gallery origin.
+- Following the original `Location` returns a `Content-Disposition` attachment filename.
+- Following the video `Location` with `Range: bytes=0-1023` returns `206 Partial Content`.
+
+- [ ] **Step 6: Smoke the browser workflows**
+
+On the RC after CORS is applied and `IMMICH_S3_SERVE_MODE=redirect` is set:
+
+```text
+1. Hard refresh the production host and confirm the active service worker is the new build.
+2. Open /photos and fast-scroll through several hundred thumbnails.
+3. Confirm visible thumbnails leave blurred preview state.
+4. Open an image viewer that uses the original endpoint.
+5. Download a single original and confirm the saved filename matches the asset name.
+6. Play a video and seek to the middle.
+7. Open a person page and use face crop or face editor flows.
+8. Use copy-to-clipboard on an image.
+9. If a Cast receiver is available, cast a video and confirm playback starts after the content-type probe.
+10. Open browser devtools and confirm /api/assets media requests are 302 responses instead of long-running proxied streams.
+11. Confirm /api/users/me and /api/server/ping respond during and after fast scroll.
+```
+
+Expected: No global blurred-media stall, no pile-up of long-running API media streams, downloads keep filenames, Cast does not fail on the content-type probe, and canvas workflows do not throw tainted-canvas errors.
+
+- [ ] **Step 7: Commit generated files and final verification fixes**
+
+Run:
+
+```bash
+git status --short
+git add open-api web/src server/src docs/docs docs/plans
+git commit -m "test: verify s3 direct media delivery"
+```
+
+Only create this commit if Task 7 produced generated OpenAPI updates or verification fixes. If Task 7 produced no file changes, skip the commit and keep the previous task commits.
+
+---
+
+## Rollout Notes
+
+- `redirect` is the actual architecture fix for browser-readable S3 because the API stops streaming media bytes.
+- `proxy` remains supported, but only benefits from the service-worker bypass; it still streams S3 bytes through Gallery.
+- Apply bucket CORS before switching the production instance to redirect mode.
+- Old service workers can mask the fix. The RC smoke must include a hard refresh or service-worker update verification.
+- Treat presigned URLs as temporary credentials while they are valid.
+
+## Full Verification Command Set
+
+Run this before requesting review:
+
+```bash
+pnpm --dir server test src/utils/file.spec.ts src/backends/disk-storage.backend.spec.ts src/backends/s3-storage.backend.spec.ts src/services/asset-media.service.spec.ts --run
+pnpm --dir web test src/lib/utils.spec.ts src/lib/services/asset.service.spec.ts src/service-worker/index.spec.ts src/lib/components/Image.spec.ts src/lib/actions/__test__/image-loader.spec.ts src/lib/utils/people-utils.spec.ts src/lib/managers/edit/transform-manager.svelte.spec.ts src/lib/utils/cast/gcast-destination.svelte.spec.ts --run
+pnpm --dir server check
+pnpm --dir web check:typescript
+pnpm --dir web check:svelte
+pnpm --dir docs exec prettier --check plans/2026-05-02-s3-direct-media-delivery-design.md plans/2026-05-02-s3-direct-media-delivery-plan.md docs/features/s3-storage.md docs/install/environment-variables.md
+pnpm --dir server build
+pnpm --dir server sync:open-api
+```
+
+Expected: all commands pass, and `git status --short` only shows intentional source, docs, and generated OpenAPI changes.

--- a/e2e/src/ui/generators/timeline/model-objects.ts
+++ b/e2e/src/ui/generators/timeline/model-objects.ts
@@ -47,7 +47,7 @@ export function generateAsset(
   ownerId: string,
   rng: SeededRandom,
 ): MockTimelineAsset {
-  const from = DateTime.fromObject({ year, month, day }).setZone('UTC');
+  const from = DateTime.fromObject({ year, month, day }, { zone: 'UTC' });
   const to = from.endOf('day');
   const date = faker.date.between({ from: from.toJSDate(), to: to.toJSDate() });
   const isVideo = rng.next() < GENERATION_CONSTANTS.VIDEO_PROBABILITY;

--- a/e2e/src/ui/mock-network/broken-asset-network.ts
+++ b/e2e/src/ui/mock-network/broken-asset-network.ts
@@ -139,9 +139,6 @@ export const setupBrokenAssetMockApiRoutes = async (context: BrowserContext, moc
   });
 
   await context.route('**/api/assets/*/thumbnail?size=*', async (route, request) => {
-    if (!route.request().serviceWorker()) {
-      return route.continue();
-    }
     const pattern = /\/api\/assets\/(?<assetId>[^/]+)\/thumbnail\?size=(?<size>preview|thumbnail)/;
     const match = request.url().match(pattern);
     if (!match?.groups || !mockStack.assetMap.has(match.groups.assetId)) {

--- a/e2e/src/ui/mock-network/face-editor-network.ts
+++ b/e2e/src/ui/mock-network/face-editor-network.ts
@@ -115,9 +115,6 @@ export const setupFaceEditorMockApiRoutes = async (
   });
 
   await context.route('**/api/people/*/thumbnail', async (route) => {
-    if (!route.request().serviceWorker()) {
-      return route.continue();
-    }
     return route.fulfill({
       status: 200,
       headers: { 'content-type': 'image/jpeg' },

--- a/e2e/src/ui/mock-network/timeline-network.ts
+++ b/e2e/src/ui/mock-network/timeline-network.ts
@@ -106,9 +106,6 @@ export const setupTimelineMockApiRoutes = async (
     }
 
     if (match.groups.size === 'preview') {
-      if (!route.request().serviceWorker()) {
-        return route.continue();
-      }
       const asset = getAsset(timelineRestData, match.groups.assetId);
       return route.fulfill({
         status: 200,
@@ -120,9 +117,6 @@ export const setupTimelineMockApiRoutes = async (
       });
     }
     if (match.groups.size === 'thumbnail') {
-      if (!route.request().serviceWorker()) {
-        return route.continue();
-      }
       const asset = getAsset(timelineRestData, match.groups.assetId);
       return route.fulfill({
         status: 200,

--- a/e2e/src/ui/specs/asset-viewer/asset-viewer.e2e-spec.ts
+++ b/e2e/src/ui/specs/asset-viewer/asset-viewer.e2e-spec.ts
@@ -88,6 +88,7 @@ test.describe('asset-viewer', () => {
       await assetViewerUtils.waitForViewerLoad(page, asset);
       await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${asset.id}`);
 
+      await page.getByLabel('View next asset').waitFor();
       await page.keyboard.press('ArrowRight');
       await assetViewerUtils.waitForViewerLoad(page, assets[index + 1]);
       await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[index + 1].id}`);
@@ -100,6 +101,7 @@ test.describe('asset-viewer', () => {
       await assetViewerUtils.waitForViewerLoad(page, asset);
       await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${asset.id}`);
 
+      await page.getByLabel('View previous asset').waitFor();
       await page.keyboard.press('ArrowLeft');
       await assetViewerUtils.waitForViewerLoad(page, assets[index - 1]);
       await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[index - 1].id}`);
@@ -139,6 +141,7 @@ test.describe('asset-viewer', () => {
 
       // Navigate forward 3 times, waiting for each navigation to fully complete
       for (let i = 1; i <= 3; i++) {
+        await page.getByLabel('View next asset').waitFor();
         await page.keyboard.press('ArrowRight');
         await assetViewerUtils.waitForViewerLoad(page, assets[index + i]);
         await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[index + i].id}`);
@@ -146,6 +149,7 @@ test.describe('asset-viewer', () => {
 
       // Navigate backward 3 times to return to original
       for (let i = 2; i >= 0; i--) {
+        await page.getByLabel('View previous asset').waitFor();
         await page.keyboard.press('ArrowLeft');
         await assetViewerUtils.waitForViewerLoad(page, assets[index + i]);
         await expect.poll(() => new URL(page.url()).pathname).toBe(`/photos/${assets[index + i].id}`);

--- a/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
+++ b/e2e/src/ui/specs/timeline/timeline.e2e-spec.ts
@@ -328,7 +328,16 @@ test.describe('Timeline', () => {
       const rng = new SeededRandom(6637);
       const selectedMonths = selectRandomMultiple(yearMonths, 20, rng);
       for (const month of selectedMonths) {
-        await page.locator(`[data-segment-year-month="${month}"]`).click({ force: true });
+        const segment = page.locator(`[data-segment-year-month="${month}"]`);
+        const scrubberBox = await page.locator('[data-id="scrubber"]').boundingBox();
+        const segmentBox = await segment.boundingBox();
+        if (!scrubberBox || !segmentBox) {
+          throw new Error(`Unable to find scrubber segment for ${month}`);
+        }
+        await page.mouse.move(scrubberBox.x + scrubberBox.width / 2, scrubberBox.y + scrubberBox.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(segmentBox.x + segmentBox.width / 2, segmentBox.y + segmentBox.height / 2, { steps: 5 });
+        await page.mouse.up();
         const matchingMonth = await poll(page, async () => {
           for (const thumb of await thumbnailUtils.locator(page).all()) {
             const box = await thumb.boundingBox();

--- a/mobile/openapi/lib/api/assets_api.dart
+++ b/mobile/openapi/lib/api/assets_api.dart
@@ -284,13 +284,16 @@ class AssetsApi {
   ///
   /// * [String] id (required):
   ///
+  /// * [bool] download:
+  ///   Return original asset as an attachment download
+  ///
   /// * [bool] edited:
   ///   Return edited asset if available
   ///
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<Response> downloadAssetWithHttpInfo(String id, { bool? edited, String? key, String? slug, }) async {
+  Future<Response> downloadAssetWithHttpInfo(String id, { bool? download, bool? edited, String? key, String? slug, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/assets/{id}/original'
       .replaceAll('{id}', id);
@@ -302,6 +305,9 @@ class AssetsApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
+    if (download != null) {
+      queryParams.addAll(_queryParams('', 'download', download));
+    }
     if (edited != null) {
       queryParams.addAll(_queryParams('', 'edited', edited));
     }
@@ -334,14 +340,17 @@ class AssetsApi {
   ///
   /// * [String] id (required):
   ///
+  /// * [bool] download:
+  ///   Return original asset as an attachment download
+  ///
   /// * [bool] edited:
   ///   Return edited asset if available
   ///
   /// * [String] key:
   ///
   /// * [String] slug:
-  Future<MultipartFile?> downloadAsset(String id, { bool? edited, String? key, String? slug, }) async {
-    final response = await downloadAssetWithHttpInfo(id,  edited: edited, key: key, slug: slug, );
+  Future<MultipartFile?> downloadAsset(String id, { bool? download, bool? edited, String? key, String? slug, }) async {
+    final response = await downloadAssetWithHttpInfo(id,  download: download, edited: edited, key: key, slug: slug, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4088,6 +4088,16 @@
         "operationId": "downloadAsset",
         "parameters": [
           {
+            "name": "download",
+            "required": false,
+            "in": "query",
+            "description": "Return original asset as an attachment download",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
             "name": "edited",
             "required": false,
             "in": "query",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -4831,7 +4831,8 @@ export function getAssetOcr({ id }: {
 /**
  * Download original asset
  */
-export function downloadAsset({ edited, id, key, slug }: {
+export function downloadAsset({ download, edited, id, key, slug }: {
+    download?: boolean;
     edited?: boolean;
     id: string;
     key?: string;
@@ -4841,6 +4842,7 @@ export function downloadAsset({ edited, id, key, slug }: {
         status: 200;
         data: Blob;
     }>(`/assets/${encodeURIComponent(id)}/original${QS.query(QS.explode({
+        download,
         edited,
         key,
         slug

--- a/server/src/backends/disk-storage.backend.spec.ts
+++ b/server/src/backends/disk-storage.backend.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { DiskStorageBackend } from 'src/backends/disk-storage.backend';
+import { CacheControl } from 'src/enum';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 describe('DiskStorageBackend', () => {
@@ -76,7 +77,10 @@ describe('DiskStorageBackend', () => {
 
   describe('getServeStrategy', () => {
     it('should always return file strategy with full path', async () => {
-      const strategy = await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', 'image/webp');
+      const strategy = await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', {
+        contentType: 'image/webp',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
       expect(strategy).toEqual({
         type: 'file',
         path: join(testDir, 'thumbs/user1/ab/cd/thumb.webp'),

--- a/server/src/backends/disk-storage.backend.ts
+++ b/server/src/backends/disk-storage.backend.ts
@@ -3,7 +3,7 @@ import { access, mkdir, opendir, rm, stat, unlink, writeFile } from 'node:fs/pro
 import { dirname, isAbsolute, join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
+import { ServeOptions, ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
 
 export class DiskStorageBackend implements StorageBackend {
   constructor(private mediaLocation: string) {}
@@ -58,7 +58,7 @@ export class DiskStorageBackend implements StorageBackend {
     return this.getFolderSize(this.resolvePath(prefix));
   }
 
-  getServeStrategy(key: string, _contentType: string): Promise<ServeStrategy> {
+  getServeStrategy(key: string, _options: ServeOptions): Promise<ServeStrategy> {
     return Promise.resolve({ type: 'file', path: this.resolvePath(key) });
   }
 

--- a/server/src/backends/s3-storage.backend.integration.spec.ts
+++ b/server/src/backends/s3-storage.backend.integration.spec.ts
@@ -2,6 +2,7 @@ import { CreateBucketCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/cl
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
+import { CacheControl } from 'src/enum';
 import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -100,7 +101,10 @@ describe.skipIf(!canRunDocker)('S3StorageBackend integration (MinIO)', () => {
 
   it('should return presigned URL in redirect mode', async () => {
     await backend.put('test/presigned.txt', Buffer.from('presigned data'));
-    const strategy = await backend.getServeStrategy('test/presigned.txt', 'text/plain');
+    const strategy = await backend.getServeStrategy('test/presigned.txt', {
+      contentType: 'text/plain',
+      cacheControl: CacheControl.PrivateWithCache,
+    });
     expect(strategy.type).toBe('redirect');
     if (strategy.type === 'redirect') {
       expect(strategy.url).toContain('test/presigned.txt');
@@ -156,7 +160,10 @@ describe.skipIf(!canRunDocker)('S3StorageBackend integration (MinIO)', () => {
     });
 
     await backend.put('test/proxy.txt', Buffer.from('proxy content'));
-    const strategy = await proxyBackend.getServeStrategy('test/proxy.txt', 'text/plain');
+    const strategy = await proxyBackend.getServeStrategy('test/proxy.txt', {
+      contentType: 'text/plain',
+      cacheControl: CacheControl.PrivateWithCache,
+    });
     expect(strategy.type).toBe('stream');
     if (strategy.type === 'stream') {
       const chunks: Buffer[] = [];

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -27,9 +27,10 @@ vi.mock('@aws-sdk/lib-storage', () => ({
   })),
 }));
 
-import { S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
+import { CacheControl } from 'src/enum';
 
 describe('S3StorageBackend', () => {
   let backend: S3StorageBackend;
@@ -118,12 +119,52 @@ describe('S3StorageBackend', () => {
 
   describe('getServeStrategy', () => {
     it('should return redirect with presigned URL when serveMode is redirect', async () => {
-      const strategy = await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', 'image/webp');
+      const strategy = await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', {
+        contentType: 'image/webp',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
       expect(strategy.type).toBe('redirect');
       if (strategy.type === 'redirect') {
         expect(strategy.url).toContain('X-Amz-Signature');
       }
       expect(getSignedUrl).toHaveBeenCalled();
+    });
+
+    it('should include response override metadata in redirect presigned URLs', async () => {
+      const strategy = await backend.getServeStrategy('upload/user1/photo.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+        fileName: 'Vacation Photo.jpg',
+        disposition: 'attachment',
+      });
+
+      expect(strategy.type).toBe('redirect');
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          Key: 'upload/user1/photo.jpg',
+          ResponseContentType: 'image/jpeg',
+          ResponseContentDisposition: `attachment; filename*=UTF-8''Vacation%20Photo.jpg`,
+        }),
+      );
+    });
+
+    it('should sign a high-cardinality redirect burst without opening S3 read streams', async () => {
+      const strategies = await Promise.all(
+        Array.from({ length: 200 }, (_, index) =>
+          backend.getServeStrategy(`thumbs/user1/aa/bb/thumb-${index}.webp`, {
+            contentType: 'image/webp',
+            cacheControl: CacheControl.PrivateWithCache,
+            fileName: `thumb-${index}.webp`,
+            disposition: 'inline',
+          }),
+        ),
+      );
+
+      expect(strategies).toHaveLength(200);
+      expect(strategies.every((strategy) => strategy.type === 'redirect')).toBe(true);
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(getSignedUrl).toHaveBeenCalledTimes(200);
     });
 
     it('should return stream when serveMode is proxy', async () => {
@@ -143,7 +184,10 @@ describe('S3StorageBackend', () => {
         ContentLength: 7,
       });
 
-      const strategy = await proxyBackend.getServeStrategy('key.jpg', 'image/jpeg');
+      const strategy = await proxyBackend.getServeStrategy('key.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
       expect(strategy.type).toBe('stream');
     });
 
@@ -165,8 +209,14 @@ describe('S3StorageBackend', () => {
         )
         .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
 
-      const first = proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const second = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
+      const first = proxyBackend.getServeStrategy('first.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+      const second = proxyBackend.getServeStrategy('second.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
       await Promise.resolve();
 
       expect(proxyClient.send).toHaveBeenCalledTimes(1);
@@ -195,8 +245,14 @@ describe('S3StorageBackend', () => {
         .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('first')]), ContentLength: 5 })
         .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
 
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
+      const first = await proxyBackend.getServeStrategy('first.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+      const secondPromise = proxyBackend.getServeStrategy('second.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
       expect(proxyClient.send).toHaveBeenCalledTimes(1);
       if (first.type === 'stream') {
         for await (const _chunk of first.stream) {
@@ -223,8 +279,16 @@ describe('S3StorageBackend', () => {
         ContentLength: 6,
       });
 
-      await expect(proxyBackend.getServeStrategy('first.jpg', 'image/jpeg')).rejects.toThrow('denied');
-      const second = await proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
+      await expect(
+        proxyBackend.getServeStrategy('first.jpg', {
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+      ).rejects.toThrow('denied');
+      const second = await proxyBackend.getServeStrategy('second.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
 
       expect(second.type).toBe('stream');
       expect(proxyClient.send).toHaveBeenCalledTimes(2);
@@ -248,8 +312,14 @@ describe('S3StorageBackend', () => {
         .mockResolvedValueOnce({ Body: erroringStream, ContentLength: 5 })
         .mockResolvedValueOnce({ Body: Readable.from([Buffer.from('second')]), ContentLength: 6 });
 
-      const first = await proxyBackend.getServeStrategy('first.jpg', 'image/jpeg');
-      const secondPromise = proxyBackend.getServeStrategy('second.jpg', 'image/jpeg');
+      const first = await proxyBackend.getServeStrategy('first.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+      const secondPromise = proxyBackend.getServeStrategy('second.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
       if (first.type === 'stream') {
         await expect(
           (async () => {
@@ -266,7 +336,10 @@ describe('S3StorageBackend', () => {
     });
 
     it('should not acquire proxy read slots in redirect mode', async () => {
-      const strategy = await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', 'image/webp');
+      const strategy = await backend.getServeStrategy('thumbs/user1/ab/cd/thumb.webp', {
+        contentType: 'image/webp',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
 
       expect(strategy.type).toBe('redirect');
       expect(mockSend).not.toHaveBeenCalled();

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -188,11 +188,9 @@ export class S3StorageBackend implements StorageBackend {
       );
     }
 
-    const url = await getSignedUrl(
-      this.client,
-      new GetObjectCommand(commandInput),
-      { expiresIn: this.presignedUrlExpiry },
-    );
+    const url = await getSignedUrl(this.client, new GetObjectCommand(commandInput), {
+      expiresIn: this.presignedUrlExpiry,
+    });
 
     return { type: 'redirect', url };
   }

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -2,6 +2,7 @@ import {
   DeleteObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
+  GetObjectCommandInput,
   HeadObjectCommand,
   ListObjectsV2Command,
   S3Client,
@@ -15,7 +16,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
+import { ServeOptions, ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
+import { getContentDispositionHeader } from 'src/utils/file';
 
 class AsyncLimiter {
   private active = 0;
@@ -162,7 +164,7 @@ export class S3StorageBackend implements StorageBackend {
     return stream;
   }
 
-  async getServeStrategy(key: string, contentType: string): Promise<ServeStrategy> {
+  async getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy> {
     if (this.serveMode === 'proxy') {
       const release = await this.proxyReadLimiter.acquire();
       try {
@@ -174,13 +176,21 @@ export class S3StorageBackend implements StorageBackend {
       }
     }
 
+    const commandInput: GetObjectCommandInput = {
+      Bucket: this.bucket,
+      Key: key,
+      ResponseContentType: options.contentType,
+    };
+    if (options.fileName) {
+      commandInput.ResponseContentDisposition = getContentDispositionHeader(
+        options.disposition ?? 'inline',
+        options.fileName,
+      );
+    }
+
     const url = await getSignedUrl(
       this.client,
-      new GetObjectCommand({
-        Bucket: this.bucket,
-        Key: key,
-        ResponseContentType: contentType,
-      }),
+      new GetObjectCommand(commandInput),
       { expiresIn: this.presignedUrlExpiry },
     );
 

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -165,6 +165,7 @@ const AssetCopySchema = z
 const AssetDownloadOriginalSchema = z
   .object({
     edited: stringToBool.default(false).optional().describe('Return edited asset if available'),
+    download: stringToBool.default(false).optional().describe('Return original asset as an attachment download'),
   })
   .meta({ id: 'AssetDownloadOriginalDto' });
 

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -1,4 +1,13 @@
 import { Readable } from 'node:stream';
+import { CacheControl } from 'src/enum';
+import type { ContentDisposition } from 'src/utils/file';
+
+export type ServeOptions = {
+  contentType: string;
+  cacheControl: CacheControl;
+  fileName?: string;
+  disposition?: ContentDisposition;
+};
 
 export type ServeStrategy =
   | { type: 'file'; path: string }
@@ -25,7 +34,7 @@ export interface StorageBackend {
   getPrefixUsage(prefix: string): Promise<number>;
 
   /** Determine how to serve this file to a client */
-  getServeStrategy(key: string, contentType: string): Promise<ServeStrategy>;
+  getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy>;
 
   /**
    * Download content to a local temp file for processing by tools

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -511,6 +511,22 @@ describe(AssetMediaService.name, () => {
       );
     });
 
+    it('should mark explicit original downloads as attachments', async () => {
+      const asset = AssetFactory.create();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForOriginal.mockResolvedValue(asset);
+
+      await expect(sut.downloadOriginal(authStub.admin, asset.id, { download: true })).resolves.toEqual(
+        new ImmichFileResponse({
+          path: asset.originalPath,
+          fileName: asset.originalFileName,
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithCache,
+          disposition: 'attachment',
+        }),
+      );
+    });
+
     it('should create a safe redirect response for S3 originals', async () => {
       const asset = AssetFactory.create({
         originalPath: 'upload/admin/aa/bb/image.jpg',

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -16,7 +16,7 @@ import { AssetMediaService } from 'src/services/asset-media.service';
 import { StorageService } from 'src/services/storage.service';
 import { UploadBody } from 'src/types';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
-import { ImmichFileResponse } from 'src/utils/file';
+import { ImmichFileResponse, ImmichRedirectResponse } from 'src/utils/file';
 import { AssetFileFactory } from 'test/factories/asset-file.factory';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
@@ -511,6 +511,41 @@ describe(AssetMediaService.name, () => {
       );
     });
 
+    it('should create a safe redirect response for S3 originals', async () => {
+      const asset = AssetFactory.create({
+        originalPath: 'upload/admin/aa/bb/image.jpg',
+        originalFileName: 'image.jpg',
+      });
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockResolvedValue({
+          type: 'redirect',
+          url: 'https://s3.example.com/image.jpg?X-Amz-Signature=abc',
+        }),
+      };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForOriginal.mockResolvedValue(asset);
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        await expect(sut.downloadOriginal(authStub.admin, asset.id, {})).resolves.toEqual(
+          expect.objectContaining({
+            url: 'https://s3.example.com/image.jpg?X-Amz-Signature=abc',
+            cacheControl: CacheControl.PrivateWithoutCache,
+          }),
+        );
+        expect(s3Backend.getServeStrategy).toHaveBeenCalledWith('upload/admin/aa/bb/image.jpg', {
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithCache,
+          fileName: 'image.jpg',
+          disposition: 'inline',
+        });
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
+    });
+
     it('should download edited file by default when edits exist', async () => {
       const editedAsset = AssetFactory.from()
         .edit()
@@ -639,6 +674,52 @@ describe(AssetMediaService.name, () => {
           fileName: `IMG_${asset.id}_thumbnail.jpg`,
         }),
       );
+    });
+
+    it('should return safe redirects for a burst of S3 thumbnail loads without API streaming', async () => {
+      const asset = AssetFactory.from()
+        .file({ type: AssetFileType.Thumbnail, path: 'thumbs/admin/aa/bb/thumb.jpg' })
+        .build();
+      const path = asset.files[0].path;
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockResolvedValue({
+          type: 'redirect',
+          url: 'https://s3.example.com/thumb.jpg?X-Amz-Signature=abc',
+        }),
+      };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForThumbnail.mockResolvedValue({ ...asset, path });
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        const results = await Promise.all(
+          Array.from({ length: 150 }, () =>
+            sut.viewThumbnail(authStub.admin, asset.id, { size: AssetMediaSize.THUMBNAIL }),
+          ),
+        );
+
+        expect(results).toHaveLength(150);
+        expect(results.every((result) => result instanceof ImmichRedirectResponse)).toBe(true);
+        for (const result of results) {
+          expect(result).toEqual(
+            expect.objectContaining({
+              url: 'https://s3.example.com/thumb.jpg?X-Amz-Signature=abc',
+              cacheControl: CacheControl.PrivateWithoutCache,
+            }),
+          );
+        }
+        expect(s3Backend.getServeStrategy).toHaveBeenCalledTimes(150);
+        expect(s3Backend.getServeStrategy).toHaveBeenNthCalledWith(1, path, {
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithCache,
+          fileName: `IMG_${asset.id}_thumbnail.jpg`,
+          disposition: 'inline',
+        });
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
     });
 
     it('should get preview file', async () => {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -182,6 +182,7 @@ export class AssetMediaService extends BaseService {
       mimeTypes.lookup(path),
       CacheControl.PrivateWithCache,
       getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
+      dto.download ? 'attachment' : 'inline',
     );
   }
 

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -72,7 +72,13 @@ import { UserTable } from 'src/schema/tables/user.table';
 import { GenerateThumbnailOptions, ImageDimensions } from 'src/types';
 import { AccessRequest, checkAccess, requireAccess } from 'src/utils/access';
 import { getConfig, updateConfig } from 'src/utils/config';
-import { ImmichFileResponse, ImmichMediaResponse, ImmichRedirectResponse, ImmichStreamResponse } from 'src/utils/file';
+import {
+  ContentDisposition,
+  ImmichFileResponse,
+  ImmichMediaResponse,
+  ImmichRedirectResponse,
+  ImmichStreamResponse,
+} from 'src/utils/file';
 import { clamp } from 'src/utils/misc';
 
 type FaceThumbnailBounds = {
@@ -249,11 +255,18 @@ export class BaseService {
     contentType: string,
     cacheControl: CacheControl,
     fileName?: string,
+    disposition: ContentDisposition = 'inline',
   ): Promise<ImmichMediaResponse> {
     // lazy import to avoid circular dependency (StorageService extends BaseService)
     const { StorageService } = await import('./storage.service.js');
     const backend = StorageService.resolveBackendForKey(filePath);
-    const strategy: ServeStrategy = await backend.getServeStrategy(filePath, contentType);
+    const strategy: ServeStrategy = await backend.getServeStrategy(filePath, {
+      contentType,
+      cacheControl,
+      fileName,
+      disposition,
+    });
+    const responseDisposition = disposition === 'inline' ? undefined : disposition;
 
     switch (strategy.type) {
       case 'file': {
@@ -262,12 +275,13 @@ export class BaseService {
           contentType,
           cacheControl,
           fileName,
+          disposition: responseDisposition,
         });
       }
       case 'redirect': {
         return new ImmichRedirectResponse({
           url: strategy.url,
-          cacheControl,
+          cacheControl: CacheControl.PrivateWithoutCache,
         });
       }
       case 'stream': {
@@ -277,6 +291,7 @@ export class BaseService {
           length: strategy.length,
           cacheControl,
           fileName,
+          disposition: responseDisposition,
         });
       }
     }

--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -240,6 +240,56 @@ describe('sendFile with ImmichMediaResponse', () => {
     expect(res.header).toHaveBeenCalledWith('Content-Disposition', `inline; filename*=UTF-8''my-photo.jpg`);
   });
 
+  it('should send file response with attachment disposition', async () => {
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      headersSent: false,
+      sendFile: vi.fn((_path: string, _options: any, cb: (err?: Error) => void) => cb()),
+    } as any;
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichFileResponse({
+          path: '/tmp/test-file.jpg',
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithCache,
+          fileName: 'my photo.jpg',
+          disposition: 'attachment',
+        }),
+      mockLogger,
+    );
+
+    expect(res.header).toHaveBeenCalledWith('Content-Disposition', `attachment; filename*=UTF-8''my%20photo.jpg`);
+  });
+
+  it('should set expiry-safe cache-control for redirect responses', async () => {
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      redirect: vi.fn(),
+      headersSent: false,
+    } as any;
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichRedirectResponse({
+          url: 'https://s3.example.com/signed-url',
+          cacheControl: CacheControl.PrivateWithoutCache,
+        }),
+      mockLogger,
+    );
+
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, no-cache, no-transform');
+    expect(res.redirect).toHaveBeenCalledWith('https://s3.example.com/signed-url');
+  });
+
   it('should reject file path with traversal segments', async () => {
     const res = {
       set: vi.fn(),

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -21,11 +21,18 @@ export function getLivePhotoMotionFilename(stillName: string, motionName: string
   return getFileNameWithoutExtension(stillName) + extname(motionName);
 }
 
+export type ContentDisposition = 'inline' | 'attachment';
+
+export const getContentDispositionHeader = (disposition: ContentDisposition, fileName: string): string => {
+  return `${disposition}; filename*=UTF-8''${encodeURIComponent(fileName)}`;
+};
+
 export class ImmichFileResponse {
   public readonly path!: string;
   public readonly contentType!: string;
   public readonly cacheControl!: CacheControl;
   public readonly fileName?: string;
+  public readonly disposition?: ContentDisposition;
 
   constructor(response: ImmichFileResponse) {
     Object.assign(this, response);
@@ -47,6 +54,7 @@ export class ImmichStreamResponse {
   public readonly length?: number;
   public readonly cacheControl!: CacheControl;
   public readonly fileName?: string;
+  public readonly disposition?: ContentDisposition;
 
   constructor(response: ImmichStreamResponse) {
     Object.assign(this, response);
@@ -108,7 +116,7 @@ export const sendFile = async (
         res.header('Content-Length', String(file.length));
       }
       if (file.fileName) {
-        res.header('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(file.fileName)}`);
+        res.header('Content-Disposition', getContentDispositionHeader(file.disposition ?? 'inline', file.fileName));
       }
       file.stream.pipe(res);
       return;
@@ -122,7 +130,7 @@ export const sendFile = async (
 
     res.header('Content-Type', file.contentType);
     if (file.fileName) {
-      res.header('Content-Disposition', `inline; filename*=UTF-8''${encodeURIComponent(file.fileName)}`);
+      res.header('Content-Disposition', getContentDispositionHeader(file.disposition ?? 'inline', file.fileName));
     }
 
     const resolvedPath = resolve(file.path);

--- a/web/src/lib/actions/__test__/image-loader.spec.ts
+++ b/web/src/lib/actions/__test__/image-loader.spec.ts
@@ -1,0 +1,38 @@
+import { loadImage } from '$lib/actions/image-loader.svelte';
+
+vi.mock('$lib/utils/sw-messaging', () => ({
+  cancelImageUrl: vi.fn(),
+}));
+
+describe('loadImage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets anonymous CORS before assigning src', () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const img = originalCreateElement('img');
+    const operations: string[] = [];
+
+    Object.defineProperty(img, 'crossOrigin', {
+      configurable: true,
+      set: (value: string) => operations.push(`crossOrigin:${value}`),
+    });
+    Object.defineProperty(img, 'src', {
+      configurable: true,
+      set: (value: string) => operations.push(`src:${value}`),
+    });
+
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+      if (tagName === 'img') {
+        return img;
+      }
+
+      return originalCreateElement(tagName);
+    }) as typeof document.createElement);
+
+    loadImage('/preview.jpg', vi.fn(), vi.fn());
+
+    expect(operations).toEqual(['crossOrigin:anonymous', 'src:/preview.jpg']);
+  });
+});

--- a/web/src/lib/actions/image-loader.svelte.ts
+++ b/web/src/lib/actions/image-loader.svelte.ts
@@ -9,6 +9,7 @@ export function loadImage(src: string, onLoad: () => void, onError: () => void, 
   const img = document.createElement('img');
   img.addEventListener('load', handleLoad);
   img.addEventListener('error', handleError);
+  img.crossOrigin = 'anonymous';
 
   onStart?.();
   img.src = src;

--- a/web/src/lib/components/Image.spec.ts
+++ b/web/src/lib/components/Image.spec.ts
@@ -18,6 +18,20 @@ describe('Image component', () => {
     expect(img!.getAttribute('src')).toBe('/test.jpg');
   });
 
+  it('loads images with anonymous CORS by default', () => {
+    const { baseElement } = render(Image, { src: '/test.jpg', alt: 'test' });
+    const img = baseElement.querySelector('img')!;
+
+    expect(img.getAttribute('crossorigin')).toBe('anonymous');
+  });
+
+  it('allows callers to override the CORS mode', () => {
+    const { baseElement } = render(Image, { src: '/test.jpg', alt: 'test', crossorigin: 'use-credentials' });
+    const img = baseElement.querySelector('img')!;
+
+    expect(img.getAttribute('crossorigin')).toBe('use-credentials');
+  });
+
   it('does not render an img element when src is undefined', () => {
     const { baseElement } = render(Image, { src: undefined });
     const img = baseElement.querySelector('img');

--- a/web/src/lib/components/Image.svelte
+++ b/web/src/lib/components/Image.svelte
@@ -12,7 +12,7 @@
     ref?: HTMLImageElement;
   };
 
-  let { src, onStart, onLoad, onError, ref = $bindable(), ...rest }: Props = $props();
+  let { src, onStart, onLoad, onError, ref = $bindable(), crossorigin = 'anonymous', ...rest }: Props = $props();
 
   let capturedSource: string | undefined = $state();
   let loaded = $state(false);
@@ -72,6 +72,7 @@
     <img
       bind:this={ref}
       src={capturedSource}
+      {crossorigin}
       {...rest}
       style:visibility={isFirefox && !loaded ? 'hidden' : undefined}
       onload={handleLoad}

--- a/web/src/lib/managers/edit/transform-manager.svelte.spec.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.spec.ts
@@ -1,0 +1,11 @@
+import source from './transform-manager.svelte.ts?raw';
+
+describe('transformManager', () => {
+  it('sets anonymous CORS before loading the preview image', () => {
+    const crossOriginIndex = source.indexOf("this.imgElement.crossOrigin = 'anonymous';");
+    const srcIndex = source.indexOf('this.imgElement.src = imageURL;');
+
+    expect(crossOriginIndex).toBeGreaterThanOrEqual(0);
+    expect(crossOriginIndex).toBeLessThan(srcIndex);
+  });
+});

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -189,6 +189,7 @@ class TransformManager implements EditToolManager {
     this.originalImageSize = { width: originalSize.width ?? 0, height: originalSize.height ?? 0 };
 
     this.imgElement = new Image();
+    this.imgElement.crossOrigin = 'anonymous';
 
     const imageURL = getAssetMediaUrl({
       id: asset.id,

--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -10,18 +10,36 @@ import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 import { userAdminFactory } from '@test-data/factories/user-factory';
 import { vitest } from 'vitest';
 
+const { downloadUrlMock } = vitest.hoisted(() => ({
+  downloadUrlMock: vitest.fn(),
+}));
+
 vitest.mock('@immich/ui', () => ({
   toastManager: {
     primary: vitest.fn(),
   },
 }));
 
+vitest.mock('$lib/utils/asset-utils', async () => {
+  const originalModule = await vitest.importActual<typeof import('$lib/utils/asset-utils')>('$lib/utils/asset-utils');
+  return {
+    ...originalModule,
+    downloadUrl: downloadUrlMock,
+  };
+});
+
 vitest.mock('$lib/utils/i18n', () => ({
   getFormatter: vitest.fn(),
   getPreferredLocale: vitest.fn(),
 }));
 
-vitest.mock('@immich/sdk');
+vitest.mock('@immich/sdk', async () => {
+  const originalModule = await vitest.importActual<typeof import('@immich/sdk')>('@immich/sdk');
+  return {
+    ...originalModule,
+    getAssetInfo: vitest.fn(),
+  };
+});
 
 vitest.mock('$lib/managers/asset-viewer-manager.svelte', () => ({
   assetViewerManager: {
@@ -177,6 +195,23 @@ describe('AssetService', () => {
       expect($t).toHaveBeenNthCalledWith(1, 'downloading_asset_filename', { values: { filename: 'asset.heic' } });
       expect($t).toHaveBeenNthCalledWith(2, 'downloading_asset_filename', { values: { filename: 'asset-motion.mov' } });
       expect(toastManager.primary).toHaveBeenCalledWith('formatter');
+    });
+
+    it('should request attachment disposition for single-asset downloads', async () => {
+      downloadUrlMock.mockClear();
+      const $t = vitest.fn().mockReturnValue('formatter');
+      vitest.mocked(getFormatter).mockResolvedValue($t);
+      const asset = assetFactory.build({ id: 'asset-1', originalFileName: 'asset.jpg', thumbhash: 'cache-1' });
+
+      await handleDownloadAsset(asset, { edited: false });
+
+      expect(downloadUrlMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/assets/asset-1/original'),
+        'asset.jpg',
+      );
+      expect(downloadUrlMock.mock.calls[0][0]).toContain('download=true');
+      expect(downloadUrlMock.mock.calls[0][0]).toContain('edited=false');
+      expect(downloadUrlMock.mock.calls[0][0]).toContain('c=cache-1');
     });
   });
 });

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -378,7 +378,7 @@ export const handleDownloadAsset = async (asset: AssetResponseDto, { edited }: {
 
     try {
       toastManager.primary($t('downloading_asset_filename', { values: { filename } }));
-      downloadUrl(getAssetMediaUrl({ id, size: AssetMediaSize.Original, edited, cacheKey }), filename);
+      downloadUrl(getAssetMediaUrl({ id, size: AssetMediaSize.Original, edited, cacheKey, download: true }), filename);
     } catch (error) {
       handleError(error, $t('errors.error_downloading', { values: { filename } }));
     }

--- a/web/src/lib/utils.spec.ts
+++ b/web/src/lib/utils.spec.ts
@@ -1,9 +1,37 @@
-import { getAssetUrl, getMemoryTitle, getReleaseType } from '$lib/utils';
-import { AssetTypeEnum, MemoryType, type MemoryResponseDto } from '@immich/sdk';
+import { getAssetMediaUrl, getAssetUrl, getMemoryTitle, getReleaseType } from '$lib/utils';
+import { AssetMediaSize, AssetTypeEnum, MemoryType, type MemoryResponseDto } from '@immich/sdk';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 
 describe('utils', () => {
+  describe(getAssetMediaUrl.name, () => {
+    it('adds download=true to original media URLs when requested', () => {
+      const url = getAssetMediaUrl({
+        id: 'asset-1',
+        size: AssetMediaSize.Original,
+        edited: false,
+        cacheKey: 'cache-1',
+        download: true,
+      });
+
+      expect(url).toContain('/api/assets/asset-1/original');
+      expect(url).toContain('download=true');
+      expect(url).toContain('edited=false');
+      expect(url).toContain('c=cache-1');
+    });
+
+    it('does not add download=true to thumbnail media URLs', () => {
+      const url = getAssetMediaUrl({
+        id: 'asset-1',
+        size: AssetMediaSize.Thumbnail,
+        download: true,
+      });
+
+      expect(url).toContain('/api/assets/asset-1/thumbnail');
+      expect(url).not.toContain('download=true');
+    });
+  });
+
   describe(getAssetUrl.name, () => {
     it('should return thumbnail URL for static images', () => {
       const asset = assetFactory.build({

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -189,7 +189,13 @@ export const createUrl = (path: string, parameters?: Record<string, unknown>) =>
   return getBaseUrl() + url.pathname + url.search + url.hash;
 };
 
-type AssetUrlOptions = { id: string; cacheKey?: string | null; edited?: boolean; size?: AssetMediaSize };
+type AssetUrlOptions = {
+  id: string;
+  cacheKey?: string | null;
+  edited?: boolean;
+  size?: AssetMediaSize;
+  download?: boolean;
+};
 
 export const getAssetUrl = ({
   asset,
@@ -234,10 +240,16 @@ export const targetImageSize = (asset: AssetResponseDto, forceOriginal: boolean)
 };
 
 export const getAssetMediaUrl = (options: AssetUrlOptions) => {
-  const { id, size, cacheKey: c, edited = true } = options;
+  const { id, size, cacheKey: c, edited = true, download } = options;
   const isOriginal = size === AssetMediaSize.Original;
   const path = isOriginal ? getAssetOriginalPath(id) : getAssetThumbnailPath(id);
-  return createUrl(path, { ...authManager.params, size: isOriginal ? undefined : size, c, edited });
+  return createUrl(path, {
+    ...authManager.params,
+    size: isOriginal ? undefined : size,
+    c,
+    edited,
+    download: isOriginal ? download : undefined,
+  });
 };
 
 export const getAssetPlaybackUrl = (options: AssetUrlOptions) => {

--- a/web/src/lib/utils/cast/gcast-destination.svelte.spec.ts
+++ b/web/src/lib/utils/cast/gcast-destination.svelte.spec.ts
@@ -1,0 +1,107 @@
+import * as gcast from './gcast-destination.svelte';
+
+vi.mock('$lib/managers/cast-manager.svelte', () => ({
+  CastDestinationType: { GCAST: 'gcast' },
+  CastState: { IDLE: 'IDLE', PLAYING: 'PLAYING' },
+}));
+
+type GCastModule = typeof gcast & {
+  getMediaContentType?: (mediaUrl: string) => Promise<string>;
+};
+
+class MediaInfo {
+  constructor(
+    public contentId: string,
+    public contentType: string,
+  ) {}
+}
+
+class QueueItem {
+  constructor(public media: MediaInfo) {}
+}
+
+class QueueLoadRequest {
+  repeatMode: string | undefined;
+
+  constructor(public items: QueueItem[]) {}
+}
+
+const getMediaContentType = () => (gcast as GCastModule).getMediaContentType!;
+
+const stubFetch = (contentType: string | null = 'image/jpeg') => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(undefined, {
+      headers: contentType ? { 'content-type': contentType } : undefined,
+    }),
+  );
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  return fetchMock;
+};
+
+const stubChrome = () => {
+  vi.stubGlobal('chrome', {
+    cast: {
+      media: {
+        MediaInfo,
+        QueueItem,
+        QueueLoadRequest,
+        RepeatMode: { SINGLE: 'SINGLE' },
+      },
+    },
+  });
+};
+
+describe('getMediaContentType', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses a ranged GET request to read media headers', async () => {
+    const fetchMock = stubFetch('image/jpeg');
+
+    await expect(getMediaContentType()('/media/original.jpg')).resolves.toBe('image/jpeg');
+
+    expect(fetchMock).toHaveBeenCalledWith('/media/original.jpg', {
+      method: 'GET',
+      headers: { Range: 'bytes=0-0' },
+    });
+  });
+
+  it('throws when the media response has no content type', async () => {
+    stubFetch(null);
+
+    await expect(getMediaContentType()('/media/original.jpg')).rejects.toThrow('No content type found for media url');
+  });
+});
+
+describe('GCastDestination', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads media using the content type from a ranged GET probe', async () => {
+    const fetchMock = stubFetch('image/heic');
+    stubChrome();
+    const destination = new gcast.GCastDestination();
+    const queueLoad = vi.fn();
+
+    destination.isAvailable = true;
+    destination.isConnected = true;
+    (destination as unknown as { session: { queueLoad: typeof queueLoad } }).session = { queueLoad };
+
+    await destination.loadMedia('/api/assets/asset-1/original?c=cache-1', 'session-1');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/assets/asset-1/original?c=cache-1', {
+      method: 'GET',
+      headers: { Range: 'bytes=0-0' },
+    });
+    expect(queueLoad).toHaveBeenCalledOnce();
+
+    const queueRequest = queueLoad.mock.calls[0][0] as QueueLoadRequest;
+    expect(queueRequest.repeatMode).toBe('SINGLE');
+    expect(queueRequest.items[0].media.contentId).toBe('/api/assets/asset-1/original?c=cache-1&sessionKey=session-1');
+    expect(queueRequest.items[0].media.contentType).toBe('image/heic');
+  });
+});

--- a/web/src/lib/utils/cast/gcast-destination.svelte.ts
+++ b/web/src/lib/utils/cast/gcast-destination.svelte.ts
@@ -10,6 +10,17 @@ enum SESSION_DISCOVERY_CAUSE {
   ACTIVE_SESSION,
 }
 
+export const getMediaContentType = async (mediaUrl: string): Promise<string> => {
+  const mediaResponse = await fetch(mediaUrl, { method: 'GET', headers: { Range: 'bytes=0-0' } });
+  const contentType = mediaResponse.headers.get('content-type');
+
+  if (!contentType) {
+    throw new Error('No content type found for media url');
+  }
+
+  return contentType;
+};
+
 export class GCastDestination implements ICastDestination {
   type = CastDestinationType.GCAST;
   isAvailable = $state<boolean>(false);
@@ -103,12 +114,7 @@ export class GCastDestination implements ICastDestination {
 
     // we need to send content type in the request
     // in the future we can swap this out for an API call to get image metadata
-    const assetHead = await fetch(mediaUrl, { method: 'HEAD' });
-    const contentType = assetHead.headers.get('content-type');
-
-    if (!contentType) {
-      throw new Error('No content type found for media url');
-    }
+    const contentType = await getMediaContentType(mediaUrl);
 
     // build the authenticated media request and send it to the cast device
     const authenticatedUrl = `${mediaUrl}&sessionKey=${sessionKey}`;

--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -1,6 +1,7 @@
 import type { Faces } from '$lib/stores/people.store';
 import type { Size } from '$lib/utils/container-utils';
-import { getBoundingBox } from '$lib/utils/people-utils';
+import { getBoundingBox, zoomImageToBase64 } from '$lib/utils/people-utils';
+import { AssetTypeEnum } from '@immich/sdk';
 
 const makeFace = (overrides: Partial<Faces> = {}): Faces => ({
   id: 'face-1',
@@ -66,5 +67,82 @@ describe('getBoundingBox', () => {
 
     expect(boxes).toHaveLength(2);
     expect(boxes[0].left).toBeLessThan(boxes[1].left);
+  });
+});
+
+describe(zoomImageToBase64.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sets anonymous CORS before loading video thumbnails and face crop images', async () => {
+    const operations: Array<{ imageIndex: number; type: 'crossOrigin' | 'src'; value: string | null }> = [];
+    let imageCount = 0;
+
+    class TestImage extends EventTarget {
+      readonly imageIndex = imageCount++;
+      naturalWidth = 4000;
+      naturalHeight = 3000;
+      private source = '';
+
+      set crossOrigin(value: string | null) {
+        operations.push({ imageIndex: this.imageIndex, type: 'crossOrigin', value });
+      }
+
+      get crossOrigin() {
+        return 'anonymous';
+      }
+
+      set src(value: string) {
+        this.source = value;
+        operations.push({ imageIndex: this.imageIndex, type: 'src', value });
+      }
+
+      get src() {
+        return this.source;
+      }
+
+      override addEventListener(...args: Parameters<EventTarget['addEventListener']>) {
+        super.addEventListener(...args);
+
+        if (args[0] === 'load') {
+          queueMicrotask(() => this.dispatchEvent(new Event('load')));
+        }
+      }
+    }
+
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+          toDataURL: vi.fn(() => 'data:image/png;base64,face'),
+        } as unknown as HTMLCanvasElement;
+      }
+
+      return originalCreateElement(tagName);
+    }) as typeof document.createElement);
+
+    vi.stubGlobal('Image', TestImage);
+
+    await expect(zoomImageToBase64(makeFace(), 'asset-1', AssetTypeEnum.Video, undefined)).resolves.toBe(
+      'data:image/png;base64,face',
+    );
+
+    for (const imageIndex of [0, 1]) {
+      const crossOriginIndex = operations.findIndex(
+        (operation) => operation.imageIndex === imageIndex && operation.type === 'crossOrigin',
+      );
+      const srcIndex = operations.findIndex(
+        (operation) => operation.imageIndex === imageIndex && operation.type === 'src',
+      );
+
+      expect(crossOriginIndex).toBeGreaterThanOrEqual(0);
+      expect(crossOriginIndex).toBeLessThan(srcIndex);
+      expect(operations[crossOriginIndex].value).toBe('anonymous');
+    }
   });
 });

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -39,6 +39,7 @@ export const zoomImageToBase64 = async (
   } else if (assetType === AssetTypeEnum.Video) {
     const data = getAssetMediaUrl({ id: assetId });
     const img: HTMLImageElement = new Image();
+    img.crossOrigin = 'anonymous';
     img.src = data;
 
     await new Promise<void>((resolve) => {
@@ -64,6 +65,7 @@ export const zoomImageToBase64 = async (
   const faceHeight = coordinates.y2 - coordinates.y1;
 
   const faceImage = new Image();
+  faceImage.crossOrigin = 'anonymous';
   faceImage.src = image.src;
 
   await new Promise((resolve) => {

--- a/web/src/service-worker/index.spec.ts
+++ b/web/src/service-worker/index.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addEventListenerMock = vi.fn();
+
+vi.mock('./request', () => ({
+  handleCancel: vi.fn(),
+  handleFetch: vi.fn(() => Promise.resolve(new Response())),
+}));
+
+const loadServiceWorker = async () => {
+  vi.resetModules();
+  addEventListenerMock.mockClear();
+  vi.stubGlobal('addEventListener', addEventListenerMock);
+  vi.stubGlobal('clients', { claim: vi.fn() });
+  vi.stubGlobal('skipWaiting', vi.fn());
+
+  await import('./index');
+
+  return addEventListenerMock.mock.calls;
+};
+
+describe('service worker', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not register a fetch listener', async () => {
+    const calls = await loadServiceWorker();
+
+    expect(calls).not.toContainEqual(expect.arrayContaining(['fetch']));
+  });
+
+  it('does not respond to asset media requests during a thumbnail burst', async () => {
+    const calls = await loadServiceWorker();
+    const fetchListeners = calls
+      .filter(([eventName]) => eventName === 'fetch')
+      .map(([, listener]) => listener as (event: FetchEvent) => void);
+
+    const respondWith = vi.fn();
+
+    for (let index = 0; index < 200; index++) {
+      const id = `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+      const request = new Request(`${location.origin}/api/assets/${id}/thumbnail?c=cache-${index}`);
+      const event = { request, respondWith } as unknown as FetchEvent;
+
+      for (const listener of fetchListeners) {
+        listener(event);
+      }
+    }
+
+    expect(respondWith).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/service-worker/index.ts
+++ b/web/src/service-worker/index.ts
@@ -4,9 +4,6 @@
 /// <reference lib="webworker" />
 
 import { installMessageListener } from './messaging';
-import { handleFetch as handleAssetFetch } from './request';
-
-const ASSET_REQUEST_REGEX = /^\/api\/assets\/[a-f0-9-]+\/(original|thumbnail)/;
 
 const sw = globalThis as unknown as ServiceWorkerGlobalScope;
 
@@ -18,20 +15,6 @@ const handleInstall = (event: ExtendableEvent) => {
   event.waitUntil(sw.skipWaiting());
 };
 
-const handleFetch = (event: FetchEvent): void => {
-  if (event.request.method !== 'GET') {
-    return;
-  }
-
-  // Cache requests for thumbnails
-  const url = new URL(event.request.url);
-  if (url.origin === self.location.origin && ASSET_REQUEST_REGEX.test(url.pathname)) {
-    event.respondWith(handleAssetFetch(event.request));
-    return;
-  }
-};
-
 sw.addEventListener('install', handleInstall, { passive: true });
 sw.addEventListener('activate', handleActivate, { passive: true });
-sw.addEventListener('fetch', handleFetch, { passive: true });
 installMessageListener();


### PR DESCRIPTION
## Why

Direct S3 media delivery changes asset media endpoints from server-proxied byte streams into responses that can redirect clients to signed S3 URLs. That reduces server bandwidth and keeps object storage as the media delivery path, but it also changes client assumptions around CORS, exposed response headers, range probing, service-worker interception, and original-download filenames.

This branch closes those gaps so the server can hand clients enough metadata for redirected media responses and the web clients can load, transform, cast, and download media correctly when the final bytes come from S3-compatible storage.

## What changed

- Added S3 media response metadata plumbing and filename preservation for original asset downloads.
- Updated storage backend/media-service contracts and OpenAPI/client generation for the new media response shape.
- Adjusted web image loading, asset fetches, transform handling, people thumbnails, and Google Cast probing to handle redirected media and CORS/range behavior.
- Stopped the service worker from intercepting asset media requests that should go directly to storage.
- Updated web e2e mocks so direct browser media requests are fulfilled without relying on service-worker interception.
- Documented the direct S3 media delivery design, rollout plan, and related environment settings.

## Validation

- `PLAYWRIGHT_DISABLE_WEBSERVER=1 pnpm exec playwright test --project=ui --reporter=line --workers=3 --retries=0`
- `pnpm run lint` in `e2e`
- `pnpm run check` in `e2e`
- `git diff --check`

CI is running on this PR.
