### PR TITLE
feat(web): add typed search filters

### DIFF
--- a/docs/docs/features/search-palette.md
+++ b/docs/docs/features/search-palette.md
@@ -221,6 +221,41 @@ When you open the palette from a page that supports inline search, Gallery prelo
 
 The URL carries the query in `q` and, when needed, the sort in `sort=asc` or `sort=desc`. Clearing the search chip removes `q` and returns the page to its normal date ordering.
 
+### Typed filter syntax
+
+You can add advanced filters directly to a palette search by typing `key:value` tokens alongside normal search text:
+
+```text
+beach person:anna from:2025 to:2026 camera:nikon
+```
+
+Pressing <kbd>Enter</kbd> applies the plain words as the search query and applies the typed filters to the current searchable page's filter state. On **Photos**, the query stays on `/photos`; inside a shared space, it stays scoped to that space. Pages without a searchable context fall back to the Photos timeline.
+
+Typed filters are a keyboard shortcut for the existing filter panel. After submission, the active filter chips and filter panel reflect the same filters, and the URL can be refreshed or shared.
+
+Supported filters:
+
+| Filter                             | Example           | Notes                                                                   |
+| ---------------------------------- | ----------------- | ----------------------------------------------------------------------- |
+| `person:<name>` or `people:<name>` | `person:anna`     | Resolves to a matching named face. Repeat to filter by multiple people. |
+| `tag:<name>` or `tags:<name>`      | `tag:nature`      | Resolves to a matching tag. Repeat to filter by multiple tags.          |
+| `from:<date>`                      | `from:2025`       | Start date. Accepts `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`.                 |
+| `to:<date>`                        | `to:2026-03`      | End date. Accepts `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`.                   |
+| `city:<value>`                     | `city:"New York"` | Filters by reverse-geocoded city.                                       |
+| `country:<value>`                  | `country:Germany` | Filters by reverse-geocoded country.                                    |
+| `camera:<value>`                   | `camera:nikon`    | Resolves to a known camera make or model.                               |
+| `type:<photo\|image\|video>`       | `type:video`      | `photo` is treated as `image`.                                          |
+| `favorite:<true\|false>`           | `favorite:true`   | Also accepts `yes`, `no`, `1`, and `0`.                                 |
+| `rating:<1-5>`                     | `rating:4`        | Filters by minimum star rating.                                         |
+
+Use quotes when a filter value contains spaces:
+
+```text
+person:"Anna Maria" city:"New York"
+```
+
+Filters are resolved only when you press <kbd>Enter</kbd>, not while you type. If a person, tag, or camera value has no match, or if multiple matches are possible, the palette stays open and asks you to fix or choose a result. Invalid filters such as `persn:anna`, `rating:9`, `from:soon`, or a repeated scalar filter block submission instead of being ignored.
+
 ## Recents
 
 Every destination or free-text search you activate is added to a **Recent** list (per user, per browser). When you reopen the palette with an empty query, your last few activations are shown immediately so you can repeat a workflow with two keystrokes.

--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -11,6 +11,8 @@ Contextual CLIP search is powered by the [VectorChord](https://github.com/tensor
 
 In addition, Gallery offers advanced search functionality, allowing you to find specific content using customizable search filters. These filters include location, one or more faces, specific albums, and more. You can try out the search filters on the [Demo site](https://demo.opennoodle.de).
 
+The Search Palette also supports typed filter syntax, so you can apply filters from the keyboard with searches like `beach person:anna from:2025 type:video`. See [Search Palette typed filter syntax](/features/search-palette#typed-filter-syntax) for the supported keys and resolution behavior.
+
 You can search the following types of content:
 
 | Type                                | Description                                           |

--- a/docs/superpowers/plans/2026-05-03-typed-search-filters.md
+++ b/docs/superpowers/plans/2026-05-03-typed-search-filters.md
@@ -132,6 +132,7 @@ export type TypedSearchParseResult = {
 ### Task 0: Baseline Verification
 
 **Files:**
+
 - Read: `open-api/typescript-sdk/package.json`
 - Read: `web/vite.config.ts`
 - No production edits
@@ -165,6 +166,7 @@ If no files changed, do not commit. If a repo-local generated artifact had to be
 ### Task 1: Parser TDD
 
 **Files:**
+
 - Create: `web/src/lib/utils/typed-search/typed-search-parser.ts`
 - Create: `web/src/lib/utils/typed-search/typed-search-parser.spec.ts`
 
@@ -390,7 +392,12 @@ export function parseTypedSearch(raw: string): TypedSearchParseResult {
     }
 
     if (RESOLUTION_KEYS.has(key as TypedSearchResolutionKey)) {
-      resolutionTokens.push({ kind: 'resolution', key: key as TypedSearchResolutionKey, raw: piece.raw, value: piece.value });
+      resolutionTokens.push({
+        kind: 'resolution',
+        key: key as TypedSearchResolutionKey,
+        raw: piece.raw,
+        value: piece.value,
+      });
       displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'pending-entity' });
       continue;
     }
@@ -460,6 +467,7 @@ git commit -m "feat(web): add typed search parser"
 ### Task 2: URL Serialization And Hydration TDD
 
 **Files:**
+
 - Modify: `web/src/lib/utils/searchable-page-search.ts`
 - Create: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
 - Create: `web/src/lib/utils/typed-search/typed-search-name-cache.ts`
@@ -656,7 +664,17 @@ export const SEARCHABLE_PAGE_FILTER_PARAMS = [
 export type SearchablePageFilterState = Partial<
   Pick<
     FilterState,
-    'personIds' | 'tagIds' | 'city' | 'country' | 'make' | 'model' | 'mediaType' | 'isFavorite' | 'rating' | 'dateAfter' | 'dateBefore'
+    | 'personIds'
+    | 'tagIds'
+    | 'city'
+    | 'country'
+    | 'make'
+    | 'model'
+    | 'mediaType'
+    | 'isFavorite'
+    | 'rating'
+    | 'dateAfter'
+    | 'dateBefore'
   >
 >;
 ```
@@ -703,7 +721,7 @@ export function buildSearchablePageUrl(
   query: string,
   sortOrder: SearchablePageSortOrder = 'relevance',
   filters?: FilterState,
-): string | null
+): string | null;
 ```
 
 Inside it, after query/sort handling:
@@ -794,6 +812,7 @@ git commit -m "feat(web): serialize typed search filters in URLs"
 ### Task 3: Destination Page Hydration TDD
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`
 - Create: `web/src/test-data/mocks/active-filters-bar-actions.stub.svelte`
@@ -945,7 +964,9 @@ vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
 
 ```ts
 it('hydrates typed filter URL params into the space FilterState', async () => {
-  mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&people=space-person-1&city=Berlin&type=video');
+  mockPage.url = new URL(
+    'https://gallery.test/spaces/space-1/photos?q=beach&people=space-person-1&city=Berlin&type=video',
+  );
 
   renderPage({ space: makeSpace(), members: [makeMember()] });
 
@@ -1127,6 +1148,7 @@ git commit -m "feat(web): hydrate typed search filters from URLs"
 ### Task 4: Resolver TDD
 
 **Files:**
+
 - Create: `web/src/lib/utils/typed-search/typed-search-resolver.ts`
 - Create: `web/src/lib/utils/typed-search/typed-search-resolver.spec.ts`
 
@@ -1249,7 +1271,10 @@ describe('resolveTypedSearchFilters', () => {
       hasUnnamedPeople: false,
     });
 
-    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna person:bob tag:travel tag:family'), {});
+    const result = await resolveTypedSearchFilters(
+      parseTypedSearch('person:anna person:bob tag:travel tag:family'),
+      {},
+    );
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -1296,7 +1321,10 @@ describe('resolveTypedSearchFilters', () => {
 
     await resolveTypedSearchFilters(parseTypedSearch('person:anna camera:nikon'), { spaceId: 'space-1' });
 
-    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }), expect.anything());
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ spaceId: 'space-1' }),
+      expect.anything(),
+    );
   });
 
   it('uses space-scoped people from filter suggestions when resolving people inside a space', async () => {
@@ -1452,10 +1480,30 @@ export async function resolveTypedSearchFilters(
         filters.personIds.push(matches[0].id);
         personNames.set(matches[0].id, matches[0].name || matches[0].id);
       } else if (matches.length === 0) {
-        issues.push({ code: 'no-match', key: 'person', raw: token.raw, value: token.value, message: `No person found for "${token.value}"` });
+        issues.push({
+          code: 'no-match',
+          key: 'person',
+          raw: token.raw,
+          value: token.value,
+          message: `No person found for "${token.value}"`,
+        });
       } else {
-        issues.push({ code: 'ambiguous', key: 'person', raw: token.raw, value: token.value, message: `Choose a person for "${token.value}"` });
-        choices.push(...matches.map((person) => ({ tokenRaw: token.raw, key: 'person' as const, id: person.id, label: person.name || person.id, value: token.value })));
+        issues.push({
+          code: 'ambiguous',
+          key: 'person',
+          raw: token.raw,
+          value: token.value,
+          message: `Choose a person for "${token.value}"`,
+        });
+        choices.push(
+          ...matches.map((person) => ({
+            tokenRaw: token.raw,
+            key: 'person' as const,
+            id: person.id,
+            label: person.name || person.id,
+            value: token.value,
+          })),
+        );
       }
     }
 
@@ -1468,7 +1516,9 @@ export async function resolveTypedSearchFilters(
     }
   }
 
-  return issues.length > 0 ? { ok: false, queryText: parsed.queryText, issues, choices } : { ok: true, queryText: parsed.queryText, filters, personNames, tagNames };
+  return issues.length > 0
+    ? { ok: false, queryText: parsed.queryText, issues, choices }
+    : { ok: true, queryText: parsed.queryText, filters, personNames, tagNames };
 }
 ```
 
@@ -1500,6 +1550,7 @@ git commit -m "feat(web): resolve typed search filters"
 ### Task 5: GlobalSearchManager Commit TDD
 
 **Files:**
+
 - Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
 - Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
 
@@ -1621,8 +1672,19 @@ describe('GlobalSearchManager typed search commit', () => {
 
   it('blocks navigation and exposes issues when resolution fails', async () => {
     const manager = new GlobalSearchManager();
-    const issue = { code: 'no-match', key: 'person', raw: 'person:anna', value: 'anna', message: 'No person found for "anna"' };
-    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({ ok: false, queryText: 'beach', issues: [issue], choices: [] });
+    const issue = {
+      code: 'no-match',
+      key: 'person',
+      raw: 'person:anna',
+      value: 'anna',
+      message: 'No person found for "anna"',
+    };
+    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+      ok: false,
+      queryText: 'beach',
+      issues: [issue],
+      choices: [],
+    });
 
     await manager.activateSearch('beach person:anna');
 
@@ -1632,8 +1694,20 @@ describe('GlobalSearchManager typed search commit', () => {
 
   it('stores an ambiguity choice and clears matching issue state', () => {
     const manager = new GlobalSearchManager();
-    const issue = { code: 'ambiguous', key: 'person', raw: 'person:anna', value: 'anna', message: 'Choose a person for "anna"' };
-    const choice = { tokenRaw: 'person:anna', key: 'person' as const, id: 'person-2', label: 'Anna Maria', value: 'anna' };
+    const issue = {
+      code: 'ambiguous',
+      key: 'person',
+      raw: 'person:anna',
+      value: 'anna',
+      message: 'Choose a person for "anna"',
+    };
+    const choice = {
+      tokenRaw: 'person:anna',
+      key: 'person' as const,
+      id: 'person-2',
+      label: 'Anna Maria',
+      value: 'anna',
+    };
     manager.typedSearchIssues = [issue];
     manager.typedSearchChoices = [choice];
     manager.typedSearchDisplayTokens = [{ raw: 'person:anna', key: 'person', value: 'anna', status: 'error', issue }];
@@ -1681,7 +1755,11 @@ Expected: FAIL because `activateSearch` is synchronous, manager has no typed iss
 Modify `global-search-manager.svelte.ts`:
 
 ```ts
-import { parseTypedSearch, type TypedSearchDisplayToken, type TypedSearchIssue } from '$lib/utils/typed-search/typed-search-parser';
+import {
+  parseTypedSearch,
+  type TypedSearchDisplayToken,
+  type TypedSearchIssue,
+} from '$lib/utils/typed-search/typed-search-parser';
 import { resolveTypedSearchFilters, type TypedSearchChoice } from '$lib/utils/typed-search/typed-search-resolver';
 import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 ```
@@ -1839,6 +1917,7 @@ git commit -m "feat(web): commit typed search filters from global search"
 ### Task 6: Token Rail UI TDD
 
 **Files:**
+
 - Create: `web/src/lib/components/global-search/typed-search-token-rail.svelte`
 - Create: `web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts`
 - Modify: `web/src/lib/components/global-search/global-search.svelte`
@@ -1880,7 +1959,13 @@ describe('TypedSearchTokenRail', () => {
             key: 'person',
             value: 'anna',
             status: 'error',
-            issue: { code: 'no-match', raw: 'person:anna', key: 'person', value: 'anna', message: 'No person found for "anna"' },
+            issue: {
+              code: 'no-match',
+              raw: 'person:anna',
+              key: 'person',
+              value: 'anna',
+              message: 'No person found for "anna"',
+            },
           },
         ],
       },
@@ -1954,7 +2039,15 @@ Expected: PASS.
 In `global-search.spec.ts`, include `getFilterSuggestions` in the existing `@immich/sdk` import and mock:
 
 ```ts
-import { AssetVisibility, getFilterSuggestions, getMlHealth, searchAssets, searchPerson, searchPlaces, searchSmart } from '@immich/sdk';
+import {
+  AssetVisibility,
+  getFilterSuggestions,
+  getMlHealth,
+  searchAssets,
+  searchPerson,
+  searchPlaces,
+  searchSmart,
+} from '@immich/sdk';
 ```
 
 ```ts
@@ -1991,7 +2084,9 @@ it('keeps the palette open and shows typed search issues after failed Enter comm
   const m = new GlobalSearchManager();
   m.open();
   vi.spyOn(m, 'activateSearch').mockImplementation(async () => {
-    m.typedSearchIssues = [{ code: 'no-match', key: 'person', raw: 'person:anna', value: 'anna', message: 'No person found for "anna"' }];
+    m.typedSearchIssues = [
+      { code: 'no-match', key: 'person', raw: 'person:anna', value: 'anna', message: 'No person found for "anna"' },
+    ];
   });
   render(GlobalSearch, { props: { manager: m } });
 
@@ -2005,7 +2100,9 @@ it('keeps the palette open and shows typed search issues after failed Enter comm
 it('renders ambiguity choices and sends selection to the manager', async () => {
   const m = new GlobalSearchManager();
   const selectSpy = vi.spyOn(m, 'selectTypedSearchChoice');
-  m.typedSearchIssues = [{ code: 'ambiguous', key: 'person', raw: 'person:anna', value: 'anna', message: 'Choose a person for "anna"' }];
+  m.typedSearchIssues = [
+    { code: 'ambiguous', key: 'person', raw: 'person:anna', value: 'anna', message: 'Choose a person for "anna"' },
+  ];
   m.typedSearchChoices = [
     { tokenRaw: 'person:anna', key: 'person', id: 'person-1', label: 'Anna', value: 'anna' },
     { tokenRaw: 'person:anna', key: 'person', id: 'person-2', label: 'Anna Maria', value: 'anna' },
@@ -2121,6 +2218,7 @@ git commit -m "feat(web): show typed search filter tokens"
 ### Task 7: Final Integration Verification
 
 **Files:**
+
 - No planned code edits unless verification exposes a defect
 
 - [ ] **Step 1: Run focused typed search tests**

--- a/docs/superpowers/plans/2026-05-03-typed-search-filters.md
+++ b/docs/superpowers/plans/2026-05-03-typed-search-filters.md
@@ -1,0 +1,1469 @@
+# Typed Search Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add typed filter syntax to the global search bar so users can commit searches such as `beach person:anna from:2025 type:photo` into context-aware `/photos` or `/spaces/:id` results.
+
+**Architecture:** Keep the feature split into pure parser, URL serialization, resolver, and UI integration units. Parsing and token display happen while typing with no network calls; resolving people, tags, and cameras happens only on Enter. Destination pages hydrate the same `FilterState` used by the existing filter panel.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest, Testing Library Svelte, existing `@immich/sdk`, existing `FilterState`, existing global search manager and command palette.
+
+---
+
+## File Structure
+
+- Create: `web/src/lib/utils/typed-search/typed-search-parser.ts`
+  - Owns raw string tokenization, scalar validation, query extraction, display token metadata, duplicate detection, date expansion, and syntax issues.
+- Create: `web/src/lib/utils/typed-search/typed-search-parser.spec.ts`
+  - Unit tests for parser behavior. No SDK or Svelte dependencies.
+- Create: `web/src/lib/utils/typed-search/typed-search-resolver.ts`
+  - Owns Enter-only resolution of `person:`, `tag:`, and `camera:` tokens into a `FilterState` patch and display-name maps.
+- Create: `web/src/lib/utils/typed-search/typed-search-resolver.spec.ts`
+  - Unit tests with mocked `@immich/sdk` calls for resolution success, ambiguity, missing matches, and SDK errors.
+- Create: `web/src/lib/components/global-search/typed-search-token-rail.svelte`
+  - Renders the quiet inline token rail behind/around the command input while preserving normal text input behavior.
+- Create: `web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts`
+  - Component tests for token states and accessible labels.
+- Modify: `web/src/lib/utils/searchable-page-search.ts`
+  - Extends existing helpers with typed filter serialization and hydration.
+- Modify: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+  - Adds URL round-trip tests for typed filters and sort/query preservation.
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
+  - Adds typed-search parse state, commit issues, ambiguity state, and `activateSearch()` commit path.
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+  - Adds manager tests for Enter commit, all-or-nothing blocking, resolver errors, context-aware destinations, and recents.
+- Modify: `web/src/lib/components/global-search/global-search.svelte`
+  - Renders token rail, issue rows, ambiguity rows, and routes Enter through typed-search commit.
+- Modify: `web/src/lib/components/global-search/__tests__/global-search.spec.ts`
+  - Adds integration tests for no resolver calls while typing, token rendering, failed commit behavior, ambiguity selection, and successful navigation.
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
+  - Hydrates typed filter URL params into local `FilterState`; clears typed filter params with search/filter clear actions.
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`
+  - Adds photos page URL hydration tests.
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+  - Hydrates typed filter URL params into local `FilterState`; clears typed filter params with search/filter clear actions.
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
+  - Adds space page URL hydration tests.
+
+## Common Types And APIs
+
+Use these exported shapes so tasks stay consistent:
+
+```ts
+export type TypedSearchFilterKey =
+  | 'person'
+  | 'tag'
+  | 'from'
+  | 'to'
+  | 'city'
+  | 'country'
+  | 'camera'
+  | 'type'
+  | 'favorite'
+  | 'rating';
+
+export type TypedSearchResolutionKey = 'person' | 'tag' | 'camera';
+export type TypedSearchIssueCode =
+  | 'unknown-key'
+  | 'empty-value'
+  | 'invalid-date'
+  | 'invalid-range'
+  | 'invalid-rating'
+  | 'invalid-type'
+  | 'invalid-favorite'
+  | 'duplicate-filter'
+  | 'unterminated-quote'
+  | 'escaped-quote'
+  | 'no-match'
+  | 'ambiguous'
+  | 'resolver-error';
+
+export type TypedSearchIssue = {
+  code: TypedSearchIssueCode;
+  message: string;
+  raw: string;
+  key?: string;
+  value?: string;
+};
+
+export type TypedSearchScalarToken = {
+  kind: 'scalar';
+  key: Exclude<TypedSearchFilterKey, TypedSearchResolutionKey>;
+  raw: string;
+  value: string;
+  normalizedValue: string | number | boolean;
+};
+
+export type TypedSearchResolutionToken = {
+  kind: 'resolution';
+  key: TypedSearchResolutionKey;
+  raw: string;
+  value: string;
+};
+
+export type TypedSearchDisplayToken = {
+  raw: string;
+  key: string;
+  value: string;
+  status: 'recognized' | 'pending-entity' | 'resolved-entity' | 'error';
+  issue?: TypedSearchIssue;
+};
+
+export type TypedSearchParseResult = {
+  raw: string;
+  queryText: string;
+  scalarTokens: TypedSearchScalarToken[];
+  resolutionTokens: TypedSearchResolutionToken[];
+  displayTokens: TypedSearchDisplayToken[];
+  issues: TypedSearchIssue[];
+};
+```
+
+---
+
+### Task 0: Baseline Verification
+
+**Files:**
+- Read: `open-api/typescript-sdk/package.json`
+- Read: `web/vite.config.ts`
+- No production edits
+
+- [ ] **Step 1: Build the workspace SDK package**
+
+Run:
+
+```bash
+pnpm --filter @immich/sdk build
+```
+
+Expected: exit 0 and `open-api/typescript-sdk/build/index.js` exists.
+
+- [ ] **Step 2: Run existing focused smoke tests**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: existing tests pass. If unrelated existing tests fail, record the failure and continue only after confirming the failure exists before feature edits.
+
+- [ ] **Step 3: Commit baseline note if a repo-local workaround was required**
+
+If no files changed, do not commit. If a repo-local generated artifact had to be created and tracked, stop and ask before committing generated output.
+
+---
+
+### Task 1: Parser TDD
+
+**Files:**
+- Create: `web/src/lib/utils/typed-search/typed-search-parser.ts`
+- Create: `web/src/lib/utils/typed-search/typed-search-parser.spec.ts`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Create `web/src/lib/utils/typed-search/typed-search-parser.spec.ts` with:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { parseTypedSearch } from './typed-search-parser';
+
+describe('parseTypedSearch', () => {
+  it('extracts plain query text and recognized filters', () => {
+    const result = parseTypedSearch('beach person:anna from:2025 to:2026 camera:nikon type:photo');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.resolutionTokens).toEqual([
+      { kind: 'resolution', key: 'person', raw: 'person:anna', value: 'anna' },
+      { kind: 'resolution', key: 'camera', raw: 'camera:nikon', value: 'nikon' },
+    ]);
+    expect(result.scalarTokens).toMatchObject([
+      { kind: 'scalar', key: 'from', raw: 'from:2025', value: '2025', normalizedValue: '2025-01-01' },
+      { kind: 'scalar', key: 'to', raw: 'to:2026', value: '2026', normalizedValue: '2026-12-31' },
+      { kind: 'scalar', key: 'type', raw: 'type:photo', value: 'photo', normalizedValue: 'image' },
+    ]);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('supports quoted values with spaces', () => {
+    const result = parseTypedSearch('beach person:"Anna Maria" city:"New York"');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.resolutionTokens).toEqual([
+      { kind: 'resolution', key: 'person', raw: 'person:"Anna Maria"', value: 'Anna Maria' },
+    ]);
+    expect(result.scalarTokens).toMatchObject([
+      { kind: 'scalar', key: 'city', raw: 'city:"New York"', value: 'New York', normalizedValue: 'New York' },
+    ]);
+  });
+
+  it('rejects unknown alphabetic key value tokens', () => {
+    const result = parseTypedSearch('beach persn:anna');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.issues).toEqual([
+      {
+        code: 'unknown-key',
+        key: 'persn',
+        raw: 'persn:anna',
+        value: 'anna',
+        message: 'Unknown filter "persn"',
+      },
+    ]);
+  });
+
+  it('keeps non-filter colon text in the query', () => {
+    const result = parseTypedSearch('IMG_1234.jpg ratio:3:2 http://example.test');
+
+    expect(result.queryText).toBe('IMG_1234.jpg http://example.test');
+    expect(result.issues).toEqual([
+      {
+        code: 'unknown-key',
+        key: 'ratio',
+        raw: 'ratio:3:2',
+        value: '3:2',
+        message: 'Unknown filter "ratio"',
+      },
+    ]);
+  });
+
+  it('rejects invalid scalar values', () => {
+    const result = parseTypedSearch('from:soon to:2026-99-01 rating:9 type:gif favorite:maybe');
+
+    expect(result.issues.map((issue) => issue.code)).toEqual([
+      'invalid-date',
+      'invalid-date',
+      'invalid-rating',
+      'invalid-type',
+      'invalid-favorite',
+    ]);
+  });
+
+  it('rejects empty values and unterminated quotes on commit parse', () => {
+    const result = parseTypedSearch('person: city:"New York');
+
+    expect(result.issues.map((issue) => issue.code)).toEqual(['empty-value', 'unterminated-quote']);
+  });
+
+  it('rejects duplicate scalar filters but allows repeated people and tags', () => {
+    const result = parseTypedSearch('person:anna person:bob tag:travel tag:family city:Berlin city:Paris');
+
+    expect(result.resolutionTokens.map((token) => token.raw)).toEqual([
+      'person:anna',
+      'person:bob',
+      'tag:travel',
+      'tag:family',
+    ]);
+    expect(result.issues).toEqual([
+      {
+        code: 'duplicate-filter',
+        key: 'city',
+        raw: 'city:Paris',
+        value: 'Paris',
+        message: 'Filter "city" can only be used once',
+      },
+    ]);
+  });
+
+  it('rejects a date range where from is after to', () => {
+    const result = parseTypedSearch('from:2026 to:2025');
+
+    expect(result.issues).toEqual([
+      {
+        code: 'invalid-range',
+        key: 'from',
+        raw: 'from:2026',
+        value: '2026',
+        message: 'Start date must be before end date',
+      },
+    ]);
+  });
+
+  it('normalizes keys and boolean or media values case-insensitively', () => {
+    const result = parseTypedSearch('TYPE:Photo FAVORITE:Yes rating:4');
+
+    expect(result.scalarTokens).toMatchObject([
+      { key: 'type', normalizedValue: 'image' },
+      { key: 'favorite', normalizedValue: true },
+      { key: 'rating', normalizedValue: 4 },
+    ]);
+    expect(result.issues).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run parser tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-parser.spec.ts
+```
+
+Expected: FAIL because `./typed-search-parser` does not exist.
+
+- [ ] **Step 3: Implement parser types and behavior**
+
+Create `web/src/lib/utils/typed-search/typed-search-parser.ts` with the common types from this plan and:
+
+```ts
+const FILTER_KEYS = new Set<TypedSearchFilterKey>([
+  'person',
+  'tag',
+  'from',
+  'to',
+  'city',
+  'country',
+  'camera',
+  'type',
+  'favorite',
+  'rating',
+]);
+
+const RESOLUTION_KEYS = new Set<TypedSearchResolutionKey>(['person', 'tag', 'camera']);
+const REPEATABLE_KEYS = new Set<TypedSearchFilterKey>(['person', 'tag']);
+
+export function parseTypedSearch(raw: string): TypedSearchParseResult {
+  const pieces = splitSearch(raw);
+  const queryParts: string[] = [];
+  const scalarTokens: TypedSearchScalarToken[] = [];
+  const resolutionTokens: TypedSearchResolutionToken[] = [];
+  const displayTokens: TypedSearchDisplayToken[] = [];
+  const issues: TypedSearchIssue[] = [];
+  const seenScalarKeys = new Set<string>();
+
+  for (const piece of pieces) {
+    if (!piece.key) {
+      queryParts.push(piece.raw);
+      continue;
+    }
+
+    const key = piece.key.toLowerCase() as TypedSearchFilterKey;
+    if (!FILTER_KEYS.has(key)) {
+      const issue = makeIssue('unknown-key', piece.raw, `Unknown filter "${piece.key}"`, piece.key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key: piece.key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (piece.issue) {
+      const issue = makeIssue(piece.issue, piece.raw, issueMessage(piece.issue, key), key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (!piece.value.trim()) {
+      const issue = makeIssue('empty-value', piece.raw, `Filter "${key}" needs a value`, key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (!REPEATABLE_KEYS.has(key) && seenScalarKeys.has(key)) {
+      const issue = makeIssue('duplicate-filter', piece.raw, `Filter "${key}" can only be used once`, key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (RESOLUTION_KEYS.has(key as TypedSearchResolutionKey)) {
+      resolutionTokens.push({ kind: 'resolution', key: key as TypedSearchResolutionKey, raw: piece.raw, value: piece.value });
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'pending-entity' });
+      continue;
+    }
+
+    seenScalarKeys.add(key);
+    const scalar = normalizeScalarToken(key, piece.raw, piece.value);
+    if ('issue' in scalar) {
+      issues.push(scalar.issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue: scalar.issue });
+      continue;
+    }
+    scalarTokens.push(scalar.token);
+    displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'recognized' });
+  }
+
+  const rangeIssue = validateDateRange(scalarTokens);
+  if (rangeIssue) {
+    issues.push(rangeIssue);
+    const token = displayTokens.find((item) => item.key === 'from');
+    if (token) {
+      token.status = 'error';
+      token.issue = rangeIssue;
+    }
+  }
+
+  return {
+    raw,
+    queryText: queryParts.join(' ').trim().replace(/\s+/g, ' '),
+    scalarTokens,
+    resolutionTokens,
+    displayTokens,
+    issues,
+  };
+}
+```
+
+Implement helper functions in the same file:
+
+- `splitSearch(raw)` scans whitespace-delimited pieces while preserving quoted values.
+- `normalizeScalarToken(key, raw, value)` validates `from`, `to`, `city`, `country`, `type`, `favorite`, and `rating`.
+- `expandDate(value, boundary)` accepts `YYYY`, `YYYY-MM`, and `YYYY-MM-DD`.
+- `validateDateRange(tokens)` compares normalized `from` and `to`.
+- `makeIssue(code, raw, message, key, value)` creates `TypedSearchIssue`.
+
+- [ ] **Step 4: Run parser tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-parser.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit parser slice**
+
+Run:
+
+```bash
+git add web/src/lib/utils/typed-search/typed-search-parser.ts web/src/lib/utils/typed-search/typed-search-parser.spec.ts
+git commit -m "feat(web): add typed search parser"
+```
+
+---
+
+### Task 2: URL Serialization And Hydration TDD
+
+**Files:**
+- Modify: `web/src/lib/utils/searchable-page-search.ts`
+- Modify: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+
+- [ ] **Step 1: Write failing URL tests**
+
+Append to `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`:
+
+```ts
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import {
+  buildSearchablePageUrl,
+  clearSearchablePageFilterParams,
+  getSearchablePageFilterState,
+} from '$lib/utils/searchable-page-search';
+
+describe('typed filter URL state', () => {
+  it('serializes typed filters into photos URLs while preserving query and sort', () => {
+    const url = new URL('https://gallery.test/photos?view=timeline');
+    const filters = {
+      ...createFilterState(),
+      personIds: ['person-1', 'person-2'],
+      tagIds: ['tag-1'],
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Nikon',
+      model: 'Z8',
+      mediaType: 'image' as const,
+      isFavorite: true,
+      rating: 4,
+      dateAfter: '2025-01-01',
+      dateBefore: '2026-12-31',
+      sortOrder: 'asc' as const,
+    };
+
+    const result = buildSearchablePageUrl(url, 'beach', 'asc', filters);
+
+    expect(result).toBe(
+      '/photos?view=timeline&q=beach&sort=asc&people=person-1%2Cperson-2&tags=tag-1&city=Berlin&country=Germany&make=Nikon&model=Z8&type=image&favorite=true&rating=4&from=2025-01-01&to=2026-12-31',
+    );
+  });
+
+  it('hydrates typed filter params into FilterState', () => {
+    const url = new URL(
+      'https://gallery.test/photos?q=beach&people=person-1%2Cperson-2&tags=tag-1&type=video&favorite=false&rating=5&from=2025-01-01&to=2026-12-31',
+    );
+
+    expect(getSearchablePageFilterState(url)).toEqual({
+      personIds: ['person-1', 'person-2'],
+      tagIds: ['tag-1'],
+      mediaType: 'video',
+      isFavorite: false,
+      rating: 5,
+      dateAfter: '2025-01-01',
+      dateBefore: '2026-12-31',
+    });
+  });
+
+  it('drops invalid typed filter URL params without crashing', () => {
+    const url = new URL('https://gallery.test/photos?type=gif&favorite=maybe&rating=9&from=soon&to=2026-99-01');
+
+    expect(getSearchablePageFilterState(url)).toEqual({});
+  });
+
+  it('clears only typed filter params', () => {
+    const params = new URLSearchParams('q=beach&sort=desc&people=p1&city=Berlin&view=timeline');
+
+    clearSearchablePageFilterParams(params);
+
+    expect(params.toString()).toBe('q=beach&sort=desc&view=timeline');
+  });
+});
+```
+
+- [ ] **Step 2: Run URL tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+```
+
+Expected: FAIL because `clearSearchablePageFilterParams` and `getSearchablePageFilterState` are missing and `buildSearchablePageUrl` does not accept filters.
+
+- [ ] **Step 3: Implement URL helpers**
+
+Modify `web/src/lib/utils/searchable-page-search.ts`:
+
+```ts
+import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+
+export const SEARCHABLE_PAGE_FILTER_PARAMS = [
+  'people',
+  'tags',
+  'city',
+  'country',
+  'make',
+  'model',
+  'type',
+  'favorite',
+  'rating',
+  'from',
+  'to',
+] as const;
+
+export type SearchablePageFilterState = Partial<
+  Pick<
+    FilterState,
+    'personIds' | 'tagIds' | 'city' | 'country' | 'make' | 'model' | 'mediaType' | 'isFavorite' | 'rating' | 'dateAfter' | 'dateBefore'
+  >
+>;
+```
+
+Add helpers:
+
+```ts
+export function clearSearchablePageFilterParams(params: URLSearchParams) {
+  for (const key of SEARCHABLE_PAGE_FILTER_PARAMS) {
+    params.delete(key);
+  }
+}
+
+export function getSearchablePageFilterState(url: URL): SearchablePageFilterState {
+  const result: SearchablePageFilterState = {};
+  const people = splitListParam(url.searchParams.get('people'));
+  const tags = splitListParam(url.searchParams.get('tags'));
+  const rating = parseRating(url.searchParams.get('rating'));
+  const type = parseMediaType(url.searchParams.get('type'));
+  const favorite = parseFavorite(url.searchParams.get('favorite'));
+  const from = parseDateParam(url.searchParams.get('from'));
+  const to = parseDateParam(url.searchParams.get('to'));
+
+  if (people.length > 0) result.personIds = people;
+  if (tags.length > 0) result.tagIds = tags;
+  if (url.searchParams.get('city')) result.city = url.searchParams.get('city') ?? undefined;
+  if (url.searchParams.get('country')) result.country = url.searchParams.get('country') ?? undefined;
+  if (url.searchParams.get('make')) result.make = url.searchParams.get('make') ?? undefined;
+  if (url.searchParams.get('model')) result.model = url.searchParams.get('model') ?? undefined;
+  if (type) result.mediaType = type;
+  if (favorite !== undefined) result.isFavorite = favorite;
+  if (rating !== undefined) result.rating = rating;
+  if (from) result.dateAfter = from;
+  if (to) result.dateBefore = to;
+  return result;
+}
+```
+
+Update `buildSearchablePageUrl` signature:
+
+```ts
+export function buildSearchablePageUrl(
+  url: URL,
+  query: string,
+  sortOrder: SearchablePageSortOrder = 'relevance',
+  filters?: FilterState,
+): string | null
+```
+
+Inside it, after query/sort handling:
+
+```ts
+clearSearchablePageFilterParams(params);
+if (filters) {
+  appendSearchablePageFilterParams(params, filters);
+}
+```
+
+Add `appendSearchablePageFilterParams`, `splitListParam`, `parseRating`, `parseMediaType`, `parseFavorite`, and `parseDateParam` in the same file.
+
+- [ ] **Step 4: Run URL tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit URL slice**
+
+Run:
+
+```bash
+git add web/src/lib/utils/searchable-page-search.ts web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+git commit -m "feat(web): serialize typed search filters in URLs"
+```
+
+---
+
+### Task 3: Destination Page Hydration TDD
+
+**Files:**
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
+
+- [ ] **Step 1: Write failing photos hydration test**
+
+Append to `Photos page search URL state` in `photos-page.spec.ts`:
+
+```ts
+it('hydrates typed filter URL params into the photos FilterState', () => {
+  mockPage.url = new URL(
+    'https://gallery.test/photos?q=beach&people=person-1&tags=tag-1&type=image&favorite=true&rating=4&from=2025-01-01&to=2025-12-31',
+  );
+
+  renderPage();
+
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-person-ids', 'person-1');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-tag-ids', 'tag-1');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'image');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-favorite', 'true');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-rating', '4');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-after', '2025-01-01');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-before', '2025-12-31');
+});
+```
+
+- [ ] **Step 2: Write failing spaces hydration test**
+
+Append to `spaces-page.spec.ts`:
+
+```ts
+it('hydrates typed filter URL params into the space FilterState', async () => {
+  mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&people=space-person-1&city=Berlin&type=video');
+
+  renderPage({ space: makeSpace(), members: [makeMember()] });
+
+  expect(await screen.findByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-person-ids', 'space-person-1');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-city', 'Berlin');
+  expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'video');
+});
+```
+
+- [ ] **Step 3: Run page tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
+```
+
+Expected: FAIL because route components ignore typed filter URL params.
+
+- [ ] **Step 4: Implement photos hydration**
+
+Modify imports in `photos +page.svelte`:
+
+```ts
+import {
+  buildSearchablePageUrl,
+  getSearchablePageFilterState,
+  getSearchablePageState,
+} from '$lib/utils/searchable-page-search';
+```
+
+Initialize filters:
+
+```ts
+const initialSearchState = getSearchablePageState(page.url);
+const initialFilterState = getSearchablePageFilterState(page.url);
+let filters = $state<FilterState>({
+  ...createFilterState(),
+  ...initialFilterState,
+  sortOrder: initialSearchState.sortOrder,
+});
+let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
+```
+
+Update the URL sync effect token and assignment:
+
+```ts
+const nextFilterState = getSearchablePageFilterState(page.url);
+const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
+filters = {
+  ...createFilterState(),
+  ...nextFilterState,
+  sortOrder: nextSearchState.sortOrder,
+};
+```
+
+Keep the existing smart facet reset when query changes, and also reset facets when filter URL params change.
+
+- [ ] **Step 5: Implement spaces hydration**
+
+Make the same import, initial state, and URL sync changes in the spaces page. In the space-change effect, use:
+
+```ts
+const nextFilterState = getSearchablePageFilterState(page.url);
+filters = {
+  ...createFilterState(),
+  ...nextFilterState,
+  sortOrder: nextSearchState.sortOrder,
+};
+lastHandledSearchState = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
+```
+
+- [ ] **Step 6: Run page tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit route hydration slice**
+
+Run:
+
+```bash
+git add 'web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte' 'web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
+git commit -m "feat(web): hydrate typed search filters from URLs"
+```
+
+---
+
+### Task 4: Resolver TDD
+
+**Files:**
+- Create: `web/src/lib/utils/typed-search/typed-search-resolver.ts`
+- Create: `web/src/lib/utils/typed-search/typed-search-resolver.spec.ts`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Create `typed-search-resolver.spec.ts`:
+
+```ts
+import { AssetTypeEnum, getFilterSuggestions, searchPerson } from '@immich/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseTypedSearch } from './typed-search-parser';
+import { resolveTypedSearchFilters } from './typed-search-resolver';
+
+vi.mock('@immich/sdk', async () => ({
+  ...(await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk')),
+  searchPerson: vi.fn(),
+  getFilterSuggestions: vi.fn(),
+}));
+
+describe('resolveTypedSearchFilters', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [AssetTypeEnum.Image, AssetTypeEnum.Video],
+      hasUnnamedPeople: false,
+    });
+  });
+
+  it('resolves a single person, tag, and camera make', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([{ id: 'person-1', name: 'Anna' } as never]);
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: ['Nikon'],
+      cameraModels: [],
+      tags: [{ id: 'tag-1', value: 'Travel' }],
+      ratings: [4],
+      mediaTypes: [AssetTypeEnum.Image],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('beach person:anna tag:travel camera:nikon'), {});
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.queryText).toBe('beach');
+      expect(result.filters.personIds).toEqual(['person-1']);
+      expect(result.filters.tagIds).toEqual(['tag-1']);
+      expect(result.filters.make).toBe('Nikon');
+      expect(result.personNames.get('person-1')).toBe('Anna');
+      expect(result.tagNames.get('tag-1')).toBe('Travel');
+    }
+  });
+
+  it('blocks when person resolution has no match', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([]);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'no-match', key: 'person', value: 'anna' });
+    }
+  });
+
+  it('blocks when person resolution is ambiguous', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([
+      { id: 'person-1', name: 'Anna' },
+      { id: 'person-2', name: 'Anna Maria' },
+    ] as never);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'person', value: 'anna' });
+      expect(result.choices).toHaveLength(2);
+    }
+  });
+
+  it('passes spaceId to suggestion-backed resolution', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([{ id: 'space-person-1', name: 'Anna' } as never]);
+
+    await resolveTypedSearchFilters(parseTypedSearch('person:anna camera:nikon'), { spaceId: 'space-1' });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }));
+  });
+
+  it('blocks when camera matches both make and model', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: ['Nikon'],
+      cameraModels: ['Nikon'],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('camera:nikon'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'camera', value: 'nikon' });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run resolver tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-resolver.spec.ts
+```
+
+Expected: FAIL because `typed-search-resolver` does not exist.
+
+- [ ] **Step 3: Implement resolver**
+
+Create `typed-search-resolver.ts` with:
+
+```ts
+import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { AssetTypeEnum, getFilterSuggestions, searchPerson } from '@immich/sdk';
+import type { TypedSearchIssue, TypedSearchParseResult } from './typed-search-parser';
+
+export type TypedSearchChoice = {
+  tokenRaw: string;
+  key: 'person' | 'tag' | 'camera';
+  id?: string;
+  label: string;
+  value: string;
+  field?: 'make' | 'model';
+};
+
+export type TypedSearchResolveContext = {
+  spaceId?: string;
+  signal?: AbortSignal;
+};
+
+export type TypedSearchResolveResult =
+  | {
+      ok: true;
+      queryText: string;
+      filters: FilterState;
+      personNames: Map<string, string>;
+      tagNames: Map<string, string>;
+    }
+  | {
+      ok: false;
+      queryText: string;
+      issues: TypedSearchIssue[];
+      choices: TypedSearchChoice[];
+    };
+
+export async function resolveTypedSearchFilters(
+  parsed: TypedSearchParseResult,
+  context: TypedSearchResolveContext,
+): Promise<TypedSearchResolveResult> {
+  const filters = createFilterState();
+  const issues: TypedSearchIssue[] = [...parsed.issues];
+  const choices: TypedSearchChoice[] = [];
+  const personNames = new Map<string, string>();
+  const tagNames = new Map<string, string>();
+
+  for (const token of parsed.scalarTokens) {
+    applyScalar(filters, token.key, token.normalizedValue);
+  }
+
+  const suggestions = parsed.resolutionTokens.some((token) => token.key === 'tag' || token.key === 'camera')
+    ? await getFilterSuggestions({ spaceId: context.spaceId }, { signal: context.signal })
+    : undefined;
+
+  for (const token of parsed.resolutionTokens) {
+    if (token.key === 'person') {
+      const people = await searchPerson({ name: token.value, withHidden: false }, { signal: context.signal });
+      const exact = people.filter((person) => person.name.toLowerCase() === token.value.toLowerCase());
+      const matches = exact.length > 0 ? exact : people;
+      if (matches.length === 1) {
+        filters.personIds.push(matches[0].id);
+        personNames.set(matches[0].id, matches[0].name || matches[0].id);
+      } else if (matches.length === 0) {
+        issues.push({ code: 'no-match', key: 'person', raw: token.raw, value: token.value, message: `No person found for "${token.value}"` });
+      } else {
+        issues.push({ code: 'ambiguous', key: 'person', raw: token.raw, value: token.value, message: `Choose a person for "${token.value}"` });
+        choices.push(...matches.map((person) => ({ tokenRaw: token.raw, key: 'person' as const, id: person.id, label: person.name || person.id, value: token.value })));
+      }
+    }
+
+    if (token.key === 'tag' && suggestions) {
+      resolveTagToken(token, suggestions.tags, filters, tagNames, issues, choices);
+    }
+
+    if (token.key === 'camera' && suggestions) {
+      resolveCameraToken(token, suggestions.cameraMakes, suggestions.cameraModels ?? [], filters, issues, choices);
+    }
+  }
+
+  return issues.length > 0 ? { ok: false, queryText: parsed.queryText, issues, choices } : { ok: true, queryText: parsed.queryText, filters, personNames, tagNames };
+}
+```
+
+Add local helpers `applyScalar`, `resolveTagToken`, and `resolveCameraToken`. Keep all matching case-insensitive. For SDK errors other than abort, return one `resolver-error` issue.
+
+- [ ] **Step 4: Run resolver tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-resolver.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit resolver slice**
+
+Run:
+
+```bash
+git add web/src/lib/utils/typed-search/typed-search-resolver.ts web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
+git commit -m "feat(web): resolve typed search filters"
+```
+
+---
+
+### Task 5: GlobalSearchManager Commit TDD
+
+**Files:**
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+- [ ] **Step 1: Write failing manager tests**
+
+Add mocks near the existing mocks in `global-search-manager.svelte.spec.ts`:
+
+```ts
+const { typedSearchMock } = vi.hoisted(() => ({
+  typedSearchMock: {
+    parseTypedSearch: vi.fn(),
+    resolveTypedSearchFilters: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/utils/typed-search/typed-search-parser', () => ({
+  parseTypedSearch: typedSearchMock.parseTypedSearch,
+}));
+
+vi.mock('$lib/utils/typed-search/typed-search-resolver', () => ({
+  resolveTypedSearchFilters: typedSearchMock.resolveTypedSearchFilters,
+}));
+```
+
+Add tests:
+
+```ts
+describe('GlobalSearchManager typed search commit', () => {
+  beforeEach(() => {
+    typedSearchMock.parseTypedSearch.mockReset();
+    typedSearchMock.resolveTypedSearchFilters.mockReset();
+    mockPage.url = new URL('https://gallery.test/photos');
+  });
+
+  it('navigates with typed filters when resolution succeeds', async () => {
+    const manager = new GlobalSearchManager();
+    typedSearchMock.parseTypedSearch.mockReturnValue({ queryText: 'beach', scalarTokens: [], resolutionTokens: [], displayTokens: [], issues: [] });
+    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+      ok: true,
+      queryText: 'beach',
+      filters: {
+        personIds: ['person-1'],
+        tagIds: [],
+        mediaType: 'all',
+        sortOrder: 'desc',
+        dateAfter: '2025-01-01',
+      },
+      personNames: new Map([['person-1', 'Anna']]),
+      tagNames: new Map(),
+    });
+
+    await manager.activateSearch('beach person:anna from:2025');
+
+    expect(goto).toHaveBeenCalledWith('/photos?q=beach&people=person-1&from=2025-01-01');
+    expect(manager.typedSearchIssues).toEqual([]);
+  });
+
+  it('blocks navigation and exposes issues when resolution fails', async () => {
+    const manager = new GlobalSearchManager();
+    const issue = { code: 'no-match', key: 'person', raw: 'person:anna', value: 'anna', message: 'No person found for "anna"' };
+    typedSearchMock.parseTypedSearch.mockReturnValue({ queryText: 'beach', scalarTokens: [], resolutionTokens: [], displayTokens: [], issues: [] });
+    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({ ok: false, queryText: 'beach', issues: [issue], choices: [] });
+
+    await manager.activateSearch('beach person:anna');
+
+    expect(goto).not.toHaveBeenCalled();
+    expect(manager.typedSearchIssues).toEqual([issue]);
+  });
+
+  it('falls back to photos when current page is not searchable', async () => {
+    mockPage.url = new URL('https://gallery.test/albums');
+    const manager = new GlobalSearchManager();
+    typedSearchMock.parseTypedSearch.mockReturnValue({ queryText: 'beach', scalarTokens: [], resolutionTokens: [], displayTokens: [], issues: [] });
+    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+      ok: true,
+      queryText: 'beach',
+      filters: { personIds: [], tagIds: [], mediaType: 'all', sortOrder: 'desc' },
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+
+    await manager.activateSearch('beach');
+
+    expect(goto).toHaveBeenCalledWith('/photos?q=beach');
+  });
+});
+```
+
+- [ ] **Step 2: Run manager tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: FAIL because `activateSearch` is synchronous and manager has no typed issue state.
+
+- [ ] **Step 3: Implement manager commit state**
+
+Modify `global-search-manager.svelte.ts`:
+
+```ts
+import { parseTypedSearch, type TypedSearchDisplayToken, type TypedSearchIssue } from '$lib/utils/typed-search/typed-search-parser';
+import { resolveTypedSearchFilters, type TypedSearchChoice } from '$lib/utils/typed-search/typed-search-resolver';
+```
+
+Add state:
+
+```ts
+typedSearchDisplayTokens = $state<TypedSearchDisplayToken[]>([]);
+typedSearchIssues = $state<TypedSearchIssue[]>([]);
+typedSearchChoices = $state<TypedSearchChoice[]>([]);
+```
+
+Add a parse helper:
+
+```ts
+parseTypedSearchDraft(text = this.query) {
+  const parsed = parseTypedSearch(text);
+  this.typedSearchDisplayTokens = parsed.displayTokens;
+  if (this.typedSearchIssues.length === 0) {
+    this.typedSearchChoices = [];
+  }
+  return parsed;
+}
+```
+
+Change `activateSearch` to async:
+
+```ts
+async activateSearch(text: string): Promise<void> {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  const parsed = this.parseTypedSearchDraft(trimmed);
+  const spaceId = page.url.pathname.startsWith('/spaces/') ? page.url.pathname.split('/').filter(Boolean)[1] : undefined;
+  const resolved = await resolveTypedSearchFilters(parsed, { spaceId, signal: this.closeSignal });
+
+  if (!resolved.ok) {
+    this.typedSearchIssues = resolved.issues;
+    this.typedSearchChoices = resolved.choices;
+    this.typedSearchDisplayTokens = parsed.displayTokens.map((token) => {
+      const issue = resolved.issues.find((item) => item.raw === token.raw);
+      return issue ? { ...token, status: 'error' as const, issue } : token;
+    });
+    return;
+  }
+
+  this.typedSearchIssues = [];
+  this.typedSearchChoices = [];
+  addEntry({
+    kind: 'query',
+    id: `query:${trimmed.toLowerCase()}`,
+    text: trimmed,
+    lastUsed: Date.now(),
+  });
+  void goto(this.buildSearchDestination(resolved.queryText, resolved.filters));
+}
+```
+
+Update `buildSearchDestination(text: string, filters?: FilterState)` and pass filters into `buildSearchablePageUrl`. For non-searchable fallback, construct `/photos` params using a temporary URL and `buildSearchablePageUrl(new URL('/photos', page.url), text, this.searchSortOrder, filters)`.
+
+- [ ] **Step 4: Update call sites that assume synchronous activateSearch**
+
+In `global-search-manager.svelte.ts`, wrap internal calls:
+
+```ts
+void this.activateSearch(entry.text);
+```
+
+In `global-search.svelte`, existing calls already use `manager.activateSearch(...)`; convert click and key handlers to `void manager.activateSearch(...)`.
+
+- [ ] **Step 5: Run manager tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit manager slice**
+
+Run:
+
+```bash
+git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts web/src/lib/components/global-search/global-search.svelte
+git commit -m "feat(web): commit typed search filters from global search"
+```
+
+---
+
+### Task 6: Token Rail UI TDD
+
+**Files:**
+- Create: `web/src/lib/components/global-search/typed-search-token-rail.svelte`
+- Create: `web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts`
+- Modify: `web/src/lib/components/global-search/global-search.svelte`
+- Modify: `web/src/lib/components/global-search/__tests__/global-search.spec.ts`
+
+- [ ] **Step 1: Write failing token rail component tests**
+
+Create `typed-search-token-rail.spec.ts`:
+
+```ts
+import TypedSearchTokenRail from '$lib/components/global-search/typed-search-token-rail.svelte';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+describe('TypedSearchTokenRail', () => {
+  it('renders recognized and pending tokens quietly', () => {
+    render(TypedSearchTokenRail, {
+      props: {
+        tokens: [
+          { raw: 'from:2025', key: 'from', value: '2025', status: 'recognized' },
+          { raw: 'person:anna', key: 'person', value: 'anna', status: 'pending-entity' },
+        ],
+      },
+    });
+
+    expect(screen.getByText('from')).toBeVisible();
+    expect(screen.getByText('2025')).toBeVisible();
+    expect(screen.getByText('person')).toBeVisible();
+    expect(screen.getByText('anna')).toBeVisible();
+    expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
+  });
+
+  it('renders error tokens with issue text', () => {
+    render(TypedSearchTokenRail, {
+      props: {
+        tokens: [
+          {
+            raw: 'person:anna',
+            key: 'person',
+            value: 'anna',
+            status: 'error',
+            issue: { code: 'no-match', raw: 'person:anna', key: 'person', value: 'anna', message: 'No person found for "anna"' },
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'error');
+    expect(screen.getByLabelText('No person found for "anna"')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run token rail tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
+```
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement token rail component**
+
+Create `typed-search-token-rail.svelte`:
+
+```svelte
+<script lang="ts">
+  import type { TypedSearchDisplayToken } from '$lib/utils/typed-search/typed-search-parser';
+
+  interface Props {
+    tokens: TypedSearchDisplayToken[];
+  }
+
+  let { tokens }: Props = $props();
+</script>
+
+{#if tokens.length > 0}
+  <div class="flex min-w-0 flex-wrap items-center gap-1.5 px-3 pb-2" data-testid="typed-search-token-rail">
+    {#each tokens as token (`${token.raw}:${token.status}`)}
+      <span
+        data-testid={`typed-search-token-${token.key}`}
+        data-status={token.status}
+        aria-label={token.issue?.message}
+        class="inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-[11px] leading-none
+          {token.status === 'error'
+            ? 'border-red-400/70 bg-red-50 text-red-700 dark:border-red-500/50 dark:bg-red-950/30 dark:text-red-200'
+            : token.status === 'pending-entity'
+              ? 'border-dashed border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-600 dark:bg-gray-800/60 dark:text-gray-300'
+              : 'border-gray-200 bg-subtle/60 text-gray-700 dark:border-gray-700 dark:text-gray-200'}"
+      >
+        <span class="font-semibold">{token.key}</span>
+        <span class="truncate">{token.value}</span>
+      </span>
+    {/each}
+  </div>
+{/if}
+```
+
+- [ ] **Step 4: Run token rail tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing palette integration tests**
+
+Add to `global-search.spec.ts`:
+
+```ts
+it('renders typed search tokens while typing without resolving filters', async () => {
+  const m = new GlobalSearchManager();
+  const parseSpy = vi.spyOn(m, 'parseTypedSearchDraft');
+  m.open();
+  render(GlobalSearch, { props: { manager: m } });
+
+  await user.type(screen.getByRole('combobox'), 'beach person:anna from:2025');
+
+  expect(parseSpy).toHaveBeenCalled();
+  expect(screen.getByTestId('typed-search-token-rail')).toBeInTheDocument();
+  expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
+  expect(searchPerson).not.toHaveBeenCalled();
+});
+
+it('keeps the palette open and shows typed search issues after failed Enter commit', async () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  vi.spyOn(m, 'activateSearch').mockImplementation(async () => {
+    m.typedSearchIssues = [{ code: 'no-match', key: 'person', raw: 'person:anna', value: 'anna', message: 'No person found for "anna"' }];
+  });
+  render(GlobalSearch, { props: { manager: m } });
+
+  await user.type(screen.getByRole('combobox'), 'person:anna');
+  await user.keyboard('{Enter}');
+
+  expect(screen.getByText('No person found for "anna"')).toBeVisible();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6: Run palette tests and verify red**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/global-search/__tests__/global-search.spec.ts
+```
+
+Expected: FAIL because the palette does not render token rail or issue rows.
+
+- [ ] **Step 7: Integrate token rail and issue rows**
+
+Modify `global-search.svelte` imports:
+
+```ts
+import TypedSearchTokenRail from './typed-search-token-rail.svelte';
+```
+
+After the existing `Command.Input` row, render:
+
+```svelte
+<TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
+```
+
+In the input sync effect or `oninput`, call:
+
+```ts
+manager.parseTypedSearchDraft(inputValue);
+```
+
+Above normal command groups, render issues:
+
+```svelte
+{#if manager.typedSearchIssues.length > 0}
+  <Command.Group class="mb-4" data-typed-search-issues>
+    <Command.GroupHeading class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+      Search filters
+    </Command.GroupHeading>
+    <div class="space-y-1 px-3">
+      {#each manager.typedSearchIssues as issue (`${issue.raw}:${issue.code}`)}
+        <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-200">
+          {issue.message}
+        </div>
+      {/each}
+    </div>
+  </Command.Group>
+{/if}
+```
+
+- [ ] **Step 8: Run UI tests and verify green**
+
+Run:
+
+```bash
+pnpm --dir web exec vitest --run src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit UI slice**
+
+Run:
+
+```bash
+git add web/src/lib/components/global-search/typed-search-token-rail.svelte web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts web/src/lib/components/global-search/global-search.svelte web/src/lib/components/global-search/__tests__/global-search.spec.ts
+git commit -m "feat(web): show typed search filter tokens"
+```
+
+---
+
+### Task 7: Final Integration Verification
+
+**Files:**
+- No planned code edits unless verification exposes a defect
+
+- [ ] **Step 1: Run focused typed search tests**
+
+Run:
+
+```bash
+pnpm --filter @immich/sdk build
+pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-parser.spec.ts src/lib/utils/typed-search/typed-search-resolver.spec.ts src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type and Svelte checks**
+
+Run:
+
+```bash
+pnpm --dir web run check:svelte
+pnpm --dir web run check:typescript
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint for touched files or full web lint**
+
+Run:
+
+```bash
+pnpm --dir web run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke in dev server**
+
+Run:
+
+```bash
+pnpm --dir web dev --host 0.0.0.0 --port 3000
+```
+
+Open the app, then smoke these flows:
+
+- From `/photos`, open global search and enter `beach from:2025 type:photo`; Enter navigates to `/photos?q=beach&from=2025-01-01&type=image`.
+- From `/photos`, enter `person:thisdoesnotexist`; Enter keeps the palette open and shows one issue row.
+- From `/spaces/space-1/photos`, enter `beach city:Berlin`; Enter stays under that space route and applies `city=Berlin`.
+- Type `beach person:anna` without Enter; people resolution is not called until Enter.
+
+- [ ] **Step 5: Handle verification defects with TDD**
+
+If Step 1, 2, 3, or 4 exposes a defect, return to the task that owns the broken behavior, add a focused failing test in that task's test file, implement the fix, rerun that task's focused command, rerun Task 7 Step 1, and commit using that task's file list and commit-message pattern. If no defects are found, do not create a verification-only commit.

--- a/docs/superpowers/plans/2026-05-03-typed-search-filters.md
+++ b/docs/superpowers/plans/2026-05-03-typed-search-filters.md
@@ -20,18 +20,22 @@
   - Owns Enter-only resolution of `person:`, `tag:`, and `camera:` tokens into a `FilterState` patch and display-name maps.
 - Create: `web/src/lib/utils/typed-search/typed-search-resolver.spec.ts`
   - Unit tests with mocked `@immich/sdk` calls for resolution success, ambiguity, missing matches, and SDK errors.
+- Create: `web/src/lib/utils/typed-search/typed-search-name-cache.ts`
+  - Stores resolver-provided person/tag display names in `sessionStorage` by destination URL so active chips can show labels immediately after palette navigation.
+- Create: `web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts`
+  - Unit tests for storing, reading, one-shot consumption, and malformed storage data.
 - Create: `web/src/lib/components/global-search/typed-search-token-rail.svelte`
   - Renders the quiet inline token rail behind/around the command input while preserving normal text input behavior.
 - Create: `web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts`
   - Component tests for token states and accessible labels.
 - Modify: `web/src/lib/utils/searchable-page-search.ts`
   - Extends existing helpers with typed filter serialization and hydration.
-- Modify: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
-  - Adds URL round-trip tests for typed filters and sort/query preservation.
+- Create: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+  - Adds URL round-trip tests for existing searchable-page behavior and typed filters.
 - Modify: `web/src/lib/managers/global-search-manager.svelte.ts`
   - Adds typed-search parse state, commit issues, ambiguity state, and `activateSearch()` commit path.
 - Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
-  - Adds manager tests for Enter commit, all-or-nothing blocking, resolver errors, context-aware destinations, and recents.
+  - Adds manager tests for Enter commit, all-or-nothing blocking, resolver errors, live-provider plain-query payloads, context-aware destinations, and recents.
 - Modify: `web/src/lib/components/global-search/global-search.svelte`
   - Renders token rail, issue rows, ambiguity rows, and routes Enter through typed-search commit.
 - Modify: `web/src/lib/components/global-search/__tests__/global-search.spec.ts`
@@ -39,11 +43,15 @@
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
   - Hydrates typed filter URL params into local `FilterState`; clears typed filter params with search/filter clear actions.
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`
-  - Adds photos page URL hydration tests.
+  - Adds photos page URL hydration and clear-filter URL sync tests.
+- Create: `web/src/test-data/mocks/active-filters-bar-actions.stub.svelte`
+  - Exposes active-filter clear/remove callbacks for destination page route tests.
+- Modify: `web/src/test-data/mocks/smart-search-results.stub.svelte`
+  - Exposes filter fields as data attributes for route hydration assertions.
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
   - Hydrates typed filter URL params into local `FilterState`; clears typed filter params with search/filter clear actions.
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
-  - Adds space page URL hydration tests.
+  - Adds space page URL hydration and active-filter URL sync tests.
 
 ## Common Types And APIs
 
@@ -143,7 +151,7 @@ Expected: exit 0 and `open-api/typescript-sdk/build/index.js` exists.
 Run:
 
 ```bash
-pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/space-search.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts
 ```
 
 Expected: existing tests pass. If unrelated existing tests fail, record the failure and continue only after confirming the failure exists before feature edits.
@@ -243,6 +251,20 @@ describe('parseTypedSearch', () => {
     const result = parseTypedSearch('person: city:"New York');
 
     expect(result.issues.map((issue) => issue.code)).toEqual(['empty-value', 'unterminated-quote']);
+  });
+
+  it('rejects escaped quote sequences in quoted values', () => {
+    const result = parseTypedSearch('person:"Anna \\"The Ace\\""');
+
+    expect(result.issues).toEqual([
+      {
+        code: 'escaped-quote',
+        key: 'person',
+        raw: 'person:"Anna \\"The Ace\\""',
+        value: 'Anna \\"The Ace\\"',
+        message: 'Escaped quotes are not supported in filters',
+      },
+    ]);
   });
 
   it('rejects duplicate scalar filters but allows repeated people and tags', () => {
@@ -408,6 +430,7 @@ export function parseTypedSearch(raw: string): TypedSearchParseResult {
 Implement helper functions in the same file:
 
 - `splitSearch(raw)` scans whitespace-delimited pieces while preserving quoted values.
+- `splitSearch(raw)` must leave URL-like strings containing `://` as plain query text instead of treating `http:` as an unknown filter.
 - `normalizeScalarToken(key, raw, value)` validates `from`, `to`, `city`, `country`, `type`, `favorite`, and `rating`.
 - `expandDate(value, boundary)` accepts `YYYY`, `YYYY-MM`, and `YYYY-MM-DD`.
 - `validateDateRange(tokens)` compares normalized `from` and `to`.
@@ -438,19 +461,56 @@ git commit -m "feat(web): add typed search parser"
 
 **Files:**
 - Modify: `web/src/lib/utils/searchable-page-search.ts`
-- Modify: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+- Create: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+- Create: `web/src/lib/utils/typed-search/typed-search-name-cache.ts`
+- Create: `web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts`
 
 - [ ] **Step 1: Write failing URL tests**
 
-Append to `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`:
+Create `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`:
 
 ```ts
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import {
   buildSearchablePageUrl,
   clearSearchablePageFilterParams,
+  getSearchablePageState,
   getSearchablePageFilterState,
 } from '$lib/utils/searchable-page-search';
+
+describe('searchable page URL state', () => {
+  it('detects photos as a searchable page', () => {
+    const state = getSearchablePageState(new URL('https://gallery.test/photos?q=beach'));
+
+    expect(state).toMatchObject({
+      basePath: '/photos',
+      isSearchable: true,
+      query: 'beach',
+      sortOrder: 'relevance',
+    });
+  });
+
+  it('detects spaces and space photos as searchable pages', () => {
+    expect(getSearchablePageState(new URL('https://gallery.test/spaces/space-1')).basePath).toBe('/spaces/space-1');
+    expect(getSearchablePageState(new URL('https://gallery.test/spaces/space-1/photos')).basePath).toBe(
+      '/spaces/space-1/photos',
+    );
+  });
+
+  it('builds the existing query-only URL without filters', () => {
+    const url = new URL('https://gallery.test/photos?view=timeline');
+
+    expect(buildSearchablePageUrl(url, 'beach')).toBe('/photos?view=timeline&q=beach');
+  });
+
+  it('preserves existing typed filter params when no replacement filter state is supplied', () => {
+    const url = new URL('https://gallery.test/photos?q=beach&people=person-1&city=Berlin&view=timeline');
+
+    expect(buildSearchablePageUrl(url, 'sunset', 'asc')).toBe(
+      '/photos?q=sunset&people=person-1&city=Berlin&view=timeline&sort=asc',
+    );
+  });
+});
 
 describe('typed filter URL state', () => {
   it('serializes typed filters into photos URLs while preserving query and sort', () => {
@@ -476,6 +536,20 @@ describe('typed filter URL state', () => {
     expect(result).toBe(
       '/photos?view=timeline&q=beach&sort=asc&people=person-1%2Cperson-2&tags=tag-1&city=Berlin&country=Germany&make=Nikon&model=Z8&type=image&favorite=true&rating=4&from=2025-01-01&to=2026-12-31',
     );
+  });
+
+  it('serializes typed filters into space URLs', () => {
+    const url = new URL('https://gallery.test/spaces/space-1/photos?panel=closed');
+    const filters = {
+      ...createFilterState(),
+      city: 'Berlin',
+      mediaType: 'video' as const,
+      sortOrder: 'relevance' as const,
+    };
+
+    const result = buildSearchablePageUrl(url, 'beach', 'relevance', filters);
+
+    expect(result).toBe('/spaces/space-1/photos?panel=closed&q=beach&city=Berlin&type=video');
   });
 
   it('hydrates typed filter params into FilterState', () => {
@@ -510,15 +584,53 @@ describe('typed filter URL state', () => {
 });
 ```
 
+Create `web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest';
+import { consumeTypedSearchNames, storeTypedSearchNames } from './typed-search-name-cache';
+
+describe('typed search name cache', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('stores and consumes names by destination URL', () => {
+    storeTypedSearchNames('/photos?q=beach&people=person-1', {
+      personNames: new Map([['person-1', 'Anna']]),
+      tagNames: new Map([['tag-1', 'Travel']]),
+    });
+
+    const result = consumeTypedSearchNames('/photos?q=beach&people=person-1');
+
+    expect(result.personNames).toEqual(new Map([['person-1', 'Anna']]));
+    expect(result.tagNames).toEqual(new Map([['tag-1', 'Travel']]));
+    expect(consumeTypedSearchNames('/photos?q=beach&people=person-1')).toEqual({
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+
+  it('ignores malformed storage data', () => {
+    sessionStorage.setItem('typed-search:names:/photos', '{not-json');
+
+    expect(consumeTypedSearchNames('/photos')).toEqual({
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+});
+```
+
 - [ ] **Step 2: Run URL tests and verify red**
 
 Run:
 
 ```bash
-pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/utils/typed-search/typed-search-name-cache.spec.ts
 ```
 
-Expected: FAIL because `clearSearchablePageFilterParams` and `getSearchablePageFilterState` are missing and `buildSearchablePageUrl` does not accept filters.
+Expected: FAIL because `clearSearchablePageFilterParams`, `getSearchablePageFilterState`, and typed-search name cache helpers are missing and `buildSearchablePageUrl` does not accept filters.
 
 - [ ] **Step 3: Implement URL helpers**
 
@@ -597,20 +709,73 @@ export function buildSearchablePageUrl(
 Inside it, after query/sort handling:
 
 ```ts
-clearSearchablePageFilterParams(params);
-if (filters) {
+if (filters !== undefined) {
+  clearSearchablePageFilterParams(params);
   appendSearchablePageFilterParams(params, filters);
 }
 ```
 
 Add `appendSearchablePageFilterParams`, `splitListParam`, `parseRating`, `parseMediaType`, `parseFavorite`, and `parseDateParam` in the same file.
 
+Create `web/src/lib/utils/typed-search/typed-search-name-cache.ts`:
+
+```ts
+type StoredTypedSearchNames = {
+  personNames: Array<[string, string]>;
+  tagNames: Array<[string, string]>;
+};
+
+const prefix = 'typed-search:names:';
+
+function emptyNames() {
+  return {
+    personNames: new Map<string, string>(),
+    tagNames: new Map<string, string>(),
+  };
+}
+
+export function storeTypedSearchNames(
+  destination: string,
+  names: { personNames: Map<string, string>; tagNames: Map<string, string> },
+) {
+  if (typeof sessionStorage === 'undefined') {
+    return;
+  }
+  const payload: StoredTypedSearchNames = {
+    personNames: [...names.personNames.entries()],
+    tagNames: [...names.tagNames.entries()],
+  };
+  sessionStorage.setItem(`${prefix}${destination}`, JSON.stringify(payload));
+}
+
+export function consumeTypedSearchNames(destination: string) {
+  if (typeof sessionStorage === 'undefined') {
+    return emptyNames();
+  }
+  const key = `${prefix}${destination}`;
+  const raw = sessionStorage.getItem(key);
+  sessionStorage.removeItem(key);
+  if (!raw) {
+    return emptyNames();
+  }
+  try {
+    const parsed = JSON.parse(raw) as StoredTypedSearchNames;
+    return {
+      personNames: new Map(parsed.personNames ?? []),
+      tagNames: new Map(parsed.tagNames ?? []),
+    };
+  } catch {
+    return emptyNames();
+  }
+}
+```
+
 - [ ] **Step 4: Run URL tests and verify green**
 
 Run:
 
 ```bash
-pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+pnpm --dir web exec vitest --run src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/utils/typed-search/typed-search-name-cache.spec.ts
 ```
 
 Expected: PASS.
@@ -620,7 +785,7 @@ Expected: PASS.
 Run:
 
 ```bash
-git add web/src/lib/utils/searchable-page-search.ts web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+git add web/src/lib/utils/searchable-page-search.ts web/src/lib/utils/__tests__/searchable-page-search.spec.ts web/src/lib/utils/typed-search/typed-search-name-cache.ts web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
 git commit -m "feat(web): serialize typed search filters in URLs"
 ```
 
@@ -631,12 +796,94 @@ git commit -m "feat(web): serialize typed search filters in URLs"
 **Files:**
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts`
+- Create: `web/src/test-data/mocks/active-filters-bar-actions.stub.svelte`
+- Modify: `web/src/test-data/mocks/smart-search-results.stub.svelte`
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
 
-- [ ] **Step 1: Write failing photos hydration test**
+- [ ] **Step 1: Extend the smart-search results test stub**
+
+Modify the `<div>` in `web/src/test-data/mocks/smart-search-results.stub.svelte` so route tests can assert hydrated filters:
+
+```svelte
+<div
+  {...rest}
+  data-testid="smart-search-results"
+  data-loading={String(isLoading)}
+  data-search-query={searchQuery}
+  data-sort-order={filters?.sortOrder ?? ''}
+  data-is-favorite={String(filters?.isFavorite)}
+  data-filter-favorite={String(filters?.isFavorite)}
+  data-filter-person-ids={filters?.personIds.join(',') ?? ''}
+  data-filter-tag-ids={filters?.tagIds.join(',') ?? ''}
+  data-filter-media-type={filters?.mediaType ?? ''}
+  data-filter-rating={filters?.rating ?? ''}
+  data-filter-date-after={filters?.dateAfter ?? ''}
+  data-filter-date-before={filters?.dateBefore ?? ''}
+  data-filter-city={filters?.city ?? ''}
+  data-filter-country={filters?.country ?? ''}
+  data-filter-make={filters?.make ?? ''}
+  data-filter-model={filters?.model ?? ''}
+  data-with-shared-spaces={String(withSharedSpaces)}
+  data-space-id={spaceId ?? ''}
+  data-country={filters?.country ?? ''}
+  data-language={language}
+  data-total={total ?? ''}
+></div>
+```
+
+Create `web/src/test-data/mocks/active-filters-bar-actions.stub.svelte` so route tests can exercise clear/remove callbacks:
+
+```svelte
+<script lang="ts">
+  type Props = {
+    searchQuery?: string;
+    onClearSearch?: () => void;
+    onClearAll?: () => void;
+    onRemoveFilter?: (type: string, id?: string) => void;
+  };
+
+  let { searchQuery = '', onClearSearch, onClearAll, onRemoveFilter }: Props = $props();
+</script>
+
+<div data-testid="active-filters-bar-stub">
+  <button type="button" data-testid="active-filters-clear-search" onclick={() => onClearSearch?.()}>Clear search</button>
+  <button
+    type="button"
+    data-testid="active-filters-clear-all"
+    onclick={() => {
+      onClearAll?.();
+      if (searchQuery) {
+        onClearSearch?.();
+      }
+    }}
+  >
+    Clear all
+  </button>
+  <button type="button" data-testid="active-filters-remove-person" onclick={() => onRemoveFilter?.('person', 'person-1')}>
+    Remove person
+  </button>
+</div>
+```
+
+- [ ] **Step 2: Write failing photos hydration test**
 
 Append to `Photos page search URL state` in `photos-page.spec.ts`:
+
+Add the mocked navigation import if it is not already present:
+
+```ts
+import { goto } from '$app/navigation';
+```
+
+Update the active filters bar mock in this spec to use the actionable stub:
+
+```ts
+vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/active-filters-bar-actions.stub.svelte');
+  return { default: MockComponent };
+});
+```
 
 ```ts
 it('hydrates typed filter URL params into the photos FilterState', () => {
@@ -655,11 +902,46 @@ it('hydrates typed filter URL params into the photos FilterState', () => {
   expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-after', '2025-01-01');
   expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-before', '2025-12-31');
 });
+
+it('clears only q when clearing the search chip', async () => {
+  mockPage.url = new URL('https://gallery.test/photos?view=timeline&q=beach&people=person-1&city=Berlin');
+
+  renderPage();
+  await fireEvent.click(await screen.findByTestId('active-filters-clear-search'));
+
+  expect(goto).toHaveBeenCalledWith('/photos?view=timeline&people=person-1&city=Berlin', {
+    replaceState: true,
+    keepFocus: true,
+    noScroll: true,
+  });
+});
+
+it('clears typed filter URL params and q when clearing all active filters', async () => {
+  mockPage.url = new URL('https://gallery.test/photos?view=timeline&q=beach&people=person-1&city=Berlin');
+
+  renderPage();
+  await fireEvent.click(await screen.findByTestId('active-filters-clear-all'));
+
+  expect(goto).toHaveBeenLastCalledWith('/photos?view=timeline', {
+    replaceState: true,
+    keepFocus: true,
+    noScroll: true,
+  });
+});
 ```
 
-- [ ] **Step 2: Write failing spaces hydration test**
+- [ ] **Step 3: Write failing spaces hydration test**
 
 Append to `spaces-page.spec.ts`:
+
+Update the active filters bar mock in this spec to use the actionable stub:
+
+```ts
+vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/active-filters-bar-actions.stub.svelte');
+  return { default: MockComponent };
+});
+```
 
 ```ts
 it('hydrates typed filter URL params into the space FilterState', async () => {
@@ -672,9 +954,22 @@ it('hydrates typed filter URL params into the space FilterState', async () => {
   expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-city', 'Berlin');
   expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'video');
 });
+
+it('removes only the selected typed filter from the space URL', async () => {
+  mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&people=person-1&city=Berlin');
+
+  renderPage({ space: makeSpace(), members: [makeMember()] });
+  await fireEvent.click(await screen.findByTestId('active-filters-remove-person'));
+
+  expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?q=beach&city=Berlin', {
+    replaceState: true,
+    keepFocus: true,
+    noScroll: true,
+  });
+});
 ```
 
-- [ ] **Step 3: Run page tests and verify red**
+- [ ] **Step 4: Run page tests and verify red**
 
 Run:
 
@@ -682,9 +977,9 @@ Run:
 pnpm --dir web exec vitest --run 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
 ```
 
-Expected: FAIL because route components ignore typed filter URL params.
+Expected: FAIL because route components ignore typed filter URL params and active filter callbacks do not sync typed filter params back to the URL, not because the test stubs lack assertion attributes.
 
-- [ ] **Step 4: Implement photos hydration**
+- [ ] **Step 5: Implement photos hydration**
 
 Modify imports in `photos +page.svelte`:
 
@@ -694,6 +989,7 @@ import {
   getSearchablePageFilterState,
   getSearchablePageState,
 } from '$lib/utils/searchable-page-search';
+import { consumeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 ```
 
 Initialize filters:
@@ -707,6 +1003,18 @@ let filters = $state<FilterState>({
   sortOrder: initialSearchState.sortOrder,
 });
 let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
+```
+
+Immediately after `personNames` and `tagNames` are initialized, consume cached names for the current route:
+
+```ts
+const initialTypedSearchNames = consumeTypedSearchNames(page.url.pathname + page.url.search);
+for (const [id, name] of initialTypedSearchNames.personNames) {
+  personNames.set(id, name);
+}
+for (const [id, name] of initialTypedSearchNames.tagNames) {
+  tagNames.set(id, name);
+}
 ```
 
 Update the URL sync effect token and assignment:
@@ -723,9 +1031,65 @@ filters = {
 
 Keep the existing smart facet reset when query changes, and also reset facets when filter URL params change.
 
-- [ ] **Step 5: Implement spaces hydration**
+Update `clearSearch()` so clearing the search chip preserves the current filter state instead of preserving stale filter params from `page.url`:
 
-Make the same import, initial state, and URL sync changes in the spaces page. In the space-change effect, use:
+```ts
+function clearSearch() {
+  isLoading = false;
+  const nextUrl = buildSearchablePageUrl(page.url, '', filters.sortOrder, filters);
+  if (!nextUrl) {
+    return;
+  }
+  void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+}
+```
+
+Add a local URL sync helper and use it from active filter callbacks:
+
+```ts
+function syncFilterUrl(nextFilters: FilterState) {
+  const nextUrl = buildSearchablePageUrl(page.url, committedQuery, nextFilters.sortOrder, nextFilters);
+  if (!nextUrl) {
+    return;
+  }
+  void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+}
+```
+
+Update `onRemoveFilter` and `onClearAll`:
+
+```svelte
+onRemoveFilter={(type, id) => {
+  const nextFilters = handlePhotosRemoveFilter(filters, type, id);
+  filters = nextFilters;
+  syncFilterUrl(nextFilters);
+}}
+onClearAll={() => {
+  const nextFilters = clearFilters(filters);
+  filters = nextFilters;
+  if (!committedQuery.trim()) {
+    syncFilterUrl(nextFilters);
+  }
+}}
+```
+
+- [ ] **Step 6: Implement spaces hydration**
+
+Make the same import, initial state, active-filter URL sync, and URL-state sync changes in the spaces page. Use the spaces page's existing `committedSearchQuery` name where the photos page uses `committedQuery`.
+
+Update `clearSearch()`, `handleRemoveFilter()`, and `onClearAll` with the same URL-sync rules:
+
+```ts
+function handleRemoveFilter(type: string, id?: string) {
+  const nextFilters = handleSpaceRemoveFilter(filters, type, id);
+  filters = nextFilters;
+  syncFilterUrl(nextFilters);
+}
+```
+
+When `onClearAll` runs and `committedSearchQuery.trim()` is non-empty, let the active filters bar's follow-up `onClearSearch` write the combined no-query/no-filter URL. If there is no query, call `syncFilterUrl(nextFilters)` immediately.
+
+In the space-change effect, use:
 
 ```ts
 const nextFilterState = getSearchablePageFilterState(page.url);
@@ -737,7 +1101,9 @@ filters = {
 lastHandledSearchState = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
 ```
 
-- [ ] **Step 6: Run page tests and verify green**
+Also consume cached typed-search names in the spaces page using the same `consumeTypedSearchNames(page.url.pathname + page.url.search)` pattern after `personNames` and `tagNames` are initialized.
+
+- [ ] **Step 7: Run page tests and verify green**
 
 Run:
 
@@ -747,12 +1113,12 @@ pnpm --dir web exec vitest --run 'src/routes/(user)/photos/[[assetId=id]]/photos
 
 Expected: PASS.
 
-- [ ] **Step 7: Commit route hydration slice**
+- [ ] **Step 8: Commit route hydration slice**
 
 Run:
 
 ```bash
-git add 'web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte' 'web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
+git add 'web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte' 'web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' web/src/test-data/mocks/active-filters-bar-actions.stub.svelte web/src/test-data/mocks/smart-search-results.stub.svelte 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte' 'web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
 git commit -m "feat(web): hydrate typed search filters from URLs"
 ```
 
@@ -847,12 +1213,112 @@ describe('resolveTypedSearchFilters', () => {
     }
   });
 
+  it('uses a selected ambiguity choice without calling SDK resolution again for that token', async () => {
+    const selectedChoices = new Map([
+      [
+        'person:anna',
+        { tokenRaw: 'person:anna', key: 'person' as const, id: 'person-2', label: 'Anna Maria', value: 'anna' },
+      ],
+    ]);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), { selectedChoices });
+
+    expect(searchPerson).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.personIds).toEqual(['person-2']);
+      expect(result.personNames.get('person-2')).toBe('Anna Maria');
+    }
+  });
+
+  it('accumulates repeated people and tags in input order', async () => {
+    vi.mocked(searchPerson)
+      .mockResolvedValueOnce([{ id: 'person-1', name: 'Anna' } as never])
+      .mockResolvedValueOnce([{ id: 'person-2', name: 'Bob' } as never]);
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [
+        { id: 'tag-1', value: 'Travel' },
+        { id: 'tag-2', value: 'Family' },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna person:bob tag:travel tag:family'), {});
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.personIds).toEqual(['person-1', 'person-2']);
+      expect(result.filters.tagIds).toEqual(['tag-1', 'tag-2']);
+    }
+  });
+
+  it('blocks when tag has no match', async () => {
+    const result = await resolveTypedSearchFilters(parseTypedSearch('tag:vacation'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'no-match', key: 'tag', value: 'vacation' });
+    }
+  });
+
+  it('blocks when tag resolution is ambiguous', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [
+        { id: 'tag-1', value: 'Travel' },
+        { id: 'tag-2', value: 'Travel 2025' },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('tag:trav'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'tag', value: 'trav' });
+      expect(result.choices).toHaveLength(2);
+    }
+  });
+
   it('passes spaceId to suggestion-backed resolution', async () => {
     vi.mocked(searchPerson).mockResolvedValue([{ id: 'space-person-1', name: 'Anna' } as never]);
 
     await resolveTypedSearchFilters(parseTypedSearch('person:anna camera:nikon'), { spaceId: 'space-1' });
 
-    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }));
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }), expect.anything());
+  });
+
+  it('uses space-scoped people from filter suggestions when resolving people inside a space', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [{ id: 'space-person-1', name: 'Anna' }],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), { spaceId: 'space-1' });
+
+    expect(searchPerson).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.personIds).toEqual(['space-person-1']);
+      expect(result.personNames.get('space-person-1')).toBe('Anna');
+    }
   });
 
   it('blocks when camera matches both make and model', async () => {
@@ -874,6 +1340,26 @@ describe('resolveTypedSearchFilters', () => {
       expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'camera', value: 'nikon' });
     }
   });
+
+  it('blocks when camera has no match', async () => {
+    const result = await resolveTypedSearchFilters(parseTypedSearch('camera:nikon'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'no-match', key: 'camera', value: 'nikon' });
+    }
+  });
+
+  it('returns a resolver-error issue for SDK failures', async () => {
+    vi.mocked(searchPerson).mockRejectedValue(new Error('network down'));
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'resolver-error', message: 'network down' });
+    }
+  });
 });
 ```
 
@@ -893,7 +1379,7 @@ Create `typed-search-resolver.ts` with:
 
 ```ts
 import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
-import { AssetTypeEnum, getFilterSuggestions, searchPerson } from '@immich/sdk';
+import { getFilterSuggestions, searchPerson } from '@immich/sdk';
 import type { TypedSearchIssue, TypedSearchParseResult } from './typed-search-parser';
 
 export type TypedSearchChoice = {
@@ -908,6 +1394,7 @@ export type TypedSearchChoice = {
 export type TypedSearchResolveContext = {
   spaceId?: string;
   signal?: AbortSignal;
+  selectedChoices?: Map<string, TypedSearchChoice>;
 };
 
 export type TypedSearchResolveResult =
@@ -939,12 +1426,25 @@ export async function resolveTypedSearchFilters(
     applyScalar(filters, token.key, token.normalizedValue);
   }
 
-  const suggestions = parsed.resolutionTokens.some((token) => token.key === 'tag' || token.key === 'camera')
+  const needsSuggestions = parsed.resolutionTokens.some(
+    (token) => token.key === 'tag' || token.key === 'camera' || (token.key === 'person' && context.spaceId),
+  );
+  const suggestions = needsSuggestions
     ? await getFilterSuggestions({ spaceId: context.spaceId }, { signal: context.signal })
     : undefined;
 
   for (const token of parsed.resolutionTokens) {
+    const selectedChoice = context.selectedChoices?.get(token.raw);
+    if (selectedChoice) {
+      applySelectedChoice(selectedChoice, filters, personNames, tagNames);
+      continue;
+    }
+
     if (token.key === 'person') {
+      if (context.spaceId && suggestions) {
+        resolvePersonTokenFromSuggestions(token, suggestions.people, filters, personNames, issues, choices);
+        continue;
+      }
       const people = await searchPerson({ name: token.value, withHidden: false }, { signal: context.signal });
       const exact = people.filter((person) => person.name.toLowerCase() === token.value.toLowerCase());
       const matches = exact.length > 0 ? exact : people;
@@ -972,7 +1472,9 @@ export async function resolveTypedSearchFilters(
 }
 ```
 
-Add local helpers `applyScalar`, `resolveTagToken`, and `resolveCameraToken`. Keep all matching case-insensitive. For SDK errors other than abort, return one `resolver-error` issue.
+Wrap the SDK calls in `try/catch`. Re-throw abort errors so palette close still cancels work; for other SDK errors, return `{ ok: false, queryText: parsed.queryText, issues: [{ code: 'resolver-error', raw: parsed.raw, message }], choices: [] }`.
+
+Add local helpers `applyScalar`, `applySelectedChoice`, `resolvePersonTokenFromSuggestions`, `resolveTagToken`, and `resolveCameraToken`. Keep all matching case-insensitive; prefer exact entity/tag matches when one exists, return `ambiguous` when multiple non-exact suggestions match, and return `no-match` when nothing matches.
 
 - [ ] **Step 4: Run resolver tests and verify green**
 
@@ -1008,33 +1510,40 @@ Add mocks near the existing mocks in `global-search-manager.svelte.spec.ts`:
 ```ts
 const { typedSearchMock } = vi.hoisted(() => ({
   typedSearchMock: {
-    parseTypedSearch: vi.fn(),
     resolveTypedSearchFilters: vi.fn(),
   },
-}));
-
-vi.mock('$lib/utils/typed-search/typed-search-parser', () => ({
-  parseTypedSearch: typedSearchMock.parseTypedSearch,
 }));
 
 vi.mock('$lib/utils/typed-search/typed-search-resolver', () => ({
   resolveTypedSearchFilters: typedSearchMock.resolveTypedSearchFilters,
 }));
+
+vi.mock('$lib/utils/typed-search/typed-search-name-cache', () => ({
+  storeTypedSearchNames: vi.fn(),
+}));
 ```
+
+Add this import near the existing test imports:
+
+```ts
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
+```
+
+Use the real `parseTypedSearch()` implementation in this manager spec. Do not mock the parser here: the existing manager file has many `setQuery()` tests that call `vi.resetAllMocks()`, and a parser mock would create broad unrelated failures unless every existing `beforeEach` restored its implementation.
 
 Add tests:
 
 ```ts
 describe('GlobalSearchManager typed search commit', () => {
   beforeEach(() => {
-    typedSearchMock.parseTypedSearch.mockReset();
     typedSearchMock.resolveTypedSearchFilters.mockReset();
+    vi.mocked(storeTypedSearchNames).mockClear();
+    vi.mocked(goto).mockClear();
     mockPage.url = new URL('https://gallery.test/photos');
   });
 
   it('navigates with typed filters when resolution succeeds', async () => {
     const manager = new GlobalSearchManager();
-    typedSearchMock.parseTypedSearch.mockReturnValue({ queryText: 'beach', scalarTokens: [], resolutionTokens: [], displayTokens: [], issues: [] });
     typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
       ok: true,
       queryText: 'beach',
@@ -1055,10 +1564,64 @@ describe('GlobalSearchManager typed search commit', () => {
     expect(manager.typedSearchIssues).toEqual([]);
   });
 
+  it('dispatches live providers with the plain query while preserving raw top-search commit text', async () => {
+    const manager = new GlobalSearchManager();
+    const providers = (manager as unknown as { providers: Record<keyof Sections, Provider> }).providers;
+    const photosRun = vi.fn().mockResolvedValue({ status: 'empty' as const });
+    providers.photos.run = photosRun;
+
+    manager.setQuery('beach camera:nikon');
+
+    await vi.waitFor(() => expect(photosRun).toHaveBeenCalledWith('beach', expect.anything(), expect.anything()));
+    expect(manager.topSearchMatch).toEqual({ id: 'top-search', query: 'beach', rawQuery: 'beach camera:nikon' });
+  });
+
+  it('blocks parser issues before calling the resolver', async () => {
+    const manager = new GlobalSearchManager();
+
+    await manager.activateSearch('beach persn:anna');
+
+    expect(typedSearchMock.resolveTypedSearchFilters).not.toHaveBeenCalled();
+    expect(goto).not.toHaveBeenCalled();
+    expect(manager.typedSearchIssues[0]).toMatchObject({ code: 'unknown-key', raw: 'persn:anna' });
+  });
+
+  it('stores resolver names for the destination URL before navigating', async () => {
+    const manager = new GlobalSearchManager();
+    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+      ok: true,
+      queryText: 'beach',
+      filters: { personIds: ['person-1'], tagIds: ['tag-1'], mediaType: 'all', sortOrder: 'desc' },
+      personNames: new Map([['person-1', 'Anna']]),
+      tagNames: new Map([['tag-1', 'Travel']]),
+    });
+
+    await manager.activateSearch('beach person:anna tag:travel');
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?q=beach&people=person-1&tags=tag-1', {
+      personNames: new Map([['person-1', 'Anna']]),
+      tagNames: new Map([['tag-1', 'Travel']]),
+    });
+  });
+
+  it('supports filter-only searches without q', async () => {
+    const manager = new GlobalSearchManager();
+    typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+      ok: true,
+      queryText: '',
+      filters: { personIds: ['person-1'], tagIds: [], mediaType: 'all', sortOrder: 'desc' },
+      personNames: new Map([['person-1', 'Anna']]),
+      tagNames: new Map(),
+    });
+
+    await manager.activateSearch('person:anna');
+
+    expect(goto).toHaveBeenCalledWith('/photos?people=person-1');
+  });
+
   it('blocks navigation and exposes issues when resolution fails', async () => {
     const manager = new GlobalSearchManager();
     const issue = { code: 'no-match', key: 'person', raw: 'person:anna', value: 'anna', message: 'No person found for "anna"' };
-    typedSearchMock.parseTypedSearch.mockReturnValue({ queryText: 'beach', scalarTokens: [], resolutionTokens: [], displayTokens: [], issues: [] });
     typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({ ok: false, queryText: 'beach', issues: [issue], choices: [] });
 
     await manager.activateSearch('beach person:anna');
@@ -1067,10 +1630,27 @@ describe('GlobalSearchManager typed search commit', () => {
     expect(manager.typedSearchIssues).toEqual([issue]);
   });
 
+  it('stores an ambiguity choice and clears matching issue state', () => {
+    const manager = new GlobalSearchManager();
+    const issue = { code: 'ambiguous', key: 'person', raw: 'person:anna', value: 'anna', message: 'Choose a person for "anna"' };
+    const choice = { tokenRaw: 'person:anna', key: 'person' as const, id: 'person-2', label: 'Anna Maria', value: 'anna' };
+    manager.typedSearchIssues = [issue];
+    manager.typedSearchChoices = [choice];
+    manager.typedSearchDisplayTokens = [{ raw: 'person:anna', key: 'person', value: 'anna', status: 'error', issue }];
+
+    manager.selectTypedSearchChoice(choice);
+
+    expect(manager.selectedTypedSearchChoices.get('person:anna')).toEqual(choice);
+    expect(manager.typedSearchIssues).toEqual([]);
+    expect(manager.typedSearchChoices).toEqual([]);
+    expect(manager.typedSearchDisplayTokens).toEqual([
+      { raw: 'person:anna', key: 'person', value: 'Anna Maria', status: 'resolved-entity' },
+    ]);
+  });
+
   it('falls back to photos when current page is not searchable', async () => {
     mockPage.url = new URL('https://gallery.test/albums');
     const manager = new GlobalSearchManager();
-    typedSearchMock.parseTypedSearch.mockReturnValue({ queryText: 'beach', scalarTokens: [], resolutionTokens: [], displayTokens: [], issues: [] });
     typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
       ok: true,
       queryText: 'beach',
@@ -1094,7 +1674,7 @@ Run:
 pnpm --dir web exec vitest --run src/lib/managers/global-search-manager.svelte.spec.ts
 ```
 
-Expected: FAIL because `activateSearch` is synchronous and manager has no typed issue state.
+Expected: FAIL because `activateSearch` is synchronous, manager has no typed issue state, and live provider batches still use the raw query.
 
 - [ ] **Step 3: Implement manager commit state**
 
@@ -1103,6 +1683,7 @@ Modify `global-search-manager.svelte.ts`:
 ```ts
 import { parseTypedSearch, type TypedSearchDisplayToken, type TypedSearchIssue } from '$lib/utils/typed-search/typed-search-parser';
 import { resolveTypedSearchFilters, type TypedSearchChoice } from '$lib/utils/typed-search/typed-search-resolver';
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 ```
 
 Add state:
@@ -1111,6 +1692,9 @@ Add state:
 typedSearchDisplayTokens = $state<TypedSearchDisplayToken[]>([]);
 typedSearchIssues = $state<TypedSearchIssue[]>([]);
 typedSearchChoices = $state<TypedSearchChoice[]>([]);
+// eslint-disable-next-line svelte/prefer-svelte-reactivity
+selectedTypedSearchChoices = new Map<string, TypedSearchChoice>();
+typedSearchPlainQuery = $state('');
 ```
 
 Add a parse helper:
@@ -1119,12 +1703,55 @@ Add a parse helper:
 parseTypedSearchDraft(text = this.query) {
   const parsed = parseTypedSearch(text);
   this.typedSearchDisplayTokens = parsed.displayTokens;
-  if (this.typedSearchIssues.length === 0) {
-    this.typedSearchChoices = [];
+  this.typedSearchPlainQuery = parsed.queryText;
+  this.typedSearchIssues = [];
+  this.typedSearchChoices = [];
+  for (const key of [...this.selectedTypedSearchChoices.keys()]) {
+    if (!parsed.resolutionTokens.some((token) => token.raw === key)) {
+      this.selectedTypedSearchChoices.delete(key);
+    }
   }
   return parsed;
 }
 ```
+
+Add a choice helper:
+
+```ts
+selectTypedSearchChoice(choice: TypedSearchChoice) {
+  this.selectedTypedSearchChoices.set(choice.tokenRaw, choice);
+  this.typedSearchIssues = this.typedSearchIssues.filter((issue) => issue.raw !== choice.tokenRaw);
+  this.typedSearchChoices = this.typedSearchChoices.filter((item) => item.tokenRaw !== choice.tokenRaw);
+  this.typedSearchDisplayTokens = this.typedSearchDisplayTokens.map((token) =>
+    token.raw === choice.tokenRaw
+      ? { raw: token.raw, key: token.key, value: choice.label, status: 'resolved-entity' as const }
+      : token,
+  );
+}
+```
+
+Update live provider payload and top-search display so live results use plain query text, while Enter still commits the raw input:
+
+```ts
+private getSearchProviderPayload(): string {
+  if (this.scope !== 'all') {
+    return this.payload;
+  }
+  return this.typedSearchPlainQuery;
+}
+```
+
+Use `getSearchProviderPayload()` in `runBatch()` for entity providers when `scope === 'all'`. Keep prefix scopes (`@`, `#`, `/`, `>`) using `this.payload`. Update the top-search type and derived value:
+
+In `setQuery()`, call `parseTypedSearchDraft()` after `this.query` is updated and before the debounced batch is scheduled. For non-`all` prefix scopes, clear typed-search display/issues/choices so prefix modes do not show stale typed tokens.
+
+In `runBatch()`, derive `providerPayload = scope === 'all' ? this.getSearchProviderPayload() : payload` and use `providerPayload` for min-length checks and `provider.run(providerPayload, mode, signal)`. Keep the original `payload` for bare-prefix detection so `@`, `#`, `/`, and `>` behavior remains unchanged.
+
+```ts
+type TopSearchMatch = { id: 'top-search'; query: string; rawQuery: string };
+```
+
+For all-scope typed search, return `{ id: 'top-search', query: this.typedSearchPlainQuery || query, rawQuery: query }` so a filter-only search can still be committed.
 
 Change `activateSearch` to async:
 
@@ -1136,8 +1763,19 @@ async activateSearch(text: string): Promise<void> {
   }
 
   const parsed = this.parseTypedSearchDraft(trimmed);
+  if (parsed.issues.length > 0) {
+    this.typedSearchIssues = parsed.issues;
+    this.typedSearchChoices = [];
+    this.typedSearchDisplayTokens = parsed.displayTokens;
+    return;
+  }
+
   const spaceId = page.url.pathname.startsWith('/spaces/') ? page.url.pathname.split('/').filter(Boolean)[1] : undefined;
-  const resolved = await resolveTypedSearchFilters(parsed, { spaceId, signal: this.closeSignal });
+  const resolved = await resolveTypedSearchFilters(parsed, {
+    spaceId,
+    signal: this.closeSignal,
+    selectedChoices: this.selectedTypedSearchChoices,
+  });
 
   if (!resolved.ok) {
     this.typedSearchIssues = resolved.issues;
@@ -1157,11 +1795,13 @@ async activateSearch(text: string): Promise<void> {
     text: trimmed,
     lastUsed: Date.now(),
   });
-  void goto(this.buildSearchDestination(resolved.queryText, resolved.filters));
+  const destination = this.buildSearchDestination(resolved.queryText, resolved.filters);
+  storeTypedSearchNames(destination, { personNames: resolved.personNames, tagNames: resolved.tagNames });
+  void goto(destination);
 }
 ```
 
-Update `buildSearchDestination(text: string, filters?: FilterState)` and pass filters into `buildSearchablePageUrl`. For non-searchable fallback, construct `/photos` params using a temporary URL and `buildSearchablePageUrl(new URL('/photos', page.url), text, this.searchSortOrder, filters)`.
+Update `buildSearchDestination(text: string, filters?: FilterState)` and pass filters into `buildSearchablePageUrl`. For non-searchable fallback, construct `/photos` params using a temporary URL and `buildSearchablePageUrl(new URL('/photos', page.url), text, this.searchSortOrder, filters)`. Return a string from every branch; if `buildSearchablePageUrl` unexpectedly returns `null` for the fallback URL, return `/photos`.
 
 - [ ] **Step 4: Update call sites that assume synchronous activateSearch**
 
@@ -1172,6 +1812,8 @@ void this.activateSearch(entry.text);
 ```
 
 In `global-search.svelte`, existing calls already use `manager.activateSearch(...)`; convert click and key handlers to `void manager.activateSearch(...)`.
+
+When the active item is `manager.topSearchMatch`, pass `manager.topSearchMatch.rawQuery` to `activateSearch()` and keep `manager.topSearchMatch.query` for display text.
 
 - [ ] **Step 5: Run manager tests and verify green**
 
@@ -1309,21 +1951,40 @@ Expected: PASS.
 
 - [ ] **Step 5: Write failing palette integration tests**
 
+In `global-search.spec.ts`, include `getFilterSuggestions` in the existing `@immich/sdk` import and mock:
+
+```ts
+import { AssetVisibility, getFilterSuggestions, getMlHealth, searchAssets, searchPerson, searchPlaces, searchSmart } from '@immich/sdk';
+```
+
+```ts
+getFilterSuggestions: vi.fn().mockResolvedValue({
+  people: [],
+  countries: [],
+  cameraMakes: [],
+  cameraModels: [],
+  tags: [],
+  ratings: [],
+  mediaTypes: [],
+  hasUnnamedPeople: false,
+}),
+```
+
 Add to `global-search.spec.ts`:
 
 ```ts
-it('renders typed search tokens while typing without resolving filters', async () => {
+it('renders typed search tokens while typing without resolving suggestion-backed filters', async () => {
   const m = new GlobalSearchManager();
   const parseSpy = vi.spyOn(m, 'parseTypedSearchDraft');
   m.open();
   render(GlobalSearch, { props: { manager: m } });
 
-  await user.type(screen.getByRole('combobox'), 'beach person:anna from:2025');
+  await user.type(screen.getByRole('combobox'), 'beach camera:nikon from:2025');
 
   expect(parseSpy).toHaveBeenCalled();
   expect(screen.getByTestId('typed-search-token-rail')).toBeInTheDocument();
-  expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
-  expect(searchPerson).not.toHaveBeenCalled();
+  expect(screen.getByTestId('typed-search-token-camera')).toHaveAttribute('data-status', 'pending-entity');
+  expect(getFilterSuggestions).not.toHaveBeenCalled();
 });
 
 it('keeps the palette open and shows typed search issues after failed Enter commit', async () => {
@@ -1340,6 +2001,28 @@ it('keeps the palette open and shows typed search issues after failed Enter comm
   expect(screen.getByText('No person found for "anna"')).toBeVisible();
   expect(screen.getByRole('dialog')).toBeInTheDocument();
 });
+
+it('renders ambiguity choices and sends selection to the manager', async () => {
+  const m = new GlobalSearchManager();
+  const selectSpy = vi.spyOn(m, 'selectTypedSearchChoice');
+  m.typedSearchIssues = [{ code: 'ambiguous', key: 'person', raw: 'person:anna', value: 'anna', message: 'Choose a person for "anna"' }];
+  m.typedSearchChoices = [
+    { tokenRaw: 'person:anna', key: 'person', id: 'person-1', label: 'Anna', value: 'anna' },
+    { tokenRaw: 'person:anna', key: 'person', id: 'person-2', label: 'Anna Maria', value: 'anna' },
+  ];
+  m.open();
+  render(GlobalSearch, { props: { manager: m } });
+
+  await user.click(screen.getByRole('button', { name: 'Anna Maria' }));
+
+  expect(selectSpy).toHaveBeenCalledWith({
+    tokenRaw: 'person:anna',
+    key: 'person',
+    id: 'person-2',
+    label: 'Anna Maria',
+    value: 'anna',
+  });
+});
 ```
 
 - [ ] **Step 6: Run palette tests and verify red**
@@ -1350,7 +2033,7 @@ Run:
 pnpm --dir web exec vitest --run src/lib/components/global-search/__tests__/global-search.spec.ts
 ```
 
-Expected: FAIL because the palette does not render token rail or issue rows.
+Expected: FAIL because the palette does not render token rail, issue rows, or ambiguity choice rows.
 
 - [ ] **Step 7: Integrate token rail and issue rows**
 
@@ -1391,6 +2074,29 @@ Above normal command groups, render issues:
 {/if}
 ```
 
+Below issue rows, render ambiguity choices:
+
+```svelte
+{#if manager.typedSearchChoices.length > 0}
+  <Command.Group class="mb-4" data-typed-search-choices>
+    <Command.GroupHeading class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+      Choose filter value
+    </Command.GroupHeading>
+    <div class="space-y-1 px-3">
+      {#each manager.typedSearchChoices as choice (`${choice.tokenRaw}:${choice.key}:${choice.id ?? choice.field ?? choice.label}`)}
+        <button
+          type="button"
+          class="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm hover:bg-primary/10"
+          onclick={() => manager.selectTypedSearchChoice(choice)}
+        >
+          <span>{choice.label}</span>
+        </button>
+      {/each}
+    </div>
+  </Command.Group>
+{/if}
+```
+
 - [ ] **Step 8: Run UI tests and verify green**
 
 Run:
@@ -1423,7 +2129,7 @@ Run:
 
 ```bash
 pnpm --filter @immich/sdk build
-pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-parser.spec.ts src/lib/utils/typed-search/typed-search-resolver.spec.ts src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
+pnpm --dir web exec vitest --run src/lib/utils/typed-search/typed-search-parser.spec.ts src/lib/utils/typed-search/typed-search-resolver.spec.ts src/lib/utils/typed-search/typed-search-name-cache.spec.ts src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts 'src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts' 'src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts'
 ```
 
 Expected: PASS.

--- a/docs/superpowers/specs/2026-05-03-search-filter-syntax-design.md
+++ b/docs/superpowers/specs/2026-05-03-search-filter-syntax-design.md
@@ -1,0 +1,267 @@
+# Typed Search Filters Design
+
+Status: approved for implementation planning
+Date: 2026-05-03
+Worktree: `/home/pierre/dev/gallery/.worktrees/brainstorm-search-filter-syntax`
+Branch: `brainstorm/search-filter-syntax`
+
+## Problem
+
+Gallery has a capable search and filter stack, but adding filters currently requires leaving the keyboard flow and using the filter panel. Power users should be able to include filters directly in the search bar, for example:
+
+```text
+beach person:anna from:2025 to:2026 camera:nikon
+```
+
+The typed syntax should be a shortcut over the existing filter model, not a replacement for the filter panel.
+
+## Goals
+
+- Let users type existing search filters in the global search bar.
+- Preserve plain search text as the smart-search query.
+- Apply typed filters only when the user commits with Enter.
+- Keep live global-search results cheap by not resolving or applying typed filters while typing.
+- Use the current searchable context when possible: `/photos` stays on photos, `/spaces/:id` stays in that space, and other pages fall back to `/photos`.
+- Serialize committed filters into the URL so refresh, share links, browser history, active filter chips, and the filter panel stay aligned.
+- Block submission when any typed filter is invalid, ambiguous, or unresolved.
+
+## Non-Goals
+
+- Do not build a full token editor in the first version.
+- Do not support boolean logic, grouping, negation, or arbitrary search expressions in the first version.
+- Do not silently drop failed filters and submit the remaining query.
+- Do not replace the existing filter panel or active filter chip UI.
+
+## User Experience
+
+The search input becomes a quiet command-token rail. Recognized completed `key:value` filters render as compact inline tokens inside the search field wrapper, while non-filter words remain normal editable query text.
+
+Tokens should use restrained visuals that match the existing command palette:
+
+- `recognized`: syntactically valid scalar filters such as `from:2025`, `rating:4`, or `type:video`.
+- `pending entity`: syntactically valid entity filters such as `person:anna` or `tag:vacation` before Enter resolution.
+- `resolved entity`: an entity token that has been disambiguated in the current palette session.
+- `error`: a token that failed validation or resolution after Enter.
+
+The token display should not become a separate visual system. Prefer compact key/value styling such as `person Anna` and `from 2025`, with subtle border/background treatment and existing primary/error colors. Do not add a separate "will apply filters" preview row when inline tokens are visible.
+
+Keyboard behavior stays simple:
+
+- Backspace edits the raw input normally.
+- Arrow keys continue to navigate the command palette.
+- Enter commits the search when all tokens are valid.
+- Enter resolves the active ambiguity when a resolution row is selected.
+- Failed tokens keep the palette open and show issue rows below the input.
+
+## Syntax
+
+The first version supports existing filter concepts only:
+
+- `person:<name>`: resolves to one or more person IDs.
+- `tag:<name>`: resolves to one or more tag IDs.
+- `from:<date>`: maps to `dateAfter`.
+- `to:<date>`: maps to `dateBefore`.
+- `city:<value>`: maps to `city`.
+- `country:<value>`: maps to `country`.
+- `camera:<value>`: maps to camera make/model matching.
+- `type:<photo|image|video>`: maps to `mediaType`.
+- `favorite:<true|false|yes|no>`: maps to `isFavorite`.
+- `rating:<1-5>`: maps to `rating`.
+
+Plain words outside recognized filter tokens become the search query. For example:
+
+```text
+beach person:anna from:2025
+```
+
+commits query `beach` plus person/date filters.
+
+Quoted values are part of v1 so names and places with spaces work:
+
+```text
+person:"Anna Maria" city:"New York"
+```
+
+Unknown alphabetic `key:value` tokens should become invalid tokens and block submission with a useful issue row. This keeps typos such as `persn:anna` visible instead of silently treating them as query text.
+
+## Date Semantics
+
+Date tokens should accept:
+
+- `YYYY`
+- `YYYY-MM`
+- `YYYY-MM-DD`
+
+`from:` should map to the start of the supplied period:
+
+- `from:2025` -> `2025-01-01`
+- `from:2025-06` -> `2025-06-01`
+- `from:2025-06-14` -> `2025-06-14`
+
+`to:` should map to the end of the supplied period as an inclusive date stored in `FilterState.dateBefore`:
+
+- `to:2026` -> `2026-12-31`
+- `to:2026-03` -> `2026-03-31`
+- `to:2026-03-10` -> `2026-03-10`
+
+This matches the existing `buildFilterContext()` behavior, which turns `dateBefore` into an exclusive UTC end internally.
+
+## Commit And Resolution
+
+Typed filters are all-or-nothing on Enter.
+
+Commit flow:
+
+1. Parse the raw input into query text, scalar tokens, entity tokens, and invalid tokens.
+2. Validate scalar filters locally.
+3. Resolve `person:` and `tag:` tokens in the current context.
+4. If any token fails, keep the palette open and mark the token.
+5. If every token succeeds, build a destination URL with `q`, `sort`, and serialized filters.
+6. Navigate to the context-aware destination.
+7. Destination pages hydrate their local `FilterState` from the URL and run existing result/facet logic.
+
+Resolution behavior:
+
+- A single strong entity match can be applied automatically.
+- Multiple plausible matches block submission and show selectable rows.
+- No match blocks submission and marks the token as unresolved.
+- Selecting an ambiguity row resolves that token. If no other issues remain, the user may press Enter again to submit.
+
+## Architecture
+
+### `typed-search-parser`
+
+A pure utility that accepts raw input and returns:
+
+- `queryText`
+- recognized scalar tokens
+- pending entity tokens
+- invalid tokens
+- display tokens for the inline rail
+
+This module should have no network or Svelte dependencies.
+
+### `typed-search-resolver`
+
+Runs only on Enter. It resolves entity tokens and produces either:
+
+- a `FilterState` patch that can be serialized into the destination URL, or
+- blocking issues for unresolved, ambiguous, or invalid tokens.
+
+For `/spaces/:id`, person resolution should prefer space-scoped people/facets where available. For `/photos`, it should resolve globally. Tags should follow the same contextual pattern where the API supports it.
+
+### `searchable-page-search`
+
+Extend the existing URL helpers so typed filters can be serialized alongside `q` and `sort`.
+
+The current helper already preserves the searchable base path for photos and spaces. The new behavior should add filter params while keeping this context-aware routing.
+
+### Destination Pages
+
+`/photos` and `/spaces/:id` should hydrate URL filter params into local `FilterState` on initial load and relevant client-side URL changes.
+
+The existing search flow should then remain responsible for:
+
+- smart-search result fetching
+- metadata/timeline filter options
+- smart facet loading
+- active filter chip rendering
+- filter panel state
+
+## URL Serialization
+
+Use explicit, readable query params for filters rather than encoding the full filter state as JSON. Use these names unless implementation discovers a concrete collision with existing routes:
+
+- `people=<id>,<id>`
+- `tags=<id>,<id>`
+- `city=<value>`
+- `country=<value>`
+- `make=<value>`
+- `model=<value>`
+- `type=image|video`
+- `favorite=true|false`
+- `rating=1..5`
+- `from=YYYY-MM-DD`
+- `to=YYYY-MM-DD`
+
+The URL layer should preserve existing unrelated params where the current helper already does so, and clearing filters should remove only filter params plus any query params explicitly cleared by the user action.
+
+## Camera Matching
+
+`camera:<value>` is a convenience alias over the existing camera filter. It should resolve to the most appropriate existing camera field:
+
+- If the value clearly matches a make, set `make`.
+- If it clearly matches a model, set `model`.
+- If it is ambiguous between make and model, block commit and show choices.
+
+The first implementation should match against current camera suggestions. It should not invent camera values that the current filter UI could not apply.
+
+## Error Handling
+
+Typed-filter commit errors are separate from provider/search errors.
+
+Invalid scalar examples:
+
+- `from:soon`
+- `to:2026-99-01`
+- `rating:seven`
+- `rating:9`
+- `type:gif`
+- `favorite:maybe`
+
+Entity examples:
+
+- `person:anna` with no matches -> unresolved token, no navigation.
+- `person:anna` with multiple matches -> ambiguity rows, no navigation.
+- `tag:vacation` with no matches -> unresolved token, no navigation.
+
+The issue rows should be concise and actionable. The user should be able to edit the original text and retry without losing input.
+
+## Testing
+
+Parser tests:
+
+- plain query extraction
+- recognized filters
+- quoted values
+- malformed tokens
+- unknown keys
+- duplicate filters
+- date validation
+- rating validation
+- type/favorite validation
+
+Resolver tests:
+
+- no entity match
+- single strong entity match
+- ambiguous entity matches
+- repeated people/tags
+- space-scoped resolution
+- abort/error handling
+
+URL/state tests:
+
+- serialize filters into `/photos`
+- serialize filters into `/spaces/:id`
+- hydrate URL params into `FilterState`
+- preserve query and sort
+- clear typed filters correctly
+- keep active filter chips in sync with hydrated state
+
+Component tests:
+
+- inline token rendering
+- no resolver calls while typing
+- Enter blocked on invalid tokens
+- issue rows for unresolved tokens
+- ambiguity rows and selection
+- successful context-aware navigation
+
+## Implementation Notes
+
+- Keep parser and URL helpers independent from Svelte components.
+- Avoid introducing a second filter state model. Typed search should produce the same `FilterState` shape the existing filter panel uses.
+- Do not fetch entity suggestions on every keystroke in v1.
+- Use the current global-search manager activation path as the commit integration point.
+- The initial worktree baseline test attempt failed because the web test invocation expanded into the broader suite and many files failed to resolve `@immich/sdk`. Implementation planning should include a focused verification command that first ensures workspace SDK packages are available.

--- a/docs/superpowers/specs/2026-05-03-search-filter-syntax-design.md
+++ b/docs/superpowers/specs/2026-05-03-search-filter-syntax-design.md
@@ -57,14 +57,14 @@ Keyboard behavior stays simple:
 
 The first version supports existing filter concepts only:
 
-- `person:<name>`: resolves to one or more person IDs.
-- `tag:<name>`: resolves to one or more tag IDs.
+- `person:<name>`: resolves to one person ID; repeated tokens accumulate multiple people.
+- `tag:<name>`: resolves to one tag ID; repeated tokens accumulate multiple tags.
 - `from:<date>`: maps to `dateAfter`.
 - `to:<date>`: maps to `dateBefore`.
 - `city:<value>`: maps to `city`.
 - `country:<value>`: maps to `country`.
-- `camera:<value>`: maps to camera make/model matching.
-- `type:<photo|image|video>`: maps to `mediaType`.
+- `camera:<value>`: resolves through camera make/model suggestions.
+- `type:<photo|image|video>`: maps to `mediaType`; `photo` is an alias for `image`.
 - `favorite:<true|false|yes|no>`: maps to `isFavorite`.
 - `rating:<1-5>`: maps to `rating`.
 
@@ -82,7 +82,18 @@ Quoted values are part of v1 so names and places with spaces work:
 person:"Anna Maria" city:"New York"
 ```
 
+Quoted values must support spaces. Escaped quotes inside values are not part of v1. Unterminated quotes should remain editable while typing and become invalid tokens on Enter.
+
 Unknown alphabetic `key:value` tokens should become invalid tokens and block submission with a useful issue row. This keeps typos such as `persn:anna` visible instead of silently treating them as query text.
+
+Empty values are invalid for every typed filter. While the user is still typing, incomplete tokens such as `person:` may render as pending input; on Enter they block submission.
+
+Duplicate and conflicting filters should be deterministic:
+
+- `person:` and `tag:` may appear multiple times and should accumulate resolved IDs.
+- Repeating scalar filters such as `from:`, `to:`, `city:`, `country:`, `camera:`, `type:`, `favorite:`, and `rating:` should block submission instead of silently choosing one value.
+- `from:` later than `to:` should block submission.
+- `camera:` may set either `make` or `model`; if separate `make` or `model` URL params already exist, typed camera filters should replace only the field they resolve to during commit.
 
 ## Date Semantics
 
@@ -114,7 +125,7 @@ Commit flow:
 
 1. Parse the raw input into query text, scalar tokens, entity tokens, and invalid tokens.
 2. Validate scalar filters locally.
-3. Resolve `person:` and `tag:` tokens in the current context.
+3. Resolve suggestion-backed tokens (`person:`, `tag:`, and `camera:`) in the current context.
 4. If any token fails, keep the palette open and mark the token.
 5. If every token succeeds, build a destination URL with `q`, `sort`, and serialized filters.
 6. Navigate to the context-aware destination.
@@ -143,12 +154,12 @@ This module should have no network or Svelte dependencies.
 
 ### `typed-search-resolver`
 
-Runs only on Enter. It resolves entity tokens and produces either:
+Runs only on Enter. It resolves entity and suggestion-backed tokens and produces either:
 
 - a `FilterState` patch that can be serialized into the destination URL, or
 - blocking issues for unresolved, ambiguous, or invalid tokens.
 
-For `/spaces/:id`, person resolution should prefer space-scoped people/facets where available. For `/photos`, it should resolve globally. Tags should follow the same contextual pattern where the API supports it.
+For `/spaces/:id`, person resolution should prefer space-scoped people/facets where available. For `/photos`, it should resolve globally. Tags and cameras should follow the same contextual pattern where the API supports it.
 
 ### `searchable-page-search`
 
@@ -167,6 +178,8 @@ The existing search flow should then remain responsible for:
 - smart facet loading
 - active filter chip rendering
 - filter panel state
+
+When URL hydration includes person or tag IDs, destination pages must populate `personNames` and `tagNames` maps from resolver output when navigating from the palette, or from filter suggestions/facets after refresh. Active filter chips may temporarily fall back to IDs only while names are loading.
 
 ## URL Serialization
 
@@ -217,6 +230,30 @@ Entity examples:
 
 The issue rows should be concise and actionable. The user should be able to edit the original text and retry without losing input.
 
+## TDD Requirements
+
+Implementation should use red-green-refactor for every behavior change. No production code should be added for a parser, resolver, URL helper, or component behavior until a focused test for that behavior has been written and observed failing for the expected reason.
+
+Recommended order:
+
+1. Add parser tests first, run them, and confirm they fail because `typed-search-parser` does not exist or lacks the behavior.
+2. Implement the smallest parser slice that makes those tests pass.
+3. Add URL serialization/hydration tests and confirm they fail before changing `searchable-page-search` or route state.
+4. Implement the smallest URL/state slice that makes those tests pass.
+5. Add resolver tests with mocked SDK calls and confirm the desired failure before adding resolver behavior.
+6. Implement the smallest resolver slice that makes those tests pass.
+7. Add component/manager tests for token rendering, Enter commit, blocking issues, ambiguity selection, and navigation.
+8. Implement UI and manager integration only after those tests fail correctly.
+
+Focused verification commands should use direct vitest invocation so arguments do not expand into the full web suite:
+
+```bash
+pnpm --filter @immich/sdk build
+pnpm --dir web exec vitest --run <focused-spec-file>
+```
+
+The broader web suite should be run only after the SDK workspace package has been built and focused tests are green.
+
 ## Testing
 
 Parser tests:
@@ -224,12 +261,22 @@ Parser tests:
 - plain query extraction
 - recognized filters
 - quoted values
+- unterminated quotes
+- escaped quote sequences rejected as invalid input
 - malformed tokens
 - unknown keys
 - duplicate filters
+- empty values
+- repeated `person:` and `tag:` accumulation
+- repeated scalar filter rejection
 - date validation
+- date range ordering where `from:` is after `to:`
+- `YYYY`, `YYYY-MM`, and `YYYY-MM-DD` expansion
 - rating validation
 - type/favorite validation
+- `type:photo` aliasing to `image`
+- case normalization for keys and boolean/media values
+- preserving colon-containing plain text that is not an alphabetic `key:value` filter
 
 Resolver tests:
 
@@ -238,6 +285,11 @@ Resolver tests:
 - ambiguous entity matches
 - repeated people/tags
 - space-scoped resolution
+- camera make match
+- camera model match
+- ambiguous camera make/model match
+- no camera match
+- resolver output includes display names for hydrated person/tag chips
 - abort/error handling
 
 URL/state tests:
@@ -246,6 +298,11 @@ URL/state tests:
 - serialize filters into `/spaces/:id`
 - hydrate URL params into `FilterState`
 - preserve query and sort
+- preserve unrelated URL params that the current helper preserves
+- remove only typed filter params when clearing filters
+- invalid URL params fall back safely without crashing
+- `type=photo` is not emitted; `type=image` is emitted
+- multiple people/tags round-trip through URL encoding
 - clear typed filters correctly
 - keep active filter chips in sync with hydrated state
 
@@ -256,6 +313,12 @@ Component tests:
 - Enter blocked on invalid tokens
 - issue rows for unresolved tokens
 - ambiguity rows and selection
+- no navigation on invalid, unresolved, ambiguous, or resolver-error commits
+- successful `/photos` navigation
+- successful `/spaces/:id` and `/spaces/:id/photos` navigation
+- fallback `/photos` navigation from non-searchable pages
+- raw input remains editable after a failed commit
+- resolved entity token state resets when the raw token text changes
 - successful context-aware navigation
 
 ## Implementation Notes

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -57,6 +57,24 @@ describe('ActiveFiltersBar', () => {
     expect(chips[0].textContent).not.toContain(',');
   });
 
+  it('should render chip for city only when no country', () => {
+    const filters = createFilterState();
+    filters.city = 'New York City';
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('New York City');
+    expect(chips[0].textContent).not.toContain(',');
+  });
+
   it('should render chip for rating as "\u2605 3+"', () => {
     const filters = createFilterState();
     filters.rating = 3;

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -112,7 +112,29 @@ describe('FilterPanel', () => {
     expect(queryByTestId('filter-section-media')).toBeTruthy();
   });
 
-  it('should work without onFilterChange callback', () => {
+  it('should call onFiltersChange when filters are changed inside the panel', async () => {
+    const onFiltersChange = vi.fn();
+
+    render(FilterPanel, {
+      props: {
+        config: {
+          sections: ['location'],
+          providers: {
+            locations: () => Promise.resolve([{ value: 'Germany', type: 'country' as const }]),
+            cities: () => Promise.resolve([]),
+          },
+        },
+        timeBuckets: [],
+        onFiltersChange,
+      },
+    });
+
+    await fireEvent.click(await screen.findByTestId('location-country-Germany'));
+
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ country: 'Germany', city: undefined }));
+  });
+
+  it('should work without onFiltersChange callback', () => {
     const { queryByTestId } = render(FilterPanel, {
       props: {
         config: { sections: ['rating'], providers: {} },

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -245,6 +245,35 @@ describe('PeopleFilter', () => {
 
     expect(getByTestId('people-empty').textContent).toBe('No people found');
   });
+
+  it('should display orphaned selected person name from typed search cache', () => {
+    const { getByTestId } = render(PeopleFilter, {
+      props: {
+        people: [{ id: 'p-other', name: 'Other Person' }],
+        selectedIds: ['p-cat'],
+        selectedNames: new Map([['p-cat', 'cat']]),
+        onSelectionChange: () => {},
+      },
+    });
+
+    const orphanItem = getByTestId('people-item-p-cat');
+    expect(orphanItem.textContent).toContain('cat');
+    expect(orphanItem.textContent).not.toContain('p-cat');
+  });
+
+  it('should show typed selected person even when suggestions are empty', () => {
+    const { getByTestId, queryByTestId } = render(PeopleFilter, {
+      props: {
+        people: [],
+        selectedIds: ['p-cat'],
+        selectedNames: new Map([['p-cat', 'cat']]),
+        onSelectionChange: () => {},
+      },
+    });
+
+    expect(queryByTestId('people-empty')).toBeNull();
+    expect(getByTestId('people-item-p-cat').textContent).toContain('cat');
+  });
 });
 
 describe('LocationFilter', () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -420,6 +420,24 @@ describe('LocationFilter', () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
+  it('should show a selected city-only filter before a country is expanded', () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['United States of America'],
+        selectedCity: 'New York City',
+        onCityFetch: () => Promise.resolve(['New York City', 'Seattle']),
+        onSelectionChange,
+      },
+    });
+
+    const selectedCity = getByTestId('location-city-New York City');
+    expect(selectedCity.className).toContain('font-medium');
+    expect(selectedCity.textContent).toContain('New York City');
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
   it('should clear a city-only selection when clicking the selected city', async () => {
     const onSelectionChange = vi.fn();
 

--- a/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-sections.spec.ts
@@ -398,6 +398,49 @@ describe('LocationFilter', () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
+  it('should mark a city-only selection as selected under its matching country', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['United States of America'],
+        selectedCity: 'New York City',
+        onCityFetch: () => Promise.resolve(['New York City', 'Seattle']),
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-United States of America'));
+    onSelectionChange.mockClear();
+
+    await waitFor(() => expect(queryByTestId('location-city-New York City')).toBeTruthy());
+    const selectedCity = getByTestId('location-city-New York City');
+    expect(selectedCity.className).toContain('font-medium');
+    expect(selectedCity.textContent).toContain('New York City');
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  it('should clear a city-only selection when clicking the selected city', async () => {
+    const onSelectionChange = vi.fn();
+
+    const { getByTestId, queryByTestId } = render(LocationFilter, {
+      props: {
+        countries: ['United States of America'],
+        selectedCity: 'New York City',
+        onCityFetch: () => Promise.resolve(['New York City', 'Seattle']),
+        onSelectionChange,
+      },
+    });
+
+    await fireEvent.click(getByTestId('location-country-United States of America'));
+    await waitFor(() => expect(queryByTestId('location-city-New York City')).toBeTruthy());
+    onSelectionChange.mockClear();
+
+    await fireEvent.click(getByTestId('location-city-New York City'));
+
+    expect(onSelectionChange).toHaveBeenCalledWith(undefined, undefined);
+  });
+
   it('should keep a selected city visible when it does not match the active search', async () => {
     const onSelectionChange = vi.fn();
 

--- a/web/src/lib/components/filter-panel/__tests__/tags-filter.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/tags-filter.spec.ts
@@ -168,6 +168,36 @@ describe('TagsFilter', () => {
     expect(orphanItem.textContent).toContain('t-never-seen');
   });
 
+  it('should display orphaned selected tag name from typed search cache', () => {
+    const tags = [{ id: 't1', name: 'Vacation' }];
+    const { getByTestId } = render(TagsFilter, {
+      props: {
+        tags,
+        selectedIds: ['t-nature'],
+        selectedNames: new Map([['t-nature', 'nature']]),
+        onSelectionChange: () => {},
+      },
+    });
+
+    const orphanItem = getByTestId('tags-item-t-nature');
+    expect(orphanItem.textContent).toContain('nature');
+    expect(orphanItem.textContent).not.toContain('t-nature');
+  });
+
+  it('should show typed selected tag even when suggestions are empty', () => {
+    const { getByTestId, queryByTestId } = render(TagsFilter, {
+      props: {
+        tags: [],
+        selectedIds: ['t-nature'],
+        selectedNames: new Map([['t-nature', 'nature']]),
+        onSelectionChange: () => {},
+      },
+    });
+
+    expect(queryByTestId('tags-empty')).toBeNull();
+    expect(getByTestId('tags-item-t-nature').textContent).toContain('nature');
+  });
+
   it('should set aria-pressed on tag buttons', () => {
     const tags = makeTags(3);
     const { getByTestId } = render(TagsFilter, {

--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -65,6 +65,8 @@
     // Location chip
     if (filters.city && filters.country) {
       result.push({ type: 'location', label: `${filters.city}, ${filters.country}` });
+    } else if (filters.city) {
+      result.push({ type: 'location', label: filters.city });
     } else if (filters.country) {
       result.push({ type: 'location', label: filters.country });
     }

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -39,6 +39,7 @@
     filters?: FilterState;
     personNames?: Map<string, string>;
     tagNames?: Map<string, string>;
+    onFiltersChange?: (filters: FilterState) => void;
     persistCollapsed?: boolean;
     storageKey?: string;
     hidden?: boolean;
@@ -52,6 +53,7 @@
     filters = $bindable(createFilterState()),
     personNames,
     tagNames,
+    onFiltersChange,
     storageKey = 'gallery-filter-visible-sections',
     hidden = false,
     persistCollapsed = true,
@@ -556,40 +558,57 @@
     }
   });
 
+  function updateFilters(nextFilters: FilterState) {
+    filters = nextFilters;
+    onFiltersChange?.(nextFilters);
+  }
+
   function handlePeopleChange(ids: string[]) {
-    filters = { ...filters, personIds: ids };
+    updateFilters({ ...filters, personIds: ids });
   }
 
   function handleLocationChange(country?: string, city?: string) {
-    filters = { ...filters, country, city };
+    updateFilters({ ...filters, country, city });
   }
 
   function handleCameraChange(make?: string, model?: string) {
-    filters = { ...filters, make, model };
+    updateFilters({ ...filters, make, model });
   }
 
   function handleTagsChange(ids: string[]) {
-    filters = { ...filters, tagIds: ids };
+    updateFilters({ ...filters, tagIds: ids });
   }
 
   function handleRatingChange(rating?: number) {
-    filters = { ...filters, rating };
+    updateFilters({ ...filters, rating });
   }
 
   function handleMediaTypeChange(type: 'all' | 'image' | 'video') {
-    filters = { ...filters, mediaType: type };
+    updateFilters({ ...filters, mediaType: type });
   }
 
   function handleCustomDateRangeChange(dateAfter: string | undefined, dateBefore: string | undefined) {
-    filters = { ...filters, dateAfter, dateBefore, selectedYear: undefined, selectedMonth: undefined };
+    updateFilters({ ...filters, dateAfter, dateBefore, selectedYear: undefined, selectedMonth: undefined });
   }
 
   function handleYearSelect(year: number | undefined) {
-    filters = { ...filters, dateAfter: undefined, dateBefore: undefined, selectedYear: year, selectedMonth: undefined };
+    updateFilters({
+      ...filters,
+      dateAfter: undefined,
+      dateBefore: undefined,
+      selectedYear: year,
+      selectedMonth: undefined,
+    });
   }
 
   function handleMonthSelect(year: number, month: number | undefined) {
-    filters = { ...filters, dateAfter: undefined, dateBefore: undefined, selectedYear: year, selectedMonth: month };
+    updateFilters({
+      ...filters,
+      dateAfter: undefined,
+      dateBefore: undefined,
+      selectedYear: year,
+      selectedMonth: month,
+    });
   }
 
   function hasActiveFilter(section: string): boolean {
@@ -793,7 +812,7 @@
               <FavoritesFilter
                 selected={filters.isFavorite}
                 onToggle={(value) => {
-                  filters = { ...filters, isFavorite: value };
+                  updateFilters({ ...filters, isFavorite: value });
                 }}
               />
             {/if}

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -37,6 +37,8 @@
     config: FilterPanelConfig;
     timeBuckets: Array<{ timeBucket: string; count: number }>;
     filters?: FilterState;
+    personNames?: Map<string, string>;
+    tagNames?: Map<string, string>;
     persistCollapsed?: boolean;
     storageKey?: string;
     hidden?: boolean;
@@ -48,6 +50,8 @@
     config,
     timeBuckets,
     filters = $bindable(createFilterState()),
+    personNames,
+    tagNames,
     storageKey = 'gallery-filter-visible-sections',
     hidden = false,
     persistCollapsed = true,
@@ -738,6 +742,7 @@
               <PeopleFilter
                 {people}
                 selectedIds={filters.personIds}
+                selectedNames={personNames}
                 onSelectionChange={handlePeopleChange}
                 emptyText={hasUnnamedPeople ? 'Name people to use this filter' : undefined}
               />
@@ -770,7 +775,12 @@
                 onSelectionChange={handleCameraChange}
               />
             {:else if section === 'tags'}
-              <TagsFilter {tags} selectedIds={filters.tagIds} onSelectionChange={handleTagsChange} />
+              <TagsFilter
+                {tags}
+                selectedIds={filters.tagIds}
+                selectedNames={tagNames}
+                onSelectionChange={handleTagsChange}
+              />
             {:else if section === 'rating'}
               <RatingFilter selectedRating={filters.rating} {availableRatings} onRatingChange={handleRatingChange} />
             {:else if section === 'media'}

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -238,6 +238,23 @@
     return Math.max(0, getFilteredCities(country).length - getVisibleCities(country).length);
   }
 
+  let cityOnlySelectionHasVisibleRow = $derived.by(() => {
+    if (!selectedCity || selectedCountry) {
+      return false;
+    }
+
+    for (const country of visibleCountries) {
+      const cityRowsVisible =
+        (expandedCountry === country || (normalizedSearchQuery && getVisibleCities(country).length > 0)) &&
+        !loadingCitiesByCountry[country];
+      if (cityRowsVisible && getVisibleCities(country).includes(selectedCity)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
   function showAllCities(country: string) {
     expandedCityLists = { ...expandedCityLists, [country]: true };
   }
@@ -310,6 +327,23 @@
           {/if}
         </div>
         <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left">{orphanedCountry}</span>
+      </button>
+    {/if}
+
+    {#if selectedCity && !selectedCountry && !cityOnlySelectionHasVisibleRow}
+      <button
+        type="button"
+        class="-mx-2 flex w-[calc(100%+1rem)] items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium hover:bg-subtle"
+        onclick={() => onSelectionChange(undefined, undefined)}
+        aria-pressed="true"
+        data-testid="location-city-{selectedCity}"
+      >
+        <div
+          class="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border-2 border-immich-primary bg-immich-primary dark:border-immich-dark-primary dark:bg-immich-dark-primary"
+        >
+          <div class="h-1.5 w-1.5 rounded-full bg-white dark:bg-black"></div>
+        </div>
+        <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left">{selectedCity}</span>
       </button>
     {/if}
 

--- a/web/src/lib/components/filter-panel/location-filter.svelte
+++ b/web/src/lib/components/filter-panel/location-filter.svelte
@@ -254,7 +254,11 @@
   }
 
   function handleCityClick(city: string, country: string) {
-    if (selectedCity === city) {
+    if (selectedCity === city && !selectedCountry) {
+      // City-only filters can come from typed search syntax. Clicking the selected
+      // city should clear that city filter rather than turning it into country-only.
+      onSelectionChange(undefined, undefined);
+    } else if (selectedCity === city) {
       // Deselect city, keep country
       onSelectionChange(country, undefined);
     } else {
@@ -345,7 +349,7 @@
       <!-- Cities (indented when country is expanded) -->
       {#if (expandedCountry === country || (normalizedSearchQuery && visibleCities.length > 0)) && !loadingCitiesByCountry[country]}
         {#each visibleCities as city (city)}
-          {@const isCitySelected = selectedCity === city && selectedCountry === country}
+          {@const isCitySelected = selectedCity === city && (!selectedCountry || selectedCountry === country)}
           <button
             type="button"
             class="-mx-2 ml-5 flex w-[calc(100%-1.25rem+1rem)] items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-subtle {isCitySelected

--- a/web/src/lib/components/filter-panel/people-filter.svelte
+++ b/web/src/lib/components/filter-panel/people-filter.svelte
@@ -7,11 +7,12 @@
   interface Props {
     people: PersonOption[];
     selectedIds: string[];
+    selectedNames?: Map<string, string>;
     onSelectionChange: (ids: string[]) => void;
     emptyText?: string;
   }
 
-  let { people, selectedIds, onSelectionChange, emptyText = 'No people found' }: Props = $props();
+  let { people, selectedIds, selectedNames, onSelectionChange, emptyText = 'No people found' }: Props = $props();
 
   let searchQuery = $state('');
   let showAll = $state(false);
@@ -33,7 +34,7 @@
         const cached = personCache.get(id);
         return {
           id,
-          name: cached?.name ?? id,
+          name: selectedNames?.get(id) ?? cached?.name ?? id,
           thumbnailUrl: cached?.thumbnailUrl,
           isOrphaned: true,
         } as PersonOption & { isOrphaned: boolean };
@@ -81,7 +82,7 @@
 </script>
 
 <div data-testid="people-filter">
-  {#if people.length === 0}
+  {#if people.length === 0 && orphanedPeople.length === 0}
     <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="people-empty">{emptyText}</p>
   {:else}
     <!-- Search input -->

--- a/web/src/lib/components/filter-panel/tags-filter.svelte
+++ b/web/src/lib/components/filter-panel/tags-filter.svelte
@@ -7,10 +7,11 @@
   interface Props {
     tags: TagOption[];
     selectedIds: string[];
+    selectedNames?: Map<string, string>;
     onSelectionChange: (ids: string[]) => void;
   }
 
-  let { tags, selectedIds, onSelectionChange }: Props = $props();
+  let { tags, selectedIds, selectedNames, onSelectionChange }: Props = $props();
 
   let searchQuery = $state('');
   let showAll = $state(false);
@@ -38,7 +39,9 @@
 
   // Orphaned tags: selected but not in current results
   let orphanedTags = $derived(
-    selectedIds.filter((id) => !tags.some((t) => t.id === id)).map((id) => ({ id, name: tagNameCache.get(id) ?? id })),
+    selectedIds
+      .filter((id) => !tags.some((t) => t.id === id))
+      .map((id) => ({ id, name: selectedNames?.get(id) ?? tagNameCache.get(id) ?? id })),
   );
 
   let filteredTags = $derived(
@@ -61,7 +64,7 @@
 </script>
 
 <div data-testid="tags-filter">
-  {#if tags.length === 0}
+  {#if tags.length === 0 && orphanedTags.length === 0}
     <p class="text-sm text-gray-400 dark:text-gray-500" data-testid="tags-empty">No tags available</p>
   {:else}
     <!-- Search input -->

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -97,6 +97,29 @@ describe('global-search-input-trigger', () => {
     expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
   });
 
+  it('keeps committed raw typed search text after opening the inline dropdown', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountains&tags=tag-nature');
+    storeTypedSearchNames(
+      '/photos?q=mountains&tags=tag-nature',
+      {
+        personNames: new Map(),
+        tagNames: new Map([['tag-nature', 'nature']]),
+      },
+      'tag:nature mountains',
+    );
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    expect(input).toHaveValue('tag:nature mountains');
+
+    await user.click(input);
+
+    expect(input).toHaveValue('tag:nature mountains');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+  });
+
   it('pressing Enter after clearing the top search field clears the committed search', async () => {
     mockPage.url = new URL('https://gallery.test/photos?q=mountains');
     const activateSearchSpy = vi.spyOn(globalSearchManager, 'activateSearch').mockImplementation(async () => {});

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -38,6 +38,21 @@ describe('global-search-input-trigger', () => {
     expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
   });
 
+  it('renders typed filter pills while using the inline dropdown search field', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.click(input);
+    await user.type(input, 'person:anna');
+
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+    expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
+    expect(screen.getByTestId('typed-search-token-person-key')).toHaveTextContent('person');
+    expect(screen.getByTestId('typed-search-token-person-value')).toHaveTextContent('anna');
+  });
+
   it('keeps the dropdown panel closed until the search field receives focus', async () => {
     const user = userEvent.setup();
 

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -47,7 +47,10 @@ describe('global-search-input-trigger', () => {
     await user.click(input);
     await user.type(input, 'person:anna');
 
-    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+    const dropdownPanel = document.querySelector('[data-cmdk-dropdown-panel]');
+
+    expect(dropdownPanel).not.toBeNull();
+    expect(dropdownPanel as HTMLElement).toContainElement(screen.getByTestId('typed-search-token-rail'));
     expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
     expect(screen.getByTestId('typed-search-token-person-key')).toHaveTextContent('person');
     expect(screen.getByTestId('typed-search-token-person-value')).toHaveTextContent('anna');

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -77,7 +77,7 @@ describe('global-search-input-trigger', () => {
 
   it('pressing Enter after clearing the top search field clears the committed search', async () => {
     mockPage.url = new URL('https://gallery.test/photos?q=mountains');
-    const activateSearchSpy = vi.spyOn(globalSearchManager, 'activateSearch').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(globalSearchManager, 'activateSearch').mockImplementation(async () => {});
     const user = userEvent.setup();
 
     render(GlobalSearchInputTrigger);

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -1,4 +1,5 @@
 import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -21,6 +22,7 @@ describe('global-search-input-trigger', () => {
     mockPage.url = new URL('https://gallery.test/photos');
     mockPage.route.id = null;
     mockPage.params = {};
+    sessionStorage.clear();
   });
 
   it('opens a dropdown from an editable search field', async () => {
@@ -75,6 +77,23 @@ describe('global-search-input-trigger', () => {
     render(GlobalSearchInputTrigger);
 
     expect(screen.getByRole('combobox', { name: 'cmdk_placeholder' })).toHaveValue('mountains');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
+  it('shows committed raw typed search text while the search field is closed', () => {
+    mockPage.url = new URL('https://gallery.test/photos?people=person-cat');
+    storeTypedSearchNames(
+      '/photos?people=person-cat',
+      {
+        personNames: new Map([['person-cat', 'cat']]),
+        tagNames: new Map(),
+      },
+      'person:cat',
+    );
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByRole('combobox', { name: 'cmdk_placeholder' })).toHaveValue('person:cat');
     expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
   });
 

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -49,7 +49,7 @@ import { commandContextManager } from '$lib/managers/command-context-manager.sve
 import { GlobalSearchManager, type Provider, type Sections } from '$lib/managers/global-search-manager.svelte';
 import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
 import { addEntry, getEntries, __resetForTests as resetRecentStore } from '$lib/stores/cmdk-recent';
-import { AssetVisibility, getMlHealth, searchAssets, searchSmart } from '@immich/sdk';
+import { AssetVisibility, getFilterSuggestions, getMlHealth, searchAssets, searchSmart } from '@immich/sdk';
 import { modalManager } from '@immich/ui';
 import GlobalSearch from '../global-search.svelte';
 
@@ -87,6 +87,16 @@ vi.mock('@immich/sdk', async () => {
     searchPerson: vi.fn().mockResolvedValue([]),
     searchPlaces: vi.fn().mockResolvedValue([]),
     getAllTags: vi.fn().mockResolvedValue([]),
+    getFilterSuggestions: vi.fn().mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    }),
     getMlHealth: vi.fn().mockResolvedValue({ smartSearchHealthy: true }),
   };
 });
@@ -358,6 +368,73 @@ describe('global-search root', () => {
     expect(screen.queryByText(/cmdk_helper|Start typing/)).toBeNull();
   });
 
+  it('renders typed search tokens while typing without resolving suggestion-backed filters', async () => {
+    const m = new GlobalSearchManager();
+    const parseSpy = vi.spyOn(m, 'parseTypedSearchDraft');
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'beach camera:nikon from:2025');
+
+    expect(parseSpy).toHaveBeenCalled();
+    expect(screen.getByTestId('typed-search-token-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('typed-search-token-camera')).toHaveAttribute('data-status', 'pending-entity');
+    expect(getFilterSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('keeps the palette open and shows typed search issues after failed Enter commit', async () => {
+    const m = new GlobalSearchManager();
+    m.open();
+    vi.spyOn(m, 'activateSearch').mockImplementation(async () => {
+      m.typedSearchIssues = [
+        {
+          code: 'no-match',
+          key: 'person',
+          raw: 'person:anna',
+          value: 'anna',
+          message: 'No person found for "anna"',
+        },
+      ];
+    });
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'person:anna');
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByText('No person found for "anna"')).toBeVisible();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('renders ambiguity choices and sends selection to the manager', async () => {
+    const m = new GlobalSearchManager();
+    const selectSpy = vi.spyOn(m, 'selectTypedSearchChoice');
+    m.open();
+    m.typedSearchIssues = [
+      {
+        code: 'ambiguous',
+        key: 'person',
+        raw: 'person:anna',
+        value: 'anna',
+        message: 'Choose a person for "anna"',
+      },
+    ];
+    m.typedSearchChoices = [
+      { tokenRaw: 'person:anna', key: 'person', id: 'person-1', label: 'Anna', value: 'anna' },
+      { tokenRaw: 'person:anna', key: 'person', id: 'person-2', label: 'Anna Maria', value: 'anna' },
+    ];
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.click(screen.getByRole('button', { name: 'Anna Maria' }));
+
+    expect(selectSpy).toHaveBeenCalledWith({
+      tokenRaw: 'person:anna',
+      key: 'person',
+      id: 'person-2',
+      label: 'Anna Maria',
+      value: 'anna',
+    });
+  });
+
   it('combobox has maxlength="256"', () => {
     const m = new GlobalSearchManager();
     m.open();
@@ -533,6 +610,17 @@ describe('global-search root', () => {
     await user.keyboard('{Enter}');
 
     expect(activateSearchSpy).toHaveBeenCalledWith('');
+  });
+
+  it('pressing Enter on typed filters commits the raw search text, not the plain preview label', async () => {
+    const m = new GlobalSearchManager();
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'beach camera:nikon{enter}');
+
+    expect(activateSearchSpy).toHaveBeenCalledWith('beach camera:nikon');
   });
 
   it('pressing Enter on an almost-exact command query activates the promoted command instead of search', async () => {

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -623,6 +623,19 @@ describe('global-search root', () => {
     expect(activateSearchSpy).toHaveBeenCalledWith('beach camera:nikon');
   });
 
+  it('pressing Enter on a filter-only tags query commits search instead of navigating to Tags', async () => {
+    const m = new GlobalSearchManager();
+    const activateSpy = vi.spyOn(m, 'activate').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'tags:nature{enter}');
+
+    expect(activateSearchSpy).toHaveBeenCalledWith('tags:nature');
+    expect(activateSpy).not.toHaveBeenCalledWith('nav', expect.objectContaining({ id: 'nav:userPages:tags' }));
+  });
+
   it('pressing Enter on an almost-exact command query activates the promoted command instead of search', async () => {
     const m = new GlobalSearchManager();
     const activateSpy = vi.spyOn(m, 'activate').mockImplementation(() => {});

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -385,7 +385,7 @@ describe('global-search root', () => {
   it('keeps the palette open and shows typed search issues after failed Enter commit', async () => {
     const m = new GlobalSearchManager();
     m.open();
-    vi.spyOn(m, 'activateSearch').mockImplementation(async () => {
+    vi.spyOn(m, 'activateSearch').mockImplementation(() => {
       m.typedSearchIssues = [
         {
           code: 'no-match',
@@ -395,6 +395,7 @@ describe('global-search root', () => {
           message: 'No person found for "anna"',
         },
       ];
+      return Promise.resolve();
     });
     render(GlobalSearch, { props: { manager: m } });
 

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -613,6 +613,24 @@ describe('global-search root', () => {
     expect(activateSearchSpy).toHaveBeenCalledWith('');
   });
 
+  it('does not restore stale modal input text after the manager clears on reopen', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+    const m = new GlobalSearchManager();
+    m.open('modal');
+    render(GlobalSearch, { props: { manager: m } });
+
+    await user.type(screen.getByRole('combobox'), 'beach');
+    await m.activateSearch('beach');
+    m.close();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(m.query).toBe('');
+    mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
+
+    m.open('modal');
+
+    await vi.waitFor(() => expect(screen.getByRole('combobox')).toHaveValue(''));
+  });
+
   it('pressing Enter on typed filters commits the raw search text, not the plain preview label', async () => {
     const m = new GlobalSearchManager();
     const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -599,7 +599,7 @@ describe('global-search root', () => {
   it('pressing Enter after clearing the modal input clears the committed search', async () => {
     mockPage.url = new URL('https://gallery.test/photos?q=mountain');
     const m = new GlobalSearchManager();
-    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
     m.open('modal');
     render(GlobalSearch, { props: { manager: m } });
 

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -587,7 +587,7 @@ describe('global-search root', () => {
 
   it('pressing Enter on typed text activates the promoted search row', async () => {
     const m = new GlobalSearchManager();
-    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
     m.open();
     render(GlobalSearch, { props: { manager: m } });
 
@@ -626,7 +626,7 @@ describe('global-search root', () => {
   it('pressing Enter on an almost-exact command query activates the promoted command instead of search', async () => {
     const m = new GlobalSearchManager();
     const activateSpy = vi.spyOn(m, 'activate').mockImplementation(() => {});
-    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
     m.open();
     render(GlobalSearch, { props: { manager: m } });
 
@@ -828,7 +828,7 @@ describe('global-search root', () => {
   it('activateRecent("query", ...) replays through activateSearch on the current page', () => {
     addEntry({ kind: 'query', id: 'query:sunset', text: 'sunset', lastUsed: 1 });
     const m = new GlobalSearchManager();
-    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    const activateSearchSpy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
     m.open();
     render(GlobalSearch, { props: { manager: m } });
 

--- a/web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
@@ -1,0 +1,47 @@
+import TypedSearchTokenRail from '$lib/components/global-search/typed-search-token-rail.svelte';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+describe('TypedSearchTokenRail', () => {
+  it('renders recognized and pending tokens quietly', () => {
+    render(TypedSearchTokenRail, {
+      props: {
+        tokens: [
+          { raw: 'from:2025', key: 'from', value: '2025', status: 'recognized' },
+          { raw: 'person:anna', key: 'person', value: 'anna', status: 'pending-entity' },
+        ],
+      },
+    });
+
+    expect(screen.getByText('from')).toBeVisible();
+    expect(screen.getByText('2025')).toBeVisible();
+    expect(screen.getByText('person')).toBeVisible();
+    expect(screen.getByText('anna')).toBeVisible();
+    expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
+  });
+
+  it('renders error tokens with issue text', () => {
+    render(TypedSearchTokenRail, {
+      props: {
+        tokens: [
+          {
+            raw: 'person:anna',
+            key: 'person',
+            value: 'anna',
+            status: 'error',
+            issue: {
+              code: 'no-match',
+              raw: 'person:anna',
+              key: 'person',
+              value: 'anna',
+              message: 'No person found for "anna"',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'error');
+    expect(screen.getByLabelText('No person found for "anna"')).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
@@ -30,6 +30,23 @@ describe('TypedSearchTokenRail', () => {
     expect(screen.getByTestId('typed-search-token-rail')).toHaveClass('px-4', 'pt-2', 'pb-1');
   });
 
+  it('renders typed filters as substantial key-value capsules', () => {
+    render(TypedSearchTokenRail, {
+      props: {
+        tokens: [{ raw: 'person:anna', key: 'person', value: 'anna', status: 'pending-entity' }],
+      },
+    });
+
+    expect(screen.getByTestId('typed-search-token-person')).toHaveClass(
+      'min-h-7',
+      'overflow-hidden',
+      'rounded-full',
+      'text-xs',
+    );
+    expect(screen.getByTestId('typed-search-token-person-key')).toHaveClass('uppercase', 'tracking-[0.08em]');
+    expect(screen.getByTestId('typed-search-token-person-value')).toHaveClass('px-2.5', 'py-1.5');
+  });
+
   it('renders error tokens with issue text', () => {
     render(TypedSearchTokenRail, {
       props: {

--- a/web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts
@@ -20,6 +20,16 @@ describe('TypedSearchTokenRail', () => {
     expect(screen.getByTestId('typed-search-token-person')).toHaveAttribute('data-status', 'pending-entity');
   });
 
+  it('gives filter chips breathing room below the input row', () => {
+    render(TypedSearchTokenRail, {
+      props: {
+        tokens: [{ raw: 'person:anna', key: 'person', value: 'anna', status: 'pending-entity' }],
+      },
+    });
+
+    expect(screen.getByTestId('typed-search-token-rail')).toHaveClass('px-4', 'pt-2', 'pb-1');
+  });
+
   it('renders error tokens with issue text', () => {
     render(TypedSearchTokenRail, {
       props: {

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -27,6 +27,7 @@
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { page } from '$app/state';
   import { getSearchablePageState } from '$lib/utils/searchable-page-search';
+  import TypedSearchTokenRail from './typed-search-token-rail.svelte';
 
   interface Props {
     manager: GlobalSearchManager;
@@ -372,7 +373,7 @@
       return;
     }
     if (e.key === 'Enter' && manager.topSearchMatch && manager.activeItemId === manager.topSearchMatch.id) {
-      manager.activateSearch(manager.topSearchMatch.query);
+      void manager.activateSearch(manager.topSearchMatch.rawQuery);
       e.preventDefault();
       return;
     }
@@ -451,8 +452,8 @@
         <kbd
           class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
           >{hotkeyLabel}</kbd
-        >
       </div>
+      <TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
 
       {#if showDropdownPanel}
         <div
@@ -479,6 +480,44 @@
             </div>
           {/if}
           <Command.List class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto py-2">
+            {#if manager.typedSearchIssues.length > 0}
+              <Command.Group class="mb-4" data-typed-search-issues>
+                <Command.GroupHeading
+                  class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                >
+                  Search filters
+                </Command.GroupHeading>
+                <div class="space-y-1 px-3">
+                  {#each manager.typedSearchIssues as issue (`${issue.raw}:${issue.code}`)}
+                    <div
+                      class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-200"
+                    >
+                      {issue.message}
+                    </div>
+                  {/each}
+                </div>
+              </Command.Group>
+            {/if}
+            {#if manager.typedSearchChoices.length > 0}
+              <Command.Group class="mb-4" data-typed-search-choices>
+                <Command.GroupHeading
+                  class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                >
+                  Choose filter value
+                </Command.GroupHeading>
+                <div class="space-y-1 px-3">
+                  {#each manager.typedSearchChoices as choice (`${choice.tokenRaw}:${choice.key}:${choice.id ?? choice.field ?? choice.label}`)}
+                    <button
+                      type="button"
+                      class="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm hover:bg-primary/10"
+                      onclick={() => manager.selectTypedSearchChoice(choice)}
+                    >
+                      <span>{choice.label}</span>
+                    </button>
+                  {/each}
+                </div>
+              </Command.Group>
+            {/if}
             {#if inputValue.trim() === ''}
               {#if recentEntries.length > 0}
                 <Command.Group>
@@ -526,7 +565,8 @@
                   <div class="px-1">
                     <button
                       type="button"
-                      onclick={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
+                      onclick={() =>
+                        manager.topSearchMatch && void manager.activateSearch(manager.topSearchMatch.rawQuery)}
                       class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId ===
                       manager.topSearchMatch.id
                         ? 'bg-primary/10'
@@ -763,6 +803,7 @@
             aria-label={inputValue === '' ? $t('close') : $t('clear')}
           />
         </div>
+        <TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
         {#if showProgressStripe}
           <div
             aria-hidden="true"
@@ -804,6 +845,44 @@
               </div>
             {/if}
             <Command.List class="flex-1 overflow-y-auto py-2">
+              {#if manager.typedSearchIssues.length > 0}
+                <Command.Group class="mb-4" data-typed-search-issues>
+                  <Command.GroupHeading
+                    class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    Search filters
+                  </Command.GroupHeading>
+                  <div class="space-y-1 px-3">
+                    {#each manager.typedSearchIssues as issue (`${issue.raw}:${issue.code}`)}
+                      <div
+                        class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-200"
+                      >
+                        {issue.message}
+                      </div>
+                    {/each}
+                  </div>
+                </Command.Group>
+              {/if}
+              {#if manager.typedSearchChoices.length > 0}
+                <Command.Group class="mb-4" data-typed-search-choices>
+                  <Command.GroupHeading
+                    class="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    Choose filter value
+                  </Command.GroupHeading>
+                  <div class="space-y-1 px-3">
+                    {#each manager.typedSearchChoices as choice (`${choice.tokenRaw}:${choice.key}:${choice.id ?? choice.field ?? choice.label}`)}
+                      <button
+                        type="button"
+                        class="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm hover:bg-primary/10"
+                        onclick={() => manager.selectTypedSearchChoice(choice)}
+                      >
+                        <span>{choice.label}</span>
+                      </button>
+                    {/each}
+                  </div>
+                </Command.Group>
+              {/if}
               {#if inputValue.trim() === ''}
                 {#if recentEntries.length > 0}
                   <Command.Group>
@@ -873,7 +952,8 @@
                     <div class="px-1">
                       <button
                         type="button"
-                        onclick={() => manager.topSearchMatch && manager.activateSearch(manager.topSearchMatch.query)}
+                        onclick={() =>
+                          manager.topSearchMatch && void manager.activateSearch(manager.topSearchMatch.rawQuery)}
                         class="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start {manager.activeItemId ===
                         manager.topSearchMatch.id
                           ? 'bg-primary/10'

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -368,7 +368,7 @@
       return;
     }
     if (e.key === 'Enter' && inputValue.trim() === '' && getSearchablePageState(page.url).query !== '') {
-      manager.activateSearch('');
+      void manager.activateSearch('');
       e.preventDefault();
       return;
     }

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -455,7 +455,6 @@
           {hotkeyLabel}
         </kbd>
       </div>
-      <TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
 
       {#if showDropdownPanel}
         <div
@@ -481,6 +480,7 @@
               </button>
             </div>
           {/if}
+          <TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
           <Command.List
             class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto pb-2 {manager.typedSearchDisplayTokens.length > 0
               ? 'pt-1'

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -27,6 +27,7 @@
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { page } from '$app/state';
   import { getSearchablePageState } from '$lib/utils/searchable-page-search';
+  import { getTypedSearchDisplayText } from '$lib/utils/typed-search/typed-search-name-cache';
   import TypedSearchTokenRail from './typed-search-token-rail.svelte';
 
   interface Props {
@@ -52,7 +53,8 @@
   );
   $effect(() => {
     if (variant === 'dropdown' && !showDropdownPanel) {
-      inputValue = closedDropdownSearchState?.query ?? '';
+      inputValue =
+        getTypedSearchDisplayText(page.url.pathname + page.url.search) ?? closedDropdownSearchState?.query ?? '';
       return;
     }
     inputValue = manager.query;

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -479,7 +479,12 @@
               </button>
             </div>
           {/if}
-          <Command.List class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto py-2">
+          <Command.List
+            class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto pb-2 {manager
+              .typedSearchDisplayTokens.length > 0
+              ? 'pt-1'
+              : 'pt-2'}"
+          >
             {#if manager.typedSearchIssues.length > 0}
               <Command.Group class="mb-4" data-typed-search-issues>
                 <Command.GroupHeading
@@ -844,7 +849,9 @@
                 </button>
               </div>
             {/if}
-            <Command.List class="flex-1 overflow-y-auto py-2">
+            <Command.List
+              class="flex-1 overflow-y-auto pb-2 {manager.typedSearchDisplayTokens.length > 0 ? 'pt-1' : 'pt-2'}"
+            >
               {#if manager.typedSearchIssues.length > 0}
                 <Command.Group class="mb-4" data-typed-search-issues>
                   <Command.GroupHeading

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -451,7 +451,9 @@
         />
         <kbd
           class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
-          >{hotkeyLabel}</kbd
+        >
+          {hotkeyLabel}
+        </kbd>
       </div>
       <TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
 
@@ -480,8 +482,7 @@
             </div>
           {/if}
           <Command.List
-            class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto pb-2 {manager
-              .typedSearchDisplayTokens.length > 0
+            class="max-h-[min(520px,calc(100vh-8rem))] overflow-y-auto pb-2 {manager.typedSearchDisplayTokens.length > 0
               ? 'pt-1'
               : 'pt-2'}"
           >

--- a/web/src/lib/components/global-search/typed-search-token-rail.svelte
+++ b/web/src/lib/components/global-search/typed-search-token-rail.svelte
@@ -6,6 +6,32 @@
   }
 
   let { tokens }: Props = $props();
+
+  function tokenClass(status: TypedSearchDisplayToken['status']) {
+    switch (status) {
+      case 'error':
+        return 'border-red-400/70 bg-red-50 text-red-700 shadow-red-950/5 dark:border-red-400/40 dark:bg-red-950/35 dark:text-red-100';
+      case 'pending-entity':
+        return 'border-sky-300/70 bg-sky-50 text-sky-800 shadow-sky-950/5 dark:border-sky-400/35 dark:bg-sky-950/30 dark:text-sky-100';
+      case 'resolved-entity':
+        return 'border-emerald-300/70 bg-emerald-50 text-emerald-800 shadow-emerald-950/5 dark:border-emerald-400/35 dark:bg-emerald-950/30 dark:text-emerald-100';
+      case 'recognized':
+        return 'border-gray-200 bg-white/80 text-gray-800 shadow-gray-950/5 dark:border-gray-600/70 dark:bg-white/[0.07] dark:text-gray-100';
+    }
+  }
+
+  function keyClass(status: TypedSearchDisplayToken['status']) {
+    switch (status) {
+      case 'error':
+        return 'bg-red-100/80 text-red-700 dark:bg-red-400/10 dark:text-red-200';
+      case 'pending-entity':
+        return 'bg-sky-100/80 text-sky-700 dark:bg-sky-300/10 dark:text-sky-200';
+      case 'resolved-entity':
+        return 'bg-emerald-100/80 text-emerald-700 dark:bg-emerald-300/10 dark:text-emerald-200';
+      case 'recognized':
+        return 'bg-gray-100/90 text-gray-600 dark:bg-white/[0.08] dark:text-gray-300';
+    }
+  }
 </script>
 
 {#if tokens.length > 0}
@@ -15,15 +41,18 @@
         data-testid={`typed-search-token-${token.key}`}
         data-status={token.status}
         aria-label={token.issue?.message}
-        class="inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-[11px] leading-none
-          {token.status === 'error'
-          ? 'border-red-400/70 bg-red-50 text-red-700 dark:border-red-500/50 dark:bg-red-950/30 dark:text-red-200'
-          : token.status === 'pending-entity'
-            ? 'border-dashed border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-600 dark:bg-gray-800/60 dark:text-gray-300'
-            : 'border-gray-200 bg-subtle/60 text-gray-700 dark:border-gray-700 dark:text-gray-200'}"
+        class="inline-flex min-h-7 max-w-full items-stretch overflow-hidden rounded-full border text-xs leading-none shadow-sm
+          shadow-black/5 ring-1 ring-white/10 {tokenClass(token.status)}"
       >
-        <span class="font-semibold">{token.key}</span>
-        <span class="truncate">{token.value}</span>
+        <span
+          data-testid={`typed-search-token-${token.key}-key`}
+          class="flex items-center px-2 py-1.5 font-semibold uppercase tracking-[0.08em] {keyClass(token.status)}"
+        >
+          {token.key}
+        </span>
+        <span data-testid={`typed-search-token-${token.key}-value`} class="flex min-w-0 items-center px-2.5 py-1.5">
+          <span class="truncate">{token.value}</span>
+        </span>
       </span>
     {/each}
   </div>

--- a/web/src/lib/components/global-search/typed-search-token-rail.svelte
+++ b/web/src/lib/components/global-search/typed-search-token-rail.svelte
@@ -9,27 +9,35 @@
 
   function tokenClass(status: TypedSearchDisplayToken['status']) {
     switch (status) {
-      case 'error':
+      case 'error': {
         return 'border-red-400/70 bg-red-50 text-red-700 shadow-red-950/5 dark:border-red-400/40 dark:bg-red-950/35 dark:text-red-100';
-      case 'pending-entity':
+      }
+      case 'pending-entity': {
         return 'border-sky-300/70 bg-sky-50 text-sky-800 shadow-sky-950/5 dark:border-sky-400/35 dark:bg-sky-950/30 dark:text-sky-100';
-      case 'resolved-entity':
+      }
+      case 'resolved-entity': {
         return 'border-emerald-300/70 bg-emerald-50 text-emerald-800 shadow-emerald-950/5 dark:border-emerald-400/35 dark:bg-emerald-950/30 dark:text-emerald-100';
-      case 'recognized':
+      }
+      case 'recognized': {
         return 'border-gray-200 bg-white/80 text-gray-800 shadow-gray-950/5 dark:border-gray-600/70 dark:bg-white/[0.07] dark:text-gray-100';
+      }
     }
   }
 
   function keyClass(status: TypedSearchDisplayToken['status']) {
     switch (status) {
-      case 'error':
+      case 'error': {
         return 'bg-red-100/80 text-red-700 dark:bg-red-400/10 dark:text-red-200';
-      case 'pending-entity':
+      }
+      case 'pending-entity': {
         return 'bg-sky-100/80 text-sky-700 dark:bg-sky-300/10 dark:text-sky-200';
-      case 'resolved-entity':
+      }
+      case 'resolved-entity': {
         return 'bg-emerald-100/80 text-emerald-700 dark:bg-emerald-300/10 dark:text-emerald-200';
-      case 'recognized':
+      }
+      case 'recognized': {
         return 'bg-gray-100/90 text-gray-600 dark:bg-white/[0.08] dark:text-gray-300';
+      }
     }
   }
 </script>

--- a/web/src/lib/components/global-search/typed-search-token-rail.svelte
+++ b/web/src/lib/components/global-search/typed-search-token-rail.svelte
@@ -9,7 +9,7 @@
 </script>
 
 {#if tokens.length > 0}
-  <div class="flex min-w-0 flex-wrap items-center gap-1.5 px-3 pb-2" data-testid="typed-search-token-rail">
+  <div class="flex min-w-0 flex-wrap items-center gap-1.5 px-4 pt-2 pb-1" data-testid="typed-search-token-rail">
     {#each tokens as token (`${token.raw}:${token.status}`)}
       <span
         data-testid={`typed-search-token-${token.key}`}

--- a/web/src/lib/components/global-search/typed-search-token-rail.svelte
+++ b/web/src/lib/components/global-search/typed-search-token-rail.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { TypedSearchDisplayToken } from '$lib/utils/typed-search/typed-search-parser';
+
+  interface Props {
+    tokens: TypedSearchDisplayToken[];
+  }
+
+  let { tokens }: Props = $props();
+</script>
+
+{#if tokens.length > 0}
+  <div class="flex min-w-0 flex-wrap items-center gap-1.5 px-3 pb-2" data-testid="typed-search-token-rail">
+    {#each tokens as token (`${token.raw}:${token.status}`)}
+      <span
+        data-testid={`typed-search-token-${token.key}`}
+        data-status={token.status}
+        aria-label={token.issue?.message}
+        class="inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-[11px] leading-none
+          {token.status === 'error'
+          ? 'border-red-400/70 bg-red-50 text-red-700 dark:border-red-500/50 dark:bg-red-950/30 dark:text-red-200'
+          : token.status === 'pending-entity'
+            ? 'border-dashed border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-600 dark:bg-gray-800/60 dark:text-gray-300'
+            : 'border-gray-200 bg-subtle/60 text-gray-700 dark:border-gray-700 dark:text-gray-200'}"
+      >
+        <span class="font-semibold">{token.key}</span>
+        <span class="truncate">{token.value}</span>
+      </span>
+    {/each}
+  </div>
+{/if}

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1609,6 +1609,20 @@ describe('activate("command")', () => {
     expect(m.consumeKeepOpenOnNextNavigate()).toBe(false);
   });
 
+  it('applySearchSort serializes registered searchable page filters', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?view=timeline&rating=2');
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), rating: 3 }));
+
+    await m.applySearchSort('asc', '');
+
+    expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=timeline&sort=asc&rating=3', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
   it('open resets pre-search page sorting back to relevance for a new search session', () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/photos?sort=asc');

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1858,6 +1858,16 @@ describe('topNavigationMatch', () => {
     expect(m.topNavigationMatch?.id).toBe('nav:userPages:people');
   });
 
+  it('does not promote navigation when the matching word is typed-filter syntax', () => {
+    const m = new GlobalSearchManager();
+    m.open();
+    m.setQuery('tags:nature beach');
+
+    expect(m.topNavigationMatch).toBeNull();
+    expect(m.topSearchMatch).toEqual({ id: 'top-search', query: 'beach', rawQuery: 'tags:nature beach' });
+    expect(m.sections.navigation.status).toBe('empty');
+  });
+
   it('promotes Favorites when the user types "favorites" (prefix match)', () => {
     // Query chosen so it does NOT also match any command label — `album` now
     // trips `cmd:new_album` which (correctly) suppresses the nav promotion.
@@ -2687,6 +2697,13 @@ describe('commands provider', () => {
 
     expect(manager.topCommandMatch?.id).toBe('cmd:space_add_member');
     expect(manager.topCommandMatch?.id).not.toBe('cmd:selection_add_to_album');
+  });
+
+  it('topCommandMatch does not promote commands when typed filters are present', () => {
+    manager.setQuery('from:2025 theme');
+
+    expect(manager.topCommandMatch).toBeNull();
+    expect(manager.topSearchMatch).toEqual({ id: 'top-search', query: 'theme', rawQuery: 'from:2025 theme' });
   });
 
   it('under `@alice`, commands section is empty', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1519,7 +1519,7 @@ describe('activate("command")', () => {
     it('stores an ambiguity choice and clears matching issue state', () => {
       const manager = new GlobalSearchManager();
       const issue = {
-        code: 'ambiguous',
+        code: 'ambiguous' as const,
         key: 'person',
         raw: 'person:anna',
         value: 'anna',
@@ -5428,7 +5428,7 @@ describe('prefix scoping — defensive recent replay of scoped query', () => {
 
   it('activateRecent({kind:query, text:"@alice"}) replays the raw scoped text through activateSearch', () => {
     const m = new GlobalSearchManager();
-    const spy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    const spy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
 
     m.activateRecent({ kind: 'query', id: 'query:@alice', text: '@alice', lastUsed: Date.now() });
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -300,6 +300,23 @@ describe('GlobalSearchManager (skeleton)', () => {
     expect(m.searchSortOrder).toBe('relevance');
   });
 
+  it('open() clears the modal query once even when the activated text search has cached display text', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos');
+    mockResolvedTypedSearch('beach');
+
+    m.open('modal');
+    await m.activateSearch('beach');
+    m.close();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
+    vi.mocked(getTypedSearchDisplayText).mockReturnValue('beach');
+
+    m.open('modal');
+
+    expect(m.query).toBe('');
+    expect(m.searchSortOrder).toBe('relevance');
+  });
+
   it('open() still hydrates the dropdown query after activating a text search', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/photos');

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -270,12 +270,13 @@ describe('GlobalSearchManager (skeleton)', () => {
     expect(manager.searchSortOrder).toBe('asc');
   });
 
-  it('open() clears the modal query once after activating a text search', () => {
+  it('open() clears the modal query once after activating a text search', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/photos');
+    mockResolvedTypedSearch('beach');
 
     m.open('modal');
-    m.activateSearch('beach');
+    await m.activateSearch('beach');
     m.close();
     mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
 
@@ -285,12 +286,13 @@ describe('GlobalSearchManager (skeleton)', () => {
     expect(m.searchSortOrder).toBe('relevance');
   });
 
-  it('open() still hydrates the dropdown query after activating a text search', () => {
+  it('open() still hydrates the dropdown query after activating a text search', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/photos');
+    mockResolvedTypedSearch('beach');
 
     m.open('modal');
-    m.activateSearch('beach');
+    await m.activateSearch('beach');
     m.close();
     mockPage.url = new URL('https://gallery.test/photos?q=beach&sort=asc');
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -40,6 +40,7 @@ vi.mock('$lib/utils/typed-search/typed-search-resolver', () => ({
 }));
 
 vi.mock('$lib/utils/typed-search/typed-search-name-cache', () => ({
+  getTypedSearchDisplayText: vi.fn(() => undefined),
   storeTypedSearchNames: vi.fn(),
 }));
 
@@ -47,7 +48,7 @@ import { goto } from '$app/navigation';
 import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import * as recentModule from '$lib/stores/cmdk-recent';
 import { addEntry, getEntries, __resetForTests as resetRecentStore } from '$lib/stores/cmdk-recent';
-import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
+import { getTypedSearchDisplayText, storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import {
   AssetVisibility,
   getAlbumInfo,
@@ -91,6 +92,8 @@ afterEach(() => {
   mockPage.route.id = null;
   mockPage.params = {};
   mockPage.url = new URL('https://gallery.test/photos');
+  vi.mocked(getTypedSearchDisplayText).mockReset();
+  vi.mocked(getTypedSearchDisplayText).mockReturnValue(undefined);
   commandContextManager.setAlbum(null);
   commandContextManager.setSpace(null);
   commandContextManager.setSelection(null);
@@ -268,6 +271,17 @@ describe('GlobalSearchManager (skeleton)', () => {
     expect(manager.isOpen).toBe(true);
     expect(manager.query).toBe('beach');
     expect(manager.searchSortOrder).toBe('asc');
+  });
+
+  it('open() hydrates cached raw typed search text for searchable page filters', () => {
+    mockPage.url = new URL('https://gallery.test/photos?q=mountains&tags=tag-nature');
+    vi.mocked(getTypedSearchDisplayText).mockReturnValue('tag:nature mountains');
+
+    manager.open('dropdown');
+
+    expect(getTypedSearchDisplayText).toHaveBeenCalledWith('/photos?q=mountains&tags=tag-nature');
+    expect(manager.query).toBe('tag:nature mountains');
+    expect(manager.searchSortOrder).toBe('relevance');
   });
 
   it('open() clears the modal query once after activating a text search', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -29,9 +29,25 @@ vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
   featureFlagsManager: mockFlags,
 }));
 
+const { typedSearchMock } = vi.hoisted(() => ({
+  typedSearchMock: {
+    resolveTypedSearchFilters: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/utils/typed-search/typed-search-resolver', () => ({
+  resolveTypedSearchFilters: typedSearchMock.resolveTypedSearchFilters,
+}));
+
+vi.mock('$lib/utils/typed-search/typed-search-name-cache', () => ({
+  storeTypedSearchNames: vi.fn(),
+}));
+
 import { goto } from '$app/navigation';
+import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import * as recentModule from '$lib/stores/cmdk-recent';
 import { addEntry, getEntries, __resetForTests as resetRecentStore } from '$lib/stores/cmdk-recent';
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import {
   AssetVisibility,
   getAlbumInfo,
@@ -154,6 +170,16 @@ vi.mock('svelte-i18n', async (orig) => {
 });
 
 const flushMicrotasks = () => new Promise((resolve) => queueMicrotask(() => resolve(undefined)));
+
+function mockResolvedTypedSearch(queryText = 'beach', filters: FilterState = createFilterState()) {
+  typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+    ok: true,
+    queryText,
+    filters,
+    personNames: new Map(),
+    tagNames: new Map(),
+  });
+}
 
 const makeTimelineAsset = (overrides: Partial<TimelineAsset> = {}): TimelineAsset =>
   ({
@@ -1344,12 +1370,13 @@ describe('activate("command")', () => {
     expect(getEntries()).toEqual([]);
   });
 
-  it('activateSearch preserves same-route params, drops stale space asset ids, and carries an explicit sort', () => {
+  it('activateSearch preserves same-route params, drops stale space asset ids, and carries an explicit sort', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos/asset-123?view=grid');
     m.searchSortOrder = 'asc';
+    mockResolvedTypedSearch('beach');
 
-    m.activateSearch('beach');
+    await m.activateSearch('beach');
 
     expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach&sort=asc');
   });
@@ -1364,22 +1391,176 @@ describe('activate("command")', () => {
     expect(getEntries()).toEqual([]);
   });
 
-  it('activateSearch falls back to /photos and drops unrelated params', () => {
+  it('activateSearch falls back to /photos and drops unrelated params', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/albums?view=list');
+    mockResolvedTypedSearch('beach');
 
-    m.activateSearch('beach');
+    await m.activateSearch('beach');
 
     expect(goto).toHaveBeenCalledWith('/photos?q=beach');
   });
 
-  it('activateSearch falls back from /spaces/:id/people to /photos', () => {
+  it('activateSearch falls back from /spaces/:id/people to /photos', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/spaces/space-1/people');
+    mockResolvedTypedSearch('beach');
 
-    m.activateSearch('beach');
+    await m.activateSearch('beach');
 
     expect(goto).toHaveBeenCalledWith('/photos?q=beach');
+  });
+
+  describe('GlobalSearchManager typed search commit', () => {
+    beforeEach(() => {
+      typedSearchMock.resolveTypedSearchFilters.mockReset();
+      vi.mocked(storeTypedSearchNames).mockClear();
+      vi.mocked(goto).mockClear();
+      mockPage.url = new URL('https://gallery.test/photos');
+    });
+
+    it('navigates with typed filters when resolution succeeds', async () => {
+      const manager = new GlobalSearchManager();
+      typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+        ok: true,
+        queryText: 'beach',
+        filters: {
+          ...createFilterState(),
+          personIds: ['person-1'],
+          dateAfter: '2025-01-01',
+        },
+        personNames: new Map([['person-1', 'Anna']]),
+        tagNames: new Map(),
+      });
+
+      await manager.activateSearch('beach person:anna from:2025');
+
+      expect(goto).toHaveBeenCalledWith('/photos?q=beach&people=person-1&from=2025-01-01');
+      expect(manager.typedSearchIssues).toEqual([]);
+    });
+
+    it('dispatches live providers with the plain query while preserving raw top-search commit text', async () => {
+      const manager = new GlobalSearchManager();
+      const providers = (manager as unknown as { providers: Record<keyof Sections, Provider> }).providers;
+      const photosRun = vi.fn().mockResolvedValue({ status: 'empty' as const });
+      providers.photos.run = photosRun;
+
+      manager.setQuery('beach camera:nikon');
+
+      await vi.waitFor(() => expect(photosRun).toHaveBeenCalledWith('beach', expect.anything(), expect.anything()));
+      expect(manager.topSearchMatch).toEqual({ id: 'top-search', query: 'beach', rawQuery: 'beach camera:nikon' });
+    });
+
+    it('blocks parser issues before calling the resolver', async () => {
+      const manager = new GlobalSearchManager();
+
+      await manager.activateSearch('beach persn:anna');
+
+      expect(typedSearchMock.resolveTypedSearchFilters).not.toHaveBeenCalled();
+      expect(goto).not.toHaveBeenCalled();
+      expect(manager.typedSearchIssues[0]).toMatchObject({ code: 'unknown-key', raw: 'persn:anna' });
+    });
+
+    it('stores resolver names for the destination URL before navigating', async () => {
+      const manager = new GlobalSearchManager();
+      typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+        ok: true,
+        queryText: 'beach',
+        filters: { ...createFilterState(), personIds: ['person-1'], tagIds: ['tag-1'] },
+        personNames: new Map([['person-1', 'Anna']]),
+        tagNames: new Map([['tag-1', 'Travel']]),
+      });
+
+      await manager.activateSearch('beach person:anna tag:travel');
+
+      expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?q=beach&people=person-1&tags=tag-1', {
+        personNames: new Map([['person-1', 'Anna']]),
+        tagNames: new Map([['tag-1', 'Travel']]),
+      });
+    });
+
+    it('supports filter-only searches without q', async () => {
+      const manager = new GlobalSearchManager();
+      typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+        ok: true,
+        queryText: '',
+        filters: { ...createFilterState(), personIds: ['person-1'] },
+        personNames: new Map([['person-1', 'Anna']]),
+        tagNames: new Map(),
+      });
+
+      await manager.activateSearch('person:anna');
+
+      expect(goto).toHaveBeenCalledWith('/photos?people=person-1');
+    });
+
+    it('blocks navigation and exposes issues when resolution fails', async () => {
+      const manager = new GlobalSearchManager();
+      const issue = {
+        code: 'no-match',
+        key: 'person',
+        raw: 'person:anna',
+        value: 'anna',
+        message: 'No person found for "anna"',
+      };
+      typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+        ok: false,
+        queryText: 'beach',
+        issues: [issue],
+        choices: [],
+      });
+
+      await manager.activateSearch('beach person:anna');
+
+      expect(goto).not.toHaveBeenCalled();
+      expect(manager.typedSearchIssues).toEqual([issue]);
+    });
+
+    it('stores an ambiguity choice and clears matching issue state', () => {
+      const manager = new GlobalSearchManager();
+      const issue = {
+        code: 'ambiguous',
+        key: 'person',
+        raw: 'person:anna',
+        value: 'anna',
+        message: 'Choose a person for "anna"',
+      };
+      const choice = {
+        tokenRaw: 'person:anna',
+        key: 'person' as const,
+        id: 'person-2',
+        label: 'Anna Maria',
+        value: 'anna',
+      };
+      manager.typedSearchIssues = [issue];
+      manager.typedSearchChoices = [choice];
+      manager.typedSearchDisplayTokens = [{ raw: 'person:anna', key: 'person', value: 'anna', status: 'error', issue }];
+
+      manager.selectTypedSearchChoice(choice);
+
+      expect(manager.selectedTypedSearchChoices.get('person:anna')).toEqual(choice);
+      expect(manager.typedSearchIssues).toEqual([]);
+      expect(manager.typedSearchChoices).toEqual([]);
+      expect(manager.typedSearchDisplayTokens).toEqual([
+        { raw: 'person:anna', key: 'person', value: 'Anna Maria', status: 'resolved-entity' },
+      ]);
+    });
+
+    it('falls back to photos when current page is not searchable', async () => {
+      mockPage.url = new URL('https://gallery.test/albums');
+      const manager = new GlobalSearchManager();
+      typedSearchMock.resolveTypedSearchFilters.mockResolvedValue({
+        ok: true,
+        queryText: 'beach',
+        filters: createFilterState(),
+        personNames: new Map(),
+        tagNames: new Map(),
+      });
+
+      await manager.activateSearch('beach');
+
+      expect(goto).toHaveBeenCalledWith('/photos?q=beach');
+    });
   });
 
   it('applySearchSort immediately updates the current searchable page and marks the next navigate to keep the palette open', async () => {
@@ -1461,7 +1642,7 @@ describe('activateRecent()', () => {
 
   it('query entries replay through activateSearch without changing mode', () => {
     const m = new GlobalSearchManager();
-    const spy = vi.spyOn(m, 'activateSearch').mockImplementation(() => {});
+    const spy = vi.spyOn(m, 'activateSearch').mockImplementation(async () => {});
 
     m.mode = 'ocr';
     m.activateRecent({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
@@ -1715,7 +1896,7 @@ describe('topSearchMatch', () => {
   it('is present only for non-empty all-scope queries', () => {
     const m = new GlobalSearchManager();
     m.query = ' beach ';
-    expect(m.topSearchMatch).toEqual({ id: 'top-search', query: 'beach' });
+    expect(m.topSearchMatch).toEqual({ id: 'top-search', query: 'beach', rawQuery: 'beach' });
 
     m.query = '';
     expect(m.topSearchMatch).toBeNull();

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1383,11 +1383,11 @@ describe('activate("command")', () => {
     expect(goto).toHaveBeenCalledWith('/spaces/space-1/photos?view=grid&q=beach&sort=asc');
   });
 
-  it('activateSearch with empty text clears the committed searchable-page query', () => {
+  it('activateSearch with empty text clears the committed searchable-page query', async () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/photos?q=mountain&sort=asc&view=grid');
 
-    m.activateSearch('');
+    await m.activateSearch('');
 
     expect(goto).toHaveBeenCalledWith('/photos?view=grid');
     expect(getEntries()).toEqual([]);

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1475,10 +1475,14 @@ describe('activate("command")', () => {
 
       await manager.activateSearch('beach person:anna tag:travel');
 
-      expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?q=beach&people=person-1&tags=tag-1', {
-        personNames: new Map([['person-1', 'Anna']]),
-        tagNames: new Map([['tag-1', 'Travel']]),
-      });
+      expect(storeTypedSearchNames).toHaveBeenCalledWith(
+        '/photos?q=beach&people=person-1&tags=tag-1',
+        {
+          personNames: new Map([['person-1', 'Anna']]),
+          tagNames: new Map([['tag-1', 'Travel']]),
+        },
+        'beach person:anna tag:travel',
+      );
     });
 
     it('supports filter-only searches without q', async () => {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -11,7 +11,7 @@ import {
   getSearchablePageState,
   type SearchablePageSortOrder,
 } from '$lib/utils/searchable-page-search';
-import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
+import { getTypedSearchDisplayText, storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import {
   parseTypedSearch,
   type TypedSearchDisplayToken,
@@ -626,13 +626,19 @@ export class GlobalSearchManager {
     this.isOpen = true;
     this.presentation = presentation;
     const currentPageSearchState = getSearchablePageState(page.url);
-    if (presentation === 'modal' && this.clearQueryOnNextModalOpen) {
+    const typedDisplayText = currentPageSearchState.isSearchable
+      ? getTypedSearchDisplayText(page.url.pathname + page.url.search)
+      : undefined;
+    if (presentation === 'modal' && this.clearQueryOnNextModalOpen && typedDisplayText === undefined) {
       this.query = '';
       this.searchSortOrder = 'relevance';
       this.clearQueryOnNextModalOpen = false;
     } else if (currentPageSearchState.isSearchable) {
-      this.query = currentPageSearchState.query;
+      this.query = typedDisplayText ?? currentPageSearchState.query;
       this.searchSortOrder = currentPageSearchState.query ? currentPageSearchState.sortOrder : 'relevance';
+      if (typedDisplayText !== undefined) {
+        this.clearQueryOnNextModalOpen = false;
+      }
       this.parseTypedSearchDraft(this.query);
     } else {
       this.query = '';

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1754,6 +1754,9 @@ export class GlobalSearchManager {
     if (this.scope !== 'all') {
       return null;
     }
+    if (this.typedSearchDisplayTokens.length > 0) {
+      return null;
+    }
     const q = this.query.trim();
     if (q.length === 0) {
       return null;
@@ -1808,6 +1811,9 @@ export class GlobalSearchManager {
     // section itself lists matching commands — promoting + deduping here would
     // make the section render empty, so only promote under unscoped 'all'.
     if (this.scope !== 'all') {
+      return null;
+    }
+    if (this.typedSearchDisplayTokens.length > 0) {
       return null;
     }
     const q = this.query.trim();
@@ -1968,12 +1974,17 @@ export class GlobalSearchManager {
     // provider can branch: non-nav entity scopes hide the section entirely, bare
     // `>` returns the full filtered catalog sorted alphabetically, and fuzzy search
     // runs when there's a payload under scope 'all' or 'nav'.
-    this.sections.navigation = this.runNavigationProvider(this.payload, this.scope);
+    const searchProviderPayload = this.getSearchProviderPayload();
+    this.sections.navigation = this.runNavigationProvider(searchProviderPayload, this.scope);
     // Commands mirror navigation: synchronous on every keystroke, bypasses the debounce.
     // Pass the current `topCommandMatch.id` so a command that is promoted to the top-
     // result slot doesn't also render inside its own section (same dedup shape the
     // component applies for nav).
-    this.sections.commands = this.runCommandsProvider(this.payload, this.scope, this.topCommandMatch?.id ?? null);
+    this.sections.commands = this.runCommandsProvider(
+      searchProviderPayload,
+      this.scope,
+      this.topCommandMatch?.id ?? null,
+    );
     // The prior cursor may point at a nav/entity item that no longer exists in the new
     // results. Reconcile synchronously so the highlight doesn't lag the displayed list.
     this.reconcileCursor();

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1390,7 +1390,7 @@ export class GlobalSearchManager {
     });
     this.clearQueryOnNextModalOpen = true;
     const destination = this.buildSearchDestination(resolved.queryText, resolved.filters);
-    storeTypedSearchNames(destination, { personNames: resolved.personNames, tagNames: resolved.tagNames });
+    storeTypedSearchNames(destination, { personNames: resolved.personNames, tagNames: resolved.tagNames }, trimmed);
     void goto(destination);
   }
 

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -357,6 +357,7 @@ export class GlobalSearchManager {
   private storageListener?: (e: StorageEvent) => void;
   private mlProbed = false;
   private keepOpenOnNextNavigate = false;
+  private searchablePageFiltersProvider?: () => FilterState | undefined;
 
   /**
    * Catalogs fetched lazily on first provider run and shared for the remainder of the
@@ -1311,7 +1312,7 @@ export class GlobalSearchManager {
   async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {
     this.searchSortOrder = sortOrder;
 
-    const nextUrl = buildSearchablePageUrl(page.url, text, sortOrder);
+    const nextUrl = buildSearchablePageUrl(page.url, text, sortOrder, this.searchablePageFiltersProvider?.());
     if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
       return;
     }
@@ -1327,6 +1328,16 @@ export class GlobalSearchManager {
       this.keepOpenOnNextNavigate = false;
       throw error;
     }
+  }
+
+  registerSearchablePageFilters(provider: () => FilterState | undefined) {
+    this.searchablePageFiltersProvider = provider;
+
+    return () => {
+      if (this.searchablePageFiltersProvider === provider) {
+        this.searchablePageFiltersProvider = undefined;
+      }
+    };
   }
 
   async activateSearch(text: string): Promise<void> {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
+import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
 import { Route } from '$lib/route';
@@ -10,6 +11,13 @@ import {
   getSearchablePageState,
   type SearchablePageSortOrder,
 } from '$lib/utils/searchable-page-search';
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
+import {
+  parseTypedSearch,
+  type TypedSearchDisplayToken,
+  type TypedSearchIssue,
+} from '$lib/utils/typed-search/typed-search-parser';
+import { resolveTypedSearchFilters, type TypedSearchChoice } from '$lib/utils/typed-search/typed-search-resolver';
 import {
   getAlbumInfo,
   getAlbumNames,
@@ -91,7 +99,7 @@ export type ActiveItem =
   | { kind: 'nav'; data: NavigationItem }
   | { kind: 'command'; data: CommandItem };
 
-type TopSearchMatch = { id: 'top-search'; query: string };
+type TopSearchMatch = { id: 'top-search'; query: string; rawQuery: string };
 
 const VALID_MODES: ReadonlySet<SearchMode> = new Set(['smart', 'metadata', 'description', 'ocr']);
 // Slice size for the albums section. Kept as a named constant so the buildProviders
@@ -219,6 +227,23 @@ function loadSearchQueryType(): SearchMode {
   return 'smart';
 }
 
+function hasSerializableFilters(filters: FilterState | undefined): boolean {
+  return (
+    filters !== undefined &&
+    (filters.personIds.length > 0 ||
+      filters.tagIds.length > 0 ||
+      !!filters.city ||
+      !!filters.country ||
+      !!filters.make ||
+      !!filters.model ||
+      filters.mediaType !== 'all' ||
+      filters.isFavorite !== undefined ||
+      filters.rating !== undefined ||
+      !!filters.dateAfter ||
+      !!filters.dateBefore)
+  );
+}
+
 export class GlobalSearchManager {
   isOpen = $state(false);
   presentation = $state<SearchPresentation>('modal');
@@ -228,6 +253,12 @@ export class GlobalSearchManager {
   parsedQuery = $derived<ParsedQuery>(parseScope(this.query));
   scope = $derived<Scope>(this.parsedQuery.scope);
   payload = $derived<string>(this.parsedQuery.payload);
+  typedSearchDisplayTokens = $state<TypedSearchDisplayToken[]>([]);
+  typedSearchIssues = $state<TypedSearchIssue[]>([]);
+  typedSearchChoices = $state<TypedSearchChoice[]>([]);
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  selectedTypedSearchChoices = new Map<string, TypedSearchChoice>();
+  typedSearchPlainQuery = $state('');
   sections = $state<Sections>({
     photos: idle,
     people: idle,
@@ -601,9 +632,11 @@ export class GlobalSearchManager {
     } else if (currentPageSearchState.isSearchable) {
       this.query = currentPageSearchState.query;
       this.searchSortOrder = currentPageSearchState.query ? currentPageSearchState.sortOrder : 'relevance';
+      this.parseTypedSearchDraft(this.query);
     } else {
       this.query = '';
       this.searchSortOrder = 'relevance';
+      this.clearTypedSearchDraft();
     }
     if (this.closeController.signal.aborted) {
       this.closeController = new AbortController();
@@ -976,6 +1009,7 @@ export class GlobalSearchManager {
     // Reset query so reopening and re-typing the same string is not a no-op
     // (setQuery short-circuits when `this.query === text`).
     this.query = '';
+    this.clearTypedSearchDraft();
     this.searchSortOrder = 'relevance';
   }
 
@@ -1215,13 +1249,53 @@ export class GlobalSearchManager {
     void goto(route);
   }
 
-  private buildSearchDestination(text: string): string {
-    const searchablePageUrl = buildSearchablePageUrl(page.url, text, this.searchSortOrder);
+  parseTypedSearchDraft(text = this.query) {
+    const parsed = parseTypedSearch(text);
+    this.typedSearchDisplayTokens = parsed.displayTokens;
+    this.typedSearchPlainQuery = parsed.queryText;
+    this.typedSearchIssues = [];
+    this.typedSearchChoices = [];
+    for (const key of [...this.selectedTypedSearchChoices.keys()]) {
+      if (!parsed.resolutionTokens.some((token) => token.raw === key)) {
+        this.selectedTypedSearchChoices.delete(key);
+      }
+    }
+    return parsed;
+  }
+
+  clearTypedSearchDraft() {
+    this.typedSearchDisplayTokens = [];
+    this.typedSearchPlainQuery = '';
+    this.typedSearchIssues = [];
+    this.typedSearchChoices = [];
+    this.selectedTypedSearchChoices.clear();
+  }
+
+  selectTypedSearchChoice(choice: TypedSearchChoice) {
+    this.selectedTypedSearchChoices.set(choice.tokenRaw, choice);
+    this.typedSearchIssues = this.typedSearchIssues.filter((issue) => issue.raw !== choice.tokenRaw);
+    this.typedSearchChoices = this.typedSearchChoices.filter((item) => item.tokenRaw !== choice.tokenRaw);
+    this.typedSearchDisplayTokens = this.typedSearchDisplayTokens.map((token) =>
+      token.raw === choice.tokenRaw
+        ? { raw: token.raw, key: token.key, value: choice.label, status: 'resolved-entity' as const }
+        : token,
+    );
+  }
+
+  private getSearchProviderPayload(): string {
+    if (this.scope !== 'all') {
+      return this.payload;
+    }
+    return this.typedSearchPlainQuery;
+  }
+
+  private buildSearchDestination(text: string, filters?: FilterState): string {
+    const searchablePageUrl = buildSearchablePageUrl(page.url, text, this.searchSortOrder, filters);
     if (searchablePageUrl) {
       return searchablePageUrl;
     }
 
-    if (page.url.pathname.startsWith('/map')) {
+    if (page.url.pathname.startsWith('/map') && !hasSerializableFilters(filters)) {
       // Ephemeral serialization for navigation only; no reactive state is retained.
       // eslint-disable-next-line svelte/prefer-svelte-reactivity
       const params = new URLSearchParams(page.url.searchParams);
@@ -1229,14 +1303,9 @@ export class GlobalSearchManager {
       return `/map?${params.toString()}`;
     }
 
-    // Ephemeral serialization for navigation only; no reactive state is retained.
+    // Ephemeral URL object for destination construction only; no reactive state is retained.
     // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const fresh = new URLSearchParams();
-    fresh.set('q', text);
-    if (this.searchSortOrder !== 'relevance') {
-      fresh.set('sort', this.searchSortOrder);
-    }
-    return `/photos?${fresh.toString()}`;
+    return buildSearchablePageUrl(new URL('/photos', page.url), text, this.searchSortOrder, filters) ?? '/photos';
   }
 
   async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {
@@ -1260,7 +1329,7 @@ export class GlobalSearchManager {
     }
   }
 
-  activateSearch(text: string): void {
+  async activateSearch(text: string): Promise<void> {
     const trimmed = text.trim();
     if (!trimmed) {
       const searchablePageUrl = buildSearchablePageUrl(page.url, '');
@@ -1273,6 +1342,35 @@ export class GlobalSearchManager {
       return;
     }
 
+    const parsed = this.parseTypedSearchDraft(trimmed);
+    if (parsed.issues.length > 0) {
+      this.typedSearchIssues = parsed.issues;
+      this.typedSearchChoices = [];
+      this.typedSearchDisplayTokens = parsed.displayTokens;
+      return;
+    }
+
+    const spaceId = page.url.pathname.startsWith('/spaces/')
+      ? page.url.pathname.split('/').filter(Boolean)[1]
+      : undefined;
+    const resolved = await resolveTypedSearchFilters(parsed, {
+      spaceId,
+      signal: this.closeSignal,
+      selectedChoices: this.selectedTypedSearchChoices,
+    });
+
+    if (!resolved.ok) {
+      this.typedSearchIssues = resolved.issues;
+      this.typedSearchChoices = resolved.choices;
+      this.typedSearchDisplayTokens = parsed.displayTokens.map((token) => {
+        const issue = resolved.issues.find((item) => item.raw === token.raw);
+        return issue ? { ...token, status: 'error' as const, issue } : token;
+      });
+      return;
+    }
+
+    this.typedSearchIssues = [];
+    this.typedSearchChoices = [];
     addEntry({
       kind: 'query',
       id: `query:${trimmed.toLowerCase()}`,
@@ -1280,7 +1378,9 @@ export class GlobalSearchManager {
       lastUsed: Date.now(),
     });
     this.clearQueryOnNextModalOpen = true;
-    void goto(this.buildSearchDestination(trimmed));
+    const destination = this.buildSearchDestination(resolved.queryText, resolved.filters);
+    storeTypedSearchNames(destination, { personNames: resolved.personNames, tagNames: resolved.tagNames });
+    void goto(destination);
   }
 
   activate(kind: 'photo' | 'person' | 'place' | 'tag' | 'nav' | 'command', item: unknown) {
@@ -1448,7 +1548,7 @@ export class GlobalSearchManager {
       return;
     }
     if (entry.kind === 'query') {
-      this.activateSearch(entry.text);
+      void this.activateSearch(entry.text);
       return;
     }
     const now = Date.now();
@@ -1578,7 +1678,7 @@ export class GlobalSearchManager {
     // throws (not just returns a rejected promise) still lands in the .catch handler.
     // Symmetric with runBatch's defensive wrapper.
     Promise.resolve()
-      .then(() => this.providers.photos.run(this.query, this.mode, signal))
+      .then(() => this.providers.photos.run(this.getSearchProviderPayload(), this.mode, signal))
       .then((result) => {
         if (setModeBatch !== this.batchController) {
           return;
@@ -1694,7 +1794,7 @@ export class GlobalSearchManager {
     if (this.topCommandMatch !== null || this.topNavigationMatch !== null) {
       return null;
     }
-    return { id: 'top-search', query };
+    return { id: 'top-search', query: this.typedSearchPlainQuery || query, rawQuery: query };
   });
 
   /**
@@ -1821,8 +1921,14 @@ export class GlobalSearchManager {
     this.batchController = null;
     this.photosController?.abort();
     this.photosController = null;
+    if (this.scope === 'all') {
+      this.parseTypedSearchDraft(text);
+    } else {
+      this.clearTypedSearchDraft();
+    }
 
     if (text.trim() === '') {
+      this.clearTypedSearchDraft();
       this.sections = {
         photos: idle,
         people: idle,
@@ -1903,6 +2009,7 @@ export class GlobalSearchManager {
     // in setQuery and is NOT an entity section.
     const scope = this.scope;
     const payload = this.payload;
+    const providerPayload = this.getSearchProviderPayload();
     const inScope = ENTITY_KEYS_BY_SCOPE[scope];
     for (const key of ['photos', 'people', 'places', 'tags', 'albums', 'spaces'] as const) {
       if (!inScope.includes(key)) {
@@ -1923,7 +2030,7 @@ export class GlobalSearchManager {
       //     the provider's bare-prefix branch renders suggestions.
       const isBare = scope !== 'all' && payload === '';
       const minRequired = scope === 'all' ? provider.minQueryLength : 1;
-      if (!isBare && payload.length < minRequired) {
+      if (!isBare && providerPayload.length < minRequired) {
         this.sections[key] = idle;
         continue;
       }
@@ -1947,7 +2054,7 @@ export class GlobalSearchManager {
       // Promise.resolve().then(...) guarantees that a provider which synchronously
       // throws (not just returns a rejected promise) still lands in the .catch handler.
       Promise.resolve()
-        .then(() => provider.run(payload, mode, signal))
+        .then(() => provider.run(providerPayload, mode, signal))
         .then((result) => {
           if (batch !== this.batchController) {
             return;

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -629,7 +629,7 @@ export class GlobalSearchManager {
     const typedDisplayText = currentPageSearchState.isSearchable
       ? getTypedSearchDisplayText(page.url.pathname + page.url.search)
       : undefined;
-    if (presentation === 'modal' && this.clearQueryOnNextModalOpen && typedDisplayText === undefined) {
+    if (presentation === 'modal' && this.clearQueryOnNextModalOpen) {
       this.query = '';
       this.searchSortOrder = 'relevance';
       this.clearQueryOnNextModalOpen = false;

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1255,7 +1255,7 @@ export class GlobalSearchManager {
     this.typedSearchPlainQuery = parsed.queryText;
     this.typedSearchIssues = [];
     this.typedSearchChoices = [];
-    for (const key of [...this.selectedTypedSearchChoices.keys()]) {
+    for (const key of this.selectedTypedSearchChoices.keys()) {
       if (!parsed.resolutionTokens.some((token) => token.raw === key)) {
         this.selectedTypedSearchChoices.delete(key);
       }

--- a/web/src/lib/modals/RepresentativeFacePickerModal.spec.ts
+++ b/web/src/lib/modals/RepresentativeFacePickerModal.spec.ts
@@ -2,6 +2,7 @@ import type { PersonFacePageResponseDto, PersonFaceResponseDto } from '@immich/s
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { afterEach } from 'vitest';
 import RepresentativeFacePickerModal from './RepresentativeFacePickerModal.svelte';
 
 vi.mock('@immich/ui', async (importOriginal: () => Promise<typeof import('@immich/ui')>) => {
@@ -46,6 +47,13 @@ const makePage = (overrides: Partial<PersonFacePageResponseDto> = {}): PersonFac
 });
 
 const getThumbnailUrl = (face: PersonFaceResponseDto) => `/thumbnail/${face.id}`;
+
+// Drain bits-ui Modal's deferred body-scroll-lock cleanup before happy-dom tears
+// down `document`. Otherwise CI can report an unhandled `document is not defined`
+// after all assertions in this file have passed.
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+});
 
 describe('RepresentativeFacePickerModal', () => {
   it('shows a stable skeleton grid while loading', () => {

--- a/web/src/lib/modals/ShortcutsModal.spec.ts
+++ b/web/src/lib/modals/ShortcutsModal.spec.ts
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import ShortcutsModal from './ShortcutsModal.svelte';
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({
+  authManager: {
+    authenticated: false,
+    preferences: { ratings: { enabled: false } },
+  },
+}));
+
+describe('ShortcutsModal', () => {
+  it('uses the Gallery logo in the modal header', () => {
+    render(ShortcutsModal, { props: { onClose: vi.fn() } });
+
+    expect(screen.getByRole('img', { name: 'Gallery logo' })).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Immich logo' })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/modals/ShortcutsModal.svelte
+++ b/web/src/lib/modals/ShortcutsModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import Logo from '$lib/components/shared-components/Logo.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
-  import { Icon, Modal, ModalBody } from '@immich/ui';
+  import { CardTitle, CloseButton, Icon, Modal, ModalBody, ModalHeader } from '@immich/ui';
   import { mdiInformationOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
@@ -55,6 +56,15 @@
 </script>
 
 <Modal title={$t('keyboard_shortcuts')} size="medium" {onClose}>
+  <ModalHeader>
+    <div class="flex items-center justify-between gap-2">
+      <Logo variant="icon" size="tiny" />
+      <CardTitle tag="p" class="grow text-lg font-semibold text-dark/90 dark:text-white/90">
+        {$t('keyboard_shortcuts')}
+      </CardTitle>
+      <CloseButton class="-me-2" onclick={onClose} />
+    </div>
+  </ModalHeader>
   <ModalBody>
     <div class="grid grid-cols-1 gap-4 px-4 pb-4 md:grid-cols-2">
       {#if shortcuts.general.length > 0}

--- a/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+++ b/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
@@ -1,0 +1,113 @@
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import {
+  buildSearchablePageUrl,
+  clearSearchablePageFilterParams,
+  getSearchablePageFilterState,
+  getSearchablePageState,
+} from '$lib/utils/searchable-page-search';
+import { describe, expect, it } from 'vitest';
+
+describe('searchable page URL state', () => {
+  it('detects photos as a searchable page', () => {
+    const state = getSearchablePageState(new URL('https://gallery.test/photos?q=beach'));
+
+    expect(state).toMatchObject({
+      basePath: '/photos',
+      isSearchable: true,
+      query: 'beach',
+      sortOrder: 'relevance',
+    });
+  });
+
+  it('detects spaces and space photos as searchable pages', () => {
+    expect(getSearchablePageState(new URL('https://gallery.test/spaces/space-1')).basePath).toBe('/spaces/space-1');
+    expect(getSearchablePageState(new URL('https://gallery.test/spaces/space-1/photos')).basePath).toBe(
+      '/spaces/space-1/photos',
+    );
+  });
+
+  it('builds the existing query-only URL without filters', () => {
+    const url = new URL('https://gallery.test/photos?view=timeline');
+
+    expect(buildSearchablePageUrl(url, 'beach')).toBe('/photos?view=timeline&q=beach');
+  });
+
+  it('preserves existing typed filter params when no replacement filter state is supplied', () => {
+    const url = new URL('https://gallery.test/photos?q=beach&people=person-1&city=Berlin&view=timeline');
+
+    expect(buildSearchablePageUrl(url, 'sunset', 'asc')).toBe(
+      '/photos?q=sunset&people=person-1&city=Berlin&view=timeline&sort=asc',
+    );
+  });
+});
+
+describe('typed filter URL state', () => {
+  it('serializes typed filters into photos URLs while preserving query and sort', () => {
+    const url = new URL('https://gallery.test/photos?view=timeline');
+    const filters = {
+      ...createFilterState(),
+      personIds: ['person-1', 'person-2'],
+      tagIds: ['tag-1'],
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Nikon',
+      model: 'Z8',
+      mediaType: 'image' as const,
+      isFavorite: true,
+      rating: 4,
+      dateAfter: '2025-01-01',
+      dateBefore: '2026-12-31',
+      sortOrder: 'asc' as const,
+    };
+
+    const result = buildSearchablePageUrl(url, 'beach', 'asc', filters);
+
+    expect(result).toBe(
+      '/photos?view=timeline&q=beach&sort=asc&people=person-1%2Cperson-2&tags=tag-1&city=Berlin&country=Germany&make=Nikon&model=Z8&type=image&favorite=true&rating=4&from=2025-01-01&to=2026-12-31',
+    );
+  });
+
+  it('serializes typed filters into space URLs', () => {
+    const url = new URL('https://gallery.test/spaces/space-1/photos?panel=closed');
+    const filters = {
+      ...createFilterState(),
+      city: 'Berlin',
+      mediaType: 'video' as const,
+      sortOrder: 'relevance' as const,
+    };
+
+    const result = buildSearchablePageUrl(url, 'beach', 'relevance', filters);
+
+    expect(result).toBe('/spaces/space-1/photos?panel=closed&q=beach&city=Berlin&type=video');
+  });
+
+  it('hydrates typed filter params into FilterState', () => {
+    const url = new URL(
+      'https://gallery.test/photos?q=beach&people=person-1%2Cperson-2&tags=tag-1&type=video&favorite=false&rating=5&from=2025-01-01&to=2026-12-31',
+    );
+
+    expect(getSearchablePageFilterState(url)).toEqual({
+      personIds: ['person-1', 'person-2'],
+      tagIds: ['tag-1'],
+      mediaType: 'video',
+      isFavorite: false,
+      rating: 5,
+      dateAfter: '2025-01-01',
+      dateBefore: '2026-12-31',
+    });
+  });
+
+  it('drops invalid typed filter URL params without crashing', () => {
+    const url = new URL('https://gallery.test/photos?type=gif&favorite=maybe&rating=9&from=soon&to=2026-99-01');
+
+    expect(getSearchablePageFilterState(url)).toEqual({});
+  });
+
+  it('clears only typed filter params', () => {
+    const params = new URLSearchParams('q=beach&sort=desc&people=p1&city=Berlin&view=timeline');
+
+    clearSearchablePageFilterParams(params);
+
+    expect(params.toString()).toBe('q=beach&sort=desc&view=timeline');
+  });
+});

--- a/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+++ b/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
@@ -4,6 +4,7 @@ import {
   clearSearchablePageFilterParams,
   getSearchablePageFilterState,
   getSearchablePageState,
+  preserveTransientTemporalFilters,
 } from '$lib/utils/searchable-page-search';
 import { describe, expect, it } from 'vitest';
 
@@ -101,6 +102,24 @@ describe('typed filter URL state', () => {
     const url = new URL('https://gallery.test/photos?type=gif&favorite=maybe&rating=9&from=soon&to=2026-99-01');
 
     expect(getSearchablePageFilterState(url)).toEqual({});
+  });
+
+  it('preserves transient selected year and month while hydrating URL-backed filters', () => {
+    const urlFilters = getSearchablePageFilterState(new URL('https://gallery.test/photos?city=Berlin'));
+
+    expect(preserveTransientTemporalFilters(urlFilters, { selectedYear: 2023, selectedMonth: 6 })).toEqual({
+      city: 'Berlin',
+      selectedYear: 2023,
+      selectedMonth: 6,
+    });
+  });
+
+  it('does not preserve transient year selection over an explicit custom date range', () => {
+    const urlFilters = getSearchablePageFilterState(new URL('https://gallery.test/photos?from=2024-01-01'));
+
+    expect(preserveTransientTemporalFilters(urlFilters, { selectedYear: 2023, selectedMonth: 6 })).toEqual({
+      dateAfter: '2024-01-01',
+    });
   });
 
   it('clears only typed filter params', () => {

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -33,6 +33,8 @@ export type SearchablePageFilterState = Partial<
   >
 >;
 
+export type SearchablePageTransientTemporalState = Partial<Pick<FilterState, 'selectedYear' | 'selectedMonth'>>;
+
 type SearchablePageState = {
   basePath: string | null;
   isSearchable: boolean;
@@ -185,6 +187,21 @@ export function getSearchablePageFilterState(url: URL): SearchablePageFilterStat
   }
 
   return result;
+}
+
+export function preserveTransientTemporalFilters<T extends SearchablePageFilterState>(
+  filters: T,
+  transient?: SearchablePageTransientTemporalState,
+): T & SearchablePageTransientTemporalState {
+  if (transient?.selectedYear === undefined || filters.dateAfter || filters.dateBefore) {
+    return filters;
+  }
+
+  return {
+    ...filters,
+    selectedYear: transient.selectedYear,
+    selectedMonth: transient.selectedMonth,
+  };
 }
 
 function appendSearchablePageFilterParams(params: URLSearchParams, filters: FilterState) {

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -224,10 +224,12 @@ function appendSearchablePageFilterParams(params: URLSearchParams, filters: Filt
 }
 
 function splitListParam(value: string | null): string[] {
-  return value
-    ?.split(',')
-    .map((item) => item.trim())
-    .filter(Boolean) ?? [];
+  return (
+    value
+      ?.split(',')
+      .map((item) => item.trim())
+      .filter(Boolean) ?? []
+  );
 }
 
 function parseRating(value: string | null): number | undefined {

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -1,4 +1,37 @@
+import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+
 export type SearchablePageSortOrder = 'relevance' | 'asc' | 'desc';
+
+export const SEARCHABLE_PAGE_FILTER_PARAMS = [
+  'people',
+  'tags',
+  'city',
+  'country',
+  'make',
+  'model',
+  'type',
+  'favorite',
+  'rating',
+  'from',
+  'to',
+] as const;
+
+export type SearchablePageFilterState = Partial<
+  Pick<
+    FilterState,
+    | 'personIds'
+    | 'tagIds'
+    | 'city'
+    | 'country'
+    | 'make'
+    | 'model'
+    | 'mediaType'
+    | 'isFavorite'
+    | 'rating'
+    | 'dateAfter'
+    | 'dateBefore'
+  >
+>;
 
 type SearchablePageState = {
   basePath: string | null;
@@ -66,6 +99,7 @@ export function buildSearchablePageUrl(
   url: URL,
   query: string,
   sortOrder: SearchablePageSortOrder = 'relevance',
+  filters?: FilterState,
 ): string | null {
   const basePath = getSearchablePageBasePath(url.pathname);
   if (!basePath) {
@@ -91,6 +125,152 @@ export function buildSearchablePageUrl(
     }
   }
 
+  if (filters !== undefined) {
+    clearSearchablePageFilterParams(params);
+    appendSearchablePageFilterParams(params, filters);
+  }
+
   const search = params.toString();
   return basePath + (search ? `?${search}` : '');
+}
+
+export function clearSearchablePageFilterParams(params: URLSearchParams) {
+  for (const key of SEARCHABLE_PAGE_FILTER_PARAMS) {
+    params.delete(key);
+  }
+}
+
+export function getSearchablePageFilterState(url: URL): SearchablePageFilterState {
+  const result: SearchablePageFilterState = {};
+  const people = splitListParam(url.searchParams.get('people'));
+  const tags = splitListParam(url.searchParams.get('tags'));
+  const rating = parseRating(url.searchParams.get('rating'));
+  const mediaType = parseMediaType(url.searchParams.get('type'));
+  const favorite = parseFavorite(url.searchParams.get('favorite'));
+  const from = parseDateParam(url.searchParams.get('from'));
+  const to = parseDateParam(url.searchParams.get('to'));
+
+  if (people.length > 0) {
+    result.personIds = people;
+  }
+  if (tags.length > 0) {
+    result.tagIds = tags;
+  }
+  if (url.searchParams.get('city')) {
+    result.city = url.searchParams.get('city') ?? undefined;
+  }
+  if (url.searchParams.get('country')) {
+    result.country = url.searchParams.get('country') ?? undefined;
+  }
+  if (url.searchParams.get('make')) {
+    result.make = url.searchParams.get('make') ?? undefined;
+  }
+  if (url.searchParams.get('model')) {
+    result.model = url.searchParams.get('model') ?? undefined;
+  }
+  if (mediaType) {
+    result.mediaType = mediaType;
+  }
+  if (favorite !== undefined) {
+    result.isFavorite = favorite;
+  }
+  if (rating !== undefined) {
+    result.rating = rating;
+  }
+  if (from) {
+    result.dateAfter = from;
+  }
+  if (to) {
+    result.dateBefore = to;
+  }
+
+  return result;
+}
+
+function appendSearchablePageFilterParams(params: URLSearchParams, filters: FilterState) {
+  if (filters.personIds.length > 0) {
+    params.set('people', filters.personIds.join(','));
+  }
+  if (filters.tagIds.length > 0) {
+    params.set('tags', filters.tagIds.join(','));
+  }
+  if (filters.city) {
+    params.set('city', filters.city);
+  }
+  if (filters.country) {
+    params.set('country', filters.country);
+  }
+  if (filters.make) {
+    params.set('make', filters.make);
+  }
+  if (filters.model) {
+    params.set('model', filters.model);
+  }
+  if (filters.mediaType !== 'all') {
+    params.set('type', filters.mediaType);
+  }
+  if (filters.isFavorite !== undefined) {
+    params.set('favorite', String(filters.isFavorite));
+  }
+  if (filters.rating !== undefined) {
+    params.set('rating', String(filters.rating));
+  }
+  if (filters.dateAfter) {
+    params.set('from', filters.dateAfter);
+  }
+  if (filters.dateBefore) {
+    params.set('to', filters.dateBefore);
+  }
+}
+
+function splitListParam(value: string | null): string[] {
+  return value
+    ?.split(',')
+    .map((item) => item.trim())
+    .filter(Boolean) ?? [];
+}
+
+function parseRating(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const rating = Number(value);
+  return Number.isInteger(rating) && rating >= 1 && rating <= 5 ? rating : undefined;
+}
+
+function parseMediaType(value: string | null): 'image' | 'video' | undefined {
+  return value === 'image' || value === 'video' ? value : undefined;
+}
+
+function parseFavorite(value: string | null): boolean | undefined {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return undefined;
+}
+
+function parseDateParam(value: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return undefined;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    return undefined;
+  }
+
+  return value;
 }

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { consumeTypedSearchNames, getTypedSearchDisplayText, storeTypedSearchNames } from './typed-search-name-cache';
+import {
+  consumeTypedSearchNames,
+  consumeTypedSearchNamesInto,
+  getTypedSearchDisplayText,
+  storeTypedSearchNames,
+} from './typed-search-name-cache';
 
 describe('typed search name cache', () => {
   beforeEach(() => {
@@ -44,5 +49,29 @@ describe('typed search name cache', () => {
     expect(getTypedSearchDisplayText('/photos?people=person-cat')).toBe('person:cat');
     consumeTypedSearchNames('/photos?people=person-cat');
     expect(getTypedSearchDisplayText('/photos?people=person-cat')).toBe('person:cat');
+  });
+
+  it('merges consumed names into existing name maps for same-page navigations', () => {
+    const personNames = new Map<string, string>([['person-anna', 'Anna']]);
+    const tagNames = new Map<string, string>();
+
+    storeTypedSearchNames('/photos?q=nature&people=person-cat&tags=tag-nature', {
+      personNames: new Map([['person-cat', 'cat']]),
+      tagNames: new Map([['tag-nature', 'nature']]),
+    });
+
+    consumeTypedSearchNamesInto('/photos?q=nature&people=person-cat&tags=tag-nature', personNames, tagNames);
+
+    expect(personNames).toEqual(
+      new Map([
+        ['person-anna', 'Anna'],
+        ['person-cat', 'cat'],
+      ]),
+    );
+    expect(tagNames).toEqual(new Map([['tag-nature', 'nature']]));
+    expect(consumeTypedSearchNames('/photos?q=nature&people=person-cat&tags=tag-nature')).toEqual({
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
   });
 });

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { consumeTypedSearchNames, storeTypedSearchNames } from './typed-search-name-cache';
+import { consumeTypedSearchNames, getTypedSearchDisplayText, storeTypedSearchNames } from './typed-search-name-cache';
 
 describe('typed search name cache', () => {
   beforeEach(() => {
@@ -29,5 +29,20 @@ describe('typed search name cache', () => {
       personNames: new Map(),
       tagNames: new Map(),
     });
+  });
+
+  it('keeps raw typed search display text after consuming names', () => {
+    storeTypedSearchNames(
+      '/photos?people=person-cat',
+      {
+        personNames: new Map([['person-cat', 'cat']]),
+        tagNames: new Map(),
+      },
+      'person:cat',
+    );
+
+    expect(getTypedSearchDisplayText('/photos?people=person-cat')).toBe('person:cat');
+    consumeTypedSearchNames('/photos?people=person-cat');
+    expect(getTypedSearchDisplayText('/photos?people=person-cat')).toBe('person:cat');
   });
 });

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.spec.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { consumeTypedSearchNames, storeTypedSearchNames } from './typed-search-name-cache';
+
+describe('typed search name cache', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('stores and consumes names by destination URL', () => {
+    storeTypedSearchNames('/photos?q=beach&people=person-1', {
+      personNames: new Map([['person-1', 'Anna']]),
+      tagNames: new Map([['tag-1', 'Travel']]),
+    });
+
+    const result = consumeTypedSearchNames('/photos?q=beach&people=person-1');
+
+    expect(result.personNames).toEqual(new Map([['person-1', 'Anna']]));
+    expect(result.tagNames).toEqual(new Map([['tag-1', 'Travel']]));
+    expect(consumeTypedSearchNames('/photos?q=beach&people=person-1')).toEqual({
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+
+  it('ignores malformed storage data', () => {
+    sessionStorage.setItem('typed-search:names:/photos', '{not-json');
+
+    expect(consumeTypedSearchNames('/photos')).toEqual({
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+});

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.ts
@@ -43,8 +43,8 @@ export function consumeTypedSearchNames(destination: string) {
   try {
     const parsed = JSON.parse(raw) as StoredTypedSearchNames;
     return {
-      personNames: new Map(parsed.personNames ?? []),
-      tagNames: new Map(parsed.tagNames ?? []),
+      personNames: parsed.personNames ? new Map(parsed.personNames) : new Map<string, string>(),
+      tagNames: parsed.tagNames ? new Map(parsed.tagNames) : new Map<string, string>(),
     };
   } catch {
     return emptyNames();

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.ts
@@ -1,0 +1,52 @@
+type StoredTypedSearchNames = {
+  personNames: Array<[string, string]>;
+  tagNames: Array<[string, string]>;
+};
+
+const prefix = 'typed-search:names:';
+
+function emptyNames() {
+  return {
+    personNames: new Map<string, string>(),
+    tagNames: new Map<string, string>(),
+  };
+}
+
+export function storeTypedSearchNames(
+  destination: string,
+  names: { personNames: Map<string, string>; tagNames: Map<string, string> },
+) {
+  if (typeof sessionStorage === 'undefined') {
+    return;
+  }
+
+  const payload: StoredTypedSearchNames = {
+    personNames: [...names.personNames.entries()],
+    tagNames: [...names.tagNames.entries()],
+  };
+
+  sessionStorage.setItem(`${prefix}${destination}`, JSON.stringify(payload));
+}
+
+export function consumeTypedSearchNames(destination: string) {
+  if (typeof sessionStorage === 'undefined') {
+    return emptyNames();
+  }
+
+  const key = `${prefix}${destination}`;
+  const raw = sessionStorage.getItem(key);
+  sessionStorage.removeItem(key);
+  if (!raw) {
+    return emptyNames();
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as StoredTypedSearchNames;
+    return {
+      personNames: new Map(parsed.personNames ?? []),
+      tagNames: new Map(parsed.tagNames ?? []),
+    };
+  } catch {
+    return emptyNames();
+  }
+}

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.ts
@@ -4,6 +4,7 @@ type StoredTypedSearchNames = {
 };
 
 const prefix = 'typed-search:names:';
+const displayPrefix = 'typed-search:display:';
 
 function emptyNames() {
   return {
@@ -15,6 +16,7 @@ function emptyNames() {
 export function storeTypedSearchNames(
   destination: string,
   names: { personNames: Map<string, string>; tagNames: Map<string, string> },
+  displayText?: string,
 ) {
   if (typeof sessionStorage === 'undefined') {
     return;
@@ -26,6 +28,18 @@ export function storeTypedSearchNames(
   };
 
   sessionStorage.setItem(`${prefix}${destination}`, JSON.stringify(payload));
+  const trimmedDisplayText = displayText?.trim();
+  if (trimmedDisplayText) {
+    sessionStorage.setItem(`${displayPrefix}${destination}`, trimmedDisplayText);
+  }
+}
+
+export function getTypedSearchDisplayText(destination: string): string | undefined {
+  if (typeof sessionStorage === 'undefined') {
+    return undefined;
+  }
+
+  return sessionStorage.getItem(`${displayPrefix}${destination}`) ?? undefined;
 }
 
 export function consumeTypedSearchNames(destination: string) {

--- a/web/src/lib/utils/typed-search/typed-search-name-cache.ts
+++ b/web/src/lib/utils/typed-search/typed-search-name-cache.ts
@@ -3,6 +3,10 @@ type StoredTypedSearchNames = {
   tagNames: Array<[string, string]>;
 };
 
+type NameMapSink = {
+  set(id: string, name: string): unknown;
+};
+
 const prefix = 'typed-search:names:';
 const displayPrefix = 'typed-search:display:';
 
@@ -62,5 +66,15 @@ export function consumeTypedSearchNames(destination: string) {
     };
   } catch {
     return emptyNames();
+  }
+}
+
+export function consumeTypedSearchNamesInto(destination: string, personNames: NameMapSink, tagNames: NameMapSink) {
+  const names = consumeTypedSearchNames(destination);
+  for (const [id, name] of names.personNames) {
+    personNames.set(id, name);
+  }
+  for (const [id, name] of names.tagNames) {
+    tagNames.set(id, name);
   }
 }

--- a/web/src/lib/utils/typed-search/typed-search-parser.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-parser.spec.ts
@@ -94,14 +94,16 @@ describe('parseTypedSearch', () => {
   });
 
   it('rejects escaped quote sequences in quoted values', () => {
-    const result = parseTypedSearch('person:"Anna \\"The Ace\\""');
+    const raw = String.raw`person:"Anna \"The Ace\""`;
+    const value = String.raw`Anna \"The Ace\"`;
+    const result = parseTypedSearch(raw);
 
     expect(result.issues).toEqual([
       {
         code: 'escaped-quote',
         key: 'person',
-        raw: 'person:"Anna \\"The Ace\\""',
-        value: 'Anna \\"The Ace\\"',
+        raw,
+        value,
         message: 'Escaped quotes are not supported in filters',
       },
     ]);

--- a/web/src/lib/utils/typed-search/typed-search-parser.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-parser.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { parseTypedSearch } from './typed-search-parser';
+
+describe('parseTypedSearch', () => {
+  it('extracts plain query text and recognized filters', () => {
+    const result = parseTypedSearch('beach person:anna from:2025 to:2026 camera:nikon type:photo');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.resolutionTokens).toEqual([
+      { kind: 'resolution', key: 'person', raw: 'person:anna', value: 'anna' },
+      { kind: 'resolution', key: 'camera', raw: 'camera:nikon', value: 'nikon' },
+    ]);
+    expect(result.scalarTokens).toMatchObject([
+      { kind: 'scalar', key: 'from', raw: 'from:2025', value: '2025', normalizedValue: '2025-01-01' },
+      { kind: 'scalar', key: 'to', raw: 'to:2026', value: '2026', normalizedValue: '2026-12-31' },
+      { kind: 'scalar', key: 'type', raw: 'type:photo', value: 'photo', normalizedValue: 'image' },
+    ]);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('supports quoted values with spaces', () => {
+    const result = parseTypedSearch('beach person:"Anna Maria" city:"New York"');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.resolutionTokens).toEqual([
+      { kind: 'resolution', key: 'person', raw: 'person:"Anna Maria"', value: 'Anna Maria' },
+    ]);
+    expect(result.scalarTokens).toMatchObject([
+      { kind: 'scalar', key: 'city', raw: 'city:"New York"', value: 'New York', normalizedValue: 'New York' },
+    ]);
+  });
+
+  it('rejects unknown alphabetic key value tokens', () => {
+    const result = parseTypedSearch('beach persn:anna');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.issues).toEqual([
+      {
+        code: 'unknown-key',
+        key: 'persn',
+        raw: 'persn:anna',
+        value: 'anna',
+        message: 'Unknown filter "persn"',
+      },
+    ]);
+  });
+
+  it('keeps non-filter colon text in the query', () => {
+    const result = parseTypedSearch('IMG_1234.jpg ratio:3:2 http://example.test');
+
+    expect(result.queryText).toBe('IMG_1234.jpg http://example.test');
+    expect(result.issues).toEqual([
+      {
+        code: 'unknown-key',
+        key: 'ratio',
+        raw: 'ratio:3:2',
+        value: '3:2',
+        message: 'Unknown filter "ratio"',
+      },
+    ]);
+  });
+
+  it('rejects invalid scalar values', () => {
+    const result = parseTypedSearch('from:soon to:2026-99-01 rating:9 type:gif favorite:maybe');
+
+    expect(result.issues.map((issue) => issue.code)).toEqual([
+      'invalid-date',
+      'invalid-date',
+      'invalid-rating',
+      'invalid-type',
+      'invalid-favorite',
+    ]);
+  });
+
+  it('rejects empty values and unterminated quotes on commit parse', () => {
+    const result = parseTypedSearch('person: city:"New York');
+
+    expect(result.issues.map((issue) => issue.code)).toEqual(['empty-value', 'unterminated-quote']);
+  });
+
+  it('rejects escaped quote sequences in quoted values', () => {
+    const result = parseTypedSearch('person:"Anna \\"The Ace\\""');
+
+    expect(result.issues).toEqual([
+      {
+        code: 'escaped-quote',
+        key: 'person',
+        raw: 'person:"Anna \\"The Ace\\""',
+        value: 'Anna \\"The Ace\\"',
+        message: 'Escaped quotes are not supported in filters',
+      },
+    ]);
+  });
+
+  it('rejects duplicate scalar filters but allows repeated people and tags', () => {
+    const result = parseTypedSearch('person:anna person:bob tag:travel tag:family city:Berlin city:Paris');
+
+    expect(result.resolutionTokens.map((token) => token.raw)).toEqual([
+      'person:anna',
+      'person:bob',
+      'tag:travel',
+      'tag:family',
+    ]);
+    expect(result.issues).toEqual([
+      {
+        code: 'duplicate-filter',
+        key: 'city',
+        raw: 'city:Paris',
+        value: 'Paris',
+        message: 'Filter "city" can only be used once',
+      },
+    ]);
+  });
+
+  it('rejects a date range where from is after to', () => {
+    const result = parseTypedSearch('from:2026 to:2025');
+
+    expect(result.issues).toEqual([
+      {
+        code: 'invalid-range',
+        key: 'from',
+        raw: 'from:2026',
+        value: '2026',
+        message: 'Start date must be before end date',
+      },
+    ]);
+  });
+
+  it('normalizes keys and boolean or media values case-insensitively', () => {
+    const result = parseTypedSearch('TYPE:Photo FAVORITE:Yes rating:4');
+
+    expect(result.scalarTokens).toMatchObject([
+      { key: 'type', normalizedValue: 'image' },
+      { key: 'favorite', normalizedValue: true },
+      { key: 'rating', normalizedValue: 4 },
+    ]);
+    expect(result.issues).toEqual([]);
+  });
+});

--- a/web/src/lib/utils/typed-search/typed-search-parser.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-parser.spec.ts
@@ -30,6 +30,21 @@ describe('parseTypedSearch', () => {
     ]);
   });
 
+  it('accepts plural people and tags aliases', () => {
+    const result = parseTypedSearch('people:anna tags:nature beach');
+
+    expect(result.queryText).toBe('beach');
+    expect(result.resolutionTokens).toEqual([
+      { kind: 'resolution', key: 'person', raw: 'people:anna', value: 'anna' },
+      { kind: 'resolution', key: 'tag', raw: 'tags:nature', value: 'nature' },
+    ]);
+    expect(result.displayTokens).toMatchObject([
+      { raw: 'people:anna', key: 'person', value: 'anna', status: 'pending-entity' },
+      { raw: 'tags:nature', key: 'tag', value: 'nature', status: 'pending-entity' },
+    ]);
+    expect(result.issues).toEqual([]);
+  });
+
   it('rejects unknown alphabetic key value tokens', () => {
     const result = parseTypedSearch('beach persn:anna');
 

--- a/web/src/lib/utils/typed-search/typed-search-parser.ts
+++ b/web/src/lib/utils/typed-search/typed-search-parser.ts
@@ -95,6 +95,10 @@ const FILTER_KEYS = new Set<TypedSearchFilterKey>([
 
 const RESOLUTION_KEYS = new Set<TypedSearchResolutionKey>(['person', 'tag', 'camera']);
 const REPEATABLE_KEYS = new Set<TypedSearchFilterKey>(['person', 'tag']);
+const FILTER_KEY_ALIASES: Record<string, TypedSearchFilterKey> = {
+  people: 'person',
+  tags: 'tag',
+};
 
 export function parseTypedSearch(raw: string): TypedSearchParseResult {
   const pieces = splitSearch(raw);
@@ -111,8 +115,8 @@ export function parseTypedSearch(raw: string): TypedSearchParseResult {
       continue;
     }
 
-    const key = piece.key.toLowerCase() as TypedSearchFilterKey;
-    if (!FILTER_KEYS.has(key)) {
+    const key = normalizeFilterKey(piece.key);
+    if (!key) {
       const issue = makeIssue('unknown-key', piece.raw, `Unknown filter "${piece.key}"`, piece.key, piece.value);
       issues.push(issue);
       displayTokens.push({ raw: piece.raw, key: piece.key, value: piece.value, status: 'error', issue });
@@ -181,6 +185,12 @@ export function parseTypedSearch(raw: string): TypedSearchParseResult {
     displayTokens,
     issues,
   };
+}
+
+function normalizeFilterKey(rawKey: string): TypedSearchFilterKey | undefined {
+  const lowerKey = rawKey.toLowerCase();
+  const aliasedKey = FILTER_KEY_ALIASES[lowerKey] ?? lowerKey;
+  return FILTER_KEYS.has(aliasedKey as TypedSearchFilterKey) ? (aliasedKey as TypedSearchFilterKey) : undefined;
 }
 
 function splitSearch(raw: string): ParsedPiece[] {

--- a/web/src/lib/utils/typed-search/typed-search-parser.ts
+++ b/web/src/lib/utils/typed-search/typed-search-parser.ts
@@ -1,0 +1,380 @@
+export type TypedSearchFilterKey =
+  | 'person'
+  | 'tag'
+  | 'from'
+  | 'to'
+  | 'city'
+  | 'country'
+  | 'camera'
+  | 'type'
+  | 'favorite'
+  | 'rating';
+
+export type TypedSearchResolutionKey = 'person' | 'tag' | 'camera';
+
+export type TypedSearchIssueCode =
+  | 'unknown-key'
+  | 'empty-value'
+  | 'invalid-date'
+  | 'invalid-range'
+  | 'invalid-rating'
+  | 'invalid-type'
+  | 'invalid-favorite'
+  | 'duplicate-filter'
+  | 'unterminated-quote'
+  | 'escaped-quote'
+  | 'no-match'
+  | 'ambiguous'
+  | 'resolver-error';
+
+export type TypedSearchIssue = {
+  code: TypedSearchIssueCode;
+  message: string;
+  raw: string;
+  key?: string;
+  value?: string;
+};
+
+export type TypedSearchScalarToken = {
+  kind: 'scalar';
+  key: Exclude<TypedSearchFilterKey, TypedSearchResolutionKey>;
+  raw: string;
+  value: string;
+  normalizedValue: string | number | boolean;
+};
+
+export type TypedSearchResolutionToken = {
+  kind: 'resolution';
+  key: TypedSearchResolutionKey;
+  raw: string;
+  value: string;
+};
+
+export type TypedSearchDisplayToken = {
+  raw: string;
+  key: string;
+  value: string;
+  status: 'recognized' | 'pending-entity' | 'resolved-entity' | 'error';
+  issue?: TypedSearchIssue;
+};
+
+export type TypedSearchParseResult = {
+  raw: string;
+  queryText: string;
+  scalarTokens: TypedSearchScalarToken[];
+  resolutionTokens: TypedSearchResolutionToken[];
+  displayTokens: TypedSearchDisplayToken[];
+  issues: TypedSearchIssue[];
+};
+
+type ParsedPiece = {
+  raw: string;
+  key?: string;
+  value: string;
+  issue?: 'unterminated-quote' | 'escaped-quote';
+};
+
+type ScalarResult =
+  | { token: TypedSearchScalarToken }
+  | {
+      issue: TypedSearchIssue;
+    };
+
+const FILTER_KEYS = new Set<TypedSearchFilterKey>([
+  'person',
+  'tag',
+  'from',
+  'to',
+  'city',
+  'country',
+  'camera',
+  'type',
+  'favorite',
+  'rating',
+]);
+
+const RESOLUTION_KEYS = new Set<TypedSearchResolutionKey>(['person', 'tag', 'camera']);
+const REPEATABLE_KEYS = new Set<TypedSearchFilterKey>(['person', 'tag']);
+
+export function parseTypedSearch(raw: string): TypedSearchParseResult {
+  const pieces = splitSearch(raw);
+  const queryParts: string[] = [];
+  const scalarTokens: TypedSearchScalarToken[] = [];
+  const resolutionTokens: TypedSearchResolutionToken[] = [];
+  const displayTokens: TypedSearchDisplayToken[] = [];
+  const issues: TypedSearchIssue[] = [];
+  const seenScalarKeys = new Set<string>();
+
+  for (const piece of pieces) {
+    if (!piece.key) {
+      queryParts.push(piece.raw);
+      continue;
+    }
+
+    const key = piece.key.toLowerCase() as TypedSearchFilterKey;
+    if (!FILTER_KEYS.has(key)) {
+      const issue = makeIssue('unknown-key', piece.raw, `Unknown filter "${piece.key}"`, piece.key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key: piece.key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (piece.issue) {
+      const issue = makeIssue(piece.issue, piece.raw, issueMessage(piece.issue, key), key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (!piece.value.trim()) {
+      const issue = makeIssue('empty-value', piece.raw, `Filter "${key}" needs a value`, key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (!REPEATABLE_KEYS.has(key) && seenScalarKeys.has(key)) {
+      const issue = makeIssue('duplicate-filter', piece.raw, `Filter "${key}" can only be used once`, key, piece.value);
+      issues.push(issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue });
+      continue;
+    }
+
+    if (RESOLUTION_KEYS.has(key as TypedSearchResolutionKey)) {
+      resolutionTokens.push({
+        kind: 'resolution',
+        key: key as TypedSearchResolutionKey,
+        raw: piece.raw,
+        value: piece.value,
+      });
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'pending-entity' });
+      continue;
+    }
+
+    seenScalarKeys.add(key);
+    const scalar = normalizeScalarToken(key, piece.raw, piece.value);
+    if ('issue' in scalar) {
+      issues.push(scalar.issue);
+      displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'error', issue: scalar.issue });
+      continue;
+    }
+
+    scalarTokens.push(scalar.token);
+    displayTokens.push({ raw: piece.raw, key, value: piece.value, status: 'recognized' });
+  }
+
+  const rangeIssue = validateDateRange(scalarTokens);
+  if (rangeIssue) {
+    issues.push(rangeIssue);
+    const token = displayTokens.find((item) => item.key === 'from');
+    if (token) {
+      token.status = 'error';
+      token.issue = rangeIssue;
+    }
+  }
+
+  return {
+    raw,
+    queryText: queryParts.join(' ').trim().replace(/\s+/g, ' '),
+    scalarTokens,
+    resolutionTokens,
+    displayTokens,
+    issues,
+  };
+}
+
+function splitSearch(raw: string): ParsedPiece[] {
+  const parts: string[] = [];
+  let current = '';
+  let inQuote = false;
+
+  for (let index = 0; index < raw.length; index++) {
+    const char = raw[index];
+    if (char === '"' && raw[index - 1] !== '\\') {
+      inQuote = !inQuote;
+    }
+
+    if (/\s/.test(char) && !inQuote) {
+      if (current) {
+        parts.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts.map(parsePiece);
+}
+
+function parsePiece(raw: string): ParsedPiece {
+  if (raw.includes('://')) {
+    return { raw, value: '' };
+  }
+
+  const match = /^([A-Za-z]+):(.*)$/s.exec(raw);
+  if (!match) {
+    return { raw, value: '' };
+  }
+
+  const [, key, rawValue] = match;
+  if (!rawValue.startsWith('"')) {
+    return { raw, key, value: rawValue };
+  }
+
+  const closingQuoteIndex = findClosingQuote(rawValue);
+  const value = closingQuoteIndex === -1 ? rawValue.slice(1) : rawValue.slice(1, closingQuoteIndex);
+  if (value.includes('\\"')) {
+    return { raw, key, value, issue: 'escaped-quote' };
+  }
+  if (closingQuoteIndex === -1) {
+    return { raw, key, value, issue: 'unterminated-quote' };
+  }
+
+  return { raw, key, value };
+}
+
+function findClosingQuote(value: string): number {
+  for (let index = 1; index < value.length; index++) {
+    if (value[index] === '"' && value[index - 1] !== '\\') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function normalizeScalarToken(key: TypedSearchFilterKey, raw: string, value: string): ScalarResult {
+  switch (key) {
+    case 'from':
+    case 'to': {
+      const normalizedValue = expandDate(value, key);
+      if (!normalizedValue) {
+        return { issue: makeIssue('invalid-date', raw, `Invalid date for "${key}"`, key, value) };
+      }
+      return { token: { kind: 'scalar', key, raw, value, normalizedValue } };
+    }
+    case 'city':
+    case 'country':
+      return { token: { kind: 'scalar', key, raw, value, normalizedValue: value } };
+    case 'type': {
+      const normalizedValue = normalizeMediaType(value);
+      if (!normalizedValue) {
+        return { issue: makeIssue('invalid-type', raw, 'Type must be photo, image, or video', key, value) };
+      }
+      return { token: { kind: 'scalar', key, raw, value, normalizedValue } };
+    }
+    case 'favorite': {
+      const normalizedValue = normalizeFavorite(value);
+      if (normalizedValue === undefined) {
+        return { issue: makeIssue('invalid-favorite', raw, 'Favorite must be true or false', key, value) };
+      }
+      return { token: { kind: 'scalar', key, raw, value, normalizedValue } };
+    }
+    case 'rating': {
+      const normalizedValue = Number(value);
+      if (!Number.isInteger(normalizedValue) || normalizedValue < 1 || normalizedValue > 5) {
+        return { issue: makeIssue('invalid-rating', raw, 'Rating must be between 1 and 5', key, value) };
+      }
+      return { token: { kind: 'scalar', key, raw, value, normalizedValue } };
+    }
+    default:
+      return { issue: makeIssue('unknown-key', raw, `Unknown filter "${key}"`, key, value) };
+  }
+}
+
+function expandDate(value: string, boundary: 'from' | 'to'): string | undefined {
+  const yearMatch = /^(\d{4})$/.exec(value);
+  if (yearMatch) {
+    return boundary === 'from' ? `${yearMatch[1]}-01-01` : `${yearMatch[1]}-12-31`;
+  }
+
+  const monthMatch = /^(\d{4})-(\d{2})$/.exec(value);
+  if (monthMatch) {
+    const [, year, month] = monthMatch;
+    const monthNumber = Number(month);
+    if (monthNumber < 1 || monthNumber > 12) {
+      return undefined;
+    }
+    if (boundary === 'from') {
+      return `${year}-${month}-01`;
+    }
+    return `${year}-${month}-${String(lastDayOfMonth(Number(year), monthNumber)).padStart(2, '0')}`;
+  }
+
+  const dayMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!dayMatch) {
+    return undefined;
+  }
+
+  const [, year, month, day] = dayMatch;
+  const yearNumber = Number(year);
+  const monthNumber = Number(month);
+  const dayNumber = Number(day);
+  if (monthNumber < 1 || monthNumber > 12 || dayNumber < 1 || dayNumber > lastDayOfMonth(yearNumber, monthNumber)) {
+    return undefined;
+  }
+
+  return `${year}-${month}-${day}`;
+}
+
+function lastDayOfMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function normalizeMediaType(value: string): 'image' | 'video' | undefined {
+  const normalized = value.toLowerCase();
+  if (normalized === 'photo' || normalized === 'photos' || normalized === 'image' || normalized === 'images') {
+    return 'image';
+  }
+  if (normalized === 'video' || normalized === 'videos') {
+    return 'video';
+  }
+  return undefined;
+}
+
+function normalizeFavorite(value: string): boolean | undefined {
+  switch (value.toLowerCase()) {
+    case 'true':
+    case 'yes':
+    case '1':
+      return true;
+    case 'false':
+    case 'no':
+    case '0':
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+function validateDateRange(tokens: TypedSearchScalarToken[]): TypedSearchIssue | undefined {
+  const from = tokens.find((token) => token.key === 'from');
+  const to = tokens.find((token) => token.key === 'to');
+  if (!from || !to || String(from.normalizedValue) <= String(to.normalizedValue)) {
+    return undefined;
+  }
+
+  return makeIssue('invalid-range', from.raw, 'Start date must be before end date', from.key, from.value);
+}
+
+function makeIssue(
+  code: TypedSearchIssueCode,
+  raw: string,
+  message: string,
+  key?: string,
+  value?: string,
+): TypedSearchIssue {
+  return { code, key, raw, value, message };
+}
+
+function issueMessage(code: 'unterminated-quote' | 'escaped-quote', key: string): string {
+  if (code === 'escaped-quote') {
+    return 'Escaped quotes are not supported in filters';
+  }
+  return `Filter "${key}" has an unterminated quote`;
+}

--- a/web/src/lib/utils/typed-search/typed-search-parser.ts
+++ b/web/src/lib/utils/typed-search/typed-search-parser.ts
@@ -179,7 +179,7 @@ export function parseTypedSearch(raw: string): TypedSearchParseResult {
 
   return {
     raw,
-    queryText: queryParts.join(' ').trim().replace(/\s+/g, ' '),
+    queryText: queryParts.join(' ').trim().replaceAll(/\s+/g, ' '),
     scalarTokens,
     resolutionTokens,
     displayTokens,
@@ -219,7 +219,7 @@ function splitSearch(raw: string): ParsedPiece[] {
     parts.push(current);
   }
 
-  return parts.map(parsePiece);
+  return parts.map((part) => parsePiece(part));
 }
 
 function parsePiece(raw: string): ParsedPiece {
@@ -239,7 +239,7 @@ function parsePiece(raw: string): ParsedPiece {
 
   const closingQuoteIndex = findClosingQuote(rawValue);
   const value = closingQuoteIndex === -1 ? rawValue.slice(1) : rawValue.slice(1, closingQuoteIndex);
-  if (value.includes('\\"')) {
+  if (value.includes(String.raw`\"`)) {
     return { raw, key, value, issue: 'escaped-quote' };
   }
   if (closingQuoteIndex === -1) {
@@ -269,8 +269,9 @@ function normalizeScalarToken(key: TypedSearchFilterKey, raw: string, value: str
       return { token: { kind: 'scalar', key, raw, value, normalizedValue } };
     }
     case 'city':
-    case 'country':
+    case 'country': {
       return { token: { kind: 'scalar', key, raw, value, normalizedValue: value } };
+    }
     case 'type': {
       const normalizedValue = normalizeMediaType(value);
       if (!normalizedValue) {
@@ -292,8 +293,9 @@ function normalizeScalarToken(key: TypedSearchFilterKey, raw: string, value: str
       }
       return { token: { kind: 'scalar', key, raw, value, normalizedValue } };
     }
-    default:
+    default: {
       return { issue: makeIssue('unknown-key', raw, `Unknown filter "${key}"`, key, value) };
+    }
   }
 }
 
@@ -351,14 +353,17 @@ function normalizeFavorite(value: string): boolean | undefined {
   switch (value.toLowerCase()) {
     case 'true':
     case 'yes':
-    case '1':
+    case '1': {
       return true;
+    }
     case 'false':
     case 'no':
-    case '0':
+    case '0': {
       return false;
-    default:
+    }
+    default: {
       return undefined;
+    }
   }
 }
 

--- a/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
@@ -1,0 +1,226 @@
+import { AssetTypeEnum, getFilterSuggestions, searchPerson } from '@immich/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseTypedSearch } from './typed-search-parser';
+import { resolveTypedSearchFilters } from './typed-search-resolver';
+
+vi.mock('@immich/sdk', async () => ({
+  ...(await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk')),
+  searchPerson: vi.fn(),
+  getFilterSuggestions: vi.fn(),
+}));
+
+describe('resolveTypedSearchFilters', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [AssetTypeEnum.Image, AssetTypeEnum.Video],
+      hasUnnamedPeople: false,
+    });
+  });
+
+  it('resolves a single person, tag, and camera make', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([{ id: 'person-1', name: 'Anna' } as never]);
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: ['Nikon'],
+      cameraModels: [],
+      tags: [{ id: 'tag-1', value: 'Travel' }],
+      ratings: [4],
+      mediaTypes: [AssetTypeEnum.Image],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('beach person:anna tag:travel camera:nikon'), {});
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.queryText).toBe('beach');
+      expect(result.filters.personIds).toEqual(['person-1']);
+      expect(result.filters.tagIds).toEqual(['tag-1']);
+      expect(result.filters.make).toBe('Nikon');
+      expect(result.personNames.get('person-1')).toBe('Anna');
+      expect(result.tagNames.get('tag-1')).toBe('Travel');
+    }
+  });
+
+  it('blocks when person resolution has no match', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([]);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'no-match', key: 'person', value: 'anna' });
+    }
+  });
+
+  it('blocks when person resolution is ambiguous', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([
+      { id: 'person-1', name: 'Anna' },
+      { id: 'person-2', name: 'Anna Maria' },
+    ] as never);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'person', value: 'anna' });
+      expect(result.choices).toHaveLength(2);
+    }
+  });
+
+  it('uses a selected ambiguity choice without calling SDK resolution again for that token', async () => {
+    const selectedChoices = new Map([
+      [
+        'person:anna',
+        { tokenRaw: 'person:anna', key: 'person' as const, id: 'person-2', label: 'Anna Maria', value: 'anna' },
+      ],
+    ]);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), { selectedChoices });
+
+    expect(searchPerson).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.personIds).toEqual(['person-2']);
+      expect(result.personNames.get('person-2')).toBe('Anna Maria');
+    }
+  });
+
+  it('accumulates repeated people and tags in input order', async () => {
+    vi.mocked(searchPerson)
+      .mockResolvedValueOnce([{ id: 'person-1', name: 'Anna' } as never])
+      .mockResolvedValueOnce([{ id: 'person-2', name: 'Bob' } as never]);
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [
+        { id: 'tag-1', value: 'Travel' },
+        { id: 'tag-2', value: 'Family' },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna person:bob tag:travel tag:family'), {});
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.personIds).toEqual(['person-1', 'person-2']);
+      expect(result.filters.tagIds).toEqual(['tag-1', 'tag-2']);
+    }
+  });
+
+  it('blocks when tag has no match', async () => {
+    const result = await resolveTypedSearchFilters(parseTypedSearch('tag:vacation'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'no-match', key: 'tag', value: 'vacation' });
+    }
+  });
+
+  it('blocks when tag resolution is ambiguous', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [
+        { id: 'tag-1', value: 'Travel' },
+        { id: 'tag-2', value: 'Travel 2025' },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('tag:trav'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'tag', value: 'trav' });
+      expect(result.choices).toHaveLength(2);
+    }
+  });
+
+  it('passes spaceId to suggestion-backed resolution', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([{ id: 'space-person-1', name: 'Anna' } as never]);
+
+    await resolveTypedSearchFilters(parseTypedSearch('person:anna camera:nikon'), { spaceId: 'space-1' });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }), expect.anything());
+  });
+
+  it('uses space-scoped people from filter suggestions when resolving people inside a space', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [{ id: 'space-person-1', name: 'Anna' }],
+      countries: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), { spaceId: 'space-1' });
+
+    expect(searchPerson).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.personIds).toEqual(['space-person-1']);
+      expect(result.personNames.get('space-person-1')).toBe('Anna');
+    }
+  });
+
+  it('blocks when camera matches both make and model', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: ['Nikon'],
+      cameraModels: ['Nikon'],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('camera:nikon'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'camera', value: 'nikon' });
+    }
+  });
+
+  it('blocks when camera has no match', async () => {
+    const result = await resolveTypedSearchFilters(parseTypedSearch('camera:nikon'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'no-match', key: 'camera', value: 'nikon' });
+    }
+  });
+
+  it('returns a resolver-error issue for SDK failures', async () => {
+    vi.mocked(searchPerson).mockRejectedValue(new Error('network down'));
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toMatchObject({ code: 'resolver-error', message: 'network down' });
+    }
+  });
+});

--- a/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
@@ -1,4 +1,10 @@
-import { AssetTypeEnum, getFilterSuggestions, searchPerson } from '@immich/sdk';
+import {
+  AssetTypeEnum,
+  getFilterSuggestions,
+  getSearchSuggestions,
+  searchPerson,
+  SearchSuggestionType,
+} from '@immich/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseTypedSearch } from './typed-search-parser';
 import { resolveTypedSearchFilters } from './typed-search-resolver';
@@ -7,6 +13,7 @@ vi.mock('@immich/sdk', async () => ({
   ...(await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk')),
   searchPerson: vi.fn(),
   getFilterSuggestions: vi.fn(),
+  getSearchSuggestions: vi.fn(),
 }));
 
 describe('resolveTypedSearchFilters', () => {
@@ -16,12 +23,12 @@ describe('resolveTypedSearchFilters', () => {
       people: [],
       countries: [],
       cameraMakes: [],
-      cameraModels: [],
       tags: [],
       ratings: [],
       mediaTypes: [AssetTypeEnum.Image, AssetTypeEnum.Video],
       hasUnnamedPeople: false,
     });
+    vi.mocked(getSearchSuggestions).mockResolvedValue([]);
   });
 
   it('resolves a single person, tag, and camera make', async () => {
@@ -30,7 +37,6 @@ describe('resolveTypedSearchFilters', () => {
       people: [],
       countries: [],
       cameraMakes: ['Nikon'],
-      cameraModels: [],
       tags: [{ id: 'tag-1', value: 'Travel' }],
       ratings: [4],
       mediaTypes: [AssetTypeEnum.Image],
@@ -102,7 +108,6 @@ describe('resolveTypedSearchFilters', () => {
       people: [],
       countries: [],
       cameraMakes: [],
-      cameraModels: [],
       tags: [
         { id: 'tag-1', value: 'Travel' },
         { id: 'tag-2', value: 'Family' },
@@ -112,7 +117,10 @@ describe('resolveTypedSearchFilters', () => {
       hasUnnamedPeople: false,
     });
 
-    const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna person:bob tag:travel tag:family'), {});
+    const result = await resolveTypedSearchFilters(
+      parseTypedSearch('person:anna person:bob tag:travel tag:family'),
+      {},
+    );
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -135,7 +143,6 @@ describe('resolveTypedSearchFilters', () => {
       people: [],
       countries: [],
       cameraMakes: [],
-      cameraModels: [],
       tags: [
         { id: 'tag-1', value: 'Travel' },
         { id: 'tag-2', value: 'Travel 2025' },
@@ -159,7 +166,10 @@ describe('resolveTypedSearchFilters', () => {
 
     await resolveTypedSearchFilters(parseTypedSearch('person:anna camera:nikon'), { spaceId: 'space-1' });
 
-    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-1' }), expect.anything());
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ spaceId: 'space-1' }),
+      expect.anything(),
+    );
   });
 
   it('uses space-scoped people from filter suggestions when resolving people inside a space', async () => {
@@ -167,7 +177,6 @@ describe('resolveTypedSearchFilters', () => {
       people: [{ id: 'space-person-1', name: 'Anna' }],
       countries: [],
       cameraMakes: [],
-      cameraModels: [],
       tags: [],
       ratings: [],
       mediaTypes: [],
@@ -189,15 +198,19 @@ describe('resolveTypedSearchFilters', () => {
       people: [],
       countries: [],
       cameraMakes: ['Nikon'],
-      cameraModels: ['Nikon'],
       tags: [],
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
     });
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['Nikon']);
 
     const result = await resolveTypedSearchFilters(parseTypedSearch('camera:nikon'), {});
 
+    expect(getSearchSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ $type: SearchSuggestionType.CameraModel }),
+      expect.anything(),
+    );
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.issues[0]).toMatchObject({ code: 'ambiguous', key: 'camera', value: 'nikon' });

--- a/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
@@ -56,6 +56,49 @@ describe('resolveTypedSearchFilters', () => {
     }
   });
 
+  it('canonicalizes city filters with case-insensitive suggestions', async () => {
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['Munich']);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('city:munich'), {});
+
+    expect(getSearchSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ $type: SearchSuggestionType.City, withSharedSpaces: true }),
+      { signal: undefined },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.city).toBe('Munich');
+    }
+  });
+
+  it('canonicalizes country filters before resolving city casing', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValue({
+      people: [],
+      countries: ['Germany'],
+      cameraMakes: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [AssetTypeEnum.Image],
+      hasUnnamedPeople: false,
+    });
+    vi.mocked(getSearchSuggestions).mockResolvedValue(['Munich']);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('country:germany city:munich'), {});
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ withSharedSpaces: true }), {
+      signal: undefined,
+    });
+    expect(getSearchSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ $type: SearchSuggestionType.City, country: 'Germany', withSharedSpaces: true }),
+      { signal: undefined },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.country).toBe('Germany');
+      expect(result.filters.city).toBe('Munich');
+    }
+  });
+
   it('blocks when person resolution has no match', async () => {
     vi.mocked(searchPerson).mockResolvedValue([]);
 

--- a/web/src/lib/utils/typed-search/typed-search-resolver.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.ts
@@ -1,0 +1,315 @@
+import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { getFilterSuggestions, searchPerson } from '@immich/sdk';
+import type {
+  TypedSearchIssue,
+  TypedSearchParseResult,
+  TypedSearchResolutionToken,
+  TypedSearchScalarToken,
+} from './typed-search-parser';
+
+export type TypedSearchChoice = {
+  tokenRaw: string;
+  key: 'person' | 'tag' | 'camera';
+  id?: string;
+  label: string;
+  value: string;
+  field?: 'make' | 'model';
+};
+
+export type TypedSearchResolveContext = {
+  spaceId?: string;
+  signal?: AbortSignal;
+  selectedChoices?: Map<string, TypedSearchChoice>;
+};
+
+export type TypedSearchResolveResult =
+  | {
+      ok: true;
+      queryText: string;
+      filters: FilterState;
+      personNames: Map<string, string>;
+      tagNames: Map<string, string>;
+    }
+  | {
+      ok: false;
+      queryText: string;
+      issues: TypedSearchIssue[];
+      choices: TypedSearchChoice[];
+    };
+
+type PersonSuggestion = {
+  id: string;
+  name?: string | null;
+};
+
+type TagSuggestion = {
+  id: string;
+  name?: string | null;
+  value?: string | null;
+};
+
+export async function resolveTypedSearchFilters(
+  parsed: TypedSearchParseResult,
+  context: TypedSearchResolveContext = {},
+): Promise<TypedSearchResolveResult> {
+  try {
+    return await resolveTypedSearchFiltersInternal(parsed, context);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
+    }
+
+    return {
+      ok: false,
+      queryText: parsed.queryText,
+      issues: [
+        {
+          code: 'resolver-error',
+          raw: parsed.raw,
+          message: error instanceof Error ? error.message : 'Unable to resolve search filters',
+        },
+      ],
+      choices: [],
+    };
+  }
+}
+
+async function resolveTypedSearchFiltersInternal(
+  parsed: TypedSearchParseResult,
+  context: TypedSearchResolveContext,
+): Promise<TypedSearchResolveResult> {
+  const filters = createFilterState();
+  const issues: TypedSearchIssue[] = [...parsed.issues];
+  const choices: TypedSearchChoice[] = [];
+  const personNames = new Map<string, string>();
+  const tagNames = new Map<string, string>();
+
+  for (const token of parsed.scalarTokens) {
+    applyScalar(filters, token);
+  }
+
+  if (issues.length > 0) {
+    return { ok: false, queryText: parsed.queryText, issues, choices };
+  }
+
+  const unresolvedTokens = parsed.resolutionTokens.filter((token) => !context.selectedChoices?.has(token.raw));
+  const needsSuggestions = unresolvedTokens.some(
+    (token) => token.key === 'tag' || token.key === 'camera' || (token.key === 'person' && context.spaceId),
+  );
+  const suggestions = needsSuggestions
+    ? await getFilterSuggestions({ spaceId: context.spaceId }, { signal: context.signal })
+    : undefined;
+
+  for (const token of parsed.resolutionTokens) {
+    const selectedChoice = context.selectedChoices?.get(token.raw);
+    if (selectedChoice) {
+      applySelectedChoice(selectedChoice, filters, personNames, tagNames);
+      continue;
+    }
+
+    if (token.key === 'person') {
+      if (context.spaceId && suggestions) {
+        resolvePersonTokenFromSuggestions(token, suggestions.people, filters, personNames, issues, choices);
+        continue;
+      }
+
+      const people = await searchPerson({ name: token.value, withHidden: false }, { signal: context.signal });
+      resolvePersonTokenFromSuggestions(token, people, filters, personNames, issues, choices);
+      continue;
+    }
+
+    if (token.key === 'tag' && suggestions) {
+      resolveTagToken(token, suggestions.tags, filters, tagNames, issues, choices);
+      continue;
+    }
+
+    if (token.key === 'camera' && suggestions) {
+      resolveCameraToken(token, suggestions.cameraMakes, suggestions.cameraModels ?? [], filters, issues, choices);
+    }
+  }
+
+  return issues.length > 0
+    ? { ok: false, queryText: parsed.queryText, issues, choices }
+    : { ok: true, queryText: parsed.queryText, filters, personNames, tagNames };
+}
+
+function applyScalar(filters: FilterState, token: TypedSearchScalarToken) {
+  switch (token.key) {
+    case 'from':
+      filters.dateAfter = String(token.normalizedValue);
+      return;
+    case 'to':
+      filters.dateBefore = String(token.normalizedValue);
+      return;
+    case 'city':
+      filters.city = String(token.normalizedValue);
+      return;
+    case 'country':
+      filters.country = String(token.normalizedValue);
+      return;
+    case 'type':
+      filters.mediaType = token.normalizedValue as FilterState['mediaType'];
+      return;
+    case 'favorite':
+      filters.isFavorite = Boolean(token.normalizedValue);
+      return;
+    case 'rating':
+      filters.rating = Number(token.normalizedValue);
+      return;
+  }
+}
+
+function applySelectedChoice(
+  choice: TypedSearchChoice,
+  filters: FilterState,
+  personNames: Map<string, string>,
+  tagNames: Map<string, string>,
+) {
+  if (choice.key === 'person' && choice.id) {
+    filters.personIds.push(choice.id);
+    personNames.set(choice.id, choice.label);
+    return;
+  }
+
+  if (choice.key === 'tag' && choice.id) {
+    filters.tagIds.push(choice.id);
+    tagNames.set(choice.id, choice.label);
+    return;
+  }
+
+  if (choice.key === 'camera' && choice.field) {
+    filters[choice.field] = choice.label;
+  }
+}
+
+function resolvePersonTokenFromSuggestions(
+  token: TypedSearchResolutionToken,
+  people: PersonSuggestion[],
+  filters: FilterState,
+  personNames: Map<string, string>,
+  issues: TypedSearchIssue[],
+  choices: TypedSearchChoice[],
+) {
+  const matches = people.filter((person) => matchesValue(person.name ?? person.id, token.value));
+  if (matches.length === 1) {
+    const match = matches[0];
+    filters.personIds.push(match.id);
+    personNames.set(match.id, match.name || match.id);
+    return;
+  }
+
+  if (matches.length === 0) {
+    issues.push(noMatchIssue(token, 'person'));
+    return;
+  }
+
+  issues.push(ambiguousIssue(token, 'person'));
+  choices.push(
+    ...matches.map((person) => ({
+      tokenRaw: token.raw,
+      key: 'person' as const,
+      id: person.id,
+      label: person.name || person.id,
+      value: token.value,
+    })),
+  );
+}
+
+function resolveTagToken(
+  token: TypedSearchResolutionToken,
+  tags: TagSuggestion[],
+  filters: FilterState,
+  tagNames: Map<string, string>,
+  issues: TypedSearchIssue[],
+  choices: TypedSearchChoice[],
+) {
+  const matches = tags.filter((tag) => matchesValue(tagLabel(tag), token.value));
+  if (matches.length === 1) {
+    const match = matches[0];
+    const label = tagLabel(match);
+    filters.tagIds.push(match.id);
+    tagNames.set(match.id, label);
+    return;
+  }
+
+  if (matches.length === 0) {
+    issues.push(noMatchIssue(token, 'tag'));
+    return;
+  }
+
+  issues.push(ambiguousIssue(token, 'tag'));
+  choices.push(
+    ...matches.map((tag) => ({
+      tokenRaw: token.raw,
+      key: 'tag' as const,
+      id: tag.id,
+      label: tagLabel(tag),
+      value: token.value,
+    })),
+  );
+}
+
+function resolveCameraToken(
+  token: TypedSearchResolutionToken,
+  cameraMakes: string[],
+  cameraModels: string[],
+  filters: FilterState,
+  issues: TypedSearchIssue[],
+  choices: TypedSearchChoice[],
+) {
+  const makeMatches = cameraMakes.filter((make) => matchesValue(make, token.value));
+  const modelMatches = cameraModels.filter((model) => matchesValue(model, token.value));
+  const matches = [
+    ...makeMatches.map((label) => ({ field: 'make' as const, label })),
+    ...modelMatches.map((label) => ({ field: 'model' as const, label })),
+  ];
+
+  if (matches.length === 1) {
+    filters[matches[0].field] = matches[0].label;
+    return;
+  }
+
+  if (matches.length === 0) {
+    issues.push(noMatchIssue(token, 'camera'));
+    return;
+  }
+
+  issues.push(ambiguousIssue(token, 'camera'));
+  choices.push(
+    ...matches.map((match) => ({
+      tokenRaw: token.raw,
+      key: 'camera' as const,
+      field: match.field,
+      label: match.label,
+      value: token.value,
+    })),
+  );
+}
+
+function matchesValue(candidate: string, value: string): boolean {
+  return candidate.toLowerCase().includes(value.toLowerCase());
+}
+
+function tagLabel(tag: TagSuggestion): string {
+  return tag.value || tag.name || tag.id;
+}
+
+function noMatchIssue(token: TypedSearchResolutionToken, key: 'person' | 'tag' | 'camera'): TypedSearchIssue {
+  return {
+    code: 'no-match',
+    key,
+    raw: token.raw,
+    value: token.value,
+    message: `No ${key} found for "${token.value}"`,
+  };
+}
+
+function ambiguousIssue(token: TypedSearchResolutionToken, key: 'person' | 'tag' | 'camera'): TypedSearchIssue {
+  return {
+    code: 'ambiguous',
+    key,
+    raw: token.raw,
+    value: token.value,
+    message: `Choose a ${key} for "${token.value}"`,
+  };
+}

--- a/web/src/lib/utils/typed-search/typed-search-resolver.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.ts
@@ -1,5 +1,5 @@
 import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
-import { getFilterSuggestions, searchPerson } from '@immich/sdk';
+import { getFilterSuggestions, getSearchSuggestions, searchPerson, SearchSuggestionType } from '@immich/sdk';
 import type {
   TypedSearchIssue,
   TypedSearchParseResult,
@@ -97,8 +97,14 @@ async function resolveTypedSearchFiltersInternal(
     (token) => token.key === 'tag' || token.key === 'camera' || (token.key === 'person' && context.spaceId),
   );
   const suggestions = needsSuggestions
-    ? await getFilterSuggestions({ spaceId: context.spaceId }, { signal: context.signal })
+    ? await getFilterSuggestions(suggestionScope(context), { signal: context.signal })
     : undefined;
+  const cameraModels = unresolvedTokens.some((token) => token.key === 'camera')
+    ? await getSearchSuggestions(
+        { $type: SearchSuggestionType.CameraModel, ...suggestionScope(context) },
+        { signal: context.signal },
+      )
+    : [];
 
   for (const token of parsed.resolutionTokens) {
     const selectedChoice = context.selectedChoices?.get(token.raw);
@@ -124,13 +130,17 @@ async function resolveTypedSearchFiltersInternal(
     }
 
     if (token.key === 'camera' && suggestions) {
-      resolveCameraToken(token, suggestions.cameraMakes, suggestions.cameraModels ?? [], filters, issues, choices);
+      resolveCameraToken(token, suggestions.cameraMakes, cameraModels, filters, issues, choices);
     }
   }
 
   return issues.length > 0
     ? { ok: false, queryText: parsed.queryText, issues, choices }
     : { ok: true, queryText: parsed.queryText, filters, personNames, tagNames };
+}
+
+function suggestionScope(context: TypedSearchResolveContext) {
+  return context.spaceId ? { spaceId: context.spaceId } : { withSharedSpaces: true };
 }
 
 function applyScalar(filters: FilterState, token: TypedSearchScalarToken) {

--- a/web/src/lib/utils/typed-search/typed-search-resolver.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.ts
@@ -84,27 +84,52 @@ async function resolveTypedSearchFiltersInternal(
   const personNames = new Map<string, string>();
   const tagNames = new Map<string, string>();
 
-  for (const token of parsed.scalarTokens) {
-    applyScalar(filters, token);
-  }
-
   if (issues.length > 0) {
     return { ok: false, queryText: parsed.queryText, issues, choices };
   }
 
+  const countryToken = parsed.scalarTokens.find((token) => token.key === 'country');
+  const cityToken = parsed.scalarTokens.find((token) => token.key === 'city');
   const unresolvedTokens = parsed.resolutionTokens.filter((token) => !context.selectedChoices?.has(token.raw));
   const needsSuggestions = unresolvedTokens.some(
     (token) => token.key === 'tag' || token.key === 'camera' || (token.key === 'person' && context.spaceId),
   );
-  const suggestions = needsSuggestions
+  const needsFilterSuggestions = needsSuggestions || countryToken !== undefined;
+  const suggestions = needsFilterSuggestions
     ? await getFilterSuggestions(suggestionScope(context), { signal: context.signal })
     : undefined;
+  const canonicalScalarValues = new Map<TypedSearchScalarToken['key'], string>();
+  if (countryToken) {
+    const country = canonicalExactMatch(suggestions?.countries ?? [], String(countryToken.normalizedValue));
+    canonicalScalarValues.set('country', country);
+  }
+
+  const country = countryToken ? canonicalScalarValues.get('country') : undefined;
+  const citySuggestions = cityToken
+    ? await getSearchSuggestions(
+        {
+          $type: SearchSuggestionType.City,
+          ...(country ? { country } : {}),
+          ...suggestionScope(context),
+        },
+        { signal: context.signal },
+      )
+    : [];
+  if (cityToken) {
+    const city = canonicalExactMatch(citySuggestions.filter(isString), String(cityToken.normalizedValue));
+    canonicalScalarValues.set('city', city);
+  }
+
   const cameraModels = unresolvedTokens.some((token) => token.key === 'camera')
     ? await getSearchSuggestions(
         { $type: SearchSuggestionType.CameraModel, ...suggestionScope(context) },
         { signal: context.signal },
       )
     : [];
+
+  for (const token of parsed.scalarTokens) {
+    applyScalar(filters, token, canonicalScalarValues.get(token.key));
+  }
 
   for (const token of parsed.resolutionTokens) {
     const selectedChoice = context.selectedChoices?.get(token.raw);
@@ -143,7 +168,7 @@ function suggestionScope(context: TypedSearchResolveContext) {
   return context.spaceId ? { spaceId: context.spaceId } : { withSharedSpaces: true };
 }
 
-function applyScalar(filters: FilterState, token: TypedSearchScalarToken) {
+function applyScalar(filters: FilterState, token: TypedSearchScalarToken, canonicalValue?: string) {
   switch (token.key) {
     case 'from': {
       filters.dateAfter = String(token.normalizedValue);
@@ -154,11 +179,11 @@ function applyScalar(filters: FilterState, token: TypedSearchScalarToken) {
       return;
     }
     case 'city': {
-      filters.city = String(token.normalizedValue);
+      filters.city = canonicalValue ?? String(token.normalizedValue);
       return;
     }
     case 'country': {
-      filters.country = String(token.normalizedValue);
+      filters.country = canonicalValue ?? String(token.normalizedValue);
       return;
     }
     case 'type': {
@@ -305,6 +330,14 @@ function resolveCameraToken(
 
 function matchesValue(candidate: string, value: string): boolean {
   return candidate.toLowerCase().includes(value.toLowerCase());
+}
+
+function canonicalExactMatch(candidates: string[], value: string): string {
+  return candidates.find((candidate) => candidate.toLowerCase() === value.toLowerCase()) ?? value;
+}
+
+function isString(value: string | null): value is string {
+  return typeof value === 'string';
 }
 
 function tagLabel(tag: TagSuggestion): string {

--- a/web/src/lib/utils/typed-search/typed-search-resolver.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.ts
@@ -145,27 +145,34 @@ function suggestionScope(context: TypedSearchResolveContext) {
 
 function applyScalar(filters: FilterState, token: TypedSearchScalarToken) {
   switch (token.key) {
-    case 'from':
+    case 'from': {
       filters.dateAfter = String(token.normalizedValue);
       return;
-    case 'to':
+    }
+    case 'to': {
       filters.dateBefore = String(token.normalizedValue);
       return;
-    case 'city':
+    }
+    case 'city': {
       filters.city = String(token.normalizedValue);
       return;
-    case 'country':
+    }
+    case 'country': {
       filters.country = String(token.normalizedValue);
       return;
-    case 'type':
+    }
+    case 'type': {
       filters.mediaType = token.normalizedValue as FilterState['mediaType'];
       return;
-    case 'favorite':
+    }
+    case 'favorite': {
       filters.isFavorite = Boolean(token.normalizedValue);
       return;
-    case 'rating':
+    }
+    case 'rating': {
       filters.rating = Number(token.normalizedValue);
       return;
+    }
   }
 }
 

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -48,6 +48,8 @@
     buildSearchablePageUrl,
     getSearchablePageFilterState,
     getSearchablePageState,
+    preserveTransientTemporalFilters,
+    type SearchablePageTransientTemporalState,
   } from '$lib/utils/searchable-page-search';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
   import {
@@ -95,6 +97,9 @@
   });
   let committedQuery = $state(initialSearchState.query);
   let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
+  let pendingFilterUrlSync = $state<
+    { url: string; transientTemporal?: SearchablePageTransientTemporalState } | undefined
+  >();
   let isLoading = $state(false);
   const showSearchResults = $derived(committedQuery.trim().length > 0);
   const options = $derived(buildPhotosTimelineOptions(filters));
@@ -383,12 +388,20 @@
     if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
       return;
     }
+    pendingFilterUrlSync = {
+      url: nextUrl,
+      transientTemporal: {
+        selectedYear: nextFilters.selectedYear,
+        selectedMonth: nextFilters.selectedMonth,
+      },
+    };
     void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
   }
 
   $effect(() => {
     const nextSearchState = getSearchablePageState(page.url);
     const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
+    const currentUrl = page.url.pathname + page.url.search;
 
     if (nextToken === lastHandledSearchState) {
       return;
@@ -396,13 +409,19 @@
 
     const queryChanged = nextSearchState.query !== committedQuery;
     untrack(() => {
+      const filterState = getSearchablePageFilterState(page.url);
+      const transientTemporal =
+        pendingFilterUrlSync?.url === currentUrl ? pendingFilterUrlSync.transientTemporal : undefined;
       committedQuery = nextSearchState.query;
       isLoading = false;
       filters = {
         ...createFilterState(),
-        ...getSearchablePageFilterState(page.url),
+        ...preserveTransientTemporalFilters(filterState, transientTemporal),
         sortOrder: nextSearchState.sortOrder,
       };
+      if (pendingFilterUrlSync?.url === currentUrl) {
+        pendingFilterUrlSync = undefined;
+      }
       consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
       if (queryChanged) {
         smartFacetInFlight?.controller.abort();

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -434,6 +434,8 @@
         timeBuckets={smartFacetBuckets}
         storageKey="gallery-filter-visible-sections-photos"
         hidden={isTimelineEmpty}
+        {personNames}
+        {tagNames}
       />
     {/key}
     <div class="flex flex-1 flex-col overflow-hidden pl-4">

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -49,7 +49,7 @@
     getSearchablePageFilterState,
     getSearchablePageState,
   } from '$lib/utils/searchable-page-search';
-  import { consumeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
+  import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
   import {
     updateStackedAssetInTimeline,
     updateUnstackedAssetInTimeline,
@@ -100,13 +100,7 @@
   const options = $derived(buildPhotosTimelineOptions(filters));
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
-  const initialTypedSearchNames = consumeTypedSearchNames(page.url.pathname + page.url.search);
-  for (const [id, name] of initialTypedSearchNames.personNames) {
-    personNames.set(id, name);
-  }
-  for (const [id, name] of initialTypedSearchNames.tagNames) {
-    tagNames.set(id, name);
-  }
+  consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
   $effect(() => globalSearchManager.registerSearchablePageFilters(() => filters));
   let smartFacets = $state<SmartSearchFacetsResponseDto>();
   let smartFacetKey = $state('');
@@ -404,6 +398,7 @@
         ...getSearchablePageFilterState(page.url),
         sortOrder: nextSearchState.sortOrder,
       };
+      consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
       if (queryChanged) {
         smartFacetInFlight?.controller.abort();
         smartFacets = undefined;

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -374,8 +374,13 @@
   }
 
   function syncFilterUrl(nextFilters: FilterState) {
-    const nextUrl = buildSearchablePageUrl(page.url, committedQuery, nextFilters.sortOrder, nextFilters);
-    if (!nextUrl) {
+    const currentSearchState = getSearchablePageState(page.url);
+    const sortOrder =
+      !committedQuery.trim() && nextFilters.sortOrder === 'desc' && !currentSearchState.hasExplicitSort
+        ? 'relevance'
+        : nextFilters.sortOrder;
+    const nextUrl = buildSearchablePageUrl(page.url, committedQuery, sortOrder, nextFilters);
+    if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
       return;
     }
     void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
@@ -431,6 +436,7 @@
         hidden={isTimelineEmpty}
         {personNames}
         {tagNames}
+        onFiltersChange={syncFilterUrl}
       />
     {/key}
     <div class="flex flex-1 flex-col overflow-hidden pl-4">

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -37,6 +37,7 @@
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { registerSelectionContext } from '$lib/managers/command-context-manager.svelte';
+  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
   import { memoryManager } from '$lib/managers/memory-manager.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import { Route } from '$lib/route';
@@ -106,6 +107,7 @@
   for (const [id, name] of initialTypedSearchNames.tagNames) {
     tagNames.set(id, name);
   }
+  $effect(() => globalSearchManager.registerSearchablePageFilters(() => filters));
   let smartFacets = $state<SmartSearchFacetsResponseDto>();
   let smartFacetKey = $state('');
   let smartFacetInFlight:

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -43,7 +43,12 @@
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { lang } from '$lib/stores/preferences.store';
   import { getAssetMediaUrl, memoryLaneTitle } from '$lib/utils';
-  import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
+  import {
+    buildSearchablePageUrl,
+    getSearchablePageFilterState,
+    getSearchablePageState,
+  } from '$lib/utils/searchable-page-search';
+  import { consumeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
   import {
     updateStackedAssetInTimeline,
     updateUnstackedAssetInTimeline,
@@ -81,17 +86,26 @@
 
   // Filter state
   const initialSearchState = getSearchablePageState(page.url);
+  const initialFilterState = getSearchablePageFilterState(page.url);
   let filters = $state<FilterState>({
     ...createFilterState(),
+    ...initialFilterState,
     sortOrder: initialSearchState.sortOrder,
   });
   let committedQuery = $state(initialSearchState.query);
-  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}`);
+  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
   let isLoading = $state(false);
   const showSearchResults = $derived(committedQuery.trim().length > 0);
   const options = $derived(buildPhotosTimelineOptions(filters));
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
+  const initialTypedSearchNames = consumeTypedSearchNames(page.url.pathname + page.url.search);
+  for (const [id, name] of initialTypedSearchNames.personNames) {
+    personNames.set(id, name);
+  }
+  for (const [id, name] of initialTypedSearchNames.tagNames) {
+    tagNames.set(id, name);
+  }
   let smartFacets = $state<SmartSearchFacetsResponseDto>();
   let smartFacetKey = $state('');
   let smartFacetInFlight:
@@ -356,7 +370,15 @@
 
   function clearSearch() {
     isLoading = false;
-    const nextUrl = buildSearchablePageUrl(page.url, '');
+    const nextUrl = buildSearchablePageUrl(page.url, '', filters.sortOrder, filters);
+    if (!nextUrl) {
+      return;
+    }
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+  }
+
+  function syncFilterUrl(nextFilters: FilterState) {
+    const nextUrl = buildSearchablePageUrl(page.url, committedQuery, nextFilters.sortOrder, nextFilters);
     if (!nextUrl) {
       return;
     }
@@ -365,7 +387,7 @@
 
   $effect(() => {
     const nextSearchState = getSearchablePageState(page.url);
-    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}`;
+    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
 
     if (nextToken === lastHandledSearchState) {
       return;
@@ -375,7 +397,11 @@
     untrack(() => {
       committedQuery = nextSearchState.query;
       isLoading = false;
-      filters = { ...filters, sortOrder: nextSearchState.sortOrder };
+      filters = {
+        ...createFilterState(),
+        ...getSearchablePageFilterState(page.url),
+        sortOrder: nextSearchState.sortOrder,
+      };
       if (queryChanged) {
         smartFacetInFlight?.controller.abort();
         smartFacets = undefined;
@@ -418,10 +444,16 @@
           {personNames}
           {tagNames}
           onRemoveFilter={(type, id) => {
-            filters = handlePhotosRemoveFilter(filters, type, id);
+            const nextFilters = handlePhotosRemoveFilter(filters, type, id);
+            filters = nextFilters;
+            syncFilterUrl(nextFilters);
           }}
           onClearAll={() => {
-            filters = clearFilters(filters);
+            const nextFilters = clearFilters(filters);
+            filters = nextFilters;
+            if (!committedQuery.trim()) {
+              syncFilterUrl(nextFilters);
+            }
           }}
         />
       {/if}

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -4,6 +4,7 @@ import TestWrapper from '$lib/components/TestWrapper.svelte';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import { lang } from '$lib/stores/preferences.store';
 import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import { AssetTypeEnum } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
@@ -227,6 +228,7 @@ describe('Photos page search URL state', () => {
     mockAssetMultiSelectManager.assets = [];
     mockMemoryManager.memories = [];
     mockRegisterSearchablePageFilters.mockReturnValue(vi.fn());
+    sessionStorage.clear();
     sdkMock.getFilterSuggestions.mockResolvedValue({
       people: [],
       countries: [],
@@ -338,6 +340,25 @@ describe('Photos page search URL state', () => {
     await fireEvent.click(screen.getByTestId('select-favorites-filter'));
 
     await waitFor(() => expect(getFilters()).toMatchObject({ isFavorite: true, sortOrder: 'desc' }));
+  });
+
+  it('passes typed search names into the photos filter panel', () => {
+    mockPage.url = new URL('https://gallery.test/photos?people=person-cat&tags=tag-nature');
+    storeTypedSearchNames('/photos?people=person-cat&tags=tag-nature', {
+      personNames: new Map([['person-cat', 'cat']]),
+      tagNames: new Map([['tag-nature', 'nature']]),
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-person-names',
+      JSON.stringify([['person-cat', 'cat']]),
+    );
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-tag-names',
+      JSON.stringify([['tag-nature', 'nature']]),
+    );
   });
 
   it('passes favorites into photos timeline options when selected', async () => {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -303,6 +303,19 @@ describe('Photos page search URL state', () => {
     });
   });
 
+  it('syncs the URL when a location typed filter is cleared from the filter panel', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?city=New+York+City');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('filter-panel-clear-location'));
+
+    expect(goto).toHaveBeenCalledWith('/photos', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
   it('clears typed filter URL params and q when clearing all active filters', async () => {
     mockPage.url = new URL('https://gallery.test/photos?view=timeline&q=beach&people=person-1&city=Berlin');
 

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -2,6 +2,7 @@ import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { lang } from '$lib/stores/preferences.store';
 import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+import { goto } from '$app/navigation';
 import { AssetTypeEnum } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
@@ -44,7 +45,7 @@ vi.mock('$lib/components/ActionMenuItem.svelte', async () => {
 });
 
 vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/active-filters-bar-actions.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -253,6 +254,49 @@ describe('Photos page search URL state', () => {
     expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'nature');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
+  });
+
+  it('hydrates typed filter URL params into the photos FilterState', () => {
+    mockPage.url = new URL(
+      'https://gallery.test/photos?q=beach&people=person-1&tags=tag-1&type=image&favorite=true&rating=4&from=2025-01-01&to=2025-12-31',
+    );
+
+    renderPage();
+
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-person-ids', 'person-1');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-tag-ids', 'tag-1');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'image');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-favorite', 'true');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-rating', '4');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-after', '2025-01-01');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-before', '2025-12-31');
+  });
+
+  it('clears only q when clearing the search chip', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?view=timeline&q=beach&people=person-1&city=Berlin');
+
+    renderPage();
+    await fireEvent.click(await screen.findByTestId('active-filters-clear-search'));
+
+    expect(goto).toHaveBeenCalledWith('/photos?view=timeline&people=person-1&city=Berlin', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
+  it('clears typed filter URL params and q when clearing all active filters', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?view=timeline&q=beach&people=person-1&city=Berlin');
+
+    renderPage();
+    await fireEvent.click(await screen.findByTestId('active-filters-clear-all'));
+
+    expect(goto).toHaveBeenLastCalledWith('/photos?view=timeline', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
   });
 
   it('exposes favorites in the photos filter panel', () => {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -1,8 +1,8 @@
+import { goto } from '$app/navigation';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { lang } from '$lib/stores/preferences.store';
 import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
-import { goto } from '$app/navigation';
 import { AssetTypeEnum } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
@@ -26,7 +26,7 @@ const { mockPage, mockAssetMultiSelectManager, mockAuthManager, mockMemoryManage
       preferences: { memories: { enabled: false } },
     },
     mockMemoryManager: {
-      memories: [],
+      memories: [] as unknown[],
     },
     mockRegisterSelectionContext: vi.fn(),
   }));

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -1,6 +1,7 @@
 import { goto } from '$app/navigation';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
+import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import { lang } from '$lib/stores/preferences.store';
 import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
 import { AssetTypeEnum } from '@immich/sdk';
@@ -9,27 +10,34 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import PhotosPage from './+page.svelte';
 
-const { mockPage, mockAssetMultiSelectManager, mockAuthManager, mockMemoryManager, mockRegisterSelectionContext } =
-  vi.hoisted(() => ({
-    mockPage: {
-      url: new URL('https://gallery.test/photos?q=nature'),
-      route: { id: '/(user)/photos/[[assetId=id]]' },
-      params: {},
-    },
-    mockAssetMultiSelectManager: {
-      selectionActive: false,
-      assets: [],
-      clear: vi.fn(),
-      isAllUserOwned: true,
-    },
-    mockAuthManager: {
-      preferences: { memories: { enabled: false } },
-    },
-    mockMemoryManager: {
-      memories: [] as unknown[],
-    },
-    mockRegisterSelectionContext: vi.fn(),
-  }));
+const {
+  mockPage,
+  mockAssetMultiSelectManager,
+  mockAuthManager,
+  mockMemoryManager,
+  mockRegisterSelectionContext,
+  mockRegisterSearchablePageFilters,
+} = vi.hoisted(() => ({
+  mockPage: {
+    url: new URL('https://gallery.test/photos?q=nature'),
+    route: { id: '/(user)/photos/[[assetId=id]]' },
+    params: {},
+  },
+  mockAssetMultiSelectManager: {
+    selectionActive: false,
+    assets: [],
+    clear: vi.fn(),
+    isAllUserOwned: true,
+  },
+  mockAuthManager: {
+    preferences: { memories: { enabled: false } },
+  },
+  mockMemoryManager: {
+    memories: [] as unknown[],
+  },
+  mockRegisterSelectionContext: vi.fn(),
+  mockRegisterSearchablePageFilters: vi.fn(() => vi.fn()),
+}));
 
 vi.mock('$app/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('$app/state', () => ({ page: mockPage }));
@@ -166,6 +174,12 @@ vi.mock('$lib/managers/command-context-manager.svelte', () => ({
   registerSelectionContext: mockRegisterSelectionContext,
 }));
 
+vi.mock('$lib/managers/global-search-manager.svelte', () => ({
+  globalSearchManager: {
+    registerSearchablePageFilters: mockRegisterSearchablePageFilters,
+  },
+}));
+
 vi.mock('$lib/managers/memory-manager.svelte', () => ({
   memoryManager: mockMemoryManager,
 }));
@@ -212,6 +226,7 @@ describe('Photos page search URL state', () => {
     mockAssetMultiSelectManager.selectionActive = false;
     mockAssetMultiSelectManager.assets = [];
     mockMemoryManager.memories = [];
+    mockRegisterSearchablePageFilters.mockReturnValue(vi.fn());
     sdkMock.getFilterSuggestions.mockResolvedValue({
       people: [],
       countries: [],
@@ -308,6 +323,21 @@ describe('Photos page search URL state', () => {
       'data-sections',
       'timeline,people,location,camera,tags,rating,media,favorites',
     );
+  });
+
+  it('registers current photos filters for global sort changes', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+    await waitFor(() => expect(mockRegisterSearchablePageFilters).toHaveBeenCalledOnce());
+    const calls = mockRegisterSearchablePageFilters.mock.calls as unknown as Array<[() => FilterState]>;
+    const getFilters = calls[0][0];
+
+    expect(getFilters().isFavorite).toBeUndefined();
+    expect(getFilters().sortOrder).toBe('desc');
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    await waitFor(() => expect(getFilters()).toMatchObject({ isFavorite: true, sortOrder: 'desc' }));
   });
 
   it('passes favorites into photos timeline options when selected', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -51,6 +51,8 @@
     buildSearchablePageUrl,
     getSearchablePageFilterState,
     getSearchablePageState,
+    preserveTransientTemporalFilters,
+    type SearchablePageTransientTemporalState,
   } from '$lib/utils/searchable-page-search';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
   import {
@@ -732,6 +734,9 @@
 
   let committedSearchQuery = $state(initialSearchState.query);
   let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
+  let pendingFilterUrlSync = $state<
+    { url: string; transientTemporal?: SearchablePageTransientTemporalState } | undefined
+  >();
   let isLoading = $state(false);
   const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
   const isTimelineEmpty = $derived(
@@ -772,6 +777,13 @@
     if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
       return;
     }
+    pendingFilterUrlSync = {
+      url: nextUrl,
+      transientTemporal: {
+        selectedYear: nextFilters.selectedYear,
+        selectedMonth: nextFilters.selectedMonth,
+      },
+    };
     void goto(nextUrl, {
       replaceState: true,
       keepFocus: true,
@@ -782,19 +794,26 @@
   $effect(() => {
     const nextSearchState = getSearchablePageState(page.url);
     const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
+    const currentUrl = page.url.pathname + page.url.search;
     if (nextToken === lastHandledSearchState) {
       return;
     }
 
     const queryChanged = nextSearchState.query !== committedSearchQuery;
     untrack(() => {
+      const filterState = getSearchablePageFilterState(page.url);
+      const transientTemporal =
+        pendingFilterUrlSync?.url === currentUrl ? pendingFilterUrlSync.transientTemporal : undefined;
       committedSearchQuery = nextSearchState.query;
       isLoading = false;
       filters = {
         ...createFilterState(),
-        ...getSearchablePageFilterState(page.url),
+        ...preserveTransientTemporalFilters(filterState, transientTemporal),
         sortOrder: nextSearchState.sortOrder,
       };
+      if (pendingFilterUrlSync?.url === currentUrl) {
+        pendingFilterUrlSync = undefined;
+      }
       consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
       if (queryChanged) {
         smartFacetInFlight?.controller.abort();

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -936,7 +936,14 @@
     <!-- Filter Panel (left sidebar) -->
     {#if viewMode === 'view'}
       {#key `${space.id}:${showSearchResults ? `spaces-search-${committedSearchQuery.trim()}:${$lang}` : 'spaces-browse'}`}
-        <FilterPanel config={filterConfig} bind:filters timeBuckets={smartFacetBuckets} hidden={isTimelineEmpty} />
+        <FilterPanel
+          config={filterConfig}
+          bind:filters
+          timeBuckets={smartFacetBuckets}
+          hidden={isTimelineEmpty}
+          {personNames}
+          {tagNames}
+        />
       {/key}
     {/if}
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -52,7 +52,7 @@
     getSearchablePageFilterState,
     getSearchablePageState,
   } from '$lib/utils/searchable-page-search';
-  import { consumeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
+  import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
   import {
     buildSmartSearchFacetKey,
     buildSmartSearchFacetsParams,
@@ -138,6 +138,7 @@
       spacePeople = [];
       personNames.clear();
       tagNames.clear();
+      consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
       isLoading = false;
       smartFacetInFlight?.controller.abort();
       smartFacets = undefined;
@@ -176,13 +177,7 @@
   });
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
-  const initialTypedSearchNames = consumeTypedSearchNames(page.url.pathname + page.url.search);
-  for (const [id, name] of initialTypedSearchNames.personNames) {
-    personNames.set(id, name);
-  }
-  for (const [id, name] of initialTypedSearchNames.tagNames) {
-    tagNames.set(id, name);
-  }
+  consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
   $effect(() => globalSearchManager.registerSearchablePageFilters(() => filters));
   let smartFacets = $state<SmartSearchFacetsResponseDto>();
   let smartFacetKey = $state('');
@@ -795,6 +790,7 @@
         ...getSearchablePageFilterState(page.url),
         sortOrder: nextSearchState.sortOrder,
       };
+      consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
       if (queryChanged) {
         smartFacetInFlight?.controller.abort();
         smartFacets = undefined;

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -39,6 +39,7 @@
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import { registerSelectionContext, registerSpaceContext } from '$lib/managers/command-context-manager.svelte';
   import { eventManager } from '$lib/managers/event-manager.svelte';
+  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
   import { Route } from '$lib/route';
   import { MAX_SPACE_ASSETS_PER_REQUEST } from '$lib/constants';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
@@ -182,6 +183,7 @@
   for (const [id, name] of initialTypedSearchNames.tagNames) {
     tagNames.set(id, name);
   }
+  $effect(() => globalSearchManager.registerSearchablePageFilters(() => filters));
   let smartFacets = $state<SmartSearchFacetsResponseDto>();
   let smartFacetKey = $state('');
   let smartFacetInFlight:

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -763,8 +763,13 @@
   };
 
   function syncFilterUrl(nextFilters: FilterState) {
-    const nextUrl = buildSearchablePageUrl(page.url, committedSearchQuery, nextFilters.sortOrder, nextFilters);
-    if (!nextUrl) {
+    const currentSearchState = getSearchablePageState(page.url);
+    const sortOrder =
+      !committedSearchQuery.trim() && nextFilters.sortOrder === 'desc' && !currentSearchState.hasExplicitSort
+        ? 'relevance'
+        : nextFilters.sortOrder;
+    const nextUrl = buildSearchablePageUrl(page.url, committedSearchQuery, sortOrder, nextFilters);
+    if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
       return;
     }
     void goto(nextUrl, {
@@ -939,6 +944,7 @@
           hidden={isTimelineEmpty}
           {personNames}
           {tagNames}
+          onFiltersChange={syncFilterUrl}
         />
       {/key}
     {/if}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -46,7 +46,12 @@
   import { lang } from '$lib/stores/preferences.store';
   import { createUrl } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
-  import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
+  import {
+    buildSearchablePageUrl,
+    getSearchablePageFilterState,
+    getSearchablePageState,
+  } from '$lib/utils/searchable-page-search';
+  import { consumeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
   import {
     buildSmartSearchFacetKey,
     buildSmartSearchFacetsParams,
@@ -118,10 +123,12 @@
   $effect(() => {
     if (data.space.id !== space.id) {
       const nextSearchState = getSearchablePageState(page.url);
+      const nextFilterState = getSearchablePageFilterState(page.url);
       space = data.space;
       members = data.members;
       filters = {
         ...createFilterState(),
+        ...nextFilterState,
         sortOrder: nextSearchState.sortOrder,
       };
       activities = [];
@@ -136,7 +143,7 @@
       smartFacetKey = '';
       smartFacetInFlight = undefined;
       committedSearchQuery = nextSearchState.query;
-      lastHandledSearchState = `${nextSearchState.query}:${nextSearchState.sortOrder}`;
+      lastHandledSearchState = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
       heroCollapsed = loadHeroCollapsed(data.space.id);
       panelOpen = false;
       viewMode = 'view';
@@ -160,12 +167,21 @@
   let timelineManager = $state<TimelineManager>() as TimelineManager;
 
   // Filter state
+  const initialFilterState = getSearchablePageFilterState(page.url);
   let filters = $state<FilterState>({
     ...createFilterState(),
+    ...initialFilterState,
     sortOrder: initialSearchState.sortOrder,
   });
   let personNames = new SvelteMap<string, string>();
   let tagNames = new SvelteMap<string, string>();
+  const initialTypedSearchNames = consumeTypedSearchNames(page.url.pathname + page.url.search);
+  for (const [id, name] of initialTypedSearchNames.personNames) {
+    personNames.set(id, name);
+  }
+  for (const [id, name] of initialTypedSearchNames.tagNames) {
+    tagNames.set(id, name);
+  }
   let smartFacets = $state<SmartSearchFacetsResponseDto>();
   let smartFacetKey = $state('');
   let smartFacetInFlight:
@@ -378,7 +394,9 @@
   };
 
   function handleRemoveFilter(type: string, id?: string) {
-    filters = handleSpaceRemoveFilter(filters, type, id);
+    const nextFilters = handleSpaceRemoveFilter(filters, type, id);
+    filters = nextFilters;
+    syncFilterUrl(nextFilters);
   }
 
   const currentMember = $derived(members.find((m) => m.userId === authManager.user.id));
@@ -716,7 +734,7 @@
   };
 
   let committedSearchQuery = $state(initialSearchState.query);
-  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}`);
+  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
   let isLoading = $state(false);
   const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
   const isTimelineEmpty = $derived(
@@ -736,7 +754,7 @@
 
   const clearSearch = () => {
     isLoading = false;
-    const nextUrl = buildSearchablePageUrl(page.url, '');
+    const nextUrl = buildSearchablePageUrl(page.url, '', filters.sortOrder, filters);
     if (!nextUrl) {
       return;
     }
@@ -747,9 +765,21 @@
     });
   };
 
+  function syncFilterUrl(nextFilters: FilterState) {
+    const nextUrl = buildSearchablePageUrl(page.url, committedSearchQuery, nextFilters.sortOrder, nextFilters);
+    if (!nextUrl) {
+      return;
+    }
+    void goto(nextUrl, {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  }
+
   $effect(() => {
     const nextSearchState = getSearchablePageState(page.url);
-    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}`;
+    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
     if (nextToken === lastHandledSearchState) {
       return;
     }
@@ -759,7 +789,8 @@
       committedSearchQuery = nextSearchState.query;
       isLoading = false;
       filters = {
-        ...filters,
+        ...createFilterState(),
+        ...getSearchablePageFilterState(page.url),
         sortOrder: nextSearchState.sortOrder,
       };
       if (queryChanged) {
@@ -918,7 +949,11 @@
           {tagNames}
           onRemoveFilter={handleRemoveFilter}
           onClearAll={() => {
-            filters = clearFilters(filters);
+            const nextFilters = clearFilters(filters);
+            filters = nextFilters;
+            if (!committedSearchQuery.trim()) {
+              syncFilterUrl(nextFilters);
+            }
           }}
           searchQuery={committedSearchQuery}
           onClearSearch={clearSearch}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -80,7 +80,7 @@ vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
 });
 
 vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/active-filters-bar-actions.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -275,6 +275,30 @@ describe('Spaces page search URL state', () => {
     expect(screen.queryByTestId('sort-toggle')).not.toBeInTheDocument();
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
+  });
+
+  it('hydrates typed filter URL params into the space FilterState', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&people=space-person-1&city=Berlin&type=video');
+
+    renderPage({ space: makeSpace(), members: [makeMember()] });
+
+    expect(await screen.findByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-person-ids', 'space-person-1');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-city', 'Berlin');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'video');
+  });
+
+  it('removes only the selected typed filter from the space URL', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&people=person-1&city=Berlin');
+
+    renderPage({ space: makeSpace(), members: [makeMember()] });
+    await fireEvent.click(await screen.findByTestId('active-filters-remove-person'));
+
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos?q=beach&city=Berlin', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
   });
 
   it('exposes favorites in the spaces filter panel', () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -314,6 +314,19 @@ describe('Spaces page search URL state', () => {
     });
   });
 
+  it('syncs the URL when a location typed filter is cleared from the space filter panel', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?city=New+York+City');
+
+    renderPage({ space: makeSpace(), members: [makeMember()] });
+    await fireEvent.click(screen.getByTestId('filter-panel-clear-location'));
+
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/photos', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
   it('exposes favorites in the spaces filter panel', () => {
     renderPage();
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -278,7 +278,9 @@ describe('Spaces page search URL state', () => {
   });
 
   it('hydrates typed filter URL params into the space FilterState', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&people=space-person-1&city=Berlin&type=video');
+    mockPage.url = new URL(
+      'https://gallery.test/spaces/space-1/photos?q=beach&people=space-person-1&city=Berlin&type=video',
+    );
 
     renderPage({ space: makeSpace(), members: [makeMember()] });
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -3,6 +3,7 @@ import TestWrapper from '$lib/components/TestWrapper.svelte';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { lang } from '$lib/stores/preferences.store';
+import { storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import type { SharedSpaceMemberResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
 import { AssetTypeEnum, AssetVisibility, SharedSpaceRole } from '@immich/sdk';
 import '@testing-library/jest-dom';
@@ -232,6 +233,7 @@ describe('Spaces page search URL state', () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
     lang.set('de');
     mockRegisterSearchablePageFilters.mockReturnValue(vi.fn());
+    sessionStorage.clear();
     vi.mocked(sdkMock.markSpaceViewed).mockResolvedValue(void 0 as never);
     sdkMock.addAssets.mockResolvedValue(void 0 as never);
     sdkMock.updateMemberPreferences.mockResolvedValue(makeMember({ sharePersonMetadata: false }));
@@ -332,6 +334,25 @@ describe('Spaces page search URL state', () => {
     await fireEvent.click(screen.getByTestId('select-favorites-filter'));
 
     await waitFor(() => expect(getFilters()).toMatchObject({ isFavorite: true, sortOrder: 'desc' }));
+  });
+
+  it('passes typed search names into the space filter panel', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?people=person-cat&tags=tag-nature');
+    storeTypedSearchNames('/spaces/space-1/photos?people=person-cat&tags=tag-nature', {
+      personNames: new Map([['person-cat', 'cat']]),
+      tagNames: new Map([['tag-nature', 'nature']]),
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-person-names',
+      JSON.stringify([['person-cat', 'cat']]),
+    );
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-tag-names',
+      JSON.stringify([['tag-nature', 'nature']]),
+    );
   });
 
   it('updates current member metadata sharing from the space menu', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -1,5 +1,6 @@
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
+import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { lang } from '$lib/stores/preferences.store';
 import type { SharedSpaceMemberResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
@@ -19,6 +20,7 @@ const {
   mockEventManager,
   mockRegisterSelectionContext,
   mockRegisterSpaceContext,
+  mockRegisterSearchablePageFilters,
 } = vi.hoisted(() => ({
   gotoMock: vi.fn().mockResolvedValue(undefined),
   mockPage: {
@@ -42,6 +44,7 @@ const {
   },
   mockRegisterSelectionContext: vi.fn(),
   mockRegisterSpaceContext: vi.fn(),
+  mockRegisterSearchablePageFilters: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('$app/navigation', () => ({ goto: gotoMock }));
@@ -134,6 +137,11 @@ vi.mock('$lib/managers/command-context-manager.svelte', () => ({
   registerSpaceContext: mockRegisterSpaceContext,
 }));
 vi.mock('$lib/managers/event-manager.svelte', () => ({ eventManager: mockEventManager }));
+vi.mock('$lib/managers/global-search-manager.svelte', () => ({
+  globalSearchManager: {
+    registerSearchablePageFilters: mockRegisterSearchablePageFilters,
+  },
+}));
 vi.mock('$lib/utils/space-hero-storage', () => ({
   loadHeroCollapsed: vi.fn().mockReturnValue(false),
   persistHeroCollapsed: vi.fn(),
@@ -223,6 +231,7 @@ describe('Spaces page search URL state', () => {
     mockAssetMultiSelectManager.assets = [];
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
     lang.set('de');
+    mockRegisterSearchablePageFilters.mockReturnValue(vi.fn());
     vi.mocked(sdkMock.markSpaceViewed).mockResolvedValue(void 0 as never);
     sdkMock.addAssets.mockResolvedValue(void 0 as never);
     sdkMock.updateMemberPreferences.mockResolvedValue(makeMember({ sharePersonMetadata: false }));
@@ -310,6 +319,19 @@ describe('Spaces page search URL state', () => {
       'data-sections',
       'timeline,people,location,camera,tags,rating,media,favorites',
     );
+  });
+
+  it('registers current space filters for global sort changes', async () => {
+    renderPage();
+    await waitFor(() => expect(mockRegisterSearchablePageFilters).toHaveBeenCalledOnce());
+    const calls = mockRegisterSearchablePageFilters.mock.calls as unknown as Array<[() => FilterState]>;
+    const getFilters = calls[0][0];
+
+    expect(getFilters().isFavorite).toBeUndefined();
+    expect(getFilters().sortOrder).toBe('desc');
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+
+    await waitFor(() => expect(getFilters()).toMatchObject({ isFavorite: true, sortOrder: 'desc' }));
   });
 
   it('updates current member metadata sharing from the space menu', async () => {

--- a/web/src/test-data/mocks/active-filters-bar-actions.stub.svelte
+++ b/web/src/test-data/mocks/active-filters-bar-actions.stub.svelte
@@ -10,7 +10,8 @@
 </script>
 
 <div data-testid="active-filters-bar-stub">
-  <button type="button" data-testid="active-filters-clear-search" onclick={() => onClearSearch?.()}>Clear search</button>
+  <button type="button" data-testid="active-filters-clear-search" onclick={() => onClearSearch?.()}>Clear search</button
+  >
   <button
     type="button"
     data-testid="active-filters-clear-all"
@@ -23,7 +24,11 @@
   >
     Clear all
   </button>
-  <button type="button" data-testid="active-filters-remove-person" onclick={() => onRemoveFilter?.('person', 'person-1')}>
+  <button
+    type="button"
+    data-testid="active-filters-remove-person"
+    onclick={() => onRemoveFilter?.('person', 'person-1')}
+  >
     Remove person
   </button>
 </div>

--- a/web/src/test-data/mocks/active-filters-bar-actions.stub.svelte
+++ b/web/src/test-data/mocks/active-filters-bar-actions.stub.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  type Props = {
+    searchQuery?: string;
+    onClearSearch?: () => void;
+    onClearAll?: () => void;
+    onRemoveFilter?: (type: string, id?: string) => void;
+  };
+
+  let { searchQuery = '', onClearSearch, onClearAll, onRemoveFilter }: Props = $props();
+</script>
+
+<div data-testid="active-filters-bar-stub">
+  <button type="button" data-testid="active-filters-clear-search" onclick={() => onClearSearch?.()}>Clear search</button>
+  <button
+    type="button"
+    data-testid="active-filters-clear-all"
+    onclick={() => {
+      onClearAll?.();
+      if (searchQuery) {
+        onClearSearch?.();
+      }
+    }}
+  >
+    Clear all
+  </button>
+  <button type="button" data-testid="active-filters-remove-person" onclick={() => onRemoveFilter?.('person', 'person-1')}>
+    Remove person
+  </button>
+</div>

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -11,16 +11,30 @@
     timeBuckets?: Array<{ timeBucket: string; count: number }>;
     personNames?: Map<string, string>;
     tagNames?: Map<string, string>;
+    onFiltersChange?: (filters: FilterState) => void;
     [key: string]: unknown;
   }
 
-  let { filters = $bindable(), config, timeBuckets = [], personNames, tagNames, ...rest }: Props = $props();
+  let {
+    filters = $bindable(),
+    config,
+    timeBuckets = [],
+    personNames,
+    tagNames,
+    onFiltersChange,
+    ...rest
+  }: Props = $props();
   let suggestions = $state('');
   let requestToken = 0;
 
+  function updateFilters(nextFilters: FilterState) {
+    filters = nextFilters;
+    onFiltersChange?.(nextFilters);
+  }
+
   function selectFavorites() {
     if (filters) {
-      filters = { ...filters, isFavorite: true };
+      updateFilters({ ...filters, isFavorite: true });
     }
   }
 
@@ -80,7 +94,7 @@
     data-testid="filter-panel-set-country"
     onclick={() => {
       if (filters) {
-        filters = { ...filters, country: 'Germany' };
+        updateFilters({ ...filters, country: 'Germany' });
       }
     }}
   >
@@ -88,10 +102,21 @@
   </button>
   <button
     type="button"
+    data-testid="filter-panel-clear-location"
+    onclick={() => {
+      if (filters) {
+        updateFilters({ ...filters, country: undefined, city: undefined });
+      }
+    }}
+  >
+    Clear location
+  </button>
+  <button
+    type="button"
     data-testid="filter-panel-set-sort-asc"
     onclick={() => {
       if (filters) {
-        filters = { ...filters, sortOrder: 'asc' };
+        updateFilters({ ...filters, sortOrder: 'asc' });
       }
     }}
   >

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -9,10 +9,12 @@
     filters?: FilterState;
     config?: FilterPanelConfig;
     timeBuckets?: Array<{ timeBucket: string; count: number }>;
+    personNames?: Map<string, string>;
+    tagNames?: Map<string, string>;
     [key: string]: unknown;
   }
 
-  let { filters = $bindable(), config, timeBuckets = [], ...rest }: Props = $props();
+  let { filters = $bindable(), config, timeBuckets = [], personNames, tagNames, ...rest }: Props = $props();
   let suggestions = $state('');
   let requestToken = 0;
 
@@ -65,6 +67,8 @@
   data-is-favorite={String(filters?.isFavorite)}
   data-time-buckets={JSON.stringify(timeBuckets)}
   data-suggestions={suggestions}
+  data-person-names={JSON.stringify([...(personNames?.entries() ?? [])])}
+  data-tag-names={JSON.stringify([...(tagNames?.entries() ?? [])])}
 >
   <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
   <button type="button" data-testid="load-city-suggestions" onclick={loadCitySuggestions}>Load cities</button>

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -31,6 +31,17 @@
   data-search-query={searchQuery}
   data-sort-order={filters?.sortOrder ?? ''}
   data-is-favorite={String(filters?.isFavorite)}
+  data-filter-favorite={String(filters?.isFavorite)}
+  data-filter-person-ids={filters?.personIds.join(',') ?? ''}
+  data-filter-tag-ids={filters?.tagIds.join(',') ?? ''}
+  data-filter-media-type={filters?.mediaType ?? ''}
+  data-filter-rating={filters?.rating ?? ''}
+  data-filter-date-after={filters?.dateAfter ?? ''}
+  data-filter-date-before={filters?.dateBefore ?? ''}
+  data-filter-city={filters?.city ?? ''}
+  data-filter-country={filters?.country ?? ''}
+  data-filter-make={filters?.make ?? ''}
+  data-filter-model={filters?.model ?? ''}
   data-with-shared-spaces={String(withSharedSpaces)}
   data-space-id={spaceId ?? ''}
   data-country={filters?.country ?? ''}


### PR DESCRIPTION
## Summary
- add typed `key:value` filters to global search and serialize them into Photos / Spaces filter URLs
- resolve people, tags, and cameras on Enter only, with blocking issue and ambiguity rows
- render typed filter pills in both modal and inline dropdown search, and document the syntax

## Verification
- pnpm --dir web exec vitest --run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts src/lib/components/global-search/__tests__/global-search.spec.ts src/lib/components/global-search/__tests__/typed-search-token-rail.spec.ts src/lib/managers/global-search-manager.svelte.spec.ts src/lib/utils/typed-search/typed-search-parser.spec.ts src/lib/utils/typed-search/typed-search-resolver.spec.ts src/lib/utils/__tests__/searchable-page-search.spec.ts
- pnpm --filter @immich/sdk build
- pnpm --dir web run check:typescript
- pnpm --dir web run check:svelte
- pnpm --dir docs run build
- git diff --check

Local lint intentionally not run; CI should lint.