### PR TITLE
fix: expose imported metadata people via identities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -387,6 +387,8 @@ jobs:
         run: pnpm install --frozen-lockfile
         if: ${{ !cancelled() }}
       - name: Start Docker Compose
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
         if: ${{ !cancelled() }}
       - name: Run e2e tests (api & cli)
@@ -451,6 +453,8 @@ jobs:
         run: pnpm exec playwright install chromium --only-shell
         if: ${{ !cancelled() }}
       - name: Docker build
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
         if: ${{ !cancelled() }}
       - name: Run e2e tests (web)

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     build:
       context: ../
       dockerfile: server/Dockerfile
+      secrets:
+        - github_token
     environment:
       DB_HOSTNAME: database
       DB_USERNAME: postgres
@@ -57,3 +59,7 @@ services:
       timeout: 5s
       retries: 30
       start_period: 10s
+
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     build:
       context: ../
       dockerfile: server/Dockerfile
+      # Build-only token for mise tool downloads; passed as a BuildKit secret,
+      # not as a runtime environment variable or image layer.
       secrets:
         - github_token
     environment:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -65,6 +65,9 @@ WORKDIR /usr/src/app
 COPY ./plugins/mise.toml ./plugins/
 ENV MISE_TRUSTED_CONFIG_PATHS=/usr/src/app/plugins/mise.toml
 ENV MISE_DATA_DIR=/buildcache/mise
+# CI passes GITHUB_TOKEN as a BuildKit secret so mise can resolve GitHub-hosted
+# plugin tool releases without unauthenticated rate-limit failures. The secret
+# is available only during this RUN step and is not persisted into the image.
 RUN --mount=type=cache,id=mise-tools-${TARGETPLATFORM},target=/buildcache/mise \
   --mount=type=secret,id=github_token \
   if [ -f /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi; \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -66,6 +66,8 @@ COPY ./plugins/mise.toml ./plugins/
 ENV MISE_TRUSTED_CONFIG_PATHS=/usr/src/app/plugins/mise.toml
 ENV MISE_DATA_DIR=/buildcache/mise
 RUN --mount=type=cache,id=mise-tools-${TARGETPLATFORM},target=/buildcache/mise \
+  --mount=type=secret,id=github_token \
+  if [ -f /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi; \
   mise install --cd plugins
 
 COPY ./plugins ./plugins/

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -1128,7 +1128,7 @@ select
   "face_search"."embedding"
 from
   "asset_face"
-  inner join "face_search" on "face_search"."faceId" = "asset_face"."id"
+  left join "face_search" on "face_search"."faceId" = "asset_face"."id"
   left join "person" on "person"."id" = "asset_face"."personId"
 where
   "asset_face"."assetId" = $1

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -78,7 +78,7 @@ type AssetFaceForMatching = {
   personId: string | null;
   identityId?: string | null;
   type?: string | null;
-  embedding: string;
+  embedding: string | null;
 };
 
 type PetFaceForMatching = {
@@ -1583,7 +1583,7 @@ export class SharedSpaceRepository {
   getAssetFacesForMatching(assetId: string): Promise<AssetFaceForMatching[]> {
     return this.db
       .selectFrom('asset_face')
-      .innerJoin('face_search', 'face_search.faceId', 'asset_face.id')
+      .leftJoin('face_search', 'face_search.faceId', 'asset_face.id')
       .leftJoin('person', 'person.id', 'asset_face.personId')
       .select([
         'asset_face.id',

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -78,6 +78,8 @@ describe(MetadataService.name, () => {
     mockReadTags();
 
     mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+    mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+    mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([]);
 
     delete process.env.TZ;
   });
@@ -1365,6 +1367,50 @@ describe(MetadataService.name, () => {
         {
           name: JobName.PersonGenerateThumbnail,
           data: { id: person.id },
+        },
+      ]);
+    });
+
+    it('should link imported metadata faces to identity-backed people', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
+      mockReadTags(makeFaceTags({ Name: person.name }));
+      mocks.person.getDistinctNames.mockResolvedValue([]);
+      mocks.person.createAll.mockResolvedValue([person.id]);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith('random-uuid');
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: 'random-uuid',
+        identityId: 'identity-1',
+        source: 'import',
+      });
+    });
+
+    it('should queue shared-space matching for imported metadata faces', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
+      mockReadTags(makeFaceTags({ Name: person.name }));
+      mocks.person.getDistinctNames.mockResolvedValue([]);
+      mocks.person.createAll.mockResolvedValue([person.id]);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).toHaveBeenCalledWith(asset.id);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: 'space-1', assetId: asset.id },
         },
       ]);
     });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -921,7 +921,7 @@ export class MetadataService extends BaseService {
       return;
     }
 
-    const facesToAdd: (Insertable<AssetFaceTable> & { assetId: string })[] = [];
+    const facesToAdd: (Insertable<AssetFaceTable> & { id: string; assetId: string; personId: string })[] = [];
     const existingNames = await this.personRepository.getDistinctNames(asset.ownerId, { withHidden: true });
     const existingNameMap = new Map(existingNames.map(({ id, name }) => [name.toLowerCase(), id]));
     const missing: (Insertable<PersonTable> & { ownerId: string })[] = [];
@@ -983,6 +983,27 @@ export class MetadataService extends BaseService {
 
     if (missingWithFaceAsset.length > 0) {
       await this.personRepository.updateAll(missingWithFaceAsset);
+    }
+
+    if (facesToAdd.length > 0) {
+      for (const face of facesToAdd) {
+        const identity = await this.faceIdentityRepository.ensurePersonIdentity(face.personId);
+        await this.faceIdentityRepository.replaceFaceIdentity({
+          assetFaceId: face.id,
+          identityId: identity.id,
+          source: 'import',
+        });
+      }
+
+      const spaceIds = (await this.sharedSpaceRepository.getSpaceIdsForAsset(asset.id)) ?? [];
+      if (spaceIds.length > 0) {
+        await this.jobRepository.queueAll(
+          spaceIds.map(({ spaceId }) => ({
+            name: JobName.SharedSpaceFaceMatch as const,
+            data: { spaceId, assetId: asset.id },
+          })),
+        );
+      }
     }
   }
 

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1624,9 +1624,8 @@ export class SharedSpaceService extends BaseService {
 
     const spaceAsset = await this.sharedSpaceRepository.getSpaceAssetAdder(spaceId, assetId);
     const assetAdderId = spaceAsset?.addedById ?? null;
-    const { machineLearning } = await this.getConfig({ withCache: true });
-    const maxDistance = machineLearning.facialRecognition.maxDistance;
     const affectedPersonIds = new Set<string>();
+    let maxDistance: number | undefined;
 
     const faces = await this.sharedSpaceRepository.getAssetFacesForMatching(assetId);
     for (const face of faces) {
@@ -1647,21 +1646,31 @@ export class SharedSpaceService extends BaseService {
         continue;
       }
 
-      const spacePerson = face.identityId
-        ? await this.findOrCreateSpacePersonForFace({
-            spaceId,
-            faceId: face.id,
-            personId: face.personId,
-            identityId: face.identityId,
-            type: face.type ?? 'person',
-          })
-        : await this.findOrCreateSpacePersonForLegacyFace({
-            spaceId,
-            faceId: face.id,
-            personId: face.personId,
-            embedding: face.embedding,
-            maxDistance,
-          });
+      let spacePerson: SpacePersonMatchResult;
+      if (face.identityId) {
+        spacePerson = await this.findOrCreateSpacePersonForFace({
+          spaceId,
+          faceId: face.id,
+          personId: face.personId,
+          identityId: face.identityId,
+          type: face.type ?? 'person',
+        });
+      } else {
+        if (!face.embedding) {
+          continue;
+        }
+        if (maxDistance === undefined) {
+          const { machineLearning } = await this.getConfig({ withCache: true });
+          maxDistance = machineLearning.facialRecognition.maxDistance;
+        }
+        spacePerson = await this.findOrCreateSpacePersonForLegacyFace({
+          spaceId,
+          faceId: face.id,
+          personId: face.personId,
+          embedding: face.embedding,
+          maxDistance,
+        });
+      }
 
       await this.sharedSpaceRepository.addPersonFaces([{ personId: spacePerson.id, assetFaceId: face.id }], {
         skipRecount: true,

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -3,19 +3,29 @@ import { Stats } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { AssetVisibility, SourceType } from 'src/enum';
 import { AssetJobRepository } from 'src/repositories/asset-job.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { ConfigRepository } from 'src/repositories/config.repository';
+import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { EventRepository } from 'src/repositories/event.repository';
+import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
+import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { MetadataRepository } from 'src/repositories/metadata.repository';
+import { PersonRepository } from 'src/repositories/person.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
 import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
 import { TagRepository } from 'src/repositories/tag.repository';
 import { DB } from 'src/schema';
 import { MetadataService } from 'src/services/metadata.service';
+import { PersonService } from 'src/services/person.service';
+import { clearConfigCache } from 'src/utils/config';
 import { newMediumService } from 'test/medium.factory';
+import { factory } from 'test/small.factory';
 import { getKyselyDB, newRandomImage } from 'test/utils';
+import { Mocked } from 'vitest';
 
 type TimeZoneTest = {
   description: string;
@@ -54,6 +64,61 @@ const setup = (db?: Kysely<DB>) => {
   return { sut, ctx };
 };
 
+const setupFaceImport = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(MetadataService, {
+    database: db || defaultDatabase,
+    real: [
+      AssetRepository,
+      AssetJobRepository,
+      ConfigRepository,
+      CryptoRepository,
+      FaceIdentityRepository,
+      MetadataRepository,
+      PersonRepository,
+      SharedSpaceRepository,
+      TagRepository,
+    ],
+    mock: [EventRepository, JobRepository, LoggingRepository, StorageRepository, SystemMetadataRepository],
+  });
+
+  ctx.getMock(EventRepository).emit.mockResolvedValue();
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll.mockResolvedValue();
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockResolvedValue({
+      metadata: { faces: { import: true } },
+      machineLearning: { facialRecognition: { minFaces: 1 } },
+    } as any);
+  ctx.getMock(StorageRepository).stat.mockResolvedValue({
+    size: 123_456,
+    mtime: new Date(654_321),
+    mtimeMs: 654_321,
+    birthtimeMs: 654_322,
+  } as Stats);
+
+  return { sut, ctx };
+};
+
+const setupPersonService = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(PersonService, {
+    database: db || defaultDatabase,
+    real: [ConfigRepository, FaceIdentityRepository],
+    mock: [LoggingRepository, SystemMetadataRepository],
+  });
+
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockResolvedValue({
+      machineLearning: { facialRecognition: { minFaces: 1 } },
+    } as any);
+
+  return { sut, ctx };
+};
+
 const createTestFile = async (exifData: Record<string, any>) => {
   const { ctx } = setup();
   const data = newRandomImage();
@@ -70,6 +135,8 @@ beforeAll(async () => {
 describe(MetadataService.name, () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    clearConfigCache();
   });
 
   it('should be defined', () => {
@@ -150,6 +217,54 @@ describe(MetadataService.name, () => {
           .executeTakeFirstOrThrow(),
         // note that this date is technically wrong. it does not throw though and should get the user's attention either way.
       ).resolves.toEqual({ dateTimeOriginal: new Date('4260-03-05T04:04:12.000Z') });
+    });
+
+    it('should expose imported metadata people through identity-backed people', async () => {
+      const { sut, ctx } = setupFaceImport();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        originalPath: '/photos/alice.jpg',
+        visibility: AssetVisibility.Timeline,
+      });
+      await ctx.newExif({ assetId: asset.id, description: '' });
+      vi.spyOn(ctx.get(MetadataRepository), 'readTags').mockResolvedValue({
+        RegionInfo: {
+          AppliedToDimensions: { W: 1000, H: 100, Unit: 'pixel' },
+          RegionList: [
+            {
+              Type: 'face',
+              Name: 'Alice Metadata',
+              Area: { X: 0.1, Y: 0.4, W: 0.2, H: 0.4, Unit: 'normalized' },
+            },
+          ],
+        },
+      });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      const { sut: personService } = setupPersonService(ctx.database);
+      const people = await personService.getAll(factory.auth({ user }), {
+        withHidden: true,
+        withSharedSpaces: true,
+        page: 1,
+        size: 50,
+      } as any);
+      const identityLinks = await ctx.database
+        .selectFrom('face_identity_face')
+        .innerJoin('asset_face', 'asset_face.id', 'face_identity_face.assetFaceId')
+        .select(['face_identity_face.source', 'asset_face.sourceType'])
+        .where('asset_face.assetId', '=', asset.id)
+        .execute();
+
+      expect(people.people).toEqual([
+        expect.objectContaining({
+          name: 'Alice Metadata',
+          numberOfAssets: 1,
+          primaryProfile: expect.objectContaining({ type: 'user-person' }),
+        }),
+      ]);
+      expect(identityLinks).toEqual([{ source: 'import', sourceType: SourceType.Exif }]);
     });
   });
 });

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -120,6 +120,21 @@ const setupPersonService = (db?: Kysely<DB>) => {
   return { sut, ctx };
 };
 
+const setupFaceIdentityBackfillService = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(PersonService, {
+    database: db || defaultDatabase,
+    real: [FaceIdentityRepository, SharedSpaceRepository],
+    mock: [JobRepository, LoggingRepository],
+  });
+
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queue.mockResolvedValue();
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll.mockResolvedValue();
+
+  return { sut, ctx };
+};
+
 const setupSharedSpaceService = (db?: Kysely<DB>) => {
   clearConfigCache();
 
@@ -422,6 +437,79 @@ describe(MetadataService.name, () => {
         name: JobName.SharedSpacePersonDedup,
         data: { spaceId: space.id },
       });
+    });
+
+    it('should backfill legacy imported metadata faces into shared spaces without embeddings', async () => {
+      const { ctx } = setupFaceImport();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({
+        ownerId: user.id,
+        name: 'Legacy Metadata',
+        faceAssetId: null,
+        identityId: null,
+      });
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        originalPath: '/photos/legacy-space-person.jpg',
+        visibility: AssetVisibility.Timeline,
+      });
+      const { assetFace } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: person.id,
+        sourceType: SourceType.Exif,
+      });
+      await ctx.database.updateTable('person').set({ faceAssetId: assetFace.id }).where('id', '=', person.id).execute();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const { sut: backfillService, ctx: backfillCtx } = setupFaceIdentityBackfillService(ctx.database);
+      const { sut: sharedSpaceService } = setupSharedSpaceService(ctx.database);
+
+      await expect(
+        ctx.database
+          .selectFrom('asset_face')
+          .leftJoin('face_search', 'face_search.faceId', 'asset_face.id')
+          .leftJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+          .select(['face_search.faceId', 'face_identity_face.identityId'])
+          .where('asset_face.id', '=', assetFace.id)
+          .executeTakeFirstOrThrow(),
+      ).resolves.toEqual({ faceId: null, identityId: null });
+
+      await expect(backfillService.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+      await expect(sharedSpaceService.handleSharedSpaceFaceMatchAll({ spaceId: space.id })).resolves.toBe(
+        JobStatus.Success,
+      );
+
+      const identityLinks = await ctx.database
+        .selectFrom('face_identity_face')
+        .select(['assetFaceId', 'source'])
+        .where('assetFaceId', '=', assetFace.id)
+        .execute();
+      const spacePeople = await ctx.database
+        .selectFrom('shared_space_person')
+        .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
+        .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+        .select([
+          'shared_space_person.name',
+          'shared_space_person.faceCount',
+          'shared_space_person.identityId',
+          'asset_face.sourceType',
+        ])
+        .where('shared_space_person.spaceId', '=', space.id)
+        .execute();
+
+      expect(identityLinks).toEqual([{ assetFaceId: assetFace.id, source: 'backfill' }]);
+      expect(backfillCtx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll).toHaveBeenCalledWith(
+        expect.arrayContaining([{ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } }]),
+      );
+      expect(spacePeople).toEqual([
+        expect.objectContaining({
+          name: 'Legacy Metadata',
+          faceCount: 1,
+          identityId: expect.any(String),
+          sourceType: SourceType.Exif,
+        }),
+      ]);
     });
   });
 });

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -3,7 +3,7 @@ import { Stats } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { AssetVisibility, SourceType } from 'src/enum';
+import { AssetVisibility, JobName, JobStatus, SharedSpaceRole, SourceType } from 'src/enum';
 import { AssetJobRepository } from 'src/repositories/asset-job.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { ConfigRepository } from 'src/repositories/config.repository';
@@ -21,6 +21,7 @@ import { TagRepository } from 'src/repositories/tag.repository';
 import { DB } from 'src/schema';
 import { MetadataService } from 'src/services/metadata.service';
 import { PersonService } from 'src/services/person.service';
+import { SharedSpaceService } from 'src/services/shared-space.service';
 import { clearConfigCache } from 'src/utils/config';
 import { newMediumService } from 'test/medium.factory';
 import { factory } from 'test/small.factory';
@@ -118,6 +119,47 @@ const setupPersonService = (db?: Kysely<DB>) => {
 
   return { sut, ctx };
 };
+
+const setupSharedSpaceService = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(SharedSpaceService, {
+    database: db || defaultDatabase,
+    real: [ConfigRepository, PersonRepository, SharedSpaceRepository],
+    mock: [JobRepository, LoggingRepository, SystemMetadataRepository],
+  });
+
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queue.mockResolvedValue();
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockResolvedValue({
+      machineLearning: { facialRecognition: { maxDistance: 0.5 } },
+    } as any);
+
+  return { sut, ctx };
+};
+
+const metadataFaceTags = (name: string) => ({
+  RegionInfo: {
+    AppliedToDimensions: { W: 1000, H: 100, Unit: 'pixel' },
+    RegionList: [
+      {
+        Type: 'face',
+        Name: name,
+        Area: { X: 0.1, Y: 0.4, W: 0.2, H: 0.4, Unit: 'normalized' },
+      },
+    ],
+  },
+});
+
+const getAssetFaceIdentityLinks = (db: Kysely<DB>, assetId: string) =>
+  db
+    .selectFrom('face_identity_face')
+    .innerJoin('asset_face', 'asset_face.id', 'face_identity_face.assetFaceId')
+    .innerJoin('person', 'person.id', 'asset_face.personId')
+    .select(['asset_face.id as assetFaceId', 'person.name', 'face_identity_face.source', 'asset_face.sourceType'])
+    .where('asset_face.assetId', '=', assetId)
+    .execute();
 
 const createTestFile = async (exifData: Record<string, any>) => {
   const { ctx } = setup();
@@ -228,18 +270,7 @@ describe(MetadataService.name, () => {
         visibility: AssetVisibility.Timeline,
       });
       await ctx.newExif({ assetId: asset.id, description: '' });
-      vi.spyOn(ctx.get(MetadataRepository), 'readTags').mockResolvedValue({
-        RegionInfo: {
-          AppliedToDimensions: { W: 1000, H: 100, Unit: 'pixel' },
-          RegionList: [
-            {
-              Type: 'face',
-              Name: 'Alice Metadata',
-              Area: { X: 0.1, Y: 0.4, W: 0.2, H: 0.4, Unit: 'normalized' },
-            },
-          ],
-        },
-      });
+      vi.spyOn(ctx.get(MetadataRepository), 'readTags').mockResolvedValue(metadataFaceTags('Alice Metadata'));
 
       await sut.handleMetadataExtraction({ id: asset.id });
 
@@ -265,6 +296,132 @@ describe(MetadataService.name, () => {
         }),
       ]);
       expect(identityLinks).toEqual([{ source: 'import', sourceType: SourceType.Exif }]);
+    });
+
+    it('should remove stale imported identity links when metadata faces are re-imported', async () => {
+      const { sut, ctx } = setupFaceImport();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        originalPath: '/photos/renamed-face.jpg',
+        visibility: AssetVisibility.Timeline,
+      });
+      await ctx.newExif({ assetId: asset.id, description: '' });
+      vi.spyOn(ctx.get(MetadataRepository), 'readTags')
+        .mockResolvedValueOnce(metadataFaceTags('Alice Metadata'))
+        .mockResolvedValueOnce(metadataFaceTags('Bob Metadata'));
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      expect(await getAssetFaceIdentityLinks(ctx.database, asset.id)).toEqual([
+        expect.objectContaining({ name: 'Alice Metadata', source: 'import', sourceType: SourceType.Exif }),
+      ]);
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(await getAssetFaceIdentityLinks(ctx.database, asset.id)).toEqual([
+        expect.objectContaining({ name: 'Bob Metadata', source: 'import', sourceType: SourceType.Exif }),
+      ]);
+    });
+
+    it('should link imported metadata faces to an existing person without an identity', async () => {
+      const { sut, ctx } = setupFaceImport();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({
+        ownerId: user.id,
+        name: 'Existing Metadata',
+        faceAssetId: null,
+        identityId: null,
+      });
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        originalPath: '/photos/existing-person.jpg',
+        visibility: AssetVisibility.Timeline,
+      });
+      await ctx.newExif({ assetId: asset.id, description: '' });
+      vi.spyOn(ctx.get(MetadataRepository), 'readTags').mockResolvedValue(metadataFaceTags('Existing Metadata'));
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      const [{ identityId }] = await ctx.database
+        .selectFrom('person')
+        .select('identityId')
+        .where('id', '=', person.id)
+        .execute();
+      const { sut: personService } = setupPersonService(ctx.database);
+      const people = await personService.getAll(factory.auth({ user }), {
+        withHidden: true,
+        withSharedSpaces: true,
+        page: 1,
+        size: 50,
+      } as any);
+
+      expect(identityId).toEqual(expect.any(String));
+      expect(await getAssetFaceIdentityLinks(ctx.database, asset.id)).toEqual([
+        expect.objectContaining({ name: 'Existing Metadata', source: 'import', sourceType: SourceType.Exif }),
+      ]);
+      expect(people.people).toContainEqual(
+        expect.objectContaining({
+          name: 'Existing Metadata',
+          numberOfAssets: 1,
+          primaryProfile: expect.objectContaining({ id: person.id, type: 'user-person' }),
+        }),
+      );
+    });
+
+    it('should expose imported metadata people in shared spaces before face detection creates embeddings', async () => {
+      const { sut, ctx } = setupFaceImport();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        originalPath: '/photos/space-person.jpg',
+        visibility: AssetVisibility.Timeline,
+      });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      await ctx.newExif({ assetId: asset.id, description: '' });
+      vi.spyOn(ctx.get(MetadataRepository), 'readTags').mockResolvedValue(metadataFaceTags('Space Metadata'));
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+      const importedFacesWithoutEmbeddings = await ctx.database
+        .selectFrom('asset_face')
+        .leftJoin('face_search', 'face_search.faceId', 'asset_face.id')
+        .select(['asset_face.id', 'face_search.faceId'])
+        .where('asset_face.assetId', '=', asset.id)
+        .where('asset_face.sourceType', '=', SourceType.Exif)
+        .execute();
+      const { sut: sharedSpaceService, ctx: sharedSpaceCtx } = setupSharedSpaceService(ctx.database);
+
+      await expect(
+        sharedSpaceService.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: asset.id }),
+      ).resolves.toBe(JobStatus.Success);
+
+      const spacePeople = await ctx.database
+        .selectFrom('shared_space_person')
+        .innerJoin('shared_space_person_face', 'shared_space_person_face.personId', 'shared_space_person.id')
+        .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+        .select([
+          'shared_space_person.name',
+          'shared_space_person.faceCount',
+          'shared_space_person.identityId',
+          'asset_face.sourceType',
+        ])
+        .where('shared_space_person.spaceId', '=', space.id)
+        .execute();
+
+      expect(importedFacesWithoutEmbeddings).toEqual([{ id: expect.any(String), faceId: null }]);
+      expect(spacePeople).toEqual([
+        expect.objectContaining({
+          name: 'Space Metadata',
+          faceCount: 1,
+          identityId: expect.any(String),
+          sourceType: SourceType.Exif,
+        }),
+      ]);
+      expect(sharedSpaceCtx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId: space.id },
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- link EXIF/XMP metadata-imported faces into face identities so `/people` can see them immediately after metadata extraction
- queue shared-space face matching when imported metadata faces are added
- add unit and medium regressions for identity-backed people visibility

## Testing
- pnpm --dir server exec prettier --check src/services/metadata.service.ts src/services/metadata.service.spec.ts test/medium/specs/services/metadata.service.spec.ts
- pnpm --dir server exec eslint src/services/metadata.service.ts src/services/metadata.service.spec.ts test/medium/specs/services/metadata.service.spec.ts --max-warnings 0
- pnpm --dir server check
- pnpm --dir server test --run src/services/metadata.service.spec.ts
- pnpm --dir server test:medium --run test/medium/specs/services/metadata.service.spec.ts