### PR TITLE
fix: show space thumbnails in sidebar

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/recent-spaces.spec.ts
+++ b/web/src/lib/components/shared-components/side-bar/recent-spaces.spec.ts
@@ -11,6 +11,11 @@ vi.mock('$lib/utils/handle-error', () => ({
   handleError: vi.fn(),
 }));
 
+vi.mock('$lib/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/utils')>()),
+  getAssetMediaUrl: vi.fn(({ id }: { id: string }) => `/api/assets/${id}/thumbnail?edited=true`),
+}));
+
 import { handleError } from '$lib/utils/handle-error';
 
 describe('RecentSpaces component', () => {
@@ -117,6 +122,22 @@ describe('RecentSpaces component', () => {
       await renderAndFlush();
 
       expect(screen.queryByTestId('sidebar-space-dot-undef-dot')).not.toBeInTheDocument();
+    });
+
+    it('shows the space thumbnail when there are no new assets', async () => {
+      const space = sharedSpaceFactory.build({
+        id: 'thumb-1',
+        newAssetCount: 0,
+        thumbnailAssetId: 'asset-thumb-1',
+      });
+      sdkMock.getAllSpaces.mockResolvedValueOnce([space]);
+      await renderAndFlush();
+
+      const thumbnail = screen.getByTestId('sidebar-space-thumbnail-thumb-1');
+      expect(thumbnail).toHaveClass('h-6', 'w-6', 'bg-cover');
+      expect(thumbnail.getAttribute('style')).toContain(
+        'background-image: url("/api/assets/asset-thumb-1/thumbnail?edited=true")',
+      );
     });
 
     it('applies correct bg class for blue color', async () => {

--- a/web/src/lib/components/shared-components/side-bar/recent-spaces.svelte
+++ b/web/src/lib/components/shared-components/side-bar/recent-spaces.svelte
@@ -3,6 +3,7 @@
   import { Route } from '$lib/route';
   import { pinnedSpaceIds } from '$lib/stores/space-view.store';
   import { userInteraction } from '$lib/stores/user.svelte';
+  import { getAssetMediaUrl } from '$lib/utils';
   import { splitPinnedSpaces } from '$lib/utils/space-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { UserAvatarColor, getAllSpaces } from '@immich/sdk';
@@ -64,14 +65,20 @@
       ? 'bg-primary/10 text-immich-primary dark:text-immich-dark-primary'
       : ''}"
   >
-    <div>
+    <div class="flex h-6 w-6 items-center justify-center">
       {#if space.newAssetCount && space.newAssetCount > 0}
         <div
           class="h-3 w-3 rounded-full {bgClasses[space.color ?? 'primary'] ?? bgClasses[UserAvatarColor.Primary]}"
           data-testid="sidebar-space-dot-{space.id}"
         ></div>
       {:else}
-        <div class="h-3 w-3"></div>
+        <div
+          class="h-6 w-6 bg-cover rounded bg-gray-200 dark:bg-gray-600"
+          style={space.thumbnailAssetId
+            ? `background-image:url('${getAssetMediaUrl({ id: space.thumbnailAssetId })}')`
+            : ''}
+          data-testid="sidebar-space-thumbnail-{space.id}"
+        ></div>
       {/if}
     </div>
     <div class="grow text-sm font-medium truncate">


### PR DESCRIPTION
## Summary
- show shared space thumbnails in the sidebar when there are no unseen assets
- keep the colored unseen-assets dot when new assets are present
- add component coverage for the thumbnail fallback

## Test plan
- pnpm --dir web exec vitest run src/lib/components/shared-components/side-bar/recent-spaces.spec.ts
- pnpm --dir web exec prettier --check src/lib/components/shared-components/side-bar/recent-spaces.svelte src/lib/components/shared-components/side-bar/recent-spaces.spec.ts
- pnpm --dir web exec eslint src/lib/components/shared-components/side-bar/recent-spaces.svelte src/lib/components/shared-components/side-bar/recent-spaces.spec.ts --max-warnings 0
- pnpm --dir web run check:svelte