### PR TITLE
fix: remove plugin build secret requirement

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -14,10 +14,6 @@ services:
     build:
       context: ../
       dockerfile: server/Dockerfile
-      # Build-only token for mise tool downloads; passed as a BuildKit secret,
-      # not as a runtime environment variable or image layer.
-      secrets:
-        - github_token
     environment:
       DB_HOSTNAME: database
       DB_USERNAME: postgres
@@ -61,7 +57,3 @@ services:
       timeout: 5s
       retries: 30
       start_period: 10s
-
-secrets:
-  github_token:
-    environment: GITHUB_TOKEN

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -65,12 +65,7 @@ WORKDIR /usr/src/app
 COPY ./plugins/mise.toml ./plugins/
 ENV MISE_TRUSTED_CONFIG_PATHS=/usr/src/app/plugins/mise.toml
 ENV MISE_DATA_DIR=/buildcache/mise
-# CI passes GITHUB_TOKEN as a BuildKit secret so mise can resolve GitHub-hosted
-# plugin tool releases without unauthenticated rate-limit failures. The secret
-# is available only during this RUN step and is not persisted into the image.
 RUN --mount=type=cache,id=mise-tools-${TARGETPLATFORM},target=/buildcache/mise \
-  --mount=type=secret,id=github_token \
-  if [ -f /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi; \
   mise install --cd plugins
 
 COPY ./plugins ./plugins/


### PR DESCRIPTION
## Summary
- remove the BuildKit github token mount from the plugin tool install in server builds
- remove the matching e2e docker compose secret wiring
- return plugin tool installation to the previous unauthenticated behavior

## Testing
- not run
- verified no remaining `github_token` references in the repo