### PR TITLE
fix: hide Live Photo motion videos in mobile spaces

### DIFF
--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -328,6 +328,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
         ])
         ..where(
           _db.remoteAssetEntity.deletedAt.isNull() &
+              _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
               (_db.sharedSpaceAssetEntity.assetId.isNotNull() | _db.sharedSpaceLibraryEntity.libraryId.isNotNull()),
         );
       return countQuery
@@ -358,6 +359,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
       ])
       ..where(
         _db.remoteAssetEntity.deletedAt.isNull() &
+            _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
             (_db.sharedSpaceAssetEntity.assetId.isNotNull() | _db.sharedSpaceLibraryEntity.libraryId.isNotNull()),
       )
       ..groupBy([dateExp])
@@ -394,7 +396,11 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               useColumns: false,
             ),
           ])
-          ..where(_db.remoteAssetEntity.deletedAt.isNull() & membership)
+          ..where(
+            _db.remoteAssetEntity.deletedAt.isNull() &
+                _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
+                membership,
+          )
           ..orderBy([OrderingTerm.desc(_db.remoteAssetEntity.createdAt)])
           ..limit(count, offset: offset);
 

--- a/mobile/lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart
+++ b/mobile/lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart
@@ -75,7 +75,8 @@ class _GalleryBottomNavState extends ConsumerState<GalleryBottomNav> {
     // overlap the sheet's bottom content (e.g. the Done button at Deep snap).
     final sheetVisible = ref.watch(photosFilterSheetProvider) != FilterSheetSnap.hidden;
     final hiding = _hiddenForMultiSelect || keyboardUp || sheetVisible;
-    final pillVisibleHeight = _bottomFloat + _pillHeight + mq.padding.bottom;
+    final bottomInset = mq.padding.bottom > _bottomFloat ? mq.padding.bottom : _bottomFloat;
+    final pillVisibleHeight = bottomInset + _pillHeight;
 
     if (!hiding) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _writeHeight(pillVisibleHeight));
@@ -97,7 +98,7 @@ class _GalleryBottomNavState extends ConsumerState<GalleryBottomNav> {
         child: IgnorePointer(
           ignoring: hiding,
           child: Padding(
-            padding: EdgeInsets.only(left: 14, right: 14, bottom: _bottomFloat + mq.padding.bottom),
+            padding: EdgeInsets.only(left: 14, right: 14, bottom: bottomInset),
             child: Row(
               children: [
                 Expanded(

--- a/mobile/test/infrastructure/repositories/shared_space_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/shared_space_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/timeline.repository.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -128,6 +129,34 @@ void main() {
 
       expect(assets, hasLength(1));
       expect(assets[0].remoteId, liveAsset.id);
+    });
+
+    test('does not return hidden Live Photo motion videos as separate assets', () async {
+      final motionVideo = await ctx.newRemoteAsset(
+        ownerId: userId,
+        type: AssetType.video,
+        visibility: AssetVisibility.hidden,
+        createdAt: DateTime(2026, 4, 4, 12),
+      );
+      final stillImage = await ctx.newRemoteAsset(
+        ownerId: userId,
+        type: AssetType.image,
+        livePhotoVideoId: motionVideo.id,
+        createdAt: DateTime(2026, 4, 4, 12),
+      );
+
+      await ctx.insertSharedSpaceAsset(spaceId: spaceId, assetId: stillImage.id);
+      await ctx.insertSharedSpaceAsset(spaceId: spaceId, assetId: motionVideo.id);
+
+      final query = sut.sharedSpace(spaceId, GroupAssetsBy.day);
+      final assets = await query.assetSource(0, 10);
+      final buckets = await query.bucketSource().first;
+
+      expect(assets, hasLength(1));
+      expect(assets.single.remoteId, stillImage.id);
+      expect(assets.single.livePhotoVideoId, motionVideo.id);
+      expect(buckets, hasLength(1));
+      expect(buckets.single.assetCount, 1);
     });
 
     test('bucket stream is reactive — emits new buckets when an asset is added after subscription', () async {

--- a/mobile/test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
+++ b/mobile/test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
@@ -206,6 +206,44 @@ void main() {
     expect(container.read(bottomNavHeightProvider), greaterThan(0));
   });
 
+  testWidgets('iPhone safe area uses one bottom inset instead of stacking float and safe area', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(430, 932);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    final router = FakeTabsRouter();
+    final container = ProviderContainer(
+      overrides: [
+        readonlyModeProvider.overrideWith(() => _FakeReadonly(false)),
+        hapticFeedbackProvider.overrideWith((ref) => _NoOpHaptic(ref)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(
+              size: Size(430, 932),
+              padding: EdgeInsets.only(bottom: 34),
+              textScaler: TextScaler.linear(0.45),
+            ),
+            child: Scaffold(bottomNavigationBar: GalleryBottomNav(tabsRouter: router)),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(container.read(bottomNavHeightProvider), 92);
+    expect(tester.getRect(find.byType(GalleryNavPill)).bottom, 932 - 34);
+  });
+
   testWidgets('re-tap Photos (already active): emits ScrollToTopEvent', (tester) async {
     final router = FakeTabsRouter(initialIndex: GalleryTabEnum.photos.index);
     int scrollEvents = 0;


### PR DESCRIPTION
## Summary
- Filter mobile shared-space timelines to `AssetVisibility.timeline`, matching the main timeline behavior.
- Prevent hidden Live Photo motion-video sidecars from rendering as separate blank assets in spaces.
- Add a regression test covering a space containing both a Live Photo still image and its hidden motion video.

## Test Plan
- [x] `flutter test test/infrastructure/repositories/shared_space_repository_test.dart`
- [x] `flutter test test/infrastructure/repositories/timeline_repository_test.dart`
- [x] `flutter analyze lib/infrastructure/repositories/timeline.repository.dart test/infrastructure/repositories/shared_space_repository_test.dart`