### PR TITLE
fix: submit mobile filter search from keyboard

### DIFF
--- a/mobile/lib/presentation/widgets/filter_sheet/search_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/search_bar.widget.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/search_focus.provider.dart';
 
@@ -45,6 +46,15 @@ class _FilterSheetSearchBarState extends ConsumerState<FilterSheetSearchBar> {
     _controller.addListener(_onChanged);
     ref.read(photosFilterProvider.notifier).setText('');
     setState(() {});
+  }
+
+  void _submit(String value) {
+    _debounce?.cancel();
+    ref.read(photosFilterProvider.notifier).setText(value);
+    FocusScope.of(context).unfocus();
+    if (value.trim().isNotEmpty) {
+      ref.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden;
+    }
   }
 
   @override
@@ -104,7 +114,7 @@ class _FilterSheetSearchBarState extends ConsumerState<FilterSheetSearchBar> {
         fillColor: Theme.of(context).colorScheme.surfaceContainer,
       ),
       textInputAction: TextInputAction.search,
-      onSubmitted: (_) => FocusScope.of(context).unfocus(),
+      onSubmitted: _submit,
     );
   }
 }

--- a/mobile/test/presentation/widgets/filter_sheet/search_bar_focus_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/search_bar_focus_test.dart
@@ -2,11 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/search_bar.widget.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/search_focus.provider.dart';
 
 import '../../../widget_tester_extensions.dart';
 
 void main() {
+  testWidgets('keyboard search submits text immediately and hides the filter sheet', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.browse;
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: Material(child: FilterSheetSearchBar())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'beach');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pump();
+
+    expect(container.read(photosFilterProvider).context, 'beach');
+    expect(container.read(photosFilterSheetProvider), FilterSheetSnap.hidden);
+  });
+
   testWidgets('mounted-before-increment: focus requested on counter rise', (tester) async {
     await tester.pumpConsumerWidget(const FilterSheetSearchBar());
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- commit the mobile filter sheet search text immediately when the keyboard Search action is pressed
- hide the filter sheet for non-empty keyboard submissions
- add a widget regression test for the keyboard submit behavior

## Testing
- mise exec -- flutter test test/presentation/widgets/filter_sheet/search_bar_focus_test.dart
- mise exec -- dart analyze lib/presentation/widgets/filter_sheet/search_bar.widget.dart test/presentation/widgets/filter_sheet/search_bar_focus_test.dart