### PR TITLE
fix(ci): install ImageMagick for branded mobile builds

### DIFF
--- a/.github/actions/apply-branding/action.yml
+++ b/.github/actions/apply-branding/action.yml
@@ -16,10 +16,18 @@ runs:
       shell: bash
       run: |
         if [[ "$RUNNER_OS" == "macOS" ]]; then
-          brew install jq coreutils gnu-sed 2>/dev/null || true
+          brew install jq coreutils gnu-sed imagemagick 2>/dev/null || true
         else
+          packages=()
           if ! command -v jq &>/dev/null; then
-            sudo apt-get update && sudo apt-get install -y jq
+            packages+=(jq)
+          fi
+          if ! command -v identify &>/dev/null || { ! command -v convert &>/dev/null && ! command -v magick &>/dev/null; }; then
+            packages+=(imagemagick)
+          fi
+          if (( ${#packages[@]} > 0 )); then
+            sudo apt-get update
+            sudo apt-get install -y "${packages[@]}"
           fi
         fi
 

--- a/.github/actions/apply-branding/dependencies_test.rb
+++ b/.github/actions/apply-branding/dependencies_test.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+action_path = File.expand_path('action.yml', __dir__)
+action = YAML.load_file(action_path)
+install_step = action.fetch('runs').fetch('steps').find { |step| step['name'] == 'Install dependencies' }
+
+abort('Install dependencies step is missing') unless install_step
+
+run_script = install_step.fetch('run')
+failures = []
+
+unless run_script.match?(/brew install[^\n]*imagemagick/)
+  failures << 'macOS dependency install must include imagemagick'
+end
+
+unless run_script.include?('packages+=(imagemagick)') && run_script.include?('apt-get install -y "${packages[@]}"')
+  failures << 'Linux dependency install must add and install the imagemagick package'
+end
+
+unless run_script.include?('command -v identify')
+  failures << 'Linux dependency check must account for ImageMagick identify, used by verify-mobile-assets.sh'
+end
+
+unless run_script.include?('command -v convert') || run_script.include?('command -v magick')
+  failures << 'Linux dependency check must account for convert or magick, used by apply-branding.sh'
+end
+
+abort(failures.join("\n")) unless failures.empty?

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "format": "prettier --cache --check .",
-    "format:fix": "prettier --cache --write --list-different ."
+    "format:fix": "prettier --cache --write --list-different .",
+    "test": "ruby actions/apply-branding/dependencies_test.rb"
   },
   "devDependencies": {
     "prettier": "^3.7.4"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -596,6 +596,9 @@ jobs:
       - name: Run formatter
         run: pnpm format
         if: ${{ !cancelled() }}
+      - name: Run tests
+        run: pnpm test
+        if: ${{ !cancelled() }}
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- install ImageMagick in the apply-branding composite action on Linux and macOS runners
- add a regression test for the action dependency bootstrap
- run that test in the existing .github CI job

## Verification
- pnpm --dir .github test
- pnpm --dir .github format
- git diff --check