### PR TITLE
fix: keep revert-to-immich migration check current

### DIFF
--- a/.github/workflows/gallery-revert-to-immich-validation.yml
+++ b/.github/workflows/gallery-revert-to-immich-validation.yml
@@ -24,6 +24,8 @@ on:
     paths:
       - 'scripts/revert-to-immich.sql'
       - 'server/src/schema/migrations-gallery/**'
+      - 'server/src/schema/migrations/**'
+      - 'server/package.json'
       - '.github/workflows/gallery-revert-to-immich-validation.yml'
 
 concurrency:
@@ -55,6 +57,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify migration coverage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          while IFS= read -r file; do
+            name=${file##*/}
+            name=${name%.ts}
+            if ! grep -qF "'${name}'" scripts/revert-to-immich.sql; then
+              echo "::error file=scripts/revert-to-immich.sql::Missing Gallery migration cleanup entry: ${name}"
+              missing=1
+            fi
+          done < <(find server/src/schema/migrations-gallery -maxdepth 1 -type f -name '*.ts' | sort)
+
+          UPSTREAM_TAG=v$(jq -r .version server/package.json)
+          upstream_migrations=$(mktemp)
+          trap 'rm -f "$upstream_migrations"' EXIT
+          gh api "repos/immich-app/immich/git/trees/${UPSTREAM_TAG}:server/src/schema/migrations" \
+            --jq '.tree[].path' | sort > "$upstream_migrations"
+
+          while IFS= read -r file; do
+            filename=${file##*/}
+            name=${filename%.ts}
+            if ! grep -qxF "$filename" "$upstream_migrations" && ! grep -qF "'${name}'" scripts/revert-to-immich.sql; then
+              echo "::error file=scripts/revert-to-immich.sql::Missing post-${UPSTREAM_TAG} upstream migration cleanup entry: ${name}"
+              missing=1
+            fi
+          done < <(find server/src/schema/migrations -maxdepth 1 -type f -name '*.ts' | sort)
+
+          exit "$missing"
 
       - name: Log in to GitHub Container Registry
         # Cheap belt-and-braces in case open-noodle/* packages ever go
@@ -279,7 +314,7 @@ jobs:
           stop_server
 
           ############################################################
-          # Step 9: boot Gallery (applies the 27 fork migrations)
+          # Step 9: boot Gallery (applies the fork migrations)
           #
           # We must wait for Gallery's geodata init to finish before stopping
           # the container. When Gallery's bundled geodata date differs from

--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -120,6 +120,10 @@ DROP TABLE IF EXISTS "shared_space_asset" CASCADE;
 DROP TABLE IF EXISTS "shared_space_member" CASCADE;
 DROP TABLE IF EXISTS "shared_space" CASCADE;
 
+-- Face identities
+DROP TABLE IF EXISTS "face_identity_face" CASCADE;
+DROP TABLE IF EXISTS "face_identity" CASCADE;
+
 -- User groups
 DROP TABLE IF EXISTS "user_group_member" CASCADE;
 DROP TABLE IF EXISTS "user_group" CASCADE;
@@ -164,6 +168,10 @@ ALTER TABLE "person"            DROP COLUMN IF EXISTS "species";
 ALTER TABLE "asset_job_status"  DROP COLUMN IF EXISTS "petsDetectedAt";
 ALTER TABLE "asset_job_status"  DROP COLUMN IF EXISTS "classifiedAt";
 ALTER TABLE "library"           DROP COLUMN IF EXISTS "createId";
+DROP INDEX IF EXISTS "asset_face_personId_idx";
+DROP INDEX IF EXISTS "person_ownerId_identityId_key";
+DROP INDEX IF EXISTS "person_identityId_idx";
+ALTER TABLE "person"            DROP COLUMN IF EXISTS "identityId";
 
 -- -----------------------------------------------------------------------------
 -- 5. Strip Gallery's merged 'classification' key out of system_metadata's
@@ -197,8 +205,16 @@ DELETE FROM "migration_overrides"
    'function_shared_space_member_delete_audit',
    'function_shared_space_member_delete_library_audit',
    'function_user_has_library_path',
+   'index_asset_face_personId_idx',
+   'index_face_identity_representativeFaceId_idx',
+   'index_person_identityId_idx',
+   'index_person_ownerId_identityId_key',
+   'index_shared_space_person_identityId_spaceId_idx',
+   'index_shared_space_person_spaceId_identityId_key',
    'trigger_asset_library_delete_audit',
    'trigger_classification_category_updatedAt',
+   'trigger_face_identity_face_updatedAt',
+   'trigger_face_identity_updatedAt',
    'trigger_library_after_insert',
    'trigger_library_user_delete_after_audit',
    'trigger_shared_space_asset_delete_audit',
@@ -324,6 +340,8 @@ DELETE FROM "kysely_migrations"
    '1778200000000-LibraryAuditTables',
    '1778210000000-AddLibrarySyncColumns',
    '1778300000000-AddLibraryUserTable',
+   '1778400000000-AddFaceIdentities',
+   '1778500000000-AddSpacePersonRepresentativeFaceSource',
 
    -- Post-v2.7.5 upstream migrations pulled in by rebase. Paired with the
    -- schema rollbacks in step 7 above.
@@ -358,7 +376,9 @@ BEGIN
       OR "name" LIKE '%LibraryAudit%'
       OR "name" LIKE '%LibrarySync%'
       OR "name" LIKE '%LibraryUser%'
-      OR "name" LIKE '%AddAssetDuplicateChecksum%';
+      OR "name" LIKE '%AddAssetDuplicateChecksum%'
+      OR "name" LIKE '%AddFaceIdentities%'
+      OR "name" LIKE '%AddSpacePersonRepresentativeFaceSource%';
   IF fork_rows_left > 0 THEN
     RAISE EXCEPTION 'revert-to-immich: % Gallery row(s) still present in kysely_migrations after cleanup — aborting.', fork_rows_left;
   END IF;
@@ -373,6 +393,7 @@ BEGIN
        'shared_space_person_face', 'shared_space_person',
        'shared_space_asset_audit', 'shared_space_member_audit',
        'shared_space_audit', 'shared_space_asset', 'shared_space_member',
+       'face_identity_face', 'face_identity',
        'shared_space', 'user_group_member', 'user_group',
        'classification_prompt_embedding', 'classification_category',
        'storage_migration_log', 'asset_duplicate_checksum'


### PR DESCRIPTION
## Summary
- remove the newest Gallery face identity migration rows and schema from `revert-to-immich.sql`
- run the revert validation workflow on upstream migration and version changes too
- add a fast migration coverage check before the Docker-backed validation

## Root cause
The failed nightly validation left `1778400000000-AddFaceIdentities` in `kysely_migrations`, so upstream Immich v2.7.5 aborted with `corrupted migrations: previously executed migration ... is missing`. The PR trigger also only watched `server/src/schema/migrations-gallery/**`, missing upstream migration changes in `server/src/schema/migrations/**` and version changes in `server/package.json`.

## Verification
- local static migration coverage check
- local Docker revert validation against `ghcr.io/open-noodle/immich-server:main` and upstream `immich-server:v2.7.5`
- `pnpm --filter immich test -- --run src/schema/composite-migration-provider.spec.ts` (ran full server unit suite due Vitest arg handling: 4180 passed, 9 skipped)
- `.github/node_modules/.bin/prettier --check .github/workflows/gallery-revert-to-immich-validation.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/gallery-revert-to-immich-validation.yml'); puts 'yaml ok'"`\n- `git diff --check`