### PR TITLE
docs: surface install CTA at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@
 </picture>
 </p>
 <h3 align="center">High performance self-hosted photo and video management solution</h3>
-<h4 align="center"><a href="https://demo.opennoodle.de">Try the live demo</a></h4>
+<h4 align="center">
+  <a href="https://opennoodle.de/install">Install in 5 minutes</a>
+  ·
+  <a href="https://demo.opennoodle.de">Try the live demo</a>
+</h4>
 <br/>
 
 > [!NOTE]
@@ -165,7 +169,7 @@ That's it. To switch back to upstream Immich later, flip the two image names bac
 
 - [Website](https://opennoodle.de)
 - [Documentation](https://docs.opennoodle.de/)
-- [Installation](https://docs.opennoodle.de/install/requirements)
+- [Installation](https://opennoodle.de/install)
 - [API Documentation](https://demo.opennoodle.de/doc) — interactive Swagger UI with all endpoints including fork-specific ones. Also available on your own instance at `/doc`
 - [Roadmap](https://opennoodle.de/roadmap)
 - [Features](#features)


### PR DESCRIPTION
## Summary
- Promotes a prominent **Install in 5 minutes → opennoodle.de/install** link to the top of the README, next to the existing demo link.
- Aligns the Links section's "Installation" entry to the same `opennoodle.de/install` URL so we have one canonical install destination from the GitHub landing.

## Why
GitHub README clicks today skew heavily toward `/roadmap` and `/features/shared-spaces/`. With no top-of-fold install CTA, visitors who scroll past the feature wall are more likely to bounce than to convert. Hoisting the install link into the same h4 row as the demo gives install equal billing without disrupting the rest of the page.

## Test plan
- [ ] Verify rendered README on the PR's "Files changed" tab shows the new h4 row with both links centered.
- [ ] Confirm both links resolve: https://opennoodle.de/install and https://demo.opennoodle.de.