### PR TITLE
docs: add Google Play link to mobile-app tip in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 > This is a **community fork** of [Immich](https://github.com/immich-app/immich) with additional features and improvements. Currently based on **Immich v2.7.5**. We regularly sync with upstream to stay up to date. See [What's Different](#whats-different-from-upstream-immich) below.
 
 > [!TIP]
-> **Noodle Gallery for iPhone is now on the App Store!** Back up your photos and browse your library on the go. [Download on the App Store](https://apps.apple.com/il/app/noodle-gallery/id6761776289)
+> **Noodle Gallery mobile apps are out!** Back up your photos and browse your library on the go. [Download on the App Store](https://apps.apple.com/il/app/noodle-gallery/id6761776289) · [Get it on Google Play](https://play.google.com/store/apps/details?id=de.opennoodle.gallery)
 
 > [!TIP]
 > **Already running Immich?** Switching to Gallery is a three-line config change — two image names in your `docker-compose.yml` and `IMMICH_VERSION=v4` in your `.env`. Your library, database, and mobile apps are fully compatible. See the [install guide](https://opennoodle.de/install/#migrate-from-immich).


### PR DESCRIPTION
## Summary
- Updates the mobile-app tip near the top of the README to mention both stores.
- Links to the Play Store listing alongside the existing App Store link, using the same `de.opennoodle.gallery` URL referenced from the docs site.

## Test plan
- [ ] On the rendered README, confirm the tip reads *"Noodle Gallery mobile apps are out!"* with both **Download on the App Store** and **Get it on Google Play** links.
- [ ] Click each link and verify the App Store and Play Store listings load.