### PR TITLE
fix: prevent classification scans from resetting face data

### DIFF
--- a/server/src/services/classification.service.spec.ts
+++ b/server/src/services/classification.service.spec.ts
@@ -4,15 +4,17 @@ import { authStub } from 'test/fixtures/auth.stub';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type ClassificationCategoryConfig = {
+  name: string;
+  prompts: string[];
+  similarity: number;
+  action: string;
+  enabled?: boolean;
+  faceExclusion?: 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
+};
+
 const makeClassificationConfig = (
-  categories: Array<{
-    name: string;
-    prompts: string[];
-    similarity: number;
-    action: string;
-    enabled?: boolean;
-    faceExclusion?: 'off' | 'any_assigned_face' | 'named_people' | 'named_visible_people';
-  }> = [],
+  categories: ClassificationCategoryConfig[] = [],
   enabled = true,
   facialRecognitionEnabled = true,
 ) => ({
@@ -26,6 +28,22 @@ const makeClassificationConfig = (
     facialRecognition: { enabled: facialRecognitionEnabled },
   },
 });
+
+const expectNoQueuedJob = (mocks: ServiceMocks, name: JobName) => {
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name,
+    data: expect.anything(),
+  });
+};
+
+const expectQueuedAssetClassify = (mocks: ServiceMocks, assetId: string) => {
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: assetId } }]);
+};
+
+const expectNoFacePrerequisiteQueues = (mocks: ServiceMocks) => {
+  expectNoQueuedJob(mocks, JobName.AssetDetectFacesQueueAll);
+  expectNoQueuedJob(mocks, JobName.FacialRecognitionQueueAll);
+};
 
 describe(ClassificationService.name, () => {
   let sut: ClassificationService;
@@ -749,6 +767,26 @@ describe(ClassificationService.name, () => {
   });
 
   describe('handleClassifyQueueAll', () => {
+    const queueAsset = { id: 'asset-1', ownerId: 'user-1' };
+    const peopleCategory: ClassificationCategoryConfig = {
+      name: 'People',
+      prompts: ['a portrait'],
+      similarity: 0.8,
+      action: 'tag',
+      faceExclusion: 'named_people',
+    };
+
+    const setupQueueAll = (
+      categories: ClassificationCategoryConfig[] = [],
+      enabled = true,
+      facialRecognitionEnabled = true,
+    ) => {
+      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([queueAsset]));
+      sut['getConfig'] = vi
+        .fn()
+        .mockResolvedValue(makeClassificationConfig(categories, enabled, facialRecognitionEnabled));
+    };
+
     it('should stream unclassified assets and queue jobs in batches', async () => {
       const assets = [
         { id: 'a1', ownerId: 'user-1' },
@@ -805,62 +843,68 @@ describe(ClassificationService.name, () => {
       expect(mocks.classification.streamUnclassifiedAssets).not.toHaveBeenCalled();
     });
 
-    it('should queue face work before forced classification when enabled categories are face-aware', async () => {
-      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig([
-          {
-            name: 'People',
-            prompts: ['a portrait'],
-            similarity: 0.8,
-            action: 'tag',
-            faceExclusion: 'named_people',
-          },
-        ]),
-      );
+    it('should not queue face prerequisites before forced classification when enabled categories are face-aware', async () => {
+      setupQueueAll([peopleCategory]);
 
       await sut.handleClassifyQueueAll({ force: true });
 
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.AssetDetectFacesQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.FacialRecognitionQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: 'asset-1' } }]);
+      expectNoFacePrerequisiteQueues(mocks);
+      expectQueuedAssetClassify(mocks, queueAsset.id);
+    });
+
+    it('should not queue face work when forced classification has no enabled face-aware categories', async () => {
+      setupQueueAll([
+        {
+          name: 'Screenshots',
+          prompts: ['screenshot'],
+          similarity: 0.8,
+          action: 'tag',
+          faceExclusion: 'off',
+        },
+        { ...peopleCategory, name: 'DisabledPeopleRule', enabled: false },
+      ]);
+
+      await sut.handleClassifyQueueAll({ force: true });
+
+      expectNoFacePrerequisiteQueues(mocks);
+      expectQueuedAssetClassify(mocks, queueAsset.id);
+    });
+
+    it('should not queue face prerequisites for non-forced classification scans', async () => {
+      setupQueueAll([peopleCategory]);
+
+      await sut.handleClassifyQueueAll({ force: false });
+
+      expect(mocks.classification.resetClassifiedAt).not.toHaveBeenCalled();
+      expectNoFacePrerequisiteQueues(mocks);
+      expectQueuedAssetClassify(mocks, queueAsset.id);
     });
 
     it('should not queue face work before forced classification when facial recognition is disabled', async () => {
-      mocks.classification.streamUnclassifiedAssets.mockReturnValue(makeStream([{ id: 'asset-1', ownerId: 'user-1' }]));
-      sut['getConfig'] = vi.fn().mockResolvedValue(
-        makeClassificationConfig(
-          [
-            {
-              name: 'People',
-              prompts: ['a portrait'],
-              similarity: 0.8,
-              action: 'tag',
-              faceExclusion: 'named_people',
-            },
-          ],
-          true,
-          false,
-        ),
-      );
+      setupQueueAll([peopleCategory], true, false);
 
       await sut.handleClassifyQueueAll({ force: true });
 
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.AssetDetectFacesQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.FacialRecognitionQueueAll,
-        data: { force: true },
-      });
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetClassify, data: { id: 'asset-1' } }]);
+      expectNoFacePrerequisiteQueues(mocks);
+      expectQueuedAssetClassify(mocks, queueAsset.id);
+    });
+
+    it('should not queue face prerequisites when multiple enabled categories are face-aware', async () => {
+      setupQueueAll([
+        peopleCategory,
+        {
+          name: 'AssignedFaces',
+          prompts: ['person'],
+          similarity: 0.8,
+          action: 'tag',
+          faceExclusion: 'any_assigned_face',
+        },
+      ]);
+
+      await sut.handleClassifyQueueAll({ force: true });
+
+      expectNoFacePrerequisiteQueues(mocks);
+      expectQueuedAssetClassify(mocks, queueAsset.id);
     });
   });
 

--- a/server/src/services/classification.service.ts
+++ b/server/src/services/classification.service.ts
@@ -107,7 +107,7 @@ export class ClassificationService extends BaseService {
 
   @OnJob({ name: JobName.AssetClassifyQueueAll, queue: QueueName.Classification })
   async handleClassifyQueueAll({ force }: JobOf<JobName.AssetClassifyQueueAll>): Promise<JobStatus> {
-    const { classification, machineLearning } = await this.getConfig({ withCache: true });
+    const { classification } = await this.getConfig({ withCache: true });
 
     if (!classification.enabled) {
       return JobStatus.Skipped;
@@ -115,15 +115,6 @@ export class ClassificationService extends BaseService {
 
     if (force) {
       await this.classificationRepository.resetClassifiedAt();
-    }
-
-    const faceAwareCategories = classification.categories.filter(
-      (category) => category.enabled && this.isFaceAwareCategory(category),
-    );
-
-    if (force && faceAwareCategories.length > 0 && isFacialRecognitionEnabled(machineLearning)) {
-      await this.jobRepository.queue({ name: JobName.AssetDetectFacesQueueAll, data: { force: true } });
-      await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
     }
 
     const stream = this.classificationRepository.streamUnclassifiedAssets();


### PR DESCRIPTION
## Summary
- Prevent forced Auto classification scans from queueing destructive face resets.
- Do not queue face-detection or facial-recognition prerequisite jobs from classification scans.
- Keep face detection and recognition owned by the normal face pipeline; classification only reads current face/person state.
- Add regression coverage ensuring classification does not dispatch `AssetDetectFacesQueueAll` or `FacialRecognitionQueueAll`, including forced face-aware scans.

Fixes #523.

## Cause
Auto classification's \"Scan all libraries\" path queues `AssetClassifyQueueAll` with `force: true`, which is appropriate for classification because it clears `classifiedAt` and re-evaluates assets against the current rules.

The bug was that `ClassificationService.handleClassifyQueueAll` reused that forced scan context for face prerequisites whenever an enabled category had `faceExclusion` enabled. It queued `AssetDetectFacesQueueAll` and `FacialRecognitionQueueAll` with `force: true`.

Those force flags are destructive by design in the face pipeline: forced face detection deletes ML faces and runs person cleanup, and forced facial recognition unassigns ML faces, unlinks identities, and wipes shared-space person state. So a classification rerun could wipe people/faces as a side effect of trying to make face-aware classification rules accurate.

## Final behavior
Classification still uses face/person state for face-exclusion rules, but it should not start or reset global face jobs. The new behavior is:

- forced classification resets only classification state (`classifiedAt`)
- classification never queues `AssetDetectFacesQueueAll`
- classification never queues `FacialRecognitionQueueAll`
- face detection and recognition remain owned by the normal ML/face pipeline
- classification jobs continue to wait for already-running face-detection/facial-recognition queues before reading face summaries

## Why this was missed
- The existing unit test encoded the wrong behavior: it explicitly expected forced classification with face-aware categories to queue forced face work.
- The implementation conflated two separate responsibilities: classification needs to read current face/person state, but it should not own destructive face reset or broad face-job scheduling.
- The test coverage checked that face work was queued, but did not assert that classification must never dispatch destructive face resets, broad facial-recognition sweeps, or global face-detection sweeps.

## Test Plan
- [x] `pnpm --dir server format`
- [x] `pnpm --dir server test src/services/classification.service.spec.ts --run`
- [x] `pnpm --dir server check`
- [x] `pnpm --dir server lint`
- [x] `git diff --check`