### PR TITLE
ci: allow explicit server hotfix release branches

### DIFF
--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -36,14 +36,34 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Require main branch
+      - name: Require main or release branch
         env:
           REF: ${{ github.ref_name }}
+          VERSION: ${{ inputs.version }}
         run: |
-          if [[ "$REF" != "main" ]]; then
-            echo "::error::Releases must be triggered from main (got: $REF)"
-            exit 1
+          set -euo pipefail
+
+          if [[ "$REF" == "main" ]]; then
+            exit 0
           fi
+
+          if [[ "$REF" == release/* ]]; then
+            if [[ -z "$VERSION" ]]; then
+              echo "::error::Server-only releases from release/* branches require an explicit version input."
+              exit 1
+            fi
+
+            if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Version must be a full semver tag like v4.55.2 (got: $VERSION)"
+              exit 1
+            fi
+
+            echo "Release branch $REF with explicit version $VERSION. Proceeding."
+            exit 0
+          fi
+
+          echo "::error::Releases must be triggered from main or release/* (got: $REF)"
+          exit 1
 
       - name: Fail if a mobile release draft is pending
         env:


### PR DESCRIPTION
## Summary
- allow `gallery-release-server-only.yml` to run from `release/*` branches when an explicit full semver version is provided
- keep existing auto-version behavior restricted to `main`
- live AWS OIDC trust for `noodle-prod-gallery-release-version-upload` has been updated to allow `main` and `release/*` for this repo

## Why
The `v4.55.2` hotfix release created the tag/release/images successfully, but the final version endpoint upload failed because the AWS trust policy only allowed `refs/heads/main`. The endpoint had to be repaired manually.

## Verification
- `git diff --check`
- YAML parsed with Ruby `YAML.load_file`
- local guard simulation: `main` passes, `release/*` with `vX.Y.Z` passes, missing/invalid versions fail, unrelated branches fail
- verified IAM trust policy now allows `repo:open-noodle/gallery:ref:refs/heads/main` and `repo:open-noodle/gallery:ref:refs/heads/release/*` with `aud=sts.amazonaws.com`

No release workflow was dispatched by this PR.