### PR TITLE
fix: preserve inherited space person names

### DIFF
--- a/e2e-auth-server/Dockerfile
+++ b/e2e-auth-server/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.1.0-alpine3.20@sha256:8fe019e0d57dbdce5f5c27c0b63d2775cf34b00e3755a7dea969802d7e0c2b25
 RUN corepack enable
-ADD package.json *.ts ./
+ADD package.json pnpm-workspace.yaml *.ts ./
 RUN pnpm install
 EXPOSE 2286
 CMD ["pnpm", "run", "start"]

--- a/e2e-auth-server/package.json
+++ b/e2e-auth-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@immich/e2e-auth-server",
   "version": "0.1.0",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "type": "module",
   "main": "auth-server.ts",
   "scripts": {

--- a/e2e-auth-server/pnpm-workspace.yaml
+++ b/e2e-auth-server/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -5412,6 +5412,109 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
     });
 
+    it('should prefer a personal profile name over a space-derived name at the same priority', async () => {
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const identityId = newUuid();
+      const personalPersonId = newUuid();
+      const otherSpacePersonId = newUuid();
+      const person = factory.sharedSpacePerson({ id: personId, spaceId, identityId, nameSource: 'none' });
+
+      mocks.sharedSpace.getSpacePersonMetadataBackfillPage.mockResolvedValue([person]);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(person);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: otherSpacePersonId,
+          sourceProfileType: 'space-person',
+          sourceProfileId: otherSpacePersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Space Name',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: true,
+        },
+        {
+          personId: personalPersonId,
+          sourceProfileType: 'user-person',
+          sourceProfileId: personalPersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Personal Name',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: true,
+        },
+      ]);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(person);
+
+      const result = await sut.backfillSpacePersonMetadata({ limit: 50 });
+
+      expect(result).toEqual({ processed: 1, inherited: 1, skipped: 0 });
+      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(
+        personId,
+        expect.objectContaining({
+          name: 'Personal Name',
+          nameSource: 'inherited',
+          nameSourceProfileType: 'user-person',
+          nameSourceProfileId: personalPersonId,
+        }),
+      );
+    });
+
+    it('should keep an inherited name when candidate names conflict', async () => {
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const identityId = newUuid();
+      const person = factory.sharedSpacePerson({
+        id: personId,
+        spaceId,
+        identityId,
+        name: 'Existing Alice',
+        nameSource: 'inherited',
+      });
+
+      mocks.sharedSpace.getSpacePersonMetadataBackfillPage.mockResolvedValue([person]);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(person);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: newUuid(),
+          userId: newUuid(),
+          role: SharedSpaceRole.Editor,
+          name: 'Alice One',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: false,
+        },
+        {
+          personId: newUuid(),
+          userId: newUuid(),
+          role: SharedSpaceRole.Editor,
+          name: 'Alice Two',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: false,
+        },
+      ]);
+
+      const result = await sut.backfillSpacePersonMetadata({ limit: 50 });
+
+      expect(result).toEqual({ processed: 1, inherited: 0, skipped: 1 });
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+    });
+
     it('should queue the next chunk without starting the backfill automatically elsewhere', async () => {
       const person = factory.sharedSpacePerson({ identityId: newUuid() });
       mocks.sharedSpace.getSpacePersonMetadataBackfillPage.mockResolvedValue([person]);

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -65,6 +65,7 @@ const ROLE_HIERARCHY: Record<SharedSpaceRole, number> = {
 };
 
 const getSharedSpaceRoleScore = (role: string) => ROLE_HIERARCHY[role as SharedSpaceRole] ?? 0;
+const getMetadataSourceScore = (sourceProfileType?: string | null) => (sourceProfileType === 'user-person' ? 1 : 0);
 
 type SpacePersonMatchResult = {
   id: string;
@@ -2129,12 +2130,11 @@ export class SharedSpaceService extends BaseService {
     const candidates = metadataCandidates.filter((item) => item.type === person.type);
     const updates: Parameters<typeof this.sharedSpaceRepository.updatePerson>[1] = {};
     const now = new Date();
-    const nameCandidate = this.selectMetadataCandidate(
-      candidates.filter((candidate) => candidate.name.trim().length > 0),
-      (candidate) => candidate.name.trim(),
-    );
+    const nameCandidates = candidates.filter((candidate) => candidate.name.trim().length > 0);
+    const birthDateCandidates = candidates.filter((candidate) => candidate.birthDate !== null);
+    const nameCandidate = this.selectMetadataCandidate(nameCandidates, (candidate) => candidate.name.trim());
     const birthDateCandidate = this.selectMetadataCandidate(
-      candidates.filter((candidate) => candidate.birthDate !== null),
+      birthDateCandidates,
       (candidate) => asBirthDateString(candidate.birthDate) ?? '',
     );
 
@@ -2144,7 +2144,7 @@ export class SharedSpaceService extends BaseService {
       updates.nameSourceProfileType = nameCandidate.candidate.sourceProfileType ?? 'user-person';
       updates.nameSourceProfileId = nameCandidate.candidate.sourceProfileId ?? nameCandidate.candidate.personId;
       updates.nameSourceUpdatedAt = now;
-    } else if (person.nameSource === 'inherited' && !nameCandidate) {
+    } else if (person.nameSource === 'inherited' && nameCandidates.length === 0) {
       updates.name = '';
       updates.nameSource = 'none';
       updates.nameSourceProfileType = null;
@@ -2159,7 +2159,7 @@ export class SharedSpaceService extends BaseService {
       updates.birthDateSourceProfileId =
         birthDateCandidate.candidate.sourceProfileId ?? birthDateCandidate.candidate.personId;
       updates.birthDateSourceUpdatedAt = now;
-    } else if (person.birthDateSource === 'inherited' && !birthDateCandidate) {
+    } else if (person.birthDateSource === 'inherited' && birthDateCandidates.length === 0) {
       updates.birthDate = null;
       updates.birthDateSource = 'none';
       updates.birthDateSourceProfileType = null;
@@ -2174,10 +2174,9 @@ export class SharedSpaceService extends BaseService {
     return false;
   }
 
-  private selectMetadataCandidate<T extends { role: string; isAssetAdder: boolean; supportingFaceCount: number }>(
-    candidates: T[],
-    getValue: (candidate: T) => string,
-  ): { candidate: T; value: string } | null {
+  private selectMetadataCandidate<
+    T extends { role: string; isAssetAdder: boolean; supportingFaceCount: number; sourceProfileType?: string | null },
+  >(candidates: T[], getValue: (candidate: T) => string): { candidate: T; value: string } | null {
     if (candidates.length === 0) {
       return null;
     }
@@ -2197,6 +2196,11 @@ export class SharedSpaceService extends BaseService {
         if (faceDelta !== 0) {
           return faceDelta;
         }
+        const sourceDelta =
+          getMetadataSourceScore(b.candidate.sourceProfileType) - getMetadataSourceScore(a.candidate.sourceProfileType);
+        if (sourceDelta !== 0) {
+          return sourceDelta;
+        }
         return 0;
       });
 
@@ -2205,7 +2209,8 @@ export class SharedSpaceService extends BaseService {
       (item) =>
         getSharedSpaceRoleScore(item.candidate.role) === getSharedSpaceRoleScore(best.role) &&
         item.candidate.isAssetAdder === best.isAssetAdder &&
-        Number(item.candidate.supportingFaceCount) === Number(best.supportingFaceCount),
+        Number(item.candidate.supportingFaceCount) === Number(best.supportingFaceCount) &&
+        getMetadataSourceScore(item.candidate.sourceProfileType) === getMetadataSourceScore(best.sourceProfileType),
     );
     const values = new Set(topCandidates.map((item) => item.value));
     return values.size === 1 ? ranked[0] : null;


### PR DESCRIPTION
## Summary
- preserve inherited shared-space person metadata when candidate names conflict
- prefer personal profile metadata over space-derived metadata when all other priority signals tie
- add regression coverage for both cases

## Tests
- pnpm --dir server exec vitest --config test/vitest.config.mjs src/services/shared-space.service.spec.ts --run
- pnpm --dir server run check
- pnpm --dir server exec prettier --check src/services/shared-space.service.ts src/services/shared-space.service.spec.ts