### PR TITLE
feat: improve shared-space face recognition fanout

### DIFF
--- a/docs/superpowers/specs/2026-05-07-shared-space-recognition-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-07-shared-space-recognition-pipeline-design.md
@@ -1,0 +1,171 @@
+# Shared Space Recognition Pipeline Design
+
+## Problem
+
+Large facial-recognition runs can create a massive `facialRecognition` queue backlog when shared spaces are enabled. The current recognition handler runs once per face, but it queues shared-space matching per asset and per space. Because an asset can have many faces and can belong to multiple spaces, the same asset-level shared-space match can be queued repeatedly during a single full run.
+
+The observed production report showed `SharedSpaceFaceMatch` jobs being appended while the queue was still draining older `FacialRecognition` jobs. Some older Redis wait-list entries also had no job hash, so the queue contained stale IDs from a prior inconsistent state. Even without a true infinite loop, this queue shape can make users wait many hours or days for large libraries.
+
+## Goals
+
+- Make full or force facial recognition scale with shared-space asset pages, not with `faces * spaces`.
+- Preserve the current single-queue ordering guarantees for face-related work.
+- Preserve shared-space people correctness after force recognition, imports, metadata refresh, library sync, duplicate merge, and manual asset additions.
+- Bound Redis job counts for large spaces.
+- Coalesce duplicate asset-level shared-space matches.
+- Add TDD coverage proving the new pipeline still assigns faces, deduplicates people, and avoids the old fan-out.
+
+## Non-Goals
+
+- Rewriting face clustering or identity matching.
+- Adding a new database-backed work-claim table.
+- Adding a separate shared-space recognition queue in this phase.
+- Changing shared-space membership or asset visibility semantics.
+- Removing single-asset shared-space matching for incremental updates.
+
+## Chosen Architecture
+
+Keep all face-related jobs in `QueueName.FacialRecognition`, but change full rebuilds from per-face shared-space fan-out to paged shared-space rebuild jobs.
+
+During force/full recognition, `handleQueueRecognizeFaces` clears obsolete pending `facialRecognition` work, clears the personal and shared-space person state, queues one `FacialRecognition` job per visible face with `skipSharedSpaceMatch: true`, and then queues one `SharedSpaceFaceMatchAll` dispatcher per face-recognition-enabled space. Because all of these jobs stay in the same single-concurrency queue, the shared-space rebuild dispatchers run only after personal recognition has finished.
+
+`SharedSpaceFaceMatchAll` becomes a dispatcher. It does not process all assets in one long job and does not enqueue one job per asset. It queues the first `SharedSpaceFaceMatchPage` job for its space. Each page processes up to `N` assets in stable keyset order with the existing `processSpaceFaceMatch(spaceId, assetId)` helper. If another page exists, the current page queues the next page. The final page queues deduplication and identity reconciliation once for the space.
+
+Incremental changes continue to use asset-level matching. `handleRecognizeFaces` can still queue `SharedSpaceFaceMatch` when `skipSharedSpaceMatch` is false. Direct sources such as metadata import, manual asset additions, library sync, and duplicate merge also queue asset-level `SharedSpaceFaceMatch` jobs when they know the affected assets. Those jobs get stable BullMQ ids by `(spaceId, assetId)` so repeated work collapses while pending.
+
+This option does not preclude a future separate `sharedSpaceRecognition` queue. The new page job boundary and stable asset-level job ids are reusable if the queue is split later.
+
+## Queue Model
+
+Keep handlers on `QueueName.FacialRecognition`:
+
+- `FacialRecognitionQueueAll`
+- `FacialRecognition`
+- `SharedSpaceFaceMatch`
+- `SharedSpaceFaceMatchAll`
+- `SharedSpaceFaceMatchPage`
+- `SharedSpaceLibraryFaceSync`
+- `SharedSpaceIdentityReconciliation`
+- `SharedSpacePersonDedup`
+
+Keep `SharedSpacePersonMetadataBackfill` on `QueueName.PeopleBackfill`.
+
+Add or reshape jobs:
+
+- `FacialRecognition`: add `skipSharedSpaceMatch?: boolean` to the job data. Force/full recognition sets it to `true`; incremental recognition leaves it false.
+- `SharedSpaceFaceMatch`: asset-level incremental match, data `{ spaceId, assetId }`, stable job id `shared-space-face-match/<spaceId>/<assetId>`, `removeOnComplete: true`.
+- `SharedSpaceFaceMatchAll`: dispatcher for all assets in one space, data `{ spaceId }`, stable job id `shared-space-face-match-all/<spaceId>`, `removeOnComplete: true`.
+- `SharedSpaceFaceMatchPage`: rebuild page, data `{ spaceId, afterAssetId?, batchSize? }`, stable job id by page cursor, `removeOnComplete: true`.
+
+## Force Recognition Flow
+
+1. User starts `facialRecognition` with `force=true`.
+2. The queue start command treats `force=true` on `QueueName.FacialRecognition` as "replace pending work": it drains waiting and delayed jobs before enqueueing `FacialRecognitionQueueAll`, even if one facial-recognition job is currently active. Other queues and non-force starts keep the existing "cannot start while active" behavior.
+3. When `FacialRecognitionQueueAll` becomes active, it drains waiting and delayed `facialRecognition` work again. This second drain catches any old active job that finished after the start command and enqueued stale follow-up work.
+4. It clears personal and shared-space person state as it does today.
+5. It queues one `FacialRecognition` job per visible face with `skipSharedSpaceMatch: true`.
+6. It queues one `SharedSpaceFaceMatchAll` dispatcher per face-recognition-enabled space after the personal face jobs.
+7. Each `FacialRecognition` job handles personal clustering only.
+8. Each `SharedSpaceFaceMatchAll` queues the first page for its space.
+9. Each page processes a bounded asset page and queues the next page when needed.
+10. The final page queues one dedup job and one identity reconciliation request for the space.
+
+For a space with 220,000 assets and page size 1,000, the rebuild uses about 220 page jobs instead of hundreds of thousands of per-face/per-space jobs.
+
+## Incremental Flow
+
+Incremental events still update shared-space people quickly:
+
+1. Source event identifies affected assets.
+2. Service queues `SharedSpaceFaceMatch` for each affected `(spaceId, assetId)`.
+3. `JobRepository` supplies stable job ids so duplicate pending asset matches collapse.
+4. Handler processes all eligible faces on the asset and queues dedup/reconciliation for affected people.
+
+Because the jobs remain in `facialRecognition`, an asset-level match queued by one face-recognition job waits behind older recognition jobs already in the queue. This preserves the existing ordering model and avoids the cross-queue race where shared-space matching could run before later faces on the same asset are recognized.
+
+## Race-Condition Safeguards
+
+- No new cross-queue ordering boundary is introduced.
+- Force recognition drains obsolete waiting and delayed `facialRecognition` work before enqueueing the replacement run and again before deleting shared-space person state.
+- `FacialRecognition` stays single-concurrency.
+- Page chains are sequential. A page queues the next page only after it finishes processing its current page.
+- Page jobs re-check that the space still exists and still has face recognition enabled before each page.
+- Asset-level shared-space jobs are idempotent and deduped by `(spaceId, assetId)` while pending.
+- Final dedup/reconciliation is queued after the final page only, not after every asset in a rebuild.
+- A future split into a separate queue requires a separate design and tests proving cross-queue ordering safety.
+
+## Existing Queue Behavior
+
+Deploying this change does not rewrite existing Redis job data. Already queued `FacialRecognition` jobs that were created before the change will not have `skipSharedSpaceMatch: true`, so if users simply let an old backlog continue, those old jobs can still produce the old fan-out shape.
+
+The supported path for an already-ballooned queue is to start `facialRecognition` again with `force=true` after deploying. That force start replaces pending waiting and delayed work with a new paged rebuild. It does not require a manual server restart beyond the normal deployment restart. It does not remove the currently active job; the active job is allowed to finish, then `FacialRecognitionQueueAll` drains any stale follow-up work before clearing and rebuilding state.
+
+## Error Handling
+
+- Page jobs are idempotent. `processSpaceFaceMatch` already skips faces assigned in the space; tests must preserve that guarantee.
+- If a page fails, BullMQ records the failure and the failed page can be retried.
+- A retried page may reprocess some assets, but assigned-face checks and insert conflict handling prevent duplicate `shared_space_person_face` rows.
+- If a space is deleted or face recognition is disabled between pages, the page exits without queuing the next page, dedup, or reconciliation.
+- Stable job ids must not prevent future legitimate work after completion; use `removeOnComplete: true`.
+- Failed shared-space match, page, dedupe, and reconciliation jobs remain visible. They should not use `removeOnFail: true`, because silently removing failed work would hide correctness problems. A failed stable-id job can block a duplicate until the failed job is retried or cleared; that is preferable to hiding data-loss symptoms.
+
+## TDD and Test Coverage
+
+Use test-driven development for each behavior change. Every production change must have a failing test first, and the implementation must be the smallest change that turns that test green. Do not batch multiple behavior changes under one broad test.
+
+Unit regression tests must prove:
+
+- Force-starting `facialRecognition` with `force=true` drains obsolete waiting and delayed jobs before enqueueing `FacialRecognitionQueueAll`.
+- Force-starting `facialRecognition` with `force=true` is allowed while one facial-recognition job is active; non-force starts and other queues keep the existing active-job rejection.
+- `FacialRecognitionQueueAll` drains obsolete waiting and delayed jobs again before clearing shared-space person tables.
+- Force recognition queues `FacialRecognition` jobs with `skipSharedSpaceMatch: true`.
+- Force recognition queues `SharedSpaceFaceMatchAll` after personal recognition jobs.
+- `handleRecognizeFaces` does not queue `SharedSpaceFaceMatch` when `skipSharedSpaceMatch` is true.
+- Incremental `handleRecognizeFaces` still queues `SharedSpaceFaceMatch` when `skipSharedSpaceMatch` is false.
+- `SharedSpaceFaceMatch` uses stable job ids by `(spaceId, assetId)` and avoids `addBulk`.
+- `SharedSpaceFaceMatchAll` dispatches the first `SharedSpaceFaceMatchPage` instead of processing all assets or queueing per-asset jobs.
+- `SharedSpaceFaceMatchPage` uses keyset pages and queues the next page only when needed.
+- Final page queues dedup and identity reconciliation once per space.
+- Empty spaces, deleted spaces, and disabled face recognition do not queue follow-up work.
+- Handler metadata confirms all face-related shared-space jobs remain on `QueueName.FacialRecognition`.
+
+Edge-case coverage must include:
+
+- Existing pre-deploy `FacialRecognition` job data without `skipSharedSpaceMatch` keeps incremental behavior unless replaced by a force run.
+- Old active job finishing after force-start drain but before `FacialRecognitionQueueAll` is handled by the second drain.
+- Asset with multiple faces queues one pending `SharedSpaceFaceMatch` by stable job id, not one distinct job per face.
+- Asset in multiple spaces queues one asset match per space.
+- A page with zero assets queues no dedup/reconciliation.
+- A page with fewer than `batchSize` assets processes once and queues final follow-up once.
+- A page with exactly `batchSize` assets queues one follow-up page without duplicating the last asset.
+- A page with `batchSize + 1` assets processes the second page and queues final dedup once.
+- Retry after partial page progress skips already-assigned faces.
+- Space disabled between pages stops the chain and does not queue dedup/reconciliation.
+- Failed shared-space jobs remain visible.
+
+Medium/integration tests must prove:
+
+- Existing `processSpaceFaceMatch` scenarios still assign faces and remain idempotent on retry.
+- Existing shared-space identity reconciliation and dedup tests still pass.
+- A force-style flow with multiple faces on the same asset produces correct shared-space people without duplicate `shared_space_person_face` assignments.
+- Direct incremental sources such as metadata import and manual asset add still update shared-space people.
+
+Verification must run:
+
+- Focused unit specs for `job.repository`, `person.service`, `shared-space.service`, and `queue.service` if queue semantics change.
+- Medium shared-space/person identity specs that exercise real database behavior.
+- Server typecheck.
+
+## Rollout
+
+Implement in two steps:
+
+1. Coalesce asset-level shared-space match jobs with stable job ids.
+2. Change force recognition to suppress per-face shared-space fan-out and dispatch paged same-queue shared-space rebuilds.
+
+After deployment, verify on a large instance:
+
+- `facialRecognition` drains without unbounded `SharedSpaceFaceMatch` growth.
+- Queue count remains near `enabledSpaces * pages`, not `faces * spaces`.
+- Shared-space people still appear after the rebuild completes.
+- Failed jobs are meaningful real failures, not stale duplicated work.

--- a/mobile/openapi/lib/model/job_name.dart
+++ b/mobile/openapi/lib/model/job_name.dart
@@ -85,6 +85,7 @@ class JobName {
   static const storageBackendMigrationSingle = JobName._(r'StorageBackendMigrationSingle');
   static const sharedSpaceFaceMatch = JobName._(r'SharedSpaceFaceMatch');
   static const sharedSpaceFaceMatchAll = JobName._(r'SharedSpaceFaceMatchAll');
+  static const sharedSpaceFaceMatchPage = JobName._(r'SharedSpaceFaceMatchPage');
   static const sharedSpaceLibraryFaceSync = JobName._(r'SharedSpaceLibraryFaceSync');
   static const sharedSpaceIdentityReconciliation = JobName._(r'SharedSpaceIdentityReconciliation');
   static const sharedSpacePersonDedup = JobName._(r'SharedSpacePersonDedup');
@@ -157,6 +158,7 @@ class JobName {
     storageBackendMigrationSingle,
     sharedSpaceFaceMatch,
     sharedSpaceFaceMatchAll,
+    sharedSpaceFaceMatchPage,
     sharedSpaceLibraryFaceSync,
     sharedSpaceIdentityReconciliation,
     sharedSpacePersonDedup,
@@ -264,6 +266,7 @@ class JobNameTypeTransformer {
         case r'StorageBackendMigrationSingle': return JobName.storageBackendMigrationSingle;
         case r'SharedSpaceFaceMatch': return JobName.sharedSpaceFaceMatch;
         case r'SharedSpaceFaceMatchAll': return JobName.sharedSpaceFaceMatchAll;
+        case r'SharedSpaceFaceMatchPage': return JobName.sharedSpaceFaceMatchPage;
         case r'SharedSpaceLibraryFaceSync': return JobName.sharedSpaceLibraryFaceSync;
         case r'SharedSpaceIdentityReconciliation': return JobName.sharedSpaceIdentityReconciliation;
         case r'SharedSpacePersonDedup': return JobName.sharedSpacePersonDedup;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -22760,6 +22760,7 @@
           "StorageBackendMigrationSingle",
           "SharedSpaceFaceMatch",
           "SharedSpaceFaceMatchAll",
+          "SharedSpaceFaceMatchPage",
           "SharedSpaceLibraryFaceSync",
           "SharedSpaceIdentityReconciliation",
           "SharedSpacePersonDedup",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -8840,6 +8840,7 @@ export enum JobName {
     StorageBackendMigrationSingle = "StorageBackendMigrationSingle",
     SharedSpaceFaceMatch = "SharedSpaceFaceMatch",
     SharedSpaceFaceMatchAll = "SharedSpaceFaceMatchAll",
+    SharedSpaceFaceMatchPage = "SharedSpaceFaceMatchPage",
     SharedSpaceLibraryFaceSync = "SharedSpaceLibraryFaceSync",
     SharedSpaceIdentityReconciliation = "SharedSpaceIdentityReconciliation",
     SharedSpacePersonDedup = "SharedSpacePersonDedup",

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -791,6 +791,7 @@ export enum JobName {
   // Shared Space Face Recognition
   SharedSpaceFaceMatch = 'SharedSpaceFaceMatch',
   SharedSpaceFaceMatchAll = 'SharedSpaceFaceMatchAll',
+  SharedSpaceFaceMatchPage = 'SharedSpaceFaceMatchPage',
   SharedSpaceLibraryFaceSync = 'SharedSpaceLibraryFaceSync',
   SharedSpaceIdentityReconciliation = 'SharedSpaceIdentityReconciliation',
   SharedSpacePersonDedup = 'SharedSpacePersonDedup',

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -313,7 +313,7 @@ describe(JobRepository.name, () => {
   );
 
   it.each(['waiting', 'delayed', 'paused'] as const)(
-    'upgrades a pending %s non-force facial-recognition coordinator when force is requested',
+    'replaces a pending %s non-force facial-recognition coordinator when force is requested',
     async (state) => {
       const { sut, queue } = setup();
       const existingJob = {
@@ -329,11 +329,38 @@ describe(JobRepository.name, () => {
 
       expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
       expect(existingJob.getState).toHaveBeenCalled();
-      expect(existingJob.remove).not.toHaveBeenCalled();
-      expect(existingJob.updateData).toHaveBeenCalledWith({ force: true });
-      expect(queue.add).not.toHaveBeenCalled();
+      expect(existingJob.remove).toHaveBeenCalled();
+      expect(existingJob.updateData).not.toHaveBeenCalled();
+      expect(queue.drain).toHaveBeenCalledWith(true);
+      expect(queue.add).toHaveBeenCalledWith(
+        JobName.FacialRecognitionQueueAll,
+        { force: true },
+        {
+          jobId: JobName.FacialRecognitionQueueAll,
+          removeOnComplete: true,
+        },
+      );
     },
   );
+
+  it('drains pending facial-recognition work before queueing a new force coordinator', async () => {
+    const { sut, queue } = setup();
+    setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+    await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+    expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+    expect(queue.drain).toHaveBeenCalledWith(true);
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FacialRecognitionQueueAll,
+      { force: true },
+      {
+        jobId: JobName.FacialRecognitionQueueAll,
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.drain.mock.invocationCallOrder[0]).toBeLessThan(queue.add.mock.invocationCallOrder[0]);
+  });
 
   it('queues a force follow-up coordinator when a non-force coordinator is active', async () => {
     const { sut, queue } = setup();
@@ -380,6 +407,28 @@ describe(JobRepository.name, () => {
     expect(existingJob.getState).toHaveBeenCalled();
     expect(existingJob.remove).not.toHaveBeenCalled();
     expect(existingJob.updateData).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('does not queue another coordinator when the force follow-up coordinator is already active', async () => {
+    const { sut, queue } = setup();
+    const activeForceFollowUp = {
+      data: { force: true },
+      getState: vi.fn().mockResolvedValue('active'),
+      remove: vi.fn().mockResolvedValue(undefined),
+    };
+    queue.getJob.mockImplementation(async (jobId: string) =>
+      jobId === 'FacialRecognitionQueueAll/force' ? activeForceFollowUp : undefined,
+    );
+    setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+    await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+    expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+    expect(queue.getJob).toHaveBeenCalledWith('FacialRecognitionQueueAll/force');
+    expect(activeForceFollowUp.getState).toHaveBeenCalled();
+    expect(activeForceFollowUp.remove).not.toHaveBeenCalled();
+    expect(queue.drain).not.toHaveBeenCalled();
     expect(queue.add).not.toHaveBeenCalled();
   });
 

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -27,6 +27,9 @@ const setup = (counts: JobCounts[] = []) => {
   const queue = {
     add: vi.fn().mockResolvedValue({}),
     addBulk: vi.fn().mockResolvedValue([]),
+    clean: vi.fn().mockResolvedValue([]),
+    drain: vi.fn().mockResolvedValue(undefined),
+    getJob: vi.fn().mockResolvedValue(undefined),
     getJobCounts: vi.fn().mockResolvedValue(emptyCounts()),
     getJobs: vi.fn().mockResolvedValue([]),
     isPaused: vi.fn().mockResolvedValue(false),
@@ -105,6 +108,31 @@ describe(JobRepository.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(
       `Waiting for ${QueueName.FaceDetection} queue to finish (0 active, 0 waiting, 0 delayed, 1 paused); queue is paused`,
     );
+  });
+
+  it('drains delayed jobs when requested', async () => {
+    const { sut, queue } = setup();
+
+    await sut.empty(QueueName.FacialRecognition, true);
+
+    expect(queue.drain).toHaveBeenCalledWith(true);
+  });
+
+  it('keeps the manual empty default drain behavior', async () => {
+    const { sut, queue } = setup();
+
+    await sut.empty(QueueName.FacialRecognition);
+
+    expect(queue.drain).toHaveBeenCalledWith(false);
+  });
+
+  it('does not clean active completed or failed jobs when draining delayed jobs', async () => {
+    const { sut, queue } = setup();
+
+    await sut.empty(QueueName.FacialRecognition, true);
+
+    expect(queue.drain).toHaveBeenCalledWith(true);
+    expect(queue.clean).not.toHaveBeenCalled();
   });
 
   it('returns queue counts and oldest job ages', async () => {
@@ -228,5 +256,146 @@ describe(JobRepository.name, () => {
       { identityId: 'identity-1', cursor: 'cursor-2', limit: 1000 },
       { jobId: 'shared-space-person-metadata-backfill/identity/identity-1/cursor-2', removeOnFail: true },
     );
+  });
+
+  it('removes a failed stable facial-recognition coordinator before requeueing it', async () => {
+    const { sut, queue } = setup();
+    const failedJob = {
+      getState: vi.fn().mockResolvedValue('failed'),
+      remove: vi.fn().mockResolvedValue(undefined),
+    };
+    queue.getJob.mockResolvedValue(failedJob);
+    setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+    await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+    expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+    expect(failedJob.getState).toHaveBeenCalled();
+    expect(failedJob.remove).toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FacialRecognitionQueueAll,
+      { force: true },
+      {
+        jobId: JobName.FacialRecognitionQueueAll,
+        removeOnComplete: true,
+      },
+    );
+  });
+
+  it.each(['active', 'waiting', 'delayed', 'paused'] as const)(
+    'does not remove a %s stable facial-recognition coordinator',
+    async (state) => {
+      const { sut, queue } = setup();
+      const existingJob = {
+        getState: vi.fn().mockResolvedValue(state),
+        remove: vi.fn().mockResolvedValue(undefined),
+      };
+      queue.getJob.mockResolvedValue(existingJob);
+      setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+      await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+      expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+      expect(existingJob.getState).toHaveBeenCalled();
+      expect(existingJob.remove).not.toHaveBeenCalled();
+      expect(queue.add).toHaveBeenCalledWith(
+        JobName.FacialRecognitionQueueAll,
+        { force: true },
+        {
+          jobId: JobName.FacialRecognitionQueueAll,
+          removeOnComplete: true,
+        },
+      );
+    },
+  );
+
+  it('does not remove failed stable shared-space jobs while queueing duplicates', async () => {
+    const { sut, queue } = setup();
+    const failedJob = {
+      getState: vi.fn().mockResolvedValue('failed'),
+      remove: vi.fn().mockResolvedValue(undefined),
+    };
+    queue.getJob.mockResolvedValue(failedJob);
+    setHandlers(sut, [JobName.SharedSpaceFaceMatchPage]);
+
+    await sut.queue({ name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1' } });
+
+    expect(queue.getJob).not.toHaveBeenCalled();
+    expect(failedJob.remove).not.toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatchPage,
+      { spaceId: 'space-1' },
+      {
+        jobId: 'shared-space-face-match-page/space-1/start',
+        removeOnComplete: true,
+      },
+    );
+  });
+
+  it('uses stable visible-failure job ids for shared-space face pipeline jobs', async () => {
+    const { sut, queue } = setup();
+    setHandlers(sut, [
+      JobName.SharedSpaceFaceMatch,
+      JobName.SharedSpaceFaceMatchAll,
+      JobName.SharedSpaceFaceMatchPage,
+      JobName.SharedSpacePersonDedup,
+      JobName.SharedSpaceIdentityReconciliation,
+    ]);
+
+    await sut.queueAll([
+      { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+      { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+      { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: 'asset-1' } },
+      { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-1' } },
+      { name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1' } },
+      { name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1', afterAssetId: 'asset-9' } },
+      { name: JobName.SharedSpacePersonDedup, data: { spaceId: 'space-1' } },
+      { name: JobName.SharedSpaceIdentityReconciliation, data: { spaceId: 'space-1' } },
+    ]);
+
+    expect(queue.addBulk).not.toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatch,
+      { spaceId: 'space-1', assetId: 'asset-1' },
+      {
+        jobId: 'shared-space-face-match/space-1/asset-1',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatch,
+      { spaceId: 'space-2', assetId: 'asset-1' },
+      {
+        jobId: 'shared-space-face-match/space-2/asset-1',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpaceFaceMatchAll, { spaceId: 'space-1' }, {
+      jobId: 'shared-space-face-match-all/space-1',
+      removeOnComplete: true,
+    });
+    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpaceFaceMatchPage, { spaceId: 'space-1' }, {
+      jobId: 'shared-space-face-match-page/space-1/start',
+      removeOnComplete: true,
+    });
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatchPage,
+      { spaceId: 'space-1', afterAssetId: 'asset-9' },
+      {
+        jobId: 'shared-space-face-match-page/space-1/after/asset-9',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpacePersonDedup, { spaceId: 'space-1' }, {
+      jobId: 'space-dedup-space-1',
+      removeOnComplete: true,
+    });
+    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpaceIdentityReconciliation, { spaceId: 'space-1' }, {
+      jobId: 'space-identity-reconcile-space-1-all-members-all-people',
+      removeOnComplete: true,
+    });
+    for (const [, , options] of queue.add.mock.calls) {
+      expect(options).not.toHaveProperty('removeOnFail', true);
+    }
   });
 });

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -283,12 +283,44 @@ describe(JobRepository.name, () => {
   });
 
   it.each(['active', 'waiting', 'delayed', 'paused'] as const)(
-    'does not remove a %s stable facial-recognition coordinator',
+    'does not remove a %s stable facial-recognition coordinator when queueing non-force work',
     async (state) => {
       const { sut, queue } = setup();
       const existingJob = {
+        data: { force: true },
         getState: vi.fn().mockResolvedValue(state),
         remove: vi.fn().mockResolvedValue(undefined),
+        updateData: vi.fn().mockResolvedValue(undefined),
+      };
+      queue.getJob.mockResolvedValue(existingJob);
+      setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+      await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: false } });
+
+      expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+      expect(existingJob.getState).toHaveBeenCalled();
+      expect(existingJob.remove).not.toHaveBeenCalled();
+      expect(existingJob.updateData).not.toHaveBeenCalled();
+      expect(queue.add).toHaveBeenCalledWith(
+        JobName.FacialRecognitionQueueAll,
+        { force: false },
+        {
+          jobId: JobName.FacialRecognitionQueueAll,
+          removeOnComplete: true,
+        },
+      );
+    },
+  );
+
+  it.each(['waiting', 'delayed', 'paused'] as const)(
+    'upgrades a pending %s non-force facial-recognition coordinator when force is requested',
+    async (state) => {
+      const { sut, queue } = setup();
+      const existingJob = {
+        data: { force: false, nightly: true },
+        getState: vi.fn().mockResolvedValue(state),
+        remove: vi.fn().mockResolvedValue(undefined),
+        updateData: vi.fn().mockResolvedValue(undefined),
       };
       queue.getJob.mockResolvedValue(existingJob);
       setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
@@ -298,16 +330,58 @@ describe(JobRepository.name, () => {
       expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
       expect(existingJob.getState).toHaveBeenCalled();
       expect(existingJob.remove).not.toHaveBeenCalled();
-      expect(queue.add).toHaveBeenCalledWith(
-        JobName.FacialRecognitionQueueAll,
-        { force: true },
-        {
-          jobId: JobName.FacialRecognitionQueueAll,
-          removeOnComplete: true,
-        },
-      );
+      expect(existingJob.updateData).toHaveBeenCalledWith({ force: true });
+      expect(queue.add).not.toHaveBeenCalled();
     },
   );
+
+  it('queues a force follow-up coordinator when a non-force coordinator is active', async () => {
+    const { sut, queue } = setup();
+    const existingJob = {
+      data: { force: false },
+      getState: vi.fn().mockResolvedValue('active'),
+      remove: vi.fn().mockResolvedValue(undefined),
+      updateData: vi.fn().mockResolvedValue(undefined),
+    };
+    queue.getJob.mockResolvedValue(existingJob);
+    setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+    await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+    expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+    expect(existingJob.getState).toHaveBeenCalled();
+    expect(existingJob.remove).not.toHaveBeenCalled();
+    expect(existingJob.updateData).not.toHaveBeenCalled();
+    expect(queue.drain).toHaveBeenCalledWith(true);
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FacialRecognitionQueueAll,
+      { force: true },
+      {
+        jobId: 'FacialRecognitionQueueAll/force',
+        removeOnComplete: true,
+      },
+    );
+  });
+
+  it('does not queue another coordinator when force recognition is already active', async () => {
+    const { sut, queue } = setup();
+    const existingJob = {
+      data: { force: true },
+      getState: vi.fn().mockResolvedValue('active'),
+      remove: vi.fn().mockResolvedValue(undefined),
+      updateData: vi.fn().mockResolvedValue(undefined),
+    };
+    queue.getJob.mockResolvedValue(existingJob);
+    setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+    await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+    expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+    expect(existingJob.getState).toHaveBeenCalled();
+    expect(existingJob.remove).not.toHaveBeenCalled();
+    expect(existingJob.updateData).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
+  });
 
   it('does not remove failed stable shared-space jobs while queueing duplicates', async () => {
     const { sut, queue } = setup();

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -28,8 +28,8 @@ const setup = (counts: JobCounts[] = []) => {
     add: vi.fn().mockResolvedValue({}),
     addBulk: vi.fn().mockResolvedValue([]),
     clean: vi.fn().mockResolvedValue([]),
-    drain: vi.fn().mockResolvedValue(undefined),
-    getJob: vi.fn().mockResolvedValue(undefined),
+    drain: vi.fn().mockResolvedValue(void 0),
+    getJob: vi.fn().mockResolvedValue(void 0),
     getJobCounts: vi.fn().mockResolvedValue(emptyCounts()),
     getJobs: vi.fn().mockResolvedValue([]),
     isPaused: vi.fn().mockResolvedValue(false),
@@ -262,7 +262,7 @@ describe(JobRepository.name, () => {
     const { sut, queue } = setup();
     const failedJob = {
       getState: vi.fn().mockResolvedValue('failed'),
-      remove: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(void 0),
     };
     queue.getJob.mockResolvedValue(failedJob);
     setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
@@ -289,8 +289,8 @@ describe(JobRepository.name, () => {
       const existingJob = {
         data: { force: true },
         getState: vi.fn().mockResolvedValue(state),
-        remove: vi.fn().mockResolvedValue(undefined),
-        updateData: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(void 0),
+        updateData: vi.fn().mockResolvedValue(void 0),
       };
       queue.getJob.mockResolvedValue(existingJob);
       setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
@@ -319,8 +319,8 @@ describe(JobRepository.name, () => {
       const existingJob = {
         data: { force: false, nightly: true },
         getState: vi.fn().mockResolvedValue(state),
-        remove: vi.fn().mockResolvedValue(undefined),
-        updateData: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(void 0),
+        updateData: vi.fn().mockResolvedValue(void 0),
       };
       queue.getJob.mockResolvedValue(existingJob);
       setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
@@ -367,8 +367,8 @@ describe(JobRepository.name, () => {
     const existingJob = {
       data: { force: false },
       getState: vi.fn().mockResolvedValue('active'),
-      remove: vi.fn().mockResolvedValue(undefined),
-      updateData: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(void 0),
+      updateData: vi.fn().mockResolvedValue(void 0),
     };
     queue.getJob.mockResolvedValue(existingJob);
     setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
@@ -395,8 +395,8 @@ describe(JobRepository.name, () => {
     const existingJob = {
       data: { force: true },
       getState: vi.fn().mockResolvedValue('active'),
-      remove: vi.fn().mockResolvedValue(undefined),
-      updateData: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(void 0),
+      updateData: vi.fn().mockResolvedValue(void 0),
     };
     queue.getJob.mockResolvedValue(existingJob);
     setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
@@ -415,10 +415,10 @@ describe(JobRepository.name, () => {
     const activeForceFollowUp = {
       data: { force: true },
       getState: vi.fn().mockResolvedValue('active'),
-      remove: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(void 0),
     };
-    queue.getJob.mockImplementation(async (jobId: string) =>
-      jobId === 'FacialRecognitionQueueAll/force' ? activeForceFollowUp : undefined,
+    queue.getJob.mockImplementation((jobId: string) =>
+      Promise.resolve(jobId === 'FacialRecognitionQueueAll/force' ? activeForceFollowUp : void 0),
     );
     setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
 
@@ -436,7 +436,7 @@ describe(JobRepository.name, () => {
     const { sut, queue } = setup();
     const failedJob = {
       getState: vi.fn().mockResolvedValue('failed'),
-      remove: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(void 0),
     };
     queue.getJob.mockResolvedValue(failedJob);
     setHandlers(sut, [JobName.SharedSpaceFaceMatchPage]);
@@ -493,14 +493,22 @@ describe(JobRepository.name, () => {
         removeOnComplete: true,
       },
     );
-    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpaceFaceMatchAll, { spaceId: 'space-1' }, {
-      jobId: 'shared-space-face-match-all/space-1',
-      removeOnComplete: true,
-    });
-    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpaceFaceMatchPage, { spaceId: 'space-1' }, {
-      jobId: 'shared-space-face-match-page/space-1/start',
-      removeOnComplete: true,
-    });
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatchAll,
+      { spaceId: 'space-1' },
+      {
+        jobId: 'shared-space-face-match-all/space-1',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatchPage,
+      { spaceId: 'space-1' },
+      {
+        jobId: 'shared-space-face-match-page/space-1/start',
+        removeOnComplete: true,
+      },
+    );
     expect(queue.add).toHaveBeenCalledWith(
       JobName.SharedSpaceFaceMatchPage,
       { spaceId: 'space-1', afterAssetId: 'asset-9' },
@@ -509,16 +517,24 @@ describe(JobRepository.name, () => {
         removeOnComplete: true,
       },
     );
-    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpacePersonDedup, { spaceId: 'space-1' }, {
-      jobId: 'space-dedup-space-1',
-      removeOnComplete: true,
-    });
-    expect(queue.add).toHaveBeenCalledWith(JobName.SharedSpaceIdentityReconciliation, { spaceId: 'space-1' }, {
-      jobId: 'space-identity-reconcile-space-1-all-members-all-people',
-      removeOnComplete: true,
-    });
-    for (const [, , options] of queue.add.mock.calls) {
-      expect(options).not.toHaveProperty('removeOnFail', true);
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpacePersonDedup,
+      { spaceId: 'space-1' },
+      {
+        jobId: 'space-dedup-space-1',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceIdentityReconciliation,
+      { spaceId: 'space-1' },
+      {
+        jobId: 'space-identity-reconcile-space-1-all-members-all-people',
+        removeOnComplete: true,
+      },
+    );
+    for (const call of queue.add.mock.calls) {
+      expect(call[2]).not.toHaveProperty('removeOnFail', true);
     }
   });
 });

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -383,12 +383,26 @@ export class JobRepository {
   ): Promise<{ add: true; options: JobsOptions } | { add: false }> {
     const existingJob = await queue.getJob(JobName.FacialRecognitionQueueAll);
     if (!existingJob) {
+      if (data.force === true) {
+        const forceFollowUpJob = await queue.getJob(FORCE_FACIAL_RECOGNITION_QUEUE_ALL_JOB_ID);
+        if (forceFollowUpJob) {
+          const forceFollowUpState = (await forceFollowUpJob.getState()) as string;
+          if (forceFollowUpState === 'active' && forceFollowUpJob.data?.force === true) {
+            return { add: false };
+          }
+        }
+
+        await queue.drain(true);
+      }
       return { add: true, options };
     }
 
     const state = (await existingJob.getState()) as string;
     if (state === 'failed') {
       await existingJob.remove();
+      if (data.force === true) {
+        await queue.drain(true);
+      }
       return { add: true, options };
     }
 
@@ -397,8 +411,9 @@ export class JobRepository {
     }
 
     if (state === 'waiting' || state === 'delayed' || state === 'paused') {
-      await existingJob.updateData(data);
-      return { add: false };
+      await existingJob.remove();
+      await queue.drain(true);
+      return { add: true, options };
     }
 
     if (state === 'active') {

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -19,6 +19,8 @@ type JobMapItem = {
   label: string;
 };
 
+const FORCE_FACIAL_RECOGNITION_QUEUE_ALL_JOB_ID = `${JobName.FacialRecognitionQueueAll}/force`;
+
 export type QueueTelemetryStatus = 'active' | 'completed' | 'failed' | 'delayed' | 'waiting' | 'paused';
 export type QueueTelemetryStalenessStatus = 'waiting' | 'delayed' | 'failed';
 
@@ -220,7 +222,12 @@ export class JobRepository {
         // need to use add() instead of addBulk() for jobId deduplication
         const queue = this.getQueue(queueName);
         if (item.name === JobName.FacialRecognitionQueueAll) {
-          await this.removeFailedStableJob(queue, job.options.jobId);
+          const action = await this.prepareFacialRecognitionQueueAll(queue, item.data, job.options);
+          if (!action.add) {
+            continue;
+          }
+
+          job.options = action.options;
         }
 
         promises.push(queue.add(item.name, item.data, job.options));
@@ -363,10 +370,49 @@ export class JobRepository {
       return;
     }
 
-    const state = await existingJob.getState();
+    const state = (await existingJob.getState()) as string;
     if (state === 'failed') {
       await existingJob.remove();
     }
+  }
+
+  private async prepareFacialRecognitionQueueAll(
+    queue: Queue,
+    data: JobOf<JobName.FacialRecognitionQueueAll>,
+    options: JobsOptions,
+  ): Promise<{ add: true; options: JobsOptions } | { add: false }> {
+    const existingJob = await queue.getJob(JobName.FacialRecognitionQueueAll);
+    if (!existingJob) {
+      return { add: true, options };
+    }
+
+    const state = (await existingJob.getState()) as string;
+    if (state === 'failed') {
+      await existingJob.remove();
+      return { add: true, options };
+    }
+
+    if (data.force !== true) {
+      return { add: true, options };
+    }
+
+    if (state === 'waiting' || state === 'delayed' || state === 'paused') {
+      await existingJob.updateData(data);
+      return { add: false };
+    }
+
+    if (state === 'active') {
+      if (existingJob.data?.force === true) {
+        return { add: false };
+      }
+
+      await queue.drain(true);
+      const forceOptions = { ...options, jobId: FORCE_FACIAL_RECOGNITION_QUEUE_ALL_JOB_ID };
+      await this.removeFailedStableJob(queue, FORCE_FACIAL_RECOGNITION_QUEUE_ALL_JOB_ID);
+      return { add: true, options: forceOptions };
+    }
+
+    return { add: true, options };
   }
 
   private getQueue(queue: QueueName): Queue {

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -153,8 +153,8 @@ export class JobRepository {
     return this.getQueue(name).resume();
   }
 
-  empty(name: QueueName) {
-    return this.getQueue(name).drain();
+  empty(name: QueueName, delayed = false): Promise<void> {
+    return this.getQueue(name).drain(delayed);
   }
 
   clear(name: QueueName, type: QueueCleanType) {
@@ -218,7 +218,12 @@ export class JobRepository {
 
       if (job.options?.jobId) {
         // need to use add() instead of addBulk() for jobId deduplication
-        promises.push(this.getQueue(queueName).add(item.name, item.data, job.options));
+        const queue = this.getQueue(queueName);
+        if (item.name === JobName.FacialRecognitionQueueAll) {
+          await this.removeFailedStableJob(queue, job.options.jobId);
+        }
+
+        promises.push(queue.add(item.name, item.data, job.options));
       } else {
         itemsByQueue[queueName] = itemsByQueue[queueName] || [];
         itemsByQueue[queueName].push(job);
@@ -293,7 +298,7 @@ export class JobRepository {
         return { priority: 1 };
       }
       case JobName.FacialRecognitionQueueAll: {
-        return { jobId: JobName.FacialRecognitionQueueAll };
+        return { jobId: JobName.FacialRecognitionQueueAll, removeOnComplete: true };
       }
       case JobName.FaceIdentityBackfill: {
         const data = item.data as { stage?: string; cursor?: string };
@@ -308,14 +313,34 @@ export class JobRepository {
       case JobName.SharedSpaceBulkAddAssets: {
         return { jobId: `bulk-add-${item.data.spaceId}-${item.data.userId}` };
       }
+      case JobName.SharedSpaceFaceMatch: {
+        return {
+          jobId: `shared-space-face-match/${item.data.spaceId}/${item.data.assetId}`,
+          removeOnComplete: true,
+        };
+      }
+      case JobName.SharedSpaceFaceMatchAll: {
+        return {
+          jobId: `shared-space-face-match-all/${item.data.spaceId}`,
+          removeOnComplete: true,
+        };
+      }
+      case JobName.SharedSpaceFaceMatchPage: {
+        const data = item.data as { spaceId: string; afterAssetId?: string };
+        const cursor = data.afterAssetId ? `after/${data.afterAssetId}` : 'start';
+        return {
+          jobId: `shared-space-face-match-page/${data.spaceId}/${cursor}`,
+          removeOnComplete: true,
+        };
+      }
       case JobName.SharedSpacePersonDedup: {
-        return { jobId: `space-dedup-${item.data.spaceId}` };
+        return { jobId: `space-dedup-${item.data.spaceId}`, removeOnComplete: true };
       }
       case JobName.SharedSpaceIdentityReconciliation: {
         const data = item.data as { spaceId: string; userId?: string; spacePersonId?: string };
         return {
           jobId: `space-identity-reconcile-${data.spaceId}-${data.userId ?? 'all-members'}-${data.spacePersonId ?? 'all-people'}`,
-          removeOnFail: true,
+          removeOnComplete: true,
         };
       }
       case JobName.SharedSpacePersonMetadataBackfill: {
@@ -329,6 +354,18 @@ export class JobRepository {
       default: {
         return null;
       }
+    }
+  }
+
+  private async removeFailedStableJob(queue: Queue, jobId: string) {
+    const existingJob = await queue.getJob(jobId);
+    if (!existingJob) {
+      return;
+    }
+
+    const state = await existingJob.getState();
+    if (state === 'failed') {
+      await existingJob.remove();
     }
   }
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1121,7 +1121,31 @@ describe(PersonService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.AssetDetectFaces,
-          data: { id: asset.id },
+          data: { id: asset.id, force: true },
+        },
+      ]);
+    });
+
+    it('marks force-created asset face-detection jobs so recognition fan-out can be suppressed', async () => {
+      const asset1 = AssetFactory.create();
+      const asset2 = AssetFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset1, asset2]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([person]);
+      mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
+
+      await sut.handleQueueDetectFaces({ force: true });
+
+      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(true);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.AssetDetectFaces,
+          data: { id: asset1.id, force: true },
+        },
+        {
+          name: JobName.AssetDetectFaces,
+          data: { id: asset2.id, force: true },
         },
       ]);
     });
@@ -1165,7 +1189,7 @@ describe(PersonService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.AssetDetectFaces,
-          data: { id: asset.id },
+          data: { id: asset.id, force: true },
         },
       ]);
       expect(mocks.person.delete).toHaveBeenCalledWith([person.id]);
@@ -1628,6 +1652,61 @@ describe(PersonService.name, () => {
       ]);
       expect(mocks.person.reassignFace).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    });
+
+    it('forced detection queues only the force recognition coordinator when it creates new faces', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).exif().build();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.crypto.randomUUID.mockReturnValue(face.id);
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.person.refreshFaces.mockResolvedValue();
+
+      await sut.handleDetectFaces({ id: asset.id, force: true });
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: face.id, assetId: asset.id })],
+        [],
+        [{ faceId: face.id, embedding: '[1, 2, 3, 4]' }],
+      );
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
+    it('non-force detection keeps immediate incremental recognition for new faces', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).exif().build();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.crypto.randomUUID.mockReturnValue(face.id);
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.person.refreshFaces.mockResolvedValue();
+
+      await sut.handleDetectFaces({ id: asset.id, force: false });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+        { name: JobName.FacialRecognition, data: { id: face.id } },
+      ]);
+    });
+
+    it('keeps old pre-deploy asset-detection jobs without force on the incremental path', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).exif().build();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.crypto.randomUUID.mockReturnValue(face.id);
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.person.refreshFaces.mockResolvedValue();
+
+      await sut.handleDetectFaces({ id: asset.id });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+        { name: JobName.FacialRecognition, data: { id: face.id } },
+      ]);
     });
 
     it('should delete an existing face not among the new detected faces', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -33,7 +33,7 @@ import {
   getForDetectedFaces,
   getForFacialRecognitionJob,
 } from 'test/mappers';
-import { newDate, newUuid } from 'test/small.factory';
+import { factory, newDate, newUuid } from 'test/small.factory';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
 
 describe(PersonService.name, () => {
@@ -1265,13 +1265,82 @@ describe(PersonService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.FacialRecognition,
-          data: { id: face.id, deferred: false },
+          data: { id: face.id, deferred: false, skipSharedSpaceMatch: true },
         },
       ]);
       expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
         lastRun: expect.any(String),
       });
       expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: false });
+    });
+
+    it('force recognition drains stale facial-recognition work after prerequisites and before clearing space people', async () => {
+      const face = AssetFaceFactory.create();
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
+
+      await sut.handleQueueRecognizeFaces({ force: true });
+
+      expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(
+        QueueName.ThumbnailGeneration,
+        QueueName.FaceDetection,
+      );
+      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.job.empty.mock.invocationCallOrder[0],
+      );
+      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.person.unassignFaces.mock.invocationCallOrder[0],
+      );
+      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.faceIdentity.unlinkFacesBySourceType.mock.invocationCallOrder[0],
+      );
+      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.sharedSpace.deleteAllPersonFaces.mock.invocationCallOrder[0],
+      );
+      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.sharedSpace.deleteAllPersons.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('force recognition queues personal face jobs with shared-space matching suppressed', async () => {
+      const face = AssetFaceFactory.create();
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
+
+      await sut.handleQueueRecognizeFaces({ force: true });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.FacialRecognition,
+          data: { id: face.id, deferred: false, skipSharedSpaceMatch: true },
+        },
+      ]);
+    });
+
+    it('non-force recognition keeps incremental shared-space matching enabled', async () => {
+      const face = AssetFaceFactory.create();
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+
+      await sut.handleQueueRecognizeFaces({ force: false });
+
+      expect(mocks.job.empty).not.toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.FacialRecognition,
+          data: { id: face.id, deferred: false },
+        },
+      ]);
     });
 
     it('should unlink existing ML identity links when force resets recognition assignments', async () => {
@@ -1346,6 +1415,11 @@ describe(PersonService.name, () => {
       expect(mocks.systemMetadata.get).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState);
       expect(mocks.person.getLatestFaceDate).toHaveBeenCalledOnce();
       expect(mocks.person.getAllFaces).not.toHaveBeenCalled();
+      expect(mocks.job.empty).not.toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.person.unassignFaces).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.unlinkFacesBySourceType).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
       expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
       expect(mocks.person.vacuum).not.toHaveBeenCalled();
@@ -1378,7 +1452,7 @@ describe(PersonService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.FacialRecognition,
-          data: { id: face.id, deferred: false },
+          data: { id: face.id, deferred: false, skipSharedSpaceMatch: true },
         },
       ]);
       expect(mocks.person.delete).toHaveBeenCalledWith([person.id]);

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1949,6 +1949,39 @@ describe(PersonService.name, () => {
       });
     });
 
+    it('does not queue shared-space matching for force jobs when face already has a person', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+
+      expect(await sut.handleRecognizeFaces({ id: face.id, skipSharedSpaceMatch: true })).toBe(JobStatus.Skipped);
+
+      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(face.personId);
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: face.id,
+        identityId: 'identity-1',
+        source: 'owner-person',
+      });
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+    });
+
+    it('keeps old pre-deploy facial-recognition jobs on the incremental path', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+
+      await sut.handleRecognizeFaces({ id: face.id });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatch,
+        data: { spaceId: 'space-1', assetId: face.assetId },
+      });
+    });
+
     it('should link identity when a face already has an assigned person', async () => {
       const asset = AssetFactory.create();
       const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
@@ -2093,6 +2126,56 @@ describe(PersonService.name, () => {
         sourceIdentityIds: [sourceIdentityId],
         source: 'shared-space-evidence',
       });
+    });
+
+    it('does not queue shared-space matching for force jobs after assigning a person', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+      const noPerson = AssetFaceFactory.create({ assetId: asset.id });
+      const primaryFace = AssetFaceFactory.from().person().build();
+      const sourceIdentityId = 'source-identity';
+      const targetIdentityId = 'target-identity';
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue([{ ...primaryFace, distance: 0.2 } as FaceSearchResult]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.person.create.mockResolvedValue(person);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+        identityId: targetIdentityId,
+        distance: 0.2,
+      });
+      mocks.faceIdentity.mergeIdentities.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 0,
+      });
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id, skipSharedSpaceMatch: true })).toBe(JobStatus.Success);
+
+      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+        faceIds: [noPerson.id],
+        newPersonId: primaryFace.personId,
+      });
+      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(primaryFace.personId);
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: noPerson.id,
+        identityId: sourceIdentityId,
+        source: 'owner-person',
+      });
+      expect((mocks.faceIdentity as any).findClosestAccessibleIdentityForFace).toHaveBeenCalledWith({
+        userId: asset.ownerId,
+        embedding: '[1, 2, 3, 4]',
+        maxDistance: 0.5,
+        type: 'person',
+        excludeIdentityId: sourceIdentityId,
+      });
+      expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
+        source: 'shared-space-evidence',
+      });
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
     });
 
     it('should match existing person if their birth date is unknown', async () => {
@@ -2305,6 +2388,21 @@ describe(PersonService.name, () => {
       expect(mocks.search.searchFaces).toHaveBeenCalledTimes(1);
       expect(mocks.person.create).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    });
+
+    it('preserves shared-space suppression when deferring a force-created face job', async () => {
+      const asset = AssetFactory.create();
+      const noPerson = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
+      mocks.search.searchFaces.mockResolvedValue([{ ...noPerson, distance: 0 } as FaceSearchResult]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id, skipSharedSpaceMatch: true })).toBe(JobStatus.Skipped);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognition,
+        data: { id: noPerson.id, deferred: true, skipSharedSpaceMatch: true },
+      });
     });
 
     it('should defer non-core faces to end of queue', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -714,6 +714,10 @@ export class PersonService extends BaseService {
       }
     }
 
+    if (force) {
+      await this.jobRepository.empty(QueueName.FacialRecognition, true);
+    }
+
     const { waiting } = await this.jobRepository.getJobCounts(QueueName.FacialRecognition);
 
     if (force) {
@@ -741,9 +745,19 @@ export class PersonService extends BaseService {
       force ? undefined : { personId: null, sourceType: SourceType.MachineLearning },
     );
 
-    let jobs: { name: JobName.FacialRecognition; data: { id: string; deferred: false } }[] = [];
+    let jobs: {
+      name: JobName.FacialRecognition;
+      data: { id: string; deferred: false; skipSharedSpaceMatch?: true };
+    }[] = [];
     for await (const face of facePagination) {
-      jobs.push({ name: JobName.FacialRecognition, data: { id: face.id, deferred: false } });
+      jobs.push({
+        name: JobName.FacialRecognition,
+        data: {
+          id: face.id,
+          deferred: false,
+          ...(force ? { skipSharedSpaceMatch: true as const } : {}),
+        },
+      });
 
       if (jobs.length === JOBS_ASSET_PAGINATION_SIZE) {
         await this.jobRepository.queueAll(jobs);

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -782,8 +782,9 @@ export class PersonService extends BaseService {
 
     // Queue SharedSpaceFaceMatchAll AFTER recognition jobs so it runs last.
     // This catches EXIF/manual-sourced faces whose personIds survive
-    // unassignFaces (non-ML source). Queued after recognition jobs so
-    // ML faces have been processed by the per-face space matching path first.
+    // unassignFaces (non-ML source). Force-created recognition jobs suppress
+    // incremental space matching, so the paged rebuild is the authoritative
+    // shared-space reconciliation pass.
     if (force) {
       const spaceIds = await this.sharedSpaceRepository.getSpaceIdsWithFaceRecognitionEnabled();
       await this.jobRepository.queueAll(

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -800,7 +800,11 @@ export class PersonService extends BaseService {
   }
 
   @OnJob({ name: JobName.FacialRecognition, queue: QueueName.FacialRecognition })
-  async handleRecognizeFaces({ id, deferred }: JobOf<JobName.FacialRecognition>): Promise<JobStatus> {
+  async handleRecognizeFaces({
+    id,
+    deferred,
+    skipSharedSpaceMatch,
+  }: JobOf<JobName.FacialRecognition>): Promise<JobStatus> {
     const { machineLearning } = await this.getConfig({ withCache: true });
     if (!isFacialRecognitionEnabled(machineLearning)) {
       return JobStatus.Skipped;
@@ -825,6 +829,10 @@ export class PersonService extends BaseService {
     if (face.personId) {
       this.logger.debug(`Face ${id} already has a person assigned`);
       await this.replaceFaceIdentity(face.personId, face.id, 'owner-person');
+
+      if (skipSharedSpaceMatch) {
+        return JobStatus.Skipped;
+      }
 
       // Still queue space face matching — this face may belong to a space
       // that was created/linked after the face was originally recognized.
@@ -859,7 +867,9 @@ export class PersonService extends BaseService {
         });
 
     // `matches` also includes the face itself
-    if (machineLearning.facialRecognition.minFaces > 1 && matches.length <= 1 && !accessibleIdentityMatch) {
+    const matchedOnlySelf =
+      machineLearning.facialRecognition.minFaces > 1 && matches.length <= 1 && !accessibleIdentityMatch;
+    if (matchedOnlySelf && !skipSharedSpaceMatch) {
       this.logger.debug(`Face ${id} only matched the face itself, skipping`);
       return JobStatus.Skipped;
     }
@@ -869,7 +879,19 @@ export class PersonService extends BaseService {
       face.asset.visibility === AssetVisibility.Timeline;
     if (!isCore && !deferred) {
       this.logger.debug(`Deferring non-core face ${id} for later processing`);
-      await this.jobRepository.queue({ name: JobName.FacialRecognition, data: { id, deferred: true } });
+      await this.jobRepository.queue({
+        name: JobName.FacialRecognition,
+        data: {
+          id,
+          deferred: true,
+          ...(skipSharedSpaceMatch ? { skipSharedSpaceMatch: true } : {}),
+        },
+      });
+      return JobStatus.Skipped;
+    }
+
+    if (matchedOnlySelf) {
+      this.logger.debug(`Face ${id} only matched the face itself, skipping`);
       return JobStatus.Skipped;
     }
 
@@ -908,6 +930,10 @@ export class PersonService extends BaseService {
         sourceIdentityId,
         match: personId === createdPersonId ? accessibleIdentityMatch : undefined,
       });
+    }
+
+    if (skipSharedSpaceMatch) {
+      return JobStatus.Success;
     }
 
     // Queue shared space face matching for any spaces containing this asset

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -574,7 +574,13 @@ export class PersonService extends BaseService {
     let jobs: JobItem[] = [];
     const assets = this.assetJobRepository.streamForDetectFacesJob(force);
     for await (const asset of assets) {
-      jobs.push({ name: JobName.AssetDetectFaces, data: { id: asset.id } });
+      jobs.push({
+        name: JobName.AssetDetectFaces,
+        data: {
+          id: asset.id,
+          ...(force === true ? { force: true } : {}),
+        },
+      });
 
       if (jobs.length >= JOBS_ASSET_PAGINATION_SIZE) {
         await this.jobRepository.queueAll(jobs);
@@ -592,7 +598,7 @@ export class PersonService extends BaseService {
   }
 
   @OnJob({ name: JobName.AssetDetectFaces, queue: QueueName.FaceDetection })
-  async handleDetectFaces({ id }: JobOf<JobName.AssetDetectFaces>): Promise<JobStatus> {
+  async handleDetectFaces({ id, force }: JobOf<JobName.AssetDetectFaces>): Promise<JobStatus> {
     const { machineLearning } = await this.getConfig({ withCache: true });
     if (!isFacialRecognitionEnabled(machineLearning)) {
       return JobStatus.Skipped;
@@ -665,8 +671,15 @@ export class PersonService extends BaseService {
 
     if (facesToAdd.length > 0) {
       this.logger.log(`Detected ${facesToAdd.length} new faces in asset ${id}`);
-      const jobs = facesToAdd.map((face) => ({ name: JobName.FacialRecognition, data: { id: face.id } }) as const);
-      await this.jobRepository.queueAll([{ name: JobName.FacialRecognitionQueueAll, data: { force: false } }, ...jobs]);
+      if (force) {
+        await this.jobRepository.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+      } else {
+        const jobs = facesToAdd.map((face) => ({ name: JobName.FacialRecognition, data: { id: face.id } }) as const);
+        await this.jobRepository.queueAll([
+          { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+          ...jobs,
+        ]);
+      }
     } else if (embeddings.length > 0) {
       this.logger.log(`Added ${embeddings.length} face embeddings for asset ${id}`);
     }

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -497,6 +497,56 @@ describe(QueueService.name, () => {
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
+    it('force-starts facial recognition by draining pending work before queueing even when active', async () => {
+      mocks.job.isActive.mockResolvedValue(true);
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+
+      await sut.runCommandLegacy(QueueName.FacialRecognition, { command: QueueCommand.Start, force: true });
+
+      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(mocks.job.queue.mock.invocationCallOrder[0]);
+    });
+
+    it('force-starts facial recognition by draining pending work before queueing when inactive', async () => {
+      mocks.job.isActive.mockResolvedValue(false);
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+
+      await sut.runCommandLegacy(QueueName.FacialRecognition, { command: QueueCommand.Start, force: true });
+
+      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(mocks.job.queue.mock.invocationCallOrder[0]);
+    });
+
+    it('still rejects non-force facial recognition starts while active', async () => {
+      mocks.job.isActive.mockResolvedValue(true);
+
+      await expect(
+        sut.runCommandLegacy(QueueName.FacialRecognition, { command: QueueCommand.Start, force: false }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(mocks.job.empty).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
+
+    it('still rejects active force starts for queues other than facial recognition', async () => {
+      mocks.job.isActive.mockResolvedValue(true);
+
+      await expect(
+        sut.runCommandLegacy(QueueName.VideoConversion, { command: QueueCommand.Start, force: true }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(mocks.job.empty).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
+
     it('should handle a start video conversion command', async () => {
       mocks.job.isActive.mockResolvedValue(false);
       mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -497,32 +497,30 @@ describe(QueueService.name, () => {
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
-    it('force-starts facial recognition by draining pending work before queueing even when active', async () => {
+    it('force-starts facial recognition through the coordinator without pre-draining active work', async () => {
       mocks.job.isActive.mockResolvedValue(true);
       mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
 
       await sut.runCommandLegacy(QueueName.FacialRecognition, { command: QueueCommand.Start, force: true });
 
-      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.job.empty).not.toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FacialRecognitionQueueAll,
         data: { force: true },
       });
-      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(mocks.job.queue.mock.invocationCallOrder[0]);
     });
 
-    it('force-starts facial recognition by draining pending work before queueing when inactive', async () => {
+    it('delegates inactive force-start pending replacement to the facial-recognition coordinator', async () => {
       mocks.job.isActive.mockResolvedValue(false);
       mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
 
       await sut.runCommandLegacy(QueueName.FacialRecognition, { command: QueueCommand.Start, force: true });
 
-      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.job.empty).not.toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FacialRecognitionQueueAll,
         data: { force: true },
       });
-      expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(mocks.job.queue.mock.invocationCallOrder[0]);
     });
 
     it('still rejects non-force facial recognition starts while active', async () => {

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -191,10 +191,6 @@ export class QueueService extends BaseService {
 
     await this.eventRepository.emit('QueueStart', { name });
 
-    if (replacePendingFacialRecognition) {
-      await this.jobRepository.empty(QueueName.FacialRecognition, true);
-    }
-
     switch (name) {
       case QueueName.VideoConversion: {
         return this.jobRepository.queue({ name: JobName.AssetEncodeVideoQueueAll, data: { force } });

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -183,12 +183,17 @@ export class QueueService extends BaseService {
   }
 
   private async start(name: QueueName, { force }: QueueCommandDto): Promise<void> {
+    const replacePendingFacialRecognition = name === QueueName.FacialRecognition && force === true;
     const isActive = await this.jobRepository.isActive(name);
-    if (isActive) {
+    if (isActive && !replacePendingFacialRecognition) {
       throw new BadRequestException(`Job is already running`);
     }
 
     await this.eventRepository.emit('QueueStart', { name });
+
+    if (replacePendingFacialRecognition) {
+      await this.jobRepository.empty(QueueName.FacialRecognition, true);
+    }
 
     switch (name) {
       case QueueName.VideoConversion: {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -15,6 +15,7 @@ import {
   MetadataKey,
   NotificationLevel,
   NotificationType,
+  QueueName,
   SharedSpaceActivityType,
   SharedSpaceRole,
   UserAvatarColor,
@@ -3569,179 +3570,396 @@ describe(SharedSpaceService.name, () => {
   });
 
   describe('handleSharedSpaceFaceMatchAll', () => {
-    it('should skip when space not found', async () => {
-      mocks.sharedSpace.getById.mockResolvedValue(void 0);
+    it('keeps shared-space face pipeline handlers on the facial-recognition queue', () => {
+      const reflector = new Reflector();
+      const cases = [
+        [sut.handleSharedSpaceFaceMatch, JobName.SharedSpaceFaceMatch],
+        [sut.handleSharedSpaceFaceMatchAll, JobName.SharedSpaceFaceMatchAll],
+        [sut.handleSharedSpaceFaceMatchPage, JobName.SharedSpaceFaceMatchPage],
+        [sut.handleSharedSpaceLibraryFaceSync, JobName.SharedSpaceLibraryFaceSync],
+        [sut.handleSharedSpaceIdentityReconciliation, JobName.SharedSpaceIdentityReconciliation],
+        [sut.handleSharedSpacePersonDedup, JobName.SharedSpacePersonDedup],
+      ] as const;
 
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId: 'space-1' });
-
-      expect(result).toBe(JobStatus.Skipped);
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
-      );
+      for (const [handler, name] of cases) {
+        expect(reflector.get(MetadataKey.JobConfig, handler)).toEqual({ name, queue: QueueName.FacialRecognition });
+      }
     });
 
-    it('should skip when face recognition is disabled', async () => {
-      const space = factory.sharedSpace({ faceRecognitionEnabled: false });
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId: space.id });
-
-      expect(result).toBe(JobStatus.Skipped);
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
-      );
-    });
-
-    it('should process pages sequentially without queueing per-asset child jobs', async () => {
+    it('dispatches the first page without processing assets inline', async () => {
       const spaceId = newUuid();
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-
-      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getAssetIdsInSpacePage
-        .mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }])
-        .mockResolvedValueOnce([{ assetId: 'a3' }]);
-      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
-
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId });
-
-      expect(result).toBe(JobStatus.Success);
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenNthCalledWith(1, spaceId, { limit: 2 });
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenNthCalledWith(2, spaceId, {
-        limit: 2,
-        afterAssetId: 'a2',
-      });
-      expect(processSpy).toHaveBeenNthCalledWith(1, spaceId, 'a1');
-      expect(processSpy).toHaveBeenNthCalledWith(2, spaceId, 'a2');
-      expect(processSpy).toHaveBeenNthCalledWith(3, spaceId, 'a3');
-      expect(mocks.job.queueAll).not.toHaveBeenCalled();
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.SharedSpacePersonDedup,
-        data: { spaceId },
-      });
-    });
-
-    it('should read an empty final page when the first page is exactly the batch size', async () => {
-      const spaceId = newUuid();
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-
-      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getAssetIdsInSpacePage
-        .mockResolvedValueOnce([{ assetId: 'asset-1' }, { assetId: 'asset-2' }])
-        .mockResolvedValueOnce([]);
-      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
-
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId });
-
-      expect(result).toBe(JobStatus.Success);
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledTimes(2);
-      expect(processSpy).toHaveBeenCalledTimes(2);
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.SharedSpacePersonDedup,
-        data: { spaceId },
-      });
-    });
-
-    it('should succeed without dedup when there are no assets to process', async () => {
-      const spaceId = newUuid();
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValue([{ assetId: 'asset-1' }]);
       const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
 
       const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId });
 
       expect(result).toBe(JobStatus.Success);
       expect(processSpy).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: { spaceId },
+      });
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
       );
     });
 
-    it('should stop without dedup when face recognition is disabled between pages', async () => {
-      const spaceId = newUuid();
-      const enabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-      const disabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+    it('does not dispatch pages when the space is missing or disabled', async () => {
+      mocks.sharedSpace.getById.mockResolvedValueOnce(void 0);
+      expect(await sut.handleSharedSpaceFaceMatchAll({ spaceId: 'missing-space' })).toBe(JobStatus.Skipped);
 
-      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
-      mocks.sharedSpace.getById
-        .mockResolvedValueOnce(enabled)
-        .mockResolvedValueOnce(enabled)
-        .mockResolvedValueOnce(disabled);
-      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }]);
-      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+      mocks.sharedSpace.getById.mockResolvedValueOnce(factory.sharedSpace({ faceRecognitionEnabled: false }));
+      expect(await sut.handleSharedSpaceFaceMatchAll({ spaceId: 'disabled-space' })).toBe(JobStatus.Skipped);
 
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId });
-
-      expect(result).toBe(JobStatus.Success);
-      expect(processSpy).toHaveBeenCalledTimes(2);
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
       );
     });
+  });
 
-    it('should stop without dedup when the space is deleted between pages', async () => {
+  describe('handleSharedSpaceFaceMatchPage', () => {
+    it('processes a final partial page and queues final follow-up once', async () => {
       const spaceId = newUuid();
-      const enabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-
-      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
-      mocks.sharedSpace.getById
-        .mockResolvedValueOnce(enabled)
-        .mockResolvedValueOnce(enabled)
-        .mockResolvedValueOnce(void 0);
-      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }]);
-      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
-
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId });
-
-      expect(result).toBe(JobStatus.Success);
-      expect(processSpy).toHaveBeenCalledTimes(2);
-      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
-      );
-    });
-
-    it('should re-check the space before queuing final dedup', async () => {
-      const spaceId = newUuid();
-      const enabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
-      const disabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
-
-      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
-      mocks.sharedSpace.getById
-        .mockResolvedValueOnce(enabled)
-        .mockResolvedValueOnce(enabled)
-        .mockResolvedValueOnce(disabled);
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
       mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }]);
-      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue(['space-person-1']);
 
-      const result = await sut.handleSharedSpaceFaceMatchAll({ spaceId });
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 });
 
       expect(result).toBe(JobStatus.Success);
-      expect(processSpy).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
-      );
-    });
-
-    it('should queue full-space identity reconciliation after matching all assets', async () => {
-      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: 'space-1', faceRecognitionEnabled: true }));
-      mocks.sharedSpace.getAssetIdsInSpacePage
-        .mockResolvedValueOnce([{ assetId: 'asset-1' }])
-        .mockResolvedValueOnce([]);
-      mockOneAffectedSpacePerson();
-
-      await sut.handleSharedSpaceFaceMatchAll({ spaceId: 'space-1' });
-
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 3 });
+      expect(processSpy).toHaveBeenCalledWith(spaceId, 'a1');
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpaceIdentityReconciliation,
-        data: { spaceId: 'space-1' },
+        data: { spaceId },
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
+      );
+    });
+
+    it('uses lookahead to queue the next page without processing the lookahead asset', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([
+        { assetId: 'a1' },
+        { assetId: 'a2' },
+        { assetId: 'a3' },
+      ]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(processSpy).toHaveBeenCalledTimes(2);
+      expect(processSpy).toHaveBeenNthCalledWith(1, spaceId, 'a1');
+      expect(processSpy).toHaveBeenNthCalledWith(2, spaceId, 'a2');
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: { spaceId, afterAssetId: 'a2', batchSize: 2 },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
+    });
+
+    it('treats exactly batchSize assets as the final page', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }]);
+      vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
+      );
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceIdentityReconciliation,
+        data: { spaceId },
+      });
+    });
+
+    it('queues final follow-up once even when retry sees no newly affected people', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }]);
+      vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.job.queue.mock.calls.filter(([job]) => job.name === JobName.SharedSpacePersonDedup)).toHaveLength(1);
+      expect(
+        mocks.job.queue.mock.calls.filter(([job]) => job.name === JobName.SharedSpaceIdentityReconciliation),
+      ).toHaveLength(1);
+    });
+
+    it('clamps an invalid batch size so page jobs cannot loop without processing assets', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 0 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 2 });
+      expect(processSpy).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: { spaceId, afterAssetId: 'a1' },
+      });
+    });
+
+    it('does not queue final follow-up for empty, deleted, or disabled spaces', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValueOnce(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
+
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
+
+      mocks.sharedSpace.getById.mockResolvedValueOnce(void 0);
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Skipped);
+
+      mocks.sharedSpace.getById.mockResolvedValueOnce(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false }));
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Skipped);
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+      );
+    });
+
+    it('re-checks the space before final follow-up', async () => {
+      const spaceId = newUuid();
+      const enabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const disabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+      mocks.sharedSpace.getById.mockResolvedValueOnce(enabled).mockResolvedValueOnce(disabled);
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }]);
+      vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue(['space-person-1']);
+
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+      );
+    });
+
+    it('allows an incremental match that ran early to be repaired by the later page rebuild', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'asset-early' }]);
+      const processSpy = vi
+        .spyOn(sut as any, 'processSpaceFaceMatch')
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(['space-person-1']);
+
+      expect(await sut.handleSharedSpaceFaceMatch({ spaceId, assetId: 'asset-early' })).toBe(JobStatus.Success);
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
+
+      expect(processSpy).toHaveBeenNthCalledWith(1, spaceId, 'asset-early');
+      expect(processSpy).toHaveBeenNthCalledWith(2, spaceId, 'asset-early');
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceIdentityReconciliation,
+        data: { spaceId },
+      });
+    });
+
+    it('finalizes an empty continuation page', async () => {
+      const spaceId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, afterAssetId: 'a2', batchSize: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getById).toHaveBeenCalledTimes(2);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, {
+        limit: 3,
+        afterAssetId: 'a2',
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceIdentityReconciliation,
+        data: { spaceId },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
+      );
+    });
+
+    it('falls back to the default batch size for NaN', async () => {
+      const spaceId = newUuid();
+      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: Number.NaN });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 3 });
+    });
+
+    it('floors fractional batch sizes and propagates the normalized override', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 1.8 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 2 });
+      expect(processSpy).toHaveBeenCalledTimes(1);
+      expect(processSpy).toHaveBeenCalledWith(spaceId, 'a1');
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: { spaceId, afterAssetId: 'a1', batchSize: 1 },
+      });
+    });
+
+    it('clamps negative batch sizes without propagating the invalid override', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: -5 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 2 });
+      expect(processSpy).toHaveBeenCalledTimes(1);
+      expect(processSpy).toHaveBeenCalledWith(spaceId, 'a1');
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: { spaceId, afterAssetId: 'a1' },
+      });
+    });
+
+    it('falls back to the default batch size for Infinity', async () => {
+      const spaceId = newUuid();
+      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: Number.POSITIVE_INFINITY });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 3 });
+    });
+
+    it('caps huge finite batch sizes at the default page size', async () => {
+      const spaceId = newUuid();
+      (sut as any).sharedSpaceFaceMatchBatchSize = 2;
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 1e100 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenCalledWith(spaceId, { limit: 3 });
+    });
+
+    it('continues a multi-page chain without repeating or skipping assets', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetIdsInSpacePage
+        .mockResolvedValueOnce([{ assetId: 'a1' }, { assetId: 'a2' }, { assetId: 'a3' }])
+        .mockResolvedValueOnce([{ assetId: 'a3' }]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
+      expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, afterAssetId: 'a2', batchSize: 2 })).toBe(
+        JobStatus.Success,
+      );
+
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenNthCalledWith(1, spaceId, { limit: 3 });
+      expect(mocks.sharedSpace.getAssetIdsInSpacePage).toHaveBeenNthCalledWith(2, spaceId, {
+        limit: 3,
+        afterAssetId: 'a2',
+      });
+      expect(processSpy).toHaveBeenNthCalledWith(1, spaceId, 'a1');
+      expect(processSpy).toHaveBeenNthCalledWith(2, spaceId, 'a2');
+      expect(processSpy).toHaveBeenNthCalledWith(3, spaceId, 'a3');
+      expect(processSpy).toHaveBeenCalledTimes(3);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: { spaceId, afterAssetId: 'a2', batchSize: 2 },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceIdentityReconciliation,
+        data: { spaceId },
+      });
+    });
+
+    it('does not queue the next page when the space is disabled before queueing the next page', async () => {
+      const spaceId = newUuid();
+      const enabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const disabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+      mocks.sharedSpace.getById.mockResolvedValueOnce(enabled).mockResolvedValueOnce(disabled);
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([
+        { assetId: 'a1' },
+        { assetId: 'a2' },
+        { assetId: 'a3' },
+      ]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(processSpy).toHaveBeenCalledTimes(2);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+      );
+    });
+
+    it('does not queue the next page when the space is deleted before queueing the next page', async () => {
+      const spaceId = newUuid();
+      const enabled = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      mocks.sharedSpace.getById.mockResolvedValueOnce(enabled).mockResolvedValueOnce(void 0);
+      mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([
+        { assetId: 'a1' },
+        { assetId: 'a2' },
+        { assetId: 'a3' },
+      ]);
+      const processSpy = vi.spyOn(sut as any, 'processSpaceFaceMatch').mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(processSpy).toHaveBeenCalledTimes(2);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+      );
     });
   });
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3725,7 +3725,9 @@ describe(SharedSpaceService.name, () => {
 
     it('does not queue final follow-up for empty, deleted, or disabled spaces', async () => {
       const spaceId = newUuid();
-      mocks.sharedSpace.getById.mockResolvedValueOnce(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getById.mockResolvedValueOnce(
+        factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }),
+      );
       mocks.sharedSpace.getAssetIdsInSpacePage.mockResolvedValueOnce([]);
 
       expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
@@ -3733,10 +3735,14 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValueOnce(void 0);
       expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Skipped);
 
-      mocks.sharedSpace.getById.mockResolvedValueOnce(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false }));
+      mocks.sharedSpace.getById.mockResolvedValueOnce(
+        factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false }),
+      );
       expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Skipped);
 
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
       );
@@ -3752,7 +3758,9 @@ describe(SharedSpaceService.name, () => {
 
       expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
 
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
       );
@@ -3932,7 +3940,9 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
       );
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
       );
@@ -3956,7 +3966,9 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchPage }),
       );
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpacePersonDedup }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
       );

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1,5 +1,4 @@
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { setImmediate } from 'node:timers/promises';
 import { AssetFace, SharedSpacePerson } from 'src/database';
 import { OnJob } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
@@ -1575,61 +1574,98 @@ export class SharedSpaceService extends BaseService {
 
   @OnJob({ name: JobName.SharedSpaceFaceMatchAll, queue: QueueName.FacialRecognition })
   async handleSharedSpaceFaceMatchAll({ spaceId }: JobOf<JobName.SharedSpaceFaceMatchAll>): Promise<JobStatus> {
-    const batchSize = this.sharedSpaceFaceMatchBatchSize;
-    let processedAny = false;
-    let affectedAny = false;
-    let afterAssetId: string | undefined;
-
-    const initialSpace = await this.sharedSpaceRepository.getById(spaceId);
-    if (!initialSpace || !initialSpace.faceRecognitionEnabled) {
+    const space = await this.sharedSpaceRepository.getById(spaceId);
+    if (!space || !space.faceRecognitionEnabled) {
       return JobStatus.Skipped;
     }
 
-    while (true) {
-      const currentSpace = await this.sharedSpaceRepository.getById(spaceId);
-      if (!currentSpace || !currentSpace.faceRecognitionEnabled) {
-        return JobStatus.Success;
-      }
+    await this.jobRepository.queue({
+      name: JobName.SharedSpaceFaceMatchPage,
+      data: { spaceId },
+    });
 
-      const assets = await this.sharedSpaceRepository.getAssetIdsInSpacePage(spaceId, {
-        limit: batchSize,
-        ...(afterAssetId ? { afterAssetId } : {}),
-      });
+    return JobStatus.Success;
+  }
 
-      if (assets.length === 0) {
-        break;
-      }
-
-      for (const { assetId } of assets) {
-        const affectedPersonIds = await this.processSpaceFaceMatch(spaceId, assetId);
-        affectedAny ||= affectedPersonIds.length > 0;
-        processedAny = true;
-      }
-
-      afterAssetId = assets.at(-1)?.assetId;
-      if (assets.length < batchSize) {
-        break;
-      }
-
-      await setImmediate();
+  @OnJob({ name: JobName.SharedSpaceFaceMatchPage, queue: QueueName.FacialRecognition })
+  async handleSharedSpaceFaceMatchPage({
+    spaceId,
+    afterAssetId,
+    batchSize,
+  }: JobOf<JobName.SharedSpaceFaceMatchPage>): Promise<JobStatus> {
+    const space = await this.sharedSpaceRepository.getById(spaceId);
+    if (!space || !space.faceRecognitionEnabled) {
+      return JobStatus.Skipped;
     }
 
-    if (processedAny) {
-      const finalSpace = await this.sharedSpaceRepository.getById(spaceId);
-      if (!finalSpace || !finalSpace.faceRecognitionEnabled) {
+    const { pageSize, propagatedBatchSize } = this.getSharedSpaceFaceMatchPageSize(batchSize);
+    const assets = await this.sharedSpaceRepository.getAssetIdsInSpacePage(spaceId, {
+      limit: pageSize + 1,
+      ...(afterAssetId ? { afterAssetId } : {}),
+    });
+
+    if (assets.length === 0) {
+      if (afterAssetId) {
+        await this.queueSharedSpaceFaceMatchFinalFollowUp(spaceId);
+      }
+      return JobStatus.Success;
+    }
+
+    const assetsToProcess = assets.slice(0, pageSize);
+    const hasNextPage = assets.length > pageSize;
+
+    for (const { assetId } of assetsToProcess) {
+      await this.processSpaceFaceMatch(spaceId, assetId);
+    }
+
+    const lastProcessedAssetId = assetsToProcess.at(-1)?.assetId;
+    if (hasNextPage && lastProcessedAssetId) {
+      const nextPageSpace = await this.sharedSpaceRepository.getById(spaceId);
+      if (!nextPageSpace || !nextPageSpace.faceRecognitionEnabled) {
         return JobStatus.Success;
       }
 
       await this.jobRepository.queue({
-        name: JobName.SharedSpacePersonDedup,
-        data: { spaceId },
+        name: JobName.SharedSpaceFaceMatchPage,
+        data: {
+          spaceId,
+          afterAssetId: lastProcessedAssetId,
+          ...(propagatedBatchSize ? { batchSize: propagatedBatchSize } : {}),
+        },
       });
-      if (affectedAny) {
-        await this.queueSpaceIdentityReconciliation({ spaceId });
-      }
+      return JobStatus.Success;
     }
 
+    await this.queueSharedSpaceFaceMatchFinalFollowUp(spaceId);
+
     return JobStatus.Success;
+  }
+
+  private getSharedSpaceFaceMatchPageSize(batchSize: number | undefined): {
+    pageSize: number;
+    propagatedBatchSize?: number;
+  } {
+    const candidate = batchSize ?? this.sharedSpaceFaceMatchBatchSize;
+    const finiteCandidate = Number.isFinite(candidate) ? candidate : this.sharedSpaceFaceMatchBatchSize;
+    const pageSize = Math.min(this.sharedSpaceFaceMatchBatchSize, Math.max(1, Math.floor(finiteCandidate)));
+    const propagatedBatchSize =
+      batchSize !== undefined && Number.isFinite(batchSize) && batchSize > 0 ? pageSize : undefined;
+
+    return { pageSize, propagatedBatchSize };
+  }
+
+  private async queueSharedSpaceFaceMatchFinalFollowUp(spaceId: string): Promise<void> {
+    const finalSpace = await this.sharedSpaceRepository.getById(spaceId);
+    if (!finalSpace || !finalSpace.faceRecognitionEnabled) {
+      return;
+    }
+
+    await this.jobRepository.queue({
+      name: JobName.SharedSpacePersonDedup,
+      data: { spaceId },
+    });
+
+    await this.queueSpaceIdentityReconciliation({ spaceId });
   }
 
   @OnJob({ name: JobName.SharedSpacePersonDedup, queue: QueueName.FacialRecognition })

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -222,8 +222,16 @@ export interface ISidecarWriteJob extends IEntityJob {
   tags?: true;
 }
 
+export interface IAssetDetectFacesJob extends IEntityJob {
+  force?: boolean;
+}
+
 export interface IDeferrableJob extends IEntityJob {
   deferred?: boolean;
+}
+
+export interface IFacialRecognitionJob extends IDeferrableJob {
+  skipSharedSpaceMatch?: boolean;
 }
 
 export interface INightlyJob extends IBaseJob {
@@ -242,6 +250,12 @@ export interface ISharedSpaceFaceMatchJob extends IBaseJob {
 
 export interface ISharedSpaceFaceMatchAllJob extends IBaseJob {
   spaceId: string;
+}
+
+export interface ISharedSpaceFaceMatchPageJob extends IBaseJob {
+  spaceId: string;
+  afterAssetId?: string;
+  batchSize?: number;
 }
 
 export interface ISharedSpaceLibraryFaceSyncJob extends IBaseJob {
@@ -393,9 +407,9 @@ export type JobItem =
 
   // Facial Recognition
   | { name: JobName.AssetDetectFacesQueueAll; data: IBaseJob }
-  | { name: JobName.AssetDetectFaces; data: IEntityJob }
+  | { name: JobName.AssetDetectFaces; data: IAssetDetectFacesJob }
   | { name: JobName.FacialRecognitionQueueAll; data: INightlyJob }
-  | { name: JobName.FacialRecognition; data: IDeferrableJob }
+  | { name: JobName.FacialRecognition; data: IFacialRecognitionJob }
   | { name: JobName.FaceIdentityBackfill; data: IFaceIdentityBackfillJob }
   | { name: JobName.PersonGenerateThumbnail; data: IEntityJob }
 
@@ -466,6 +480,7 @@ export type JobItem =
   // Shared Space Face Recognition
   | { name: JobName.SharedSpaceFaceMatch; data: ISharedSpaceFaceMatchJob }
   | { name: JobName.SharedSpaceFaceMatchAll; data: ISharedSpaceFaceMatchAllJob }
+  | { name: JobName.SharedSpaceFaceMatchPage; data: ISharedSpaceFaceMatchPageJob }
   | { name: JobName.SharedSpaceLibraryFaceSync; data: ISharedSpaceLibraryFaceSyncJob }
   | { name: JobName.SharedSpaceIdentityReconciliation; data: ISharedSpaceIdentityReconciliationJob }
   | { name: JobName.SharedSpacePersonDedup; data: ISharedSpacePersonDedupJob }

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -154,6 +154,34 @@ const setupSharedSpaceService = (db?: Kysely<DB>) => {
   return { sut, ctx };
 };
 
+const drainSharedSpaceFaceJobs = async (
+  sharedSpaceService: SharedSpaceService,
+  ctx: ReturnType<typeof setupSharedSpaceService>['ctx'],
+) => {
+  const jobs = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+  let cursor = 0;
+
+  while (cursor < jobs.queue.mock.calls.length) {
+    const queued = jobs.queue.mock.calls.slice(cursor).map(([job]) => job);
+    cursor = jobs.queue.mock.calls.length;
+
+    for (const job of queued) {
+      if (job.name === JobName.SharedSpaceFaceMatchAll) {
+        await sharedSpaceService.handleSharedSpaceFaceMatchAll(job.data);
+      }
+      if (job.name === JobName.SharedSpaceFaceMatchPage) {
+        await sharedSpaceService.handleSharedSpaceFaceMatchPage(job.data);
+      }
+      if (job.name === JobName.SharedSpacePersonDedup) {
+        await sharedSpaceService.handleSharedSpacePersonDedup(job.data);
+      }
+      if (job.name === JobName.SharedSpaceIdentityReconciliation) {
+        await sharedSpaceService.handleSharedSpaceIdentityReconciliation(job.data);
+      }
+    }
+  }
+};
+
 const metadataFaceTags = (name: string) => ({
   RegionInfo: {
     AppliedToDimensions: { W: 1000, H: 100, Unit: 'pixel' },
@@ -463,7 +491,7 @@ describe(MetadataService.name, () => {
       await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
       await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
       const { sut: backfillService, ctx: backfillCtx } = setupFaceIdentityBackfillService(ctx.database);
-      const { sut: sharedSpaceService } = setupSharedSpaceService(ctx.database);
+      const { sut: sharedSpaceService, ctx: sharedSpaceCtx } = setupSharedSpaceService(ctx.database);
 
       await expect(
         ctx.database
@@ -479,6 +507,7 @@ describe(MetadataService.name, () => {
       await expect(sharedSpaceService.handleSharedSpaceFaceMatchAll({ spaceId: space.id })).resolves.toBe(
         JobStatus.Success,
       );
+      await drainSharedSpaceFaceJobs(sharedSpaceService, sharedSpaceCtx);
 
       const identityLinks = await ctx.database
         .selectFrom('face_identity_face')

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { Kysely } from 'kysely';
 import { SearchSuggestionType } from 'src/dtos/search.dto';
-import { AssetVisibility, SharedSpaceRole } from 'src/enum';
+import { AssetVisibility, JobName, SharedSpaceRole } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { ConfigRepository } from 'src/repositories/config.repository';
@@ -65,6 +65,29 @@ const setupSharedSpace = (db?: Kysely<DB>) => {
   jobs.queue.mockResolvedValue();
   jobs.queueAll.mockResolvedValue();
   return { ctx, sut, faceIdentityRepository: ctx.get(FaceIdentityRepository), jobs };
+};
+
+const drainSharedSpaceFaceJobs = async (sharedSpaceService: SharedSpaceService, jobs: Mocked<JobRepository>) => {
+  let cursor = 0;
+  while (cursor < jobs.queue.mock.calls.length) {
+    const queued = jobs.queue.mock.calls.slice(cursor).map(([job]) => job);
+    cursor = jobs.queue.mock.calls.length;
+
+    for (const job of queued) {
+      if (job.name === JobName.SharedSpaceFaceMatchAll) {
+        await sharedSpaceService.handleSharedSpaceFaceMatchAll(job.data);
+      }
+      if (job.name === JobName.SharedSpaceFaceMatchPage) {
+        await sharedSpaceService.handleSharedSpaceFaceMatchPage(job.data);
+      }
+      if (job.name === JobName.SharedSpacePersonDedup) {
+        await sharedSpaceService.handleSharedSpacePersonDedup(job.data);
+      }
+      if (job.name === JobName.SharedSpaceIdentityReconciliation) {
+        await sharedSpaceService.handleSharedSpaceIdentityReconciliation(job.data);
+      }
+    }
+  }
 };
 
 const setupSearch = (db?: Kysely<DB>) => {
@@ -1245,15 +1268,7 @@ describe('People identity RBAC projection', () => {
       }),
     );
 
-    const queuedOnJoin = sharedJobs.queue.mock.calls.map(([job]) => job);
-    for (const job of queuedOnJoin) {
-      if (job.name === 'SharedSpaceFaceMatchAll') {
-        await sharedSpaceService.handleSharedSpaceFaceMatchAll(job.data);
-      }
-      if (job.name === 'SharedSpaceIdentityReconciliation') {
-        await sharedSpaceService.handleSharedSpaceIdentityReconciliation(job.data);
-      }
-    }
+    await drainSharedSpaceFaceJobs(sharedSpaceService, sharedJobs);
 
     const spacePeople = await sharedSpaceService.getSpacePeople(authFor(owner), space.id);
     expect(spacePeople).toEqual([expect.objectContaining({ name: 'Owner Shared Name' })]);

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -894,6 +894,53 @@ describe('People identity RBAC projection', () => {
     expect(afterRemoval).toEqual({ people: [], total: 0, hidden: 0, hasNextPage: false });
   });
 
+  it('matches one photo independently across ten face-recognition spaces', async () => {
+    const { ctx, sut: sharedSpaceService, faceIdentityRepository } = setupSharedSpace();
+    const { user: owner } = await ctx.newUser();
+    const { result: person } = await ctx.newPerson({ ownerId: owner.id, name: 'Ten Space Source' });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    await ctx.database.insertInto('face_search').values({ faceId, embedding: newEmbedding() }).execute();
+    const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
+    await faceIdentityRepository.linkFace({ assetFaceId: faceId, identityId: identity.id, source: 'owner-person' });
+
+    const spaces = [];
+    for (let index = 0; index < 10; index++) {
+      const { space } = await ctx.newSharedSpace({
+        createdById: owner.id,
+        faceRecognitionEnabled: true,
+        name: `Space ${index}`,
+      });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+      spaces.push(space);
+    }
+
+    for (const space of spaces) {
+      await sharedSpaceService.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: asset.id });
+    }
+
+    const faceRows = await ctx.database
+      .selectFrom('shared_space_person_face')
+      .innerJoin('shared_space_person', 'shared_space_person.id', 'shared_space_person_face.personId')
+      .select([
+        'shared_space_person.id as personId',
+        'shared_space_person.spaceId as spaceId',
+        'shared_space_person.identityId as identityId',
+      ])
+      .where('shared_space_person_face.assetFaceId', '=', faceId)
+      .execute();
+
+    expect(faceRows).toHaveLength(10);
+    expect(new Set(faceRows.map((row) => row.spaceId))).toEqual(new Set(spaces.map((space) => space.id)));
+    expect(new Set(faceRows.map((row) => row.personId)).size).toBe(10);
+    expect(faceRows).toEqual(
+      expect.arrayContaining(
+        spaces.map((space) => expect.objectContaining({ spaceId: space.id, identityId: identity.id })),
+      ),
+    );
+  });
+
   it('inherits an owner name into a space person and updates global people for later invitees after owner rename', async () => {
     const { ctx, sut, faceIdentityRepository } = setup();
     const { sut: sharedSpaceService } = setupSharedSpace();

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -894,8 +894,8 @@ describe('People identity RBAC projection', () => {
     expect(afterRemoval).toEqual({ people: [], total: 0, hidden: 0, hasNextPage: false });
   });
 
-  it('matches one photo independently across ten face-recognition spaces', async () => {
-    const { ctx, sut: sharedSpaceService, faceIdentityRepository } = setupSharedSpace();
+  it('materializes one photo independently across ten face-recognition spaces during full rebuilds', async () => {
+    const { ctx, sut: sharedSpaceService, faceIdentityRepository, jobs } = setupSharedSpace();
     const { user: owner } = await ctx.newUser();
     const { result: person } = await ctx.newPerson({ ownerId: owner.id, name: 'Ten Space Source' });
     const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
@@ -917,8 +917,10 @@ describe('People identity RBAC projection', () => {
     }
 
     for (const space of spaces) {
-      await sharedSpaceService.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: asset.id });
+      await sharedSpaceService.handleSharedSpaceFaceMatchAll({ spaceId: space.id });
     }
+
+    await drainSharedSpaceFaceJobs(sharedSpaceService, jobs);
 
     const faceRows = await ctx.database
       .selectFrom('shared_space_person_face')


### PR DESCRIPTION
## Summary
- replace force facial-recognition restarts through the stable coordinator instead of accumulating pending work
- split full shared-space face materialization into paged jobs with stable dedup IDs
- suppress per-face shared-space fanout during force recognition and rebuild spaces after recognition completes
- add unit and medium coverage for retriggered force starts, paged rebuild edges, and one photo shared across ten spaces

## Testing
- corepack pnpm --filter immich check
- corepack pnpm --dir server format
- corepack pnpm --dir server lint
- corepack pnpm --dir server exec vitest --config test/vitest.config.mjs run src/repositories/job.repository.spec.ts src/services/shared-space.service.spec.ts
- corepack pnpm --dir server exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/services/people-identity-rbac.spec.ts

CI babysitting is in progress.