### PR TITLE
fix(web): add has no album filter

### DIFF
--- a/mobile/openapi/lib/api/gallery_map_api.dart
+++ b/mobile/openapi/lib/api/gallery_map_api.dart
@@ -33,6 +33,9 @@ class GalleryMapApi {
   /// * [bool] isFavorite:
   ///   Filter by favorite status
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [String] make:
   ///   Camera make
   ///
@@ -62,7 +65,7 @@ class GalleryMapApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include shared space assets
-  Future<Response> getFilteredMapMarkersWithHttpInfo({ String? city, String? country, bool? isFavorite, String? make, String? model, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, }) async {
+  Future<Response> getFilteredMapMarkersWithHttpInfo({ String? city, String? country, bool? isFavorite, bool? isNotInAlbum, String? make, String? model, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/gallery/map/markers';
 
@@ -81,6 +84,9 @@ class GalleryMapApi {
     }
     if (isFavorite != null) {
       queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
+    }
+    if (isNotInAlbum != null) {
+      queryParams.addAll(_queryParams('', 'isNotInAlbum', isNotInAlbum));
     }
     if (make != null) {
       queryParams.addAll(_queryParams('', 'make', make));
@@ -142,6 +148,9 @@ class GalleryMapApi {
   /// * [bool] isFavorite:
   ///   Filter by favorite status
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [String] make:
   ///   Camera make
   ///
@@ -171,8 +180,8 @@ class GalleryMapApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include shared space assets
-  Future<List<MapMarkerResponseDto>?> getFilteredMapMarkers({ String? city, String? country, bool? isFavorite, String? make, String? model, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, }) async {
-    final response = await getFilteredMapMarkersWithHttpInfo( city: city, country: country, isFavorite: isFavorite, make: make, model: model, personIds: personIds, rating: rating, spaceId: spaceId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, withSharedSpaces: withSharedSpaces, );
+  Future<List<MapMarkerResponseDto>?> getFilteredMapMarkers({ String? city, String? country, bool? isFavorite, bool? isNotInAlbum, String? make, String? model, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, }) async {
+    final response = await getFilteredMapMarkersWithHttpInfo( city: city, country: country, isFavorite: isFavorite, isNotInAlbum: isNotInAlbum, make: make, model: model, personIds: personIds, rating: rating, spaceId: spaceId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, withSharedSpaces: withSharedSpaces, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -138,6 +138,9 @@ class SearchApi {
   /// * [bool] isFavorite:
   ///   Filter by favorites
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [String] make:
   ///   Filter by camera make
   ///
@@ -167,7 +170,7 @@ class SearchApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include shared spaces the user is a member of
-  Future<Response> getFilterSuggestionsWithHttpInfo({ String? albumId, String? city, String? country, bool? isFavorite, String? make, AssetTypeEnum? mediaType, String? model, List<String>? personIds, int? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+  Future<Response> getFilterSuggestionsWithHttpInfo({ String? albumId, String? city, String? country, bool? isFavorite, bool? isNotInAlbum, String? make, AssetTypeEnum? mediaType, String? model, List<String>? personIds, int? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/suggestions/filters';
 
@@ -189,6 +192,9 @@ class SearchApi {
     }
     if (isFavorite != null) {
       queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
+    }
+    if (isNotInAlbum != null) {
+      queryParams.addAll(_queryParams('', 'isNotInAlbum', isNotInAlbum));
     }
     if (make != null) {
       queryParams.addAll(_queryParams('', 'make', make));
@@ -253,6 +259,9 @@ class SearchApi {
   /// * [bool] isFavorite:
   ///   Filter by favorites
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [String] make:
   ///   Filter by camera make
   ///
@@ -282,8 +291,8 @@ class SearchApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include shared spaces the user is a member of
-  Future<FilterSuggestionsResponseDto?> getFilterSuggestions({ String? albumId, String? city, String? country, bool? isFavorite, String? make, AssetTypeEnum? mediaType, String? model, List<String>? personIds, int? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
-    final response = await getFilterSuggestionsWithHttpInfo( albumId: albumId, city: city, country: country, isFavorite: isFavorite, make: make, mediaType: mediaType, model: model, personIds: personIds, rating: rating, spaceId: spaceId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
+  Future<FilterSuggestionsResponseDto?> getFilterSuggestions({ String? albumId, String? city, String? country, bool? isFavorite, bool? isNotInAlbum, String? make, AssetTypeEnum? mediaType, String? model, List<String>? personIds, int? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+    final response = await getFilterSuggestionsWithHttpInfo( albumId: albumId, city: city, country: country, isFavorite: isFavorite, isNotInAlbum: isNotInAlbum, make: make, mediaType: mediaType, model: model, personIds: personIds, rating: rating, spaceId: spaceId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -319,6 +328,9 @@ class SearchApi {
   /// * [bool] isFavorite:
   ///   Filter by favorites
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [String] lensModel:
   ///   Filter by lens model
   ///
@@ -351,7 +363,7 @@ class SearchApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include suggestions from shared spaces the user is a member of
-  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, bool? isFavorite, String? lensModel, String? make, String? model, List<String>? personIds, int? rating, String? spaceId, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+  Future<Response> getSearchSuggestionsWithHttpInfo(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, bool? isFavorite, bool? isNotInAlbum, String? lensModel, String? make, String? model, List<String>? personIds, int? rating, String? spaceId, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/search/suggestions';
 
@@ -373,6 +385,9 @@ class SearchApi {
     }
     if (isFavorite != null) {
       queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
+    }
+    if (isNotInAlbum != null) {
+      queryParams.addAll(_queryParams('', 'isNotInAlbum', isNotInAlbum));
     }
     if (lensModel != null) {
       queryParams.addAll(_queryParams('', 'lensModel', lensModel));
@@ -443,6 +458,9 @@ class SearchApi {
   /// * [bool] isFavorite:
   ///   Filter by favorites
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [String] lensModel:
   ///   Filter by lens model
   ///
@@ -475,8 +493,8 @@ class SearchApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include suggestions from shared spaces the user is a member of
-  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, bool? isFavorite, String? lensModel, String? make, String? model, List<String>? personIds, int? rating, String? spaceId, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
-    final response = await getSearchSuggestionsWithHttpInfo(type,  albumId: albumId, country: country, includeNull: includeNull, isFavorite: isFavorite, lensModel: lensModel, make: make, model: model, personIds: personIds, rating: rating, spaceId: spaceId, state: state, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
+  Future<List<String>?> getSearchSuggestions(SearchSuggestionType type, { String? albumId, String? country, bool? includeNull, bool? isFavorite, bool? isNotInAlbum, String? lensModel, String? make, String? model, List<String>? personIds, int? rating, String? spaceId, String? state, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, bool? withSharedSpaces, }) async {
+    final response = await getSearchSuggestionsWithHttpInfo(type,  albumId: albumId, country: country, includeNull: includeNull, isFavorite: isFavorite, isNotInAlbum: isNotInAlbum, lensModel: lensModel, make: make, model: model, personIds: personIds, rating: rating, spaceId: spaceId, state: state, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, withSharedSpaces: withSharedSpaces, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/timeline_api.dart
+++ b/mobile/openapi/lib/api/timeline_api.dart
@@ -42,6 +42,9 @@ class TimelineApi {
   /// * [bool] isFavorite:
   ///   Filter by favorite status (true for favorites only, false for non-favorites only)
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [bool] isTrashed:
   ///   Filter by trash status (true for trashed assets only, false for non-trashed only)
   ///
@@ -108,7 +111,7 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<Response> getTimeBucketWithHttpInfo(String timeBucket, { String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
+  Future<Response> getTimeBucketWithHttpInfo(String timeBucket, { String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isNotInAlbum, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/timeline/bucket';
 
@@ -133,6 +136,9 @@ class TimelineApi {
     }
     if (isFavorite != null) {
       queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
+    }
+    if (isNotInAlbum != null) {
+      queryParams.addAll(_queryParams('', 'isNotInAlbum', isNotInAlbum));
     }
     if (isTrashed != null) {
       queryParams.addAll(_queryParams('', 'isTrashed', isTrashed));
@@ -243,6 +249,9 @@ class TimelineApi {
   /// * [bool] isFavorite:
   ///   Filter by favorite status (true for favorites only, false for non-favorites only)
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [bool] isTrashed:
   ///   Filter by trash status (true for trashed assets only, false for non-trashed only)
   ///
@@ -309,8 +318,8 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<TimeBucketAssetResponseDto?> getTimeBucket(String timeBucket, { String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
-    final response = await getTimeBucketWithHttpInfo(timeBucket,  albumId: albumId, bbox: bbox, city: city, country: country, isFavorite: isFavorite, isTrashed: isTrashed, key: key, make: make, model: model, order: order, personId: personId, personIds: personIds, rating: rating, slug: slug, spaceId: spaceId, spacePersonId: spacePersonId, spacePersonIds: spacePersonIds, tagId: tagId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withSharedSpaces: withSharedSpaces, withStacked: withStacked, );
+  Future<TimeBucketAssetResponseDto?> getTimeBucket(String timeBucket, { String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isNotInAlbum, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
+    final response = await getTimeBucketWithHttpInfo(timeBucket,  albumId: albumId, bbox: bbox, city: city, country: country, isFavorite: isFavorite, isNotInAlbum: isNotInAlbum, isTrashed: isTrashed, key: key, make: make, model: model, order: order, personId: personId, personIds: personIds, rating: rating, slug: slug, spaceId: spaceId, spacePersonId: spacePersonId, spacePersonIds: spacePersonIds, tagId: tagId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withSharedSpaces: withSharedSpaces, withStacked: withStacked, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -347,6 +356,9 @@ class TimelineApi {
   /// * [bool] isFavorite:
   ///   Filter by favorite status (true for favorites only, false for non-favorites only)
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [bool] isTrashed:
   ///   Filter by trash status (true for trashed assets only, false for non-trashed only)
   ///
@@ -413,7 +425,7 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<Response> getTimeBucketsWithHttpInfo({ String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
+  Future<Response> getTimeBucketsWithHttpInfo({ String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isNotInAlbum, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/timeline/buckets';
 
@@ -438,6 +450,9 @@ class TimelineApi {
     }
     if (isFavorite != null) {
       queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
+    }
+    if (isNotInAlbum != null) {
+      queryParams.addAll(_queryParams('', 'isNotInAlbum', isNotInAlbum));
     }
     if (isTrashed != null) {
       queryParams.addAll(_queryParams('', 'isTrashed', isTrashed));
@@ -544,6 +559,9 @@ class TimelineApi {
   /// * [bool] isFavorite:
   ///   Filter by favorite status (true for favorites only, false for non-favorites only)
   ///
+  /// * [bool] isNotInAlbum:
+  ///   Filter assets not in any album
+  ///
   /// * [bool] isTrashed:
   ///   Filter by trash status (true for trashed assets only, false for non-trashed only)
   ///
@@ -610,8 +628,8 @@ class TimelineApi {
   ///
   /// * [bool] withStacked:
   ///   Include stacked assets in the response. When true, only primary assets from stacks are returned.
-  Future<List<TimeBucketsResponseDto>?> getTimeBuckets({ String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
-    final response = await getTimeBucketsWithHttpInfo( albumId: albumId, bbox: bbox, city: city, country: country, isFavorite: isFavorite, isTrashed: isTrashed, key: key, make: make, model: model, order: order, personId: personId, personIds: personIds, rating: rating, slug: slug, spaceId: spaceId, spacePersonId: spacePersonId, spacePersonIds: spacePersonIds, tagId: tagId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withSharedSpaces: withSharedSpaces, withStacked: withStacked, );
+  Future<List<TimeBucketsResponseDto>?> getTimeBuckets({ String? albumId, String? bbox, String? city, String? country, bool? isFavorite, bool? isNotInAlbum, bool? isTrashed, String? key, String? make, String? model, AssetOrder? order, String? personId, List<String>? personIds, int? rating, String? slug, String? spaceId, String? spacePersonId, List<String>? spacePersonIds, String? tagId, List<String>? tagIds, String? takenAfter, String? takenBefore, AssetTypeEnum? type, String? userId, AssetVisibility? visibility, bool? withCoordinates, bool? withPartners, bool? withSharedSpaces, bool? withStacked, }) async {
+    final response = await getTimeBucketsWithHttpInfo( albumId: albumId, bbox: bbox, city: city, country: country, isFavorite: isFavorite, isNotInAlbum: isNotInAlbum, isTrashed: isTrashed, key: key, make: make, model: model, order: order, personId: personId, personIds: personIds, rating: rating, slug: slug, spaceId: spaceId, spacePersonId: spacePersonId, spacePersonIds: spacePersonIds, tagId: tagId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, userId: userId, visibility: visibility, withCoordinates: withCoordinates, withPartners: withPartners, withSharedSpaces: withSharedSpaces, withStacked: withStacked, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/model/smart_search_facets_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_facets_dto.dart
@@ -16,6 +16,7 @@ class SmartSearchFacetsDto {
     this.city,
     this.country,
     this.isFavorite,
+    this.isNotInAlbum,
     this.language,
     this.make,
     this.model,
@@ -46,6 +47,15 @@ class SmartSearchFacetsDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isFavorite;
+
+  /// Filter assets not in any album
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isNotInAlbum;
 
   /// Search language code
   ///
@@ -144,6 +154,7 @@ class SmartSearchFacetsDto {
     other.city == city &&
     other.country == country &&
     other.isFavorite == isFavorite &&
+    other.isNotInAlbum == isNotInAlbum &&
     other.language == language &&
     other.make == make &&
     other.model == model &&
@@ -165,6 +176,7 @@ class SmartSearchFacetsDto {
     (city == null ? 0 : city!.hashCode) +
     (country == null ? 0 : country!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
+    (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (language == null ? 0 : language!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
     (model == null ? 0 : model!.hashCode) +
@@ -181,7 +193,7 @@ class SmartSearchFacetsDto {
     (withSharedSpaces == null ? 0 : withSharedSpaces!.hashCode);
 
   @override
-  String toString() => 'SmartSearchFacetsDto[city=$city, country=$country, isFavorite=$isFavorite, language=$language, make=$make, model=$model, personIds=$personIds, query=$query, queryAssetId=$queryAssetId, rating=$rating, spaceId=$spaceId, spacePersonIds=$spacePersonIds, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, type=$type, withSharedSpaces=$withSharedSpaces]';
+  String toString() => 'SmartSearchFacetsDto[city=$city, country=$country, isFavorite=$isFavorite, isNotInAlbum=$isNotInAlbum, language=$language, make=$make, model=$model, personIds=$personIds, query=$query, queryAssetId=$queryAssetId, rating=$rating, spaceId=$spaceId, spacePersonIds=$spacePersonIds, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, type=$type, withSharedSpaces=$withSharedSpaces]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -199,6 +211,11 @@ class SmartSearchFacetsDto {
       json[r'isFavorite'] = this.isFavorite;
     } else {
     //  json[r'isFavorite'] = null;
+    }
+    if (this.isNotInAlbum != null) {
+      json[r'isNotInAlbum'] = this.isNotInAlbum;
+    } else {
+    //  json[r'isNotInAlbum'] = null;
     }
     if (this.language != null) {
       json[r'language'] = this.language;
@@ -281,6 +298,7 @@ class SmartSearchFacetsDto {
         city: mapValueOfType<String>(json, r'city'),
         country: mapValueOfType<String>(json, r'country'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
+        isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         language: mapValueOfType<String>(json, r'language'),
         make: mapValueOfType<String>(json, r'make'),
         model: mapValueOfType<String>(json, r'model'),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -5600,6 +5600,15 @@
             }
           },
           {
+            "name": "isNotInAlbum",
+            "required": false,
+            "in": "query",
+            "description": "Filter assets not in any album",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "make",
             "required": false,
             "in": "query",
@@ -10925,6 +10934,15 @@
             }
           },
           {
+            "name": "isNotInAlbum",
+            "required": false,
+            "in": "query",
+            "description": "Filter assets not in any album",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "lensModel",
             "required": false,
             "in": "query",
@@ -11139,6 +11157,15 @@
             "required": false,
             "in": "query",
             "description": "Filter by favorites",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "isNotInAlbum",
+            "required": false,
+            "in": "query",
+            "description": "Filter assets not in any album",
             "schema": {
               "type": "boolean"
             }
@@ -17272,6 +17299,15 @@
             }
           },
           {
+            "name": "isNotInAlbum",
+            "required": false,
+            "in": "query",
+            "description": "Filter assets not in any album",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "isTrashed",
             "required": false,
             "in": "query",
@@ -17604,6 +17640,15 @@
             "required": false,
             "in": "query",
             "description": "Filter by favorite status (true for favorites only, false for non-favorites only)",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "isNotInAlbum",
+            "required": false,
+            "in": "query",
+            "description": "Filter assets not in any album",
             "schema": {
               "type": "boolean"
             }
@@ -28001,6 +28046,10 @@
           },
           "isFavorite": {
             "description": "Filter by favorite status",
+            "type": "boolean"
+          },
+          "isNotInAlbum": {
+            "description": "Filter assets not in any album",
             "type": "boolean"
           },
           "language": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2044,6 +2044,8 @@ export type SmartSearchFacetsDto = {
     country?: string | null;
     /** Filter by favorite status */
     isFavorite?: boolean;
+    /** Filter assets not in any album */
+    isNotInAlbum?: boolean;
     /** Search language code */
     language?: string;
     /** Filter by camera make */
@@ -5206,10 +5208,11 @@ export function reassignFacesById({ id, faceDto }: {
 /**
  * Get filtered map markers
  */
-export function getFilteredMapMarkers({ city, country, isFavorite, make, model, personIds, rating, spaceId, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
+export function getFilteredMapMarkers({ city, country, isFavorite, isNotInAlbum, make, model, personIds, rating, spaceId, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
     city?: string;
     country?: string;
     isFavorite?: boolean;
+    isNotInAlbum?: boolean;
     make?: string;
     model?: string;
     personIds?: string[];
@@ -5228,6 +5231,7 @@ export function getFilteredMapMarkers({ city, country, isFavorite, make, model, 
         city,
         country,
         isFavorite,
+        isNotInAlbum,
         make,
         model,
         personIds,
@@ -6408,11 +6412,12 @@ export function searchAssetStatistics({ statisticsSearchDto }: {
 /**
  * Retrieve search suggestions
  */
-export function getSearchSuggestions({ albumId, country, includeNull, isFavorite, lensModel, make, model, personIds, rating, spaceId, state, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
+export function getSearchSuggestions({ albumId, country, includeNull, isFavorite, isNotInAlbum, lensModel, make, model, personIds, rating, spaceId, state, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
     albumId?: string;
     country?: string;
     includeNull?: boolean;
     isFavorite?: boolean;
+    isNotInAlbum?: boolean;
     lensModel?: string;
     make?: string;
     model?: string;
@@ -6434,6 +6439,7 @@ export function getSearchSuggestions({ albumId, country, includeNull, isFavorite
         country,
         includeNull,
         isFavorite,
+        isNotInAlbum,
         lensModel,
         make,
         model,
@@ -6453,11 +6459,12 @@ export function getSearchSuggestions({ albumId, country, includeNull, isFavorite
 /**
  * Retrieve dynamic filter suggestions
  */
-export function getFilterSuggestions({ albumId, city, country, isFavorite, make, mediaType, model, personIds, rating, spaceId, tagIds, takenAfter, takenBefore, withSharedSpaces }: {
+export function getFilterSuggestions({ albumId, city, country, isFavorite, isNotInAlbum, make, mediaType, model, personIds, rating, spaceId, tagIds, takenAfter, takenBefore, withSharedSpaces }: {
     albumId?: string;
     city?: string;
     country?: string;
     isFavorite?: boolean;
+    isNotInAlbum?: boolean;
     make?: string;
     mediaType?: AssetTypeEnum;
     model?: string;
@@ -6477,6 +6484,7 @@ export function getFilterSuggestions({ albumId, city, country, isFavorite, make,
         city,
         country,
         isFavorite,
+        isNotInAlbum,
         make,
         mediaType,
         model,
@@ -7846,12 +7854,13 @@ export function tagAssets({ id, bulkIdsDto }: {
 /**
  * Get time bucket
  */
-export function getTimeBucket({ albumId, bbox, city, country, isFavorite, isTrashed, key, make, model, order, personId, personIds, rating, slug, spaceId, spacePersonId, spacePersonIds, tagId, tagIds, takenAfter, takenBefore, timeBucket, $type, userId, visibility, withCoordinates, withPartners, withSharedSpaces, withStacked }: {
+export function getTimeBucket({ albumId, bbox, city, country, isFavorite, isNotInAlbum, isTrashed, key, make, model, order, personId, personIds, rating, slug, spaceId, spacePersonId, spacePersonIds, tagId, tagIds, takenAfter, takenBefore, timeBucket, $type, userId, visibility, withCoordinates, withPartners, withSharedSpaces, withStacked }: {
     albumId?: string;
     bbox?: string;
     city?: string;
     country?: string;
     isFavorite?: boolean;
+    isNotInAlbum?: boolean;
     isTrashed?: boolean;
     key?: string;
     make?: string;
@@ -7886,6 +7895,7 @@ export function getTimeBucket({ albumId, bbox, city, country, isFavorite, isTras
         city,
         country,
         isFavorite,
+        isNotInAlbum,
         isTrashed,
         key,
         make,
@@ -7917,12 +7927,13 @@ export function getTimeBucket({ albumId, bbox, city, country, isFavorite, isTras
 /**
  * Get time buckets
  */
-export function getTimeBuckets({ albumId, bbox, city, country, isFavorite, isTrashed, key, make, model, order, personId, personIds, rating, slug, spaceId, spacePersonId, spacePersonIds, tagId, tagIds, takenAfter, takenBefore, $type, userId, visibility, withCoordinates, withPartners, withSharedSpaces, withStacked }: {
+export function getTimeBuckets({ albumId, bbox, city, country, isFavorite, isNotInAlbum, isTrashed, key, make, model, order, personId, personIds, rating, slug, spaceId, spacePersonId, spacePersonIds, tagId, tagIds, takenAfter, takenBefore, $type, userId, visibility, withCoordinates, withPartners, withSharedSpaces, withStacked }: {
     albumId?: string;
     bbox?: string;
     city?: string;
     country?: string;
     isFavorite?: boolean;
+    isNotInAlbum?: boolean;
     isTrashed?: boolean;
     key?: string;
     make?: string;
@@ -7956,6 +7967,7 @@ export function getTimeBuckets({ albumId, bbox, city, country, isFavorite, isTra
         city,
         country,
         isFavorite,
+        isNotInAlbum,
         isTrashed,
         key,
         make,

--- a/server/src/dtos/gallery-map.dto.spec.ts
+++ b/server/src/dtos/gallery-map.dto.spec.ts
@@ -82,4 +82,27 @@ describe('FilteredMapMarkerDto', () => {
       expect(result.data?.country).toBeUndefined();
     });
   });
+
+  describe('isNotInAlbum', () => {
+    it('should coerce true string to boolean', () => {
+      const result = parse({ isNotInAlbum: 'true' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.isNotInAlbum).toBe(true);
+    });
+
+    it('should coerce false string to boolean', () => {
+      const result = parse({ isNotInAlbum: 'false' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.isNotInAlbum).toBe(false);
+    });
+
+    it('should leave undefined when not provided', () => {
+      const result = parse({});
+
+      expect(result.success).toBe(true);
+      expect(result.data?.isNotInAlbum).toBeUndefined();
+    });
+  });
 });

--- a/server/src/dtos/gallery-map.dto.ts
+++ b/server/src/dtos/gallery-map.dto.ts
@@ -35,6 +35,7 @@ const FilteredMapMarkerSchema = z
     takenAfter: isoDatetimeToDate.optional().describe('Filter assets taken after this date'),
     takenBefore: isoDatetimeToDate.optional().describe('Filter assets taken before this date'),
     isFavorite: stringToBool.optional().describe('Filter by favorite status'),
+    isNotInAlbum: stringToBool.optional().describe('Filter assets not in any album'),
     city: z.string().optional().describe('Filter by city'),
     country: z.string().optional().describe('Filter by country'),
     withSharedSpaces: stringToBool.optional().describe('Include shared space assets'),

--- a/server/src/dtos/search.dto.spec.ts
+++ b/server/src/dtos/search.dto.spec.ts
@@ -1,0 +1,48 @@
+import {
+  FilterSuggestionsRequestDto,
+  SearchSuggestionRequestDto,
+  SearchSuggestionType,
+  SmartSearchDto,
+  SmartSearchFacetsDto,
+} from 'src/dtos/search.dto';
+
+describe('search DTO albumless filters', () => {
+  it('should accept isNotInAlbum on smart search requests', () => {
+    const result = SmartSearchDto.schema.safeParse({ query: 'beach', isNotInAlbum: true });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.isNotInAlbum).toBe(true);
+  });
+
+  it('should accept isNotInAlbum on smart search facet requests', () => {
+    const result = SmartSearchFacetsDto.schema.safeParse({ query: 'beach', isNotInAlbum: true });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.isNotInAlbum).toBe(true);
+  });
+
+  it('should coerce isNotInAlbum on filter suggestion requests', () => {
+    const result = FilterSuggestionsRequestDto.schema.safeParse({ isNotInAlbum: 'true' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.isNotInAlbum).toBe(true);
+  });
+
+  it('should coerce isNotInAlbum on dependent search suggestion requests', () => {
+    const result = SearchSuggestionRequestDto.schema.safeParse({
+      type: SearchSuggestionType.CITY,
+      country: 'Germany',
+      isNotInAlbum: 'true',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.isNotInAlbum).toBe(true);
+  });
+
+  it('should reject unrelated album values on suggestion requests instead of treating them as albumless', () => {
+    const result = FilterSuggestionsRequestDto.schema.safeParse({ album: 'none' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.isNotInAlbum).toBeUndefined();
+  });
+});

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -105,6 +105,7 @@ const SmartSearchSchema = BaseSearchWithResultsSchema.extend({
 const SmartSearchFacetsSchema = BaseSearchSchema.pick({
   type: true,
   isFavorite: true,
+  isNotInAlbum: true,
   takenBefore: true,
   takenAfter: true,
   city: true,
@@ -178,6 +179,7 @@ const SearchSuggestionRequestBaseSchema = z.object({
     .describe('Filter by tag IDs'),
   rating: z.coerce.number().int().min(1).max(5).optional().describe('Filter by rating (1-5)'),
   isFavorite: stringToBool.optional().describe('Filter by favorites'),
+  isNotInAlbum: stringToBool.optional().describe('Filter assets not in any album'),
   make: z.string().optional().describe('Filter by camera make'),
   model: z.string().optional().describe('Filter by camera model'),
   lensModel: z.string().optional().describe('Filter by lens model'),
@@ -276,6 +278,7 @@ const FilterSuggestionsRequestBaseSchema = z.object({
   rating: z.coerce.number().int().min(1).max(5).optional().describe('Filter by rating (1-5)'),
   mediaType: AssetTypeSchema.optional().describe('Filter by asset type'),
   isFavorite: stringToBool.optional().describe('Filter by favorites'),
+  isNotInAlbum: stringToBool.optional().describe('Filter assets not in any album'),
   takenAfter: isoDatetimeToDate.optional().describe('Filter by taken date (after)'),
   takenBefore: isoDatetimeToDate.optional().describe('Filter by taken date (before)'),
   albumId: z.uuidv4().optional().describe('Scope to a specific album'),

--- a/server/src/dtos/time-bucket.dto.spec.ts
+++ b/server/src/dtos/time-bucket.dto.spec.ts
@@ -51,4 +51,20 @@ describe('TimeBucketDto', () => {
       expect(result.data?.tagIds).toEqual(['3fe388e4-2078-44d7-b36c-39d9dee3a657']);
     });
   });
+
+  describe('isNotInAlbum query param handling', () => {
+    it('should coerce true string to boolean', () => {
+      const result = TimeBucketDto.schema.safeParse({ isNotInAlbum: 'true' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.isNotInAlbum).toBe(true);
+    });
+
+    it('should coerce false string to boolean', () => {
+      const result = TimeBucketDto.schema.safeParse({ isNotInAlbum: 'false' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.isNotInAlbum).toBe(false);
+    });
+  });
 });

--- a/server/src/dtos/time-bucket.dto.ts
+++ b/server/src/dtos/time-bucket.dto.ts
@@ -19,6 +19,7 @@ const TimeBucketQueryBaseSchema = z
     isFavorite: stringToBool
       .optional()
       .describe('Filter by favorite status (true for favorites only, false for non-favorites only)'),
+    isNotInAlbum: stringToBool.optional().describe('Filter assets not in any album'),
     isTrashed: stringToBool
       .optional()
       .describe('Filter by trash status (true for trashed assets only, false for non-trashed only)'),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -73,6 +73,7 @@ interface LivePhotoSearchOptions {
 
 interface AssetBuilderOptions {
   isFavorite?: boolean;
+  isNotInAlbum?: boolean;
   isTrashed?: boolean;
   isDuplicate?: boolean;
   albumId?: string;
@@ -908,6 +909,11 @@ export class AssetRepository {
               .innerJoin('album_asset', 'asset.id', 'album_asset.assetId')
               .where('album_asset.albumId', '=', asUuid(options.albumId!)),
           )
+          .$if(!!options.isNotInAlbum && !options.albumId, (qb) =>
+            qb.where((eb) =>
+              eb.not(eb.exists((eb) => eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
+            ),
+          )
           .$if(!!options.spaceId, (qb) =>
             qb.where((eb) =>
               eb.or([
@@ -1041,6 +1047,11 @@ export class AssetRepository {
                   .whereRef('album_asset.assetId', '=', 'asset.id')
                   .where('album_asset.albumId', '=', asUuid(options.albumId!)),
               ),
+            ),
+          )
+          .$if(!!options.isNotInAlbum && !options.albumId, (qb) =>
+            qb.where((eb) =>
+              eb.not(eb.exists((eb) => eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
             ),
           )
           .$if(!!options.spaceId, (qb) =>

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -413,6 +413,28 @@ describe(SearchRepository.name, () => {
 
       expect(sql).toContain('false');
     });
+
+    it('filters suggestion asset ids to assets without album membership', () => {
+      const sql = compileFilteredAssetIds(sut, { isNotInAlbum: true });
+
+      expect(sql).toContain('"album_asset"');
+      expect(sql).toContain('not exists');
+      expect(sql).toContain('"album_asset"."assetId" = "asset"."id"');
+    });
+
+    it('does not add album exclusion for false has-no-album filters', () => {
+      const sql = compileFilteredAssetIds(sut, { isNotInAlbum: false });
+
+      expect(sql).not.toContain('"album_asset"');
+    });
+
+    it('filters dependent EXIF suggestions to assets without album membership', () => {
+      const sql = compileExifField(sut, 'model', { isNotInAlbum: true });
+
+      expect(sql).toContain('"album_asset"');
+      expect(sql).toContain('not exists');
+      expect(sql).toContain('"album_asset"."assetId" = "asset"."id"');
+    });
   });
 
   describe('album-scoped suggestions', () => {

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -216,6 +216,10 @@ export interface SuggestionScopeOptions {
   takenBefore?: Date;
 }
 
+interface ExifSuggestionScopeOptions extends SuggestionScopeOptions {
+  isNotInAlbum?: boolean;
+}
+
 interface FilterSuggestionFilterOptions {
   personIds?: string[];
   identityIds?: string[];
@@ -228,9 +232,10 @@ interface FilterSuggestionFilterOptions {
   rating?: number;
   mediaType?: AssetType;
   isFavorite?: boolean;
+  isNotInAlbum?: boolean;
 }
 
-export interface GetStatesOptions extends SuggestionScopeOptions {
+export interface GetStatesOptions extends ExifSuggestionScopeOptions {
   country?: string;
 }
 
@@ -238,17 +243,17 @@ export interface GetCitiesOptions extends SuggestionScopeOptions, FilterSuggesti
   state?: string;
 }
 
-export interface GetCameraModelsOptions extends SuggestionScopeOptions {
+export interface GetCameraModelsOptions extends ExifSuggestionScopeOptions {
   make?: string;
   lensModel?: string;
 }
 
-export interface GetCameraMakesOptions extends SuggestionScopeOptions {
+export interface GetCameraMakesOptions extends ExifSuggestionScopeOptions {
   model?: string;
   lensModel?: string;
 }
 
-export interface GetCameraLensModelsOptions extends SuggestionScopeOptions {
+export interface GetCameraLensModelsOptions extends ExifSuggestionScopeOptions {
   make?: string;
   model?: string;
 }
@@ -1016,7 +1021,7 @@ export class SearchRepository {
       .execute();
   }
 
-  async getCountries(userIds: string[], options?: SuggestionScopeOptions): Promise<string[]> {
+  async getCountries(userIds: string[], options?: ExifSuggestionScopeOptions): Promise<string[]> {
     const res = await this.getExifField('country', userIds, options).execute();
     return res.map((row) => row.country!);
   }
@@ -1177,7 +1182,7 @@ export class SearchRepository {
   private applySuggestionScope<T extends SelectQueryBuilder<DB, any, any>>(
     qb: T,
     userIds: string[],
-    options?: SuggestionScopeOptions,
+    options?: ExifSuggestionScopeOptions,
   ) {
     return qb
       .$if(!!options?.albumId, (qb) =>
@@ -1257,7 +1262,7 @@ export class SearchRepository {
   private getExifField<K extends 'city' | 'state' | 'country' | 'make' | 'model' | 'lensModel'>(
     field: K,
     userIds: string[],
-    options?: SuggestionScopeOptions,
+    options?: ExifSuggestionScopeOptions,
   ) {
     return this.applySuggestionScope(
       this.db
@@ -1272,6 +1277,11 @@ export class SearchRepository {
       userIds,
       options,
     )
+      .$if(!!options?.isNotInAlbum && !options?.albumId, (qb) =>
+        qb.where((eb) =>
+          eb.not(eb.exists((eb) => eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
+        ),
+      )
       .$if(!!options?.takenAfter, (qb) => qb.where('asset.fileCreatedAt', '>=', options!.takenAfter!))
       .$if(!!options?.takenBefore, (qb) => qb.where('asset.fileCreatedAt', '<', options!.takenBefore!));
   }
@@ -1289,6 +1299,11 @@ export class SearchRepository {
       options,
     )
       .$if(!!options.forceEmptyResult, (qb) => qb.where(sql<SqlBool>`false`))
+      .$if(!!options.isNotInAlbum && !options.albumId, (qb) =>
+        qb.where((eb) =>
+          eb.not(eb.exists((eb) => eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
+        ),
+      )
       .$if(!!options.takenAfter, (qb) => qb.where('asset.fileCreatedAt', '>=', options.takenAfter!))
       .$if(!!options.takenBefore, (qb) => qb.where('asset.fileCreatedAt', '<', options.takenBefore!))
       .$if(needsExifJoin, (qb) =>

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -8025,6 +8025,7 @@ describe(SharedSpaceService.name, () => {
         country: 'France',
         rating: 4,
         make: 'Canon',
+        isNotInAlbum: true,
       });
 
       expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
@@ -8035,8 +8036,22 @@ describe(SharedSpaceService.name, () => {
           country: 'France',
           rating: 4,
           make: 'Canon',
+          isNotInAlbum: true,
           personMatchAny: true,
           tagMatchAny: true,
+        }),
+      );
+    });
+
+    it('should pass false has-no-album to repository without enabling the filter', async () => {
+      const auth = factory.auth();
+      mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);
+
+      await sut.getFilteredMapMarkers(auth, { isNotInAlbum: false });
+
+      expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isNotInAlbum: false,
         }),
       );
     });

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -735,6 +735,7 @@ export class SharedSpaceService extends BaseService {
       takenAfter: dto.takenAfter,
       takenBefore: dto.takenBefore,
       isFavorite: dto.isFavorite,
+      isNotInAlbum: dto.isNotInAlbum,
       city: dto.city,
       country: dto.country,
       visibility: AssetVisibility.Timeline,

--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -673,6 +673,18 @@ describe(TimelineService.name, () => {
       expect(mocks.asset.getTimeBuckets).toHaveBeenCalledWith(expect.objectContaining({ tagIds: ['tag-1', 'tag-2'] }));
     });
 
+    it('should pass has-no-album through to asset repository for getTimeBuckets', async () => {
+      mocks.asset.getTimeBuckets.mockResolvedValue([]);
+      await sut.getTimeBuckets(authStub.admin, { isNotInAlbum: true });
+      expect(mocks.asset.getTimeBuckets).toHaveBeenCalledWith(expect.objectContaining({ isNotInAlbum: true }));
+    });
+
+    it('should pass false has-no-album through for getTimeBuckets without enabling the filter', async () => {
+      mocks.asset.getTimeBuckets.mockResolvedValue([]);
+      await sut.getTimeBuckets(authStub.admin, { isNotInAlbum: false });
+      expect(mocks.asset.getTimeBuckets).toHaveBeenCalledWith(expect.objectContaining({ isNotInAlbum: false }));
+    });
+
     it('should not require tag ownership to filter by tagIds', async () => {
       mocks.asset.getTimeBuckets.mockResolvedValue([{ timeBucket: '2024-01-01', count: 5 }]);
       // user1 filters by tags they do not own — should succeed without TagRead check
@@ -817,6 +829,19 @@ describe(TimelineService.name, () => {
           takenAfter: '2023-08-01T00:00:00.000Z',
           takenBefore: '2023-08-31T23:59:59.999Z',
         }),
+        authStub.admin,
+      );
+    });
+
+    it('should pass has-no-album through for getTimeBucket', async () => {
+      const json = `[{ id: ['asset-id'] }]`;
+      mocks.asset.getTimeBucket.mockResolvedValue({ assets: json });
+
+      await sut.getTimeBucket(authStub.admin, { timeBucket: '2023-08-01', isNotInAlbum: true });
+
+      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
+        '2023-08-01',
+        expect.objectContaining({ isNotInAlbum: true }),
         authStub.admin,
       );
     });

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -160,8 +160,56 @@ describe('ActiveFiltersBar', () => {
     expect(removedType).toBe('favorites');
   });
 
+  it('should render chip for has-no-album filter', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    const { getAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    const chips = getAllByTestId('active-chip');
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toContain('Has no album');
+  });
+
+  it('should remove has-no-album filter on chip close', async () => {
+    let removedType: string | undefined;
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    const { getByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: (type: string) => {
+          removedType = type;
+        },
+        onClearAll: () => {},
+      },
+    });
+
+    await fireEvent.click(getByTestId('chip-close'));
+    expect(removedType).toBe('albums');
+  });
+
   it('should not render a favorites chip for isFavorite false', () => {
     const filters = { ...createFilterState(), isFavorite: false };
+
+    const { queryAllByTestId } = render(ActiveFiltersBar, {
+      props: {
+        filters,
+        onRemoveFilter: () => {},
+        onClearAll: () => {},
+      },
+    });
+
+    expect(queryAllByTestId('active-chip')).toHaveLength(0);
+  });
+
+  it('should not render a has-no-album chip for false', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: false };
 
     const { queryAllByTestId } = render(ActiveFiltersBar, {
       props: {

--- a/web/src/lib/components/filter-panel/__tests__/albums-filter.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/albums-filter.spec.ts
@@ -1,0 +1,42 @@
+import AlbumsFilter from '$lib/components/filter-panel/albums-filter.svelte';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('AlbumsFilter', () => {
+  it('should render All and Has no album buttons', () => {
+    render(AlbumsFilter, { props: { selected: undefined, onToggle: vi.fn() } });
+
+    expect(screen.getByTestId('albums-all')).toBeInTheDocument();
+    expect(screen.getByTestId('albums-none')).toBeInTheDocument();
+  });
+
+  it('should highlight All when selected is undefined', () => {
+    render(AlbumsFilter, { props: { selected: undefined, onToggle: vi.fn() } });
+
+    expect(screen.getByTestId('albums-all').className).toContain('border-immich-primary');
+  });
+
+  it('should highlight Has no album when selected is true', () => {
+    render(AlbumsFilter, { props: { selected: true, onToggle: vi.fn() } });
+
+    expect(screen.getByTestId('albums-none').className).toContain('border-immich-primary');
+  });
+
+  it('should call onToggle with true when Has no album is clicked', () => {
+    const onToggle = vi.fn();
+    render(AlbumsFilter, { props: { selected: undefined, onToggle } });
+
+    screen.getByTestId('albums-none').click();
+
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('should call onToggle with undefined when All is clicked', () => {
+    const onToggle = vi.fn();
+    render(AlbumsFilter, { props: { selected: true, onToggle } });
+
+    screen.getByTestId('albums-all').click();
+
+    expect(onToggle).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -134,6 +134,38 @@ describe('FilterPanel', () => {
     expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ country: 'Germany', city: undefined }));
   });
 
+  it('should update filters when has-no-album is selected', async () => {
+    const onFiltersChange = vi.fn();
+
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['albums' as FilterSection], providers: {} },
+        timeBuckets: [],
+        onFiltersChange,
+      },
+    });
+
+    await fireEvent.click(screen.getByTestId('albums-none'));
+
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ isNotInAlbum: true }));
+  });
+
+  it('should show active state for has-no-album when collapsed', async () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    render(FilterPanel, {
+      props: {
+        config: { sections: ['albums' as FilterSection], providers: {} },
+        timeBuckets: [],
+        filters,
+      },
+    });
+
+    await fireEvent.click(screen.getByTestId('collapse-panel-btn'));
+
+    expect(screen.getByTestId('collapsed-icon-strip').querySelector('.bg-immich-primary')).toBeTruthy();
+  });
+
   it('should work without onFiltersChange callback', () => {
     const { queryByTestId } = render(FilterPanel, {
       props: {

--- a/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-state.spec.ts
@@ -45,6 +45,12 @@ describe('FilterState utilities', () => {
     expect(getActiveFilterCount(state)).toBe(3);
   });
 
+  it('should count has-no-album as an active filter', () => {
+    const state = { ...createFilterState(), isNotInAlbum: true };
+
+    expect(getActiveFilterCount(state)).toBe(1);
+  });
+
   it('should count selectedYear as an active filter', () => {
     const state = createFilterState();
     state.selectedYear = 2023;
@@ -102,6 +108,15 @@ describe('FilterState utilities', () => {
     expect(cleared.rating).toBeUndefined();
     expect(cleared.sortOrder).toBe('asc'); // preserved!
     expect(cleared.mediaType).toBe('all');
+  });
+
+  it('should clear has-no-album while preserving sortOrder', () => {
+    const state = { ...createFilterState(), isNotInAlbum: true, sortOrder: 'asc' as const };
+
+    const cleared = clearFilters(state);
+
+    expect(cleared.isNotInAlbum).toBeUndefined();
+    expect(cleared.sortOrder).toBe('asc');
   });
 
   it('should preserve relevance sortOrder on clearFilters', () => {
@@ -171,13 +186,21 @@ describe('buildFilterContext', () => {
     state.tagIds = ['tag-1'];
     state.rating = 4;
     state.isFavorite = true;
+    const stateWithAlbums = { ...state, isNotInAlbum: true };
 
-    expect(buildFilterContext(state)).toEqual({
+    expect(buildFilterContext(stateWithAlbums)).toEqual({
       personIds: ['person-1'],
       tagIds: ['tag-1'],
       rating: 4,
       isFavorite: true,
+      isNotInAlbum: true,
     });
+  });
+
+  it('should exclude has-no-album from dependent suggestion context when requested', () => {
+    const state = { ...createFilterState(), isNotInAlbum: true, rating: 4 };
+
+    expect(buildFilterContext(state, ['isNotInAlbum'])).toEqual({ rating: 4 });
   });
 
   it('should exclude requested filters from dependent suggestion context', () => {

--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -101,6 +101,11 @@
       result.push({ type: 'favorites', label: 'Favorites' });
     }
 
+    // Albums chip
+    if (filters.isNotInAlbum === true) {
+      result.push({ type: 'albums', label: 'Has no album' });
+    }
+
     // Timeline chip
     const customDateLabel = buildCustomDateLabel(filters.dateAfter, filters.dateBefore);
     if (customDateLabel) {

--- a/web/src/lib/components/filter-panel/albums-filter.svelte
+++ b/web/src/lib/components/filter-panel/albums-filter.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { Icon } from '@immich/ui';
+  import { mdiImageAlbum, mdiImageOffOutline } from '@mdi/js';
+
+  interface Props {
+    selected?: boolean;
+    onToggle: (value: boolean | undefined) => void;
+  }
+
+  let { selected, onToggle }: Props = $props();
+</script>
+
+<div class="flex gap-1.5" data-testid="albums-filter">
+  <button
+    type="button"
+    class="flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs {selected === undefined
+      ? 'border-immich-primary bg-immich-primary/10 text-immich-primary dark:border-immich-dark-primary dark:bg-immich-dark-primary/20 dark:text-immich-dark-primary'
+      : 'border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400'}"
+    onclick={() => onToggle(undefined)}
+    data-testid="albums-all"
+  >
+    <Icon icon={mdiImageAlbum} size="14" />
+    All
+  </button>
+  <button
+    type="button"
+    class="flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs {selected === true
+      ? 'border-immich-primary bg-immich-primary/10 text-immich-primary dark:border-immich-dark-primary dark:bg-immich-dark-primary/20 dark:text-immich-dark-primary'
+      : 'border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400'}"
+    onclick={() => onToggle(true)}
+    data-testid="albums-none"
+  >
+    <Icon icon={mdiImageOffOutline} size="14" />
+    Has no album
+  </button>
+</div>

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -13,6 +13,7 @@
     mdiStar,
     mdiImage,
     mdiHeart,
+    mdiImageAlbum,
   } from '@mdi/js';
   import { untrack } from 'svelte';
   import type {
@@ -32,6 +33,7 @@
   import RatingFilter from './rating-filter.svelte';
   import MediaTypeFilter from './media-type-filter.svelte';
   import FavoritesFilter from './favorites-filter.svelte';
+  import AlbumsFilter from './albums-filter.svelte';
 
   interface Props {
     config: FilterPanelConfig;
@@ -110,6 +112,7 @@
       rating: filters.rating,
       mediaType: filters.mediaType,
       isFavorite: filters.isFavorite,
+      isNotInAlbum: filters.isNotInAlbum,
       sortOrder: filters.sortOrder,
       dateAfter: filters.dateAfter,
       dateBefore: filters.dateBefore,
@@ -331,6 +334,7 @@
     rating: mdiStar,
     media: mdiImage,
     favorites: mdiHeart,
+    albums: mdiImageAlbum,
   };
 
   const sectionTitles: Record<string, string> = {
@@ -342,6 +346,7 @@
     rating: 'Rating',
     media: 'Media Type',
     favorites: 'Favorites',
+    albums: 'Albums',
   };
 
   const sectionToggleLabels: Record<string, string> = {
@@ -352,7 +357,7 @@
 
   type StoredSectionSet = string[] | { selected?: string[]; known?: string[] };
 
-  const LEGACY_INTRODUCED_SECTIONS = new Set<FilterSectionType>(['favorites']);
+  const LEGACY_INTRODUCED_SECTIONS = new Set<FilterSectionType>(['favorites', 'albums']);
 
   function isFilterSection(value: string, configSections: FilterSectionType[]): value is FilterSectionType {
     return configSections.includes(value as FilterSectionType);
@@ -634,6 +639,9 @@
       case 'favorites': {
         return filters.isFavorite !== undefined;
       }
+      case 'albums': {
+        return filters.isNotInAlbum === true;
+      }
       case 'timeline': {
         return (
           filters.dateAfter !== undefined || filters.dateBefore !== undefined || filters.selectedYear !== undefined
@@ -813,6 +821,13 @@
                 selected={filters.isFavorite}
                 onToggle={(value) => {
                   updateFilters({ ...filters, isFavorite: value });
+                }}
+              />
+            {:else if section === 'albums'}
+              <AlbumsFilter
+                selected={filters.isNotInAlbum}
+                onToggle={(value) => {
+                  updateFilters({ ...filters, isNotInAlbum: value });
                 }}
               />
             {/if}

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -1,4 +1,13 @@
-export type FilterSection = 'timeline' | 'people' | 'location' | 'camera' | 'tags' | 'rating' | 'media' | 'favorites';
+export type FilterSection =
+  | 'timeline'
+  | 'people'
+  | 'location'
+  | 'camera'
+  | 'tags'
+  | 'rating'
+  | 'media'
+  | 'favorites'
+  | 'albums';
 
 export interface PersonOption {
   id: string;
@@ -57,6 +66,7 @@ export interface FilterState {
   rating?: number;
   mediaType: 'all' | 'image' | 'video';
   isFavorite?: boolean;
+  isNotInAlbum?: boolean;
   sortOrder: 'asc' | 'desc' | 'relevance';
   dateAfter?: string;
   dateBefore?: string;
@@ -86,6 +96,7 @@ export function getActiveFilterCount(state: FilterState): number {
     (state.rating === undefined ? 0 : 1) +
     (state.mediaType === 'all' ? 0 : 1) +
     (state.isFavorite === undefined ? 0 : 1) +
+    (state.isNotInAlbum === true ? 1 : 0) +
     (hasTemporalFilter ? 1 : 0)
   );
 }
@@ -97,6 +108,7 @@ export type FilterContext = {
   tagIds?: string[];
   rating?: number;
   isFavorite?: boolean;
+  isNotInAlbum?: boolean;
 };
 
 function hasDateValue(value: string | undefined): value is string {
@@ -162,6 +174,10 @@ export function buildFilterContext(
     context.isFavorite = state.isFavorite;
   }
 
+  if (includes('isNotInAlbum') && state.isNotInAlbum === true) {
+    context.isNotInAlbum = true;
+  }
+
   const validDateAfter = includes('dateAfter') ? dateOnlyToUtcStart(state.dateAfter) : undefined;
   const validDateBefore = includes('dateBefore') ? dateOnlyToExclusiveUtcEnd(state.dateBefore) : undefined;
 
@@ -197,6 +213,7 @@ export function clearFilters(state: FilterState): FilterState {
     rating: undefined,
     mediaType: 'all',
     isFavorite: undefined,
+    isNotInAlbum: undefined,
     dateAfter: undefined,
     dateBefore: undefined,
     selectedYear: undefined,

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -36,6 +36,7 @@ describe('buildMapFilterConfig', () => {
       'rating',
       'media',
       'favorites',
+      'albums',
     ]);
   });
 
@@ -82,6 +83,22 @@ describe('buildMapFilterConfig', () => {
       await config.suggestionsProvider!(emptyFilters);
 
       expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-123' }));
+    });
+
+    it('should pass has-no-album to filter suggestions', async () => {
+      const config = buildMapFilterConfig();
+      await config.suggestionsProvider!({ ...emptyFilters, isNotInAlbum: true });
+
+      expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isNotInAlbum: true }));
+    });
+
+    it('should omit has-no-album from filter suggestions when false', async () => {
+      const config = buildMapFilterConfig();
+      await config.suggestionsProvider!({ ...emptyFilters, isNotInAlbum: false });
+
+      expect(getFilterSuggestions).toHaveBeenCalledWith(
+        expect.not.objectContaining({ isNotInAlbum: expect.anything() }),
+      );
     });
 
     it('should map people with thumbnail URLs', async () => {

--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -17,6 +17,18 @@ describe('buildMapMarkerOptions', () => {
       }),
     );
   });
+
+  it('includes has-no-album in map marker options', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    expect(buildMapMarkerOptions(filters)).toEqual(expect.objectContaining({ isNotInAlbum: true }));
+  });
+
+  it('omits has-no-album from map marker options when false', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: false };
+
+    expect(buildMapMarkerOptions(filters)).not.toHaveProperty('isNotInAlbum');
+  });
 });
 
 describe('buildMapTimeBucketOptions', () => {
@@ -30,6 +42,7 @@ describe('buildMapTimeBucketOptions', () => {
       rating: 4,
       mediaType: 'video' as const,
       isFavorite: true,
+      isNotInAlbum: true,
       selectedYear: 2015,
       selectedMonth: 3,
     };
@@ -43,6 +56,7 @@ describe('buildMapTimeBucketOptions', () => {
       tagIds: ['tag-1'],
       rating: 4,
       isFavorite: true,
+      isNotInAlbum: true,
       $type: AssetTypeEnum.Video,
       takenAfter: '2015-03-01T00:00:00.000Z',
       takenBefore: '2015-04-01T00:00:00.000Z',
@@ -60,6 +74,18 @@ describe('buildMapTimeBucketOptions', () => {
       spaceId: 'space-123',
       country: 'Australia',
       $type: AssetTypeEnum.Image,
+    });
+  });
+
+  it('includes has-no-album in space map time bucket requests', () => {
+    const filters = {
+      ...createFilterState(),
+      isNotInAlbum: true,
+    };
+
+    expect(buildMapTimeBucketOptions(filters, 'space-123')).toEqual({
+      spaceId: 'space-123',
+      isNotInAlbum: true,
     });
   });
 
@@ -91,6 +117,7 @@ describe('buildMapTimelineOptions', () => {
       personIds: ['person-1'],
       tagIds: ['tag-1'],
       rating: 4,
+      isNotInAlbum: true,
       mediaType: 'image' as const,
       selectedYear: 2024,
       selectedMonth: 7,
@@ -105,6 +132,7 @@ describe('buildMapTimelineOptions', () => {
       personIds: ['person-1'],
       tagIds: ['tag-1'],
       rating: 4,
+      isNotInAlbum: true,
       $type: AssetTypeEnum.Image,
       takenAfter: '2024-07-01T00:00:00.000Z',
       takenBefore: '2024-08-01T00:00:00.000Z',
@@ -115,6 +143,7 @@ describe('buildMapTimelineOptions', () => {
     const filters = {
       ...createFilterState(),
       personIds: ['space-person-1'],
+      isNotInAlbum: true,
     };
     const selectedClusterIds = new Set(['asset-1']);
 
@@ -123,6 +152,7 @@ describe('buildMapTimelineOptions', () => {
       spaceId: 'space-1',
       assetFilter: selectedClusterIds,
       spacePersonIds: ['space-person-1'],
+      isNotInAlbum: true,
     });
   });
 

--- a/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
@@ -132,6 +132,20 @@ describe('buildPhotosTimelineOptions', () => {
     expect(options).not.toHaveProperty('withSharedSpaces');
   });
 
+  it('should include has-no-album when selected', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+    const options = buildPhotosTimelineOptions(filters);
+
+    expect(options.isNotInAlbum).toBe(true);
+  });
+
+  it('should omit has-no-album when it is false', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: false };
+    const options = buildPhotosTimelineOptions(filters);
+
+    expect(options).not.toHaveProperty('isNotInAlbum');
+  });
+
   it('should handle multiple simultaneous filters', () => {
     const filters = {
       ...createFilterState(),
@@ -142,6 +156,7 @@ describe('buildPhotosTimelineOptions', () => {
       tagIds: ['t1', 't2'],
       rating: 3,
       mediaType: 'image' as const,
+      isNotInAlbum: true,
       sortOrder: 'asc' as const,
       selectedYear: 2023,
     };
@@ -152,6 +167,7 @@ describe('buildPhotosTimelineOptions', () => {
     expect(options.make).toBe('Sony');
     expect(options.tagIds).toEqual(['t1', 't2']);
     expect(options.rating).toBe(3);
+    expect(options.isNotInAlbum).toBe(true);
     expect(options.$type).toBe(AssetTypeEnum.Image);
     expect(options.order).toBe(AssetOrder.Asc);
     expect(options.takenAfter).toBeDefined();
@@ -229,6 +245,13 @@ describe('handlePhotosRemoveFilter', () => {
 
     expect(handlePhotosRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
     expect(handlePhotosRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
+  });
+
+  it('should clear has-no-album filter', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    expect(handlePhotosRemoveFilter(filters, 'albums').isNotInAlbum).toBeUndefined();
+    expect(handlePhotosRemoveFilter(filters, 'isNotInAlbum').isNotInAlbum).toBeUndefined();
   });
 
   it('should preserve sortOrder when removing filters', () => {

--- a/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+++ b/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
@@ -55,6 +55,7 @@ describe('typed filter URL state', () => {
       model: 'Z8',
       mediaType: 'image' as const,
       isFavorite: true,
+      isNotInAlbum: true,
       rating: 4,
       dateAfter: '2025-01-01',
       dateBefore: '2026-12-31',
@@ -64,8 +65,15 @@ describe('typed filter URL state', () => {
     const result = buildSearchablePageUrl(url, 'beach', 'asc', filters);
 
     expect(result).toBe(
-      '/photos?view=timeline&q=beach&sort=asc&people=person-1%2Cperson-2&tags=tag-1&city=Berlin&country=Germany&make=Nikon&model=Z8&type=image&favorite=true&rating=4&from=2025-01-01&to=2026-12-31',
+      '/photos?view=timeline&q=beach&sort=asc&people=person-1%2Cperson-2&tags=tag-1&city=Berlin&country=Germany&make=Nikon&model=Z8&type=image&favorite=true&album=none&rating=4&from=2025-01-01&to=2026-12-31',
     );
+  });
+
+  it('omits has-no-album from URLs when false', () => {
+    const url = new URL('https://gallery.test/photos');
+    const filters = { ...createFilterState(), isNotInAlbum: false };
+
+    expect(buildSearchablePageUrl(url, '', 'desc', filters)).toBe('/photos?sort=desc');
   });
 
   it('serializes typed filters into space URLs', () => {
@@ -84,7 +92,7 @@ describe('typed filter URL state', () => {
 
   it('hydrates typed filter params into FilterState', () => {
     const url = new URL(
-      'https://gallery.test/photos?q=beach&people=person-1%2Cperson-2&tags=tag-1&type=video&favorite=false&rating=5&from=2025-01-01&to=2026-12-31',
+      'https://gallery.test/photos?q=beach&people=person-1%2Cperson-2&tags=tag-1&type=video&favorite=false&album=none&rating=5&from=2025-01-01&to=2026-12-31',
     );
 
     expect(getSearchablePageFilterState(url)).toEqual({
@@ -92,6 +100,7 @@ describe('typed filter URL state', () => {
       tagIds: ['tag-1'],
       mediaType: 'video',
       isFavorite: false,
+      isNotInAlbum: true,
       rating: 5,
       dateAfter: '2025-01-01',
       dateBefore: '2026-12-31',
@@ -99,7 +108,9 @@ describe('typed filter URL state', () => {
   });
 
   it('drops invalid typed filter URL params without crashing', () => {
-    const url = new URL('https://gallery.test/photos?type=gif&favorite=maybe&rating=9&from=soon&to=2026-99-01');
+    const url = new URL(
+      'https://gallery.test/photos?type=gif&favorite=maybe&album=all&rating=9&from=soon&to=2026-99-01',
+    );
 
     expect(getSearchablePageFilterState(url)).toEqual({});
   });
@@ -123,7 +134,7 @@ describe('typed filter URL state', () => {
   });
 
   it('clears only typed filter params', () => {
-    const params = new URLSearchParams('q=beach&sort=desc&people=p1&city=Berlin&view=timeline');
+    const params = new URLSearchParams('q=beach&sort=desc&people=p1&city=Berlin&album=none&view=timeline');
 
     clearSearchablePageFilterParams(params);
 

--- a/web/src/lib/utils/__tests__/space-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/space-filter-options.spec.ts
@@ -80,6 +80,23 @@ describe('buildSpaceTimelineOptions', () => {
       }),
     );
   });
+
+  it('preserves has-no-album in spaces timeline options', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).toEqual(
+      expect.objectContaining({
+        spaceId: 'space-1',
+        isNotInAlbum: true,
+      }),
+    );
+  });
+
+  it('omits has-no-album when it is false', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: false };
+
+    expect(buildSpaceTimelineOptions('space-1', filters)).not.toHaveProperty('isNotInAlbum');
+  });
 });
 
 describe('handleSpaceRemoveFilter', () => {
@@ -104,5 +121,12 @@ describe('handleSpaceRemoveFilter', () => {
 
     expect(handleSpaceRemoveFilter(filters, 'favorites').isFavorite).toBeUndefined();
     expect(handleSpaceRemoveFilter(filters, 'isFavorite').isFavorite).toBeUndefined();
+  });
+
+  it('clears has-no-album when removing albums filter', () => {
+    const filters = { ...createFilterState(), isNotInAlbum: true };
+
+    expect(handleSpaceRemoveFilter(filters, 'albums').isNotInAlbum).toBeUndefined();
+    expect(handleSpaceRemoveFilter(filters, 'isNotInAlbum').isNotInAlbum).toBeUndefined();
   });
 });

--- a/web/src/lib/utils/__tests__/space-search.spec.ts
+++ b/web/src/lib/utils/__tests__/space-search.spec.ts
@@ -138,6 +138,24 @@ describe('buildSmartSearchParams', () => {
       expect(result.isFavorite).toBeUndefined();
     });
 
+    it('sets isNotInAlbum when has-no-album is selected', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: { ...baseFilters, isNotInAlbum: true },
+      });
+
+      expect(result.isNotInAlbum).toBe(true);
+    });
+
+    it('omits isNotInAlbum when has-no-album is false', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: { ...baseFilters, isNotInAlbum: false },
+      });
+
+      expect(result.isNotInAlbum).toBeUndefined();
+    });
+
     it('builds takenAfter/takenBefore for selectedYear + selectedMonth (January)', () => {
       const result = buildSmartSearchParams({
         query: 'beach',
@@ -195,6 +213,7 @@ describe('buildSmartSearchParams', () => {
           selectedMonth: 3,
           sortOrder: 'desc',
           isFavorite: true,
+          isNotInAlbum: true,
         },
         spaceId: 'space-1',
       });
@@ -212,6 +231,7 @@ describe('buildSmartSearchParams', () => {
       expect(result.takenBefore).toBeDefined();
       expect(result.order).toBe(AssetOrder.Desc);
       expect(result.isFavorite).toBe(true);
+      expect(result.isNotInAlbum).toBe(true);
     });
 
     it('does not include empty string fields', () => {

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -14,7 +14,17 @@ import {
 } from '@immich/sdk';
 
 export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
-  const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
+  const sections = [
+    'timeline',
+    'people',
+    'location',
+    'camera',
+    'tags',
+    'rating',
+    'media',
+    'favorites',
+    'albums',
+  ] as const;
 
   const suggestionsProvider = async (filters: FilterState) => {
     const context = buildFilterContext(filters);
@@ -33,6 +43,7 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
             ? AssetTypeEnum.Image
             : AssetTypeEnum.Video,
       isFavorite: filters.isFavorite,
+      isNotInAlbum: filters.isNotInAlbum === true ? true : undefined,
       takenAfter: context?.takenAfter,
       takenBefore: context?.takenBefore,
       ...(spaceId ? { spaceId } : { withSharedSpaces: true }),

--- a/web/src/lib/utils/map-filter-options.ts
+++ b/web/src/lib/utils/map-filter-options.ts
@@ -25,6 +25,9 @@ function applyCommonMapFilters(base: Record<string, unknown>, filters: FilterSta
   if (filters.isFavorite !== undefined) {
     base.isFavorite = filters.isFavorite;
   }
+  if (filters.isNotInAlbum === true) {
+    base.isNotInAlbum = true;
+  }
   if (filters.city) {
     base.city = filters.city;
   }

--- a/web/src/lib/utils/photos-filter-options.ts
+++ b/web/src/lib/utils/photos-filter-options.ts
@@ -35,6 +35,9 @@ export function buildPhotosTimelineOptions(filters: FilterState): Record<string,
   if (filters.isFavorite !== undefined) {
     base.isFavorite = filters.isFavorite;
   }
+  if (filters.isNotInAlbum === true) {
+    base.isNotInAlbum = true;
+  }
   if (filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
@@ -94,6 +97,10 @@ export function handlePhotosRemoveFilter(filters: FilterState, type: string, id?
     case 'favorites':
     case 'isFavorite': {
       return { ...filters, isFavorite: undefined };
+    }
+    case 'albums':
+    case 'isNotInAlbum': {
+      return { ...filters, isNotInAlbum: undefined };
     }
     case 'timeline': {
       return {

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -11,6 +11,7 @@ export const SEARCHABLE_PAGE_FILTER_PARAMS = [
   'model',
   'type',
   'favorite',
+  'album',
   'rating',
   'from',
   'to',
@@ -27,6 +28,7 @@ export type SearchablePageFilterState = Partial<
     | 'model'
     | 'mediaType'
     | 'isFavorite'
+    | 'isNotInAlbum'
     | 'rating'
     | 'dateAfter'
     | 'dateBefore'
@@ -149,6 +151,7 @@ export function getSearchablePageFilterState(url: URL): SearchablePageFilterStat
   const rating = parseRating(url.searchParams.get('rating'));
   const mediaType = parseMediaType(url.searchParams.get('type'));
   const favorite = parseFavorite(url.searchParams.get('favorite'));
+  const isNotInAlbum = parseAlbumFilter(url.searchParams.get('album'));
   const from = parseDateParam(url.searchParams.get('from'));
   const to = parseDateParam(url.searchParams.get('to'));
 
@@ -175,6 +178,9 @@ export function getSearchablePageFilterState(url: URL): SearchablePageFilterStat
   }
   if (favorite !== undefined) {
     result.isFavorite = favorite;
+  }
+  if (isNotInAlbum === true) {
+    result.isNotInAlbum = true;
   }
   if (rating !== undefined) {
     result.rating = rating;
@@ -229,6 +235,9 @@ function appendSearchablePageFilterParams(params: URLSearchParams, filters: Filt
   if (filters.isFavorite !== undefined) {
     params.set('favorite', String(filters.isFavorite));
   }
+  if (filters.isNotInAlbum === true) {
+    params.set('album', 'none');
+  }
   if (filters.rating !== undefined) {
     params.set('rating', String(filters.rating));
   }
@@ -270,6 +279,10 @@ function parseFavorite(value: string | null): boolean | undefined {
     return false;
   }
   return undefined;
+}
+
+function parseAlbumFilter(value: string | null): boolean | undefined {
+  return value === 'none' ? true : undefined;
 }
 
 function parseDateParam(value: string | null): string | undefined {

--- a/web/src/lib/utils/space-filter-options.ts
+++ b/web/src/lib/utils/space-filter-options.ts
@@ -28,6 +28,9 @@ export function buildSpaceTimelineOptions(spaceId: string, filters: FilterState)
   if (filters.isFavorite !== undefined) {
     base.isFavorite = filters.isFavorite;
   }
+  if (filters.isNotInAlbum === true) {
+    base.isNotInAlbum = true;
+  }
   if (filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
@@ -68,6 +71,10 @@ export function handleSpaceRemoveFilter(filters: FilterState, type: string, id?:
     case 'favorites':
     case 'isFavorite': {
       return { ...filters, isFavorite: undefined };
+    }
+    case 'albums':
+    case 'isNotInAlbum': {
+      return { ...filters, isNotInAlbum: undefined };
     }
     case 'timeline': {
       return {

--- a/web/src/lib/utils/space-search.ts
+++ b/web/src/lib/utils/space-search.ts
@@ -61,6 +61,9 @@ export function buildSmartSearchParams(args: SmartSearchParamsArgs): SmartSearch
   if (filters.mediaType !== 'all') {
     params.type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }
+  if (filters.isNotInAlbum === true) {
+    params.isNotInAlbum = true;
+  }
   const context = buildFilterContext(filters);
   if (context?.takenAfter) {
     params.takenAfter = context.takenAfter;

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -112,6 +112,25 @@ describe('Map page query intersection', () => {
     });
   });
 
+  it('exposes has-no-album in the map filter panel', () => {
+    renderPage();
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums',
+    );
+  });
+
+  it('passes has-no-album to filtered map markers when selected', async () => {
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-has-no-album-filter'));
+    await flushQueryDebounce();
+
+    await waitFor(() => {
+      expect(sdkMock.getFilteredMapMarkers).toHaveBeenCalledWith(expect.objectContaining({ isNotInAlbum: true }));
+    });
+  });
+
   it('intersects map markers with paginated searchSmart ids when q is present', async () => {
     mockPage.url = new URL('https://gallery.test/map?q=beach');
     sdkMock.getFilteredMapMarkers.mockResolvedValue([

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -155,6 +155,7 @@
             ? AssetTypeEnum.Image
             : AssetTypeEnum.Video,
       isFavorite: nextFilters.isFavorite,
+      isNotInAlbum: nextFilters.isNotInAlbum === true ? true : undefined,
       takenAfter: context?.takenAfter,
       takenBefore: context?.takenBefore,
       ...(nextFilters.isFavorite === undefined ? { withSharedSpaces: true } : {}),
@@ -251,7 +252,7 @@
   };
 
   const filterConfig: FilterPanelConfig = {
-    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'],
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'],
     suggestionsProvider: async (nextFilters: FilterState) => {
       if (!showSearchResults) {
         return loadPhotoFilterSuggestions(nextFilters);

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -275,7 +275,7 @@ describe('Photos page search URL state', () => {
 
   it('hydrates typed filter URL params into the photos FilterState', () => {
     mockPage.url = new URL(
-      'https://gallery.test/photos?q=beach&people=person-1&tags=tag-1&type=image&favorite=true&rating=4&from=2025-01-01&to=2025-12-31',
+      'https://gallery.test/photos?q=beach&people=person-1&tags=tag-1&type=image&favorite=true&album=none&rating=4&from=2025-01-01&to=2025-12-31',
     );
 
     renderPage();
@@ -285,6 +285,7 @@ describe('Photos page search URL state', () => {
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-tag-ids', 'tag-1');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'image');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-favorite', 'true');
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-not-in-album', 'true');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-rating', '4');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-after', '2025-01-01');
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-date-before', '2025-12-31');
@@ -336,8 +337,18 @@ describe('Photos page search URL state', () => {
 
     expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
       'data-sections',
-      'timeline,people,location,camera,tags,rating,media,favorites',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums',
     );
+  });
+
+  it('passes has-no-album into photos timeline options when hydrated from the URL', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?album=none');
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(buildPhotosTimelineOptions).toHaveBeenCalledWith(expect.objectContaining({ isNotInAlbum: true }));
+    });
   });
 
   it('registers current photos filters for global sort changes', async () => {
@@ -405,6 +416,27 @@ describe('Photos page search URL state', () => {
     for (const [request] of sdkMock.getSearchSuggestions.mock.calls) {
       expect(request).not.toHaveProperty('withSharedSpaces');
     }
+  });
+
+  it('narrows photos suggestions and dependent providers to has-no-album when selected', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-has-no-album-filter'));
+    await fireEvent.click(screen.getByTestId('load-city-suggestions'));
+    await fireEvent.click(screen.getByTestId('load-camera-model-suggestions'));
+
+    await waitFor(() => {
+      expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ isNotInAlbum: true, withSharedSpaces: true }),
+      );
+      expect(sdkMock.getSearchSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ country: 'Germany', isNotInAlbum: true }),
+      );
+      expect(sdkMock.getSearchSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ make: 'Sony', isNotInAlbum: true }),
+      );
+    });
   });
 
   it('fetches smart facets for committed photos search and passes exact total to results', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -237,6 +237,7 @@
             ? AssetTypeEnum.Image
             : AssetTypeEnum.Video,
       isFavorite: nextFilters.isFavorite,
+      isNotInAlbum: nextFilters.isNotInAlbum === true ? true : undefined,
       takenAfter: context?.takenAfter,
       takenBefore: context?.takenBefore,
       spaceId: space.id,
@@ -332,7 +333,7 @@
   };
 
   const filterConfig: FilterPanelConfig = {
-    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'],
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'],
     suggestionsProvider: async (nextFilters: FilterState) => {
       if (!showSearchResults) {
         return loadSpaceFilterSuggestions(nextFilters);

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -332,8 +332,16 @@ describe('Spaces page search URL state', () => {
 
     expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
       'data-sections',
-      'timeline,people,location,camera,tags,rating,media,favorites',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums',
     );
+  });
+
+  it('hydrates has-no-album from the space URL into search results', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&album=none');
+
+    renderPage();
+
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-not-in-album', 'true');
   });
 
   it('registers current space filters for global sort changes', async () => {
@@ -410,6 +418,27 @@ describe('Spaces page search URL state', () => {
       spaceId: 'space-1',
     });
     expect(sdkMock.searchSmartFacets.mock.calls[1][0].smartSearchFacetsDto).not.toHaveProperty('withSharedSpaces');
+  });
+
+  it('narrows space suggestions and dependent providers to has-no-album when selected', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('select-has-no-album-filter'));
+    await fireEvent.click(screen.getByTestId('load-city-suggestions'));
+    await fireEvent.click(screen.getByTestId('load-camera-model-suggestions'));
+
+    await waitFor(() => {
+      expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ spaceId: 'space-1', isNotInAlbum: true }),
+      );
+      expect(sdkMock.getSearchSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ country: 'Germany', spaceId: 'space-1', isNotInAlbum: true }),
+      );
+      expect(sdkMock.getSearchSuggestions).toHaveBeenCalledWith(
+        expect.objectContaining({ make: 'Sony', spaceId: 'space-1', isNotInAlbum: true }),
+      );
+    });
   });
 
   it('fetches smart facets with spaceId for committed space search', async () => {

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -38,6 +38,12 @@
     }
   }
 
+  function selectHasNoAlbum() {
+    if (filters) {
+      updateFilters({ ...filters, isNotInAlbum: true });
+    }
+  }
+
   function loadCitySuggestions() {
     if (filters) {
       void config?.providers?.cities?.('Germany', buildFilterContext(filters, ['country', 'city']));
@@ -79,12 +85,14 @@
   data-sections={config?.sections.join(',') ?? ''}
   data-country={filters?.country ?? ''}
   data-is-favorite={String(filters?.isFavorite)}
+  data-is-not-in-album={String(filters?.isNotInAlbum)}
   data-time-buckets={JSON.stringify(timeBuckets)}
   data-suggestions={suggestions}
   data-person-names={JSON.stringify([...(personNames?.entries() ?? [])])}
   data-tag-names={JSON.stringify([...(tagNames?.entries() ?? [])])}
 >
   <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
+  <button type="button" data-testid="select-has-no-album-filter" onclick={selectHasNoAlbum}>Has no album</button>
   <button type="button" data-testid="load-city-suggestions" onclick={loadCitySuggestions}>Load cities</button>
   <button type="button" data-testid="load-camera-model-suggestions" onclick={loadCameraModelSuggestions}>
     Load camera models

--- a/web/src/test-data/mocks/filter-panel-favorites.stub.svelte
+++ b/web/src/test-data/mocks/filter-panel-favorites.stub.svelte
@@ -18,6 +18,10 @@
     filters = { ...filters, isFavorite: true };
   }
 
+  function selectHasNoAlbum() {
+    filters = { ...filters, isNotInAlbum: true };
+  }
+
   function loadCitySuggestions() {
     void config?.providers?.cities?.('Germany', buildFilterContext(filters, ['country', 'city']));
   }
@@ -32,8 +36,10 @@
   data-testid="filter-panel-stub"
   data-sections={config?.sections.join(',') ?? ''}
   data-is-favorite={String(filters?.isFavorite)}
+  data-is-not-in-album={String(filters?.isNotInAlbum)}
 >
   <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
+  <button type="button" data-testid="select-has-no-album-filter" onclick={selectHasNoAlbum}>Has no album</button>
   <button type="button" data-testid="load-city-suggestions" onclick={loadCitySuggestions}>Load cities</button>
   <button type="button" data-testid="load-camera-model-suggestions" onclick={loadCameraModelSuggestions}>
     Load camera models

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -32,6 +32,7 @@
   data-sort-order={filters?.sortOrder ?? ''}
   data-is-favorite={String(filters?.isFavorite)}
   data-filter-favorite={String(filters?.isFavorite)}
+  data-filter-not-in-album={String(filters?.isNotInAlbum)}
   data-filter-person-ids={filters?.personIds.join(',') ?? ''}
   data-filter-tag-ids={filters?.tagIds.join(',') ?? ''}
   data-filter-media-type={filters?.mediaType ?? ''}


### PR DESCRIPTION
## Summary
- add an Albums section to FilterPanel with a "Has no album" option
- wire `isNotInAlbum` through photos, spaces, map, smart search, URL state, active chips, suggestions, and time bucket requests
- extend server DTOs/repositories and regenerate OpenAPI/TypeScript SDK support
- add regression coverage for component behavior, URL edge cases, API DTO coercion, service pass-through, and SQL filtering

Fixes #535

## Tests
- pnpm --dir web test --run src/lib/components/filter-panel/__tests__/filter-state.spec.ts src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts src/lib/components/filter-panel/__tests__/albums-filter.spec.ts src/lib/components/filter-panel/__tests__/filter-panel.spec.ts src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/space-filter-options.spec.ts src/lib/utils/__tests__/map-filter-options.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts src/lib/utils/__tests__/searchable-page-search.spec.ts src/lib/utils/__tests__/space-search.spec.ts "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts" "src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts"
- pnpm --dir server test --run src/repositories/search.repository.spec.ts src/dtos/search.dto.spec.ts src/dtos/gallery-map.dto.spec.ts src/dtos/time-bucket.dto.spec.ts src/services/timeline.service.spec.ts src/services/shared-space.service.spec.ts
- pnpm --dir web check:typescript && pnpm --dir web check:svelte
- pnpm --dir server check
- git diff --check