### PR TITLE
fix(server): respect min faces for space people

### DIFF
--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -1535,7 +1535,7 @@ describe('/shared-spaces', () => {
       expect(status).toBe(200);
       const ids = (body as Array<{ id: string }>).map((p) => p.id);
       expect(ids).toContain(namedPersonId);
-      expect(ids).toContain(unnamedPersonId);
+      expect(ids).not.toContain(unnamedPersonId);
       expect(ids).toContain(petPersonId);
       // Sanity check: namedPersonId and aliceGlobalId are different UUIDs.
       expect(namedPersonId).not.toBe(aliceGlobalId);
@@ -1561,13 +1561,13 @@ describe('/shared-spaces', () => {
       expect(ids).toContain(hiddenPersonId);
     });
 
-    it('unnamed persons are included in the default listing', async () => {
+    it('below-threshold unnamed persons are excluded from the default listing', async () => {
       const { status, body } = await request(app)
         .get(`/shared-spaces/${spaceId}/people`)
         .set('Authorization', `Bearer ${owner.accessToken}`);
       expect(status).toBe(200);
       const ids = (body as Array<{ id: string }>).map((p) => p.id);
-      expect(ids).toContain(unnamedPersonId);
+      expect(ids).not.toContain(unnamedPersonId);
     });
 
     it('?named=true returns only persons with non-empty names', async () => {

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -439,6 +439,10 @@ from
 where
   "shared_space_person"."spaceId" = $1
   and "shared_space_person"."isHidden" = $2
+  and (
+    "shared_space_person"."name" != $3
+    or "shared_space_person"."assetCount" >= $4
+  )
 order by
   NULLIF(shared_space_person.name, '') asc nulls last,
   CASE
@@ -446,7 +450,7 @@ order by
   END desc nulls last,
   "shared_space_person"."id"
 limit
-  $3
+  $5
 
 -- SharedSpaceRepository.countPersonsBySpaceId
 WITH
@@ -485,6 +489,10 @@ WITH
     WHERE
       "shared_space_person"."spaceId" = $7
       AND "shared_space_person"."name" ILIKE $8 ESCAPE '\'
+      AND (
+        "shared_space_person"."name" != ''
+        OR "shared_space_person"."assetCount" >= $9
+      )
   ),
   "person_keys" AS (
     SELECT
@@ -522,8 +530,8 @@ WITH
           INNER JOIN "shared_space_person" ON "shared_space_person"."id" = "shared_space_person_face"."personId"
         WHERE
           "shared_space_person_face"."assetFaceId" = "asset_face"."id"
-          AND "shared_space_person"."spaceId" = $9
-          AND "shared_space_person"."name" ILIKE $10 ESCAPE '\'
+          AND "shared_space_person"."spaceId" = $10
+          AND "shared_space_person"."name" ILIKE $11 ESCAPE '\'
       )
   )
 SELECT
@@ -580,20 +588,32 @@ WITH
         BOOL_OR(
           "shared_space_person"."id" IS NOT NULL
           AND "shared_space_person"."name" ILIKE $7 ESCAPE '\'
+          AND (
+            "shared_space_person"."name" != ''
+            OR "shared_space_person"."assetCount" >= $8
+          )
         ),
         false
       ) AS "hasMatchingAssignment",
       COALESCE(
         BOOL_OR(
           "shared_space_person"."isHidden" = false
-          AND "shared_space_person"."name" ILIKE $8 ESCAPE '\'
+          AND "shared_space_person"."name" ILIKE $9 ESCAPE '\'
+          AND (
+            "shared_space_person"."name" != ''
+            OR "shared_space_person"."assetCount" >= $10
+          )
         ),
         false
       ) AS "hasMatchingVisibleAssignment",
       COALESCE(
         BOOL_OR(
           "shared_space_person"."isHidden" = true
-          AND "shared_space_person"."name" ILIKE $9 ESCAPE '\'
+          AND "shared_space_person"."name" ILIKE $11 ESCAPE '\'
+          AND (
+            "shared_space_person"."name" != ''
+            OR "shared_space_person"."assetCount" >= $12
+          )
         ),
         false
       ) AS "hasMatchingHiddenAssignment"
@@ -601,7 +621,7 @@ WITH
       "detected_faces"
       LEFT JOIN "shared_space_person_face" ON "shared_space_person_face"."assetFaceId" = "detected_faces"."assetFaceId"
       LEFT JOIN "shared_space_person" ON "shared_space_person"."id" = "shared_space_person_face"."personId"
-      AND "shared_space_person"."spaceId" = $10
+      AND "shared_space_person"."spaceId" = $13
     GROUP BY
       "detected_faces"."assetFaceId"
   ),
@@ -625,10 +645,10 @@ WITH
       "detected_faces"
       INNER JOIN "shared_space_person_face" ON "shared_space_person_face"."assetFaceId" = "detected_faces"."assetFaceId"
       INNER JOIN "shared_space_person" ON "shared_space_person"."id" = "shared_space_person_face"."personId"
-      AND "shared_space_person"."spaceId" = $11
+      AND "shared_space_person"."spaceId" = $14
     WHERE
       true
-      AND "shared_space_person"."name" ILIKE $12 ESCAPE '\'
+      AND "shared_space_person"."name" ILIKE $15 ESCAPE '\'
   ),
   "matching_person_keys" AS (
     SELECT

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -643,7 +643,10 @@ export class SharedSpaceRepository {
   }
 
   @GenerateSql({
-    params: [DummyValue.UUID, { withHidden: false, petsEnabled: true, limit: 50, offset: 0, named: false }],
+    params: [
+      DummyValue.UUID,
+      { withHidden: false, petsEnabled: true, limit: 50, offset: 0, named: false, minimumFaceCount: 3 },
+    ],
   })
   getPersonsBySpaceId(
     spaceId: string,
@@ -656,6 +659,7 @@ export class SharedSpaceRepository {
       name?: string;
       takenAfter?: Date;
       takenBefore?: Date;
+      minimumFaceCount?: number;
     },
   ) {
     const escapedName = options.name
@@ -663,6 +667,7 @@ export class SharedSpaceRepository {
       .replaceAll('%', String.raw`\%`)
       .replaceAll('_', String.raw`\_`);
     const namePattern = escapedName ? `%${escapedName}%` : undefined;
+    const minimumFaceCount = options.minimumFaceCount;
 
     return this.db
       .selectFrom('shared_space_person')
@@ -672,6 +677,14 @@ export class SharedSpaceRepository {
       .$if(!options.petsEnabled, (qb) => qb.where('shared_space_person.type', '!=', 'pet'))
       .$if(!!options.named, (qb) => qb.where('shared_space_person.name', '!=', ''))
       .$if(!!namePattern, (qb) => qb.where(() => sql`"shared_space_person"."name" ILIKE ${namePattern} ESCAPE '\\'`))
+      .$if(minimumFaceCount !== undefined, (qb) =>
+        qb.where((eb) =>
+          eb.or([
+            eb('shared_space_person.name', '!=', ''),
+            eb('shared_space_person.assetCount', '>=', minimumFaceCount!),
+          ]),
+        ),
+      )
       .$if(!!options.takenAfter || !!options.takenBefore, (qb) =>
         qb.where((eb) =>
           eb.exists(
@@ -719,7 +732,7 @@ export class SharedSpaceRepository {
   }
 
   @GenerateSql({
-    params: [DummyValue.UUID, { petsEnabled: true, named: false, name: 'Alice' }],
+    params: [DummyValue.UUID, { petsEnabled: true, named: false, name: 'Alice', minimumFaceCount: 3 }],
   })
   async countPersonsBySpaceId(
     spaceId: string,
@@ -729,6 +742,7 @@ export class SharedSpaceRepository {
       name?: string;
       takenAfter?: Date;
       takenBefore?: Date;
+      minimumFaceCount?: number;
     },
   ) {
     const escapedName = options.name
@@ -736,6 +750,7 @@ export class SharedSpaceRepository {
       .replaceAll('%', String.raw`\%`)
       .replaceAll('_', String.raw`\_`);
     const namePattern = escapedName ? `%${escapedName}%` : undefined;
+    const minimumFaceCount = options.minimumFaceCount;
     const visibilityFilter = sql`"asset"."visibility" IN (${sql.join(visibleSpaceAssetVisibilities)})`;
     const takenAfterFilter = options.takenAfter ? sql`AND "asset"."fileCreatedAt" >= ${options.takenAfter}` : sql``;
     const takenBeforeFilter = options.takenBefore ? sql`AND "asset"."fileCreatedAt" < ${options.takenBefore}` : sql``;
@@ -744,6 +759,15 @@ export class SharedSpaceRepository {
     const namePersonFilter = namePattern
       ? sql`AND "shared_space_person"."name" ILIKE ${namePattern} ESCAPE '\\'`
       : sql``;
+    const minimumPersonFilter =
+      minimumFaceCount === undefined
+        ? sql``
+        : sql`
+            AND (
+              "shared_space_person"."name" != ''
+              OR "shared_space_person"."assetCount" >= ${minimumFaceCount}
+            )
+          `;
     const datePersonFilter =
       options.takenAfter || options.takenBefore
         ? sql`
@@ -818,6 +842,7 @@ export class SharedSpaceRepository {
           ${petPersonFilter}
           ${namedPersonFilter}
           ${namePersonFilter}
+          ${minimumPersonFilter}
           ${datePersonFilter}
       ),
       "person_keys" AS (
@@ -849,7 +874,7 @@ export class SharedSpaceRepository {
     return result.rows[0]!;
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, { petsEnabled: true, named: false, name: 'Alice' }] })
+  @GenerateSql({ params: [DummyValue.UUID, { petsEnabled: true, named: false, name: 'Alice', minimumFaceCount: 3 }] })
   async getPeopleFaceStatisticsBySpaceId(
     spaceId: string,
     options: {
@@ -858,6 +883,7 @@ export class SharedSpaceRepository {
       name?: string;
       takenAfter?: Date;
       takenBefore?: Date;
+      minimumFaceCount?: number;
     },
   ): Promise<PeopleFaceStatistics> {
     const escapedName = options.name
@@ -865,6 +891,7 @@ export class SharedSpaceRepository {
       .replaceAll('%', String.raw`\%`)
       .replaceAll('_', String.raw`\_`);
     const namePattern = escapedName ? `%${escapedName}%` : undefined;
+    const minimumFaceCount = options.minimumFaceCount;
     const visibilityFilter = sql`"asset"."visibility" IN (${sql.join(visibleSpaceAssetVisibilities)})`;
     const takenAfterFilter = options.takenAfter ? sql`AND "asset"."fileCreatedAt" >= ${options.takenAfter}` : sql``;
     const takenBeforeFilter = options.takenBefore ? sql`AND "asset"."fileCreatedAt" < ${options.takenBefore}` : sql``;
@@ -873,6 +900,15 @@ export class SharedSpaceRepository {
     const namePersonFilter = namePattern
       ? sql`AND "shared_space_person"."name" ILIKE ${namePattern} ESCAPE '\\'`
       : sql``;
+    const minimumPersonFilter =
+      minimumFaceCount === undefined
+        ? sql``
+        : sql`
+            AND (
+              "shared_space_person"."name" != ''
+              OR "shared_space_person"."assetCount" >= ${minimumFaceCount}
+            )
+          `;
     const hasAssignedPersonFaceFilter = !!options.named || !!namePattern;
     const includeFaceFilter = hasAssignedPersonFaceFilter
       ? sql`WHERE "hasMatchingAssignment" = true`
@@ -918,18 +954,21 @@ export class SharedSpaceRepository {
             ${petPersonFilter}
             ${namedPersonFilter}
             ${namePersonFilter}
+            ${minimumPersonFilter}
           ), false) AS "hasMatchingAssignment",
           COALESCE(BOOL_OR(
             "shared_space_person"."isHidden" = false
             ${petPersonFilter}
             ${namedPersonFilter}
             ${namePersonFilter}
+            ${minimumPersonFilter}
           ), false) AS "hasMatchingVisibleAssignment",
           COALESCE(BOOL_OR(
             "shared_space_person"."isHidden" = true
             ${petPersonFilter}
             ${namedPersonFilter}
             ${namePersonFilter}
+            ${minimumPersonFilter}
           ), false) AS "hasMatchingHiddenAssignment"
         FROM "detected_faces"
         LEFT JOIN "shared_space_person_face"

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3871,6 +3871,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -3897,6 +3898,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: false,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -3923,6 +3925,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -3952,6 +3955,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -3990,6 +3994,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4025,6 +4030,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4064,6 +4070,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4128,6 +4135,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4153,6 +4161,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4196,6 +4205,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: true,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4220,6 +4230,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: undefined,
@@ -4243,6 +4254,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: 10,
         offset: undefined,
         named: undefined,
@@ -4266,6 +4278,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: 5,
         offset: undefined,
         named: undefined,
@@ -4325,6 +4338,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: true,
         petsEnabled: false,
+        minimumFaceCount: 3,
         limit: 5,
         offset: undefined,
         named: undefined,
@@ -4348,6 +4362,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: 50,
         offset: 10,
         named: undefined,
@@ -4371,6 +4386,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: false,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: true,
@@ -4394,6 +4410,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.getPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         withHidden: true,
         petsEnabled: true,
+        minimumFaceCount: 3,
         limit: undefined,
         offset: undefined,
         named: true,
@@ -4443,6 +4460,7 @@ describe(SharedSpaceService.name, () => {
       expect(result).toEqual({ total: 152, hidden: 3, detectedFaceCount: 1201 });
       expect(mocks.sharedSpace.countPersonsBySpaceId).toHaveBeenCalledWith(spaceId, {
         petsEnabled: false,
+        minimumFaceCount: 3,
         named: undefined,
         name: 'Ali',
         takenAfter,
@@ -4512,6 +4530,7 @@ describe(SharedSpaceService.name, () => {
       });
       expect((mocks.sharedSpace as any).getPeopleFaceStatisticsBySpaceId).toHaveBeenCalledWith(spaceId, {
         petsEnabled: false,
+        minimumFaceCount: 3,
         named: true,
         name: 'Ali',
         takenAfter,

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -802,6 +802,7 @@ export class SharedSpaceService extends BaseService {
       return [];
     }
 
+    const { machineLearning } = await this.getConfig({ withCache: false });
     const persons = await this.sharedSpaceRepository.getPersonsBySpaceId(spaceId, {
       withHidden: query?.withHidden ?? false,
       petsEnabled: space.petsEnabled,
@@ -811,6 +812,7 @@ export class SharedSpaceService extends BaseService {
       name: query?.name,
       takenAfter: query?.takenAfter,
       takenBefore: query?.takenBefore,
+      minimumFaceCount: machineLearning.facialRecognition.minFaces,
     });
 
     const aliases =
@@ -832,12 +834,14 @@ export class SharedSpaceService extends BaseService {
       return { total: 0, hidden: 0, detectedFaceCount: 0 };
     }
 
+    const { machineLearning } = await this.getConfig({ withCache: false });
     return this.sharedSpaceRepository.countPersonsBySpaceId(spaceId, {
       petsEnabled: space.petsEnabled,
       named: query?.named,
       name: query?.name,
       takenAfter: query?.takenAfter,
       takenBefore: query?.takenBefore,
+      minimumFaceCount: machineLearning.facialRecognition.minFaces,
     });
   }
 
@@ -859,12 +863,14 @@ export class SharedSpaceService extends BaseService {
       };
     }
 
+    const { machineLearning } = await this.getConfig({ withCache: false });
     return this.sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(spaceId, {
       petsEnabled: space.petsEnabled,
       named: query?.named,
       name: query?.name,
       takenAfter: query?.takenAfter,
       takenBefore: query?.takenBefore,
+      minimumFaceCount: machineLearning.facialRecognition.minFaces,
     });
   }
 

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1417,6 +1417,51 @@ describe(SharedSpaceRepository.name, () => {
       expect(result[0].name).toBe('No Thumbnail Person');
     });
 
+    it('should exclude unnamed space persons below the minimum face count', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const assets = await Promise.all(
+        Array.from({ length: 6 }).map(() => ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline })),
+      );
+      for (const { asset } of assets) {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      }
+      const faces = [];
+      for (const { asset } of assets) {
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+        faces.push(assetFace);
+      }
+
+      const namedSingleFace = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Named',
+        representativeFaceId: faces[0].id,
+      });
+      const unnamedLowEvidence = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: faces[1].id,
+      });
+      const unnamedEnoughEvidence = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: faces[3].id,
+      });
+      await sut.addPersonFaces([
+        { personId: namedSingleFace.id, assetFaceId: faces[0].id },
+        { personId: unnamedLowEvidence.id, assetFaceId: faces[1].id },
+        { personId: unnamedLowEvidence.id, assetFaceId: faces[2].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[3].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[4].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[5].id },
+      ]);
+
+      const result = await sut.getPersonsBySpaceId(space.id, { minimumFaceCount: 3 });
+
+      expect(result.map((person) => person.id)).toEqual([namedSingleFace.id, unnamedEnoughEvidence.id]);
+    });
+
     it('should return space persons whose representativeFace has no global personId', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
@@ -1779,6 +1824,52 @@ describe(SharedSpaceRepository.name, () => {
       expect(Number(result.total)).toBe(1);
       expect(Number(result.hidden)).toBe(0);
       expect(Number(result.detectedFaceCount)).toBe(2);
+    });
+
+    it('should count unnamed space persons only when they meet the minimum face count', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const assets = await Promise.all(
+        Array.from({ length: 6 }).map(() => ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline })),
+      );
+      for (const { asset } of assets) {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      }
+      const faces = [];
+      for (const { asset } of assets) {
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+        faces.push(assetFace);
+      }
+      const namedSingleFace = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Named',
+        representativeFaceId: faces[0].id,
+      });
+      const unnamedLowEvidence = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: faces[1].id,
+      });
+      const unnamedEnoughEvidence = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: faces[3].id,
+      });
+      await sut.addPersonFaces([
+        { personId: namedSingleFace.id, assetFaceId: faces[0].id },
+        { personId: unnamedLowEvidence.id, assetFaceId: faces[1].id },
+        { personId: unnamedLowEvidence.id, assetFaceId: faces[2].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[3].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[4].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[5].id },
+      ]);
+
+      const result = await sut.countPersonsBySpaceId(space.id, { minimumFaceCount: 3 });
+
+      expect(Number(result.total)).toBe(2);
+      expect(Number(result.hidden)).toBe(0);
+      expect(Number(result.detectedFaceCount)).toBe(6);
     });
 
     it('should count a face reachable directly and through a linked library once', async () => {
@@ -2425,6 +2516,54 @@ describe(SharedSpaceRepository.name, () => {
         assignedVisibleFaceCount: 1,
         assignedHiddenFaceCount: 0,
         unassignedFaceCount: 1,
+      });
+    });
+
+    it('getPeopleFaceStatisticsBySpaceId treats below-threshold unnamed assignments as unassigned', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const assets = await Promise.all(
+        Array.from({ length: 6 }).map(() => ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline })),
+      );
+      for (const { asset } of assets) {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      }
+      const faces = [];
+      for (const { asset } of assets) {
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+        faces.push(assetFace);
+      }
+
+      const namedSingleFace = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Named',
+        representativeFaceId: faces[0].id,
+      });
+      const unnamedLowEvidence = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: faces[1].id,
+      });
+      const unnamedEnoughEvidence = await sut.createPerson({
+        spaceId: space.id,
+        name: '',
+        representativeFaceId: faces[3].id,
+      });
+      await sut.addPersonFaces([
+        { personId: namedSingleFace.id, assetFaceId: faces[0].id },
+        { personId: unnamedLowEvidence.id, assetFaceId: faces[1].id },
+        { personId: unnamedLowEvidence.id, assetFaceId: faces[2].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[3].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[4].id },
+        { personId: unnamedEnoughEvidence.id, assetFaceId: faces[5].id },
+      ]);
+
+      expectStats(await sut.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 3 }), {
+        detectedFaceCount: 6,
+        assignedVisibleFaceCount: 4,
+        assignedHiddenFaceCount: 0,
+        unassignedFaceCount: 2,
       });
     });
   });


### PR DESCRIPTION
## Summary
- apply the ML facial-recognition minFaces threshold to shared-space people lists and counts
- keep named space people visible while treating below-threshold unnamed assignments as unassigned in face stats
- add medium repository coverage and update service forwarding expectations/generated SQL

## Tests
- pnpm --dir server build
- pnpm --dir server sync:sql
- pnpm --dir server test src/services/shared-space.service.spec.ts
- pnpm --dir server test:medium test/medium/specs/repositories/shared-space.repository.spec.ts
- pnpm --dir server check
- pnpm --dir server lint