### PR TITLE
fix: align people stats with face identity scope

### DIFF
--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -472,9 +472,9 @@ WITH
       AND asset_face."isVisible" = true
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
-      AND asset.visibility = $2
+      AND asset.visibility IN ($2, $3)
       AND (
-        asset."ownerId" = $3
+        asset."ownerId" = $4
         OR EXISTS (
           SELECT
             1
@@ -520,7 +520,7 @@ WITH
     FROM
       person
     WHERE
-      person."ownerId" = $4
+      person."ownerId" = $5
       AND person."identityId" IS NOT NULL
       AND EXISTS (
         SELECT
@@ -543,7 +543,7 @@ WITH
       shared_space_person
       INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_person."spaceId"
       LEFT JOIN shared_space_person_alias ON shared_space_person_alias."personId" = shared_space_person.id
-      AND shared_space_person_alias."userId" = $5
+      AND shared_space_person_alias."userId" = $6
     WHERE
       shared_space_person."identityId" IS NOT NULL
       AND EXISTS (
@@ -585,7 +585,7 @@ WITH
       INNER JOIN identity_counts ON identity_counts."identityId" = identity_visibility."identityId"
     WHERE
       identity_visibility."hasNamedProfile" = true
-      OR identity_counts."visibleAssetCount" >= $6
+      OR identity_counts."visibleAssetCount" >= $7
   )
 SELECT
   (
@@ -632,9 +632,9 @@ WITH
       AND asset_face."isVisible" = true
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
-      AND asset.visibility = $2
+      AND asset.visibility IN ($2, $3)
       AND (
-        asset."ownerId" = $3
+        asset."ownerId" = $4
         OR EXISTS (
           SELECT
             1
@@ -681,7 +681,7 @@ WITH
     FROM
       person
     WHERE
-      person."ownerId" = $4
+      person."ownerId" = $5
       AND person."identityId" IS NOT NULL
       AND EXISTS (
         SELECT
@@ -704,7 +704,7 @@ WITH
       shared_space_person
       INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_person."spaceId"
       LEFT JOIN shared_space_person_alias ON shared_space_person_alias."personId" = shared_space_person.id
-      AND shared_space_person_alias."userId" = $5
+      AND shared_space_person_alias."userId" = $6
     WHERE
       shared_space_person."identityId" IS NOT NULL
       AND EXISTS (
@@ -753,7 +753,7 @@ WITH
       INNER JOIN identity_counts ON identity_counts."identityId" = identity_visibility."identityId"
     WHERE
       identity_visibility."hasNamedProfile" = true
-      OR identity_counts."visibleAssetCount" >= $6
+      OR identity_counts."visibleAssetCount" >= $7
   ),
   face_classification AS (
     SELECT

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -391,7 +391,7 @@ where
   and "asset"."ownerId" = $3
   and "asset"."deletedAt" is null
   and "asset"."isOffline" = $4
-  and "asset"."visibility" = 'timeline'
+  and "asset"."visibility" in ($5, $6)
   and "asset_face"."deletedAt" is null
   and "asset_face"."isVisible" is true
 select
@@ -403,7 +403,7 @@ where
   "asset"."ownerId" = $1
   and "asset"."deletedAt" is null
   and "asset"."isOffline" = $2
-  and "asset"."visibility" = 'timeline'
+  and "asset"."visibility" in ($3, $4)
   and "asset_face"."deletedAt" is null
   and "asset_face"."isVisible" is true
 
@@ -420,7 +420,7 @@ WITH
       "asset"."ownerId" = $1
       AND "asset"."deletedAt" IS NULL
       AND "asset"."isOffline" = false
-      AND "asset"."visibility" = $2
+      AND "asset"."visibility" IN ($2, $3)
       AND "asset_face"."deletedAt" IS NULL
       AND "asset_face"."isVisible" = true
   ),
@@ -444,14 +444,14 @@ WITH
         WHEN "person"."id" IS NOT NULL
         AND (
           NULLIF(BTRIM("person"."name"), '') IS NOT NULL
-          OR "person_face_counts"."assetCount" >= $3
+          OR "person_face_counts"."assetCount" >= $4
         ) THEN "person"."isHidden"
         ELSE NULL
       END AS "isHidden"
     FROM
       "eligible_faces"
       LEFT JOIN "person" ON "person"."id" = "eligible_faces"."personId"
-      AND "person"."ownerId" = $4
+      AND "person"."ownerId" = $5
       LEFT JOIN "person_face_counts" ON "person_face_counts"."personId" = "person"."id"
   )
 SELECT

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -1417,13 +1417,14 @@ select
   "asset_face"."id",
   "asset_face"."assetId",
   "asset_face"."personId",
-  "person"."identityId",
+  "face_identity_face"."identityId",
   "person"."type",
   "face_search"."embedding"
 from
   "asset_face"
   left join "face_search" on "face_search"."faceId" = "asset_face"."id"
   left join "person" on "person"."id" = "asset_face"."personId"
+  left join "face_identity_face" on "face_identity_face"."assetFaceId" = "asset_face"."id"
 where
   "asset_face"."assetId" = $1
   and "asset_face"."deletedAt" is null

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -77,6 +77,8 @@ type SpacePersonBackfillIdentityGroup = {
   representativeFaceId: string;
 };
 
+const peopleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+
 export type ScopedPersonTokenResolution = {
   identityIds: string[];
   legacyPersonIds: string[];
@@ -536,7 +538,7 @@ export class FaceIdentityRepository {
           AND asset_face."isVisible" = true
           AND asset."deletedAt" IS NULL
           AND asset."isOffline" = false
-          AND asset.visibility = ${AssetVisibility.Timeline}
+          AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
           AND (
             asset."ownerId" = ${userId}
             OR EXISTS (
@@ -651,7 +653,7 @@ export class FaceIdentityRepository {
           AND asset_face."isVisible" = true
           AND asset."deletedAt" IS NULL
           AND asset."isOffline" = false
-          AND asset.visibility = ${AssetVisibility.Timeline}
+          AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
           AND (
             asset."ownerId" = ${userId}
             OR EXISTS (

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -61,6 +61,8 @@ export interface PeopleFaceStatisticsOptions {
   minimumFaceCount?: number;
 }
 
+const peopleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+
 export interface DeleteFacesOptions {
   sourceType: SourceType;
 }
@@ -537,7 +539,7 @@ export class PersonRepository {
       .where('asset.ownerId', '=', userId)
       .where('asset.deletedAt', 'is', null)
       .where('asset.isOffline', '=', false)
-      .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+      .where('asset.visibility', 'in', peopleAssetVisibilities)
       .where('asset_face.deletedAt', 'is', null)
       .where('asset_face.isVisible', 'is', true)
       .executeTakeFirstOrThrow();
@@ -549,7 +551,7 @@ export class PersonRepository {
       .where('asset.ownerId', '=', userId)
       .where('asset.deletedAt', 'is', null)
       .where('asset.isOffline', '=', false)
-      .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+      .where('asset.visibility', 'in', peopleAssetVisibilities)
       .where('asset_face.deletedAt', 'is', null)
       .where('asset_face.isVisible', 'is', true)
       .executeTakeFirstOrThrow();
@@ -577,7 +579,7 @@ export class PersonRepository {
         WHERE "asset"."ownerId" = ${userId}
           AND "asset"."deletedAt" IS NULL
           AND "asset"."isOffline" = false
-          AND "asset"."visibility" = ${AssetVisibility.Timeline}
+          AND "asset"."visibility" IN (${sql.join(peopleAssetVisibilities)})
           AND "asset_face"."deletedAt" IS NULL
           AND "asset_face"."isVisible" = true
       ),

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1962,11 +1962,12 @@ export class SharedSpaceRepository {
       .selectFrom('asset_face')
       .leftJoin('face_search', 'face_search.faceId', 'asset_face.id')
       .leftJoin('person', 'person.id', 'asset_face.personId')
+      .leftJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
       .select([
         'asset_face.id',
         'asset_face.assetId',
         'asset_face.personId',
-        'person.identityId',
+        'face_identity_face.identityId',
         'person.type',
         'face_search.embedding',
       ])

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -712,6 +712,27 @@ describe(FaceIdentityRepository.name, () => {
       }
     });
 
+    it('includes archived owned identity faces in global people overview statistics', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Archived Person' });
+        const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+        await expect(sut.getAccessiblePeopleStatistics(user.id, { minimumFaceCount: 1 })).resolves.toEqual({
+          total: 1,
+          hidden: 0,
+          detectedFaceCount: 1,
+        });
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
     it('dedupes an identity represented by both personal and space-person rows', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
@@ -1037,19 +1058,20 @@ describe(FaceIdentityRepository.name, () => {
       }
     });
 
-    it('excludes invalid global assets and face rows', async () => {
+    it('includes archived assets but excludes invalid global assets and face rows', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
 
       try {
         const valid = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
         await ctx.newAssetFace({ assetId: valid.asset.id });
+        const archived = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+        await ctx.newAssetFace({ assetId: archived.asset.id });
 
         const invalidAssets = await Promise.all([
           ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline, deletedAt: new Date() }),
           ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline, isOffline: true }),
           ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked }),
-          ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive }),
         ]);
         for (const { asset } of invalidAssets) {
           await ctx.newAssetFace({ assetId: asset.id });
@@ -1060,11 +1082,11 @@ describe(FaceIdentityRepository.name, () => {
         await ctx.newAssetFace({ assetId: invalidFaceAsset.asset.id, deletedAt: new Date() });
 
         await expect(sut.getAccessiblePeopleFaceStatistics(user.id, { minimumFaceCount: 1 })).resolves.toEqual({
-          detectedFaceCount: 1,
+          detectedFaceCount: 2,
           assignedVisibleFaceCount: 0,
           namedVisiblePersonCount: 0,
           assignedHiddenFaceCount: 0,
-          unassignedFaceCount: 1,
+          unassignedFaceCount: 2,
         });
       } finally {
         await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -61,7 +61,7 @@ describe(PersonRepository.name, () => {
       expect(result.total - result.hidden).toBe(0);
     });
 
-    it('excludes out-of-scope assets and non-visible or deleted faces from detectedFaceCount', async () => {
+    it('includes archived assets but excludes other out-of-scope assets and non-visible or deleted faces from detectedFaceCount', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { asset: validAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
@@ -92,7 +92,7 @@ describe(PersonRepository.name, () => {
       await expect(sut.getPeopleOverviewStatistics(user.id)).resolves.toEqual({
         total: 1,
         hidden: 0,
-        detectedFaceCount: 1,
+        detectedFaceCount: 2,
       });
     });
 
@@ -207,7 +207,7 @@ describe(PersonRepository.name, () => {
       });
     });
 
-    it('excludes deleted assets, offline assets, locked assets, archived assets, non-visible faces, and deleted faces', async () => {
+    it('includes archived assets but excludes deleted assets, offline assets, locked assets, non-visible faces, and deleted faces', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { person } = await ctx.newPerson({ ownerId: user.id, isHidden: false });
@@ -234,8 +234,8 @@ describe(PersonRepository.name, () => {
       await ctx.newAssetFace({ assetId: validAsset.id, personId: person.id, deletedAt: new Date() });
 
       await expect(sut.getPeopleFaceStatistics(user.id)).resolves.toEqual({
-        detectedFaceCount: 1,
-        assignedVisibleFaceCount: 1,
+        detectedFaceCount: 2,
+        assignedVisibleFaceCount: 2,
         namedVisiblePersonCount: 1,
         assignedHiddenFaceCount: 0,
         unassignedFaceCount: 0,
@@ -289,7 +289,7 @@ describe(PersonRepository.name, () => {
       await ctx.newAssetFace({ assetId: otherAsset.id, personId: otherNamed.id });
 
       await expect(sut.getPeopleFaceStatistics(user.id)).resolves.toMatchObject({
-        namedVisiblePersonCount: 2,
+        namedVisiblePersonCount: 3,
       });
     });
 

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1159,6 +1159,35 @@ describe(SharedSpaceRepository.name, () => {
 
       expect(result.map((f) => f.id)).toEqual([visibleFace.id]);
     });
+
+    it('returns the face identity link instead of a stale person identity', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const [staleIdentity, currentFaceIdentity] = await ctx.database
+        .insertInto('face_identity')
+        .values([{ type: 'person' }, { type: 'person' }])
+        .returningAll()
+        .execute();
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      await ctx.database.updateTable('person').set({ identityId: staleIdentity.id }).where('id', '=', person.id).execute();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id, isVisible: true });
+      await ctx.database.insertInto('face_search').values({ faceId: assetFace.id, embedding: newEmbedding() }).execute();
+      await ctx.database
+        .insertInto('face_identity_face')
+        .values({ assetFaceId: assetFace.id, identityId: currentFaceIdentity.id, source: 'owner-person' })
+        .execute();
+
+      const result = await sut.getAssetFacesForMatching(asset.id);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: assetFace.id,
+          personId: person.id,
+          identityId: currentFaceIdentity.id,
+        }),
+      ]);
+    });
   });
 
   describe('recountPersons with filters', () => {

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1169,10 +1169,17 @@ describe(SharedSpaceRepository.name, () => {
         .returningAll()
         .execute();
       const { person } = await ctx.newPerson({ ownerId: user.id });
-      await ctx.database.updateTable('person').set({ identityId: staleIdentity.id }).where('id', '=', person.id).execute();
+      await ctx.database
+        .updateTable('person')
+        .set({ identityId: staleIdentity.id })
+        .where('id', '=', person.id)
+        .execute();
       const { asset } = await ctx.newAsset({ ownerId: user.id });
       const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id, isVisible: true });
-      await ctx.database.insertInto('face_search').values({ faceId: assetFace.id, embedding: newEmbedding() }).execute();
+      await ctx.database
+        .insertInto('face_search')
+        .values({ faceId: assetFace.id, embedding: newEmbedding() })
+        .execute();
       await ctx.database
         .insertInto('face_identity_face')
         .values({ assetFaceId: assetFace.id, identityId: currentFaceIdentity.id, source: 'owner-person' })

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -894,7 +894,7 @@ describe('People identity RBAC projection', () => {
     expect(afterRemoval).toEqual({ people: [], total: 0, hidden: 0, hasNextPage: false });
   });
 
-  it('materializes one photo independently across ten face-recognition spaces during full rebuilds', async () => {
+  it('materializes one photo by face identity independently across ten face-recognition spaces during full rebuilds', async () => {
     const { ctx, sut: sharedSpaceService, faceIdentityRepository, jobs } = setupSharedSpace();
     const { user: owner } = await ctx.newUser();
     const { result: person } = await ctx.newPerson({ ownerId: owner.id, name: 'Ten Space Source' });
@@ -903,6 +903,12 @@ describe('People identity RBAC projection', () => {
     await ctx.database.insertInto('face_search').values({ faceId, embedding: newEmbedding() }).execute();
     const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
     await faceIdentityRepository.linkFace({ assetFaceId: faceId, identityId: identity.id, source: 'owner-person' });
+    const staleIdentity = await ctx.database
+      .insertInto('face_identity')
+      .values({ type: 'person' })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database.updateTable('person').set({ identityId: staleIdentity.id }).where('id', '=', person.id).execute();
 
     const spaces = [];
     for (let index = 0; index < 10; index++) {

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -908,7 +908,11 @@ describe('People identity RBAC projection', () => {
       .values({ type: 'person' })
       .returningAll()
       .executeTakeFirstOrThrow();
-    await ctx.database.updateTable('person').set({ identityId: staleIdentity.id }).where('id', '=', person.id).execute();
+    await ctx.database
+      .updateTable('person')
+      .set({ identityId: staleIdentity.id })
+      .where('id', '=', person.id)
+      .execute();
 
     const spaces = [];
     for (let index = 0; index < 10; index++) {

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -6,6 +6,7 @@ import { FaceIdentityRepository } from 'src/repositories/face-identity.repositor
 import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
+import { SearchRepository } from 'src/repositories/search.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
 import { DB } from 'src/schema';
@@ -27,6 +28,7 @@ const setup = (db?: Kysely<DB>) => {
       PersonRepository,
       ConfigRepository,
       SystemMetadataRepository,
+      SearchRepository,
     ],
     mock: [LoggingRepository, JobRepository],
   });
@@ -40,6 +42,29 @@ const setup = (db?: Kysely<DB>) => {
     sharedSpaceRepository: ctx.get(SharedSpaceRepository),
     jobs,
   };
+};
+
+const drainSharedSpaceFaceJobs = async (sharedSpaceService: SharedSpaceService, jobs: Mocked<JobRepository>) => {
+  let cursor = 0;
+  while (cursor < jobs.queue.mock.calls.length) {
+    const queued = jobs.queue.mock.calls.slice(cursor).map(([job]) => job);
+    cursor = jobs.queue.mock.calls.length;
+
+    for (const job of queued) {
+      if (job.name === JobName.SharedSpaceFaceMatchAll) {
+        await sharedSpaceService.handleSharedSpaceFaceMatchAll(job.data);
+      }
+      if (job.name === JobName.SharedSpaceFaceMatchPage) {
+        await sharedSpaceService.handleSharedSpaceFaceMatchPage(job.data);
+      }
+      if (job.name === JobName.SharedSpacePersonDedup) {
+        await sharedSpaceService.handleSharedSpacePersonDedup(job.data);
+      }
+      if (job.name === JobName.SharedSpaceIdentityReconciliation) {
+        await sharedSpaceService.handleSharedSpaceIdentityReconciliation(job.data);
+      }
+    }
+  }
 };
 
 beforeAll(async () => {
@@ -163,7 +188,7 @@ describe('SharedSpaceService linked-library face identity repair', () => {
   });
 
   it('full-space rematch repairs stale selected-space face assignments from linked libraries', async () => {
-    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
     const { user } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
     await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
@@ -185,6 +210,7 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     });
 
     await expect(sut.handleSharedSpaceFaceMatchAll({ spaceId: space.id })).resolves.toBe(JobStatus.Success);
+    await drainSharedSpaceFaceJobs(sut, jobs);
 
     const correctPerson = await ctx.database
       .selectFrom('shared_space_person')
@@ -341,7 +367,7 @@ describe('SharedSpaceService linked-library face identity repair', () => {
   });
 
   it('full-space rematch removes type-incompatible assignments without inflating stats', async () => {
-    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
     const { user } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
     await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
@@ -364,6 +390,7 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     });
 
     await expect(sut.handleSharedSpaceFaceMatchAll({ spaceId: space.id })).resolves.toBe(JobStatus.Success);
+    await drainSharedSpaceFaceJobs(sut, jobs);
 
     await expect(sharedSpaceRepository.getPersonFaceAssignmentsForSpace(face.assetFace.id, space.id)).resolves.toEqual(
       [],


### PR DESCRIPTION
## Summary
- include archived timeline-visible assets in personal and accessible people statistics
- classify shared-space face matching by the per-face identity link instead of stale person.identityId
- add regression coverage for archived stats, stale identity materialization, and one photo across ten spaces

## Tests
- corepack pnpm exec vitest --config test/vitest.config.medium.mjs test/medium/specs/repositories/person.repository.spec.ts test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/repositories/shared-space.repository.spec.ts test/medium/specs/repositories/face-identity-query-shape.spec.ts test/medium/specs/services/people-identity-rbac.spec.ts test/medium/specs/repositories/shared-space-face-matching.spec.ts
- corepack pnpm check
- corepack pnpm lint
- git diff --check