### PR TITLE
feat: scale face identity backfill with durable targeted rematches

### DIFF
--- a/docs/superpowers/plans/2026-05-09-face-identity-backfill-phased-fanout.md
+++ b/docs/superpowers/plans/2026-05-09-face-identity-backfill-phased-fanout.md
@@ -1,0 +1,1237 @@
+# Face Identity Backfill Phased Fan-Out Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make face identity backfill phase-aware so it repairs identity state first, then queues only exact targeted shared-space projection work with TDD proof for fan-out, races, and edge cases.
+
+**Architecture:** Add a phase-aware backfill work summary in `FaceIdentityRepository`, derive the compatibility `hasBackfillWork()` from it, and update `PersonService.handleFaceIdentityBackfill()` to fan out only when identity work is clean. Keep full force recognition rebuilds on the existing `SharedSpaceFaceMatchAll` path, while identity backfill queues only deduped `SharedSpaceFaceMatch` jobs with `source: 'identity-backfill'`.
+
+**Tech Stack:** TypeScript, NestJS services, Kysely SQL, BullMQ job repository, Vitest unit tests, Gallery medium DB tests.
+
+---
+
+## File Structure
+
+- Modify: `server/src/repositories/face-identity.repository.ts`
+  - Owns `FaceIdentityBackfillWork`, phase-aware SQL predicates, compatibility `hasBackfillWork()`, and exact projection target discovery.
+- Modify: `server/src/services/person.service.ts`
+  - Owns `FaceIdentityBackfill` orchestration, phase gating, targeted queue fan-out, and metadata avoidance from identity-backfill finalization.
+- Modify: `server/src/repositories/job.repository.ts`
+  - Owns stable job ids for root/cursor backfills and identity-backfill `SharedSpaceFaceMatch` jobs.
+- Modify: `server/src/types.ts`
+  - Owns the optional `source: 'identity-backfill'` job data field.
+- Modify: `server/src/services/person.service.spec.ts`
+  - Unit coverage for bootstrap, phase gating, fan-out, batching, no metadata race, and full-reset preservation.
+- Modify: `server/src/repositories/job.repository.spec.ts`
+  - Unit coverage for stable job ids and no normal-vs-backfill face-match collision.
+- Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+  - Medium DB coverage for phase summary categories, target discovery, exclusions, same-photo multi-space, direct+library dedupe, and stale assignment repair.
+- Modify: `server/test/medium/specs/services/metadata.service.spec.ts`
+  - Medium service coverage for legacy imported metadata faces using targeted backfill.
+
+## Execution Preflight
+
+- [ ] **Step 1: Start from a TDD-clean implementation baseline**
+
+The current worktree may contain earlier uncommitted server edits. Preserve the committed design/spec docs, but do not let existing production hunks satisfy tests without a red phase.
+
+Run:
+
+```bash
+git status --short
+git diff --name-only -- server/src/repositories/face-identity.repository.ts server/src/repositories/job.repository.spec.ts server/src/repositories/job.repository.ts server/src/services/person.service.spec.ts server/src/services/person.service.ts server/src/types.ts server/test/medium/specs/repositories/face-identity.repository.spec.ts server/test/medium/specs/services/metadata.service.spec.ts
+```
+
+Expected in this worktree before cleanup: those server files may be listed as modified.
+
+If they are modified before implementation starts, save the prototype diff for reference and restore only those server files:
+
+```bash
+git diff -- server/src/repositories/face-identity.repository.ts server/src/repositories/job.repository.spec.ts server/src/repositories/job.repository.ts server/src/services/person.service.spec.ts server/src/services/person.service.ts server/src/types.ts server/test/medium/specs/repositories/face-identity.repository.spec.ts server/test/medium/specs/services/metadata.service.spec.ts > /tmp/face-identity-backfill-prototype.diff
+git restore -- server/src/repositories/face-identity.repository.ts server/src/repositories/job.repository.spec.ts server/src/repositories/job.repository.ts server/src/services/person.service.spec.ts server/src/services/person.service.ts server/src/types.ts server/test/medium/specs/repositories/face-identity.repository.spec.ts server/test/medium/specs/services/metadata.service.spec.ts
+git status --short
+```
+
+Expected after cleanup: only committed docs remain clean, and no server implementation files are modified. Keep `/tmp/face-identity-backfill-prototype.diff` as a reference only; do not apply it wholesale.
+
+## Task 1: Repository Phase Summary
+
+**Files:**
+- Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+- Modify: `server/src/repositories/face-identity.repository.ts`
+
+- [ ] **Step 1: Write failing medium tests for phase-aware work summary**
+
+Add tests near the existing `hasBackfillWork()` tests:
+
+```ts
+it('classifies personal identity work separately from projection work', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const { person } = await ctx.newPerson({ ownerId: user.id, identityId: null });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+    await expect(sut.getBackfillWork()).resolves.toEqual({
+      hasPersonalIdentityWork: true,
+      hasSpacePersonIdentityWork: false,
+      hasSharedSpaceProjectionWork: false,
+    });
+    await expect(sut.hasBackfillWork()).resolves.toBe(true);
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+
+it('classifies shared-space identity repair separately from projection work', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const first = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const second = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: first.identity.id,
+        representativeFaceId: first.assetFace.id,
+        type: 'person',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await linkSpaceFace(ctx, spacePerson.id, first.assetFace.id);
+    await linkSpaceFace(ctx, spacePerson.id, second.assetFace.id);
+
+    await expect(sut.getBackfillWork()).resolves.toEqual({
+      hasPersonalIdentityWork: false,
+      hasSpacePersonIdentityWork: true,
+      hasSharedSpaceProjectionWork: true,
+    });
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+
+it('classifies projection work only when identities are already linked', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const linked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+
+    await expect(sut.getBackfillWork()).resolves.toEqual({
+      hasPersonalIdentityWork: false,
+      hasSpacePersonIdentityWork: false,
+      hasSharedSpaceProjectionWork: true,
+    });
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+      { spaceId: space.id, assetId: linked.asset.id },
+    ]);
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused medium tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "classifies"
+```
+
+Expected: FAIL because `getBackfillWork()` is not defined.
+
+- [ ] **Step 3: Implement the phase-aware repository API**
+
+In `server/src/repositories/face-identity.repository.ts`, add the type near `SpacePersonBackfillResult`:
+
+```ts
+export type FaceIdentityBackfillWork = {
+  hasPersonalIdentityWork: boolean;
+  hasSpacePersonIdentityWork: boolean;
+  hasSharedSpaceProjectionWork: boolean;
+};
+```
+
+Replace `hasBackfillWork()` with a wrapper and add `getBackfillWork()`:
+
+```ts
+async getBackfillWork(): Promise<FaceIdentityBackfillWork> {
+  const result = await sql<FaceIdentityBackfillWork>`
+    SELECT
+      (
+        EXISTS (
+          SELECT 1
+          FROM person
+          WHERE person."identityId" IS NULL
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM asset_face
+          INNER JOIN asset ON asset.id = asset_face."assetId"
+          LEFT JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
+          WHERE asset_face."personId" IS NOT NULL
+            AND asset_face."deletedAt" IS NULL
+            AND asset_face."isVisible" = true
+            AND asset."deletedAt" IS NULL
+            AND face_identity_face."assetFaceId" IS NULL
+        )
+      ) AS "hasPersonalIdentityWork",
+      EXISTS (
+        SELECT 1
+        FROM shared_space_person
+        INNER JOIN shared_space ON shared_space.id = shared_space_person."spaceId"
+        INNER JOIN shared_space_person_face
+          ON shared_space_person_face."personId" = shared_space_person.id
+        INNER JOIN asset_face
+          ON asset_face.id = shared_space_person_face."assetFaceId"
+        INNER JOIN face_identity_face
+          ON face_identity_face."assetFaceId" = asset_face.id
+        WHERE shared_space."faceRecognitionEnabled" = true
+          AND asset_face."deletedAt" IS NULL
+          AND asset_face."isVisible" = true
+          AND shared_space_person."identityId" IS DISTINCT FROM face_identity_face."identityId"
+      ) AS "hasSpacePersonIdentityWork",
+      EXISTS (
+        SELECT 1
+        FROM asset_face
+        INNER JOIN asset ON asset.id = asset_face."assetId"
+        INNER JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
+        WHERE asset_face."personId" IS NOT NULL
+          AND asset_face."deletedAt" IS NULL
+          AND asset_face."isVisible" = true
+          AND asset."deletedAt" IS NULL
+          AND asset."isOffline" = false
+          AND asset.visibility IN (${AssetVisibility.Timeline}, ${AssetVisibility.Archive})
+          AND (
+            EXISTS (
+              SELECT 1
+              FROM shared_space_asset
+              INNER JOIN shared_space ON shared_space.id = shared_space_asset."spaceId"
+              WHERE shared_space_asset."assetId" = asset.id
+                AND shared_space."faceRecognitionEnabled" = true
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM shared_space_person_face
+                  INNER JOIN shared_space_person
+                    ON shared_space_person.id = shared_space_person_face."personId"
+                  WHERE shared_space_person_face."assetFaceId" = asset_face.id
+                    AND shared_space_person."spaceId" = shared_space.id
+                )
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM shared_space_library
+              INNER JOIN shared_space ON shared_space.id = shared_space_library."spaceId"
+              WHERE shared_space_library."libraryId" = asset."libraryId"
+                AND shared_space."faceRecognitionEnabled" = true
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM shared_space_person_face
+                  INNER JOIN shared_space_person
+                    ON shared_space_person.id = shared_space_person_face."personId"
+                  WHERE shared_space_person_face."assetFaceId" = asset_face.id
+                    AND shared_space_person."spaceId" = shared_space.id
+                )
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM shared_space_person_face
+              INNER JOIN shared_space_person
+                ON shared_space_person.id = shared_space_person_face."personId"
+              INNER JOIN shared_space ON shared_space.id = shared_space_person."spaceId"
+              WHERE shared_space_person_face."assetFaceId" = asset_face.id
+                AND shared_space."faceRecognitionEnabled" = true
+                AND shared_space_person."identityId" IS DISTINCT FROM face_identity_face."identityId"
+            )
+          )
+      ) AS "hasSharedSpaceProjectionWork"
+  `.execute(this.db);
+
+  return (
+    result.rows[0] ?? {
+      hasPersonalIdentityWork: false,
+      hasSpacePersonIdentityWork: false,
+      hasSharedSpaceProjectionWork: false,
+    }
+  );
+}
+
+async hasBackfillWork(): Promise<boolean> {
+  const work = await this.getBackfillWork();
+  return work.hasPersonalIdentityWork || work.hasSpacePersonIdentityWork || work.hasSharedSpaceProjectionWork;
+}
+```
+
+- [ ] **Step 4: Run the focused medium tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "classifies"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts server/src/repositories/face-identity.repository.ts
+git commit -m "feat: split face identity backfill work phases"
+```
+
+## Task 2: Projection Target Predicate Coverage
+
+**Files:**
+- Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+- Modify: `server/src/repositories/face-identity.repository.ts`
+
+- [ ] **Step 1: Write failing medium tests for projection target alignment and exclusions**
+
+Add tests near `returns targeted shared-space face match work for missing and stale space projections`:
+
+```ts
+it('keeps projection work summary aligned with target discovery', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const linked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+
+    await expect(sut.getBackfillWork()).resolves.toMatchObject({ hasSharedSpaceProjectionWork: true });
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+      { spaceId: space.id, assetId: linked.asset.id },
+    ]);
+
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: linked.identity.id,
+        representativeFaceId: linked.assetFace.id,
+        type: 'person',
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await linkSpaceFace(ctx, spacePerson.id, linked.assetFace.id);
+
+    await expect(sut.getBackfillWork()).resolves.toMatchObject({ hasSharedSpaceProjectionWork: false });
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([]);
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+
+it('dedupes direct and linked-library projection targets for the same asset in the same space', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    const linked = await newIdentityFace(ctx, sut, { ownerId: user.id, libraryId: library.id });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+      { spaceId: space.id, assetId: linked.asset.id },
+    ]);
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+
+it('excludes disabled spaces and ineligible assets from projection targets', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const timeline = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const offline = await newIdentityFace(ctx, sut, { ownerId: user.id, isOffline: true });
+    const deleted = await newIdentityFace(ctx, sut, { ownerId: user.id, deletedAt: new Date() });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: disabled } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: disabled.id, userId: user.id, role: SharedSpaceRole.Owner });
+    for (const assetId of [timeline.asset.id, offline.asset.id, deleted.asset.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: disabled.id, assetId, addedById: user.id });
+    }
+
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+      { spaceId: space.id, assetId: timeline.asset.id },
+    ]);
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+```
+
+Extend the local `newIdentityFace()` helper in this spec file so it accepts `libraryId`, `isOffline`, and `deletedAt`, then passes those values into `ctx.newAsset()`.
+
+- [ ] **Step 2: Run focused medium tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "projection target|direct and linked-library|ineligible assets"
+```
+
+Expected: FAIL if target discovery and summary predicates disagree or helper inputs are unsupported.
+
+- [ ] **Step 3: Align projection SQL and helper inputs**
+
+In `getSharedSpaceFaceMatchTargets()`, keep the existing `UNION` direct/library shape and ensure both halves apply:
+
+```ts
+WHERE shared_space."faceRecognitionEnabled" = true
+  AND asset."deletedAt" IS NULL
+  AND asset."isOffline" = false
+  AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
+  AND asset_face."personId" IS NOT NULL
+  AND asset_face."deletedAt" IS NULL
+  AND asset_face."isVisible" = true
+  ${assetFaceFilter}
+```
+
+Keep the outer target selection as:
+
+```ts
+targets AS (
+  SELECT DISTINCT "spaceId", "assetId"
+  FROM face_spaces
+  ${backfillWorkFilter}
+)
+SELECT "spaceId", "assetId"
+FROM targets
+ORDER BY "spaceId", "assetId"
+${limit}
+```
+
+Replace the local medium-test helper signature with:
+
+```ts
+const newIdentityFace = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  sut: FaceIdentityRepository,
+  input: {
+    ownerId: string;
+    name?: string;
+    isHidden?: boolean;
+    libraryId?: string | null;
+    isOffline?: boolean;
+    deletedAt?: Date | null;
+    visibility?: AssetVisibility;
+  },
+) => {
+  const { person } = await ctx.newPerson({
+    ownerId: input.ownerId,
+    name: input.name ?? '',
+    isHidden: input.isHidden ?? false,
+  });
+  const { asset } = await ctx.newAsset({
+    ownerId: input.ownerId,
+    libraryId: input.libraryId,
+    isOffline: input.isOffline ?? false,
+    deletedAt: input.deletedAt ?? null,
+    visibility: input.visibility ?? AssetVisibility.Timeline,
+  });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'backfill' });
+  return { person, asset, assetFace, identity };
+};
+```
+
+- [ ] **Step 4: Run focused medium tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "projection target|direct and linked-library|ineligible assets"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts server/src/repositories/face-identity.repository.ts
+git commit -m "test: cover shared-space projection target predicates"
+```
+
+## Task 3: Job Data and Stable IDs
+
+**Files:**
+- Modify: `server/src/types.ts`
+- Modify: `server/src/repositories/job.repository.spec.ts`
+- Modify: `server/src/repositories/job.repository.ts`
+
+- [ ] **Step 1: Write failing unit test for identity-backfill face-match job ids**
+
+Add to `server/src/repositories/job.repository.spec.ts` near the stable-id tests:
+
+```ts
+it('uses distinct stable ids for identity-backfill shared-space face matches', async () => {
+  const { sut, queue } = setup();
+  setHandlers(sut, [JobName.SharedSpaceFaceMatch]);
+
+  await sut.queueAll([
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+    },
+  ]);
+
+  expect(queue.add).toHaveBeenCalledWith(
+    JobName.SharedSpaceFaceMatch,
+    { spaceId: 'space-1', assetId: 'asset-1' },
+    { jobId: 'shared-space-face-match/space-1/asset-1', removeOnComplete: true },
+  );
+  expect(queue.add).toHaveBeenCalledWith(
+    JobName.SharedSpaceFaceMatch,
+    { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+    { jobId: 'shared-space-face-match/identity-backfill/space-1/asset-1', removeOnComplete: true },
+  );
+});
+```
+
+- [ ] **Step 2: Run focused unit test and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/repositories/job.repository.spec.ts -t "identity-backfill shared-space face matches"
+```
+
+Expected: FAIL because `source` is not typed or not included in the job id.
+
+- [ ] **Step 3: Implement job data type and stable id**
+
+In `server/src/types.ts`:
+
+```ts
+export interface ISharedSpaceFaceMatchJob extends IBaseJob {
+  spaceId: string;
+  assetId: string;
+  source?: 'identity-backfill';
+}
+```
+
+In `server/src/repositories/job.repository.ts`, update `getJobOptions()`:
+
+```ts
+case JobName.SharedSpaceFaceMatch: {
+  const source = item.data.source === 'identity-backfill' ? 'identity-backfill/' : '';
+  return {
+    jobId: `shared-space-face-match/${source}${item.data.spaceId}/${item.data.assetId}`,
+    removeOnComplete: true,
+  };
+}
+```
+
+- [ ] **Step 4: Run focused unit test and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/repositories/job.repository.spec.ts -t "identity-backfill shared-space face matches"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/types.ts server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts
+git commit -m "feat: key identity-backfill face match jobs separately"
+```
+
+## Task 4: PersonService Phase Gating
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Update test setup for the phase-aware repository method**
+
+In `beforeEach()` of `server/src/services/person.service.spec.ts`, add:
+
+```ts
+(mocks.faceIdentity as any).getBackfillWork ??= vi.fn().mockResolvedValue({
+  hasPersonalIdentityWork: false,
+  hasSpacePersonIdentityWork: false,
+  hasSharedSpaceProjectionWork: false,
+});
+```
+
+- [ ] **Step 2: Write failing service tests for identity-work gating**
+
+Add to `describe('handleFaceIdentityBackfill')`:
+
+```ts
+it('requeues identity backfill without projection fan-out when identity work remains after final pages', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: true,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+  expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+  );
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.SharedSpacePersonMetadataBackfill,
+    data: {},
+  });
+});
+
+it('does not discover projection targets until paginated personal backfill is complete', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+    processed: 1,
+    nextCursor: 'person-cursor',
+    affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FaceIdentityBackfill,
+    data: { stage: 'person', cursor: 'person-cursor' },
+  });
+  expect((mocks.faceIdentity as any).getBackfillWork).not.toHaveBeenCalled();
+  expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+
+it('does not discover projection targets until paginated space-person backfill is complete', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({
+    processed: 1,
+    nextCursor: 'space-person-cursor',
+    conflictCount: 0,
+    affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FaceIdentityBackfill,
+    data: { stage: 'space-person', cursor: 'space-person-cursor' },
+  });
+  expect((mocks.faceIdentity as any).getBackfillWork).not.toHaveBeenCalled();
+  expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run focused service tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "identity backfill|paginated"
+```
+
+Expected: FAIL because `handleFaceIdentityBackfill()` still uses broad `hasBackfillWork()` or queues metadata/fan-out at the wrong time.
+
+- [ ] **Step 4: Implement phase gating in `handleFaceIdentityBackfill()`**
+
+In `server/src/services/person.service.ts`, replace the final broad work check with:
+
+```ts
+const work = await this.faceIdentityRepository.getBackfillWork();
+
+if (work.hasPersonalIdentityWork || work.hasSpacePersonIdentityWork) {
+  await this.jobRepository.queue({
+    name: JobName.FaceIdentityBackfill,
+    data: {},
+  });
+  return JobStatus.Success;
+}
+
+if (work.hasSharedSpaceProjectionWork) {
+  affectedSpaceAssets.push(...(await this.faceIdentityRepository.getSharedSpaceFaceMatchBackfillTargets()));
+}
+
+await this.queueSharedSpaceFaceMatchTargets(affectedSpaceAssets);
+
+return JobStatus.Success;
+```
+
+Remove the identity-backfill finalization call to global `queueSpacePersonMetadataBackfill()`. Keep other callers of metadata backfill unchanged.
+
+- [ ] **Step 5: Run focused service tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "identity backfill|paginated"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/services/person.service.ts server/src/services/person.service.spec.ts
+git commit -m "feat: gate identity backfill projection fanout"
+```
+
+## Task 5: Targeted Fan-Out Deduping and Batching
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Write failing service tests for exact targeted queueing**
+
+Add to `describe('handleFaceIdentityBackfill')`:
+
+```ts
+it('queues exact deduped projection targets after identity work is clean', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+    processed: 1,
+    affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+  });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({
+    processed: 0,
+    conflictCount: 0,
+    affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+  });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([
+    { spaceId: 'space-2', assetId: 'asset-2' },
+    { spaceId: 'space-1', assetId: 'asset-1' },
+  ]);
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+    },
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { spaceId: 'space-2', assetId: 'asset-2', source: 'identity-backfill' },
+    },
+  ]);
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+  );
+});
+
+it('does not call queueAll for an empty targeted face-match list', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: false,
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+
+it('does not write an empty trailing batch for exactly one full chunk', async () => {
+  const targets = Array.from({ length: 1000 }, (_, index) => ({
+    spaceId: 'space-1',
+    assetId: `asset-${index.toString().padStart(4, '0')}`,
+  }));
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue(targets);
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queueAll.mock.calls[0][0]).toHaveLength(1000);
+});
+```
+
+- [ ] **Step 2: Run focused service tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "deduped projection targets|empty targeted|empty trailing"
+```
+
+Expected: FAIL until the batching helper skips empty arrays and uses identity-backfill source.
+
+- [ ] **Step 3: Implement deduped bounded queue writes**
+
+In `server/src/services/person.service.ts`, add or update:
+
+```ts
+private async queueSharedSpaceFaceMatchTargets(targets: SharedSpaceFaceMatchTarget[]): Promise<void> {
+  const uniqueTargets = [
+    ...new Map(
+      targets
+        .toSorted((a, b) => a.spaceId.localeCompare(b.spaceId) || a.assetId.localeCompare(b.assetId))
+        .map((target) => [`${target.spaceId}:${target.assetId}`, target]),
+    ).values(),
+  ];
+
+  if (uniqueTargets.length === 0) {
+    return;
+  }
+
+  let jobs: JobItem[] = [];
+  for (const { spaceId, assetId } of uniqueTargets) {
+    jobs.push({
+      name: JobName.SharedSpaceFaceMatch as const,
+      data: { spaceId, assetId, source: 'identity-backfill' },
+    });
+
+    if (jobs.length >= JOBS_ASSET_PAGINATION_SIZE) {
+      await this.jobRepository.queueAll(jobs);
+      jobs = [];
+    }
+  }
+
+  if (jobs.length > 0) {
+    await this.jobRepository.queueAll(jobs);
+  }
+}
+```
+
+Ensure the `server/src/services/person.service.ts` imports include:
+
+```ts
+import { SharedSpaceFaceMatchTarget } from 'src/repositories/face-identity.repository';
+import { JobItem } from 'src/types';
+```
+
+- [ ] **Step 4: Run focused service tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "deduped projection targets|empty targeted|empty trailing"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/services/person.service.ts server/src/services/person.service.spec.ts
+git commit -m "feat: queue targeted identity backfill face matches"
+```
+
+## Task 6: Metadata Ordering and Manual Backfill Preservation
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify: `server/src/services/job.service.spec.ts`
+
+- [ ] **Step 1: Write failing tests for metadata ordering**
+
+Replace or update the old expectation that identity backfill globally queues metadata after processed rows. In `server/src/services/person.service.spec.ts`, add:
+
+```ts
+it('does not queue global metadata backfill from identity-backfill finalization when targeted face matches are queued', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+    processed: 1,
+    affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+  });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: false,
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+    },
+  ]);
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.SharedSpacePersonMetadataBackfill,
+    data: {},
+  });
+});
+```
+
+In `server/src/services/job.service.spec.ts`, keep manual global metadata behavior explicit:
+
+```ts
+it('should queue a SharedSpacePersonMetadataBackfill job', async () => {
+  await sut.create({ name: 'shared-space-person-metadata-backfill' as ManualJobName });
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonMetadataBackfill, data: {} });
+});
+```
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts src/services/job.service.spec.ts -t "metadata backfill|SharedSpacePersonMetadataBackfill"
+```
+
+Expected: FAIL if identity-backfill finalization still queues global metadata.
+
+- [ ] **Step 3: Remove identity-backfill global metadata finalization**
+
+In `handleFaceIdentityBackfill()`, ensure the final block does not include:
+
+```ts
+await this.queueSpacePersonMetadataBackfill();
+```
+
+Do not change `queueSpacePersonMetadataBackfill()` callers in shared-space service or explicit manual job handling.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts src/services/job.service.spec.ts -t "metadata backfill|SharedSpacePersonMetadataBackfill"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/services/person.service.ts server/src/services/person.service.spec.ts server/src/services/job.service.spec.ts
+git commit -m "fix: avoid identity backfill metadata race"
+```
+
+## Task 7: Medium End-to-End Backfill Proof
+
+**Files:**
+- Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+- Modify: `server/test/medium/specs/services/metadata.service.spec.ts`
+
+- [ ] **Step 1: Write failing medium test for paginated no-loss fan-out**
+
+Add this service-level medium test to `server/test/medium/specs/services/metadata.service.spec.ts`, using the existing `setupFaceIdentityBackfillService()` helper. The test creates affected targets before final fan-out and proves the final projection scan rediscovers them.
+
+```ts
+it('rediscovers page-one projection work after paginated identity backfill finishes', async () => {
+  const { ctx } = setupFaceImport();
+  const { user } = await ctx.newUser();
+  try {
+    const first = await ctx.newPerson({ ownerId: user.id, identityId: null });
+    const second = await ctx.newPerson({ ownerId: user.id, identityId: null });
+    const { asset: firstAsset } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: secondAsset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAssetFace({ assetId: firstAsset.id, personId: first.person.id });
+    await ctx.newAssetFace({ assetId: secondAsset.id, personId: second.person.id });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: firstAsset.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: secondAsset.id, addedById: user.id });
+    const { sut: backfillService, ctx: backfillCtx } = setupFaceIdentityBackfillService(ctx.database);
+
+    await expect(backfillService.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+    const queuedJobs = backfillCtx
+      .getMock<JobRepository, Mocked<JobRepository>>(JobRepository)
+      .queueAll.mock.calls.flatMap(([jobs]) => jobs)
+      .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+    expect(queuedJobs).toEqual(
+      expect.arrayContaining([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: space.id, assetId: firstAsset.id, source: 'identity-backfill' } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: space.id, assetId: secondAsset.id, source: 'identity-backfill' } },
+      ]),
+    );
+    expect(queuedJobs).toHaveLength(2);
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+```
+
+- [ ] **Step 2: Write failing medium tests for same-photo multi-space materialization**
+
+Add or extend the existing same-photo test:
+
+```ts
+it('materializes one targeted projection per enabled space for the same photo in 10 spaces', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const { person } = await ctx.newPerson({ ownerId: user.id });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    await sut.backfillPersonalIdentities({ limit: 100 });
+    const enabledSpaceIds: string[] = [];
+    for (let index = 0; index < 10; index++) {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      enabledSpaceIds.push(space.id);
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    }
+    const { space: disabledSpace } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
+
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual(
+      enabledSpaceIds.sort().map((spaceId) => ({ spaceId, assetId: asset.id })),
+    );
+    await expect(
+      ctx.database
+        .selectFrom('face_identity_face')
+        .select('assetFaceId')
+        .where('assetFaceId', '=', assetFace.id)
+        .executeTakeFirst(),
+    ).resolves.toEqual({ assetFaceId: assetFace.id });
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
+```
+
+- [ ] **Step 3: Run focused medium tests and verify RED**
+
+Run:
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts -t "rediscovers page-one|same photo in 10 spaces|legacy imported metadata faces"
+```
+
+Expected: FAIL for missing service behavior or assertion mismatch before final implementation is complete.
+
+- [ ] **Step 4: Implement minimal fixes discovered by medium tests**
+
+Use the production code from Tasks 1-6. If the medium tests expose a mismatch, keep the fix inside:
+
+```ts
+FaceIdentityRepository.getBackfillWork()
+FaceIdentityRepository.getSharedSpaceFaceMatchBackfillTargets()
+PersonService.handleFaceIdentityBackfill()
+PersonService.queueSharedSpaceFaceMatchTargets()
+```
+
+Do not add `SharedSpaceFaceMatchAll` fallback in identity backfill.
+
+- [ ] **Step 5: Run focused medium tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts -t "rediscovers page-one|same photo in 10 spaces|legacy imported metadata faces"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts server/test/medium/specs/services/metadata.service.spec.ts server/src/repositories/face-identity.repository.ts server/src/services/person.service.ts
+git commit -m "test: prove targeted identity backfill materialization"
+```
+
+## Task 8: Full Reset Preservation and Race Guard
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Verify the existing force-reset full rebuild test remains present**
+
+Confirm `server/src/services/person.service.spec.ts` has this force-reset regression test under the `force wipes space state` describe block:
+
+```ts
+it('should wipe shared_space_person tables and queue SharedSpaceFaceMatchAll per space when force=true', async () => {
+  const face = AssetFaceFactory.from().person().build();
+  mocks.job.getJobCounts.mockResolvedValue({
+    active: 1,
+    waiting: 0,
+    paused: 0,
+    completed: 0,
+    failed: 0,
+    delayed: 0,
+  });
+  mocks.person.getAll.mockReturnValue(makeStream([face.person!]));
+  mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+  mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+  mocks.person.unassignFaces.mockResolvedValue();
+  mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['space-a', 'space-b']);
+
+  await sut.handleQueueRecognizeFaces({ force: true });
+
+  expect(mocks.sharedSpace.deleteAllPersonFaces).toHaveBeenCalledOnce();
+  expect(mocks.sharedSpace.deleteAllPersons).toHaveBeenCalledOnce();
+  expect(mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled).toHaveBeenCalledOnce();
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-a' } },
+    { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-b' } },
+  ]);
+});
+```
+
+- [ ] **Step 2: Write failing service test for no identity-backfill full rebuild**
+
+Add to `describe('handleFaceIdentityBackfill')`:
+
+```ts
+it('does not queue full shared-space rebuilds when identity backfill is retriggered during face recognition work', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: true,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+  );
+});
+```
+
+- [ ] **Step 3: Run focused tests and verify RED for the new identity-backfill test**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "force face recognition|retriggered during face recognition"
+```
+
+Expected: the existing force-reset test PASSes; the new retrigger test FAILs if identity backfill still has a full rebuild path.
+
+- [ ] **Step 4: Preserve existing force reset code and remove identity-backfill full rebuild hooks**
+
+In `handleQueueRecognizeFaces({ force: true })`, keep:
+
+```ts
+const spaceIds = await this.sharedSpaceRepository.getSpaceIdsWithFaceRecognitionEnabled();
+await this.jobRepository.queueAll(
+  spaceIds.map((spaceId) => ({
+    name: JobName.SharedSpaceFaceMatchAll as const,
+    data: { spaceId },
+  })),
+);
+```
+
+In `handleFaceIdentityBackfill()`, do not call:
+
+```ts
+this.sharedSpaceRepository.getSpaceIdsWithFaceRecognitionEnabled()
+```
+
+and do not queue:
+
+```ts
+{ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId } }
+```
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "force face recognition|retriggered during face recognition"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: preserve full reset rebuild boundary"
+```
+
+## Task 9: Final Verification
+
+**Files:**
+- No new file edits unless verification exposes a bug.
+
+- [ ] **Step 1: Run focused unit suite**
+
+```bash
+corepack pnpm --dir server test src/services/person.service.spec.ts src/repositories/job.repository.spec.ts src/services/job.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused medium suite**
+
+```bash
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts
+```
+
+Expected: PASS. If unrelated local EXIF fixtures are missing, rerun with the focused `-t` filters from Tasks 1, 2, and 7 and record the fixture limitation in the final implementation summary.
+
+- [ ] **Step 3: Run typecheck, lint, and full unit tests**
+
+```bash
+corepack pnpm --dir server check
+corepack pnpm --dir server lint
+corepack pnpm --dir server test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Check diff hygiene**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: `git diff --check` has no output. `git status --short` lists only intentional committed or ready-to-commit changes.
+
+- [ ] **Step 5: Commit any verification-only test fixes**
+
+If Step 1-4 required small fixes:
+
+```bash
+git add server/src server/test/medium/specs
+git commit -m "test: harden face identity backfill coverage"
+```
+
+Expected: no uncommitted implementation or test changes remain after the final commit.
+
+## Self-Review Checklist
+
+- [ ] Spec coverage: every goal in `docs/superpowers/specs/2026-05-09-face-identity-backfill-phased-fanout-design.md` maps to a task above.
+- [ ] TDD proof: each behavior change has a RED command before production code.
+- [ ] Race proof: identity work remaining, cursor races, retriggers, queue failures, and stale targets are covered by service or medium tests.
+- [ ] Fan-out proof: identity backfill queues `SharedSpaceFaceMatch` only, never `SharedSpaceFaceMatchAll`.
+- [ ] Edge proof: same photo in 10 spaces, disabled spaces, direct+library dedupe, stale assignment repair, deleted/offline/invisible inputs, and legacy imported metadata faces are covered.
+- [ ] Metadata proof: identity-backfill finalization does not queue global metadata ahead of targeted face-match jobs.
+- [ ] Compatibility proof: force reset full rebuild path remains unchanged.

--- a/docs/superpowers/plans/2026-05-09-face-identity-backfill-phased-fanout.md
+++ b/docs/superpowers/plans/2026-05-09-face-identity-backfill-phased-fanout.md
@@ -20,8 +20,12 @@
   - Owns stable job ids for root/cursor backfills and identity-backfill `SharedSpaceFaceMatch` jobs.
 - Modify: `server/src/types.ts`
   - Owns the optional `source: 'identity-backfill'` job data field.
+- Modify: `server/src/services/shared-space.service.ts`
+  - Owns current-state checks when stale targeted jobs execute after asset/space/library changes.
 - Modify: `server/src/services/person.service.spec.ts`
   - Unit coverage for bootstrap, phase gating, fan-out, batching, no metadata race, and full-reset preservation.
+- Modify: `server/src/services/shared-space.service.spec.ts`
+  - Unit coverage for stale targeted job execution after target removal or face-recognition disablement.
 - Modify: `server/src/repositories/job.repository.spec.ts`
   - Unit coverage for stable job ids and no normal-vs-backfill face-match collision.
 - Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
@@ -44,7 +48,12 @@ git diff --name-only -- server/src/repositories/face-identity.repository.ts serv
 
 Expected in this worktree before cleanup: those server files may be listed as modified.
 
-If they are modified before implementation starts, save the prototype diff for reference and restore only those server files:
+If they are modified before implementation starts, first determine ownership:
+
+- If the diffs are the earlier prototype from this branch, save them as a reference patch and remove them from the execution worktree before writing the first red test.
+- If any hunk appears user-owned or unrelated to this backfill work, do not restore it. Create a fresh implementation worktree from `HEAD` and execute the plan there instead.
+
+For prototype-owned diffs only, use:
 
 ```bash
 git diff -- server/src/repositories/face-identity.repository.ts server/src/repositories/job.repository.spec.ts server/src/repositories/job.repository.ts server/src/services/person.service.spec.ts server/src/services/person.service.ts server/src/types.ts server/test/medium/specs/repositories/face-identity.repository.spec.ts server/test/medium/specs/services/metadata.service.spec.ts > /tmp/face-identity-backfill-prototype.diff
@@ -53,6 +62,16 @@ git status --short
 ```
 
 Expected after cleanup: only committed docs remain clean, and no server implementation files are modified. Keep `/tmp/face-identity-backfill-prototype.diff` as a reference only; do not apply it wholesale.
+
+For user-owned or ambiguous diffs, create a clean execution worktree:
+
+```bash
+git worktree add ../fix-shared-space-backfill-targeted-rematch-impl HEAD
+cd ../fix-shared-space-backfill-targeted-rematch-impl
+git status --short
+```
+
+Expected: clean status before the first red test.
 
 ## Task 1: Repository Phase Summary
 
@@ -160,11 +179,11 @@ export type FaceIdentityBackfillWork = {
 };
 ```
 
-Replace `hasBackfillWork()` with a wrapper and add `getBackfillWork()`:
+Replace `hasBackfillWork()` with a wrapper and add `getBackfillWork()`. The projection boolean must be derived from `getSharedSpaceFaceMatchBackfillTargets({ limit: 1 })` so it uses the exact same predicate as target discovery:
 
 ```ts
 async getBackfillWork(): Promise<FaceIdentityBackfillWork> {
-  const result = await sql<FaceIdentityBackfillWork>`
+  const result = await sql<Pick<FaceIdentityBackfillWork, 'hasPersonalIdentityWork' | 'hasSpacePersonIdentityWork'>>`
     SELECT
       (
         EXISTS (
@@ -198,70 +217,15 @@ async getBackfillWork(): Promise<FaceIdentityBackfillWork> {
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
           AND shared_space_person."identityId" IS DISTINCT FROM face_identity_face."identityId"
-      ) AS "hasSpacePersonIdentityWork",
-      EXISTS (
-        SELECT 1
-        FROM asset_face
-        INNER JOIN asset ON asset.id = asset_face."assetId"
-        INNER JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
-        WHERE asset_face."personId" IS NOT NULL
-          AND asset_face."deletedAt" IS NULL
-          AND asset_face."isVisible" = true
-          AND asset."deletedAt" IS NULL
-          AND asset."isOffline" = false
-          AND asset.visibility IN (${AssetVisibility.Timeline}, ${AssetVisibility.Archive})
-          AND (
-            EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN shared_space ON shared_space.id = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-                AND shared_space."faceRecognitionEnabled" = true
-                AND NOT EXISTS (
-                  SELECT 1
-                  FROM shared_space_person_face
-                  INNER JOIN shared_space_person
-                    ON shared_space_person.id = shared_space_person_face."personId"
-                  WHERE shared_space_person_face."assetFaceId" = asset_face.id
-                    AND shared_space_person."spaceId" = shared_space.id
-                )
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN shared_space ON shared_space.id = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-                AND shared_space."faceRecognitionEnabled" = true
-                AND NOT EXISTS (
-                  SELECT 1
-                  FROM shared_space_person_face
-                  INNER JOIN shared_space_person
-                    ON shared_space_person.id = shared_space_person_face."personId"
-                  WHERE shared_space_person_face."assetFaceId" = asset_face.id
-                    AND shared_space_person."spaceId" = shared_space.id
-                )
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_person_face
-              INNER JOIN shared_space_person
-                ON shared_space_person.id = shared_space_person_face."personId"
-              INNER JOIN shared_space ON shared_space.id = shared_space_person."spaceId"
-              WHERE shared_space_person_face."assetFaceId" = asset_face.id
-                AND shared_space."faceRecognitionEnabled" = true
-                AND shared_space_person."identityId" IS DISTINCT FROM face_identity_face."identityId"
-            )
-          )
-      ) AS "hasSharedSpaceProjectionWork"
+      ) AS "hasSpacePersonIdentityWork"
   `.execute(this.db);
+  const projectionTargets = await this.getSharedSpaceFaceMatchBackfillTargets({ limit: 1 });
 
-  return (
-    result.rows[0] ?? {
-      hasPersonalIdentityWork: false,
-      hasSpacePersonIdentityWork: false,
-      hasSharedSpaceProjectionWork: false,
-    }
-  );
+  return {
+    hasPersonalIdentityWork: result.rows[0]?.hasPersonalIdentityWork ?? false,
+    hasSpacePersonIdentityWork: result.rows[0]?.hasSpacePersonIdentityWork ?? false,
+    hasSharedSpaceProjectionWork: projectionTargets.length > 0,
+  };
 }
 
 async hasBackfillWork(): Promise<boolean> {
@@ -373,6 +337,55 @@ it('excludes disabled spaces and ineligible assets from projection targets', asy
     await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
   }
 });
+
+it('excludes deleted invisible unassigned and identity-less faces from projection targets', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  try {
+    const eligible = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const deletedFace = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const invisibleFace = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const unassignedFace = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    const identityless = await newIdentityFace(ctx, sut, { ownerId: user.id });
+    await ctx.database
+      .updateTable('asset_face')
+      .set({ deletedAt: new Date() })
+      .where('id', '=', deletedFace.assetFace.id)
+      .execute();
+    await ctx.database
+      .updateTable('asset_face')
+      .set({ isVisible: false })
+      .where('id', '=', invisibleFace.assetFace.id)
+      .execute();
+    await ctx.database
+      .updateTable('asset_face')
+      .set({ personId: null })
+      .where('id', '=', unassignedFace.assetFace.id)
+      .execute();
+    await ctx.database.deleteFrom('face_identity_face').where('assetFaceId', '=', identityless.assetFace.id).execute();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    for (const assetId of [
+      eligible.asset.id,
+      deletedFace.asset.id,
+      invisibleFace.asset.id,
+      unassignedFace.asset.id,
+      identityless.asset.id,
+    ]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId, addedById: user.id });
+    }
+
+    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+      { spaceId: space.id, assetId: eligible.asset.id },
+    ]);
+    await expect(sut.getBackfillWork()).resolves.toMatchObject({
+      hasPersonalIdentityWork: true,
+      hasSharedSpaceProjectionWork: true,
+    });
+  } finally {
+    await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+  }
+});
 ```
 
 Extend the local `newIdentityFace()` helper in this spec file so it accepts `libraryId`, `isOffline`, and `deletedAt`, then passes those values into `ctx.newAsset()`.
@@ -382,7 +395,7 @@ Extend the local `newIdentityFace()` helper in this spec file so it accepts `lib
 Run:
 
 ```bash
-corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "projection target|direct and linked-library|ineligible assets"
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "projection target|direct and linked-library|ineligible assets|identity-less faces"
 ```
 
 Expected: FAIL if target discovery and summary predicates disagree or helper inputs are unsupported.
@@ -456,7 +469,7 @@ const newIdentityFace = async (
 Run:
 
 ```bash
-corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "projection target|direct and linked-library|ineligible assets"
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -t "projection target|direct and linked-library|ineligible assets|identity-less faces"
 ```
 
 Expected: PASS.
@@ -742,6 +755,47 @@ it('queues exact deduped projection targets after identity work is clean', async
   );
 });
 
+it('rediscovers earlier-page targets after paginated identity backfill completes', async () => {
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValueOnce({
+    processed: 1,
+    nextCursor: 'person-cursor',
+    affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+  });
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+
+  mocks.job.queue.mockClear();
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValueOnce({ processed: 1 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValueOnce({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([
+    { spaceId: 'space-1', assetId: 'asset-1' },
+    { spaceId: 'space-1', assetId: 'asset-2' },
+  ]);
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person', cursor: 'person-cursor' })).resolves.toBe(
+    JobStatus.Success,
+  );
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+    },
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { spaceId: 'space-1', assetId: 'asset-2', source: 'identity-backfill' },
+    },
+  ]);
+});
+
 it('does not call queueAll for an empty targeted face-match list', async () => {
   mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
   mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
@@ -775,6 +829,81 @@ it('does not write an empty trailing batch for exactly one full chunk', async ()
   expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
   expect(mocks.job.queueAll.mock.calls[0][0]).toHaveLength(1000);
 });
+
+it('logs a projection invariant warning instead of falling back to a full rebuild when projection work has no targets', async () => {
+  const warn = vi.spyOn((sut as any).logger, 'warn').mockImplementation(() => undefined);
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([]);
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('projection backfill work was reported but no targets were found'),
+  );
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled).not.toHaveBeenCalled();
+});
+
+it('regenerates targeted projection work on a later run after a queue write failure', async () => {
+  const target = { spaceId: 'space-1', assetId: 'asset-1' };
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 1 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([target]);
+  mocks.job.queueAll.mockRejectedValueOnce(new Error('redis write failed'));
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).rejects.toThrow('redis write failed');
+
+  mocks.job.queueAll.mockReset();
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { ...target, source: 'identity-backfill' },
+    },
+  ]);
+});
+
+it('regenerates only remaining current targets after a later queue batch fails', async () => {
+  const targets = Array.from({ length: 1001 }, (_, index) => ({
+    spaceId: 'space-1',
+    assetId: `asset-${index.toString().padStart(4, '0')}`,
+  }));
+  const remainingTarget = targets.at(-1)!;
+  mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 1 });
+  mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+  (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+    hasPersonalIdentityWork: false,
+    hasSpacePersonIdentityWork: false,
+    hasSharedSpaceProjectionWork: true,
+  });
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValueOnce(targets);
+  mocks.job.queueAll.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('redis write failed'));
+
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).rejects.toThrow('redis write failed');
+
+  mocks.job.queueAll.mockReset();
+  (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValueOnce([remainingTarget]);
+  await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.SharedSpaceFaceMatch,
+      data: { ...remainingTarget, source: 'identity-backfill' },
+    },
+  ]);
+});
 ```
 
 - [ ] **Step 2: Run focused service tests and verify RED**
@@ -782,14 +911,26 @@ it('does not write an empty trailing batch for exactly one full chunk', async ()
 Run:
 
 ```bash
-corepack pnpm --dir server test src/services/person.service.spec.ts -t "deduped projection targets|empty targeted|empty trailing"
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "deduped projection targets|earlier-page targets|empty targeted|empty trailing|projection invariant|queue write failure|queue batch fails"
 ```
 
-Expected: FAIL until the batching helper skips empty arrays and uses identity-backfill source.
+Expected: FAIL until the batching helper skips empty arrays, uses identity-backfill source, logs the empty-target invariant, and leaves queue-failure recovery to regenerated DB-derived targets.
 
 - [ ] **Step 3: Implement deduped bounded queue writes**
 
-In `server/src/services/person.service.ts`, add or update:
+In `server/src/services/person.service.ts`, update the projection target discovery block so an inconsistent empty target list logs a warning without falling back to a full rebuild:
+
+```ts
+if (work.hasSharedSpaceProjectionWork) {
+  const projectionTargets = await this.faceIdentityRepository.getSharedSpaceFaceMatchBackfillTargets();
+  if (projectionTargets.length === 0) {
+    this.logger.warn('Face identity projection backfill work was reported but no targets were found');
+  }
+  affectedSpaceAssets.push(...projectionTargets);
+}
+```
+
+Then add or update the bounded queue helper:
 
 ```ts
 private async queueSharedSpaceFaceMatchTargets(targets: SharedSpaceFaceMatchTarget[]): Promise<void> {
@@ -836,7 +977,7 @@ import { JobItem } from 'src/types';
 Run:
 
 ```bash
-corepack pnpm --dir server test src/services/person.service.spec.ts -t "deduped projection targets|empty targeted|empty trailing"
+corepack pnpm --dir server test src/services/person.service.spec.ts -t "deduped projection targets|earlier-page targets|empty targeted|empty trailing|projection invariant|queue write failure|queue batch fails"
 ```
 
 Expected: PASS.
@@ -939,12 +1080,12 @@ git commit -m "fix: avoid identity backfill metadata race"
 - Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 - Modify: `server/test/medium/specs/services/metadata.service.spec.ts`
 
-- [ ] **Step 1: Write failing medium test for paginated no-loss fan-out**
+- [ ] **Step 1: Write failing medium test for end-to-end targeted fan-out**
 
-Add this service-level medium test to `server/test/medium/specs/services/metadata.service.spec.ts`, using the existing `setupFaceIdentityBackfillService()` helper. The test creates affected targets before final fan-out and proves the final projection scan rediscovers them.
+Add this service-level medium test to `server/test/medium/specs/services/metadata.service.spec.ts`, using the existing `setupFaceIdentityBackfillService()` helper. The unit tests above prove paginated no-loss behavior; this medium test proves the final DB-derived targets materialize through real shared-space matching.
 
 ```ts
-it('rediscovers page-one projection work after paginated identity backfill finishes', async () => {
+it('materializes DB-derived projection work after identity backfill finishes', async () => {
   const { ctx } = setupFaceImport();
   const { user } = await ctx.newUser();
   try {
@@ -959,6 +1100,7 @@ it('rediscovers page-one projection work after paginated identity backfill finis
     await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: firstAsset.id, addedById: user.id });
     await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: secondAsset.id, addedById: user.id });
     const { sut: backfillService, ctx: backfillCtx } = setupFaceIdentityBackfillService(ctx.database);
+    const { sut: sharedSpaceService, ctx: sharedSpaceCtx } = setupSharedSpaceService(ctx.database);
 
     await expect(backfillService.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
 
@@ -973,19 +1115,25 @@ it('rediscovers page-one projection work after paginated identity backfill finis
       ]),
     );
     expect(queuedJobs).toHaveLength(2);
+    for (const job of queuedJobs) {
+      await expect(sharedSpaceService.handleSharedSpaceFaceMatch(job.data)).resolves.toBe(JobStatus.Success);
+    }
+    await drainSharedSpaceFaceJobs(sharedSpaceService, sharedSpaceCtx);
+    await expect(backfillCtx.get(FaceIdentityRepository).hasBackfillWork()).resolves.toBe(false);
   } finally {
     await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
   }
 });
 ```
 
-- [ ] **Step 2: Write failing medium tests for same-photo multi-space materialization**
+- [ ] **Step 2: Write failing medium test for same-photo multi-space materialization**
 
-Add or extend the existing same-photo test:
+Add this service-level medium test to `server/test/medium/specs/services/metadata.service.spec.ts`:
 
 ```ts
 it('materializes one targeted projection per enabled space for the same photo in 10 spaces', async () => {
-  const { ctx, sut } = setup();
+  const { ctx } = setupFaceImport();
+  const sut = ctx.get(FaceIdentityRepository);
   const { user } = await ctx.newUser();
   try {
     const { person } = await ctx.newPerson({ ownerId: user.id });
@@ -1003,9 +1151,32 @@ it('materializes one targeted projection per enabled space for the same photo in
     await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
     await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
 
-    await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual(
-      enabledSpaceIds.sort().map((spaceId) => ({ spaceId, assetId: asset.id })),
+    const { sut: backfillService, ctx: backfillCtx } = setupFaceIdentityBackfillService(ctx.database);
+    const { sut: sharedSpaceService, ctx: sharedSpaceCtx } = setupSharedSpaceService(ctx.database);
+    await expect(backfillService.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+    const queuedJobs = backfillCtx
+      .getMock<JobRepository, Mocked<JobRepository>>(JobRepository)
+      .queueAll.mock.calls.flatMap(([jobs]) => jobs)
+      .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+    expect(queuedJobs).toEqual(
+      enabledSpaceIds.sort().map((spaceId) => ({
+        name: JobName.SharedSpaceFaceMatch,
+        data: { spaceId, assetId: asset.id, source: 'identity-backfill' },
+      })),
     );
+    for (const job of queuedJobs) {
+      await expect(sharedSpaceService.handleSharedSpaceFaceMatch(job.data)).resolves.toBe(JobStatus.Success);
+    }
+    await drainSharedSpaceFaceJobs(sharedSpaceService, sharedSpaceCtx);
+    await expect(
+      ctx.database
+        .selectFrom('shared_space_person_face')
+        .innerJoin('shared_space_person', 'shared_space_person.id', 'shared_space_person_face.personId')
+        .select((eb) => eb.fn.countAll().as('count'))
+        .where('shared_space_person_face.assetFaceId', '=', assetFace.id)
+        .where('shared_space_person.spaceId', 'in', enabledSpaceIds)
+        .executeTakeFirstOrThrow(),
+    ).resolves.toEqual({ count: '10' });
     await expect(
       ctx.database
         .selectFrom('face_identity_face')
@@ -1024,7 +1195,7 @@ it('materializes one targeted projection per enabled space for the same photo in
 Run:
 
 ```bash
-corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts -t "rediscovers page-one|same photo in 10 spaces|legacy imported metadata faces"
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts -t "DB-derived projection work|same photo in 10 spaces|legacy imported metadata faces"
 ```
 
 Expected: FAIL for missing service behavior or assertion mismatch before final implementation is complete.
@@ -1047,7 +1218,7 @@ Do not add `SharedSpaceFaceMatchAll` fallback in identity backfill.
 Run:
 
 ```bash
-corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts -t "rediscovers page-one|same photo in 10 spaces|legacy imported metadata faces"
+corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts test/medium/specs/services/metadata.service.spec.ts -t "DB-derived projection work|same photo in 10 spaces|legacy imported metadata faces"
 ```
 
 Expected: PASS.
@@ -1059,7 +1230,67 @@ git add server/test/medium/specs/repositories/face-identity.repository.spec.ts s
 git commit -m "test: prove targeted identity backfill materialization"
 ```
 
-## Task 8: Full Reset Preservation and Race Guard
+## Task 8: Targeted Job Execution Skip Guards
+
+**Files:**
+- Modify: `server/src/services/shared-space.service.spec.ts`
+- Modify: `server/src/services/shared-space.service.ts` only if the skip behavior is not already implemented.
+
+- [ ] **Step 1: Write or verify targeted-job execution skip tests**
+
+Ensure `describe('handleSharedSpaceFaceMatch')` contains explicit tests for stale targeted jobs:
+
+```ts
+it('skips safely when a targeted asset is no longer in the space before execution', async () => {
+  const spaceId = newUuid();
+  const assetId = newUuid();
+  mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+  mocks.sharedSpace.isAssetInSpace.mockResolvedValue(false);
+
+  const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId, source: 'identity-backfill' });
+
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonDedup, data: { spaceId } });
+});
+
+it('skips safely when face recognition is disabled before targeted execution', async () => {
+  const space = factory.sharedSpace({ faceRecognitionEnabled: false });
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+
+  const result = await sut.handleSharedSpaceFaceMatch({
+    spaceId: space.id,
+    assetId: 'asset-1',
+    source: 'identity-backfill',
+  });
+
+  expect(result).toBe(JobStatus.Skipped);
+  expect(mocks.sharedSpace.isAssetInSpace).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+});
+```
+
+The first test covers direct asset removal and linked-library removal because both collapse to `isAssetInSpace(spaceId, assetId) === false` at execution time.
+
+- [ ] **Step 2: Run focused shared-space tests**
+
+Run:
+
+```bash
+corepack pnpm --dir server test src/services/shared-space.service.spec.ts -t "targeted asset is no longer|face recognition is disabled before targeted execution"
+```
+
+Expected: PASS if existing current-state checks already cover stale targeted jobs. If either test fails, fix only `handleSharedSpaceFaceMatch()` or `processSpaceFaceMatch()` so stale jobs skip without writing person-face rows.
+
+- [ ] **Step 3: Commit if tests or fixes were added**
+
+```bash
+git add server/src/services/shared-space.service.spec.ts server/src/services/shared-space.service.ts
+git commit -m "test: cover stale targeted shared-space face jobs"
+```
+
+## Task 9: Full Reset Preservation and Race Guard
 
 **Files:**
 - Modify: `server/src/services/person.service.spec.ts`
@@ -1175,7 +1406,7 @@ git add server/src/services/person.service.spec.ts server/src/services/person.se
 git commit -m "test: preserve full reset rebuild boundary"
 ```
 
-## Task 9: Final Verification
+## Task 10: Final Verification
 
 **Files:**
 - No new file edits unless verification exposes a bug.
@@ -1183,7 +1414,7 @@ git commit -m "test: preserve full reset rebuild boundary"
 - [ ] **Step 1: Run focused unit suite**
 
 ```bash
-corepack pnpm --dir server test src/services/person.service.spec.ts src/repositories/job.repository.spec.ts src/services/job.service.spec.ts
+corepack pnpm --dir server test src/services/person.service.spec.ts src/repositories/job.repository.spec.ts src/services/job.service.spec.ts src/services/shared-space.service.spec.ts
 ```
 
 Expected: PASS.

--- a/docs/superpowers/plans/2026-05-09-face-identity-backfill-phased-fanout.md
+++ b/docs/superpowers/plans/2026-05-09-face-identity-backfill-phased-fanout.md
@@ -76,6 +76,7 @@ Expected: clean status before the first red test.
 ## Task 1: Repository Phase Summary
 
 **Files:**
+
 - Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 - Modify: `server/src/repositories/face-identity.repository.ts`
 
@@ -254,6 +255,7 @@ git commit -m "feat: split face identity backfill work phases"
 ## Task 2: Projection Target Predicate Coverage
 
 **Files:**
+
 - Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 - Modify: `server/src/repositories/face-identity.repository.ts`
 
@@ -484,6 +486,7 @@ git commit -m "test: cover shared-space projection target predicates"
 ## Task 3: Job Data and Stable IDs
 
 **Files:**
+
 - Modify: `server/src/types.ts`
 - Modify: `server/src/repositories/job.repository.spec.ts`
 - Modify: `server/src/repositories/job.repository.ts`
@@ -572,6 +575,7 @@ git commit -m "feat: key identity-backfill face match jobs separately"
 ## Task 4: PersonService Phase Gating
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 - Modify: `server/src/services/person.service.ts`
 
@@ -709,6 +713,7 @@ git commit -m "feat: gate identity backfill projection fanout"
 ## Task 5: Targeted Fan-Out Deduping and Batching
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 - Modify: `server/src/services/person.service.ts`
 
@@ -992,6 +997,7 @@ git commit -m "feat: queue targeted identity backfill face matches"
 ## Task 6: Metadata Ordering and Manual Backfill Preservation
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 - Modify: `server/src/services/job.service.spec.ts`
 
@@ -1077,6 +1083,7 @@ git commit -m "fix: avoid identity backfill metadata race"
 ## Task 7: Medium End-to-End Backfill Proof
 
 **Files:**
+
 - Modify: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 - Modify: `server/test/medium/specs/services/metadata.service.spec.ts`
 
@@ -1110,8 +1117,14 @@ it('materializes DB-derived projection work after identity backfill finishes', a
       .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
     expect(queuedJobs).toEqual(
       expect.arrayContaining([
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: space.id, assetId: firstAsset.id, source: 'identity-backfill' } },
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: space.id, assetId: secondAsset.id, source: 'identity-backfill' } },
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: space.id, assetId: firstAsset.id, source: 'identity-backfill' },
+        },
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: space.id, assetId: secondAsset.id, source: 'identity-backfill' },
+        },
       ]),
     );
     expect(queuedJobs).toHaveLength(2);
@@ -1205,10 +1218,10 @@ Expected: FAIL for missing service behavior or assertion mismatch before final i
 Use the production code from Tasks 1-6. If the medium tests expose a mismatch, keep the fix inside:
 
 ```ts
-FaceIdentityRepository.getBackfillWork()
-FaceIdentityRepository.getSharedSpaceFaceMatchBackfillTargets()
-PersonService.handleFaceIdentityBackfill()
-PersonService.queueSharedSpaceFaceMatchTargets()
+FaceIdentityRepository.getBackfillWork();
+FaceIdentityRepository.getSharedSpaceFaceMatchBackfillTargets();
+PersonService.handleFaceIdentityBackfill();
+PersonService.queueSharedSpaceFaceMatchTargets();
 ```
 
 Do not add `SharedSpaceFaceMatchAll` fallback in identity backfill.
@@ -1233,6 +1246,7 @@ git commit -m "test: prove targeted identity backfill materialization"
 ## Task 8: Targeted Job Execution Skip Guards
 
 **Files:**
+
 - Modify: `server/src/services/shared-space.service.spec.ts`
 - Modify: `server/src/services/shared-space.service.ts` only if the skip behavior is not already implemented.
 
@@ -1293,6 +1307,7 @@ git commit -m "test: cover stale targeted shared-space face jobs"
 ## Task 9: Full Reset Preservation and Race Guard
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 
 - [ ] **Step 1: Verify the existing force-reset full rebuild test remains present**
@@ -1380,7 +1395,7 @@ await this.jobRepository.queueAll(
 In `handleFaceIdentityBackfill()`, do not call:
 
 ```ts
-this.sharedSpaceRepository.getSpaceIdsWithFaceRecognitionEnabled()
+this.sharedSpaceRepository.getSpaceIdsWithFaceRecognitionEnabled();
 ```
 
 and do not queue:
@@ -1409,6 +1424,7 @@ git commit -m "test: preserve full reset rebuild boundary"
 ## Task 10: Final Verification
 
 **Files:**
+
 - No new file edits unless verification exposes a bug.
 
 - [ ] **Step 1: Run focused unit suite**

--- a/docs/superpowers/specs/2026-05-09-face-identity-backfill-phased-fanout-design.md
+++ b/docs/superpowers/specs/2026-05-09-face-identity-backfill-phased-fanout-design.md
@@ -50,6 +50,8 @@ The service keeps the current paged `FaceIdentityBackfill` job, but it only adva
 
 Once identity work is clean, the service asks the repository for exact shared-space projection targets and queues one targeted `SharedSpaceFaceMatch` per unique `(spaceId, assetId)`.
 
+The existing `hasBackfillWork()` method may remain as a compatibility wrapper for bootstrap callers, but it must be derived from the phase-aware summary. New orchestration logic must use the phase-aware summary directly so it cannot confuse identity work with projection work.
+
 ## Queue Flow
 
 `AppBootstrap` checks whether any backfill work exists. If work exists and no `FaceIdentityBackfill` is active, waiting, delayed, or paused on `QueueName.PeopleBackfill`, it queues one root `FaceIdentityBackfill` job.
@@ -68,6 +70,8 @@ Manual `FaceIdentityBackfill` starts also queue the same root job. Stable job id
 8. Merge exact projection targets with targets returned by the identity repair methods.
 9. Deduplicate and sort targets by `(spaceId, assetId)`.
 10. Queue targeted `SharedSpaceFaceMatch` jobs in bounded `queueAll` chunks.
+
+Targets collected from intermediate paginated identity pages are intentionally not queued between pages. The final projection scan is the durable source of truth for any missing or stale shared-space projection created by earlier pages. Tests must prove that no target is lost when affected faces are repaired on page one and fan-out is delayed until a later page finishes.
 
 Targeted identity-backfill face-match jobs use:
 
@@ -98,6 +102,16 @@ Additional invariants:
 - If a targeted job executes after the asset, space, library link, or face state changes, the existing `SharedSpaceFaceMatch` handler re-checks current state and skips or updates idempotently.
 - A full face recognition reset remains the authoritative full rebuild path and continues to clear shared-space person state before queueing full shared-space rebuild work.
 
+## Durability and Failure Recovery
+
+Database state is the source of truth. Queue work is derived from remaining identity/projection state and must be safe to regenerate.
+
+If `FaceIdentityBackfill` repairs identities and then fails before queueing targeted `SharedSpaceFaceMatch` jobs, no data is lost. The next bootstrap or manual `FaceIdentityBackfill` trigger reads the phase-aware summary again, sees projection work, and regenerates the missing targeted jobs.
+
+If a batched `queueAll` call partially succeeds and then fails, already queued targeted jobs are safe to run, and unqueued targets remain discoverable because their shared-space projections are still missing or stale. A later backfill run must dedupe already queued/completed work and queue only the remaining current targets.
+
+If the summary says `hasSharedSpaceProjectionWork` but target discovery returns no targets, that is a repository consistency bug. The implementation should log a warning and avoid falling back to `SharedSpaceFaceMatchAll`; tests must instead prove the summary and target discovery predicates stay aligned.
+
 ## Metadata Strategy
 
 Avoid global `SharedSpacePersonMetadataBackfill` from the identity-backfill finalization path when targeted face-match jobs are queued. A global metadata job can run on `QueueName.PeopleBackfill` before `SharedSpaceFaceMatch` jobs on `QueueName.FacialRecognition`, which can refresh metadata against stale projections.
@@ -106,10 +120,21 @@ Instead:
 
 - `SharedSpaceFaceMatch` continues to inherit metadata for touched space people while processing affected assets.
 - Dedup and reconciliation continue to queue scoped metadata backfills for affected identities.
-- Space-person identity repair should return affected targets, and if metadata-only repair is required, queue scoped metadata by identity rather than global metadata.
+- Space-person identity repair should return affected targets. If metadata-only repair is required, queue scoped metadata by identity only when no targeted face-match jobs are pending from the same backfill finalization.
 - Global `SharedSpacePersonMetadataBackfill` remains available for explicit manual/global metadata invalidation paths.
 
 This keeps identity backfill from starting broad metadata work before the targeted projection layer has caught up.
+
+## Consistency With Shared-Space Recognition Design
+
+This design builds on the shared-space recognition pipeline design from `2026-05-07-shared-space-recognition-pipeline-design.md`.
+
+The division of responsibility is:
+
+- Full force face recognition reset remains the only identity-related flow that queues `SharedSpaceFaceMatchAll`.
+- Identity backfill never queues `SharedSpaceFaceMatchAll`; it queues only targeted `SharedSpaceFaceMatch` jobs after identity data is stable.
+- Both flows continue to use `QueueName.FacialRecognition` for face-related shared-space matching, preserving the single-queue ordering guarantees from the earlier design.
+- `QueueName.PeopleBackfill` may trigger targeted face work, but it must not assume that metadata work on `PeopleBackfill` will run after `FacialRecognition` jobs.
 
 ## Trigger Matrix
 
@@ -121,6 +146,7 @@ The implementation must cover every place that can start or continue backfill wo
 - Manual `FaceIdentityBackfill`: queue root job only.
 - Manual retrigger while root is pending: BullMQ stable id dedupes to one executable root.
 - Manual retrigger while a cursor page is pending: root/cursor ids remain stable and no immediate fan-out occurs.
+- Queue service `FaceIdentityBackfill` start: queue root job only, with no direct projection fan-out.
 - Paged personal identity backfill with `nextCursor`: queue only next personal page.
 - Final personal identity page: continue to shared-space person phase.
 - Paged shared-space person identity backfill with `nextCursor`: queue only next shared-space person page.
@@ -137,6 +163,7 @@ Repository tests must prove each category independently:
 - Shared-space person attached to faces with mismatched identities is shared-space person identity work.
 - Missing shared-space person-face assignment for an eligible identity-linked face is projection work.
 - Stale shared-space person-face assignment with the wrong identity is projection work.
+- For each projection-work fixture, `hasSharedSpaceProjectionWork` and `getSharedSpaceFaceMatchBackfillTargets()` agree: projection work means at least one target, and no projection work means no target.
 - Already-correct projection is not returned as a target.
 - Direct shared-space asset membership returns the target.
 - Library-linked shared-space membership returns the target.
@@ -157,6 +184,7 @@ Service tests must prove queue behavior and race-safety:
 
 - Backfill does not call projection target discovery while a personal page has `nextCursor`.
 - Backfill does not call projection target discovery while a shared-space person page has `nextCursor`.
+- Backfill with affected targets on an early page and `nextCursor` does not queue those targets early; the final projection scan rediscovers them and queues them after identity work is clean.
 - Backfill requeues itself when the phase-aware summary reports remaining identity work after both pages complete.
 - Backfill does not queue `SharedSpaceFaceMatch`, `SharedSpaceFaceMatchAll`, or metadata when identity work remains.
 - Backfill queries projection targets only when identity work is clean and projection work remains.
@@ -169,6 +197,22 @@ Service tests must prove queue behavior and race-safety:
 - Identity-backfill targeted job ids do not collide with normal incremental `SharedSpaceFaceMatch` job ids.
 - `SharedSpaceFaceMatchAll` is never queued by identity backfill.
 - Force face recognition reset still queues `SharedSpaceFaceMatchAll` for enabled spaces.
+- Queue failure after identity repair does not require a full rebuild for recovery; a subsequent root backfill regenerates targeted projection work.
+- Scoped metadata is not queued from identity-backfill finalization when targeted face-match jobs are queued from that same finalization.
+- Explicit manual/global metadata backfill remains unchanged.
+
+## Medium Test Matrix
+
+Medium tests with a real database must prove:
+
+- A full paginated identity backfill repairs page-one faces, delays fan-out until the final page, then queues targeted jobs for the page-one assets via projection discovery.
+- Draining the targeted `SharedSpaceFaceMatch` jobs after identity backfill leaves `hasBackfillWork()` false.
+- The same photo in 10 enabled spaces queues and materializes exactly 10 space-scoped projections.
+- The same photo in 10 spaces with one disabled space queues and materializes exactly 9 projections.
+- A direct space asset plus a linked-library path for the same asset and space materializes once.
+- A stale assignment moved from identity A to identity B leaves no orphaned stale person-face assignment and recounts affected people.
+- Legacy imported metadata faces still backfill through targeted `SharedSpaceFaceMatch`, not `SharedSpaceFaceMatchAll`.
+- Full force recognition reset still follows the paged full-rebuild path from the shared-space recognition design.
 
 ## Race and Edge Cases
 
@@ -177,12 +221,15 @@ Tests must explicitly cover:
 - A full face recognition reset is already running and face identity backfill is retriggered. The backfill may queue or dedupe its root job, but it must not increase face recognition concurrency and must not queue full shared-space rebuilds.
 - A second face identity backfill trigger arrives while one is active or waiting. Only one root job should execute.
 - New identity work appears between the final page and the final work summary. The service must requeue identity backfill only.
+- New identity work appears with an id lower than the current cursor while a cursor page is running. The final work summary must catch it and requeue root backfill.
 - New projection work appears after identity work is clean. The service must queue targeted projection jobs only.
 - A target asset belongs to 10 spaces. The service must queue 10 jobs, not a full rebuild and not duplicate jobs per face.
 - A target asset has multiple faces in the same space. The service must queue one asset-level job for that space.
 - A target disappears before execution. The handler must skip safely using current-state checks.
 - A space disables face recognition before execution. The handler must skip safely.
+- A library link is removed before execution. The handler must skip safely using current-state checks.
 - A stale shared-space assignment is moved from one identity to another. Old and new affected persons are recounted and orphan cleanup runs.
+- `hasSharedSpaceProjectionWork` true with an empty target list is treated as a logged invariant violation, not as permission to queue a full rebuild.
 - Failed targeted jobs remain visible according to existing queue failure policy.
 
 ## TDD Requirements

--- a/docs/superpowers/specs/2026-05-09-face-identity-backfill-phased-fanout-design.md
+++ b/docs/superpowers/specs/2026-05-09-face-identity-backfill-phased-fanout-design.md
@@ -1,0 +1,223 @@
+# Face Identity Backfill Phased Fan-Out Design
+
+## Problem
+
+The current face identity backfill can repair personal identities, shared-space person identities, and shared-space face projections, but the queue orchestration treats all remaining work as one broad `hasBackfillWork()` boolean. That makes the service unable to distinguish between "identity data is still incomplete" and "identity data is clean, but shared-space projections need materialization."
+
+This matters for correctness and scale. If identity work is still appearing or being repaired, queuing shared-space face-match work can run projection jobs against unstable inputs. If the only remaining work is projection repair, running full shared-space rematches is too expensive for large libraries and can produce the multi-day fan-out behavior observed in production.
+
+The design goal is to make the backfill pipeline phase-aware: repair identities first, then queue only the exact shared-space projection work that is safe and necessary.
+
+## Goals
+
+- Prevent identity backfill from queueing `SharedSpaceFaceMatchAll`.
+- Queue targeted `SharedSpaceFaceMatch` jobs only for stale or missing `(spaceId, assetId)` shared-space projections.
+- Never queue shared-space projection work while personal or shared-space identity repair work remains.
+- Preserve correctness when the same photo appears in many spaces, including direct space assets and library-linked spaces.
+- Avoid data loss or stale data when a backfill is retriggered while another backfill is pending or running.
+- Keep existing full face-recognition reset behavior intact.
+- Add TDD coverage for all backfill triggers, queue transitions, edge cases, and race-safety invariants.
+
+## Non-Goals
+
+- Replacing BullMQ with a database-backed scheduler.
+- Splitting face recognition into a separate shared-space recognition queue in this phase.
+- Changing face detection or facial recognition concurrency.
+- Changing shared-space membership, library-link, visibility, archive, hidden-person, or deleted-face semantics.
+- Rebuilding the full generation-based backfill coordinator. This design leaves that option open.
+
+## Chosen Architecture
+
+Use a phased backfill model with separate repository checks for identity-layer work and shared-space projection work.
+
+The repository exposes a work summary:
+
+```ts
+type FaceIdentityBackfillWork = {
+  hasPersonalIdentityWork: boolean;
+  hasSpacePersonIdentityWork: boolean;
+  hasSharedSpaceProjectionWork: boolean;
+};
+```
+
+`hasPersonalIdentityWork` covers missing `person.identityId` rows and assigned visible faces that still need a `face_identity_face` link.
+
+`hasSpacePersonIdentityWork` covers existing shared-space people whose assigned faces now point to a different identity and therefore need repair, splitting, moving, recounting, or orphan cleanup.
+
+`hasSharedSpaceProjectionWork` covers enabled shared spaces where eligible identity-linked faces are missing a shared-space assignment or have a stale shared-space assignment.
+
+The service keeps the current paged `FaceIdentityBackfill` job, but it only advances into projection fan-out after the identity phases are clean. If identity work remains after a page completes, the service queues another `FaceIdentityBackfill` root job and returns. It does not query projection targets, queue face-match jobs, or queue metadata backfill from that incomplete state.
+
+Once identity work is clean, the service asks the repository for exact shared-space projection targets and queues one targeted `SharedSpaceFaceMatch` per unique `(spaceId, assetId)`.
+
+## Queue Flow
+
+`AppBootstrap` checks whether any backfill work exists. If work exists and no `FaceIdentityBackfill` is active, waiting, delayed, or paused on `QueueName.PeopleBackfill`, it queues one root `FaceIdentityBackfill` job.
+
+Manual `FaceIdentityBackfill` starts also queue the same root job. Stable job ids in `JobRepository` dedupe duplicate root and cursor jobs while they are pending.
+
+`FaceIdentityBackfill` execution follows this sequence:
+
+1. Run the personal identity phase for up to `FACE_IDENTITY_BACKFILL_CHUNK_SIZE` people.
+2. If the personal phase returns `nextCursor`, queue the next personal page and stop.
+3. Run the shared-space person identity phase for up to `FACE_IDENTITY_BACKFILL_CHUNK_SIZE` shared-space people.
+4. If the shared-space person phase returns `nextCursor`, queue the next shared-space person page and stop.
+5. Read the phase-aware work summary.
+6. If personal or shared-space person identity work remains, queue one root `FaceIdentityBackfill` and stop.
+7. If only shared-space projection work remains, read exact projection targets.
+8. Merge exact projection targets with targets returned by the identity repair methods.
+9. Deduplicate and sort targets by `(spaceId, assetId)`.
+10. Queue targeted `SharedSpaceFaceMatch` jobs in bounded `queueAll` chunks.
+
+Targeted identity-backfill face-match jobs use:
+
+```ts
+{
+  name: JobName.SharedSpaceFaceMatch,
+  data: { spaceId, assetId, source: 'identity-backfill' },
+}
+```
+
+The `source` keeps identity-backfill rematches distinct from normal incremental rematches for BullMQ job-id dedupe. It must not change handler behavior.
+
+## Safety Invariants
+
+The main invariant is:
+
+> Shared-space projection work must never be queued while identity-layer work remains.
+
+This prevents projection jobs from materializing against half-repaired identity data.
+
+Additional invariants:
+
+- `FaceIdentityBackfill` may requeue itself, but it must not fan out to shared-space face matching until identity work is clean.
+- `SharedSpaceFaceMatchAll` is only used by explicit full rebuild paths such as force face recognition reset and shared-space full rebuild flows.
+- Targeted backfill fan-out is bounded by unique `(spaceId, assetId)` projection targets, not by `faces * spaces`.
+- Projection target discovery must respect the same eligibility rules as shared-space face matching: enabled spaces only, eligible asset visibility only, non-deleted assets, non-offline assets, visible non-deleted assigned faces, and identity-linked faces.
+- Direct asset membership and library membership must dedupe to one target per `(spaceId, assetId)`.
+- If a targeted job executes after the asset, space, library link, or face state changes, the existing `SharedSpaceFaceMatch` handler re-checks current state and skips or updates idempotently.
+- A full face recognition reset remains the authoritative full rebuild path and continues to clear shared-space person state before queueing full shared-space rebuild work.
+
+## Metadata Strategy
+
+Avoid global `SharedSpacePersonMetadataBackfill` from the identity-backfill finalization path when targeted face-match jobs are queued. A global metadata job can run on `QueueName.PeopleBackfill` before `SharedSpaceFaceMatch` jobs on `QueueName.FacialRecognition`, which can refresh metadata against stale projections.
+
+Instead:
+
+- `SharedSpaceFaceMatch` continues to inherit metadata for touched space people while processing affected assets.
+- Dedup and reconciliation continue to queue scoped metadata backfills for affected identities.
+- Space-person identity repair should return affected targets, and if metadata-only repair is required, queue scoped metadata by identity rather than global metadata.
+- Global `SharedSpacePersonMetadataBackfill` remains available for explicit manual/global metadata invalidation paths.
+
+This keeps identity backfill from starting broad metadata work before the targeted projection layer has caught up.
+
+## Trigger Matrix
+
+The implementation must cover every place that can start or continue backfill work:
+
+- App bootstrap with no work: queue nothing.
+- App bootstrap with work and no active/pending backfill: queue one root `FaceIdentityBackfill`.
+- App bootstrap with active, waiting, delayed, or paused `FaceIdentityBackfill`: queue nothing.
+- Manual `FaceIdentityBackfill`: queue root job only.
+- Manual retrigger while root is pending: BullMQ stable id dedupes to one executable root.
+- Manual retrigger while a cursor page is pending: root/cursor ids remain stable and no immediate fan-out occurs.
+- Paged personal identity backfill with `nextCursor`: queue only next personal page.
+- Final personal identity page: continue to shared-space person phase.
+- Paged shared-space person identity backfill with `nextCursor`: queue only next shared-space person page.
+- Final shared-space person identity page with remaining identity work: queue root backfill only.
+- Final shared-space person identity page with projection-only work: queue targeted face-match jobs only.
+- Final page with no remaining work and no affected targets: queue nothing.
+
+## Repository Test Matrix
+
+Repository tests must prove each category independently:
+
+- Missing `person.identityId` is identity work.
+- Assigned visible face without `face_identity_face` is identity work.
+- Shared-space person attached to faces with mismatched identities is shared-space person identity work.
+- Missing shared-space person-face assignment for an eligible identity-linked face is projection work.
+- Stale shared-space person-face assignment with the wrong identity is projection work.
+- Already-correct projection is not returned as a target.
+- Direct shared-space asset membership returns the target.
+- Library-linked shared-space membership returns the target.
+- Direct plus library membership for the same asset and space dedupes to one target.
+- Same photo in 10 enabled spaces returns exactly 10 targets.
+- Disabled spaces are excluded.
+- Deleted assets are excluded.
+- Offline assets are excluded.
+- Ineligible asset visibility is excluded.
+- Deleted faces are excluded.
+- Invisible faces are excluded.
+- Unassigned faces are excluded.
+- Faces without identity links are not projection targets; they are identity work instead.
+
+## Service Test Matrix
+
+Service tests must prove queue behavior and race-safety:
+
+- Backfill does not call projection target discovery while a personal page has `nextCursor`.
+- Backfill does not call projection target discovery while a shared-space person page has `nextCursor`.
+- Backfill requeues itself when the phase-aware summary reports remaining identity work after both pages complete.
+- Backfill does not queue `SharedSpaceFaceMatch`, `SharedSpaceFaceMatchAll`, or metadata when identity work remains.
+- Backfill queries projection targets only when identity work is clean and projection work remains.
+- Backfill queues exactly the returned projection targets plus affected targets from repair methods.
+- Duplicate targets from repair results and projection discovery dedupe to one job.
+- More than one chunk of targets is split into bounded `queueAll` calls.
+- Exactly one full chunk does not produce an empty trailing `queueAll([])`.
+- Empty target list produces no `queueAll` call.
+- Targeted jobs include `source: 'identity-backfill'`.
+- Identity-backfill targeted job ids do not collide with normal incremental `SharedSpaceFaceMatch` job ids.
+- `SharedSpaceFaceMatchAll` is never queued by identity backfill.
+- Force face recognition reset still queues `SharedSpaceFaceMatchAll` for enabled spaces.
+
+## Race and Edge Cases
+
+Tests must explicitly cover:
+
+- A full face recognition reset is already running and face identity backfill is retriggered. The backfill may queue or dedupe its root job, but it must not increase face recognition concurrency and must not queue full shared-space rebuilds.
+- A second face identity backfill trigger arrives while one is active or waiting. Only one root job should execute.
+- New identity work appears between the final page and the final work summary. The service must requeue identity backfill only.
+- New projection work appears after identity work is clean. The service must queue targeted projection jobs only.
+- A target asset belongs to 10 spaces. The service must queue 10 jobs, not a full rebuild and not duplicate jobs per face.
+- A target asset has multiple faces in the same space. The service must queue one asset-level job for that space.
+- A target disappears before execution. The handler must skip safely using current-state checks.
+- A space disables face recognition before execution. The handler must skip safely.
+- A stale shared-space assignment is moved from one identity to another. Old and new affected persons are recounted and orphan cleanup runs.
+- Failed targeted jobs remain visible according to existing queue failure policy.
+
+## TDD Requirements
+
+Implementation must follow strict red-green-refactor:
+
+1. Add one failing unit or medium test for a single behavior.
+2. Run the focused command and confirm it fails for the expected reason.
+3. Implement the minimal production change.
+4. Run the focused command and confirm it passes.
+5. Repeat for the next behavior.
+
+Do not add production code for a behavior until its failing test exists.
+
+Focused verification must include:
+
+- `corepack pnpm --dir server test src/services/person.service.spec.ts src/repositories/job.repository.spec.ts`
+- Focused medium repository tests for `face-identity.repository.spec.ts`
+- Focused medium metadata/shared-space tests for legacy imported metadata faces and same-photo multi-space behavior
+- `corepack pnpm --dir server check`
+- `corepack pnpm --dir server lint`
+- `corepack pnpm --dir server test`
+
+If broad medium tests require unavailable local EXIF fixtures, run the focused medium tests that cover the changed database behavior and document the fixture limitation.
+
+## Rollout
+
+This change is safe for existing pending work because root and cursor `FaceIdentityBackfill` jobs continue to use the same job name and data shape. Already pending backfill pages will execute the new phase-aware finalization after deployment.
+
+Existing `SharedSpaceFaceMatchAll` jobs already queued by full recognition resets remain valid and should complete normally. The new identity-backfill path simply stops creating more full rebuild jobs.
+
+After deployment, verify on the large personal instance:
+
+- `PeopleBackfill` does not repeatedly create full shared-space rebuild jobs.
+- `FacialRecognition` queue growth is bounded by targeted `(spaceId, assetId)` jobs from backfill plus any explicit full reset work.
+- The same photo in many spaces queues one target per enabled space.
+- Personal people statistics and all-photos shared-space statistics converge after targeted jobs drain.
+- No new mismatch appears between detected faces, assigned visible people, hidden people, and unassigned counts.

--- a/e2e/src/specs/server/api/global-face-identities.e2e-spec.ts
+++ b/e2e/src/specs/server/api/global-face-identities.e2e-spec.ts
@@ -46,19 +46,29 @@ const setupGlobalFaceIdentityE2E = async (): Promise<GlobalFaceIdentityFixture> 
     utils.createPerson(userA.accessToken, { name: 'Alice Source', birthDate: '1990-01-01' }),
     utils.createPerson(userB.accessToken, { name: 'Space 2 Private Name', birthDate: '1985-05-05' }),
   ]);
-  const [assetA, assetB] = (await Promise.all([
-    utils.createAsset(userA.accessToken),
-    utils.createAsset(userB.accessToken),
-  ])) as [AssetMediaResponseDto, AssetMediaResponseDto];
+  const [assetsA, assetsB] = (await Promise.all([
+    Promise.all(Array.from({ length: 3 }, () => utils.createAsset(userA.accessToken))),
+    Promise.all(Array.from({ length: 3 }, () => utils.createAsset(userB.accessToken))),
+  ])) as [AssetMediaResponseDto[], AssetMediaResponseDto[]];
   await Promise.all([
-    utils.addSpaceAssets(userA.accessToken, space1.id, [assetA.id]),
-    utils.addSpaceAssets(userB.accessToken, space2.id, [assetB.id]),
+    utils.addSpaceAssets(
+      userA.accessToken,
+      space1.id,
+      assetsA.map((asset) => asset.id),
+    ),
+    utils.addSpaceAssets(
+      userB.accessToken,
+      space2.id,
+      assetsB.map((asset) => asset.id),
+    ),
   ]);
 
-  const [faceA, faceB] = await Promise.all([
-    utils.createFace({ assetId: assetA.id, personId: personA.id }),
-    utils.createFace({ assetId: assetB.id, personId: personB.id }),
+  const [facesA, facesB] = await Promise.all([
+    Promise.all(assetsA.map((asset) => utils.createFace({ assetId: asset.id, personId: personA.id }))),
+    Promise.all(assetsB.map((asset) => utils.createFace({ assetId: asset.id, personId: personB.id }))),
   ]);
+  const [faceA] = facesA;
+  const [faceB] = facesB;
 
   await db.query('BEGIN');
   try {
@@ -74,30 +84,32 @@ const setupGlobalFaceIdentityE2E = async (): Promise<GlobalFaceIdentityFixture> 
     ]);
     await db.query(
       `INSERT INTO "face_identity_face" ("assetFaceId", "identityId", "source")
-       VALUES ($1, $3, 'manual'), ($2, $3, 'manual')
+       SELECT unnest($1::uuid[]), $2, 'manual'
        ON CONFLICT ("assetFaceId") DO UPDATE SET
          "identityId" = EXCLUDED."identityId",
          "source" = EXCLUDED."source"`,
-      [faceA, faceB, faceIdentityId],
+      [[...facesA, ...facesB], faceIdentityId],
     );
     const space1Person = await db.query(
       `INSERT INTO "shared_space_person"
          ("spaceId", name, "birthDate", "isHidden", "faceCount", "assetCount", "representativeFaceId", "identityId", "type")
-       VALUES ($1, 'Alice Source', '1990-01-01', false, 1, 1, $2, $3, 'person')
+       VALUES ($1, 'Alice Source', '1990-01-01', false, 3, 3, $2, $3, 'person')
        RETURNING id`,
       [space1.id, faceA, faceIdentityId],
     );
     const space2Person = await db.query(
       `INSERT INTO "shared_space_person"
          ("spaceId", name, "birthDate", "isHidden", "faceCount", "assetCount", "representativeFaceId", "identityId", "type")
-       VALUES ($1, 'Space 2 Private Name', '1985-05-05', false, 1, 1, $2, $3, 'person')
+       VALUES ($1, 'Space 2 Private Name', '1985-05-05', false, 3, 3, $2, $3, 'person')
        RETURNING id`,
       [space2.id, faceB, faceIdentityId],
     );
     await db.query(
       `INSERT INTO "shared_space_person_face" ("personId", "assetFaceId")
-       VALUES ($1, $2), ($3, $4)`,
-      [space1Person.rows[0].id, faceA, space2Person.rows[0].id, faceB],
+       SELECT $1::uuid, unnest($2::uuid[])
+       UNION ALL
+       SELECT $3::uuid, unnest($4::uuid[])`,
+      [space1Person.rows[0].id, facesA, space2Person.rows[0].id, facesB],
     );
     await db.query('COMMIT');
 

--- a/e2e/src/specs/server/api/person.e2e-spec.ts
+++ b/e2e/src/specs/server/api/person.e2e-spec.ts
@@ -122,7 +122,7 @@ describe('/people', () => {
       expect(status).toBe(200);
       expect(body).toEqual({
         hasNextPage: false,
-        total: 11,
+        total: 10,
         hidden: 1,
         people: [
           expect.objectContaining({ name: 'Freddy' }),
@@ -144,7 +144,7 @@ describe('/people', () => {
 
       expect(status).toBe(200);
       expect(body.hasNextPage).toBe(false);
-      expect(body.total).toBe(11); // All persons
+      expect(body.total).toBe(10); // Eligible persons
       expect(body.hidden).toBe(1); // 'hidden_person'
 
       const people = body.people as PersonResponseDto[];
@@ -170,7 +170,7 @@ describe('/people', () => {
       expect(status).toBe(200);
       expect(body).toEqual({
         hasNextPage: false,
-        total: 11,
+        total: 10,
         hidden: 1,
         people: [
           expect.objectContaining({ name: 'Freddy' }),
@@ -195,7 +195,7 @@ describe('/people', () => {
       expect(status).toBe(200);
       expect(body).toEqual({
         hasNextPage: true,
-        total: 11,
+        total: 10,
         hidden: 1,
         people: [expect.objectContaining({ name: 'Alice' })],
       });

--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -113,6 +113,7 @@ DROP TABLE IF EXISTS "shared_space_activity" CASCADE;
 DROP TABLE IF EXISTS "shared_space_person_alias" CASCADE;
 DROP TABLE IF EXISTS "shared_space_person_face" CASCADE;
 DROP TABLE IF EXISTS "shared_space_person" CASCADE;
+DROP TABLE IF EXISTS "shared_space_face_match_backfill_target" CASCADE;
 DROP TABLE IF EXISTS "shared_space_asset_audit" CASCADE;
 DROP TABLE IF EXISTS "shared_space_member_audit" CASCADE;
 DROP TABLE IF EXISTS "shared_space_audit" CASCADE;
@@ -218,6 +219,7 @@ DELETE FROM "migration_overrides"
    'trigger_face_identity_updatedAt',
    'trigger_library_after_insert',
    'trigger_library_user_delete_after_audit',
+   'trigger_shared_space_face_match_backfill_target_updatedAt',
    'trigger_shared_space_asset_delete_audit',
    'trigger_shared_space_asset_updatedAt',
    'trigger_shared_space_delete_audit',
@@ -344,6 +346,7 @@ DELETE FROM "kysely_migrations"
    '1778400000000-AddFaceIdentities',
    '1778500000000-AddSpacePersonRepresentativeFaceSource',
    '1778600000000-SortSpacePeopleByNameIndex',
+   '1778700000000-AddSharedSpaceFaceMatchBackfillTarget',
 
    -- Post-v2.7.5 upstream migrations pulled in by rebase. Paired with the
    -- schema rollbacks in step 7 above.

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -343,69 +343,78 @@ where
   and "asset_face"."personId" = $2
 
 -- PersonRepository.getNumberOfPeople
-select
-  coalesce(count(*), 0) as "total",
-  coalesce(
-    count(*) filter (
-      where
-        "isHidden" = $1
-    ),
-    0
-  ) as "hidden"
-from
-  "person"
-where
-  exists (
-    select
-    from
-      "asset_face"
-    where
-      "asset_face"."personId" = "person"."id"
-      and "asset_face"."deletedAt" is null
-      and "asset_face"."isVisible" = $2
-      and exists (
-        select
-        from
-          "asset"
-        where
-          "asset"."id" = "asset_face"."assetId"
-          and "asset"."visibility" = 'timeline'
-          and "asset"."deletedAt" is null
-      )
+WITH
+  "eligible_people" AS (
+    SELECT
+      "person"."id",
+      "person"."isHidden"
+    FROM
+      "person"
+      INNER JOIN "asset_face" ON "asset_face"."personId" = "person"."id"
+      INNER JOIN "asset" ON "asset"."id" = "asset_face"."assetId"
+    WHERE
+      "person"."ownerId" = $1
+      AND "asset"."visibility" = $2
+      AND "asset"."deletedAt" IS NULL
+      AND "asset_face"."deletedAt" IS NULL
+      AND "asset_face"."isVisible" = true
+    GROUP BY
+      "person"."id"
+    HAVING
+      NULLIF(BTRIM("person"."name"), '') IS NOT NULL
+      OR COUNT("asset_face"."assetId") >= $3
   )
-  and "person"."ownerId" = $3
+SELECT
+  COUNT(*)::int AS "total",
+  COUNT(*) FILTER (
+    WHERE
+      "isHidden" = true
+  )::int AS "hidden"
+FROM
+  "eligible_people"
 
 -- PersonRepository.getPeopleOverviewStatistics
-select
-  count(distinct ("person"."id")) as "total",
-  count(distinct ("person"."id")) filter (
-    where
-      "person"."isHidden" = $1
-  ) as "hidden"
-from
-  "person"
-  inner join "asset_face" on "asset_face"."personId" = "person"."id"
-  inner join "asset" on "asset"."id" = "asset_face"."assetId"
-where
-  "person"."ownerId" = $2
-  and "asset"."ownerId" = $3
-  and "asset"."deletedAt" is null
-  and "asset"."isOffline" = $4
-  and "asset"."visibility" in ($5, $6)
-  and "asset_face"."deletedAt" is null
-  and "asset_face"."isVisible" is true
-select
-  count(distinct ("asset_face"."id")) as "detectedFaceCount"
-from
-  "asset_face"
-  inner join "asset" on "asset"."id" = "asset_face"."assetId"
-where
-  "asset"."ownerId" = $1
-  and "asset"."deletedAt" is null
-  and "asset"."isOffline" = $2
-  and "asset"."visibility" in ($3, $4)
-  and "asset_face"."deletedAt" is null
-  and "asset_face"."isVisible" is true
+WITH
+  "eligible_faces" AS (
+    SELECT
+      "asset_face"."id" AS "assetFaceId",
+      "asset_face"."personId"
+    FROM
+      "asset_face"
+      INNER JOIN "asset" ON "asset"."id" = "asset_face"."assetId"
+    WHERE
+      "asset"."ownerId" = $1
+      AND "asset"."deletedAt" IS NULL
+      AND "asset"."isOffline" = false
+      AND "asset"."visibility" IN ($2, $3)
+      AND "asset_face"."deletedAt" IS NULL
+      AND "asset_face"."isVisible" = true
+  ),
+  "eligible_people" AS (
+    SELECT
+      "person"."id",
+      "person"."isHidden"
+    FROM
+      "person"
+      INNER JOIN "eligible_faces" ON "eligible_faces"."personId" = "person"."id"
+    WHERE
+      "person"."ownerId" = $4
+    GROUP BY
+      "person"."id"
+    HAVING
+      NULLIF(BTRIM("person"."name"), '') IS NOT NULL
+      OR COUNT(DISTINCT "eligible_faces"."assetFaceId") >= $5
+  )
+SELECT
+  COUNT(DISTINCT "eligible_people"."id")::int AS "total",
+  COUNT(DISTINCT "eligible_people"."id") FILTER (
+    WHERE
+      "eligible_people"."isHidden" = true
+  )::int AS "hidden",
+  COUNT(DISTINCT "eligible_faces"."assetFaceId")::int AS "detectedFaceCount"
+FROM
+  "eligible_faces"
+  LEFT JOIN "eligible_people" ON "eligible_people"."id" = "eligible_faces"."personId"
 
 -- PersonRepository.getPeopleFaceStatistics
 WITH

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -1989,11 +1989,13 @@ export class FaceIdentityRepository {
       const faces = await this.db
         .selectFrom('asset_face')
         .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+        .leftJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
         .select('asset_face.id')
         .where('asset_face.personId', '=', person.id)
         .where('asset_face.deletedAt', 'is', null)
         .where('asset_face.isVisible', '=', true)
         .where('asset.deletedAt', 'is', null)
+        .where('face_identity_face.assetFaceId', 'is', null)
         .execute();
 
       const personAssetFaceIds = faces.map((face) => face.id);

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -29,6 +29,7 @@ export type LinkFaceInput = {
 export type BackfillResult = {
   processed: number;
   nextCursor?: string;
+  affectedSpaceAssets?: SharedSpaceFaceMatchBackfillTarget[];
 };
 
 export type SpacePersonBackfillResult = BackfillResult & {
@@ -44,6 +45,11 @@ export type FaceIdentityBackfillWork = {
 export type SharedSpaceFaceMatchBackfillTarget = {
   spaceId: string;
   assetId: string;
+};
+
+export type PendingSharedSpaceFaceMatchBackfillTarget = SharedSpaceFaceMatchBackfillTarget & {
+  updatedAt: Date;
+  updateId: string;
 };
 
 export type MergeIdentitiesResult = {
@@ -417,13 +423,25 @@ export class FaceIdentityRepository {
 
   async hasBackfillWork(): Promise<boolean> {
     const work = await this.getBackfillWork();
-    return work.hasPersonalIdentityWork || work.hasSpacePersonIdentityWork || work.hasSharedSpaceProjectionWork;
+    const pendingTargets = await this.getPendingSharedSpaceFaceMatchBackfillTargets({ limit: 1 });
+    return (
+      work.hasPersonalIdentityWork ||
+      work.hasSpacePersonIdentityWork ||
+      work.hasSharedSpaceProjectionWork ||
+      pendingTargets.length > 0
+    );
   }
 
   async getSharedSpaceFaceMatchBackfillTargets(
-    input: { limit?: number } = {},
+    input: { limit?: number; assetFaceIds?: string[] } = {},
   ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    if (input.assetFaceIds && input.assetFaceIds.length === 0) {
+      return [];
+    }
+
     const limit = input.limit === undefined ? sql`` : sql`LIMIT ${input.limit}`;
+    const assetFaceIds = input.assetFaceIds ? [...new Set(input.assetFaceIds)] : undefined;
+    const assetFaceFilter = assetFaceIds ? sql`AND asset_face.id IN (${sql.join(assetFaceIds)})` : sql``;
     const result = await sql<SharedSpaceFaceMatchBackfillTarget>`
       WITH face_spaces AS (
         SELECT
@@ -445,6 +463,7 @@ export class FaceIdentityRepository {
           AND asset_face."personId" IS NOT NULL
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
+          ${assetFaceFilter}
 
         UNION
 
@@ -467,6 +486,7 @@ export class FaceIdentityRepository {
           AND asset_face."personId" IS NOT NULL
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
+          ${assetFaceFilter}
       ),
       targets AS (
         SELECT DISTINCT "spaceId", "assetId"
@@ -497,6 +517,126 @@ export class FaceIdentityRepository {
     `.execute(this.db);
 
     return result.rows;
+  }
+
+  private dedupeSharedSpaceFaceMatchBackfillTargets(
+    targets: SharedSpaceFaceMatchBackfillTarget[],
+  ): SharedSpaceFaceMatchBackfillTarget[] {
+    return [
+      ...new Map(
+        targets
+          .toSorted((a, b) => a.spaceId.localeCompare(b.spaceId) || a.assetId.localeCompare(b.assetId))
+          .map((target) => [`${target.spaceId}:${target.assetId}`, target]),
+      ).values(),
+    ];
+  }
+
+  private async getSharedSpaceFaceMatchTargetsForAssetFaces(
+    assetFaceIds: string[],
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    if (assetFaceIds.length === 0) {
+      return [];
+    }
+
+    const uniqueAssetFaceIds = [...new Set(assetFaceIds)];
+    const result = await sql<SharedSpaceFaceMatchBackfillTarget>`
+      WITH face_spaces AS (
+        SELECT
+          shared_space_asset."spaceId",
+          asset.id AS "assetId"
+        FROM shared_space_asset
+        INNER JOIN shared_space ON shared_space.id = shared_space_asset."spaceId"
+        INNER JOIN asset ON asset.id = shared_space_asset."assetId"
+        INNER JOIN asset_face ON asset_face."assetId" = asset.id
+        WHERE shared_space."faceRecognitionEnabled" = true
+          AND asset."deletedAt" IS NULL
+          AND asset."isOffline" = false
+          AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
+          AND asset_face.id IN (${sql.join(uniqueAssetFaceIds)})
+          AND asset_face."personId" IS NOT NULL
+          AND asset_face."deletedAt" IS NULL
+          AND asset_face."isVisible" = true
+
+        UNION
+
+        SELECT
+          shared_space_library."spaceId",
+          asset.id AS "assetId"
+        FROM shared_space_library
+        INNER JOIN shared_space ON shared_space.id = shared_space_library."spaceId"
+        INNER JOIN asset ON asset."libraryId" = shared_space_library."libraryId"
+        INNER JOIN asset_face ON asset_face."assetId" = asset.id
+        WHERE shared_space."faceRecognitionEnabled" = true
+          AND asset."deletedAt" IS NULL
+          AND asset."isOffline" = false
+          AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
+          AND asset_face.id IN (${sql.join(uniqueAssetFaceIds)})
+          AND asset_face."personId" IS NOT NULL
+          AND asset_face."deletedAt" IS NULL
+          AND asset_face."isVisible" = true
+      )
+      SELECT DISTINCT "spaceId", "assetId"
+      FROM face_spaces
+      ORDER BY "spaceId", "assetId"
+    `.execute(this.db);
+
+    return result.rows;
+  }
+
+  private async addPendingSharedSpaceFaceMatchBackfillTargets(
+    targets: SharedSpaceFaceMatchBackfillTarget[],
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    const uniqueTargets = this.dedupeSharedSpaceFaceMatchBackfillTargets(targets);
+    if (uniqueTargets.length === 0) {
+      return [];
+    }
+
+    await this.db
+      .insertInto('shared_space_face_match_backfill_target')
+      .values(uniqueTargets)
+      .onConflict((oc) => oc.columns(['spaceId', 'assetId']).doUpdateSet({ updatedAt: sql`now()` }))
+      .execute();
+
+    return uniqueTargets;
+  }
+
+  private async addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(
+    assetFaceIds: string[],
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    return this.addPendingSharedSpaceFaceMatchBackfillTargets(
+      await this.getSharedSpaceFaceMatchTargetsForAssetFaces(assetFaceIds),
+    );
+  }
+
+  async getPendingSharedSpaceFaceMatchBackfillTargets(
+    input: { limit?: number } = {},
+  ): Promise<PendingSharedSpaceFaceMatchBackfillTarget[]> {
+    return this.db
+      .selectFrom('shared_space_face_match_backfill_target')
+      .select(['spaceId', 'assetId', 'updatedAt', 'updateId'])
+      .orderBy('spaceId')
+      .orderBy('assetId')
+      .$if(input.limit !== undefined, (qb) => qb.limit(input.limit!))
+      .$castTo<PendingSharedSpaceFaceMatchBackfillTarget>()
+      .execute();
+  }
+
+  async deletePendingSharedSpaceFaceMatchBackfillTargets(
+    targets: PendingSharedSpaceFaceMatchBackfillTarget[],
+  ): Promise<void> {
+    if (targets.length === 0) {
+      return;
+    }
+
+    for (let index = 0; index < targets.length; index += 1000) {
+      const chunk = targets.slice(index, index + 1000);
+      await sql`
+        DELETE FROM "shared_space_face_match_backfill_target"
+        WHERE ("spaceId", "assetId", "updateId") IN (${sql.join(
+          chunk.map((target) => sql`(${target.spaceId}, ${target.assetId}, ${target.updateId})`),
+        )})
+      `.execute(this.db);
+    }
   }
 
   @GenerateSql({
@@ -1844,8 +1984,8 @@ export class FaceIdentityRepository {
       .execute();
 
     const page = people.slice(0, input.limit);
+    const linkedAssetFaceIds = new Set<string>();
     for (const person of page) {
-      const identity = await this.ensurePersonIdentity(person.id);
       const faces = await this.db
         .selectFrom('asset_face')
         .innerJoin('asset', 'asset.id', 'asset_face.assetId')
@@ -1856,6 +1996,13 @@ export class FaceIdentityRepository {
         .where('asset.deletedAt', 'is', null)
         .execute();
 
+      const personAssetFaceIds = faces.map((face) => face.id);
+      for (const face of faces) {
+        linkedAssetFaceIds.add(face.id);
+      }
+      await this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(personAssetFaceIds);
+
+      const identity = await this.ensurePersonIdentity(person.id);
       for (const face of faces) {
         await this.linkFace({ assetFaceId: face.id, identityId: identity.id, source: 'backfill' });
       }
@@ -1864,6 +2011,9 @@ export class FaceIdentityRepository {
     return {
       processed: page.length,
       nextCursor: people.length > input.limit ? page.at(-1)?.id : undefined,
+      affectedSpaceAssets: this.dedupeSharedSpaceFaceMatchBackfillTargets(
+        await this.getSharedSpaceFaceMatchTargetsForAssetFaces([...linkedAssetFaceIds]),
+      ),
     };
   }
 
@@ -1877,27 +2027,37 @@ export class FaceIdentityRepository {
       .execute();
 
     const page = people.slice(0, input.limit);
+    const affectedSpaceAssets: SharedSpaceFaceMatchBackfillTarget[] = [];
     for (const person of page) {
-      await this.repairSpacePersonIdentityAssignments(person);
+      affectedSpaceAssets.push(...(await this.repairSpacePersonIdentityAssignments(person)));
     }
 
     return {
       processed: page.length,
       conflictCount: 0,
       ...(people.length > input.limit ? { nextCursor: page.at(-1)?.id } : {}),
+      affectedSpaceAssets: this.dedupeSharedSpaceFaceMatchBackfillTargets(affectedSpaceAssets),
     };
   }
 
-  private async repairSpacePersonIdentityAssignments(person: SpacePersonBackfillRow): Promise<void> {
+  private async repairSpacePersonIdentityAssignments(
+    person: SpacePersonBackfillRow,
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
     const groups = await this.getSpacePersonBackfillIdentityGroups(person.id);
     if (groups.length === 0) {
-      return;
+      return [];
     }
 
     let currentIdentityId = person.identityId;
     const affectedPersonIds = new Set<string>([person.id]);
+    const affectedSpaceAssets: SharedSpaceFaceMatchBackfillTarget[] = [];
 
     for (const group of groups) {
+      const groupAssetFaceIds = await this.getSpacePersonBackfillAssetFaceIdsForIdentity(person.id, group.identityId);
+      affectedSpaceAssets.push(
+        ...(await this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(groupAssetFaceIds)),
+      );
+
       let targetPersonId: string | undefined;
 
       if (currentIdentityId === group.identityId) {
@@ -1944,6 +2104,8 @@ export class FaceIdentityRepository {
 
     await this.recountSpacePersons([...affectedPersonIds]);
     await this.deleteOrphanedSpacePersons([...affectedPersonIds]);
+
+    return this.dedupeSharedSpaceFaceMatchBackfillTargets(affectedSpaceAssets);
   }
 
   private getSpacePersonBackfillIdentityGroups(personId: string): Promise<SpacePersonBackfillIdentityGroup[]> {
@@ -1964,6 +2126,21 @@ export class FaceIdentityRepository {
       .orderBy(sql`count(*)`, 'desc')
       .$castTo<SpacePersonBackfillIdentityGroup>()
       .execute();
+  }
+
+  private async getSpacePersonBackfillAssetFaceIdsForIdentity(personId: string, identityId: string): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom('shared_space_person_face')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+      .select('asset_face.id')
+      .where('shared_space_person_face.personId', '=', personId)
+      .where('face_identity_face.identityId', '=', identityId)
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', '=', true)
+      .execute();
+
+    return rows.map((row) => row.id);
   }
 
   private getSpacePersonByIdentity(spaceId: string, identityId: string, excludePersonId?: string) {

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -2056,11 +2056,9 @@ export class FaceIdentityRepository {
 
     for (const group of groups) {
       const groupAssetFaceIds = await this.getSpacePersonBackfillAssetFaceIdsForIdentity(person.id, group.identityId);
-      affectedSpaceAssets.push(
-        ...(await this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(groupAssetFaceIds)),
-      );
 
       let targetPersonId: string | undefined;
+      let didMutateSpacePerson = false;
 
       if (currentIdentityId === group.identityId) {
         targetPersonId = person.id;
@@ -2068,6 +2066,7 @@ export class FaceIdentityRepository {
         const existingPerson = await this.getSpacePersonByIdentity(person.spaceId, group.identityId, person.id);
         if (existingPerson) {
           targetPersonId = existingPerson.id;
+          didMutateSpacePerson = true;
         } else if (currentIdentityId) {
           const createdPerson = await this.db
             .insertInto('shared_space_person')
@@ -2080,6 +2079,7 @@ export class FaceIdentityRepository {
             .returning(['id'])
             .executeTakeFirstOrThrow();
           targetPersonId = createdPerson.id;
+          didMutateSpacePerson = true;
         } else {
           const update: { identityId: string; type: string; representativeFaceId?: string } = {
             identityId: group.identityId,
@@ -2091,6 +2091,7 @@ export class FaceIdentityRepository {
           await this.db.updateTable('shared_space_person').set(update).where('id', '=', person.id).execute();
           currentIdentityId = group.identityId;
           targetPersonId = person.id;
+          didMutateSpacePerson = true;
         }
       }
 
@@ -2101,6 +2102,11 @@ export class FaceIdentityRepository {
           toPersonId: targetPersonId,
           identityId: group.identityId,
         });
+      }
+      if (didMutateSpacePerson) {
+        affectedSpaceAssets.push(
+          ...(await this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(groupAssetFaceIds)),
+        );
       }
     }
 

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -35,6 +35,17 @@ export type SpacePersonBackfillResult = BackfillResult & {
   conflictCount: number;
 };
 
+export type FaceIdentityBackfillWork = {
+  hasPersonalIdentityWork: boolean;
+  hasSpacePersonIdentityWork: boolean;
+  hasSharedSpaceProjectionWork: boolean;
+};
+
+export type SharedSpaceFaceMatchBackfillTarget = {
+  spaceId: string;
+  assetId: string;
+};
+
 export type MergeIdentitiesResult = {
   personalProfileConflictCount: number;
   spaceProfileConflictCount: number;
@@ -358,87 +369,134 @@ export class FaceIdentityRepository {
     });
   }
 
-  async hasBackfillWork(): Promise<boolean> {
-    const result = await sql<{ hasWork: boolean }>`
+  async getBackfillWork(): Promise<FaceIdentityBackfillWork> {
+    const result = await sql<Pick<FaceIdentityBackfillWork, 'hasPersonalIdentityWork' | 'hasSpacePersonIdentityWork'>>`
       SELECT
+        (
+          EXISTS (
+            SELECT 1
+            FROM person
+            WHERE person."identityId" IS NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM asset_face
+            INNER JOIN asset ON asset.id = asset_face."assetId"
+            LEFT JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
+            WHERE asset_face."personId" IS NOT NULL
+              AND asset_face."deletedAt" IS NULL
+              AND asset_face."isVisible" = true
+              AND asset."deletedAt" IS NULL
+              AND face_identity_face."assetFaceId" IS NULL
+          )
+        ) AS "hasPersonalIdentityWork",
         EXISTS (
-          SELECT 1
-          FROM person
-          WHERE person."identityId" IS NULL
-        )
-        OR EXISTS (
-          SELECT 1
-          FROM asset_face
-          INNER JOIN asset ON asset.id = asset_face."assetId"
-          LEFT JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
-          WHERE asset_face."personId" IS NOT NULL
-            AND asset_face."deletedAt" IS NULL
-            AND asset_face."isVisible" = true
-            AND asset."deletedAt" IS NULL
-            AND face_identity_face."assetFaceId" IS NULL
-        )
-        OR EXISTS (
-          SELECT 1
-          FROM asset_face
-          INNER JOIN asset ON asset.id = asset_face."assetId"
-          INNER JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
-          WHERE asset_face."personId" IS NOT NULL
-            AND asset_face."deletedAt" IS NULL
-            AND asset_face."isVisible" = true
-            AND asset."deletedAt" IS NULL
-            AND asset."isOffline" = false
-            AND asset.visibility IN (${AssetVisibility.Timeline}, ${AssetVisibility.Archive})
-            AND (
-              EXISTS (
-                SELECT 1
-                FROM shared_space_asset
-                INNER JOIN shared_space ON shared_space.id = shared_space_asset."spaceId"
-                WHERE shared_space_asset."assetId" = asset.id
-                  AND shared_space."faceRecognitionEnabled" = true
-                  AND NOT EXISTS (
-                    SELECT 1
-                    FROM shared_space_person_face
-                    INNER JOIN shared_space_person
-                      ON shared_space_person.id = shared_space_person_face."personId"
-                    WHERE shared_space_person_face."assetFaceId" = asset_face.id
-                      AND shared_space_person."spaceId" = shared_space.id
-                  )
-              )
-              OR EXISTS (
-                SELECT 1
-                FROM shared_space_library
-                INNER JOIN shared_space ON shared_space.id = shared_space_library."spaceId"
-                WHERE shared_space_library."libraryId" = asset."libraryId"
-                  AND shared_space."faceRecognitionEnabled" = true
-                  AND NOT EXISTS (
-                    SELECT 1
-                    FROM shared_space_person_face
-                    INNER JOIN shared_space_person
-                      ON shared_space_person.id = shared_space_person_face."personId"
-                    WHERE shared_space_person_face."assetFaceId" = asset_face.id
-                      AND shared_space_person."spaceId" = shared_space.id
-                  )
-              )
-            )
-        )
-        OR EXISTS (
-          SELECT 1
-          FROM shared_space_person
-          INNER JOIN shared_space ON shared_space.id = shared_space_person."spaceId"
-          INNER JOIN shared_space_person_face
-            ON shared_space_person_face."personId" = shared_space_person.id
-          INNER JOIN asset_face
-            ON asset_face.id = shared_space_person_face."assetFaceId"
-          INNER JOIN face_identity_face
-            ON face_identity_face."assetFaceId" = asset_face.id
-          WHERE shared_space."faceRecognitionEnabled" = true
-            AND asset_face."deletedAt" IS NULL
-            AND asset_face."isVisible" = true
-            AND shared_space_person."identityId" IS DISTINCT FROM face_identity_face."identityId"
-        ) AS "hasWork"
+            SELECT 1
+            FROM shared_space_person
+            INNER JOIN shared_space ON shared_space.id = shared_space_person."spaceId"
+            INNER JOIN shared_space_person_face
+              ON shared_space_person_face."personId" = shared_space_person.id
+            INNER JOIN asset_face
+              ON asset_face.id = shared_space_person_face."assetFaceId"
+            INNER JOIN face_identity_face
+              ON face_identity_face."assetFaceId" = asset_face.id
+            WHERE shared_space."faceRecognitionEnabled" = true
+              AND asset_face."deletedAt" IS NULL
+              AND asset_face."isVisible" = true
+              AND shared_space_person."identityId" IS DISTINCT FROM face_identity_face."identityId"
+        ) AS "hasSpacePersonIdentityWork"
+    `.execute(this.db);
+    const projectionTargets = await this.getSharedSpaceFaceMatchBackfillTargets({ limit: 1 });
+
+    return {
+      hasPersonalIdentityWork: result.rows[0]?.hasPersonalIdentityWork ?? false,
+      hasSpacePersonIdentityWork: result.rows[0]?.hasSpacePersonIdentityWork ?? false,
+      hasSharedSpaceProjectionWork: projectionTargets.length > 0,
+    };
+  }
+
+  async hasBackfillWork(): Promise<boolean> {
+    const work = await this.getBackfillWork();
+    return work.hasPersonalIdentityWork || work.hasSpacePersonIdentityWork || work.hasSharedSpaceProjectionWork;
+  }
+
+  async getSharedSpaceFaceMatchBackfillTargets(
+    input: { limit?: number } = {},
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    const limit = input.limit === undefined ? sql`` : sql`LIMIT ${input.limit}`;
+    const result = await sql<SharedSpaceFaceMatchBackfillTarget>`
+      WITH face_spaces AS (
+        SELECT
+          shared_space_asset."spaceId",
+          asset.id AS "assetId",
+          asset_face.id AS "assetFaceId",
+          face_identity_face."identityId",
+          COALESCE(person.type, 'person') AS type
+        FROM shared_space_asset
+        INNER JOIN shared_space ON shared_space.id = shared_space_asset."spaceId"
+        INNER JOIN asset ON asset.id = shared_space_asset."assetId"
+        INNER JOIN asset_face ON asset_face."assetId" = asset.id
+        INNER JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
+        LEFT JOIN person ON person.id = asset_face."personId"
+        WHERE shared_space."faceRecognitionEnabled" = true
+          AND asset."deletedAt" IS NULL
+          AND asset."isOffline" = false
+          AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
+          AND asset_face."personId" IS NOT NULL
+          AND asset_face."deletedAt" IS NULL
+          AND asset_face."isVisible" = true
+
+        UNION
+
+        SELECT
+          shared_space_library."spaceId",
+          asset.id AS "assetId",
+          asset_face.id AS "assetFaceId",
+          face_identity_face."identityId",
+          COALESCE(person.type, 'person') AS type
+        FROM shared_space_library
+        INNER JOIN shared_space ON shared_space.id = shared_space_library."spaceId"
+        INNER JOIN asset ON asset."libraryId" = shared_space_library."libraryId"
+        INNER JOIN asset_face ON asset_face."assetId" = asset.id
+        INNER JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
+        LEFT JOIN person ON person.id = asset_face."personId"
+        WHERE shared_space."faceRecognitionEnabled" = true
+          AND asset."deletedAt" IS NULL
+          AND asset."isOffline" = false
+          AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
+          AND asset_face."personId" IS NOT NULL
+          AND asset_face."deletedAt" IS NULL
+          AND asset_face."isVisible" = true
+      ),
+      targets AS (
+        SELECT DISTINCT "spaceId", "assetId"
+        FROM face_spaces
+        WHERE (
+            SELECT COUNT(*)
+            FROM shared_space_person_face
+            INNER JOIN shared_space_person
+              ON shared_space_person.id = shared_space_person_face."personId"
+            WHERE shared_space_person_face."assetFaceId" = face_spaces."assetFaceId"
+              AND shared_space_person."spaceId" = face_spaces."spaceId"
+          ) != 1
+          OR NOT EXISTS (
+            SELECT 1
+            FROM shared_space_person_face
+            INNER JOIN shared_space_person
+              ON shared_space_person.id = shared_space_person_face."personId"
+            WHERE shared_space_person_face."assetFaceId" = face_spaces."assetFaceId"
+              AND shared_space_person."spaceId" = face_spaces."spaceId"
+              AND shared_space_person."identityId" IS NOT DISTINCT FROM face_spaces."identityId"
+              AND shared_space_person.type = face_spaces.type
+          )
+      )
+      SELECT "spaceId", "assetId"
+      FROM targets
+      ORDER BY "spaceId", "assetId"
+      ${limit}
     `.execute(this.db);
 
-    return result.rows[0]?.hasWork ?? false;
+    return result.rows;
   }
 
   @GenerateSql({

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -556,6 +556,14 @@ export class FaceIdentityRepository {
           AND asset_face."personId" IS NOT NULL
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
+          AND NOT EXISTS (
+            SELECT 1
+            FROM shared_space_person_face
+            INNER JOIN shared_space_person
+              ON shared_space_person.id = shared_space_person_face."personId"
+            WHERE shared_space_person_face."assetFaceId" = asset_face.id
+              AND shared_space_person."spaceId" = shared_space_asset."spaceId"
+          )
 
         UNION
 
@@ -574,6 +582,14 @@ export class FaceIdentityRepository {
           AND asset_face."personId" IS NOT NULL
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
+          AND NOT EXISTS (
+            SELECT 1
+            FROM shared_space_person_face
+            INNER JOIN shared_space_person
+              ON shared_space_person.id = shared_space_person_face."personId"
+            WHERE shared_space_person_face."assetFaceId" = asset_face.id
+              AND shared_space_person."spaceId" = shared_space_library."spaceId"
+          )
       )
       SELECT DISTINCT "spaceId", "assetId"
       FROM face_spaces

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -179,6 +179,8 @@ describe(JobRepository.name, () => {
     await sut.queueAll([
       { name: JobName.FaceIdentityBackfill, data: {} },
       { name: JobName.FaceIdentityBackfill, data: {} },
+      { name: JobName.FaceIdentityBackfill, data: { continuationId: 'continuation-1' } },
+      { name: JobName.FaceIdentityBackfill, data: { continuationId: 'continuation-2' } },
       { name: JobName.FaceIdentityBackfill, data: { stage: 'person', cursor: 'person-cursor' } },
       { name: JobName.FaceIdentityBackfill, data: { stage: 'space-person', cursor: 'space-cursor' } },
       { name: JobName.SharedSpacePersonMetadataBackfill, data: {} },
@@ -215,6 +217,16 @@ describe(JobRepository.name, () => {
         jobId: 'face-identity-backfill/root',
         removeOnFail: true,
       },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FaceIdentityBackfill,
+      { continuationId: 'continuation-1' },
+      { jobId: 'face-identity-backfill/continuation/continuation-1', removeOnFail: true },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FaceIdentityBackfill,
+      { continuationId: 'continuation-2' },
+      { jobId: 'face-identity-backfill/continuation/continuation-2', removeOnFail: true },
     );
     expect(queue.add).toHaveBeenCalledWith(
       JobName.FaceIdentityBackfill,

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -537,4 +537,35 @@ describe(JobRepository.name, () => {
       expect(call[2]).not.toHaveProperty('removeOnFail', true);
     }
   });
+
+  it('uses distinct stable job ids for identity-backfill shared-space face matches', async () => {
+    const { sut, queue } = setup();
+    setHandlers(sut, [JobName.SharedSpaceFaceMatch]);
+
+    await sut.queueAll([
+      { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+      {
+        name: JobName.SharedSpaceFaceMatch,
+        data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+      },
+    ]);
+
+    expect(queue.addBulk).not.toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatch,
+      { spaceId: 'space-1', assetId: 'asset-1' },
+      {
+        jobId: 'shared-space-face-match/space-1/asset-1',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatch,
+      { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+      {
+        jobId: 'shared-space-face-match/identity-backfill/space-1/asset-1',
+        removeOnComplete: true,
+      },
+    );
+  });
 });

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -321,8 +321,12 @@ export class JobRepository {
         return { jobId: `bulk-add-${item.data.spaceId}-${item.data.userId}` };
       }
       case JobName.SharedSpaceFaceMatch: {
+        const prefix =
+          item.data.source === 'identity-backfill'
+            ? 'shared-space-face-match/identity-backfill'
+            : 'shared-space-face-match';
         return {
-          jobId: `shared-space-face-match/${item.data.spaceId}/${item.data.assetId}`,
+          jobId: `${prefix}/${item.data.spaceId}/${item.data.assetId}`,
           removeOnComplete: true,
         };
       }

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -308,9 +308,12 @@ export class JobRepository {
         return { jobId: JobName.FacialRecognitionQueueAll, removeOnComplete: true };
       }
       case JobName.FaceIdentityBackfill: {
-        const data = item.data as { stage?: string; cursor?: string };
+        const data = item.data as { stage?: string; cursor?: string; continuationId?: string };
         if (data.cursor) {
           return { jobId: `face-identity-backfill/${data.stage ?? 'person'}/${data.cursor}`, removeOnFail: true };
+        }
+        if (data.continuationId) {
+          return { jobId: `face-identity-backfill/continuation/${data.continuationId}`, removeOnFail: true };
         }
         return { jobId: 'face-identity-backfill/root', removeOnFail: true };
       }

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -493,73 +493,83 @@ export class PersonRepository {
     };
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getNumberOfPeople(userId: string) {
-    const zero = sql.lit(0);
-    return this.db
-      .selectFrom('person')
-      .where((eb) =>
-        eb.exists((eb) =>
-          eb
-            .selectFrom('asset_face')
-            .whereRef('asset_face.personId', '=', 'person.id')
-            .where('asset_face.deletedAt', 'is', null)
-            .where('asset_face.isVisible', '=', true)
-            .where((eb) =>
-              eb.exists((eb) =>
-                eb
-                  .selectFrom('asset')
-                  .whereRef('asset.id', '=', 'asset_face.assetId')
-                  .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
-                  .where('asset.deletedAt', 'is', null),
-              ),
-            ),
-        ),
+  @GenerateSql({ params: [DummyValue.UUID, { minimumFaceCount: 3 }] })
+  async getNumberOfPeople(userId: string, options: PeopleFaceStatisticsOptions = {}) {
+    const minimumFaceCount = options.minimumFaceCount ?? 1;
+    const result = await sql<{ total: number; hidden: number }>`
+      WITH "eligible_people" AS (
+        SELECT
+          "person"."id",
+          "person"."isHidden"
+        FROM "person"
+        INNER JOIN "asset_face" ON "asset_face"."personId" = "person"."id"
+        INNER JOIN "asset" ON "asset"."id" = "asset_face"."assetId"
+        WHERE "person"."ownerId" = ${userId}
+          AND "asset"."visibility" = ${AssetVisibility.Timeline}
+          AND "asset"."deletedAt" IS NULL
+          AND "asset_face"."deletedAt" IS NULL
+          AND "asset_face"."isVisible" = true
+        GROUP BY "person"."id"
+        HAVING NULLIF(BTRIM("person"."name"), '') IS NOT NULL
+          OR COUNT("asset_face"."assetId") >= ${minimumFaceCount}
       )
-      .where('person.ownerId', '=', userId)
-      .select((eb) => eb.fn.coalesce(eb.fn.countAll<number>(), zero).as('total'))
-      .select((eb) => eb.fn.coalesce(eb.fn.countAll<number>().filterWhere('isHidden', '=', true), zero).as('hidden'))
-      .executeTakeFirstOrThrow();
+      SELECT
+        COUNT(*)::int AS "total",
+        COUNT(*) FILTER (WHERE "isHidden" = true)::int AS "hidden"
+      FROM "eligible_people"
+    `.execute(this.db);
+
+    const row = result.rows[0];
+    return {
+      total: Number(row?.total ?? 0),
+      hidden: Number(row?.hidden ?? 0),
+    };
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  async getPeopleOverviewStatistics(userId: string): Promise<PeopleOverviewStatistics> {
-    const people = await this.db
-      .selectFrom('person')
-      .innerJoin('asset_face', 'asset_face.personId', 'person.id')
-      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
-      .select((eb) => eb.fn.count(eb.fn('distinct', ['person.id'])).as('total'))
-      .select((eb) =>
-        eb.fn
-          .count(eb.fn('distinct', ['person.id']))
-          .filterWhere('person.isHidden', '=', true)
-          .as('hidden'),
+  @GenerateSql({ params: [DummyValue.UUID, { minimumFaceCount: 3 }] })
+  async getPeopleOverviewStatistics(
+    userId: string,
+    options: PeopleFaceStatisticsOptions = {},
+  ): Promise<PeopleOverviewStatistics> {
+    const minimumFaceCount = options.minimumFaceCount ?? 1;
+    const result = await sql<PeopleOverviewStatistics>`
+      WITH "eligible_faces" AS (
+        SELECT
+          "asset_face"."id" AS "assetFaceId",
+          "asset_face"."personId"
+        FROM "asset_face"
+        INNER JOIN "asset" ON "asset"."id" = "asset_face"."assetId"
+        WHERE "asset"."ownerId" = ${userId}
+          AND "asset"."deletedAt" IS NULL
+          AND "asset"."isOffline" = false
+          AND "asset"."visibility" IN (${sql.join(peopleAssetVisibilities)})
+          AND "asset_face"."deletedAt" IS NULL
+          AND "asset_face"."isVisible" = true
+      ),
+      "eligible_people" AS (
+        SELECT
+          "person"."id",
+          "person"."isHidden"
+        FROM "person"
+        INNER JOIN "eligible_faces" ON "eligible_faces"."personId" = "person"."id"
+        WHERE "person"."ownerId" = ${userId}
+        GROUP BY "person"."id"
+        HAVING NULLIF(BTRIM("person"."name"), '') IS NOT NULL
+          OR COUNT(DISTINCT "eligible_faces"."assetFaceId") >= ${minimumFaceCount}
       )
-      .where('person.ownerId', '=', userId)
-      .where('asset.ownerId', '=', userId)
-      .where('asset.deletedAt', 'is', null)
-      .where('asset.isOffline', '=', false)
-      .where('asset.visibility', 'in', peopleAssetVisibilities)
-      .where('asset_face.deletedAt', 'is', null)
-      .where('asset_face.isVisible', 'is', true)
-      .executeTakeFirstOrThrow();
+      SELECT
+        COUNT(DISTINCT "eligible_people"."id")::int AS "total",
+        COUNT(DISTINCT "eligible_people"."id") FILTER (WHERE "eligible_people"."isHidden" = true)::int AS "hidden",
+        COUNT(DISTINCT "eligible_faces"."assetFaceId")::int AS "detectedFaceCount"
+      FROM "eligible_faces"
+      LEFT JOIN "eligible_people" ON "eligible_people"."id" = "eligible_faces"."personId"
+    `.execute(this.db);
 
-    const faceCount = await this.db
-      .selectFrom('asset_face')
-      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
-      .select((eb) => eb.fn.count(eb.fn('distinct', ['asset_face.id'])).as('detectedFaceCount'))
-      .where('asset.ownerId', '=', userId)
-      .where('asset.deletedAt', 'is', null)
-      .where('asset.isOffline', '=', false)
-      .where('asset.visibility', 'in', peopleAssetVisibilities)
-      .where('asset_face.deletedAt', 'is', null)
-      .where('asset_face.isVisible', 'is', true)
-      .executeTakeFirstOrThrow();
-
+    const row = result.rows[0];
     return {
-      total: Number(people.total),
-      hidden: Number(people.hidden),
-      detectedFaceCount: Number(faceCount.detectedFaceCount),
+      total: Number(row?.total ?? 0),
+      hidden: Number(row?.hidden ?? 0),
+      detectedFaceCount: Number(row?.detectedFaceCount ?? 0),
     };
   }
 

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -69,6 +69,7 @@ import { SharedSpaceActivityTable } from 'src/schema/tables/shared-space-activit
 import { SharedSpaceAssetAuditTable } from 'src/schema/tables/shared-space-asset-audit.table';
 import { SharedSpaceAssetTable } from 'src/schema/tables/shared-space-asset.table';
 import { SharedSpaceAuditTable } from 'src/schema/tables/shared-space-audit.table';
+import { SharedSpaceFaceMatchBackfillTargetTable } from 'src/schema/tables/shared-space-face-match-backfill-target.table';
 import { SharedSpaceLibraryAuditTable } from 'src/schema/tables/shared-space-library-audit.table';
 import { SharedSpaceLibraryTable } from 'src/schema/tables/shared-space-library.table';
 import { SharedSpaceMemberAuditTable } from 'src/schema/tables/shared-space-member-audit.table';
@@ -149,6 +150,7 @@ export class ImmichDatabase {
     SharedSpaceMemberAuditTable,
     SharedSpaceAssetTable,
     SharedSpaceAssetAuditTable,
+    SharedSpaceFaceMatchBackfillTargetTable,
     SharedSpaceLibraryTable,
     SharedSpaceLibraryAuditTable,
     SharedSpaceActivityTable,
@@ -280,6 +282,7 @@ export interface DB {
   shared_space_member_audit: SharedSpaceMemberAuditTable;
   shared_space_asset: SharedSpaceAssetTable;
   shared_space_asset_audit: SharedSpaceAssetAuditTable;
+  shared_space_face_match_backfill_target: SharedSpaceFaceMatchBackfillTargetTable;
   shared_space_library: SharedSpaceLibraryTable;
   shared_space_library_audit: SharedSpaceLibraryAuditTable;
   shared_space_activity: SharedSpaceActivityTable;

--- a/server/src/schema/migrations-gallery/1778700000000-AddSharedSpaceFaceMatchBackfillTarget.ts
+++ b/server/src/schema/migrations-gallery/1778700000000-AddSharedSpaceFaceMatchBackfillTarget.ts
@@ -1,0 +1,52 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE "shared_space_face_match_backfill_target" (
+      "spaceId" uuid NOT NULL,
+      "assetId" uuid NOT NULL,
+      "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+      "updatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+      "updateId" uuid NOT NULL DEFAULT immich_uuid_v7(),
+      CONSTRAINT "shared_space_face_match_backfill_target_pkey" PRIMARY KEY ("spaceId", "assetId"),
+      CONSTRAINT "shared_space_face_match_backfill_target_spaceId_fkey" FOREIGN KEY ("spaceId") REFERENCES "shared_space" ("id") ON DELETE CASCADE,
+      CONSTRAINT "shared_space_face_match_backfill_target_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "asset" ("id") ON DELETE CASCADE
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE INDEX "shared_space_face_match_backfill_target_assetId_idx"
+    ON "shared_space_face_match_backfill_target" ("assetId")
+  `.execute(db);
+  await sql`
+    CREATE INDEX "shared_space_face_match_backfill_target_updateId_idx"
+    ON "shared_space_face_match_backfill_target" ("updateId")
+  `.execute(db);
+
+  await sql`
+    CREATE OR REPLACE TRIGGER "shared_space_face_match_backfill_target_updatedAt"
+    BEFORE UPDATE ON "shared_space_face_match_backfill_target"
+    FOR EACH ROW
+    EXECUTE FUNCTION updated_at()
+  `.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_shared_space_face_match_backfill_target_updatedAt', '{"type":"trigger","name":"shared_space_face_match_backfill_target_updatedAt","sql":"CREATE OR REPLACE TRIGGER \\"shared_space_face_match_backfill_target_updatedAt\\"\\n  BEFORE UPDATE ON \\"shared_space_face_match_backfill_target\\"\\n  FOR EACH ROW\\n  EXECUTE FUNCTION updated_at();"}'::jsonb)`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DELETE FROM "migration_overrides"
+    WHERE "name" = 'trigger_shared_space_face_match_backfill_target_updatedAt'
+  `.execute(db);
+
+  await sql`
+    DROP TRIGGER IF EXISTS "shared_space_face_match_backfill_target_updatedAt"
+    ON "shared_space_face_match_backfill_target"
+  `.execute(db);
+
+  await sql`DROP INDEX IF EXISTS "shared_space_face_match_backfill_target_updateId_idx"`.execute(db);
+
+  await sql`DROP TABLE IF EXISTS "shared_space_face_match_backfill_target"`.execute(db);
+}

--- a/server/src/schema/tables/shared-space-face-match-backfill-target.table.ts
+++ b/server/src/schema/tables/shared-space-face-match-backfill-target.table.ts
@@ -1,0 +1,30 @@
+import {
+  CreateDateColumn,
+  ForeignKeyColumn,
+  Generated,
+  Table,
+  Timestamp,
+  UpdateDateColumn,
+} from '@immich/sql-tools';
+import { UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
+import { AssetTable } from 'src/schema/tables/asset.table';
+import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
+
+@Table('shared_space_face_match_backfill_target')
+@UpdatedAtTrigger('shared_space_face_match_backfill_target_updatedAt')
+export class SharedSpaceFaceMatchBackfillTargetTable {
+  @ForeignKeyColumn(() => SharedSpaceTable, { onDelete: 'CASCADE', primary: true, index: false })
+  spaceId!: string;
+
+  @ForeignKeyColumn(() => AssetTable, { onDelete: 'CASCADE', primary: true })
+  assetId!: string;
+
+  @CreateDateColumn()
+  createdAt!: Generated<Timestamp>;
+
+  @UpdateDateColumn()
+  updatedAt!: Generated<Timestamp>;
+
+  @UpdateIdColumn({ index: true })
+  updateId!: Generated<string>;
+}

--- a/server/src/schema/tables/shared-space-face-match-backfill-target.table.ts
+++ b/server/src/schema/tables/shared-space-face-match-backfill-target.table.ts
@@ -1,11 +1,4 @@
-import {
-  CreateDateColumn,
-  ForeignKeyColumn,
-  Generated,
-  Table,
-  Timestamp,
-  UpdateDateColumn,
-} from '@immich/sql-tools';
+import { CreateDateColumn, ForeignKeyColumn, Generated, Table, Timestamp, UpdateDateColumn } from '@immich/sql-tools';
 import { UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
 import { AssetTable } from 'src/schema/tables/asset.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -47,13 +47,26 @@ describe(PersonService.name, () => {
   beforeEach(() => {
     ({ sut, mocks } = newTestService(PersonService));
     mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
-    (mocks.faceIdentity as any).getAccessiblePeople ??= vi.fn();
-    (mocks.faceIdentity as any).getAccessiblePeopleStatistics ??= vi.fn();
-    (mocks.faceIdentity as any).getAccessiblePeopleFaceStatistics ??= vi.fn();
-    (mocks.faceIdentity as any).getAccessiblePersonByProfileId ??= vi.fn();
-    (mocks.faceIdentity as any).getAccessiblePersonStatistics ??= vi.fn();
-    (mocks.faceIdentity as any).getAccessibleProfileIdentityId ??= vi.fn();
-    (mocks.faceIdentity as any).hasBackfillWork ??= vi.fn();
+    const faceIdentityMock = mocks.faceIdentity as any;
+    faceIdentityMock.getAccessiblePeople ??= vi.fn();
+    faceIdentityMock.getAccessiblePeopleStatistics ??= vi.fn();
+    faceIdentityMock.getAccessiblePeopleFaceStatistics ??= vi.fn();
+    faceIdentityMock.getAccessiblePersonByProfileId ??= vi.fn();
+    faceIdentityMock.getAccessiblePersonStatistics ??= vi.fn();
+    faceIdentityMock.getAccessibleProfileIdentityId ??= vi.fn();
+    faceIdentityMock.hasBackfillWork ??= vi.fn();
+    faceIdentityMock.getBackfillWork ??= vi.fn();
+    faceIdentityMock.getBackfillWork.mockResolvedValue({
+      hasPersonalIdentityWork: false,
+      hasSpacePersonIdentityWork: false,
+      hasSharedSpaceProjectionWork: false,
+    });
+    faceIdentityMock.getSharedSpaceFaceMatchBackfillTargets ??= vi.fn();
+    faceIdentityMock.getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([]);
+    faceIdentityMock.getPendingSharedSpaceFaceMatchBackfillTargets ??= vi.fn();
+    faceIdentityMock.getPendingSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([]);
+    faceIdentityMock.deletePendingSharedSpaceFaceMatchBackfillTargets ??= vi.fn();
+    faceIdentityMock.deletePendingSharedSpaceFaceMatchBackfillTargets.mockResolvedValue(void 0);
     (mocks.person as any).getPeopleOverviewStatistics ??= vi.fn();
     (mocks.person as any).getPeopleFaceStatistics ??= vi.fn();
     (mocks.faceIdentity as any).getAccessiblePersonByProfileId.mockResolvedValue(void 0);
@@ -72,7 +85,10 @@ describe(PersonService.name, () => {
 
       await sut.onBootstrap();
 
-      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: {},
+      });
       expect(mocks.job.searchJobs).toHaveBeenCalledWith('peopleBackfill', expect.any(Object));
     });
 
@@ -92,6 +108,22 @@ describe(PersonService.name, () => {
           name: JobName.FaceIdentityBackfill,
           timestamp: Date.now(),
           data: { stage: 'space-person', cursor: 'space-person-cursor' },
+        },
+      ]);
+
+      await sut.onBootstrap();
+
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
+
+    it('should not queue a new identity backfill root while the root backfill is active', async () => {
+      (mocks.faceIdentity as any).hasBackfillWork.mockResolvedValue(true);
+      mocks.job.searchJobs.mockResolvedValue([
+        {
+          id: 'face-identity-backfill/root',
+          name: JobName.FaceIdentityBackfill,
+          timestamp: Date.now(),
+          data: {},
         },
       ]);
 
@@ -586,8 +618,8 @@ describe(PersonService.name, () => {
       vi.spyOn(sut as any, 'ensureLocalFile').mockResolvedValue({ localPath: '/preview.jpg', cleanup });
       mocks.media.decodeImage.mockResolvedValue({
         data: Buffer.from('decoded-image'),
-        info: { width: 250, height: 250, channels: 3 },
-      } as any);
+        info: { width: 250, height: 250, channels: 3, format: 'jpeg', size: 0, premultiplied: false },
+      });
       mocks.media.generateThumbnail.mockImplementation(async (_input, _options, output) => {
         await writeFile(output, Buffer.from('cropped-face'));
       });
@@ -1488,7 +1520,7 @@ describe(PersonService.name, () => {
     });
 
     describe('force wipes space state', () => {
-      it('should wipe shared_space_person tables and queue SharedSpaceFaceMatchAll per space when force=true', async () => {
+      it('should preserve force face recognition full reset by wiping shared_space_person tables and queueing SharedSpaceFaceMatchAll per space', async () => {
         const face = AssetFaceFactory.from().person().build();
         mocks.job.getJobCounts.mockResolvedValue({
           active: 1,
@@ -1842,57 +1874,381 @@ describe(PersonService.name, () => {
       });
     });
 
-    it('should queue metadata inheritance backfill after shared-space identity links are backfilled', async () => {
-      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 1 });
-      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({
-        processed: 1,
-        conflictCount: 0,
+    it('requeues identity backfill without projection fan-out when identity work remains after final pages', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
       });
 
       await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
 
       expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { continuationId: expect.any(String) },
+      });
+      expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
       });
     });
 
-    it('should queue space face matching after identity links are backfilled', async () => {
-      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 1 });
-      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({
-        processed: 0,
-        conflictCount: 0,
+    it('alternates bounded continuation ids when identity work remains', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
       });
-      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['space-1', 'space-2']);
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { continuationId: 'a' },
+      });
+
+      mocks.job.queue.mockClear();
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person', continuationId: 'a' })).resolves.toBe(
+        JobStatus.Success,
+      );
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { continuationId: 'b' },
+      });
+    });
+
+    it('does not discover projection targets until paginated personal backfill is complete', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+        processed: 1,
+        nextCursor: 'person-cursor',
+        affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+      });
 
       await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
 
-      expect(mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled).toHaveBeenCalled();
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-1' } },
-        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-2' } },
-      ]);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { stage: 'person', cursor: 'person-cursor' },
+      });
+      expect((mocks.faceIdentity as any).getBackfillWork).not.toHaveBeenCalled();
+      expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
-    it('should queue space face matching when projection backfill work remains after an idempotent rerun', async () => {
+    it('does not discover projection targets until paginated space-person backfill is complete', async () => {
       mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
       mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({
-        processed: 0,
+        processed: 1,
+        nextCursor: 'space-person-cursor',
         conflictCount: 0,
+        affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
       });
-      mocks.faceIdentity.hasBackfillWork.mockResolvedValue(true);
-      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['space-1']);
 
       await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
 
-      expect(mocks.faceIdentity.hasBackfillWork).toHaveBeenCalled();
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-1' } },
-      ]);
       expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { stage: 'space-person', cursor: 'space-person-cursor' },
+      });
+      expect((mocks.faceIdentity as any).getBackfillWork).not.toHaveBeenCalled();
+      expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
+    it('queues exact deduped projection targets after identity work is clean', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+        processed: 1,
+        affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+      });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({
+        processed: 0,
+        conflictCount: 0,
+        affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+      });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([
+        { spaceId: 'space-2', assetId: 'asset-2' },
+        { spaceId: 'space-1', assetId: 'asset-1' },
+      ]);
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+        },
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: 'space-2', assetId: 'asset-2', source: 'identity-backfill' },
+        },
+      ]);
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+      );
+    });
+
+    it('rediscovers earlier-page targets after paginated identity backfill completes', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValueOnce({
+        processed: 1,
+        nextCursor: 'person-cursor',
+        affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+      });
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+
+      mocks.job.queue.mockClear();
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValueOnce({ processed: 1 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValueOnce({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([
+        { spaceId: 'space-1', assetId: 'asset-1' },
+        { spaceId: 'space-1', assetId: 'asset-2' },
+      ]);
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person', cursor: 'person-cursor' })).resolves.toBe(
+        JobStatus.Success,
+      );
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+        },
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: 'space-1', assetId: 'asset-2', source: 'identity-backfill' },
+        },
+      ]);
+    });
+
+    it('queues durable pending targets from earlier pages after identity work is clean', async () => {
+      const pendingTarget = { spaceId: 'space-1', assetId: 'asset-from-page-1', updatedAt: new Date() };
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValueOnce({
+        processed: 1,
+        nextCursor: 'person-cursor',
+      });
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect((mocks.faceIdentity as any).getPendingSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+
+      mocks.job.queue.mockClear();
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValueOnce({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValueOnce({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+      (mocks.faceIdentity as any).getPendingSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([pendingTarget]);
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person', cursor: 'person-cursor' })).resolves.toBe(
+        JobStatus.Success,
+      );
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: pendingTarget.spaceId, assetId: pendingTarget.assetId, source: 'identity-backfill' },
+        },
+      ]);
+      expect((mocks.faceIdentity as any).deletePendingSharedSpaceFaceMatchBackfillTargets).toHaveBeenCalledWith([
+        pendingTarget,
+      ]);
+    });
+
+    it('keeps durable pending targets when queueing targeted face matches fails', async () => {
+      const pendingTarget = { spaceId: 'space-1', assetId: 'asset-1', updatedAt: new Date() };
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+      (mocks.faceIdentity as any).getPendingSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([pendingTarget]);
+      mocks.job.queueAll.mockRejectedValueOnce(new Error('redis write failed'));
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).rejects.toThrow('redis write failed');
+
+      expect((mocks.faceIdentity as any).deletePendingSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+    });
+
+    it('does not call queueAll for an empty targeted face-match list', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
+    it('does not write an empty trailing batch for exactly one full chunk', async () => {
+      const targets = Array.from({ length: 1000 }, (_, index) => ({
+        spaceId: 'space-1',
+        assetId: `asset-${index.toString().padStart(4, '0')}`,
+      }));
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue(targets);
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll.mock.calls[0][0]).toHaveLength(1000);
+    });
+
+    it('logs a projection invariant warning instead of falling back to a full rebuild when projection work has no targets', async () => {
+      const warn = vi.spyOn((sut as any).logger, 'warn').mockImplementation(() => {});
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([]);
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('projection backfill work was reported but no targets were found'),
+      );
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled).not.toHaveBeenCalled();
+    });
+
+    it('regenerates targeted projection work on a later run after a queue write failure', async () => {
+      const target = { spaceId: 'space-1', assetId: 'asset-1' };
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 1 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([target]);
+      mocks.job.queueAll.mockRejectedValueOnce(new Error('redis write failed'));
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).rejects.toThrow('redis write failed');
+
+      mocks.job.queueAll.mockReset();
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { ...target, source: 'identity-backfill' },
+        },
+      ]);
+    });
+
+    it('regenerates only remaining current targets after a later queue batch fails', async () => {
+      const targets = Array.from({ length: 1001 }, (_, index) => ({
+        spaceId: 'space-1',
+        assetId: `asset-${index.toString().padStart(4, '0')}`,
+      }));
+      const remainingTarget = targets.at(-1)!;
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 1 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValueOnce(targets);
+      mocks.job.queueAll.mockResolvedValueOnce().mockRejectedValueOnce(new Error('redis write failed'));
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).rejects.toThrow('redis write failed');
+
+      mocks.job.queueAll.mockReset();
+      (mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets.mockResolvedValueOnce([remainingTarget]);
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { ...remainingTarget, source: 'identity-backfill' },
+        },
+      ]);
+    });
+
+    it('does not queue global metadata backfill from identity-backfill finalization when targeted face matches are queued', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+        processed: 1,
+        affectedSpaceAssets: [{ spaceId: 'space-1', assetId: 'asset-1' }],
+      } as any);
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+        },
+      ]);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
       });
+    });
+
+    it('does not queue full shared-space rebuilds when identity backfill is retriggered during face recognition work', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { continuationId: expect.any(String) },
+      });
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+      );
     });
   });
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -181,6 +181,7 @@ describe(PersonService.name, () => {
 
       expect((mocks.faceIdentity as any).getAccessiblePeople).not.toHaveBeenCalled();
       expect(mocks.person.getAllForUser).toHaveBeenCalled();
+      expect(mocks.person.getNumberOfPeople).toHaveBeenCalledWith(auth.user.id, { minimumFaceCount: 3 });
     });
 
     it('should get all hidden and visible people with thumbnails', async () => {
@@ -208,6 +209,7 @@ describe(PersonService.name, () => {
         minimumFaceCount: 3,
         withHidden: true,
       });
+      expect(mocks.person.getNumberOfPeople).toHaveBeenCalledWith(auth.user.id, { minimumFaceCount: 3 });
     });
 
     it('should get all visible people and favorites should be first in the array', async () => {
@@ -235,6 +237,7 @@ describe(PersonService.name, () => {
         minimumFaceCount: 3,
         withHidden: false,
       });
+      expect(mocks.person.getNumberOfPeople).toHaveBeenCalledWith(auth.user.id, { minimumFaceCount: 3 });
     });
   });
 
@@ -275,7 +278,9 @@ describe(PersonService.name, () => {
         detectedFaceCount: 5,
       });
 
-      expect((mocks.person as any).getPeopleOverviewStatistics).toHaveBeenCalledWith(auth.user.id);
+      expect((mocks.person as any).getPeopleOverviewStatistics).toHaveBeenCalledWith(auth.user.id, {
+        minimumFaceCount: 3,
+      });
       expect((mocks.faceIdentity as any).getAccessiblePeopleStatistics).not.toHaveBeenCalled();
     });
 
@@ -3644,6 +3649,7 @@ describe(PersonService.name, () => {
         auth.user.id,
         expect.objectContaining({ closestFaceAssetId: 'face-asset-id' }),
       );
+      expect(mocks.person.getNumberOfPeople).toHaveBeenCalledWith(auth.user.id, { minimumFaceCount: 3 });
     });
 
     it('should throw NotFoundException when closestPersonId is not found', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -44,7 +44,10 @@ import {
   SystemMetadataKey,
   VectorIndex,
 } from 'src/enum';
-import type { AccessibleIdentityFaceMatch } from 'src/repositories/face-identity.repository';
+import type {
+  AccessibleIdentityFaceMatch,
+  SharedSpaceFaceMatchBackfillTarget,
+} from 'src/repositories/face-identity.repository';
 import { BoundingBox } from 'src/repositories/machine-learning.repository';
 import { UpdateFacesData } from 'src/repositories/person.repository';
 import { AssetFaceTable } from 'src/schema/tables/asset-face.table';
@@ -504,15 +507,16 @@ export class PersonService extends BaseService {
   async handleFaceIdentityBackfill({
     stage = 'person',
     cursor,
+    continuationId,
   }: JobOf<JobName.FaceIdentityBackfill>): Promise<JobStatus> {
-    let processed = 0;
+    const affectedSpaceAssets: SharedSpaceFaceMatchBackfillTarget[] = [];
 
     if (stage === 'person') {
       const result = await this.faceIdentityRepository.backfillPersonalIdentities({
         cursor,
         limit: FACE_IDENTITY_BACKFILL_CHUNK_SIZE,
       });
-      processed += result.processed;
+      affectedSpaceAssets.push(...this.getAffectedSpaceAssets(result));
 
       if (result.nextCursor) {
         await this.jobRepository.queue({
@@ -527,7 +531,7 @@ export class PersonService extends BaseService {
       cursor: stage === 'space-person' ? cursor : undefined,
       limit: FACE_IDENTITY_BACKFILL_CHUNK_SIZE,
     });
-    processed += result.processed;
+    affectedSpaceAssets.push(...this.getAffectedSpaceAssets(result));
 
     if (result.conflictCount > 0) {
       this.logger.warn(`Face identity backfill left ${result.conflictCount} space people unresolved`);
@@ -541,20 +545,73 @@ export class PersonService extends BaseService {
       return JobStatus.Success;
     }
 
-    const shouldRebuildSpacePeople = processed > 0 || (await this.faceIdentityRepository.hasBackfillWork());
+    const work = await this.faceIdentityRepository.getBackfillWork();
 
-    if (shouldRebuildSpacePeople) {
-      const spaceIds = await this.sharedSpaceRepository.getSpaceIdsWithFaceRecognitionEnabled();
-      await this.jobRepository.queueAll(
-        spaceIds.map((spaceId) => ({
-          name: JobName.SharedSpaceFaceMatchAll as const,
-          data: { spaceId },
-        })),
-      );
-      await this.queueSpacePersonMetadataBackfill();
+    if (work.hasPersonalIdentityWork || work.hasSpacePersonIdentityWork) {
+      await this.jobRepository.queue({
+        name: JobName.FaceIdentityBackfill,
+        data: { continuationId: this.getNextFaceIdentityBackfillContinuationId(continuationId) },
+      });
+      return JobStatus.Success;
     }
 
+    const pendingTargets = await this.faceIdentityRepository.getPendingSharedSpaceFaceMatchBackfillTargets();
+
+    if (work.hasSharedSpaceProjectionWork) {
+      const projectionTargets = await this.faceIdentityRepository.getSharedSpaceFaceMatchBackfillTargets();
+      if (projectionTargets.length === 0) {
+        this.logger.warn('Face identity projection backfill work was reported but no targets were found');
+      }
+      affectedSpaceAssets.push(...projectionTargets);
+    }
+
+    await this.queueSharedSpaceFaceMatchTargets([...pendingTargets, ...affectedSpaceAssets]);
+    await this.faceIdentityRepository.deletePendingSharedSpaceFaceMatchBackfillTargets(pendingTargets);
+
     return JobStatus.Success;
+  }
+
+  private getNextFaceIdentityBackfillContinuationId(currentContinuationId?: string): string {
+    return currentContinuationId === 'a' ? 'b' : 'a';
+  }
+
+  private getAffectedSpaceAssets(result: object): SharedSpaceFaceMatchBackfillTarget[] {
+    return (result as { affectedSpaceAssets?: SharedSpaceFaceMatchBackfillTarget[] }).affectedSpaceAssets ?? [];
+  }
+
+  private async queueSharedSpaceFaceMatchTargets(
+    targets: SharedSpaceFaceMatchBackfillTarget[],
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    const uniqueTargets = [
+      ...new Map(
+        targets
+          .toSorted((a, b) => a.spaceId.localeCompare(b.spaceId) || a.assetId.localeCompare(b.assetId))
+          .map((target) => [`${target.spaceId}:${target.assetId}`, target]),
+      ).values(),
+    ];
+
+    if (uniqueTargets.length === 0) {
+      return [];
+    }
+
+    let jobs: JobItem[] = [];
+    for (const { spaceId, assetId } of uniqueTargets) {
+      jobs.push({
+        name: JobName.SharedSpaceFaceMatch as const,
+        data: { spaceId, assetId, source: 'identity-backfill' },
+      });
+
+      if (jobs.length >= JOBS_ASSET_PAGINATION_SIZE) {
+        await this.jobRepository.queueAll(jobs);
+        jobs = [];
+      }
+    }
+
+    if (jobs.length > 0) {
+      await this.jobRepository.queueAll(jobs);
+    }
+
+    return uniqueTargets;
   }
 
   @OnJob({ name: JobName.AssetDetectFacesQueueAll, queue: QueueName.FaceDetection })

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -114,7 +114,9 @@ export class PersonService extends BaseService {
       withHidden,
       closestFaceAssetId,
     });
-    const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id);
+    const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id, {
+      minimumFaceCount: machineLearning.facialRecognition.minFaces,
+    });
 
     return {
       people: items.map((person) => mapPerson(person)),
@@ -137,7 +139,9 @@ export class PersonService extends BaseService {
       });
     }
 
-    return this.personRepository.getPeopleOverviewStatistics(auth.user.id);
+    return this.personRepository.getPeopleOverviewStatistics(auth.user.id, {
+      minimumFaceCount: machineLearning.facialRecognition.minFaces,
+    });
   }
 
   async getPeopleFaceStatistics(auth: AuthDto, dto: PersonSearchDto): Promise<PeopleFaceStatisticsResponseDto> {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2840,6 +2840,48 @@ describe(SharedSpaceService.name, () => {
       expect(result).toBe(JobStatus.Skipped);
     });
 
+    it('skips safely when a targeted asset is no longer in the space before execution', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(false);
+
+      const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId, source: 'identity-backfill' });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonDedup, data: { spaceId } });
+    });
+
+    it('skips safely when face recognition is disabled before targeted execution', async () => {
+      const space = factory.sharedSpace({ faceRecognitionEnabled: false });
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+
+      const result = await sut.handleSharedSpaceFaceMatch({
+        spaceId: space.id,
+        assetId: 'asset-1',
+        source: 'identity-backfill',
+      });
+
+      expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.sharedSpace.isAssetInSpace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).not.toHaveBeenCalled();
+    });
+
     it('should skip faces that are already assigned in the space', async () => {
       const spaceId = newUuid();
       const assetId = newUuid();

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3213,6 +3213,116 @@ describe(SharedSpaceService.name, () => {
       );
     });
 
+    it('should refresh inherited metadata for an exact identity-backfill assignment', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      const faceId = newUuid();
+      const identityId = newUuid();
+      const spacePersonId = newUuid();
+      const sourcePersonId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const spacePerson = factory.sharedSpacePerson({ id: spacePersonId, spaceId, identityId, nameSource: 'none' });
+
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([
+        { id: faceId, assetId, personId: newUuid(), identityId, type: 'person', embedding: '[1,2,3]' },
+      ]);
+      mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([
+        { personId: spacePersonId, identityId, type: 'person' },
+      ]);
+      mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: sourcePersonId,
+          sourceProfileType: 'user-person',
+          sourceProfileId: sourcePersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Inherited Alice',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: false,
+        },
+      ]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId, source: 'identity-backfill' });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(
+        spacePersonId,
+        expect.objectContaining({
+          name: 'Inherited Alice',
+          nameSource: 'inherited',
+          nameSourceProfileId: sourcePersonId,
+        }),
+      );
+    });
+
+    it('should refresh inherited metadata for an exact identity-backfill pet assignment', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      const faceId = newUuid();
+      const identityId = newUuid();
+      const spacePersonId = newUuid();
+      const sourcePersonId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const spacePerson = factory.sharedSpacePerson({
+        id: spacePersonId,
+        spaceId,
+        identityId,
+        type: 'pet',
+        nameSource: 'none',
+      });
+
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([
+        { id: faceId, assetId, personId: newUuid(), identityId, type: 'pet' },
+      ]);
+      mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([
+        { personId: spacePersonId, identityId, type: 'pet' },
+      ]);
+      mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: sourcePersonId,
+          sourceProfileType: 'user-person',
+          sourceProfileId: sourcePersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Inherited Rover',
+          birthDate: null,
+          type: 'pet',
+          species: 'dog',
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: false,
+        },
+      ]);
+
+      const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId, source: 'identity-backfill' });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(
+        spacePersonId,
+        expect.objectContaining({
+          name: 'Inherited Rover',
+          nameSource: 'inherited',
+          nameSourceProfileId: sourcePersonId,
+        }),
+      );
+    });
+
     it('should skip matching when the asset is not in the target space', async () => {
       const spaceId = newUuid();
       const assetId = newUuid();
@@ -4000,7 +4110,7 @@ describe(SharedSpaceService.name, () => {
       expect(await sut.handleSharedSpaceFaceMatch({ spaceId, assetId: 'asset-early' })).toBe(JobStatus.Success);
       expect(await sut.handleSharedSpaceFaceMatchPage({ spaceId, batchSize: 2 })).toBe(JobStatus.Success);
 
-      expect(processSpy).toHaveBeenNthCalledWith(1, spaceId, 'asset-early');
+      expect(processSpy).toHaveBeenNthCalledWith(1, spaceId, 'asset-early', { refreshExactMetadata: false });
       expect(processSpy).toHaveBeenNthCalledWith(2, spaceId, 'asset-early');
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpaceIdentityReconciliation,

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1504,13 +1504,19 @@ export class SharedSpaceService extends BaseService {
   }
 
   @OnJob({ name: JobName.SharedSpaceFaceMatch, queue: QueueName.FacialRecognition })
-  async handleSharedSpaceFaceMatch({ spaceId, assetId }: JobOf<JobName.SharedSpaceFaceMatch>): Promise<JobStatus> {
+  async handleSharedSpaceFaceMatch({
+    spaceId,
+    assetId,
+    source,
+  }: JobOf<JobName.SharedSpaceFaceMatch>): Promise<JobStatus> {
     const space = await this.sharedSpaceRepository.getById(spaceId);
     if (!space || !space.faceRecognitionEnabled) {
       return JobStatus.Skipped;
     }
 
-    const affectedPersonIds = await this.processSpaceFaceMatch(spaceId, assetId);
+    const affectedPersonIds = await this.processSpaceFaceMatch(spaceId, assetId, {
+      refreshExactMetadata: source === 'identity-backfill',
+    });
     for (const spacePersonId of affectedPersonIds) {
       await this.queueSpaceIdentityReconciliation({ spaceId, spacePersonId });
     }
@@ -1915,7 +1921,11 @@ export class SharedSpaceService extends BaseService {
     return JobStatus.Success;
   }
 
-  private async processSpaceFaceMatch(spaceId: string, assetId: string): Promise<string[]> {
+  private async processSpaceFaceMatch(
+    spaceId: string,
+    assetId: string,
+    options: { refreshExactMetadata?: boolean } = {},
+  ): Promise<string[]> {
     const isAssetInSpace = await this.sharedSpaceRepository.isAssetInSpace(spaceId, assetId);
     if (!isAssetInSpace) {
       return [];
@@ -1966,6 +1976,9 @@ export class SharedSpaceService extends BaseService {
             type,
           })
         ) {
+          if (options.refreshExactMetadata) {
+            await this.inheritSpacePersonMetadata(spaceId, identitySpacePerson.id, face.identityId, assetAdderId);
+          }
           continue;
         }
 
@@ -2058,6 +2071,9 @@ export class SharedSpaceService extends BaseService {
             type: 'pet',
           })
         ) {
+          if (options.refreshExactMetadata) {
+            await this.inheritSpacePersonMetadata(spaceId, spacePerson.id, petFace.identityId, assetAdderId);
+          }
           continue;
         }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -241,6 +241,7 @@ export interface INightlyJob extends IBaseJob {
 export interface IFaceIdentityBackfillJob extends IBaseJob {
   stage?: 'person' | 'space-person';
   cursor?: string;
+  continuationId?: string;
 }
 
 export interface ISharedSpaceFaceMatchJob extends IBaseJob {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -246,6 +246,7 @@ export interface IFaceIdentityBackfillJob extends IBaseJob {
 export interface ISharedSpaceFaceMatchJob extends IBaseJob {
   spaceId: string;
   assetId: string;
+  source?: 'identity-backfill';
 }
 
 export interface ISharedSpaceFaceMatchAllJob extends IBaseJob {

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -2327,6 +2327,43 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('does not persist rematch targets for already consistent shared-space people', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Consistent' });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const identity = await sut.ensurePersonIdentity(person.id);
+      await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'backfill' });
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identity.id, representativeFaceId: assetFace.id, type: 'person' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, assetFace.id);
+
+      const result = await sut.backfillSpacePersonIdentities({ limit: 100 });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          conflictCount: 0,
+          affectedSpaceAssets: [],
+        }),
+      );
+      await expect(sut.getPendingSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([]);
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('infers shared-space person identity from a dominant linked identity with tiny noisy candidates', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -554,7 +554,10 @@ describe(FaceIdentityRepository.name, () => {
         .set({ personId: null })
         .where('id', '=', unassignedFace.assetFace.id)
         .execute();
-      await ctx.database.deleteFrom('face_identity_face').where('assetFaceId', '=', identityless.assetFace.id).execute();
+      await ctx.database
+        .deleteFrom('face_identity_face')
+        .where('assetFaceId', '=', identityless.assetFace.id)
+        .execute();
       const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
       await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
       for (const assetId of [

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -82,7 +82,15 @@ const createAccessibleSpaceIdentity = async (
 const newIdentityFace = async (
   ctx: ReturnType<typeof setup>['ctx'],
   sut: FaceIdentityRepository,
-  input: { ownerId: string; name?: string; isHidden?: boolean; visibility?: AssetVisibility },
+  input: {
+    ownerId: string;
+    name?: string;
+    isHidden?: boolean;
+    libraryId?: string | null;
+    isOffline?: boolean;
+    deletedAt?: Date | null;
+    visibility?: AssetVisibility;
+  },
 ) => {
   const { person } = await ctx.newPerson({
     ownerId: input.ownerId,
@@ -91,11 +99,14 @@ const newIdentityFace = async (
   });
   const { asset } = await ctx.newAsset({
     ownerId: input.ownerId,
+    libraryId: input.libraryId,
+    isOffline: input.isOffline ?? false,
+    deletedAt: input.deletedAt ?? null,
     visibility: input.visibility ?? AssetVisibility.Timeline,
   });
   const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
   const identity = await sut.ensurePersonIdentity(person.id);
-  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'backfill' });
 
   return { person, asset, assetFace, identity };
 };
@@ -265,6 +276,267 @@ describe(FaceIdentityRepository.name, () => {
       await sut.backfillSpacePersonIdentities({ limit: 100 });
 
       await expect(sut.hasBackfillWork()).resolves.toBe(false);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('classifies personal identity work separately from projection work', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id, identityId: null });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+      await expect(sut.hasBackfillWork()).resolves.toBe(true);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('classifies shared-space identity repair separately from projection work', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      const first = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const second = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      for (const assetId of [first.asset.id, second.asset.id]) {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId, addedById: user.id });
+      }
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({
+          spaceId: space.id,
+          identityId: first.identity.id,
+          representativeFaceId: first.assetFace.id,
+          type: 'person',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, first.assetFace.id);
+      await linkSpaceFace(ctx, spacePerson.id, second.assetFace.id);
+
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: true,
+        hasSharedSpaceProjectionWork: true,
+      });
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('does not classify disconnected stale space-person faces as projection work', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      const first = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const second = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({
+          spaceId: space.id,
+          identityId: first.identity.id,
+          representativeFaceId: first.assetFace.id,
+          type: 'person',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, first.assetFace.id);
+      await linkSpaceFace(ctx, spacePerson.id, second.assetFace.id);
+
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: true,
+        hasSharedSpaceProjectionWork: false,
+      });
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('classifies projection work only when identities are already linked', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const linked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: true,
+      });
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: linked.asset.id },
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('keeps projection work summary aligned with target discovery', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const linked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+
+      await expect(sut.getBackfillWork()).resolves.toMatchObject({ hasSharedSpaceProjectionWork: true });
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: linked.asset.id },
+      ]);
+
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({
+          spaceId: space.id,
+          identityId: linked.identity.id,
+          representativeFaceId: linked.assetFace.id,
+          type: 'person',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, linked.assetFace.id);
+
+      await expect(sut.getBackfillWork()).resolves.toMatchObject({ hasSharedSpaceProjectionWork: false });
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('targets same-identity projections with an incompatible space-person type', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const linked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({
+          spaceId: space.id,
+          identityId: linked.identity.id,
+          representativeFaceId: linked.assetFace.id,
+          type: 'pet',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, linked.assetFace.id);
+
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: linked.asset.id },
+      ]);
+      await expect(sut.getBackfillWork()).resolves.toMatchObject({ hasSharedSpaceProjectionWork: true });
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('dedupes direct and linked-library projection targets for the same asset in the same space', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+      const linked = await newIdentityFace(ctx, sut, { ownerId: user.id, libraryId: library.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: linked.asset.id },
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('excludes disabled spaces and ineligible assets from projection targets', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const timeline = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const offline = await newIdentityFace(ctx, sut, { ownerId: user.id, isOffline: true });
+      const deleted = await newIdentityFace(ctx, sut, { ownerId: user.id, deletedAt: new Date() });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      const { space: disabled } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: disabled.id, userId: user.id, role: SharedSpaceRole.Owner });
+      for (const assetId of [timeline.asset.id, offline.asset.id, deleted.asset.id]) {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId, addedById: user.id });
+        await ctx.newSharedSpaceAsset({ spaceId: disabled.id, assetId, addedById: user.id });
+      }
+
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: timeline.asset.id },
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('excludes deleted invisible unassigned and identity-less faces from projection targets', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const eligible = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const deletedFace = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const invisibleFace = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const unassignedFace = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const identityless = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      await ctx.database
+        .updateTable('asset_face')
+        .set({ deletedAt: new Date() })
+        .where('id', '=', deletedFace.assetFace.id)
+        .execute();
+      await ctx.database
+        .updateTable('asset_face')
+        .set({ isVisible: false })
+        .where('id', '=', invisibleFace.assetFace.id)
+        .execute();
+      await ctx.database
+        .updateTable('asset_face')
+        .set({ personId: null })
+        .where('id', '=', unassignedFace.assetFace.id)
+        .execute();
+      await ctx.database.deleteFrom('face_identity_face').where('assetFaceId', '=', identityless.assetFace.id).execute();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      for (const assetId of [
+        eligible.asset.id,
+        deletedFace.asset.id,
+        invisibleFace.asset.id,
+        unassignedFace.asset.id,
+        identityless.asset.id,
+      ]) {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId, addedById: user.id });
+      }
+
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: eligible.asset.id },
+      ]);
+      await expect(sut.getBackfillWork()).resolves.toMatchObject({
+        hasPersonalIdentityWork: true,
+        hasSharedSpaceProjectionWork: true,
+      });
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -275,7 +275,11 @@ describe(FaceIdentityRepository.name, () => {
       await sut.backfillPersonalIdentities({ limit: 100 });
       await sut.backfillSpacePersonIdentities({ limit: 100 });
 
-      await expect(sut.hasBackfillWork()).resolves.toBe(false);
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -469,6 +473,39 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('targets a face assigned to the wrong space-person identity for projection repair', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const linked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const wrong = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: linked.asset.id, addedById: user.id });
+      const wrongSpacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({
+          spaceId: space.id,
+          identityId: wrong.identity.id,
+          representativeFaceId: linked.assetFace.id,
+          type: 'person',
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, wrongSpacePerson.id, linked.assetFace.id);
+
+      await expect(sut.getSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([
+        { spaceId: space.id, assetId: linked.asset.id },
+      ]);
+      await expect(sut.getBackfillWork()).resolves.toMatchObject({
+        hasSpacePersonIdentityWork: true,
+        hasSharedSpaceProjectionWork: true,
+      });
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('excludes disabled spaces and ineligible assets from projection targets', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();
@@ -572,7 +609,11 @@ describe(FaceIdentityRepository.name, () => {
 
       await sut.backfillSpacePersonIdentities({ limit: 100 });
 
-      await expect(sut.hasBackfillWork()).resolves.toBe(false);
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -770,43 +811,220 @@ describe(FaceIdentityRepository.name, () => {
   });
 
   it('backfills personal identities idempotently and pages by cursor', async () => {
-    const { ctx, sut } = setup();
+    const { ctx, sut } = setup(await getKyselyDB());
     const { user } = await ctx.newUser();
-    const { person: firstPerson } = await ctx.newPerson({ ownerId: user.id });
-    const { person: secondPerson } = await ctx.newPerson({ ownerId: user.id });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace: firstFace } = await ctx.newAssetFace({ assetId: asset.id, personId: firstPerson.id });
-    const { assetFace: secondFace } = await ctx.newAssetFace({ assetId: asset.id, personId: firstPerson.id });
+    try {
+      const { person: firstPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { person: secondPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: firstFace } = await ctx.newAssetFace({ assetId: asset.id, personId: firstPerson.id });
+      const { assetFace: secondFace } = await ctx.newAssetFace({ assetId: asset.id, personId: firstPerson.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
 
-    const firstPage = await sut.backfillPersonalIdentities({ limit: 1 });
-    const secondPage = await sut.backfillPersonalIdentities({ cursor: firstPage.nextCursor, limit: 1 });
-    await sut.backfillPersonalIdentities({ limit: 100 });
-    const firstIdentity = await ctx.database
-      .selectFrom('person')
-      .select('identityId')
-      .where('id', '=', firstPerson.id)
-      .executeTakeFirstOrThrow();
-    await sut.backfillPersonalIdentities({ limit: 100 });
+      const firstPage = await sut.backfillPersonalIdentities({ limit: 1 });
+      const secondPage = await sut.backfillPersonalIdentities({ cursor: firstPage.nextCursor, limit: 1 });
+      await sut.backfillPersonalIdentities({ limit: 100 });
+      const firstIdentity = await ctx.database
+        .selectFrom('person')
+        .select('identityId')
+        .where('id', '=', firstPerson.id)
+        .executeTakeFirstOrThrow();
+      await sut.backfillPersonalIdentities({ limit: 100 });
 
-    const people = await ctx.database
-      .selectFrom('person')
-      .select(['id', 'identityId'])
-      .where('id', 'in', [firstPerson.id, secondPerson.id])
-      .orderBy('id')
-      .execute();
-    const links = await ctx.database
-      .selectFrom('face_identity_face')
-      .select(['assetFaceId', 'identityId'])
-      .where('assetFaceId', 'in', [firstFace.id, secondFace.id])
-      .orderBy('assetFaceId')
-      .execute();
+      const people = await ctx.database
+        .selectFrom('person')
+        .select(['id', 'identityId'])
+        .where('id', 'in', [firstPerson.id, secondPerson.id])
+        .orderBy('id')
+        .execute();
+      const links = await ctx.database
+        .selectFrom('face_identity_face')
+        .select(['assetFaceId', 'identityId'])
+        .where('assetFaceId', 'in', [firstFace.id, secondFace.id])
+        .orderBy('assetFaceId')
+        .execute();
 
-    expect(firstPage).toEqual({ processed: 1, nextCursor: expect.any(String) });
-    expect(secondPage.processed).toBe(1);
-    expect(people.every((person) => person.identityId)).toBe(true);
-    expect(people.find((person) => person.id === firstPerson.id)?.identityId).toBe(firstIdentity.identityId);
-    expect(links).toHaveLength(2);
-    expect(new Set(links.map((link) => link.identityId))).toEqual(new Set([firstIdentity.identityId]));
+      const affectedTargets = [
+        ...(firstPage.affectedSpaceAssets ?? []),
+        ...(secondPage.affectedSpaceAssets ?? []),
+      ].toSorted((a, b) => a.spaceId.localeCompare(b.spaceId) || a.assetId.localeCompare(b.assetId));
+
+      expect(firstPage).toEqual({
+        processed: 1,
+        affectedSpaceAssets: expect.any(Array),
+        nextCursor: expect.any(String),
+      });
+      expect(secondPage.processed).toBe(1);
+      expect(affectedTargets).toEqual([{ spaceId: space.id, assetId: asset.id }]);
+      expect(people.every((person) => person.identityId)).toBe(true);
+      expect(people.find((person) => person.id === firstPerson.id)?.identityId).toBe(firstIdentity.identityId);
+      expect(links).toHaveLength(2);
+      expect(new Set(links.map((link) => link.identityId))).toEqual(new Set([firstIdentity.identityId]));
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('persists personal-identity affected targets across enabled spaces and dedupes direct library overlap', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { library } = await ctx.newLibrary({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { asset: offlineAsset } = await ctx.newAsset({ ownerId: user.id, isOffline: true });
+      await ctx.newAssetFace({ assetId: offlineAsset.id, personId: person.id });
+      const { space: directAndLinked } = await ctx.newSharedSpace({
+        createdById: user.id,
+        faceRecognitionEnabled: true,
+      });
+      const { space: linkedOnly } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      const { space: disabled } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+      for (const spaceId of [directAndLinked.id, linkedOnly.id, disabled.id]) {
+        await ctx.newSharedSpaceMember({ spaceId, userId: user.id, role: SharedSpaceRole.Owner });
+      }
+      await ctx.newSharedSpaceAsset({ spaceId: directAndLinked.id, assetId: asset.id, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: directAndLinked.id, assetId: offlineAsset.id, addedById: user.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: directAndLinked.id, libraryId: library.id, addedById: user.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: linkedOnly.id, libraryId: library.id, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: disabled.id, assetId: asset.id, addedById: user.id });
+
+      const result = await sut.backfillPersonalIdentities({ limit: 100 });
+      const expectedTargets = [
+        { spaceId: directAndLinked.id, assetId: asset.id },
+        { spaceId: linkedOnly.id, assetId: asset.id },
+      ].toSorted((a, b) => a.spaceId.localeCompare(b.spaceId) || a.assetId.localeCompare(b.assetId));
+      const pendingTargetRows = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      const pendingTargets = pendingTargetRows.map(({ spaceId, assetId }) => ({ spaceId, assetId }));
+
+      expect(result.affectedSpaceAssets).toEqual(expectedTargets);
+      expect(pendingTargets).toEqual(expectedTargets);
+      await expect(
+        ctx.database
+          .selectFrom('face_identity_face')
+          .select('identityId')
+          .where('assetFaceId', '=', assetFace.id)
+          .executeTakeFirst(),
+      ).resolves.toEqual(expect.objectContaining({ identityId: expect.any(String) }));
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('persists one affected target per enabled space when the same photo lives in ten spaces', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const enabledSpaces = [];
+      for (let index = 0; index < 10; index++) {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+        enabledSpaces.push(space);
+      }
+      const { space: disabledSpace } = await ctx.newSharedSpace({
+        createdById: user.id,
+        faceRecognitionEnabled: false,
+      });
+      await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
+
+      const result = await sut.backfillPersonalIdentities({ limit: 100 });
+      const expectedTargets = enabledSpaces
+        .map((space) => ({ spaceId: space.id, assetId: asset.id }))
+        .toSorted((a, b) => a.spaceId.localeCompare(b.spaceId) || a.assetId.localeCompare(b.assetId));
+      const pendingTargetRows = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      const pendingTargets = pendingTargetRows.map(({ spaceId, assetId }) => ({ spaceId, assetId }));
+
+      expect(result.affectedSpaceAssets).toEqual(expectedTargets);
+      expect(pendingTargets).toEqual(expectedTargets);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('keeps pending targets that were rewritten after a worker snapshot', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+
+      await sut.backfillPersonalIdentities({ limit: 100 });
+      const snapshot = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      await sut.backfillPersonalIdentities({ limit: 100 });
+      const rewritten = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+
+      expect(rewritten[0].updateId).not.toBe(snapshot[0].updateId);
+
+      await sut.deletePendingSharedSpaceFaceMatchBackfillTargets(snapshot);
+
+      await expect(sut.getPendingSharedSpaceFaceMatchBackfillTargets()).resolves.toMatchObject([
+        { spaceId: space.id, assetId: asset.id, updateId: rewritten[0].updateId },
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('reports durable pending face-match targets as backfill work', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      await ctx.database
+        .insertInto('shared_space_face_match_backfill_target')
+        .values({ spaceId: space.id, assetId: asset.id })
+        .execute();
+
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+      await expect(sut.hasBackfillWork()).resolves.toBe(true);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('persists personal-identity pending targets before identity rows are mutated', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    const ensureSpy = vi.spyOn(sut, 'ensurePersonIdentity').mockRejectedValueOnce(new Error('identity write failed'));
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id, identityId: null });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+
+      await expect(sut.backfillPersonalIdentities({ limit: 100 })).rejects.toThrow('identity write failed');
+
+      await expect(sut.getPendingSharedSpaceFaceMatchBackfillTargets()).resolves.toMatchObject([
+        { spaceId: space.id, assetId: asset.id },
+      ]);
+      await expect(
+        ctx.database.selectFrom('person').select('identityId').where('id', '=', person.id).executeTakeFirstOrThrow(),
+      ).resolves.toEqual({ identityId: null });
+    } finally {
+      ensureSpy.mockRestore();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
   });
 
   it('does not backfill hidden or deleted faces as identity-linked faces', async () => {
@@ -1990,6 +2208,7 @@ describe(FaceIdentityRepository.name, () => {
       const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
       const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
       const { assetFace: aliceFace } = await ctx.newAssetFace({ assetId: asset.id, personId: alice.id });
       const { assetFace: bobFace } = await ctx.newAssetFace({ assetId: asset.id, personId: bob.id });
       const aliceIdentity = await sut.ensurePersonIdentity(alice.id);
@@ -2014,12 +2233,20 @@ describe(FaceIdentityRepository.name, () => {
         .execute();
 
       expect(result.conflictCount).toBe(0);
+      expect(result.affectedSpaceAssets).toEqual([{ spaceId: space.id, assetId: asset.id }]);
+      await expect(sut.getPendingSharedSpaceFaceMatchBackfillTargets()).resolves.toMatchObject([
+        { spaceId: space.id, assetId: asset.id },
+      ]);
       expect(spacePeople.filter((person) => person.identityId === aliceIdentity.id)).toHaveLength(1);
       expect(spacePeople.filter((person) => person.identityId === bobIdentity.id)).toHaveLength(1);
       expect(spacePeople.find((person) => person.identityId === aliceIdentity.id)?.faceCount).toBe(1);
       expect(spacePeople.find((person) => person.identityId === bobIdentity.id)?.faceCount).toBe(1);
       expect(spacePeople.filter((person) => person.identityId === null && person.faceCount > 0)).toHaveLength(0);
-      await expect(sut.hasBackfillWork()).resolves.toBe(false);
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: false,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -917,6 +917,77 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('does not persist personal-identity targets for already linked faces on the same backfill page', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const alreadyLinked = await newIdentityFace(ctx, sut, { ownerId: user.id });
+      const { person: missingPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { asset: missingAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: missingAssetFace } = await ctx.newAssetFace({
+        assetId: missingAsset.id,
+        personId: missingPerson.id,
+      });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: alreadyLinked.asset.id, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: missingAsset.id, addedById: user.id });
+
+      const result = await sut.backfillPersonalIdentities({ limit: 100 });
+      const pendingTargetRows = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      const pendingTargets = pendingTargetRows.map(({ spaceId, assetId }) => ({ spaceId, assetId }));
+
+      expect(result.affectedSpaceAssets).toEqual([{ spaceId: space.id, assetId: missingAsset.id }]);
+      expect(pendingTargets).toEqual([{ spaceId: space.id, assetId: missingAsset.id }]);
+      await expect(
+        ctx.database
+          .selectFrom('face_identity_face')
+          .select('identityId')
+          .where('assetFaceId', '=', missingAssetFace.id)
+          .executeTakeFirst(),
+      ).resolves.toEqual(expect.objectContaining({ identityId: expect.any(String) }));
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('persists personal-identity targets only for unlinked faces when one person has mixed linked faces', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const identity = await sut.ensurePersonIdentity(person.id);
+      const { asset: alreadyLinkedAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: alreadyLinkedFace } = await ctx.newAssetFace({
+        assetId: alreadyLinkedAsset.id,
+        personId: person.id,
+      });
+      await sut.linkFace({ assetFaceId: alreadyLinkedFace.id, identityId: identity.id, source: 'backfill' });
+      const { asset: missingAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: missingAssetFace } = await ctx.newAssetFace({ assetId: missingAsset.id, personId: person.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: alreadyLinkedAsset.id, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: missingAsset.id, addedById: user.id });
+
+      const result = await sut.backfillPersonalIdentities({ limit: 100 });
+      const pendingTargetRows = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      const pendingTargets = pendingTargetRows.map(({ spaceId, assetId }) => ({ spaceId, assetId }));
+
+      expect(result.affectedSpaceAssets).toEqual([{ spaceId: space.id, assetId: missingAsset.id }]);
+      expect(pendingTargets).toEqual([{ spaceId: space.id, assetId: missingAsset.id }]);
+      await expect(
+        ctx.database
+          .selectFrom('face_identity_face')
+          .select('identityId')
+          .where('assetFaceId', '=', missingAssetFace.id)
+          .executeTakeFirst(),
+      ).resolves.toEqual({ identityId: identity.id });
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('persists one affected target per enabled space when the same photo lives in ten spaces', async () => {
     const { ctx, sut } = setup(await getKyselyDB());
     const { user } = await ctx.newUser();
@@ -958,13 +1029,14 @@ describe(FaceIdentityRepository.name, () => {
     try {
       const { person } = await ctx.newPerson({ ownerId: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
-      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
       const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
       await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
       await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
 
       await sut.backfillPersonalIdentities({ limit: 100 });
       const snapshot = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      await ctx.database.deleteFrom('face_identity_face').where('assetFaceId', '=', assetFace.id).execute();
       await sut.backfillPersonalIdentities({ limit: 100 });
       const rewritten = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
 

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -988,6 +988,36 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('does not persist personal-identity targets for faces already assigned in the shared space', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const spacePerson = await newSpacePerson(ctx, space.id);
+      await linkSpaceFace(ctx, spacePerson.id, assetFace.id);
+
+      const result = await sut.backfillPersonalIdentities({ limit: 100 });
+      const pendingTargetRows = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+
+      expect(result.affectedSpaceAssets).toEqual([]);
+      expect(pendingTargetRows).toEqual([]);
+      await expect(
+        ctx.database
+          .selectFrom('face_identity_face')
+          .select('identityId')
+          .where('assetFaceId', '=', assetFace.id)
+          .executeTakeFirst(),
+      ).resolves.toEqual(expect.objectContaining({ identityId: expect.any(String) }));
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('persists one affected target per enabled space when the same photo lives in ten spaces', async () => {
     const { ctx, sut } = setup(await getKyselyDB());
     const { user } = await ctx.newUser();
@@ -2308,10 +2338,8 @@ describe(FaceIdentityRepository.name, () => {
         .execute();
 
       expect(result.conflictCount).toBe(0);
-      expect(result.affectedSpaceAssets).toEqual([{ spaceId: space.id, assetId: asset.id }]);
-      await expect(sut.getPendingSharedSpaceFaceMatchBackfillTargets()).resolves.toMatchObject([
-        { spaceId: space.id, assetId: asset.id },
-      ]);
+      expect(result.affectedSpaceAssets).toEqual([]);
+      await expect(sut.getPendingSharedSpaceFaceMatchBackfillTargets()).resolves.toEqual([]);
       expect(spacePeople.filter((person) => person.identityId === aliceIdentity.id)).toHaveLength(1);
       expect(spacePeople.filter((person) => person.identityId === bobIdentity.id)).toHaveLength(1);
       expect(spacePeople.find((person) => person.identityId === aliceIdentity.id)?.faceCount).toBe(1);

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -135,6 +135,33 @@ describe(PersonRepository.name, () => {
         detectedFaceCount: 0,
       });
     });
+
+    it('counts only people eligible for the personal people list when minimumFaceCount is set', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      const { person: belowThreshold } = await ctx.newPerson({ ownerId: user.id, name: '' });
+      const { person: eligibleUnnamed } = await ctx.newPerson({ ownerId: user.id, name: '' });
+      const { person: eligibleNamedHidden } = await ctx.newPerson({ ownerId: user.id, name: 'Hidden', isHidden: true });
+
+      await ctx.newAssetFace({ assetId: asset.id, personId: belowThreshold.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: belowThreshold.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: eligibleUnnamed.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: eligibleUnnamed.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: eligibleUnnamed.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: eligibleNamedHidden.id });
+      await ctx.newAssetFace({ assetId: asset.id, personId: null });
+
+      await expect(sut.getNumberOfPeople(user.id, { minimumFaceCount: 3 })).resolves.toEqual({
+        total: 2,
+        hidden: 1,
+      });
+      await expect(sut.getPeopleOverviewStatistics(user.id, { minimumFaceCount: 3 })).resolves.toEqual({
+        total: 2,
+        hidden: 1,
+        detectedFaceCount: 7,
+      });
+    });
   });
 
   describe('getPeopleFaceStatistics', () => {

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -529,7 +529,12 @@ describe(MetadataService.name, () => {
 
       expect(identityLinks).toEqual([{ assetFaceId: assetFace.id, source: 'backfill' }]);
       expect(backfillCtx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll).toHaveBeenCalledWith(
-        expect.arrayContaining([{ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } }]),
+        expect.arrayContaining([
+          {
+            name: JobName.SharedSpaceFaceMatch,
+            data: { spaceId: space.id, assetId: asset.id, source: 'identity-backfill' },
+          },
+        ]),
       );
       expect(spacePeople).toEqual([
         expect.objectContaining({

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -1885,6 +1885,11 @@ describe('People identity RBAC projection', () => {
     await expect(faceIdentityRepository.hasBackfillWork()).resolves.toBe(true);
     await faceIdentityRepository.backfillPersonalIdentities({ limit: 100 });
     await faceIdentityRepository.backfillSpacePersonIdentities({ limit: 100 });
+    const pendingBackfillTargets = await faceIdentityRepository.getPendingSharedSpaceFaceMatchBackfillTargets();
+    expect(pendingBackfillTargets).toEqual(
+      expect.arrayContaining([expect.objectContaining({ spaceId: space.id, assetId: asset.id })]),
+    );
+    await faceIdentityRepository.deletePendingSharedSpaceFaceMatchBackfillTargets(pendingBackfillTargets);
     await expect(faceIdentityRepository.hasBackfillWork()).resolves.toBe(false);
 
     const auth = authFor(member);
@@ -2013,6 +2018,11 @@ describe('People identity RBAC projection', () => {
     await expect(faceIdentityRepository.hasBackfillWork()).resolves.toBe(true);
     await faceIdentityRepository.backfillPersonalIdentities({ limit: 100 });
     await faceIdentityRepository.backfillSpacePersonIdentities({ limit: 100 });
+    const pendingBackfillTargets = await faceIdentityRepository.getPendingSharedSpaceFaceMatchBackfillTargets();
+    expect(pendingBackfillTargets).toEqual(
+      expect.arrayContaining([expect.objectContaining({ spaceId: space.id, assetId: asset.id })]),
+    );
+    await faceIdentityRepository.deletePendingSharedSpaceFaceMatchBackfillTargets(pendingBackfillTargets);
     await expect(faceIdentityRepository.hasBackfillWork()).resolves.toBe(false);
 
     const auth = authFor(member);

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -1886,10 +1886,7 @@ describe('People identity RBAC projection', () => {
     await faceIdentityRepository.backfillPersonalIdentities({ limit: 100 });
     await faceIdentityRepository.backfillSpacePersonIdentities({ limit: 100 });
     const pendingBackfillTargets = await faceIdentityRepository.getPendingSharedSpaceFaceMatchBackfillTargets();
-    expect(pendingBackfillTargets).toEqual(
-      expect.arrayContaining([expect.objectContaining({ spaceId: space.id, assetId: asset.id })]),
-    );
-    await faceIdentityRepository.deletePendingSharedSpaceFaceMatchBackfillTargets(pendingBackfillTargets);
+    expect(pendingBackfillTargets).toEqual([]);
     await expect(faceIdentityRepository.hasBackfillWork()).resolves.toBe(false);
 
     const auth = authFor(member);
@@ -2019,10 +2016,7 @@ describe('People identity RBAC projection', () => {
     await faceIdentityRepository.backfillPersonalIdentities({ limit: 100 });
     await faceIdentityRepository.backfillSpacePersonIdentities({ limit: 100 });
     const pendingBackfillTargets = await faceIdentityRepository.getPendingSharedSpaceFaceMatchBackfillTargets();
-    expect(pendingBackfillTargets).toEqual(
-      expect.arrayContaining([expect.objectContaining({ spaceId: space.id, assetId: asset.id })]),
-    );
-    await faceIdentityRepository.deletePendingSharedSpaceFaceMatchBackfillTargets(pendingBackfillTargets);
+    expect(pendingBackfillTargets).toEqual([]);
     await expect(faceIdentityRepository.hasBackfillWork()).resolves.toBe(false);
 
     const auth = authFor(member);


### PR DESCRIPTION
## Summary
- Replaces identity-backfill shared-space full fan-out with durable targeted `(spaceId, assetId)` rematch work.
- Adds `shared_space_face_match_backfill_target` as a retry-safe pending target table with guarded stale-snapshot deletion.
- Keeps identity-backfill continuation jobs dedupable and refreshes exact shared-space metadata for identity-backfill rematches.

## Test Plan
- [x] `corepack pnpm --dir server test src/repositories/job.repository.spec.ts src/services/person.service.spec.ts src/services/shared-space.service.spec.ts`
- [x] `corepack pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts`
- [x] `corepack pnpm --dir server check`
- [x] `corepack pnpm --dir server lint`
- [x] `git diff --check`

## Coverage Notes
- Covers durable pending target replay after crashes/restarts.
- Covers queue failure preserving pending work.
- Covers stale worker snapshots not deleting newer pending writes.
- Covers same photo shared into 10 enabled spaces, with disabled spaces excluded.
- Covers retrigger/continuation behavior without `SharedSpaceFaceMatchAll` fan-out.
