### PR TITLE
feat: gate people face statistics behind opt-in env var

### DIFF
--- a/docs/docs/features/facial-recognition.md
+++ b/docs/docs/features/facial-recognition.md
@@ -30,6 +30,41 @@ It can be found from the app bar when you access the detail view of a person.
 
 <img src={require('./img/facial-recognition-4.webp').default} title='Facial Recognition 4' />
 
+## Face Statistics
+
+Gallery can surface face count totals on the People pages so you can see how face recognition is progressing across your library at a glance.
+
+When enabled, you will see:
+
+- A face count next to the heading on the People page (e.g. `(124) · 8,432 faces`) and on each shared space's People page.
+- A face count next to the assets count on each person's detail page.
+- A small info icon next to the People page heading. Clicking it opens a panel breaking the totals down further:
+  - **Detected faces** — every face the face detection model has found in your library.
+  - **Assigned to visible people** — faces that have been clustered into people you can browse.
+  - **Named visible people** — visible people that you have given a name.
+  - **Assigned to hidden people** — faces clustered into people you have hidden from the People list.
+  - **Unassigned** — faces that haven't been linked to a person yet (they're either still being processed, below the _Minimum Recognized Faces_ threshold, or considered outliers).
+
+These numbers can be useful for confirming that face detection has finished running, deciding when to re-run facial recognition after tuning the settings, or understanding why a particular face hasn't been clustered yet.
+
+### Enabling face statistics
+
+Face statistics are **off by default**. To turn them on, set the `IMMICH_PEOPLE_STATISTICS_ENABLED` environment variable on the Gallery server to `true` and restart the container.
+
+```yaml
+# docker-compose.yml
+services:
+  immich-server:
+    environment:
+      IMMICH_PEOPLE_STATISTICS_ENABLED: 'true'
+```
+
+The setting is a UI toggle only — it controls whether the counts and the info panel are rendered. Turning it off does not delete any data and you can flip it back on at any time.
+
+:::tip
+If you find the totals distracting (for example on a casual family library where the exact face count isn't useful), you can leave the variable unset. The People pages will fall back to just showing the people count.
+:::
+
 ## How Face Detection Works
 
 Face detection sends the generated preview image to the machine learning service for processing. The service checks if it has the relevant model downloaded and downloads it if not. The image is decoded, pre-processed and passed to the face detection model (with hardware acceleration if configured). The bounding boxes and scores outputted from this model are used to crop and preprocess the image once again to be passed to a facial recognition model (also accelerated if configured). The embeddings from the recognition model, together with the bounding boxes and scores from the face detection model, are then sent back to the server to be added to the database. The embeddings in particular are indexed so they can be searched quickly during facial recognition clustering.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -46,6 +46,7 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 | `IMMICH_TRUSTED_PROXIES`            | List of comma-separated IPs set as trusted proxies                                                                                                     |                              | server                   | api                |
 | `IMMICH_IGNORE_MOUNT_CHECK_ERRORS`  | See [System Integrity](/administration/system-integrity)                                                                                               |                              | server                   | api, microservices |
 | `IMMICH_ALLOW_SETUP`                | When `false` disables the `/auth/admin-sign-up` endpoint                                                                                               |            `true`            | server                   | api                |
+| `IMMICH_PEOPLE_STATISTICS_ENABLED`  | When `true`, exposes face count totals and the lazy-loaded face statistics modal on the People and shared-space People pages                           |           `false`            | server                   | api                |
 
 \*1: `TZ` should be set to a `TZ identifier` from [this list][tz-list]. For example, `TZ="Etc/UTC"`.
 `TZ` is used by `exiftool` as a fallback in case the timezone cannot be determined from the image metadata. It is also used for logfile timestamps and cron job execution.

--- a/e2e/src/specs/server/api/server.e2e-spec.ts
+++ b/e2e/src/specs/server/api/server.e2e-spec.ts
@@ -119,6 +119,7 @@ describe('/server', () => {
         sidecar: true,
         trash: true,
         email: false,
+        peopleStatistics: false,
       });
     });
   });

--- a/mobile/openapi/lib/model/server_features_dto.dart
+++ b/mobile/openapi/lib/model/server_features_dto.dart
@@ -23,6 +23,7 @@ class ServerFeaturesDto {
     required this.oauthAutoLaunch,
     required this.ocr,
     required this.passwordLogin,
+    required this.peopleStatistics,
     required this.reverseGeocoding,
     required this.search,
     required this.sidecar,
@@ -60,6 +61,9 @@ class ServerFeaturesDto {
   /// Whether password login is enabled
   bool passwordLogin;
 
+  /// Whether the people face statistics UI is enabled
+  bool peopleStatistics;
+
   /// Whether reverse geocoding is enabled
   bool reverseGeocoding;
 
@@ -87,6 +91,7 @@ class ServerFeaturesDto {
     other.oauthAutoLaunch == oauthAutoLaunch &&
     other.ocr == ocr &&
     other.passwordLogin == passwordLogin &&
+    other.peopleStatistics == peopleStatistics &&
     other.reverseGeocoding == reverseGeocoding &&
     other.search == search &&
     other.sidecar == sidecar &&
@@ -106,6 +111,7 @@ class ServerFeaturesDto {
     (oauthAutoLaunch.hashCode) +
     (ocr.hashCode) +
     (passwordLogin.hashCode) +
+    (peopleStatistics.hashCode) +
     (reverseGeocoding.hashCode) +
     (search.hashCode) +
     (sidecar.hashCode) +
@@ -113,7 +119,7 @@ class ServerFeaturesDto {
     (trash.hashCode);
 
   @override
-  String toString() => 'ServerFeaturesDto[configFile=$configFile, duplicateDetection=$duplicateDetection, email=$email, facialRecognition=$facialRecognition, importFaces=$importFaces, map=$map, oauth=$oauth, oauthAutoLaunch=$oauthAutoLaunch, ocr=$ocr, passwordLogin=$passwordLogin, reverseGeocoding=$reverseGeocoding, search=$search, sidecar=$sidecar, smartSearch=$smartSearch, trash=$trash]';
+  String toString() => 'ServerFeaturesDto[configFile=$configFile, duplicateDetection=$duplicateDetection, email=$email, facialRecognition=$facialRecognition, importFaces=$importFaces, map=$map, oauth=$oauth, oauthAutoLaunch=$oauthAutoLaunch, ocr=$ocr, passwordLogin=$passwordLogin, peopleStatistics=$peopleStatistics, reverseGeocoding=$reverseGeocoding, search=$search, sidecar=$sidecar, smartSearch=$smartSearch, trash=$trash]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -127,6 +133,7 @@ class ServerFeaturesDto {
       json[r'oauthAutoLaunch'] = this.oauthAutoLaunch;
       json[r'ocr'] = this.ocr;
       json[r'passwordLogin'] = this.passwordLogin;
+      json[r'peopleStatistics'] = this.peopleStatistics;
       json[r'reverseGeocoding'] = this.reverseGeocoding;
       json[r'search'] = this.search;
       json[r'sidecar'] = this.sidecar;
@@ -154,6 +161,7 @@ class ServerFeaturesDto {
         oauthAutoLaunch: mapValueOfType<bool>(json, r'oauthAutoLaunch')!,
         ocr: mapValueOfType<bool>(json, r'ocr')!,
         passwordLogin: mapValueOfType<bool>(json, r'passwordLogin')!,
+        peopleStatistics: mapValueOfType<bool>(json, r'peopleStatistics')!,
         reverseGeocoding: mapValueOfType<bool>(json, r'reverseGeocoding')!,
         search: mapValueOfType<bool>(json, r'search')!,
         sidecar: mapValueOfType<bool>(json, r'sidecar')!,
@@ -216,6 +224,7 @@ class ServerFeaturesDto {
     'oauthAutoLaunch',
     'ocr',
     'passwordLogin',
+    'peopleStatistics',
     'reverseGeocoding',
     'search',
     'sidecar',

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -26475,6 +26475,10 @@
             "description": "Whether password login is enabled",
             "type": "boolean"
           },
+          "peopleStatistics": {
+            "description": "Whether the people face statistics UI is enabled",
+            "type": "boolean"
+          },
           "reverseGeocoding": {
             "description": "Whether reverse geocoding is enabled",
             "type": "boolean"
@@ -26507,6 +26511,7 @@
           "oauthAutoLaunch",
           "ocr",
           "passwordLogin",
+          "peopleStatistics",
           "reverseGeocoding",
           "search",
           "sidecar",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2307,6 +2307,8 @@ export type ServerFeaturesDto = {
     ocr: boolean;
     /** Whether password login is enabled */
     passwordLogin: boolean;
+    /** Whether the people face statistics UI is enabled */
+    peopleStatistics: boolean;
     /** Whether reverse geocoding is enabled */
     reverseGeocoding: boolean;
     /** Whether search is enabled */

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -77,6 +77,7 @@ export const EnvSchema = z
     IMMICH_DEMO_MODE: stringBool.optional(),
     IMMICH_DEMO_USER_EMAIL: z.string().optional(),
     IMMICH_DEMO_USER_PASSWORD: z.string().optional(),
+    IMMICH_PEOPLE_STATISTICS_ENABLED: stringBool.optional(),
     IMMICH_TRUSTED_PROXIES: trustedProxiesSchema,
     IMMICH_WORKERS_INCLUDE: z.string().optional(),
     IMMICH_WORKERS_EXCLUDE: z.string().optional(),

--- a/server/src/dtos/server.dto.ts
+++ b/server/src/dtos/server.dto.ts
@@ -137,6 +137,7 @@ const ServerFeaturesSchema = z
     search: z.boolean().describe('Whether search is enabled'),
     email: z.boolean().describe('Whether email notifications are enabled'),
     ocr: z.boolean().describe('Whether OCR is enabled'),
+    peopleStatistics: z.boolean().describe('Whether the people face statistics UI is enabled'),
   })
   .meta({ id: 'ServerFeaturesDto' });
 

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -32,6 +32,7 @@ export interface EnvData {
   configFile?: string;
   logLevel?: LogLevel;
   logFormat?: LogFormat;
+  peopleStatistics: boolean;
 
   buildMetadata: {
     build?: string;
@@ -275,6 +276,7 @@ const getEnv = (): EnvData => {
     configFile: dto.IMMICH_CONFIG_FILE,
     logLevel: dto.IMMICH_LOG_LEVEL,
     logFormat: dto.IMMICH_LOG_FORMAT || LogFormat.Console,
+    peopleStatistics: dto.IMMICH_PEOPLE_STATISTICS_ENABLED ?? false,
 
     buildMetadata: {
       build: dto.IMMICH_BUILD,

--- a/server/src/services/server.service.spec.ts
+++ b/server/src/services/server.service.spec.ts
@@ -153,8 +153,15 @@ describe(ServerService.name, () => {
         configFile: false,
         trash: true,
         email: false,
+        peopleStatistics: false,
       });
       expect(mocks.systemMetadata.get).toHaveBeenCalled();
+    });
+
+    it('should report peopleStatistics enabled when IMMICH_PEOPLE_STATISTICS_ENABLED is set', async () => {
+      mocks.config.getEnv.mockReturnValue(mockEnvData({ peopleStatistics: true }));
+      const features = await sut.getFeatures();
+      expect(features.peopleStatistics).toBe(true);
     });
 
     // Regression guard: getFeatures is called on every web-app page load; must

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -120,7 +120,7 @@ export class ServerService extends BaseService {
     // slower CPUs. Cache invalidates on ConfigUpdate.
     const { reverseGeocoding, metadata, map, machineLearning, trash, oauth, passwordLogin, notifications } =
       await this.getConfig({ withCache: true });
-    const { configFile } = this.configRepository.getEnv();
+    const { configFile, peopleStatistics } = this.configRepository.getEnv();
 
     return {
       smartSearch: isSmartSearchEnabled(machineLearning),
@@ -138,6 +138,7 @@ export class ServerService extends BaseService {
       passwordLogin: passwordLogin.enabled,
       configFile: !!configFile,
       email: notifications.smtp.enabled,
+      peopleStatistics,
     };
   }
 

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -118,6 +118,8 @@ const envData: EnvData = {
   },
 
   noColor: false,
+
+  peopleStatistics: false,
 };
 
 type MockEnvOverrides = Omit<Partial<EnvData>, 'storage'> & {

--- a/web/src/lib/components/spaces/space-people-page.spec.ts
+++ b/web/src/lib/components/spaces/space-people-page.spec.ts
@@ -18,7 +18,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import SpacePeoplePage from '../../../routes/(user)/spaces/[spaceId]/people/+page.svelte';
 
-const { gotoMock, pageStore } = vi.hoisted(() => {
+const { gotoMock, pageStore, featureFlagsMock } = vi.hoisted(() => {
   let pageValue = {
     url: new URL('http://localhost/spaces/space-1/people'),
     route: { id: '/(user)/spaces/[spaceId]/people' },
@@ -35,11 +35,15 @@ const { gotoMock, pageStore } = vi.hoisted(() => {
         return () => {};
       },
     },
+    featureFlagsMock: { value: { peopleStatistics: true } },
   };
 });
 
 vi.mock('$app/navigation', () => ({ goto: gotoMock }));
 vi.mock('$app/stores', () => ({ page: pageStore }));
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: featureFlagsMock,
+}));
 
 vi.mock('@immich/ui', async (importOriginal) => {
   const original = await importOriginal<typeof import('@immich/ui')>();
@@ -159,6 +163,7 @@ describe('Spaces people page', () => {
     sdkMock.getSpacePeople.mockResolvedValue([]);
     sdkMock.getSpacePeopleStatistics.mockResolvedValue({ total: 0, hidden: 0, detectedFaceCount: 0 });
     sdkMock.getSpacePeopleFaceStatistics.mockResolvedValue(makeFaceStatistics());
+    featureFlagsMock.value.peopleStatistics = true;
   });
 
   it('shows the visible person count and detected face count next to the heading', () => {
@@ -553,6 +558,27 @@ describe('Spaces people page', () => {
     });
 
     expect(screen.queryByRole('button', { name: 'view_face_statistics_details' })).not.toBeInTheDocument();
+  });
+
+  it('omits the face count from the header when the peopleStatistics feature flag is disabled', () => {
+    featureFlagsMock.value.peopleStatistics = false;
+    renderPage({
+      people: [makePerson({ id: 'p1' })],
+      peopleStatistics: { total: 12, hidden: 2, detectedFaceCount: 1980 },
+    });
+
+    expect(screen.getByTestId('user-page-layout')).toHaveAttribute('data-description', '(10)');
+  });
+
+  it('hides the face statistics details button when the peopleStatistics feature flag is disabled', () => {
+    featureFlagsMock.value.peopleStatistics = false;
+    renderPage({
+      people: [makePerson({ id: 'p1' })],
+      peopleStatistics: { total: 12, hidden: 2, detectedFaceCount: 1980 },
+    });
+
+    expect(screen.queryByRole('button', { name: 'view_face_statistics_details' })).not.toBeInTheDocument();
+    expect(sdkMock.getSpacePeopleFaceStatistics).not.toHaveBeenCalled();
   });
 
   it('searches people within the current space and updates the heading count', async () => {

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -14,6 +14,7 @@
   import OnEvents from '$lib/components/OnEvents.svelte';
   import { QueryParameter, SessionStorageKey } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import PersonMergeSuggestionModal from '$lib/modals/PersonMergeSuggestionModal.svelte';
   import { Route } from '$lib/route';
   import { getPersonActions } from '$lib/services/person.service';
@@ -250,6 +251,7 @@
   let countVisiblePeople = $derived(
     searchName ? searchedPeopleLocal.length : peopleCountStatistics.total - peopleCountStatistics.hidden,
   );
+  let peopleStatisticsEnabled = $derived(featureFlagsManager.value.peopleStatistics);
   let headerDescription = $derived(
     formatPeopleHeaderDescription({
       visiblePeopleCount: countVisiblePeople,
@@ -257,11 +259,14 @@
       locale: $locale,
       faceSingular: $t('face'),
       facePlural: $t('faces'),
-      includeFaceCount: !!overviewStatistics && !hasUnsupportedStatsFilter,
-      showZeroPeople: hasUnsupportedStatsFilter || (overviewStatistics?.detectedFaceCount ?? 0) > 0,
+      includeFaceCount: peopleStatisticsEnabled && !!overviewStatistics && !hasUnsupportedStatsFilter,
+      showZeroPeople:
+        hasUnsupportedStatsFilter || (peopleStatisticsEnabled && (overviewStatistics?.detectedFaceCount ?? 0) > 0),
     }),
   );
-  let showFaceStatisticsInfo = $derived(!!overviewStatistics && !hasUnsupportedStatsFilter && !!headerDescription);
+  let showFaceStatisticsInfo = $derived(
+    peopleStatisticsEnabled && !!overviewStatistics && !hasUnsupportedStatsFilter && !!headerDescription,
+  );
   let globalFaceStatisticsCacheKey = $derived(`user:${authManager.user.id}:global:people:withSharedSpaces=true`);
   const loadGlobalFaceStatistics = () => getPeopleFaceStatistics({ withSharedSpaces: true });
   let showPeople = $derived(searchName ? searchedPeopleLocal : visiblePeople);

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -28,6 +28,7 @@
   import { PersonPageViewMode, QueryParameter, SessionStorageKey } from '$lib/constants';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import PersonMergeSuggestionModal from '$lib/modals/PersonMergeSuggestionModal.svelte';
@@ -491,9 +492,11 @@
                     <p class="text-sm text-gray-500 dark:text-gray-400">
                       {$t('assets_count', { values: { count: numberOfAssets } })}
                     </p>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">
-                      {$t('faces_count', { values: { count: data.statistics.faces } })}
-                    </p>
+                    {#if featureFlagsManager.value.peopleStatistics}
+                      <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {$t('faces_count', { values: { count: data.statistics.faces } })}
+                      </p>
+                    {/if}
                     {#if person.birthDate}
                       <p class="text-sm text-gray-500 dark:text-gray-400">
                         {$t('person_birthdate', {

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/person-detail-page.spec.ts
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/person-detail-page.spec.ts
@@ -20,44 +20,44 @@ const {
   mockAssetMultiSelectManager,
   mockPage,
 } = vi.hoisted(() => {
-    const formatCount = (count: unknown, singular: string, plural: string) => {
-      const value = Number(count);
-      return `${value.toLocaleString('en-US')} ${value === 1 ? singular : plural}`;
-    };
+  const formatCount = (count: unknown, singular: string, plural: string) => {
+    const value = Number(count);
+    return `${value.toLocaleString('en-US')} ${value === 1 ? singular : plural}`;
+  };
 
-    const formatMessage = (key: string, options?: { values?: Record<string, unknown> }) => {
-      if (key === 'assets_count') {
-        return formatCount(options?.values?.count, 'asset', 'assets');
-      }
+  const formatMessage = (key: string, options?: { values?: Record<string, unknown> }) => {
+    if (key === 'assets_count') {
+      return formatCount(options?.values?.count, 'asset', 'assets');
+    }
 
-      if (key === 'faces_count') {
-        return formatCount(options?.values?.count, 'face', 'faces');
-      }
+    if (key === 'faces_count') {
+      return formatCount(options?.values?.count, 'face', 'faces');
+    }
 
-      return key;
-    };
+    return key;
+  };
 
-    return {
-      afterNavigateMock: vi.fn(),
-      featureFlagsMock: { value: { peopleStatistics: true } },
-      formatMessage,
-      gotoMock: vi.fn(),
-      invalidateAllMock: vi.fn(),
-      mockAssetMultiSelectManager: {
-        selectionActive: false,
-        assets: [],
-        clear: vi.fn(),
-        isAllUserOwned: true,
-        isAllFavorite: false,
-        isAllArchived: false,
-      },
-      mockPage: {
-        url: new URL('https://gallery.test/people/person-1'),
-        route: { id: '/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]' },
-        params: { personId: 'person-1' },
-      },
-    };
-  });
+  return {
+    afterNavigateMock: vi.fn(),
+    featureFlagsMock: { value: { peopleStatistics: true } },
+    formatMessage,
+    gotoMock: vi.fn(),
+    invalidateAllMock: vi.fn(),
+    mockAssetMultiSelectManager: {
+      selectionActive: false,
+      assets: [],
+      clear: vi.fn(),
+      isAllUserOwned: true,
+      isAllFavorite: false,
+      isAllArchived: false,
+    },
+    mockPage: {
+      url: new URL('https://gallery.test/people/person-1'),
+      route: { id: '/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]' },
+      params: { personId: 'person-1' },
+    },
+  };
+});
 
 vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
   featureFlagsManager: featureFlagsMock,

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/person-detail-page.spec.ts
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/person-detail-page.spec.ts
@@ -11,8 +11,15 @@ import userEvent from '@testing-library/user-event';
 import type { Component } from 'svelte';
 import PersonDetailPage from './+page.svelte';
 
-const { afterNavigateMock, formatMessage, gotoMock, invalidateAllMock, mockAssetMultiSelectManager, mockPage } =
-  vi.hoisted(() => {
+const {
+  afterNavigateMock,
+  featureFlagsMock,
+  formatMessage,
+  gotoMock,
+  invalidateAllMock,
+  mockAssetMultiSelectManager,
+  mockPage,
+} = vi.hoisted(() => {
     const formatCount = (count: unknown, singular: string, plural: string) => {
       const value = Number(count);
       return `${value.toLocaleString('en-US')} ${value === 1 ? singular : plural}`;
@@ -32,6 +39,7 @@ const { afterNavigateMock, formatMessage, gotoMock, invalidateAllMock, mockAsset
 
     return {
       afterNavigateMock: vi.fn(),
+      featureFlagsMock: { value: { peopleStatistics: true } },
       formatMessage,
       gotoMock: vi.fn(),
       invalidateAllMock: vi.fn(),
@@ -50,6 +58,10 @@ const { afterNavigateMock, formatMessage, gotoMock, invalidateAllMock, mockAsset
       },
     };
   });
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: featureFlagsMock,
+}));
 
 vi.mock('$app/navigation', () => ({
   afterNavigate: afterNavigateMock,
@@ -169,6 +181,7 @@ describe('Person detail page', () => {
     mockAssetMultiSelectManager.selectionActive = false;
     mockAssetMultiSelectManager.assets = [];
     sdkMock.getPerson.mockResolvedValue(makePerson());
+    featureFlagsMock.value.peopleStatistics = true;
   });
 
   it('uses same-person repair when merging a personal person with a space-primary candidate', async () => {
@@ -194,6 +207,17 @@ describe('Person detail page', () => {
 
     expect(screen.getByText('7 assets')).toBeInTheDocument();
     expect(screen.getByText('10 faces')).toBeInTheDocument();
+  });
+
+  it('hides the face count line when the peopleStatistics feature flag is disabled', () => {
+    featureFlagsMock.value.peopleStatistics = false;
+    renderPage({
+      person: makePerson({ name: 'Alice' }),
+      statistics: { assets: 7, faces: 10 },
+    });
+
+    expect(screen.getByText('7 assets')).toBeInTheDocument();
+    expect(screen.queryByText('10 faces')).not.toBeInTheDocument();
   });
 
   it('keeps the page person as the repair target when a space candidate is promoted by auto-swap', async () => {

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -19,7 +19,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import PeoplePage from './+page.svelte';
 
-const { gotoMock, pageStore } = vi.hoisted(() => {
+const { gotoMock, pageStore, featureFlagsMock } = vi.hoisted(() => {
   let pageValue = {
     url: new URL('http://localhost/people'),
     route: { id: '/(user)/people' },
@@ -36,11 +36,15 @@ const { gotoMock, pageStore } = vi.hoisted(() => {
         return () => {};
       },
     },
+    featureFlagsMock: { value: { peopleStatistics: true } },
   };
 });
 
 vi.mock('$app/navigation', () => ({ goto: gotoMock }));
 vi.mock('$app/stores', () => ({ page: pageStore }));
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: featureFlagsMock,
+}));
 
 vi.mock('@immich/ui', async (importOriginal) => {
   const original = await importOriginal<typeof import('@immich/ui')>();
@@ -138,6 +142,7 @@ describe('Global people page', () => {
     gotoMock.mockResolvedValue(undefined);
     sdkMock.searchPerson.mockResolvedValue([]);
     sdkMock.getPeopleFaceStatistics.mockResolvedValue(makeFaceStatistics());
+    featureFlagsMock.value.peopleStatistics = true;
     sdkMock.updatePerson.mockImplementation(({ id, personUpdateDto }) =>
       Promise.resolve(
         makePerson({
@@ -345,6 +350,21 @@ describe('Global people page', () => {
     renderPage([], { total: 0, hidden: 0, detectedFaceCount: 0 });
 
     expect(screen.queryByRole('button', { name: 'view_face_statistics_details' })).not.toBeInTheDocument();
+  });
+
+  it('omits the face count from the header when the peopleStatistics feature flag is disabled', () => {
+    featureFlagsMock.value.peopleStatistics = false;
+    renderPage([makePerson({ id: 'p1' })], { total: 12, hidden: 2, detectedFaceCount: 2901 });
+
+    expect(screen.getByTestId('user-page-layout')).toHaveAttribute('data-description', '(10)');
+  });
+
+  it('hides the face statistics details button when the peopleStatistics feature flag is disabled', () => {
+    featureFlagsMock.value.peopleStatistics = false;
+    renderPage([makePerson({ id: 'p1' })], { total: 12, hidden: 2, detectedFaceCount: 2901 });
+
+    expect(screen.queryByRole('button', { name: 'view_face_statistics_details' })).not.toBeInTheDocument();
+    expect(sdkMock.getPeopleFaceStatistics).not.toHaveBeenCalled();
   });
 
   it('saves global person names through the shared editable footer', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
@@ -86,8 +86,7 @@
           faceSingular: $t('face'),
           facePlural: $t('faces'),
           includeFaceCount: peopleStatisticsEnabled,
-          showZeroPeople:
-            !!searchName.trim() || (peopleStatisticsEnabled && peopleStatistics.detectedFaceCount > 0),
+          showZeroPeople: !!searchName.trim() || (peopleStatisticsEnabled && peopleStatistics.detectedFaceCount > 0),
         })
       : undefined,
   );

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
@@ -12,6 +12,7 @@
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import PersonEditBirthDateModal from '$lib/modals/PersonEditBirthDateModal.svelte';
   import { locale } from '$lib/stores/preferences.store';
   import { createUrl, handlePromiseError } from '$lib/utils';
@@ -75,6 +76,7 @@
     searchName.trim() || ($page.url.searchParams.get(QueryParameter.SEARCHED_PEOPLE) ?? '').trim(),
   );
   const activeStatisticsSearchName = $derived(activeSearchFilterName || null);
+  const peopleStatisticsEnabled = $derived(featureFlagsManager.value.peopleStatistics);
   const headerDescription = $derived(
     peopleStatistics
       ? formatPeopleHeaderDescription({
@@ -83,12 +85,17 @@
           locale: $locale,
           faceSingular: $t('face'),
           facePlural: $t('faces'),
-          showZeroPeople: !!searchName.trim() || peopleStatistics.detectedFaceCount > 0,
+          includeFaceCount: peopleStatisticsEnabled,
+          showZeroPeople:
+            !!searchName.trim() || (peopleStatisticsEnabled && peopleStatistics.detectedFaceCount > 0),
         })
       : undefined,
   );
   let showFaceStatisticsInfo = $derived(
-    !!peopleStatistics && !!headerDescription && statisticsSearchName === activeStatisticsSearchName,
+    peopleStatisticsEnabled &&
+      !!peopleStatistics &&
+      !!headerDescription &&
+      statisticsSearchName === activeStatisticsSearchName,
   );
   let spaceFaceStatisticsCacheKey = $derived(
     `user:${authManager.user.id}:space:${space.id}:people:face-statistics:name=${encodeURIComponent(activeSearchFilterName)}`,

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -19,6 +19,7 @@
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import { timeBeforeShowLoadingSpinner } from '$lib/constants';
   import PersonEditBirthDateModal from '$lib/modals/PersonEditBirthDateModal.svelte';
@@ -545,9 +546,11 @@
             <p class="text-sm text-gray-500 dark:text-gray-400">
               {$t('assets_count', { values: { count: statistics.assets } })}
             </p>
-            <p class="text-sm text-gray-500 dark:text-gray-400">
-              {$t('faces_count', { values: { count: statistics.faces } })}
-            </p>
+            {#if featureFlagsManager.value.peopleStatistics}
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                {$t('faces_count', { values: { count: statistics.faces } })}
+              </p>
+            {/if}
             {#if person.birthDate}
               <p class="text-sm text-gray-500 dark:text-gray-400">
                 {$t('person_birthdate', {

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -19,7 +19,14 @@ import type { Component } from 'svelte';
 import { load } from './+page';
 import SpacePersonDetailPage from './+page.svelte';
 
-const { gotoMock, invalidateAllMock, authenticateMock, formatMessage, mockAssetMultiSelectManager } = vi.hoisted(() => {
+const {
+  gotoMock,
+  invalidateAllMock,
+  authenticateMock,
+  featureFlagsMock,
+  formatMessage,
+  mockAssetMultiSelectManager,
+} = vi.hoisted(() => {
   const formatCount = (count: unknown, singular: string, plural: string) => {
     const value = Number(count);
     return `${value.toLocaleString('en-US')} ${value === 1 ? singular : plural}`;
@@ -41,6 +48,7 @@ const { gotoMock, invalidateAllMock, authenticateMock, formatMessage, mockAssetM
     gotoMock: vi.fn(),
     invalidateAllMock: vi.fn(),
     authenticateMock: vi.fn(),
+    featureFlagsMock: { value: { peopleStatistics: true } },
     formatMessage,
     mockAssetMultiSelectManager: {
       selectionActive: false,
@@ -55,6 +63,9 @@ const { gotoMock, invalidateAllMock, authenticateMock, formatMessage, mockAssetM
 
 vi.mock('$app/navigation', () => ({ goto: gotoMock, invalidateAll: invalidateAllMock }));
 vi.mock('$lib/utils/auth', () => ({ authenticate: authenticateMock }));
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: featureFlagsMock,
+}));
 vi.mock('$lib/managers/asset-multi-select-manager.svelte', () => ({
   assetMultiSelectManager: mockAssetMultiSelectManager,
 }));
@@ -181,6 +192,7 @@ describe('Spaces person detail page', () => {
     authenticateMock.mockResolvedValue(undefined);
     mockAssetMultiSelectManager.selectionActive = false;
     mockAssetMultiSelectManager.assets = [];
+    featureFlagsMock.value.peopleStatistics = true;
   });
 
   it('loads person metadata without fetching a separate asset id grid', async () => {
@@ -264,6 +276,17 @@ describe('Spaces person detail page', () => {
     expect(screen.getByText('5 assets')).toBeInTheDocument();
     expect(screen.getByText('10 faces')).toBeInTheDocument();
     expect(screen.queryByText('999 assets')).not.toBeInTheDocument();
+  });
+
+  it('hides the face count line when the peopleStatistics feature flag is disabled', () => {
+    featureFlagsMock.value.peopleStatistics = false;
+    renderPage({
+      person: makePerson({ assetCount: 999, faceCount: 999 }),
+      statistics: { assets: 5, faces: 10 },
+    });
+
+    expect(screen.getByText('5 assets')).toBeInTheDocument();
+    expect(screen.queryByText('10 faces')).not.toBeInTheDocument();
   });
 
   it('updates the displayed space-scoped asset count after removing selected assets', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -19,47 +19,41 @@ import type { Component } from 'svelte';
 import { load } from './+page';
 import SpacePersonDetailPage from './+page.svelte';
 
-const {
-  gotoMock,
-  invalidateAllMock,
-  authenticateMock,
-  featureFlagsMock,
-  formatMessage,
-  mockAssetMultiSelectManager,
-} = vi.hoisted(() => {
-  const formatCount = (count: unknown, singular: string, plural: string) => {
-    const value = Number(count);
-    return `${value.toLocaleString('en-US')} ${value === 1 ? singular : plural}`;
-  };
+const { gotoMock, invalidateAllMock, authenticateMock, featureFlagsMock, formatMessage, mockAssetMultiSelectManager } =
+  vi.hoisted(() => {
+    const formatCount = (count: unknown, singular: string, plural: string) => {
+      const value = Number(count);
+      return `${value.toLocaleString('en-US')} ${value === 1 ? singular : plural}`;
+    };
 
-  const formatMessage = (key: string, options?: { values?: Record<string, unknown> }) => {
-    if (key === 'assets_count') {
-      return formatCount(options?.values?.count, 'asset', 'assets');
-    }
+    const formatMessage = (key: string, options?: { values?: Record<string, unknown> }) => {
+      if (key === 'assets_count') {
+        return formatCount(options?.values?.count, 'asset', 'assets');
+      }
 
-    if (key === 'faces_count') {
-      return formatCount(options?.values?.count, 'face', 'faces');
-    }
+      if (key === 'faces_count') {
+        return formatCount(options?.values?.count, 'face', 'faces');
+      }
 
-    return key;
-  };
+      return key;
+    };
 
-  return {
-    gotoMock: vi.fn(),
-    invalidateAllMock: vi.fn(),
-    authenticateMock: vi.fn(),
-    featureFlagsMock: { value: { peopleStatistics: true } },
-    formatMessage,
-    mockAssetMultiSelectManager: {
-      selectionActive: false,
-      assets: [],
-      clear: vi.fn(),
-      isAllUserOwned: true,
-      isAllFavorite: false,
-      isAllArchived: false,
-    },
-  };
-});
+    return {
+      gotoMock: vi.fn(),
+      invalidateAllMock: vi.fn(),
+      authenticateMock: vi.fn(),
+      featureFlagsMock: { value: { peopleStatistics: true } },
+      formatMessage,
+      mockAssetMultiSelectManager: {
+        selectionActive: false,
+        assets: [],
+        clear: vi.fn(),
+        isAllUserOwned: true,
+        isAllFavorite: false,
+        isAllArchived: false,
+      },
+    };
+  });
 
 vi.mock('$app/navigation', () => ({ goto: gotoMock, invalidateAll: invalidateAllMock }));
 vi.mock('$lib/utils/auth', () => ({ authenticate: authenticateMock }));


### PR DESCRIPTION
## Summary

- Adds `IMMICH_PEOPLE_STATISTICS_ENABLED` env var (default `false`) that gates the face count totals + lazy info modal added in #531 on `/people`, `/spaces/[id]/people`, and both per-person detail pages.
- Plumbed through `EnvSchema` → `EnvData` → `ServerFeaturesDto.peopleStatistics`, so the web reads it via the existing `featureFlagsManager`.
- New "Face Statistics" section in the facial-recognition docs explaining what each stat means and how to enable it; new env-var row in `environment-variables.md`.

Off by default so casual self-hosters don't see the counts unless they opt in.

## Test plan

- [ ] Server unit tests pass (`server.service.spec.ts` extended for default-off and env-on cases).
- [ ] Web unit tests pass for all four gated surfaces (people page, space people page, person detail, space person detail).
- [ ] Manual: with `IMMICH_PEOPLE_STATISTICS_ENABLED=true`, header shows `(N) · X faces` and info icon is clickable on `/people` and `/spaces/[id]/people`; per-person detail sidebar shows `X faces` line.
- [ ] Manual: without the env var (or set to `false`), no face counts/info icon are rendered, and the People pages still render correctly.
- [ ] Mobile compatibility: existing mobile builds keep deserializing `ServerFeaturesDto` (extra `peopleStatistics` field is ignored by Dart `fromJson`).

## Notes

- OpenAPI artifacts were regenerated manually (`pnpm install` was blocked by a root-owned `i18n/node_modules/.bin/`); the spec, TS SDK, and Dart model are all in sync.
- No DB migration, no API removals, no behaviour change for existing self-hosters until they set the env var.