### PR TITLE
fix(server): queue space person metadata backfill after identity backfill

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -2101,7 +2101,7 @@ describe(PersonService.name, () => {
       expect((mocks.faceIdentity as any).deletePendingSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
     });
 
-    it('does not call queueAll for an empty targeted face-match list', async () => {
+    it('queues one metadata backfill when identity work completes without targeted face-match work', async () => {
       mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
       mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
       (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
@@ -2113,6 +2113,11 @@ describe(PersonService.name, () => {
       await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
 
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
+      });
     });
 
     it('does not write an empty trailing batch for exactly one full chunk', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -569,8 +569,11 @@ export class PersonService extends BaseService {
       affectedSpaceAssets.push(...projectionTargets);
     }
 
-    await this.queueSharedSpaceFaceMatchTargets([...pendingTargets, ...affectedSpaceAssets]);
+    const queuedTargets = await this.queueSharedSpaceFaceMatchTargets([...pendingTargets, ...affectedSpaceAssets]);
     await this.faceIdentityRepository.deletePendingSharedSpaceFaceMatchBackfillTargets(pendingTargets);
+    if (queuedTargets.length === 0) {
+      await this.queueSpacePersonMetadataBackfill();
+    }
 
     return JobStatus.Success;
   }


### PR DESCRIPTION
## Summary
- queue a single shared-space person metadata backfill after identity backfill completes with no targeted face-match work
- keep targeted face-match dispatch bounded and avoid a concurrent global metadata backfill when face-match jobs are queued
- cover the completed-without-targets path with a regression test

## Tests
- pnpm --dir server test src/services/person.service.spec.ts
- pnpm --dir server test src/services/shared-space.service.spec.ts