### PR TITLE
fix(server): clean reset identities and soften person matching

### DIFF
--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -1990,6 +1990,39 @@ export class FaceIdentityRepository {
       .execute();
   }
 
+  async deleteUnreferencedIdentities(): Promise<void> {
+    await this.db
+      .deleteFrom('face_identity')
+      .where(({ not, exists, selectFrom, ref }) =>
+        not(
+          exists(
+            selectFrom('person')
+              .select(sql`1`.as('one'))
+              .whereRef('person.identityId', '=', ref('face_identity.id')),
+          ),
+        ),
+      )
+      .where(({ not, exists, selectFrom, ref }) =>
+        not(
+          exists(
+            selectFrom('shared_space_person')
+              .select(sql`1`.as('one'))
+              .whereRef('shared_space_person.identityId', '=', ref('face_identity.id')),
+          ),
+        ),
+      )
+      .where(({ not, exists, selectFrom, ref }) =>
+        not(
+          exists(
+            selectFrom('face_identity_face')
+              .select(sql`1`.as('one'))
+              .whereRef('face_identity_face.identityId', '=', ref('face_identity.id')),
+          ),
+        ),
+      )
+      .execute();
+  }
+
   async backfillPersonalIdentities(input: { cursor?: string; limit: number }): Promise<BackfillResult> {
     const people = await this.db
       .selectFrom('person')

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -67,6 +67,8 @@ describe(PersonService.name, () => {
     faceIdentityMock.getPendingSharedSpaceFaceMatchBackfillTargets.mockResolvedValue([]);
     faceIdentityMock.deletePendingSharedSpaceFaceMatchBackfillTargets ??= vi.fn();
     faceIdentityMock.deletePendingSharedSpaceFaceMatchBackfillTargets.mockResolvedValue(void 0);
+    faceIdentityMock.deleteUnreferencedIdentities ??= vi.fn();
+    faceIdentityMock.deleteUnreferencedIdentities.mockResolvedValue(void 0);
     (mocks.person as any).getPeopleOverviewStatistics ??= vi.fn();
     (mocks.person as any).getPeopleFaceStatistics ??= vi.fn();
     (mocks.faceIdentity as any).getAccessiblePersonByProfileId.mockResolvedValue(void 0);
@@ -1424,6 +1426,30 @@ describe(PersonService.name, () => {
       await sut.handleQueueRecognizeFaces({ force: true });
 
       expect(mocks.faceIdentity.unlinkFacesBySourceType).toHaveBeenCalledWith(SourceType.MachineLearning);
+    });
+
+    it('should delete unreferenced identities after force reset removes people and shared-space people', async () => {
+      const face = AssetFaceFactory.from().person().build();
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+      mocks.person.unassignFaces.mockResolvedValue();
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
+
+      await sut.handleQueueRecognizeFaces({ force: true });
+
+      expect((mocks.faceIdentity as any).deleteUnreferencedIdentities).toHaveBeenCalledOnce();
+      expect(mocks.faceIdentity.unlinkFacesBySourceType.mock.invocationCallOrder[0]).toBeLessThan(
+        (mocks.faceIdentity as any).deleteUnreferencedIdentities.mock.invocationCallOrder[0],
+      );
+      expect(mocks.sharedSpace.deleteAllPersonFaces.mock.invocationCallOrder[0]).toBeLessThan(
+        (mocks.faceIdentity as any).deleteUnreferencedIdentities.mock.invocationCallOrder[0],
+      );
+      expect(mocks.sharedSpace.deleteAllPersons.mock.invocationCallOrder[0]).toBeLessThan(
+        (mocks.faceIdentity as any).deleteUnreferencedIdentities.mock.invocationCallOrder[0],
+      );
     });
 
     it('should run nightly if new face has been added since last run', async () => {
@@ -3471,6 +3497,78 @@ describe(PersonService.name, () => {
       await sut.handleRecognizeFaces({ id: noPerson1.id });
 
       expect(mocks.search.searchFaces).toHaveBeenCalledTimes(2);
+      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+        faceIds: [noPerson1.id],
+        newPersonId: person.id,
+      });
+    });
+
+    it('should use a relaxed existing-person search before creating a new core person', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+      const [noPerson1, noPerson2, noPerson3] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.create(),
+        AssetFaceFactory.create(),
+      ];
+      const faces = [
+        { ...noPerson1, distance: 0 },
+        { ...noPerson2, distance: 0.31 },
+        { ...noPerson3, distance: 0.34 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
+      mocks.search.searchFaces
+        .mockResolvedValueOnce(faces)
+        .mockResolvedValueOnce([{ ...noPerson2, personId: person.id, distance: 0.56 }]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
+
+      await sut.handleRecognizeFaces({ id: noPerson1.id });
+
+      expect(mocks.search.searchFaces).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          hasPerson: true,
+          maxDistance: 0.6,
+          numResults: 5,
+        }),
+      );
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+        faceIds: [noPerson1.id],
+        newPersonId: person.id,
+      });
+    });
+
+    it('should attach a deferred small cluster to a relaxed existing-person match', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+      const [noPerson1, noPerson2] = [AssetFaceFactory.create({ assetId: asset.id }), AssetFaceFactory.create()];
+      const faces = [
+        { ...noPerson1, distance: 0 },
+        { ...noPerson2, distance: 0.34 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
+      mocks.search.searchFaces
+        .mockResolvedValueOnce(faces)
+        .mockResolvedValueOnce([{ ...noPerson2, personId: person.id, distance: 0.56 }]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
+
+      await sut.handleRecognizeFaces({ id: noPerson1.id, deferred: true });
+
+      expect(mocks.search.searchFaces).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          hasPerson: true,
+          maxDistance: 0.6,
+          numResults: 5,
+        }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.PersonGenerateThumbnail }),
+      );
+      expect(mocks.person.create).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
         faceIds: [noPerson1.id],
         newPersonId: person.id,

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -66,6 +66,8 @@ import { isFacialRecognitionEnabled } from 'src/utils/misc';
 import { Point, transformPoints } from 'src/utils/transform';
 
 const FACE_IDENTITY_BACKFILL_CHUNK_SIZE = 1000;
+const EXISTING_PERSON_MATCH_DISTANCE_BUFFER = 0.1;
+const EXISTING_PERSON_MATCH_RESULT_LIMIT = 5;
 
 @Injectable()
 export class PersonService extends BaseService {
@@ -808,6 +810,7 @@ export class PersonService extends BaseService {
       // space-persons are lost by design (Force already clears named native persons).
       await this.sharedSpaceRepository.deleteAllPersonFaces();
       await this.sharedSpaceRepository.deleteAllPersons();
+      await this.faceIdentityRepository.deleteUnreferencedIdentities();
     } else if (waiting) {
       this.logger.debug(
         `Skipping facial recognition queueing because ${waiting} job${waiting > 1 ? 's are' : ' is'} already queued`,
@@ -964,8 +967,8 @@ export class PersonService extends BaseService {
       const matchWithPerson = await this.searchRepository.searchFaces({
         userIds: [face.asset.ownerId],
         embedding: face.faceSearch.embedding,
-        maxDistance: machineLearning.facialRecognition.maxDistance,
-        numResults: 1,
+        maxDistance: Math.min(1, machineLearning.facialRecognition.maxDistance + EXISTING_PERSON_MATCH_DISTANCE_BUFFER),
+        numResults: EXISTING_PERSON_MATCH_RESULT_LIMIT,
         hasPerson: true,
         minBirthDate: new Date(face.asset.fileCreatedAt),
       });


### PR DESCRIPTION
## Summary
- delete unreferenced face_identity rows during forced facial-recognition reset after people/space people are wiped
- use a slightly relaxed existing-person fallback search before creating a new person from a core self-cluster
- add regression coverage for reset cleanup and small-cluster matching

## Tests
- pnpm --dir server test src/services/person.service.spec.ts
- pnpm --dir server test src/services/shared-space.service.spec.ts
- pnpm --dir server check
- pnpm --dir server exec prettier --check src/services/person.service.ts src/services/person.service.spec.ts src/repositories/face-identity.repository.ts
- pnpm --dir server exec eslint src/services/person.service.ts src/services/person.service.spec.ts src/repositories/face-identity.repository.ts --max-warnings 0