### PR TITLE
fix(server): requeue paused shared-space face jobs

### DIFF
--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -455,7 +455,8 @@ describe(JobRepository.name, () => {
 
     await sut.queue({ name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1' } });
 
-    expect(queue.getJob).not.toHaveBeenCalled();
+    expect(queue.getJob).toHaveBeenCalledWith('shared-space-face-match-page/space-1/start');
+    expect(failedJob.getState).toHaveBeenCalled();
     expect(failedJob.remove).not.toHaveBeenCalled();
     expect(queue.add).toHaveBeenCalledWith(
       JobName.SharedSpaceFaceMatchPage,
@@ -579,5 +580,37 @@ describe(JobRepository.name, () => {
         removeOnComplete: true,
       },
     );
+  });
+
+  it.each([
+    [
+      JobName.SharedSpaceFaceMatch,
+      { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+      'shared-space-face-match/identity-backfill/space-1/asset-1',
+    ],
+    [JobName.SharedSpaceFaceMatchAll, { spaceId: 'space-1' }, 'shared-space-face-match-all/space-1'],
+    [
+      JobName.SharedSpaceFaceMatchPage,
+      { spaceId: 'space-1', afterAssetId: 'asset-9' },
+      'shared-space-face-match-page/space-1/after/asset-9',
+    ],
+  ])('replaces paused stable %s jobs before requeueing them', async (name, data, jobId) => {
+    const { sut, queue } = setup();
+    const pausedJob = {
+      getState: vi.fn().mockResolvedValue('paused'),
+      remove: vi.fn().mockResolvedValue(void 0),
+    };
+    queue.getJob.mockResolvedValue(pausedJob);
+    setHandlers(sut, [name]);
+
+    await sut.queue({ name, data } as any);
+
+    expect(queue.getJob).toHaveBeenCalledWith(jobId);
+    expect(pausedJob.getState).toHaveBeenCalled();
+    expect(pausedJob.remove).toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(name, data, {
+      jobId,
+      removeOnComplete: true,
+    });
   });
 });

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -228,6 +228,8 @@ export class JobRepository {
           }
 
           job.options = action.options;
+        } else if (this.isSharedSpaceFacePipelineJob(item.name)) {
+          await this.removePausedStableJob(queue, job.options.jobId);
         }
 
         promises.push(queue.add(item.name, item.data, job.options));
@@ -381,6 +383,26 @@ export class JobRepository {
     if (state === 'failed') {
       await existingJob.remove();
     }
+  }
+
+  private async removePausedStableJob(queue: Queue, jobId: string) {
+    const existingJob = await queue.getJob(jobId);
+    if (!existingJob) {
+      return;
+    }
+
+    const state = (await existingJob.getState()) as string;
+    if (state === 'paused') {
+      await existingJob.remove();
+    }
+  }
+
+  private isSharedSpaceFacePipelineJob(name: JobName): boolean {
+    return (
+      name === JobName.SharedSpaceFaceMatch ||
+      name === JobName.SharedSpaceFaceMatchAll ||
+      name === JobName.SharedSpaceFaceMatchPage
+    );
   }
 
   private async prepareFacialRecognitionQueueAll(

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { AssetVisibility, JobName, JobStatus, SharedSpaceRole } from 'src/enum';
+import { AssetVisibility, JobName, JobStatus, SharedSpaceRole, SourceType } from 'src/enum';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
@@ -107,6 +107,45 @@ const createIdentityFace = async (
   return { person, identity, asset, assetFace };
 };
 
+const createExifIdentityFace = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  faceIdentityRepository: FaceIdentityRepository,
+  input: {
+    ownerId: string;
+    libraryId: string;
+    personId?: string;
+    identityId?: string;
+    name?: string;
+  },
+) => {
+  const { result: person } = input.personId
+    ? {
+        result: await ctx.database
+          .selectFrom('person')
+          .selectAll()
+          .where('id', '=', input.personId)
+          .executeTakeFirstOrThrow(),
+      }
+    : await ctx.newPerson({ ownerId: input.ownerId, name: input.name ?? 'Alice EXIF' });
+  const identity =
+    input.identityId === undefined
+      ? await faceIdentityRepository.ensurePersonIdentity(person.id)
+      : { id: input.identityId, type: 'person' };
+  const { asset } = await ctx.newAsset({
+    ownerId: input.ownerId,
+    libraryId: input.libraryId,
+    visibility: AssetVisibility.Timeline,
+  });
+  const { assetFace } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: person.id,
+    sourceType: SourceType.Exif,
+  });
+  await faceIdentityRepository.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'import' });
+
+  return { person, identity, asset, assetFace };
+};
+
 const createLegacyPetFace = async (
   ctx: ReturnType<typeof setup>['ctx'],
   input: {
@@ -131,6 +170,56 @@ const createLegacyPetFace = async (
 };
 
 describe('SharedSpaceService linked-library face identity repair', () => {
+  it('full-space rematch assigns every EXIF identity face in linked libraries without embeddings', async () => {
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
+    const { user } = await ctx.newUser();
+    const { space: firstSpace } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: secondSpace } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: firstSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: secondSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: firstSpace.id, libraryId: library.id, addedById: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: secondSpace.id, libraryId: library.id, addedById: user.id });
+    const first = await createExifIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      name: 'Alice EXIF',
+    });
+    const second = await createExifIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      personId: first.person.id,
+      identityId: first.identity.id,
+    });
+
+    await expect(sut.handleSharedSpaceFaceMatchAll({ spaceId: firstSpace.id })).resolves.toBe(JobStatus.Success);
+    await expect(sut.handleSharedSpaceFaceMatchAll({ spaceId: secondSpace.id })).resolves.toBe(JobStatus.Success);
+    await drainSharedSpaceFaceJobs(sut, jobs);
+
+    for (const space of [firstSpace, secondSpace]) {
+      const people = await ctx.database
+        .selectFrom('shared_space_person')
+        .selectAll()
+        .where('spaceId', '=', space.id)
+        .where('identityId', '=', first.identity.id)
+        .execute();
+      expect(people).toHaveLength(1);
+      await expect(
+        sharedSpaceRepository.getPersonFaceAssignmentsForSpace(first.assetFace.id, space.id),
+      ).resolves.toEqual([{ personId: people[0].id, identityId: first.identity.id, type: 'person' }]);
+      await expect(
+        sharedSpaceRepository.getPersonFaceAssignmentsForSpace(second.assetFace.id, space.id),
+      ).resolves.toEqual([{ personId: people[0].id, identityId: first.identity.id, type: 'person' }]);
+      await expect(
+        sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+      ).resolves.toMatchObject({
+        detectedFaceCount: 2,
+        assignedVisibleFaceCount: 2,
+        unassignedFaceCount: 0,
+      });
+    }
+  });
+
   it('library sync creates one identity-backed space person across multiple linked libraries', async () => {
     const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
     const { user } = await ctx.newUser();


### PR DESCRIPTION
## Summary
- replace paused stable shared-space face jobs before requeueing so stale Redis paused entries do not block rebuilds
- add queue regression coverage for SharedSpaceFaceMatch, SharedSpaceFaceMatchAll, and SharedSpaceFaceMatchPage
- add EXIF-only linked-library rematch coverage without face embeddings

## Test plan
- pnpm --filter immich test --run src/repositories/job.repository.spec.ts
- pnpm --filter immich test --run src/services/person.service.spec.ts src/services/shared-space.service.spec.ts src/repositories/job.repository.spec.ts
- pnpm --filter immich test:medium --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts
- pnpm --filter immich exec prettier --check src/repositories/job.repository.ts src/repositories/job.repository.spec.ts test/medium/specs/services/shared-space-face-identity-repair.spec.ts
- pnpm --filter immich exec eslint src/repositories/job.repository.ts src/repositories/job.repository.spec.ts test/medium/specs/services/shared-space-face-identity-repair.spec.ts --max-warnings 0