### PR TITLE
fix(mobile): keep albums visible after tab navigation

### DIFF
--- a/mobile/lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart
+++ b/mobile/lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart
@@ -119,10 +119,9 @@ class _GalleryBottomNavState extends ConsumerState<GalleryBottomNav> {
   }
 
   /// Single entry point for all tab-tap side effects. Mirrors upstream
-  /// `_onNavigationSelected` in `tab_shell.page.dart`: invalidations fire on
+  /// `_onNavigationSelected` in `tab_shell.page.dart`: side effects fire on
   /// EVERY tap (including re-taps of the same tab) — the shell-level
-  /// `tabsRouter.addListener` only fires on index CHANGES, so putting
-  /// invalidations there would regress upstream behaviour.
+  /// `tabsRouter.addListener` only fires on index CHANGES.
   void _onTabTap(GalleryTabEnum tab) {
     final currentIndex = widget.tabsRouter.activeIndex;
 
@@ -135,7 +134,7 @@ class _GalleryBottomNavState extends ConsumerState<GalleryBottomNav> {
         ref.invalidate(driftMemoryFutureProvider);
         break;
       case GalleryTabEnum.albums:
-        ref.invalidate(remoteAlbumProvider);
+        unawaited(ref.read(remoteAlbumProvider.notifier).refresh());
         break;
       case GalleryTabEnum.library:
         ref.invalidate(localAlbumProvider);

--- a/mobile/test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
+++ b/mobile/test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
@@ -10,7 +10,9 @@ import 'package:immich_mobile/presentation/widgets/gallery_nav/gallery_search_bl
 import 'package:immich_mobile/providers/gallery_nav/bottom_nav_height.provider.dart';
 import 'package:immich_mobile/providers/gallery_nav/gallery_tab_enum.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
 
 import '../../../test_helpers/fake_tabs_router.dart';
 
@@ -42,6 +44,18 @@ class _NoOpHaptic extends HapticNotifier {
   dynamic heavyImpact() => null;
   @override
   dynamic vibrate() => null;
+}
+
+class _FakeRemoteAlbumNotifier extends RemoteAlbumNotifier {
+  int refreshCalls = 0;
+
+  @override
+  RemoteAlbumState build() => const RemoteAlbumState(albums: []);
+
+  @override
+  Future<void> refresh() async {
+    refreshCalls++;
+  }
 }
 
 /// Default portrait MediaQueryData (400x900) so tests exercise the pill branch.
@@ -261,13 +275,35 @@ void main() {
 
   testWidgets('tapping a different tab calls tabsRouter.setActiveIndex', (tester) async {
     final router = FakeTabsRouter(initialIndex: GalleryTabEnum.photos.index);
-    await tester.pumpWidget(_wrap(GalleryBottomNav(tabsRouter: router)));
+    await tester.pumpWidget(
+      _wrap(
+        GalleryBottomNav(tabsRouter: router),
+        overrides: [remoteAlbumProvider.overrideWith(_FakeRemoteAlbumNotifier.new)],
+      ),
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('nav_albums'.tr()));
     await tester.pumpAndSettle();
 
     expect(router.setCalls, contains(GalleryTabEnum.albums.index));
+  });
+
+  testWidgets('tapping Albums refreshes the existing album provider', (tester) async {
+    final router = FakeTabsRouter(initialIndex: GalleryTabEnum.photos.index);
+    final remoteAlbumNotifier = _FakeRemoteAlbumNotifier();
+    await tester.pumpWidget(
+      _wrap(
+        GalleryBottomNav(tabsRouter: router),
+        overrides: [remoteAlbumProvider.overrideWith(() => remoteAlbumNotifier)],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('nav_albums'.tr()));
+    await tester.pumpAndSettle();
+
+    expect(remoteAlbumNotifier.refreshCalls, 1);
   });
 
   testWidgets('readonly landscape rail: Photos destination enabled, others disabled', (tester) async {


### PR DESCRIPTION
## Summary
- refresh the existing remote album provider when opening the Albums tab instead of invalidating it
- add a regression test covering Albums tab refresh behavior

Fixes #540

## Testing
- mise x flutter@3.41.7 -- flutter test test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
- mise x flutter@3.41.7 -- dart analyze lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
- mise x flutter@3.41.7 -- flutter run -d R5CR910DN5F