### PR TITLE
fix(server): make person search case-insensitive

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -309,11 +309,14 @@ from
   "person"
 where
   "person"."ownerId" = $1
-  and f_unaccent ("person"."name") %> f_unaccent ($2)
+  and (
+    f_unaccent ("person"."name") ilike '%' || f_unaccent ($2) || '%'
+    or f_unaccent ("person"."name") %> f_unaccent ($3)
+  )
 order by
-  f_unaccent ("person"."name") <->>> f_unaccent ($3)
+  f_unaccent ("person"."name") <->>> f_unaccent ($4)
 limit
-  $4
+  $5
 
 -- PersonRepository.getDistinctNames
 select distinct

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -310,8 +310,8 @@ from
 where
   "person"."ownerId" = $1
   and (
-    f_unaccent ("person"."name") ilike '%' || f_unaccent ($2) || '%'
-    or f_unaccent ("person"."name") %> f_unaccent ($3)
+    f_unaccent ("person"."name") ILIKE '%' || f_unaccent ($2) || '%'
+    OR f_unaccent ("person"."name") %> f_unaccent ($3)
   )
 order by
   f_unaccent ("person"."name") <->>> f_unaccent ($4)

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -456,7 +456,7 @@ export class PersonRepository {
       .where('person.ownerId', '=', userId)
       .where(
         () =>
-          sql`f_unaccent("person"."name") ILIKE '%' || f_unaccent(${personName}) || '%' OR f_unaccent("person"."name") %> f_unaccent(${personName})`,
+          sql`(f_unaccent("person"."name") ILIKE '%' || f_unaccent(${personName}) || '%' OR f_unaccent("person"."name") %> f_unaccent(${personName}))`,
       )
       .orderBy(sql`f_unaccent("person"."name") <->>> f_unaccent(${personName})`)
       .limit(100)

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -454,7 +454,10 @@ export class PersonRepository {
       .selectFrom(['similarity_threshold', 'person'])
       .selectAll('person')
       .where('person.ownerId', '=', userId)
-      .where(() => sql`f_unaccent("person"."name") %> f_unaccent(${personName})`)
+      .where(
+        () =>
+          sql`f_unaccent("person"."name") ILIKE '%' || f_unaccent(${personName}) || '%' OR f_unaccent("person"."name") %> f_unaccent(${personName})`,
+      )
       .orderBy(sql`f_unaccent("person"."name") <->>> f_unaccent(${personName})`)
       .limit(100)
       .$if(!withHidden, (qb) => qb.where('person.isHidden', '=', false))

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -24,6 +24,18 @@ beforeAll(async () => {
 });
 
 describe(PersonRepository.name, () => {
+  describe('getByName', () => {
+    it('matches names case-insensitively', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'bob' });
+
+      const result = await sut.getByName(user.id, 'Bob', { withHidden: false });
+
+      expect(result.map((person) => person.id)).toContain(person.id);
+    });
+  });
+
   describe('getPeopleOverviewStatistics', () => {
     it('counts visible and hidden personal people and all detected timeline faces in owned assets', async () => {
       const { ctx, sut } = setup();


### PR DESCRIPTION
Closes #547

## Summary
- make person name search explicitly case-insensitive for substring matches
- keep existing fuzzy matching order behavior
- add a medium regression test for searching Bob when the stored name is bob

## Test plan
- `pnpm exec vitest --config test/vitest.config.medium.mjs test/medium/specs/repositories/person.repository.spec.ts -t 'matches names case-insensitively'`
- `pnpm --filter immich exec prettier --check src/repositories/person.repository.ts test/medium/specs/repositories/person.repository.spec.ts`
- `pnpm --filter immich exec eslint src/repositories/person.repository.ts test/medium/specs/repositories/person.repository.spec.ts --max-warnings 0`
- `pnpm exec vitest --config test/vitest.config.medium.mjs test/medium/specs/repositories/person.repository.spec.ts`