### PR TITLE
fix: allow lower auto-classification thresholds

### DIFF
--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -309,6 +309,26 @@ describe(SystemConfigService.name, () => {
       expect(result.classification.categories[0].faceExclusion).toBe('off');
     });
 
+    it('should accept low classification similarity thresholds', () => {
+      const result = SystemConfigSchema.parse({
+        ...defaults,
+        classification: {
+          enabled: true,
+          categories: [
+            {
+              name: 'Cars',
+              prompts: ['a car photo'],
+              similarity: 0.01,
+              action: 'tag',
+              enabled: true,
+            },
+          ],
+        },
+      });
+
+      expect(result.classification.categories[0].similarity).toBe(0.01);
+    });
+
     it('should accept all classification faceExclusion modes', () => {
       const result = SystemConfigSchema.parse({
         ...defaults,

--- a/web/src/routes/admin/system-settings/ClassificationSettings.spec.ts
+++ b/web/src/routes/admin/system-settings/ClassificationSettings.spec.ts
@@ -194,6 +194,60 @@ describe('ClassificationSettings', () => {
     expect(modalManager.showDialog).not.toHaveBeenCalled();
   });
 
+  it('should allow saving very loose similarity thresholds', async () => {
+    vi.mocked(getConfig).mockResolvedValue(makeConfig([makeCategory({ similarity: 0.28 })]));
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Screenshots')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByLabelText('Edit'));
+
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('min', '0.01');
+    expect(slider).toHaveAttribute('max', '1');
+    expect(
+      screen.getByText('Start around 0.15-0.30, then lower for broader matches or raise for stricter matches.'),
+    ).toBeInTheDocument();
+
+    await fireEvent.input(slider, { target: { value: '0.11' } });
+    await fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith({
+        systemConfigDto: expect.objectContaining({
+          classification: expect.objectContaining({
+            categories: [expect.objectContaining({ similarity: 0.11 })],
+          }),
+        }),
+      });
+    });
+  });
+
+  it('should allow saving very strict similarity thresholds', async () => {
+    vi.mocked(getConfig).mockResolvedValue(makeConfig([makeCategory({ similarity: 0.28 })]));
+
+    render(ClassificationSettings);
+    await waitFor(() => {
+      expect(screen.getByText('Screenshots')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByLabelText('Edit'));
+    await fireEvent.input(screen.getByRole('slider'), { target: { value: '0.80' } });
+    await fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(updateConfig).toHaveBeenCalledWith({
+        systemConfigDto: expect.objectContaining({
+          classification: expect.objectContaining({
+            categories: [expect.objectContaining({ similarity: 0.8 })],
+          }),
+        }),
+      });
+    });
+  });
+
   it('should NOT show rescan dialog when creating a new category', async () => {
     render(ClassificationSettings);
     await waitFor(() => {

--- a/web/src/routes/admin/system-settings/ClassificationSettings.svelte
+++ b/web/src/routes/admin/system-settings/ClassificationSettings.svelte
@@ -241,8 +241,8 @@
             <input
               id="category-similarity"
               type="range"
-              min="0.15"
-              max="0.45"
+              min="0.01"
+              max="1"
               step="0.01"
               bind:value={formSimilarity}
               {disabled}
@@ -250,6 +250,9 @@
             />
             <span class="text-xs text-gray-500 dark:text-gray-400">Strict</span>
           </div>
+          <Text size="tiny" color="muted" class="mt-1">
+            Start around 0.15-0.30, then lower for broader matches or raise for stricter matches.
+          </Text>
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
- lower the AutoClassify similarity slider floor from 0.15 to 0.01
- add UI coverage for saving very loose thresholds like 0.11
- add server config schema coverage for preserving 0.01 thresholds

Fixes #554

## Tests
- pnpm --filter @immich/sdk build
- pnpm --filter immich-web exec vitest --run src/routes/admin/system-settings/ClassificationSettings.spec.ts
- pnpm --filter immich exec vitest --config test/vitest.config.mjs --run src/services/system-config.service.spec.ts
- prettier checks for touched files