### PR TITLE
fix(server): generate HEIC thumbnails via ffmpeg

### DIFF
--- a/e2e/src/specs/server/api/asset.e2e-spec.ts
+++ b/e2e/src/specs/server/api/asset.e2e-spec.ts
@@ -1073,6 +1073,19 @@ describe('/asset', () => {
       expect(asset.exifInfo).toBeDefined();
       expect(asset.exifInfo).toMatchObject(expected.exifInfo);
       expect(asset).toMatchObject(expected);
+
+      if (input === 'formats/heic/IMG_2682.heic') {
+        await utils.waitForQueueFinish(admin.accessToken, 'thumbnailGeneration');
+
+        const { status, body, type } = await request(app)
+          .get(`/assets/${id}/thumbnail?size=thumbnail`)
+          .set('Authorization', `Bearer ${admin.accessToken}`);
+
+        expect(status).toBe(200);
+        expect(body).toBeInstanceOf(Buffer);
+        expect(body.length).toBeGreaterThan(0);
+        expect(type).toMatch(/^image\//);
+      }
     });
 
     it('should handle a duplicate', async () => {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -938,6 +938,25 @@ describe(MediaService.name, () => {
       });
     });
 
+    it('should convert HEIC through ffmpeg before decoding thumbnails', async () => {
+      const asset = AssetFactory.from({ originalFileName: 'IMG_1234.HEIC', originalPath: '/original/IMG_1234.HEIC' })
+        .exif({ fileSizeInByte: 5000, orientation: ExifOrientation.Rotate90CW.toString() })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+
+      await sut.handleGenerateThumbnails({ id: asset.id });
+
+      expect(mocks.media.extractFrame).toHaveBeenCalledWith(asset.originalPath, expect.stringContaining('.jpeg'), 0);
+      expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(expect.stringContaining('.jpeg'), {
+        colorspace: Colorspace.Srgb,
+        orientation: ExifOrientation.Rotate90CW,
+        processInvalidImages: false,
+        size: 1440,
+      });
+      expect(mocks.media.generateThumbnail).toHaveBeenCalledTimes(2);
+    });
+
     it('should not check transparency metadata for raw files without extracted images', async () => {
       const asset = AssetFactory.from({ originalFileName: 'file.dng' })
         .exif({ fileSizeInByte: 5000, profileDescription: 'Adobe RGB', bitsPerSample: 14, orientation: undefined })
@@ -1195,8 +1214,7 @@ describe(MediaService.name, () => {
       mocks.systemMetadata.get.mockResolvedValue({ image: { fullsize: { enabled: true } } });
       mocks.media.extract.mockResolvedValue({ buffer: extractedBuffer, format: RawExtractedFormat.Jpeg });
       mocks.media.getImageMetadata.mockResolvedValue({ width: 3840, height: 2160, isTransparent: false });
-      // HEIF/HIF image taken by cameras are not web-friendly, only has limited support on Safari.
-      const asset = AssetFactory.from({ originalFileName: 'image.hif' })
+      const asset = AssetFactory.from({ originalFileName: 'image.tif' })
         .exif({
           fileSizeInByte: 5000,
           profileDescription: 'Adobe RGB',
@@ -1303,8 +1321,7 @@ describe(MediaService.name, () => {
       });
       mocks.media.extract.mockResolvedValue({ buffer: extractedBuffer, format: RawExtractedFormat.Jpeg });
       mocks.media.getImageMetadata.mockResolvedValue({ width: 3840, height: 2160, isTransparent: false });
-      // HEIF/HIF image taken by cameras are not web-friendly, only has limited support on Safari.
-      const asset = AssetFactory.from({ originalFileName: 'image.hif' })
+      const asset = AssetFactory.from({ originalFileName: 'image.tif' })
         .exif({
           fileSizeInByte: 5000,
           profileDescription: 'Adobe RGB',
@@ -1343,7 +1360,7 @@ describe(MediaService.name, () => {
       });
       mocks.media.extract.mockResolvedValue({ buffer: extractedBuffer, format: RawExtractedFormat.Jpeg });
       mocks.media.getImageMetadata.mockResolvedValue({ width: 3840, height: 2160, isTransparent: false });
-      const asset = AssetFactory.from({ originalFileName: 'image.hif' })
+      const asset = AssetFactory.from({ originalFileName: 'image.tif' })
         .exif({
           fileSizeInByte: 5000,
           profileDescription: 'Adobe RGB',
@@ -1972,6 +1989,32 @@ describe(MediaService.name, () => {
       await expect(sut.handleGeneratePersonThumbnail({ id: person.id })).resolves.toBe(JobStatus.Success);
 
       expect(mocks.media.extract).not.toHaveBeenCalled();
+      expect(mocks.media.generateThumbnail).toHaveBeenCalled();
+    });
+
+    it('should convert HEIC through ffmpeg before decoding person thumbnails', async () => {
+      const person = PersonFactory.create();
+      const data = {
+        ...personThumbnailStub.newThumbnailMiddle,
+        originalPath: '/original/IMG_1234.HEIC',
+        previewPath: null,
+      };
+
+      mocks.person.getDataForThumbnailGenerationJob.mockResolvedValue(data);
+      mocks.media.generateThumbnail.mockResolvedValue();
+      mocks.media.decodeImage.mockResolvedValue({
+        data: Buffer.from(''),
+        info: { width: 2160, height: 3840 } as OutputInfo,
+      });
+
+      await expect(sut.handleGeneratePersonThumbnail({ id: person.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.media.extractFrame).toHaveBeenCalledWith(data.originalPath, expect.stringContaining('.jpeg'), 0);
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(expect.stringContaining('.jpeg'), {
+        colorspace: Colorspace.P3,
+        orientation: ExifOrientation.Horizontal,
+        processInvalidImages: false,
+      });
       expect(mocks.media.generateThumbnail).toHaveBeenCalled();
     });
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { createReadStream } from 'node:fs';
-import { unlink } from 'node:fs/promises';
-import { isAbsolute } from 'node:path';
+import { mkdtemp, rm, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
 import { DiskStorageBackend } from 'src/backends/disk-storage.backend';
 import { SystemConfig } from 'src/config';
 import { FACE_THUMBNAIL_SIZE, JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
@@ -438,6 +439,22 @@ export class MediaService extends BaseService {
     return extracted;
   }
 
+  private async extractHeifFrame(originalPath: string) {
+    const outputDir = await mkdtemp(join(tmpdir(), 'gallery-heif-thumbnail-'));
+    const outputPath = join(outputDir, 'frame.jpeg');
+
+    try {
+      await this.mediaRepository.extractFrame(originalPath, outputPath, 0);
+      return {
+        path: outputPath,
+        cleanup: () => rm(outputDir, { force: true, recursive: true }),
+      };
+    } catch (error) {
+      await rm(outputDir, { force: true, recursive: true });
+      throw error;
+    }
+  }
+
   private async decodeImage(thumbSource: string | Buffer, exifInfo: ThumbnailAsset['exifInfo'], targetSize?: number) {
     const { image } = await this.getConfig({ withCache: true });
     const colorspace = this.isSRGB(exifInfo) ? Colorspace.Srgb : image.colorspace;
@@ -461,35 +478,44 @@ export class MediaService extends BaseService {
     const inputPath = localOriginalPath ?? asset.originalPath;
     const extractEmbedded = image.extractEmbedded && mimeTypes.isRaw(asset.originalFileName);
     const extracted = extractEmbedded ? await this.extractImage(inputPath, image.preview.size) : null;
+    const heifFrame =
+      !extracted && (mimeTypes.isHeif(asset.originalFileName) || mimeTypes.isHeif(asset.originalPath))
+        ? await this.extractHeifFrame(inputPath)
+        : undefined;
     const generateFullsize =
       ((image.fullsize.enabled || asset.exifInfo.projectionType === 'EQUIRECTANGULAR') &&
         !mimeTypes.isWebSupportedImage(asset.originalPath)) ||
       useEdits;
     const convertFullsize = generateFullsize && (!extracted || !mimeTypes.isWebSupportedImage(` .${extracted.format}`));
 
-    const thumbSource = extracted ? extracted.buffer : inputPath;
-    const { data, info, colorspace } = await this.decodeImage(
-      thumbSource,
-      // only specify orientation to extracted images which don't have EXIF orientation data
-      // or it can double rotate the image
-      extracted ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
-      convertFullsize ? undefined : image.preview.size,
-    );
+    try {
+      const thumbSource = extracted ? extracted.buffer : (heifFrame?.path ?? inputPath);
+      const shouldApplyOrientation = !!extracted || !!heifFrame;
+      const { data, info, colorspace } = await this.decodeImage(
+        thumbSource,
+        // only specify orientation to extracted/converted images which don't have EXIF orientation data
+        // or it can double rotate the image
+        shouldApplyOrientation ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
+        convertFullsize ? undefined : image.preview.size,
+      );
 
-    let isTransparent = false;
-    if (!extracted && mimeTypes.canBeTransparent(asset.originalPath)) {
-      ({ isTransparent } = await this.mediaRepository.getImageMetadata(inputPath));
+      let isTransparent = false;
+      if (!extracted && mimeTypes.canBeTransparent(asset.originalPath)) {
+        ({ isTransparent } = await this.mediaRepository.getImageMetadata(inputPath));
+      }
+
+      return {
+        extracted,
+        data,
+        info,
+        colorspace,
+        convertFullsize,
+        generateFullsize,
+        isTransparent,
+      };
+    } finally {
+      await heifFrame?.cleanup();
     }
-
-    return {
-      extracted,
-      data,
-      info,
-      colorspace,
-      convertFullsize,
-      generateFullsize,
-      isTransparent,
-    };
   }
 
   private async generateImageThumbnails(
@@ -619,6 +645,7 @@ export class MediaService extends BaseService {
     // For S3 assets, download to local temp files for processing
     const originalLocal = await this.ensureLocalFile(originalPath);
     const previewLocal = previewPath ? await this.ensureLocalFile(previewPath) : undefined;
+    let heifFrame: Awaited<ReturnType<MediaService['extractHeifFrame']>> | undefined;
 
     try {
       let inputImage: string | Buffer;
@@ -631,6 +658,9 @@ export class MediaService extends BaseService {
       } else if (image.extractEmbedded && mimeTypes.isRaw(originalPath)) {
         const extracted = await this.extractImage(originalLocal.localPath, image.preview.size);
         inputImage = extracted ? extracted.buffer : originalLocal.localPath;
+      } else if (mimeTypes.isHeif(originalPath)) {
+        heifFrame = await this.extractHeifFrame(originalLocal.localPath);
+        inputImage = heifFrame.path;
       } else {
         inputImage = originalLocal.localPath;
       }
@@ -638,8 +668,9 @@ export class MediaService extends BaseService {
       const { data: decodedImage, info } = await this.mediaRepository.decodeImage(inputImage, {
         colorspace: image.colorspace,
         processInvalidImages: process.env.IMMICH_PROCESS_INVALID_IMAGES === 'true',
-        // if this is an extracted image, it may not have orientation metadata
-        orientation: Buffer.isBuffer(inputImage) && exifOrientation ? Number(exifOrientation) : undefined,
+        // if this is an extracted or converted image, it may not have orientation metadata
+        orientation:
+          (Buffer.isBuffer(inputImage) || heifFrame) && exifOrientation ? Number(exifOrientation) : undefined,
       });
 
       const thumbnailPath = StorageCore.getPersonThumbnailPath({ id, ownerId });
@@ -674,6 +705,7 @@ export class MediaService extends BaseService {
 
       return JobStatus.Success;
     } finally {
+      await heifFrame?.cleanup();
       await originalLocal.cleanup();
       await previewLocal?.cleanup();
     }

--- a/server/src/services/user.service.spec.ts
+++ b/server/src/services/user.service.spec.ts
@@ -336,6 +336,24 @@ describe(UserService.name, () => {
       });
     });
 
+    it('should convert HEIC profile uploads through ffmpeg before thumbnailing', async () => {
+      const user = factory.userAdmin({ profileImagePath: '' });
+      const file = { path: `/data/profile/${user.id}/temp-file.HEIC` } as Express.Multer.File;
+      mocks.user.get.mockResolvedValue(user);
+      mocks.user.update.mockImplementation((_, update) =>
+        Promise.resolve({ ...user, ...update, profileChangedAt: update.profileChangedAt ?? new Date() } as UserAdmin),
+      );
+
+      await sut.createProfileImage(factory.auth({ user }), file);
+
+      expect(mocks.media.extractFrame).toHaveBeenCalledWith(file.path, expect.stringContaining('.jpeg'), 0);
+      expect(mocks.media.generateThumbnail).toHaveBeenCalledWith(
+        expect.stringContaining('.jpeg'),
+        expect.any(Object),
+        expect.any(String),
+      );
+    });
+
     describe('with S3 write backend', () => {
       let mockS3Backend: { put: ReturnType<typeof vitest.fn>; getServeStrategy: ReturnType<typeof vitest.fn> };
 

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -49,11 +49,15 @@ const webSupportedImage = {
   '.webp': ['image/webp'],
 };
 
-const webUnsupportedImage = {
-  ...raw,
+const heif = {
   '.heic': ['image/heic'],
   '.heif': ['image/heif'],
   '.hif': ['image/hif'],
+};
+
+const webUnsupportedImage = {
+  ...raw,
+  ...heif,
   '.insp': ['image/jpeg'],
   '.jp2': ['image/jp2'],
   '.jpe': ['image/jpeg'],
@@ -142,8 +146,10 @@ export const mimeTypes = {
   video,
   raw,
   webUnsupportedImage,
+  heif,
 
   isAsset: (filename: string) => isType(filename, image) || isType(filename, video),
+  isHeif: (filename: string) => isType(filename, heif),
   isImage: (filename: string) => isType(filename, image),
   isWebSupportedImage: (filename: string) => isType(filename, webSupportedImage),
   isPossiblyAnimatedImage: (filename: string) => isType(filename, possiblyAnimatedImage),

--- a/server/src/utils/profile-image.ts
+++ b/server/src/utils/profile-image.ts
@@ -1,9 +1,12 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SystemConfig } from 'src/config';
 import { StorageCore } from 'src/cores/storage.core';
 import { StorageFolder } from 'src/enum';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { MediaRepository } from 'src/repositories/media.repository';
+import { mimeTypes } from 'src/utils/mime-types';
 
 type Repos = {
   media: MediaRepository;
@@ -23,18 +26,41 @@ export const generateProfileImage = async (
   );
   storageCore.ensureFolders(outputPath);
 
-  await media.generateThumbnail(
-    input,
-    {
-      colorspace: image.colorspace,
-      format: image.thumbnail.format,
-      quality: image.thumbnail.quality,
-      progressive: image.thumbnail.progressive,
-      size: image.thumbnail.size,
-      processInvalidImages: false,
-    },
-    outputPath,
-  );
+  const inputFrame =
+    typeof input === 'string' && mimeTypes.isHeif(input) ? await extractHeifFrame(media, input) : undefined;
+
+  try {
+    await media.generateThumbnail(
+      inputFrame?.path ?? input,
+      {
+        colorspace: image.colorspace,
+        format: image.thumbnail.format,
+        quality: image.thumbnail.quality,
+        progressive: image.thumbnail.progressive,
+        size: image.thumbnail.size,
+        processInvalidImages: false,
+      },
+      outputPath,
+    );
+  } finally {
+    await inputFrame?.cleanup();
+  }
 
   return outputPath;
+};
+
+const extractHeifFrame = async (media: MediaRepository, input: string) => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'gallery-heif-profile-'));
+  const outputPath = join(outputDir, 'frame.jpeg');
+
+  try {
+    await media.extractFrame(input, outputPath, 0);
+    return {
+      path: outputPath,
+      cleanup: () => rm(outputDir, { force: true, recursive: true }),
+    };
+  } catch (error) {
+    await rm(outputDir, { force: true, recursive: true });
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary
- route HEIC/HEIF/HIF asset thumbnails through ffmpeg frame extraction before Sharp decoding
- apply the same conversion to person thumbnails and HEIC profile image uploads
- add regression coverage for asset thumbnails, person thumbnails, and profile uploads

## Tests
- pnpm -C server exec vitest --config test/vitest.config.mjs --run src/services/media.service.spec.ts
- pnpm -C server exec vitest --config test/vitest.config.mjs --run src/services/user.service.spec.ts
- pnpm -C server exec prettier --check src/services/media.service.ts src/services/media.service.spec.ts src/utils/mime-types.ts src/utils/profile-image.ts src/services/user.service.spec.ts
- pnpm -C server exec eslint src/services/media.service.ts src/services/media.service.spec.ts src/utils/mime-types.ts src/utils/profile-image.ts src/services/user.service.spec.ts --max-warnings 0
- pnpm -C server check
- pnpm -C server test -- --run