### PR TITLE
fix: align person filter suggestion ids

### DIFF
--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -3184,7 +3184,8 @@ describe('tagsDisabled persists across close/reopen', () => {
     m.setQuery('tag');
     await vi.advanceTimersByTimeAsync(200);
     expect(m.sections.tags).toEqual({ status: 'error', message: 'tag_cache_too_large' });
-    const callsAfterFirst = vi.mocked(getAllTags).mock.calls.length;
+    expect((m as unknown as { tagsDisabled: boolean }).tagsDisabled).toBe(true);
+    vi.mocked(getAllTags).mockClear();
     m.close();
     m.open();
     // Swap mock to a tiny list — if tagsDisabled reset, this would succeed and repopulate.
@@ -3195,7 +3196,7 @@ describe('tagsDisabled persists across close/reopen', () => {
     await vi.advanceTimersByTimeAsync(200);
     expect(m.sections.tags).toEqual({ status: 'error', message: 'tag_cache_too_large' });
     // getAllTags should NOT have been re-invoked because tagsDisabled short-circuits.
-    expect(vi.mocked(getAllTags).mock.calls.length).toBe(callsAfterFirst);
+    expect(getAllTags).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 });

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -118,6 +118,35 @@ describe('buildAlbumDetailFilterConfig', () => {
     ]);
   });
 
+  it('maps album people suggestions by scoped filter id', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [
+        {
+          id: 'identity-group-1',
+          filterId: 'person:person-1',
+          name: 'Alice',
+          primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+        },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    } as never);
+
+    const config = buildAlbumDetailFilterConfig('album-1');
+    const result = await config.suggestionsProvider!(createFilterState());
+
+    expect(result.people[0]).toEqual(
+      expect.objectContaining({
+        id: 'person:person-1',
+        name: 'Alice',
+      }),
+    );
+  });
+
   it('passes custom dates to album detail filter suggestions', async () => {
     const config = buildAlbumDetailFilterConfig('album-1');
     await config.suggestionsProvider!({

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -147,6 +147,35 @@ describe('buildMapFilterConfig', () => {
       });
     });
 
+    it('should map global people by scoped filter id', async () => {
+      vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+        countries: [],
+        cameraMakes: [],
+        tags: [],
+        people: [
+          {
+            id: 'identity-group-1',
+            filterId: 'person:person-1',
+            name: 'Alice',
+            primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+          },
+        ],
+        ratings: [],
+        mediaTypes: [],
+        hasUnnamedPeople: false,
+      } as never);
+
+      const config = buildMapFilterConfig();
+      const result = await config.suggestionsProvider!(emptyFilters);
+
+      expect(result.people[0]).toEqual(
+        expect.objectContaining({
+          id: 'person:person-1',
+          name: 'Alice',
+        }),
+      );
+    });
+
     it('should map space-scoped people to shared-space thumbnails', async () => {
       vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
         countries: [],

--- a/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/photos-filter-options.spec.ts
@@ -1,6 +1,7 @@
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import {
   buildPhotosTimelineOptions,
+  getPhotosPersonFilterId,
   getPhotosPersonFilterThumbnailUrl,
   handlePhotosRemoveFilter,
 } from '$lib/utils/photos-filter-options';
@@ -309,5 +310,26 @@ describe('getPhotosPersonFilterThumbnailUrl', () => {
         primaryProfile: { type: Type.UserPerson, id: 'person-1' },
       }),
     ).toBe('/api/people/person-1/thumbnail');
+  });
+});
+
+describe('getPhotosPersonFilterId', () => {
+  it('uses the scoped filterId when suggestions include one', () => {
+    expect(
+      getPhotosPersonFilterId({
+        id: 'identity-group-1',
+        filterId: 'person:person-1',
+        primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+      }),
+    ).toBe('person:person-1');
+  });
+
+  it('falls back to a primary profile scoped id', () => {
+    expect(
+      getPhotosPersonFilterId({
+        id: 'identity-group-1',
+        primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+      }),
+    ).toBe('space-person:space-person-1');
   });
 });

--- a/web/src/lib/utils/__tests__/space-search.spec.ts
+++ b/web/src/lib/utils/__tests__/space-search.spec.ts
@@ -393,6 +393,36 @@ describe('mapSmartSearchFacetsToFilterSuggestions', () => {
       },
     ]);
   });
+
+  it('maps global smart-search facet people by scoped filter id', () => {
+    const result = mapSmartSearchFacetsToFilterSuggestions({
+      total: 1,
+      timeBuckets: [],
+      countries: [],
+      cities: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      people: [
+        {
+          id: 'identity-group-1',
+          filterId: 'person:person-1',
+          name: 'Ada',
+          primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+        } as never,
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+
+    expect(result.people[0]).toEqual(
+      expect.objectContaining({
+        id: 'person:person-1',
+        name: 'Ada',
+      }),
+    );
+  });
 });
 
 describe('SEARCH_FILTER_DEBOUNCE_MS', () => {

--- a/web/src/lib/utils/album-filter-config.ts
+++ b/web/src/lib/utils/album-filter-config.ts
@@ -3,7 +3,7 @@ import {
   type FilterPanelConfig,
   type FilterState,
 } from '$lib/components/filter-panel/filter-panel';
-import { getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
+import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
 
 const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
@@ -14,7 +14,7 @@ function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions
     cameraMakes: response.cameraMakes,
     tags: response.tags.map((tag) => ({ id: tag.id, name: tag.value })),
     people: response.people.map((person) => ({
-      id: person.id,
+      id: getPhotosPersonFilterId(person),
       name: person.name,
       thumbnailUrl: getPhotosPersonFilterThumbnailUrl(person),
     })),

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -4,7 +4,7 @@ import {
   type FilterState,
 } from '$lib/components/filter-panel/filter-panel';
 import { createUrl } from '$lib/utils';
-import { getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
+import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 import {
   AssetTypeEnum,
   getFilterSuggestions,
@@ -53,7 +53,7 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
       cameraMakes: response.cameraMakes,
       tags: response.tags.map((t: { id: string; value: string }) => ({ id: t.id, name: t.value })),
       people: response.people.map((p: FilterSuggestionsPersonDto) => ({
-        id: p.id,
+        id: spaceId ? p.id : getPhotosPersonFilterId(p),
         name: p.name,
         thumbnailUrl: spaceId
           ? createUrl(`/shared-spaces/${spaceId}/people/${p.primaryProfile?.id ?? p.id}/thumbnail`)

--- a/web/src/lib/utils/photos-filter-options.ts
+++ b/web/src/lib/utils/photos-filter-options.ts
@@ -3,6 +3,16 @@ import { buildFilterContext } from '$lib/components/filter-panel/filter-panel';
 import { createUrl } from '$lib/utils';
 import { AssetOrder, AssetTypeEnum, AssetVisibility, type FilterSuggestionsPersonDto } from '@immich/sdk';
 
+type PhotosPersonFilterReference = {
+  id: string;
+  filterId?: string | null;
+  primaryProfile?: {
+    type?: string;
+    id?: string;
+    spaceId?: string;
+  };
+};
+
 export function buildPhotosTimelineOptions(filters: FilterState): Record<string, unknown> {
   const includeSharedTimelineAssets = filters.isFavorite === undefined;
   const base: Record<string, unknown> = {
@@ -71,6 +81,22 @@ export function getPhotosPersonFilterThumbnailUrl(
 
   const userPersonId = person.id.startsWith('person:') ? person.id.slice('person:'.length) : person.id;
   return createUrl(`/people/${userPersonId}/thumbnail`);
+}
+
+export function getPhotosPersonFilterId(person: PhotosPersonFilterReference): string {
+  if (person.filterId) {
+    return person.filterId;
+  }
+
+  if (person.primaryProfile?.type === 'space-person' && person.primaryProfile.id) {
+    return `space-person:${person.primaryProfile.id}`;
+  }
+
+  if (person.primaryProfile?.type === 'user-person' && person.primaryProfile.id) {
+    return `person:${person.primaryProfile.id}`;
+  }
+
+  return person.id;
 }
 
 export function handlePhotosRemoveFilter(filters: FilterState, type: string, id?: string): FilterState {

--- a/web/src/lib/utils/space-search.ts
+++ b/web/src/lib/utils/space-search.ts
@@ -1,6 +1,6 @@
 import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import { createUrl } from '$lib/utils';
-import { getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
+import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 import {
   AssetOrder,
   AssetTypeEnum,
@@ -121,7 +121,7 @@ export function mapSmartSearchFacetsToFilterSuggestions(
     cameraModels: facets.cameraModels,
     tags: facets.tags.map((tag) => ({ id: tag.id, name: tag.value })),
     people: facets.people.map((person) => ({
-      id: person.id,
+      id: options.spaceId ? person.id : getPhotosPersonFilterId(person),
       name: person.name,
       thumbnailUrl: options.spaceId
         ? createUrl(`/shared-spaces/${options.spaceId}/people/${person.id}/thumbnail`)

--- a/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
@@ -48,10 +48,10 @@ describe('resolveTypedSearchFilters', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.queryText).toBe('beach');
-      expect(result.filters.personIds).toEqual(['person-1']);
+      expect(result.filters.personIds).toEqual(['person:person-1']);
       expect(result.filters.tagIds).toEqual(['tag-1']);
       expect(result.filters.make).toBe('Nikon');
-      expect(result.personNames.get('person-1')).toBe('Anna');
+      expect(result.personNames.get('person:person-1')).toBe('Anna');
       expect(result.tagNames.get('tag-1')).toBe('Travel');
     }
   });
@@ -73,6 +73,25 @@ describe('resolveTypedSearchFilters', () => {
       expect(result.filters.personIds).toEqual(['person:person-1']);
       expect(result.filters.personIds).not.toContain('identity-group-1');
       expect(result.personNames.get('person:person-1')).toBe('Anna');
+    }
+  });
+
+  it('prefixes bare global person ids from search results', async () => {
+    vi.mocked(searchPerson).mockResolvedValue([
+      {
+        id: 'b9eab58d-972f-49da-9012-171dbca3cbc3',
+        name: 'a',
+      } as never,
+    ]);
+
+    const result = await resolveTypedSearchFilters(parseTypedSearch('person:a test'), {});
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.queryText).toBe('test');
+      expect(result.filters.personIds).toEqual(['person:b9eab58d-972f-49da-9012-171dbca3cbc3']);
+      expect(result.filters.personIds).not.toContain('b9eab58d-972f-49da-9012-171dbca3cbc3');
+      expect(result.personNames.get('person:b9eab58d-972f-49da-9012-171dbca3cbc3')).toBe('a');
     }
   });
 
@@ -189,10 +208,10 @@ describe('resolveTypedSearchFilters', () => {
     expect(searchPerson).toHaveBeenCalledWith({ name: 'ann', withHidden: false }, { signal: undefined });
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.filters.personIds).toEqual(['person-1', 'person-2']);
+      expect(result.filters.personIds).toEqual(['person-1', 'person:person-2']);
       expect(result.filters.personIds).not.toContain('wrong-raw-person');
       expect(result.personNames.get('person-1')).toBe('Ann Live');
-      expect(result.personNames.get('person-2')).toBe('Ann Search');
+      expect(result.personNames.get('person:person-2')).toBe('Ann Search');
     }
   });
 
@@ -220,7 +239,7 @@ describe('resolveTypedSearchFilters', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.filters.personIds).toEqual(['person-1', 'person-2']);
+      expect(result.filters.personIds).toEqual(['person:person-1', 'person:person-2']);
       expect(result.filters.tagIds).toEqual(['tag-1', 'tag-2']);
     }
   });

--- a/web/src/lib/utils/typed-search/typed-search-resolver.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.ts
@@ -314,6 +314,10 @@ function getPersonFilterId(person: PersonSuggestion, scope: 'global' | 'space') 
     return `person:${person.primaryProfile.id}`;
   }
 
+  if (!person.id.startsWith('person:') && !person.id.startsWith('space-person:')) {
+    return `person:${person.id}`;
+  }
+
   return person.id;
 }
 

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -62,6 +62,7 @@
   import {
     buildPhotosTimelineOptions,
     getPhotosPersonFilterThumbnailUrl,
+    getPhotosPersonFilterId,
     handlePhotosRemoveFilter,
   } from '$lib/utils/photos-filter-options';
   import {
@@ -161,12 +162,12 @@
       ...(nextFilters.isFavorite === undefined ? { withSharedSpaces: true } : {}),
     });
     const mappedPeople = response.people.map((p) => ({
-      id: p.id,
+      id: getPhotosPersonFilterId(p),
       name: p.name,
       thumbnailUrl: getPhotosPersonFilterThumbnailUrl(p),
     }));
     for (const p of response.people) {
-      personNames.set(p.id, p.name);
+      personNames.set(getPhotosPersonFilterId(p), p.name);
     }
     for (const t of response.tags) {
       tagNames.set(t.id, t.value);
@@ -264,7 +265,7 @@
       }
 
       for (const p of facets.people) {
-        personNames.set(p.id, p.name);
+        personNames.set(getPhotosPersonFilterId(p), p.name);
       }
       for (const t of facets.tags) {
         tagNames.set(t.id, t.value);


### PR DESCRIPTION
## Summary
- map global person filter suggestions to scoped filter ids
- keep typed-search person filters aligned with filter panel suggestions
- add regression coverage for photos, album, map, and smart-search facet suggestion mappers

## Testing
- pnpm --filter @immich/sdk build
- pnpm --filter immich-web exec vitest run src/lib/utils/__tests__/photos-filter-options.spec.ts src/lib/utils/__tests__/map-filter-config.spec.ts src/lib/utils/__tests__/album-filter-config.spec.ts src/lib/utils/__tests__/space-search.spec.ts src/lib/utils/typed-search/typed-search-resolver.spec.ts
- pnpm --filter immich-web run check:typescript
- pnpm --filter immich-web run check:svelte