### PR TITLE
feat: show face queue job type breakdown

### DIFF
--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -577,6 +577,7 @@ Class | Method | HTTP request | Description
  - [QueueDeleteDto](doc//QueueDeleteDto.md)
  - [QueueJobResponseDto](doc//QueueJobResponseDto.md)
  - [QueueJobStatus](doc//QueueJobStatus.md)
+ - [QueueJobTypeCountsDto](doc//QueueJobTypeCountsDto.md)
  - [QueueName](doc//QueueName.md)
  - [QueueResponseDto](doc//QueueResponseDto.md)
  - [QueueResponseLegacyDto](doc//QueueResponseLegacyDto.md)

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -270,6 +270,7 @@ part 'model/queue_command_dto.dart';
 part 'model/queue_delete_dto.dart';
 part 'model/queue_job_response_dto.dart';
 part 'model/queue_job_status.dart';
+part 'model/queue_job_type_counts_dto.dart';
 part 'model/queue_name.dart';
 part 'model/queue_response_dto.dart';
 part 'model/queue_response_legacy_dto.dart';

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -576,6 +576,8 @@ class ApiClient {
           return QueueJobResponseDto.fromJson(value);
         case 'QueueJobStatus':
           return QueueJobStatusTypeTransformer().decode(value);
+        case 'QueueJobTypeCountsDto':
+          return QueueJobTypeCountsDto.fromJson(value);
         case 'QueueName':
           return QueueNameTypeTransformer().decode(value);
         case 'QueueResponseDto':

--- a/mobile/openapi/lib/model/queue_job_type_counts_dto.dart
+++ b/mobile/openapi/lib/model/queue_job_type_counts_dto.dart
@@ -1,0 +1,147 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class QueueJobTypeCountsDto {
+  /// Returns a new [QueueJobTypeCountsDto] instance.
+  QueueJobTypeCountsDto({
+    required this.active,
+    required this.delayed,
+    required this.name,
+    required this.paused,
+    required this.waiting,
+  });
+
+  /// Number of sampled active jobs with this name
+  ///
+  /// Minimum value: -9007199254740991
+  /// Maximum value: 9007199254740991
+  int active;
+
+  /// Number of sampled delayed jobs with this name
+  ///
+  /// Minimum value: -9007199254740991
+  /// Maximum value: 9007199254740991
+  int delayed;
+
+  JobName name;
+
+  /// Number of sampled paused jobs with this name
+  ///
+  /// Minimum value: -9007199254740991
+  /// Maximum value: 9007199254740991
+  int paused;
+
+  /// Number of sampled waiting jobs with this name
+  ///
+  /// Minimum value: -9007199254740991
+  /// Maximum value: 9007199254740991
+  int waiting;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is QueueJobTypeCountsDto &&
+    other.active == active &&
+    other.delayed == delayed &&
+    other.name == name &&
+    other.paused == paused &&
+    other.waiting == waiting;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (active.hashCode) +
+    (delayed.hashCode) +
+    (name.hashCode) +
+    (paused.hashCode) +
+    (waiting.hashCode);
+
+  @override
+  String toString() => 'QueueJobTypeCountsDto[active=$active, delayed=$delayed, name=$name, paused=$paused, waiting=$waiting]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'active'] = this.active;
+      json[r'delayed'] = this.delayed;
+      json[r'name'] = this.name;
+      json[r'paused'] = this.paused;
+      json[r'waiting'] = this.waiting;
+    return json;
+  }
+
+  /// Returns a new [QueueJobTypeCountsDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static QueueJobTypeCountsDto? fromJson(dynamic value) {
+    upgradeDto(value, "QueueJobTypeCountsDto");
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return QueueJobTypeCountsDto(
+        active: mapValueOfType<int>(json, r'active')!,
+        delayed: mapValueOfType<int>(json, r'delayed')!,
+        name: JobName.fromJson(json[r'name'])!,
+        paused: mapValueOfType<int>(json, r'paused')!,
+        waiting: mapValueOfType<int>(json, r'waiting')!,
+      );
+    }
+    return null;
+  }
+
+  static List<QueueJobTypeCountsDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <QueueJobTypeCountsDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = QueueJobTypeCountsDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, QueueJobTypeCountsDto> mapFromJson(dynamic json) {
+    final map = <String, QueueJobTypeCountsDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = QueueJobTypeCountsDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of QueueJobTypeCountsDto-objects as value to a dart map
+  static Map<String, List<QueueJobTypeCountsDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<QueueJobTypeCountsDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = QueueJobTypeCountsDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'active',
+    'delayed',
+    'name',
+    'paused',
+    'waiting',
+  };
+}
+

--- a/mobile/openapi/lib/model/queue_response_dto.dart
+++ b/mobile/openapi/lib/model/queue_response_dto.dart
@@ -14,12 +14,16 @@ class QueueResponseDto {
   /// Returns a new [QueueResponseDto] instance.
   QueueResponseDto({
     required this.isPaused,
+    this.jobTypes = const [],
     required this.name,
     required this.statistics,
   });
 
   /// Whether the queue is paused
   bool isPaused;
+
+  /// Sampled job type counts for display purposes
+  List<QueueJobTypeCountsDto> jobTypes;
 
   QueueName name;
 
@@ -28,6 +32,7 @@ class QueueResponseDto {
   @override
   bool operator ==(Object other) => identical(this, other) || other is QueueResponseDto &&
     other.isPaused == isPaused &&
+    _deepEquality.equals(other.jobTypes, jobTypes) &&
     other.name == name &&
     other.statistics == statistics;
 
@@ -35,15 +40,17 @@ class QueueResponseDto {
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (isPaused.hashCode) +
+    (jobTypes.hashCode) +
     (name.hashCode) +
     (statistics.hashCode);
 
   @override
-  String toString() => 'QueueResponseDto[isPaused=$isPaused, name=$name, statistics=$statistics]';
+  String toString() => 'QueueResponseDto[isPaused=$isPaused, jobTypes=$jobTypes, name=$name, statistics=$statistics]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'isPaused'] = this.isPaused;
+      json[r'jobTypes'] = this.jobTypes;
       json[r'name'] = this.name;
       json[r'statistics'] = this.statistics;
     return json;
@@ -59,6 +66,7 @@ class QueueResponseDto {
 
       return QueueResponseDto(
         isPaused: mapValueOfType<bool>(json, r'isPaused')!,
+        jobTypes: QueueJobTypeCountsDto.listFromJson(json[r'jobTypes']),
         name: QueueName.fromJson(json[r'name'])!,
         statistics: QueueStatisticsDto.fromJson(json[r'statistics'])!,
       );

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -25470,6 +25470,45 @@
         ],
         "type": "string"
       },
+      "QueueJobTypeCountsDto": {
+        "properties": {
+          "active": {
+            "description": "Number of sampled active jobs with this name",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "delayed": {
+            "description": "Number of sampled delayed jobs with this name",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "name": {
+            "$ref": "#/components/schemas/JobName"
+          },
+          "paused": {
+            "description": "Number of sampled paused jobs with this name",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "waiting": {
+            "description": "Number of sampled waiting jobs with this name",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "active",
+          "delayed",
+          "name",
+          "paused",
+          "waiting"
+        ],
+        "type": "object"
+      },
       "QueueName": {
         "description": "Queue name",
         "enum": [
@@ -25503,6 +25542,13 @@
           "isPaused": {
             "description": "Whether the queue is paused",
             "type": "boolean"
+          },
+          "jobTypes": {
+            "description": "Sampled job type counts for display purposes",
+            "items": {
+              "$ref": "#/components/schemas/QueueJobTypeCountsDto"
+            },
+            "type": "array"
           },
           "name": {
             "$ref": "#/components/schemas/QueueName"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -1723,9 +1723,22 @@ export type PluginTriggerResponseDto = {
     contextType: PluginContextType;
     "type": PluginTriggerType;
 };
+export type QueueJobTypeCountsDto = {
+    /** Number of sampled active jobs with this name */
+    active: number;
+    /** Number of sampled delayed jobs with this name */
+    delayed: number;
+    name: JobName;
+    /** Number of sampled paused jobs with this name */
+    paused: number;
+    /** Number of sampled waiting jobs with this name */
+    waiting: number;
+};
 export type QueueResponseDto = {
     /** Whether the queue is paused */
     isPaused: boolean;
+    /** Sampled job type counts for display purposes */
+    jobTypes?: QueueJobTypeCountsDto[];
     name: QueueName;
     statistics: QueueStatisticsDto;
 };
@@ -8771,14 +8784,6 @@ export enum PluginTriggerType {
     AssetCreate = "AssetCreate",
     PersonRecognized = "PersonRecognized"
 }
-export enum QueueJobStatus {
-    Active = "active",
-    Failed = "failed",
-    Completed = "completed",
-    Delayed = "delayed",
-    Waiting = "waiting",
-    Paused = "paused"
-}
 export enum JobName {
     AssetDelete = "AssetDelete",
     AssetDeleteCheck = "AssetDeleteCheck",
@@ -8850,6 +8855,14 @@ export enum JobName {
     SharedSpaceBulkAddAssets = "SharedSpaceBulkAddAssets",
     AssetClassifyQueueAll = "AssetClassifyQueueAll",
     AssetClassify = "AssetClassify"
+}
+export enum QueueJobStatus {
+    Active = "active",
+    Failed = "failed",
+    Completed = "completed",
+    Delayed = "delayed",
+    Waiting = "waiting",
+    Paused = "paused"
 }
 export enum SearchSuggestionType {
     Country = "country",

--- a/server/src/dtos/queue.dto.ts
+++ b/server/src/dtos/queue.dto.ts
@@ -58,11 +58,22 @@ export const QueueStatisticsSchema = z
   })
   .meta({ id: 'QueueStatisticsDto' });
 
+const QueueJobTypeCountsSchema = z
+  .object({
+    name: JobNameSchema,
+    active: z.int().describe('Number of sampled active jobs with this name'),
+    waiting: z.int().describe('Number of sampled waiting jobs with this name'),
+    delayed: z.int().describe('Number of sampled delayed jobs with this name'),
+    paused: z.int().describe('Number of sampled paused jobs with this name'),
+  })
+  .meta({ id: 'QueueJobTypeCountsDto' });
+
 const QueueResponseSchema = z
   .object({
     name: QueueNameSchema,
     isPaused: z.boolean().describe('Whether the queue is paused'),
     statistics: QueueStatisticsSchema,
+    jobTypes: z.array(QueueJobTypeCountsSchema).optional().describe('Sampled job type counts for display purposes'),
   })
   .meta({ id: 'QueueResponseDto' });
 
@@ -72,5 +83,6 @@ export class QueueUpdateDto extends createZodDto(QueueUpdateSchema) {}
 export class QueueDeleteDto extends createZodDto(QueueDeleteSchema) {}
 export class QueueJobSearchDto extends createZodDto(QueueJobSearchSchema) {}
 export class QueueJobResponseDto extends createZodDto(QueueJobResponseSchema) {}
+export class QueueJobTypeCountsDto extends createZodDto(QueueJobTypeCountsSchema) {}
 export class QueueStatisticsDto extends createZodDto(QueueStatisticsSchema) {}
 export class QueueResponseDto extends createZodDto(QueueResponseSchema) {}

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -172,6 +172,51 @@ describe(JobRepository.name, () => {
     expect(queue.getJobs).toHaveBeenCalledWith('failed', 0, 0, true);
   });
 
+  it('returns job type counts sampled from active and pending queue jobs', async () => {
+    const { sut, queue } = setup();
+    queue.getJobs.mockImplementation((status) => {
+      const jobs = {
+        active: [{ name: JobName.SharedSpaceFaceMatchPage }, { name: JobName.SharedSpaceFaceMatchPage }],
+        waiting: [{ name: JobName.SharedSpaceFaceMatchPage }, { name: JobName.FacialRecognition }],
+        delayed: [{ name: JobName.FacialRecognition }],
+        paused: [{ name: JobName.FaceIdentityBackfill }],
+      } as Record<string, Array<{ name: JobName }>>;
+
+      return Promise.resolve(jobs[status] ?? []);
+    });
+
+    const result = await sut.getJobTypes(QueueName.FacialRecognition);
+
+    expect(result).toEqual([
+      { name: JobName.SharedSpaceFaceMatchPage, active: 2, waiting: 1, delayed: 0, paused: 0 },
+      { name: JobName.FacialRecognition, active: 0, waiting: 1, delayed: 1, paused: 0 },
+      { name: JobName.FaceIdentityBackfill, active: 0, waiting: 0, delayed: 0, paused: 1 },
+    ]);
+    expect(queue.getJobs).toHaveBeenCalledWith('active', 0, 1000, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('waiting', 0, 1000, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('delayed', 0, 1000, true);
+    expect(queue.getJobs).toHaveBeenCalledWith('paused', 0, 1000, true);
+  });
+
+  it('does not double-count paused jobs that BullMQ also returns as waiting jobs', async () => {
+    const { sut, queue } = setup();
+    const pausedJob = { id: 'paused-job-1', name: JobName.FaceIdentityBackfill, getState: vitest.fn().mockResolvedValue('paused') };
+    queue.getJobs.mockImplementation((status) => {
+      const jobs = {
+        active: [],
+        waiting: [pausedJob],
+        delayed: [],
+        paused: [pausedJob],
+      } as Record<string, Array<typeof pausedJob>>;
+
+      return Promise.resolve(jobs[status] ?? []);
+    });
+
+    await expect(sut.getJobTypes(QueueName.FacialRecognition)).resolves.toEqual([
+      { name: JobName.FaceIdentityBackfill, active: 0, waiting: 0, delayed: 0, paused: 1 },
+    ]);
+  });
+
   it('uses stable job ids for root backfills and unique ids for cursor chunks', async () => {
     const { sut, queue } = setup();
     setHandlers(sut, [JobName.FaceIdentityBackfill, JobName.SharedSpacePersonMetadataBackfill]);

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -200,7 +200,11 @@ describe(JobRepository.name, () => {
 
   it('does not double-count paused jobs that BullMQ also returns as waiting jobs', async () => {
     const { sut, queue } = setup();
-    const pausedJob = { id: 'paused-job-1', name: JobName.FaceIdentityBackfill, getState: vitest.fn().mockResolvedValue('paused') };
+    const pausedJob = {
+      id: 'paused-job-1',
+      name: JobName.FaceIdentityBackfill,
+      getState: vitest.fn().mockResolvedValue('paused'),
+    };
     queue.getJobs.mockImplementation((status) => {
       const jobs = {
         active: [],

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -9,7 +9,7 @@ import { JobName, JobStatus, MetadataKey, QueueCleanType, QueueJobStatus, QueueN
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { EventRepository } from 'src/repositories/event.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
-import { JobCounts, JobItem, JobOf } from 'src/types';
+import { JobCounts, JobItem, JobOf, JobTypeCounts } from 'src/types';
 import { getKeyByValue, getMethodNames, ImmichStartupError } from 'src/utils/misc';
 
 type JobMapItem = {
@@ -172,6 +172,35 @@ export class JobRepository {
       'waiting',
       'paused',
     ) as unknown as Promise<JobCounts>;
+  }
+
+  async getJobTypes(name: QueueName): Promise<JobTypeCounts[]> {
+    const statuses = ['active', 'waiting', 'delayed', 'paused'] as const;
+    const counts = new Map<JobName, JobTypeCounts>();
+    const seenJobs = new Set<string>();
+
+    for (const status of statuses) {
+      const jobs = await this.getQueue(name).getJobs(status, 0, 1000, true);
+      for (const job of jobs) {
+        const actualStatus = typeof job.getState === 'function' ? await job.getState() : status;
+        if (!statuses.includes(actualStatus as (typeof statuses)[number])) {
+          continue;
+        }
+
+        const jobKey = job.id ?? `${job.name}:${actualStatus}:${seenJobs.size}`;
+        if (seenJobs.has(jobKey)) {
+          continue;
+        }
+        seenJobs.add(jobKey);
+
+        const jobName = job.name as JobName;
+        const count = counts.get(jobName) ?? { name: jobName, active: 0, waiting: 0, delayed: 0, paused: 0 };
+        count[actualStatus as (typeof statuses)[number]]++;
+        counts.set(jobName, count);
+      }
+    }
+
+    return [...counts.values()];
   }
 
   async getTelemetryMetrics(now = Date.now()): Promise<QueueTelemetryMetrics> {

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -195,6 +195,26 @@ describe(QueueService.name, () => {
         statistics: stats,
       });
     });
+
+    it('should include active and waiting job type details for the queue', async () => {
+      const stats = factory.queueStatistics({ active: 1, waiting: 1 });
+      const jobTypes = [
+        { name: JobName.SharedSpaceFaceMatchPage, active: 1, waiting: 1, delayed: 0, paused: 0 },
+        { name: JobName.FacialRecognition, active: 0, waiting: 5, delayed: 0, paused: 0 },
+      ];
+      mocks.job.getJobCounts.mockResolvedValue(stats);
+      mocks.job.getJobTypes.mockResolvedValue(jobTypes);
+      mocks.job.isPaused.mockResolvedValue(false);
+
+      const result = await sut.get(factory.auth(), QueueName.FacialRecognition);
+
+      expect(result).toEqual({
+        name: QueueName.FacialRecognition,
+        isPaused: false,
+        statistics: stats,
+        jobTypes,
+      });
+    });
   });
 
   describe('update', () => {

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -470,6 +470,15 @@ describe(QueueService.name, () => {
         expect(result[queueName].queueStatus.isPaused).toBe(false);
       }
     });
+
+    it('should not sample job types for legacy queue status polling', async () => {
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.job.isPaused.mockResolvedValue(false);
+
+      await sut.getAllLegacy(factory.auth());
+
+      expect(mocks.job.getJobTypes).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleCommand', () => {

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -130,7 +130,7 @@ export class QueueService extends BaseService {
       }
     }
 
-    const response = await this.getByName(name);
+    const response = await this.getByName(name, { includeJobTypes: false });
 
     return mapQueueLegacy(response);
   }
@@ -140,7 +140,9 @@ export class QueueService extends BaseService {
   }
 
   async getAllLegacy(auth: AuthDto): Promise<QueuesResponseLegacyDto> {
-    const responses = await this.getAll(auth);
+    const responses = await Promise.all(
+      Object.values(QueueName).map((name) => this.getByName(name, { includeJobTypes: false })),
+    );
     return mapQueuesLegacy(responses);
   }
 
@@ -174,11 +176,14 @@ export class QueueService extends BaseService {
     }
   }
 
-  private async getByName(name: QueueName): Promise<QueueResponseDto> {
+  private async getByName(
+    name: QueueName,
+    { includeJobTypes = true }: { includeJobTypes?: boolean } = {},
+  ): Promise<QueueResponseDto> {
     const [statistics, isPaused, jobTypes] = await Promise.all([
       this.jobRepository.getJobCounts(name),
       this.jobRepository.isPaused(name),
-      this.jobRepository.getJobTypes(name),
+      includeJobTypes ? this.jobRepository.getJobTypes(name) : [],
     ]);
     return { name, isPaused, statistics, ...(jobTypes.length > 0 ? { jobTypes } : {}) };
   }

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -139,7 +139,7 @@ export class QueueService extends BaseService {
     return Promise.all(Object.values(QueueName).map((name) => this.getByName(name)));
   }
 
-  async getAllLegacy(auth: AuthDto): Promise<QueuesResponseLegacyDto> {
+  async getAllLegacy(_auth: AuthDto): Promise<QueuesResponseLegacyDto> {
     const responses = await Promise.all(
       Object.values(QueueName).map((name) => this.getByName(name, { includeJobTypes: false })),
     );

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -175,11 +175,12 @@ export class QueueService extends BaseService {
   }
 
   private async getByName(name: QueueName): Promise<QueueResponseDto> {
-    const [statistics, isPaused] = await Promise.all([
+    const [statistics, isPaused, jobTypes] = await Promise.all([
       this.jobRepository.getJobCounts(name),
       this.jobRepository.isPaused(name),
+      this.jobRepository.getJobTypes(name),
     ]);
-    return { name, isPaused, statistics };
+    return { name, isPaused, statistics, ...(jobTypes.length > 0 ? { jobTypes } : {}) };
   }
 
   private async start(name: QueueName, { force }: QueueCommandDto): Promise<void> {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -366,6 +366,14 @@ export interface JobCounts {
   paused: number;
 }
 
+export interface JobTypeCounts {
+  name: JobName;
+  active: number;
+  waiting: number;
+  delayed: number;
+  paused: number;
+}
+
 export type JobItem =
   // Audit
   | { name: JobName.AuditTableCleanup; data?: IBaseJob }

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -17,6 +17,7 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     isActive: vitest.fn(),
     isPaused: vitest.fn(),
     getJobCounts: vitest.fn(),
+    getJobTypes: vitest.fn().mockResolvedValue([]),
     getTelemetryMetrics: vitest.fn(),
     clear: vitest.fn(),
     waitForQueueCompletion: vitest.fn(),

--- a/web/src/lib/services/queue.service.spec.ts
+++ b/web/src/lib/services/queue.service.spec.ts
@@ -1,0 +1,11 @@
+import { getQueueJobTypeLabel } from '$lib/services/queue.service';
+import { JobName } from '@immich/sdk';
+import { describe, expect, it } from 'vitest';
+
+describe('queue service', () => {
+  it('labels shared-space face matching jobs separately from facial recognition', () => {
+    expect(getQueueJobTypeLabel(JobName.SharedSpaceFaceMatchPage)).toBe('Shared space face matching');
+    expect(getQueueJobTypeLabel(JobName.SharedSpacePersonDedup)).toBe('Shared space people dedup');
+    expect(getQueueJobTypeLabel(JobName.FacialRecognition)).toBe('Facial recognition');
+  });
+});

--- a/web/src/lib/services/queue.service.ts
+++ b/web/src/lib/services/queue.service.ts
@@ -10,10 +10,12 @@ import { getFormatter } from '$lib/utils/i18n';
 import {
   emptyQueue,
   getQueue,
+  JobName,
   QueueCommand,
   QueueName,
   runQueueCommandLegacy,
   updateQueue,
+  type QueueJobTypeCountsDto,
   type QueueResponseDto,
 } from '@immich/sdk';
 import { modalManager, toastManager, type ActionItem, type IconLike } from '@immich/ui';
@@ -49,6 +51,30 @@ type QueueItem = {
   icon: IconLike;
   title: string;
   subtitle?: string;
+};
+
+export type QueueJobTypeCounts = QueueJobTypeCountsDto;
+
+export const getQueueJobTypeLabel = (name: JobName) => {
+  switch (name) {
+    case JobName.FacialRecognition:
+    case JobName.FacialRecognitionQueueAll:
+      return 'Facial recognition';
+    case JobName.SharedSpaceFaceMatch:
+    case JobName.SharedSpaceFaceMatchAll:
+    case JobName.SharedSpaceFaceMatchPage:
+      return 'Shared space face matching';
+    case JobName.SharedSpacePersonDedup:
+      return 'Shared space people dedup';
+    case JobName.SharedSpaceIdentityReconciliation:
+      return 'Shared space identity reconciliation';
+    case JobName.SharedSpacePersonMetadataBackfill:
+      return 'Shared space metadata propagation';
+    case JobName.FaceIdentityBackfill:
+      return 'Face identity backfill';
+    default:
+      return name.replaceAll(/([a-z])([A-Z])/g, '$1 $2');
+  }
 };
 
 export const getQueuesActions = ($t: MessageFormatter, queues: QueueResponseDto[] | undefined) => {

--- a/web/src/lib/services/queue.service.ts
+++ b/web/src/lib/services/queue.service.ts
@@ -58,22 +58,29 @@ export type QueueJobTypeCounts = QueueJobTypeCountsDto;
 export const getQueueJobTypeLabel = (name: JobName) => {
   switch (name) {
     case JobName.FacialRecognition:
-    case JobName.FacialRecognitionQueueAll:
+    case JobName.FacialRecognitionQueueAll: {
       return 'Facial recognition';
+    }
     case JobName.SharedSpaceFaceMatch:
     case JobName.SharedSpaceFaceMatchAll:
-    case JobName.SharedSpaceFaceMatchPage:
+    case JobName.SharedSpaceFaceMatchPage: {
       return 'Shared space face matching';
-    case JobName.SharedSpacePersonDedup:
+    }
+    case JobName.SharedSpacePersonDedup: {
       return 'Shared space people dedup';
-    case JobName.SharedSpaceIdentityReconciliation:
+    }
+    case JobName.SharedSpaceIdentityReconciliation: {
       return 'Shared space identity reconciliation';
-    case JobName.SharedSpacePersonMetadataBackfill:
+    }
+    case JobName.SharedSpacePersonMetadataBackfill: {
       return 'Shared space metadata propagation';
-    case JobName.FaceIdentityBackfill:
+    }
+    case JobName.FaceIdentityBackfill: {
       return 'Face identity backfill';
-    default:
+    }
+    default: {
       return name.replaceAll(/([a-z])([A-Z])/g, '$1 $2');
+    }
   }
 };
 

--- a/web/src/routes/admin/queues/QueueCard.svelte
+++ b/web/src/routes/admin/queues/QueueCard.svelte
@@ -21,6 +21,7 @@
     mdiSelectionSearch,
   } from '@mdi/js';
   import { type Component } from 'svelte';
+  import { SvelteMap } from 'svelte/reactivity';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -41,7 +42,7 @@
   let isIdle = $derived(statistics.active + statistics.waiting === 0 && !queue.isPaused);
   let multipleButtons = $derived(allText || refreshText);
   let jobTypeRows = $derived.by(() => {
-    const rows = new Map<string, Pick<QueueJobTypeCounts, 'active' | 'waiting' | 'delayed' | 'paused'>>();
+    const rows = new SvelteMap<string, Pick<QueueJobTypeCounts, 'active' | 'waiting' | 'delayed' | 'paused'>>();
     for (const jobType of queue.jobTypes ?? []) {
       const label = getQueueJobTypeLabel(jobType.name);
       const row = rows.get(label) ?? { active: 0, waiting: 0, delayed: 0, paused: 0 };
@@ -148,7 +149,9 @@
       </div>
 
       {#if jobTypeRows.length > 0}
-        <div class="mt-2 flex w-full max-w-xl flex-col divide-y divide-gray-200 rounded-lg bg-white/70 text-sm text-gray-700 dark:divide-gray-700 dark:bg-black/20 dark:text-gray-200">
+        <div
+          class="mt-2 flex w-full max-w-xl flex-col divide-y divide-gray-200 rounded-lg bg-white/70 text-sm text-gray-700 dark:divide-gray-700 dark:bg-black/20 dark:text-gray-200"
+        >
           {#each jobTypeRows as row (row.label)}
             <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-4 px-4 py-2">
               <span class="min-w-0 truncate">{row.label}</span>

--- a/web/src/routes/admin/queues/QueueCard.svelte
+++ b/web/src/routes/admin/queues/QueueCard.svelte
@@ -4,7 +4,7 @@
   import QueueCardButton from './QueueCardButton.svelte';
   import Badge from '$lib/elements/Badge.svelte';
   import { Route } from '$lib/route';
-  import { asQueueItem } from '$lib/services/queue.service';
+  import { asQueueItem, getQueueJobTypeLabel, type QueueJobTypeCounts } from '$lib/services/queue.service';
   import { locale } from '$lib/stores/preferences.store';
   import { transformToTitleCase } from '$lib/utils';
   import { QueueCommand, type QueueCommandDto, type QueueResponseDto } from '@immich/sdk';
@@ -40,6 +40,23 @@
   let waitingCount = $derived(statistics.waiting + statistics.paused + statistics.delayed);
   let isIdle = $derived(statistics.active + statistics.waiting === 0 && !queue.isPaused);
   let multipleButtons = $derived(allText || refreshText);
+  let jobTypeRows = $derived.by(() => {
+    const rows = new Map<string, Pick<QueueJobTypeCounts, 'active' | 'waiting' | 'delayed' | 'paused'>>();
+    for (const jobType of queue.jobTypes ?? []) {
+      const label = getQueueJobTypeLabel(jobType.name);
+      const row = rows.get(label) ?? { active: 0, waiting: 0, delayed: 0, paused: 0 };
+      row.active += jobType.active;
+      row.waiting += jobType.waiting;
+      row.delayed += jobType.delayed;
+      row.paused += jobType.paused;
+      rows.set(label, row);
+    }
+
+    return [...rows.entries()]
+      .map(([label, row]) => ({ label, ...row, pending: row.waiting + row.delayed + row.paused }))
+      .filter((row) => row.active + row.pending > 0)
+      .sort((a, b) => b.active - a.active || b.pending - a.pending || a.label.localeCompare(b.label));
+  });
 
   const commonClasses = 'flex place-items-center justify-between w-full py-2 sm:py-4 pe-4 ps-6';
 </script>
@@ -129,6 +146,18 @@
           <p>{$t('waiting')}</p>
         </div>
       </div>
+
+      {#if jobTypeRows.length > 0}
+        <div class="mt-2 flex w-full max-w-xl flex-col divide-y divide-gray-200 rounded-lg bg-white/70 text-sm text-gray-700 dark:divide-gray-700 dark:bg-black/20 dark:text-gray-200">
+          {#each jobTypeRows as row (row.label)}
+            <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-4 px-4 py-2">
+              <span class="min-w-0 truncate">{row.label}</span>
+              <span class="tabular-nums">{row.active.toLocaleString($locale)}</span>
+              <span class="tabular-nums text-gray-500 dark:text-gray-400">{row.pending.toLocaleString($locale)}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
     </div>
   </div>
   <div class="flex w-full flex-row overflow-hidden sm:w-32 sm:flex-col">


### PR DESCRIPTION
## Summary
- add sampled per-job-type counts to queue responses
- show grouped face recognition queue rows in the admin queue card
- update OpenAPI/TypeScript SDK artifacts

## Testing
- pnpm --dir server exec vitest run --config test/vitest.config.mjs src/repositories/job.repository.spec.ts src/services/queue.service.spec.ts
- pnpm --dir web exec vitest run src/lib/services/queue.service.spec.ts
- pnpm --dir server check
- pnpm --dir web check:typescript