### PR TITLE
fix(server): decode HEIC thumbnails via image pipeline

### DIFF
--- a/e2e/src/specs/server/api/asset.e2e-spec.ts
+++ b/e2e/src/specs/server/api/asset.e2e-spec.ts
@@ -14,6 +14,7 @@ import { DateTime } from 'luxon';
 import { randomBytes } from 'node:crypto';
 import { readFile, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
+import sharp from 'sharp';
 import { Socket } from 'socket.io-client';
 import { createUserDto, uuidDto } from 'src/fixtures';
 import { makeRandomImage } from 'src/generators';
@@ -1086,6 +1087,10 @@ describe('/asset', () => {
         expect(body).toBeInstanceOf(Buffer);
         expect(body.length).toBeGreaterThan(0);
         expect(type).toMatch(/^image\//);
+
+        const metadata = await sharp(body).metadata();
+        expect(metadata.width).toBe(333);
+        expect(metadata.height).toBe(250);
       }
     });
 

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -938,48 +938,54 @@ describe(MediaService.name, () => {
       });
     });
 
-    it('should convert HEIC through ffmpeg before decoding thumbnails', async () => {
+    it('should decode HEIC thumbnails through the image pipeline', async () => {
       const asset = AssetFactory.from({ originalFileName: 'IMG_1234.HEIC', originalPath: '/original/IMG_1234.HEIC' })
         .exif({ fileSizeInByte: 5000, orientation: ExifOrientation.Rotate90CW.toString() })
         .build();
       mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...probeStub.noAudioStreams,
-        videoStreams: [
-          { ...probeStub.videoStream2160p.videoStreams[0], index: 60, pixelFormat: 'gray', width: 2016, height: 1512 },
-          {
-            ...probeStub.videoStream2160p.videoStreams[0],
-            index: 61,
-            pixelFormat: 'yuv420p10le',
-            width: 1024,
-            height: 768,
-          },
-          {
-            ...probeStub.videoStream2160p.videoStreams[0],
-            index: 62,
-            pixelFormat: 'yuvj420p',
-            width: 416,
-            height: 312,
-          },
-        ],
-      });
 
       await sut.handleGenerateThumbnails({ id: asset.id });
 
-      expect(mocks.media.extractFrame).toHaveBeenCalledWith(
-        asset.originalPath,
-        expect.stringContaining('.jpeg'),
-        0,
-        61,
-      );
+      expect(mocks.media.probe).not.toHaveBeenCalled();
+      expect(mocks.media.extractFrame).not.toHaveBeenCalled();
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
-      expect(mocks.media.decodeImage).toHaveBeenCalledWith(expect.stringContaining('.jpeg'), {
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
         colorspace: Colorspace.Srgb,
-        orientation: ExifOrientation.Rotate90CW,
         processInvalidImages: false,
         size: 1440,
       });
       expect(mocks.media.generateThumbnail).toHaveBeenCalledTimes(2);
+    });
+
+    it('should decode S3-backed HEIC thumbnails from the local temp file through the image pipeline', async () => {
+      const cleanup = vi.fn(async () => {});
+      const ensureLocalFile = vi
+        .spyOn(
+          sut as unknown as {
+            ensureLocalFile: (filePath: string) => Promise<{ localPath: string; cleanup: () => Promise<void> }>;
+          },
+          'ensureLocalFile',
+        )
+        .mockResolvedValue({ localPath: '/tmp/immich-s3-heic.tmp', cleanup });
+      const asset = AssetFactory.from({
+        originalFileName: 'IMG_1234.HEIC',
+        originalPath: 'upload/user/12/34/asset.HEIC',
+      })
+        .exif({ fileSizeInByte: 5000, orientation: ExifOrientation.Rotate90CW.toString() })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+
+      await sut.handleGenerateThumbnails({ id: asset.id });
+
+      expect(ensureLocalFile).toHaveBeenCalledWith(asset.originalPath);
+      expect(mocks.media.probe).not.toHaveBeenCalled();
+      expect(mocks.media.extractFrame).not.toHaveBeenCalled();
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith('/tmp/immich-s3-heic.tmp', {
+        colorspace: Colorspace.Srgb,
+        processInvalidImages: false,
+        size: 1440,
+      });
+      expect(cleanup).toHaveBeenCalled();
     });
 
     it('should not check transparency metadata for raw files without extracted images', async () => {
@@ -2017,7 +2023,7 @@ describe(MediaService.name, () => {
       expect(mocks.media.generateThumbnail).toHaveBeenCalled();
     });
 
-    it('should convert HEIC through ffmpeg before decoding person thumbnails', async () => {
+    it('should decode HEIC person thumbnails through the image pipeline', async () => {
       const person = PersonFactory.create();
       const data = {
         ...personThumbnailStub.newThumbnailMiddle,
@@ -2026,19 +2032,6 @@ describe(MediaService.name, () => {
       };
 
       mocks.person.getDataForThumbnailGenerationJob.mockResolvedValue(data);
-      mocks.media.probe.mockResolvedValue({
-        ...probeStub.noAudioStreams,
-        videoStreams: [
-          { ...probeStub.videoStream2160p.videoStreams[0], index: 60, pixelFormat: 'gray', width: 2016, height: 1512 },
-          {
-            ...probeStub.videoStream2160p.videoStreams[0],
-            index: 61,
-            pixelFormat: 'yuv420p10le',
-            width: 1024,
-            height: 768,
-          },
-        ],
-      });
       mocks.media.generateThumbnail.mockResolvedValue();
       mocks.media.decodeImage.mockResolvedValue({
         data: Buffer.from(''),
@@ -2047,13 +2040,49 @@ describe(MediaService.name, () => {
 
       await expect(sut.handleGeneratePersonThumbnail({ id: person.id })).resolves.toBe(JobStatus.Success);
 
-      expect(mocks.media.extractFrame).toHaveBeenCalledWith(data.originalPath, expect.stringContaining('.jpeg'), 0, 61);
-      expect(mocks.media.decodeImage).toHaveBeenCalledWith(expect.stringContaining('.jpeg'), {
+      expect(mocks.media.probe).not.toHaveBeenCalled();
+      expect(mocks.media.extractFrame).not.toHaveBeenCalled();
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith(data.originalPath, {
         colorspace: Colorspace.P3,
-        orientation: ExifOrientation.Horizontal,
         processInvalidImages: false,
       });
       expect(mocks.media.generateThumbnail).toHaveBeenCalled();
+    });
+
+    it('should decode S3-backed HEIC person thumbnails from the local temp file through the image pipeline', async () => {
+      const cleanup = vi.fn(async () => {});
+      const ensureLocalFile = vi
+        .spyOn(
+          sut as unknown as {
+            ensureLocalFile: (filePath: string) => Promise<{ localPath: string; cleanup: () => Promise<void> }>;
+          },
+          'ensureLocalFile',
+        )
+        .mockResolvedValue({ localPath: '/tmp/immich-s3-person-heic.tmp', cleanup });
+      const person = PersonFactory.create();
+      const data = {
+        ...personThumbnailStub.newThumbnailMiddle,
+        originalPath: 'upload/user/12/34/asset.HEIC',
+        previewPath: null,
+      };
+
+      mocks.person.getDataForThumbnailGenerationJob.mockResolvedValue(data);
+      mocks.media.generateThumbnail.mockResolvedValue();
+      mocks.media.decodeImage.mockResolvedValue({
+        data: Buffer.from(''),
+        info: { width: 2160, height: 3840 } as OutputInfo,
+      });
+
+      await expect(sut.handleGeneratePersonThumbnail({ id: person.id })).resolves.toBe(JobStatus.Success);
+
+      expect(ensureLocalFile).toHaveBeenCalledWith(data.originalPath);
+      expect(mocks.media.probe).not.toHaveBeenCalled();
+      expect(mocks.media.extractFrame).not.toHaveBeenCalled();
+      expect(mocks.media.decodeImage).toHaveBeenCalledWith('/tmp/immich-s3-person-heic.tmp', {
+        colorspace: Colorspace.P3,
+        processInvalidImages: false,
+      });
+      expect(cleanup).toHaveBeenCalled();
     });
 
     it('should not use embedded preview if enabled and raw image if not exists', async () => {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { createReadStream } from 'node:fs';
-import { mkdtemp, rm, unlink } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { isAbsolute, join } from 'node:path';
+import { unlink } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
 import { DiskStorageBackend } from 'src/backends/disk-storage.backend';
 import { SystemConfig } from 'src/config';
 import { FACE_THUMBNAIL_SIZE, JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
@@ -439,36 +438,6 @@ export class MediaService extends BaseService {
     return extracted;
   }
 
-  private async extractHeifFrame(originalPath: string) {
-    const outputDir = await mkdtemp(join(tmpdir(), 'gallery-heif-thumbnail-'));
-    const outputPath = join(outputDir, 'frame.jpeg');
-
-    try {
-      await this.mediaRepository.extractFrame(
-        originalPath,
-        outputPath,
-        0,
-        await this.getHeifColorStreamIndex(originalPath),
-      );
-      return {
-        path: outputPath,
-        cleanup: () => rm(outputDir, { force: true, recursive: true }),
-      };
-    } catch (error) {
-      await rm(outputDir, { force: true, recursive: true });
-      throw error;
-    }
-  }
-
-  private async getHeifColorStreamIndex(originalPath: string) {
-    const { videoStreams } = await this.mediaRepository.probe(originalPath);
-    const [stream] = videoStreams
-      .filter(({ pixelFormat }) => !pixelFormat.startsWith('gray'))
-      .toSorted((a, b) => b.width * b.height - a.width * a.height);
-
-    return stream?.index;
-  }
-
   private async decodeImage(thumbSource: string | Buffer, exifInfo: ThumbnailAsset['exifInfo'], targetSize?: number) {
     const { image } = await this.getConfig({ withCache: true });
     const colorspace = this.isSRGB(exifInfo) ? Colorspace.Srgb : image.colorspace;
@@ -492,44 +461,35 @@ export class MediaService extends BaseService {
     const inputPath = localOriginalPath ?? asset.originalPath;
     const extractEmbedded = image.extractEmbedded && mimeTypes.isRaw(asset.originalFileName);
     const extracted = extractEmbedded ? await this.extractImage(inputPath, image.preview.size) : null;
-    const heifFrame =
-      !extracted && (mimeTypes.isHeif(asset.originalFileName) || mimeTypes.isHeif(asset.originalPath))
-        ? await this.extractHeifFrame(inputPath)
-        : undefined;
     const generateFullsize =
       ((image.fullsize.enabled || asset.exifInfo.projectionType === 'EQUIRECTANGULAR') &&
         !mimeTypes.isWebSupportedImage(asset.originalPath)) ||
       useEdits;
     const convertFullsize = generateFullsize && (!extracted || !mimeTypes.isWebSupportedImage(` .${extracted.format}`));
 
-    try {
-      const thumbSource = extracted ? extracted.buffer : (heifFrame?.path ?? inputPath);
-      const shouldApplyOrientation = !!extracted || !!heifFrame;
-      const { data, info, colorspace } = await this.decodeImage(
-        thumbSource,
-        // only specify orientation to extracted/converted images which don't have EXIF orientation data
-        // or it can double rotate the image
-        shouldApplyOrientation ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
-        convertFullsize ? undefined : image.preview.size,
-      );
+    const thumbSource = extracted ? extracted.buffer : inputPath;
+    const { data, info, colorspace } = await this.decodeImage(
+      thumbSource,
+      // only specify orientation to extracted images which don't have EXIF orientation data
+      // or it can double rotate the image
+      extracted ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
+      convertFullsize ? undefined : image.preview.size,
+    );
 
-      let isTransparent = false;
-      if (!extracted && mimeTypes.canBeTransparent(asset.originalPath)) {
-        ({ isTransparent } = await this.mediaRepository.getImageMetadata(inputPath));
-      }
-
-      return {
-        extracted,
-        data,
-        info,
-        colorspace,
-        convertFullsize,
-        generateFullsize,
-        isTransparent,
-      };
-    } finally {
-      await heifFrame?.cleanup();
+    let isTransparent = false;
+    if (!extracted && mimeTypes.canBeTransparent(asset.originalPath)) {
+      ({ isTransparent } = await this.mediaRepository.getImageMetadata(inputPath));
     }
+
+    return {
+      extracted,
+      data,
+      info,
+      colorspace,
+      convertFullsize,
+      generateFullsize,
+      isTransparent,
+    };
   }
 
   private async generateImageThumbnails(
@@ -659,7 +619,6 @@ export class MediaService extends BaseService {
     // For S3 assets, download to local temp files for processing
     const originalLocal = await this.ensureLocalFile(originalPath);
     const previewLocal = previewPath ? await this.ensureLocalFile(previewPath) : undefined;
-    let heifFrame: Awaited<ReturnType<MediaService['extractHeifFrame']>> | undefined;
 
     try {
       let inputImage: string | Buffer;
@@ -672,9 +631,6 @@ export class MediaService extends BaseService {
       } else if (image.extractEmbedded && mimeTypes.isRaw(originalPath)) {
         const extracted = await this.extractImage(originalLocal.localPath, image.preview.size);
         inputImage = extracted ? extracted.buffer : originalLocal.localPath;
-      } else if (mimeTypes.isHeif(originalPath)) {
-        heifFrame = await this.extractHeifFrame(originalLocal.localPath);
-        inputImage = heifFrame.path;
       } else {
         inputImage = originalLocal.localPath;
       }
@@ -682,9 +638,8 @@ export class MediaService extends BaseService {
       const { data: decodedImage, info } = await this.mediaRepository.decodeImage(inputImage, {
         colorspace: image.colorspace,
         processInvalidImages: process.env.IMMICH_PROCESS_INVALID_IMAGES === 'true',
-        // if this is an extracted or converted image, it may not have orientation metadata
-        orientation:
-          (Buffer.isBuffer(inputImage) || heifFrame) && exifOrientation ? Number(exifOrientation) : undefined,
+        // if this is an extracted image, it may not have orientation metadata
+        orientation: Buffer.isBuffer(inputImage) && exifOrientation ? Number(exifOrientation) : undefined,
       });
 
       const thumbnailPath = StorageCore.getPersonThumbnailPath({ id, ownerId });
@@ -719,7 +674,6 @@ export class MediaService extends BaseService {
 
       return JobStatus.Success;
     } finally {
-      await heifFrame?.cleanup();
       await originalLocal.cleanup();
       await previewLocal?.cleanup();
     }

--- a/server/src/services/user.service.spec.ts
+++ b/server/src/services/user.service.spec.ts
@@ -336,7 +336,7 @@ describe(UserService.name, () => {
       });
     });
 
-    it('should convert HEIC profile uploads through ffmpeg before thumbnailing', async () => {
+    it('should thumbnail HEIC profile uploads through the image pipeline', async () => {
       const user = factory.userAdmin({ profileImagePath: '' });
       const file = { path: `/data/profile/${user.id}/temp-file.HEIC` } as Express.Multer.File;
       mocks.user.get.mockResolvedValue(user);
@@ -346,12 +346,8 @@ describe(UserService.name, () => {
 
       await sut.createProfileImage(factory.auth({ user }), file);
 
-      expect(mocks.media.extractFrame).toHaveBeenCalledWith(file.path, expect.stringContaining('.jpeg'), 0);
-      expect(mocks.media.generateThumbnail).toHaveBeenCalledWith(
-        expect.stringContaining('.jpeg'),
-        expect.any(Object),
-        expect.any(String),
-      );
+      expect(mocks.media.extractFrame).not.toHaveBeenCalled();
+      expect(mocks.media.generateThumbnail).toHaveBeenCalledWith(file.path, expect.any(Object), expect.any(String));
     });
 
     describe('with S3 write backend', () => {

--- a/server/src/utils/profile-image.ts
+++ b/server/src/utils/profile-image.ts
@@ -1,12 +1,9 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SystemConfig } from 'src/config';
 import { StorageCore } from 'src/cores/storage.core';
 import { StorageFolder } from 'src/enum';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { MediaRepository } from 'src/repositories/media.repository';
-import { mimeTypes } from 'src/utils/mime-types';
 
 type Repos = {
   media: MediaRepository;
@@ -26,41 +23,18 @@ export const generateProfileImage = async (
   );
   storageCore.ensureFolders(outputPath);
 
-  const inputFrame =
-    typeof input === 'string' && mimeTypes.isHeif(input) ? await extractHeifFrame(media, input) : undefined;
-
-  try {
-    await media.generateThumbnail(
-      inputFrame?.path ?? input,
-      {
-        colorspace: image.colorspace,
-        format: image.thumbnail.format,
-        quality: image.thumbnail.quality,
-        progressive: image.thumbnail.progressive,
-        size: image.thumbnail.size,
-        processInvalidImages: false,
-      },
-      outputPath,
-    );
-  } finally {
-    await inputFrame?.cleanup();
-  }
+  await media.generateThumbnail(
+    input,
+    {
+      colorspace: image.colorspace,
+      format: image.thumbnail.format,
+      quality: image.thumbnail.quality,
+      progressive: image.thumbnail.progressive,
+      size: image.thumbnail.size,
+      processInvalidImages: false,
+    },
+    outputPath,
+  );
 
   return outputPath;
-};
-
-const extractHeifFrame = async (media: MediaRepository, input: string) => {
-  const outputDir = await mkdtemp(join(tmpdir(), 'gallery-heif-profile-'));
-  const outputPath = join(outputDir, 'frame.jpeg');
-
-  try {
-    await media.extractFrame(input, outputPath, 0);
-    return {
-      path: outputPath,
-      cleanup: () => rm(outputDir, { force: true, recursive: true }),
-    };
-  } catch (error) {
-    await rm(outputDir, { force: true, recursive: true });
-    throw error;
-  }
 };


### PR DESCRIPTION
## Summary
- remove the HEIC ffmpeg frame-extraction path for image, person, and profile thumbnail generation
- keep HEIC thumbnails on the normal sharp/libvips image decode pipeline, including S3 temp-file processing
- add unit and e2e coverage for HEIC thumbnails so internal HEVC tile streams are not treated as thumbnails

## Testing
- pnpm --config.verify-deps-before-run=false --dir server exec vitest --config test/vitest.config.mjs src/services/media.service.spec.ts
- pnpm --config.verify-deps-before-run=false --dir server exec vitest --config test/vitest.config.mjs src/services/media.service.spec.ts -t HEIC
- pnpm --config.verify-deps-before-run=false --dir server exec eslint src/services/media.service.ts src/services/media.service.spec.ts src/utils/profile-image.ts --max-warnings 0
- pnpm --config.verify-deps-before-run=false --dir e2e exec eslint src/specs/server/api/asset.e2e-spec.ts --max-warnings 0
- pnpm --config.verify-deps-before-run=false --dir server exec tsc --noEmit --incremental false
- pnpm --config.verify-deps-before-run=false --dir e2e exec tsc --noEmit
- git diff --check