### PR TITLE
fix(server): prevent conflicting face identity merges

### DIFF
--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -2333,6 +2333,12 @@ export class FaceIdentityRepository {
         targetIdentityId: input.targetIdentityId,
         sourceIdentityIds,
       });
+      if (personalProfileConflictCount > 0 || spaceProfileConflictCount > 0) {
+        return {
+          personalProfileConflictCount,
+          spaceProfileConflictCount,
+        };
+      }
 
       await trx
         .updateTable('face_identity_face')

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -78,6 +78,14 @@ type AccessiblePeopleSearchOptions = {
 };
 
 type ProfileKind = 'person' | 'space-person';
+type PersonalBackfillRow = {
+  id: string;
+  ownerId: string;
+  identityId: string | null;
+};
+type PersonalBackfillIdentityGroup = {
+  identityId: string;
+};
 type SpacePersonBackfillRow = {
   id: string;
   spaceId: string;
@@ -394,6 +402,18 @@ export class FaceIdentityRepository {
               AND asset_face."isVisible" = true
               AND asset."deletedAt" IS NULL
               AND face_identity_face."assetFaceId" IS NULL
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM asset_face
+            INNER JOIN asset ON asset.id = asset_face."assetId"
+            INNER JOIN person ON person.id = asset_face."personId"
+            INNER JOIN face_identity_face ON face_identity_face."assetFaceId" = asset_face.id
+            WHERE asset_face."personId" IS NOT NULL
+              AND asset_face."deletedAt" IS NULL
+              AND asset_face."isVisible" = true
+              AND asset."deletedAt" IS NULL
+              AND person."identityId" IS DISTINCT FROM face_identity_face."identityId"
           )
         ) AS "hasPersonalIdentityWork",
         EXISTS (
@@ -2026,14 +2046,14 @@ export class FaceIdentityRepository {
   async backfillPersonalIdentities(input: { cursor?: string; limit: number }): Promise<BackfillResult> {
     const people = await this.db
       .selectFrom('person')
-      .select(['id'])
+      .select(['id', 'ownerId', 'identityId'])
       .$if(!!input.cursor, (qb) => qb.where('id', '>', input.cursor!))
       .orderBy('id')
       .limit(input.limit + 1)
       .execute();
 
     const page = people.slice(0, input.limit);
-    const linkedAssetFaceIds = new Set<string>();
+    const affectedSpaceAssets: SharedSpaceFaceMatchBackfillTarget[] = [];
     for (const person of page) {
       const faces = await this.db
         .selectFrom('asset_face')
@@ -2048,24 +2068,97 @@ export class FaceIdentityRepository {
         .execute();
 
       const personAssetFaceIds = faces.map((face) => face.id);
-      for (const face of faces) {
-        linkedAssetFaceIds.add(face.id);
-      }
-      await this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(personAssetFaceIds);
+      affectedSpaceAssets.push(
+        ...(await this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces(personAssetFaceIds)),
+      );
 
       const identity = await this.ensurePersonIdentity(person.id);
       for (const face of faces) {
         await this.linkFace({ assetFaceId: face.id, identityId: identity.id, source: 'backfill' });
       }
+
+      affectedSpaceAssets.push(...(await this.repairPersonalIdentityAssignments(person)));
     }
 
     return {
       processed: page.length,
       nextCursor: people.length > input.limit ? page.at(-1)?.id : undefined,
-      affectedSpaceAssets: this.dedupeSharedSpaceFaceMatchBackfillTargets(
-        await this.getSharedSpaceFaceMatchTargetsForAssetFaces([...linkedAssetFaceIds]),
-      ),
+      affectedSpaceAssets: this.dedupeSharedSpaceFaceMatchBackfillTargets(affectedSpaceAssets),
     };
+  }
+
+  private async repairPersonalIdentityAssignments(
+    person: PersonalBackfillRow,
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]> {
+    const groups = await this.getPersonalBackfillIdentityGroups(person);
+    const affectedAssetFaceIds = new Set<string>();
+
+    for (const group of groups) {
+      const targetPerson = await this.getPersonByIdentity(person.ownerId, group.identityId, person.id);
+      if (!targetPerson) {
+        continue;
+      }
+
+      const assetFaceIds = await this.getPersonalBackfillAssetFaceIdsForIdentity(person.id, group.identityId);
+      if (assetFaceIds.length === 0) {
+        continue;
+      }
+
+      await this.db
+        .updateTable('asset_face')
+        .set({ personId: targetPerson.id })
+        .where('personId', '=', person.id)
+        .where('id', 'in', assetFaceIds)
+        .execute();
+
+      for (const assetFaceId of assetFaceIds) {
+        affectedAssetFaceIds.add(assetFaceId);
+      }
+    }
+
+    return this.addPendingSharedSpaceFaceMatchBackfillTargetsForAssetFaces([...affectedAssetFaceIds]);
+  }
+
+  private getPersonalBackfillIdentityGroups(person: PersonalBackfillRow): Promise<PersonalBackfillIdentityGroup[]> {
+    return this.db
+      .selectFrom('asset_face')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+      .select('face_identity_face.identityId')
+      .where('asset_face.personId', '=', person.id)
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', '=', true)
+      .where('asset.deletedAt', 'is', null)
+      .$if(!!person.identityId, (qb) => qb.where('face_identity_face.identityId', '!=', person.identityId!))
+      .groupBy('face_identity_face.identityId')
+      .$castTo<PersonalBackfillIdentityGroup>()
+      .execute();
+  }
+
+  private async getPersonalBackfillAssetFaceIdsForIdentity(personId: string, identityId: string): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom('asset_face')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+      .select('asset_face.id')
+      .where('asset_face.personId', '=', personId)
+      .where('face_identity_face.identityId', '=', identityId)
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', '=', true)
+      .where('asset.deletedAt', 'is', null)
+      .execute();
+
+    return rows.map((row) => row.id);
+  }
+
+  private getPersonByIdentity(ownerId: string, identityId: string, excludePersonId?: string) {
+    return this.db
+      .selectFrom('person')
+      .select(['id'])
+      .where('ownerId', '=', ownerId)
+      .where('identityId', '=', identityId)
+      .$if(!!excludePersonId, (qb) => qb.where('id', '!=', excludePersonId!))
+      .executeTakeFirst();
   }
 
   async backfillSpacePersonIdentities(input: { cursor?: string; limit: number }): Promise<SpacePersonBackfillResult> {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -2292,6 +2292,10 @@ describe(PersonService.name, () => {
     beforeEach(() => {
       mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([]);
       (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace = vi.fn().mockResolvedValue(void 0);
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 0,
+      });
       mocks.faceIdentity.mergeIdentities.mockResolvedValue({
         personalProfileConflictCount: 0,
         spaceProfileConflictCount: 0,
@@ -2513,10 +2517,57 @@ describe(PersonService.name, () => {
         type: 'person',
         excludeIdentityId: sourceIdentityId,
       });
+      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
+      });
       expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
         targetIdentityId,
         sourceIdentityIds: [sourceIdentityId],
         source: 'shared-space-evidence',
+      });
+    });
+
+    it('skips accessible shared identity merge when same-owner personal conflicts exist', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+      const sourceIdentityId = 'source-identity';
+      const targetIdentityId = 'target-identity';
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+        identityId: targetIdentityId,
+        distance: 0.2,
+      });
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 1,
+        spaceProfileConflictCount: 0,
+      });
+      mocks.faceIdentity.mergeIdentities.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 0,
+      });
+
+      await sut.handleRecognizeFaces({ id: noPerson.id });
+
+      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
+      });
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
       });
     });
 
@@ -2694,6 +2745,10 @@ describe(PersonService.name, () => {
         type: 'person',
         excludeIdentityId: null,
       });
+      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
+      });
       expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
         targetIdentityId,
         sourceIdentityIds: [sourceIdentityId],
@@ -2734,6 +2789,10 @@ describe(PersonService.name, () => {
       expect(mocks.person.create).toHaveBeenCalledWith({
         ownerId: asset.ownerId,
         faceAssetId: face.id,
+      });
+      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
       });
       expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
         targetIdentityId,

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -1069,17 +1069,22 @@ export class PersonService extends BaseService {
       return;
     }
 
-    const result = await this.faceIdentityRepository.mergeIdentities({
+    const conflicts = await this.faceIdentityRepository.getMergeConflicts({
+      targetIdentityId: claim.targetIdentityId,
+      sourceIdentityIds: [claim.sourceIdentityId],
+    });
+    if (conflicts.personalProfileConflictCount > 0 || conflicts.spaceProfileConflictCount > 0) {
+      this.logger.warn(
+        `Skipping accessible identity merge due to conflicts: ${conflicts.personalProfileConflictCount} personal, ${conflicts.spaceProfileConflictCount} space`,
+      );
+      return;
+    }
+
+    await this.faceIdentityRepository.mergeIdentities({
       targetIdentityId: claim.targetIdentityId,
       sourceIdentityIds: [claim.sourceIdentityId],
       source: 'shared-space-evidence',
     });
-
-    if (result.personalProfileConflictCount > 0 || result.spaceProfileConflictCount > 0) {
-      this.logger.warn(
-        `Accessible identity merge had conflicts: ${result.personalProfileConflictCount} personal, ${result.spaceProfileConflictCount} space`,
-      );
-    }
 
     await this.queueSpacePersonMetadataBackfill(claim.targetIdentityId);
   }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -148,6 +148,24 @@ const newLibraryIdentityFace = async (
   return { person, identity, asset, assetFace };
 };
 
+const getPersonalIdentityMismatchRows = async (ctx: ReturnType<typeof setup>['ctx'], assetFaceIds: string[]) => {
+  const rows = await ctx.database
+    .selectFrom('asset_face')
+    .innerJoin('person', 'person.id', 'asset_face.personId')
+    .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+    .select([
+      'asset_face.id as assetFaceId',
+      'asset_face.personId',
+      'person.identityId as personIdentityId',
+      'face_identity_face.identityId as faceIdentityId',
+    ])
+    .where('asset_face.id', 'in', assetFaceIds)
+    .orderBy('asset_face.id')
+    .execute();
+
+  return rows.filter((row) => row.personIdentityId !== row.faceIdentityId);
+};
+
 describe(FaceIdentityRepository.name, () => {
   it('returns no accessible identity match when multiple shared identities are within threshold', async () => {
     const { ctx, sut } = setup();
@@ -867,6 +885,152 @@ describe(FaceIdentityRepository.name, () => {
       expect(new Set(links.map((link) => link.identityId))).toEqual(new Set([firstIdentity.identityId]));
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('reports personal face identity mismatches as backfill work', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+      const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+      await sut.ensurePersonIdentity(sourcePerson.id);
+      await sut.linkFace({
+        assetFaceId: assetFace.id,
+        identityId: targetIdentity.id,
+        source: 'shared-space-evidence',
+      });
+
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+      await expect(sut.hasBackfillWork()).resolves.toBe(true);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('repairs personal face identity mismatches by moving faces to an existing same-owner target person', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+      const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+      await sut.linkFace({
+        assetFaceId: assetFace.id,
+        identityId: targetIdentity.id,
+        source: 'shared-space-evidence',
+      });
+
+      const result = await sut.backfillPersonalIdentities({ limit: 100 });
+
+      const updatedFace = await ctx.database
+        .selectFrom('asset_face')
+        .select('personId')
+        .where('id', '=', assetFace.id)
+        .executeTakeFirstOrThrow();
+      const sourceProfile = await ctx.database
+        .selectFrom('person')
+        .select('identityId')
+        .where('id', '=', sourcePerson.id)
+        .executeTakeFirstOrThrow();
+      const pendingTargetRows = await sut.getPendingSharedSpaceFaceMatchBackfillTargets();
+      const pendingTargets = pendingTargetRows.map(({ spaceId, assetId }) => ({
+        spaceId,
+        assetId,
+      }));
+
+      expect(updatedFace.personId).toBe(targetPerson.id);
+      expect(sourceProfile.identityId).toBe(sourceIdentity.id);
+      expect(await getPersonalIdentityMismatchRows(ctx, [assetFace.id])).toEqual([]);
+      expect(result.affectedSpaceAssets).toEqual([{ spaceId: space.id, assetId: asset.id }]);
+      expect(pendingTargets).toEqual([{ spaceId: space.id, assetId: asset.id }]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('repairs only mismatched personal face groups when a stale person still has correctly linked faces', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: sourceLinkedFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+      const { assetFace: targetLinkedFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+      const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+      const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+      await sut.linkFace({ assetFaceId: sourceLinkedFace.id, identityId: sourceIdentity.id, source: 'owner-person' });
+      await sut.linkFace({
+        assetFaceId: targetLinkedFace.id,
+        identityId: targetIdentity.id,
+        source: 'shared-space-evidence',
+      });
+
+      await sut.backfillPersonalIdentities({ limit: 100 });
+
+      const faces = await ctx.database
+        .selectFrom('asset_face')
+        .select(['id', 'personId'])
+        .where('id', 'in', [sourceLinkedFace.id, targetLinkedFace.id])
+        .orderBy('id')
+        .execute();
+
+      expect(faces.find((face) => face.id === sourceLinkedFace.id)?.personId).toBe(sourcePerson.id);
+      expect(faces.find((face) => face.id === targetLinkedFace.id)?.personId).toBe(targetPerson.id);
+      expect(await getPersonalIdentityMismatchRows(ctx, [sourceLinkedFace.id, targetLinkedFace.id])).toEqual([]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('does not move mismatched personal faces to a target person owned by another user', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user: sourceOwner } = await ctx.newUser();
+    const { user: targetOwner } = await ctx.newUser();
+    try {
+      const { person: sourcePerson } = await ctx.newPerson({ ownerId: sourceOwner.id });
+      const { person: otherOwnerTargetPerson } = await ctx.newPerson({ ownerId: targetOwner.id });
+      const { asset } = await ctx.newAsset({ ownerId: sourceOwner.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+      const targetIdentity = await sut.ensurePersonIdentity(otherOwnerTargetPerson.id);
+      await sut.ensurePersonIdentity(sourcePerson.id);
+      await sut.linkFace({
+        assetFaceId: assetFace.id,
+        identityId: targetIdentity.id,
+        source: 'shared-space-evidence',
+      });
+
+      await sut.backfillPersonalIdentities({ limit: 100 });
+
+      const updatedFace = await ctx.database
+        .selectFrom('asset_face')
+        .select('personId')
+        .where('id', '=', assetFace.id)
+        .executeTakeFirstOrThrow();
+
+      expect(updatedFace.personId).toBe(sourcePerson.id);
+      expect(await getPersonalIdentityMismatchRows(ctx, [assetFace.id])).toHaveLength(1);
+      await expect(sut.getBackfillWork()).resolves.toEqual({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', 'in', [sourceOwner.id, targetOwner.id]).execute();
     }
   });
 

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -2612,9 +2612,98 @@ describe(FaceIdentityRepository.name, () => {
       .executeTakeFirstOrThrow();
 
     expect(result).toEqual({ personalProfileConflictCount: 1, spaceProfileConflictCount: 0 });
-    expect(links).toEqual([{ assetFaceId: sourceFace.id, identityId: targetIdentity.id }]);
+    expect(links).toEqual([{ assetFaceId: sourceFace.id, identityId: sourceIdentity.id }]);
     expect(sourceProfile.identityId).toBe(sourceIdentity.id);
-    expect(sourceSpaceProfile.identityId).toBe(targetIdentity.id);
+    expect(sourceSpaceProfile.identityId).toBe(sourceIdentity.id);
+  });
+
+  it('does not leave a source person attached to moved identity faces when a same-owner target person exists', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
+      const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+      const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+      const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+      await sut.linkFace({
+        assetFaceId: sourceFace.id,
+        identityId: sourceIdentity.id,
+        source: 'owner-person',
+      });
+
+      await sut
+        .mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'shared-space-evidence',
+        })
+        .catch(() => {});
+
+      const faces = await ctx.database
+        .selectFrom('asset_face')
+        .innerJoin('person', 'person.id', 'asset_face.personId')
+        .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+        .select([
+          'asset_face.id as assetFaceId',
+          'asset_face.personId',
+          'person.identityId as personIdentityId',
+          'face_identity_face.identityId as faceIdentityId',
+        ])
+        .where('asset_face.id', '=', sourceFace.id)
+        .execute();
+
+      expect(faces.filter((face) => face.personIdentityId !== face.faceIdentityId)).toEqual([]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('does not leave a source space person attached to moved identity faces when a same-space target profile exists', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      const targetSpacePerson = await newSpacePerson(ctx, space.id);
+      const sourceSpacePerson = await newSpacePerson(ctx, space.id);
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id });
+      await linkSpaceFace(ctx, sourceSpacePerson.id, sourceFace.id);
+      const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+      const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+      await sut.linkFace({
+        assetFaceId: sourceFace.id,
+        identityId: sourceIdentity.id,
+        source: 'shared-space-evidence',
+      });
+
+      await sut
+        .mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'shared-space-evidence',
+        })
+        .catch(() => {});
+
+      const faces = await ctx.database
+        .selectFrom('shared_space_person_face')
+        .innerJoin('shared_space_person', 'shared_space_person.id', 'shared_space_person_face.personId')
+        .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'shared_space_person_face.assetFaceId')
+        .select([
+          'shared_space_person_face.assetFaceId as assetFaceId',
+          'shared_space_person_face.personId as spacePersonId',
+          'shared_space_person.identityId as spacePersonIdentityId',
+          'face_identity_face.identityId as faceIdentityId',
+        ])
+        .where('shared_space_person_face.assetFaceId', '=', sourceFace.id)
+        .execute();
+
+      expect(faces.filter((face) => face.spacePersonIdentityId !== face.faceIdentityId)).toEqual([]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
   });
 
   it('counts same-owner personal conflicts before identity merge', async () => {


### PR DESCRIPTION
## Summary
- prevent face identity merges from moving face links when same-owner or same-space profile conflicts exist
- preflight automatic accessible identity merges in PersonService
- add regression coverage for personal and shared-space identity/face mismatch invariants

## Tests
- pnpm --filter immich test src/services/person.service.spec.ts
- pnpm --filter immich test src/services/shared-space.service.spec.ts
- pnpm --filter immich test:medium test/medium/specs/repositories/face-identity.repository.spec.ts
- pnpm --filter immich check
- pnpm --filter immich lint
- pnpm --filter immich format