### PR TITLE
fix(server): avoid large face identity backfill parameter lists

### DIFF
--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -14,6 +14,7 @@ import type { PeopleFaceStatistics, PersonStatistics } from 'src/repositories/pe
 import { DB } from 'src/schema';
 import { FaceIdentityFaceSource, FaceIdentityFaceTable } from 'src/schema/tables/face-identity-face.table';
 import { FaceIdentityTable } from 'src/schema/tables/face-identity.table';
+import { anyUuid } from 'src/utils/database';
 import { asBirthDateString, asDateString } from 'src/utils/date';
 
 export type FaceIdentity = Selectable<FaceIdentityTable>;
@@ -95,6 +96,7 @@ type SpacePersonBackfillIdentityGroup = {
 };
 
 const peopleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+const sharedSpaceFaceMatchBackfillTargetInsertChunkSize = 1000;
 
 export type ScopedPersonTokenResolution = {
   identityIds: string[];
@@ -441,7 +443,7 @@ export class FaceIdentityRepository {
 
     const limit = input.limit === undefined ? sql`` : sql`LIMIT ${input.limit}`;
     const assetFaceIds = input.assetFaceIds ? [...new Set(input.assetFaceIds)] : undefined;
-    const assetFaceFilter = assetFaceIds ? sql`AND asset_face.id IN (${sql.join(assetFaceIds)})` : sql``;
+    const assetFaceFilter = assetFaceIds ? sql`AND asset_face.id = ${anyUuid(assetFaceIds)}` : sql``;
     const result = await sql<SharedSpaceFaceMatchBackfillTarget>`
       WITH face_spaces AS (
         SELECT
@@ -552,7 +554,7 @@ export class FaceIdentityRepository {
           AND asset."deletedAt" IS NULL
           AND asset."isOffline" = false
           AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
-          AND asset_face.id IN (${sql.join(uniqueAssetFaceIds)})
+          AND asset_face.id = ${anyUuid(uniqueAssetFaceIds)}
           AND asset_face."personId" IS NOT NULL
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
@@ -578,7 +580,7 @@ export class FaceIdentityRepository {
           AND asset."deletedAt" IS NULL
           AND asset."isOffline" = false
           AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
-          AND asset_face.id IN (${sql.join(uniqueAssetFaceIds)})
+          AND asset_face.id = ${anyUuid(uniqueAssetFaceIds)}
           AND asset_face."personId" IS NOT NULL
           AND asset_face."deletedAt" IS NULL
           AND asset_face."isVisible" = true
@@ -607,11 +609,14 @@ export class FaceIdentityRepository {
       return [];
     }
 
-    await this.db
-      .insertInto('shared_space_face_match_backfill_target')
-      .values(uniqueTargets)
-      .onConflict((oc) => oc.columns(['spaceId', 'assetId']).doUpdateSet({ updatedAt: sql`now()` }))
-      .execute();
+    for (let index = 0; index < uniqueTargets.length; index += sharedSpaceFaceMatchBackfillTargetInsertChunkSize) {
+      const chunk = uniqueTargets.slice(index, index + sharedSpaceFaceMatchBackfillTargetInsertChunkSize);
+      await this.db
+        .insertInto('shared_space_face_match_backfill_target')
+        .values(chunk)
+        .onConflict((oc) => oc.columns(['spaceId', 'assetId']).doUpdateSet({ updatedAt: sql`now()` }))
+        .execute();
+    }
 
     return uniqueTargets;
   }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1,11 +1,14 @@
 import { Kysely } from 'kysely';
 import { AssetVisibility, SharedSpaceRole } from 'src/enum';
-import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
+import {
+  FaceIdentityRepository,
+  type SharedSpaceFaceMatchBackfillTarget,
+} from 'src/repositories/face-identity.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
 import { BaseService } from 'src/services/base.service';
 import { newMediumService } from 'test/medium.factory';
-import { newEmbedding } from 'test/small.factory';
+import { newEmbedding, newUuid } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
 
 let defaultDatabase: Kysely<DB>;
@@ -17,6 +20,15 @@ const setup = (db?: Kysely<DB>) => {
     mock: [LoggingRepository],
   });
   return { ctx, sut: ctx.get(FaceIdentityRepository) };
+};
+
+type FaceIdentityRepositoryInternals = {
+  getSharedSpaceFaceMatchTargetsForAssetFaces(
+    assetFaceIds: string[],
+  ): Promise<Array<{ spaceId: string; assetId: string }>>;
+  addPendingSharedSpaceFaceMatchBackfillTargets(
+    targets: SharedSpaceFaceMatchBackfillTarget[],
+  ): Promise<SharedSpaceFaceMatchBackfillTarget[]>;
 };
 
 beforeAll(async () => {
@@ -949,6 +961,52 @@ describe(FaceIdentityRepository.name, () => {
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
+  });
+
+  it('handles large personal-identity rematch target batches without exceeding the postgres parameter limit', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const repository = sut as unknown as FaceIdentityRepositoryInternals;
+      const assetFaceIds = [assetFace.id, ...Array.from({ length: 32_999 }, () => newUuid())];
+
+      await expect(repository.getSharedSpaceFaceMatchTargetsForAssetFaces(assetFaceIds)).resolves.toEqual([
+        { spaceId: space.id, assetId: asset.id },
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
+  it('chunks large pending rematch target inserts below the postgres parameter limit', async () => {
+    const insertedChunks: SharedSpaceFaceMatchBackfillTarget[][] = [];
+    const execute = vi.fn().mockResolvedValue(void 0);
+    const db = {
+      insertInto: vi.fn(() => ({
+        values: vi.fn((values: SharedSpaceFaceMatchBackfillTarget[]) => {
+          insertedChunks.push(values);
+          return {
+            onConflict: vi.fn(() => ({ execute })),
+          };
+        }),
+      })),
+    };
+    const repository = new FaceIdentityRepository(
+      db as unknown as Kysely<DB>,
+    ) as unknown as FaceIdentityRepositoryInternals;
+    const targets = Array.from({ length: 33_000 }, () => ({ spaceId: newUuid(), assetId: newUuid() }));
+
+    await expect(repository.addPendingSharedSpaceFaceMatchBackfillTargets(targets)).resolves.toHaveLength(33_000);
+
+    expect(insertedChunks).toHaveLength(33);
+    expect(insertedChunks.every((chunk) => chunk.length <= 1000)).toBe(true);
+    expect(insertedChunks.reduce((total, chunk) => total + chunk.length, 0)).toBe(33_000);
   });
 
   it('persists personal-identity targets only for unlinked faces when one person has mixed linked faces', async () => {


### PR DESCRIPTION
## Summary
- replace large face-id IN lists in shared-space face rematch queries with a single `ANY` uuid array parameter
- chunk pending shared-space rematch target inserts so large maintenance batches stay below the postgres bind-parameter cap
- add regression coverage for the 33k-face batch path and the large pending insert path

## Tests
- `pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts --run`
- `pnpm --dir server test:medium test/medium/specs/services/metadata.service.spec.ts -t "backfill legacy imported metadata faces into shared spaces" --run`
- `pnpm --dir server check`
- `pnpm --dir server lint`