### PR TITLE
fix(server): revert relaxed existing-person matching

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -3562,9 +3562,9 @@ describe(PersonService.name, () => {
       });
     });
 
-    it('should use a relaxed existing-person search before creating a new core person', async () => {
+    it('should not use a relaxed existing-person search before creating a new core person', async () => {
       const asset = AssetFactory.create();
-      const person = PersonFactory.create();
+      const person = PersonFactory.create({ ownerId: asset.ownerId });
       const [noPerson1, noPerson2, noPerson3] = [
         AssetFaceFactory.create({ assetId: asset.id }),
         AssetFaceFactory.create(),
@@ -3577,10 +3577,9 @@ describe(PersonService.name, () => {
       ] as FaceSearchResult[];
 
       mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
-      mocks.search.searchFaces
-        .mockResolvedValueOnce(faces)
-        .mockResolvedValueOnce([{ ...noPerson2, personId: person.id, distance: 0.56 }]);
+      mocks.search.searchFaces.mockResolvedValueOnce(faces).mockResolvedValueOnce([]);
       mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
+      mocks.person.create.mockResolvedValue(person);
 
       await sut.handleRecognizeFaces({ id: noPerson1.id });
 
@@ -3588,20 +3587,19 @@ describe(PersonService.name, () => {
         2,
         expect.objectContaining({
           hasPerson: true,
-          maxDistance: 0.6,
-          numResults: 5,
+          maxDistance: 0.5,
+          numResults: 1,
         }),
       );
-      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.create).toHaveBeenCalledWith({ ownerId: asset.ownerId, faceAssetId: noPerson1.id });
       expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
         faceIds: [noPerson1.id],
         newPersonId: person.id,
       });
     });
 
-    it('should attach a deferred small cluster to a relaxed existing-person match', async () => {
+    it('should not attach a deferred small cluster to a relaxed existing-person match', async () => {
       const asset = AssetFactory.create();
-      const person = PersonFactory.create();
       const [noPerson1, noPerson2] = [AssetFaceFactory.create({ assetId: asset.id }), AssetFaceFactory.create()];
       const faces = [
         { ...noPerson1, distance: 0 },
@@ -3609,9 +3607,7 @@ describe(PersonService.name, () => {
       ] as FaceSearchResult[];
 
       mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
-      mocks.search.searchFaces
-        .mockResolvedValueOnce(faces)
-        .mockResolvedValueOnce([{ ...noPerson2, personId: person.id, distance: 0.56 }]);
+      mocks.search.searchFaces.mockResolvedValueOnce(faces).mockResolvedValueOnce([]);
       mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
 
       await sut.handleRecognizeFaces({ id: noPerson1.id, deferred: true });
@@ -3620,18 +3616,15 @@ describe(PersonService.name, () => {
         2,
         expect.objectContaining({
           hasPerson: true,
-          maxDistance: 0.6,
-          numResults: 5,
+          maxDistance: 0.5,
+          numResults: 1,
         }),
       );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.PersonGenerateThumbnail }),
       );
       expect(mocks.person.create).not.toHaveBeenCalled();
-      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
-        faceIds: [noPerson1.id],
-        newPersonId: person.id,
-      });
+      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
     });
 
     it('should handle deferred non-core face with matching person', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -66,8 +66,6 @@ import { isFacialRecognitionEnabled } from 'src/utils/misc';
 import { Point, transformPoints } from 'src/utils/transform';
 
 const FACE_IDENTITY_BACKFILL_CHUNK_SIZE = 1000;
-const EXISTING_PERSON_MATCH_DISTANCE_BUFFER = 0.1;
-const EXISTING_PERSON_MATCH_RESULT_LIMIT = 5;
 
 @Injectable()
 export class PersonService extends BaseService {
@@ -967,8 +965,8 @@ export class PersonService extends BaseService {
       const matchWithPerson = await this.searchRepository.searchFaces({
         userIds: [face.asset.ownerId],
         embedding: face.faceSearch.embedding,
-        maxDistance: Math.min(1, machineLearning.facialRecognition.maxDistance + EXISTING_PERSON_MATCH_DISTANCE_BUFFER),
-        numResults: EXISTING_PERSON_MATCH_RESULT_LIMIT,
+        maxDistance: machineLearning.facialRecognition.maxDistance,
+        numResults: 1,
         hasPerson: true,
         minBirthDate: new Date(face.asset.fileCreatedAt),
       });


### PR DESCRIPTION
## Summary

This reverts the relaxed existing-person fallback that was added to reduce manual merging pressure.

### Why

We found that slightly relaxing the existing-person matching threshold reduced some split-person cases, but it also introduced a much worse failure mode: a small number of incorrect matches could chain together and over-merge a person into a large, polluted identity. That state is significantly harder to repair than a split person.

The safer tradeoff is to keep the stricter matching logic we had before. It may leave a few more people split across identities, but it avoids creating large false clusters that are expensive to untangle later.

### What changed

- Restore the strict existing-person fallback distance.
- Remove the extra relaxed matching buffer.
- Keep the fallback limited to a single best match.
- Update the relevant unit coverage to reflect the stricter behavior.

### Recovery

This change prevents new over-merging. Existing polluted identities will need to be repaired separately by rerunning the appropriate face processing after this build is deployed.
