### PR TITLE
fix: sort people suggestions by favorites and name

### DIFF
--- a/web/src/lib/managers/cmdk-prefix.spec.ts
+++ b/web/src/lib/managers/cmdk-prefix.spec.ts
@@ -45,22 +45,28 @@ const p = (o: Partial<PersonResponseDto>): PersonResponseDto =>
   }) as PersonResponseDto;
 
 describe('personSuggestionsComparator', () => {
-  it('sorts by updatedAt desc when present on both', () => {
+  it('sorts favorite people first, then named people alphabetically, then unnamed people', () => {
+    const people = [
+      p({ id: 'unnamed', name: '', isFavorite: false }),
+      p({ id: 'named-z', name: 'Zoe', isFavorite: false }),
+      p({ id: 'favorite-z', name: 'Zelda', isFavorite: true }),
+      p({ id: 'named-a', name: 'Alice', isFavorite: false }),
+      p({ id: 'favorite-a', name: 'Anna', isFavorite: true }),
+    ];
+
+    expect(people.sort(personSuggestionsComparator).map((person) => person.id)).toEqual([
+      'favorite-a',
+      'favorite-z',
+      'named-a',
+      'named-z',
+      'unnamed',
+    ]);
+  });
+
+  it('ignores recency when sorting named people', () => {
     const a = p({ id: 'a', name: 'Alice', updatedAt: '2026-04-01T00:00:00Z' });
     const b = p({ id: 'b', name: 'Bob', updatedAt: '2026-04-15T00:00:00Z' });
-    expect([a, b].sort(personSuggestionsComparator)).toEqual([b, a]);
-  });
-
-  it('missing updatedAt treated as oldest', () => {
-    const a = p({ id: 'a', name: 'Alice', updatedAt: '2026-04-10T00:00:00Z' });
-    const b = p({ id: 'b', name: 'Bob' }); // no updatedAt
-    expect([a, b].sort(personSuggestionsComparator)).toEqual([a, b]);
-  });
-
-  it('updatedAt tie → alpha by name', () => {
-    const a = p({ id: 'a', name: 'Zack', updatedAt: '2026-04-10T00:00:00Z' });
-    const b = p({ id: 'b', name: 'Alice', updatedAt: '2026-04-10T00:00:00Z' });
-    expect([a, b].sort(personSuggestionsComparator)).toEqual([b, a]);
+    expect([b, a].sort(personSuggestionsComparator)).toEqual([a, b]);
   });
 
   it('same name tie → stable by id', () => {

--- a/web/src/lib/managers/cmdk-prefix.ts
+++ b/web/src/lib/managers/cmdk-prefix.ts
@@ -1,3 +1,4 @@
+import { comparePeopleByFavoriteAndName } from '$lib/utils/people-utils';
 import type { PersonResponseDto } from '@immich/sdk';
 
 export type Scope = 'all' | 'people' | 'tags' | 'collections' | 'nav';
@@ -24,17 +25,8 @@ export function parseScope(rawText: string): ParsedQuery {
 
 /**
  * Sort comparator for the bare-`@` suggestions list.
- * Keys (in priority order): updatedAt desc, name alpha, id alpha.
- * `updatedAt` is optional on PersonResponseDto; missing values sink to the bottom.
+ * Keys (in priority order): favorite first, named people alpha, unnamed people, id alpha.
  */
 export function personSuggestionsComparator(a: PersonResponseDto, b: PersonResponseDto): number {
-  const au = a.updatedAt ?? '';
-  const bu = b.updatedAt ?? '';
-  if (au !== bu) {
-    return bu.localeCompare(au); // desc
-  }
-  if (a.name !== b.name) {
-    return a.name.localeCompare(b.name);
-  }
-  return a.id.localeCompare(b.id);
+  return comparePeopleByFavoriteAndName(a, b);
 }

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -5880,15 +5880,17 @@ describe('prefix scoping — bare @ suggestions', () => {
     vi.useRealTimers();
   });
 
-  it('bare @ calls getAllPeople once; subsequent bare @ reads cache', async () => {
+  it('bare @ calls getAllPeople once and sorts favorites before named people', async () => {
     const m = new GlobalSearchManager();
     const getAllPeopleSpy = vi.mocked(getAllPeople);
     getAllPeopleSpy.mockResolvedValue({
       people: [
-        mockPerson('older', 'Zack', '2026-01-01T00:00:00Z'),
-        mockPerson('newer', 'Alice', '2026-04-15T00:00:00Z'),
+        mockPerson('named-z', 'Zack', '2026-01-01T00:00:00Z'),
+        { ...mockPerson('favorite-z', 'Zelda', '2026-02-01T00:00:00Z'), isFavorite: true },
+        mockPerson('named-a', 'Alice', '2026-04-15T00:00:00Z'),
+        { ...mockPerson('favorite-a', 'Anna', '2026-03-01T00:00:00Z'), isFavorite: true },
       ],
-      total: 2,
+      total: 4,
       hidden: 0,
       hasNextPage: false,
     });
@@ -5897,10 +5899,10 @@ describe('prefix scoping — bare @ suggestions', () => {
     await vi.advanceTimersByTimeAsync(150);
     await vi.runAllTimersAsync();
 
-    // Assert comparator was applied (newer updatedAt first).
+    // Assert comparator was applied (favorites first, then alpha).
     expect(m.sections.people.status).toBe('ok');
     const items = (m.sections.people as { items: { id: string }[] }).items;
-    expect(items.map((i) => i.id)).toEqual(['newer', 'older']);
+    expect(items.map((i) => i.id)).toEqual(['favorite-a', 'favorite-z', 'named-a', 'named-z']);
 
     m.setQuery('@a');
     await vi.advanceTimersByTimeAsync(150);

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -2599,9 +2599,10 @@ export class GlobalSearchManager {
         }
         try {
           const results = await searchPerson({ name: query, withHidden: false, withSharedSpaces: true }, { signal });
+          const sortedResults = [...results].sort(personSuggestionsComparator);
           return results.length === 0
             ? { status: 'empty' }
-            : { status: 'ok', items: results.slice(0, 5), total: results.length };
+            : { status: 'ok', items: sortedResults.slice(0, 5), total: sortedResults.length };
         } catch (error: unknown) {
           if (error instanceof Error && error.name === 'AbortError') {
             throw error;

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -4,6 +4,37 @@ import { mapNormalizedRectToContent, type Rect, type Size } from '$lib/utils/con
 import { AssetTypeEnum } from '@immich/sdk';
 
 export type BoundingBox = Rect & { id: string };
+export type SortablePerson = {
+  id: string;
+  name?: string | null;
+  isFavorite?: boolean;
+};
+
+const getSortablePersonName = (person: SortablePerson) => person.name?.trim() ?? '';
+
+export function comparePeopleByFavoriteAndName(a: SortablePerson, b: SortablePerson): number {
+  if (!!a.isFavorite !== !!b.isFavorite) {
+    return a.isFavorite ? -1 : 1;
+  }
+
+  const aName = getSortablePersonName(a);
+  const bName = getSortablePersonName(b);
+  const aHasName = aName.length > 0;
+  const bHasName = bName.length > 0;
+  if (aHasName !== bHasName) {
+    return aHasName ? -1 : 1;
+  }
+
+  if (aName !== bName) {
+    return aName.localeCompare(bName);
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
+export function sortPeopleByFavoriteAndName<T extends SortablePerson>(people: T[]): T[] {
+  return [...people].sort(comparePeopleByFavoriteAndName);
+}
 
 export const getPersonFaceThumbnailUrl = (personId: string, faceId: string, updatedAt?: string) =>
   createUrl(`/people/${personId}/faces/${faceId}/thumbnail`, { updatedAt });

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -24,6 +24,7 @@
   import { getGlobalPersonHref, getGlobalPersonThumbnailUrl } from '$lib/utils/global-person-route';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
+  import { sortPeopleByFavoriteAndName } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
     getAllPeople,
@@ -269,7 +270,7 @@
   );
   let globalFaceStatisticsCacheKey = $derived(`user:${authManager.user.id}:global:people:withSharedSpaces=true`);
   const loadGlobalFaceStatistics = () => getPeopleFaceStatistics({ withSharedSpaces: true });
-  let showPeople = $derived(searchName ? searchedPeopleLocal : visiblePeople);
+  let showPeople = $derived(sortPeopleByFavoriteAndName(searchName ? searchedPeopleLocal : visiblePeople));
 
   const getPersonHref = (person: PersonResponseDto) => getGlobalPersonHref(person, Route.people());
 

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -164,6 +164,24 @@ describe('Global people page', () => {
     expect(screen.getByDisplayValue('Alice')).toHaveAttribute('placeholder', 'add_a_name');
   });
 
+  it('renders favorites first, then named people alphabetically, then unnamed people', () => {
+    renderPage([
+      makePerson({ id: 'unnamed', name: '', isFavorite: false }),
+      makePerson({ id: 'named-z', name: 'Zoe', isFavorite: false }),
+      makePerson({ id: 'favorite-z', name: 'Zelda', isFavorite: true }),
+      makePerson({ id: 'named-a', name: 'Alice', isFavorite: false }),
+      makePerson({ id: 'favorite-a', name: 'Anna', isFavorite: true }),
+    ]);
+
+    expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
+      'Anna',
+      'Zelda',
+      'Alice',
+      'Zoe',
+      '',
+    ]);
+  });
+
   it('shows visible people and detected faces in the heading', () => {
     renderPage([makePerson({ id: 'p1' })], { total: 12, hidden: 2, detectedFaceCount: 2901 });
 

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
@@ -18,6 +18,7 @@
   import { createUrl, handlePromiseError } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
+  import { sortPeopleByFavoriteAndName } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
     getSpacePeople,
@@ -69,7 +70,7 @@
   let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 
   let selectHidden = $state(false);
-  const visiblePeople = $derived(people.filter((p) => !p.isHidden));
+  const visiblePeople = $derived(sortPeopleByFavoriteAndName(people.filter((p) => !p.isHidden)));
   const countVisiblePeople = $derived(peopleStatistics ? peopleStatistics.total - peopleStatistics.hidden : 0);
   const hasSearchablePeople = $derived(countVisiblePeople > 0 || visiblePeople.length > 0 || !!searchName.trim());
   const activeSearchFilterName = $derived(

--- a/web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts
@@ -146,7 +146,21 @@ describe('Space people page', () => {
     featureFlagsMock.value.peopleStatistics = true;
   });
 
-  it('keeps a newly named person in the same visible position until the page is refreshed', async () => {
+  it('renders named people alphabetically before unnamed people', () => {
+    renderPage([
+      makeSpacePerson({ id: 'space-person-unnamed', name: '' }),
+      makeSpacePerson({ id: 'space-person-zoe', name: 'Zoe' }),
+      makeSpacePerson({ id: 'space-person-alice', name: 'Alice' }),
+    ]);
+
+    expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
+      'Alice',
+      'Zoe',
+      '',
+    ]);
+  });
+
+  it('moves a newly named person into alphabetical order', async () => {
     const bob = makeSpacePerson({ id: 'space-person-bob', name: 'Bob' });
     const unnamed = makeSpacePerson({ id: 'space-person-unnamed', name: '' });
     const renamed = makeSpacePerson({ id: 'space-person-unnamed', name: 'Aaron' });
@@ -175,7 +189,7 @@ describe('Space people page', () => {
     expect(sdkMock.getSpacePeople).not.toHaveBeenCalled();
 
     const updatedInputs = screen.getAllByPlaceholderText('add_a_name');
-    expect(updatedInputs[0]).toHaveValue('Bob');
-    expect(updatedInputs[1]).toHaveValue('Aaron');
+    expect(updatedInputs[0]).toHaveValue('Aaron');
+    expect(updatedInputs[1]).toHaveValue('Bob');
   });
 });


### PR DESCRIPTION
## Summary
- sort people suggestions favorite-first, then by name, with unnamed people last
- apply the same ordering on global and space people pages
- cover the search manager and people page ordering with tests

Fixes #564

## Testing
- pnpm --dir web exec vitest run src/lib/managers/global-search-manager.svelte.spec.ts src/lib/managers/cmdk-prefix.spec.ts src/routes/'(user)'/people/people-page.spec.ts src/routes/'(user)'/spaces/'[spaceId]'/people/space-people-page.spec.ts
- pnpm --dir web run check:typescript
- pnpm --dir web run check:svelte