### PR TITLE
fix(server): roll back incomplete asset uploads

### DIFF
--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -422,6 +422,43 @@ describe(AssetMediaService.name, () => {
       expect(mocks.user.updateUsage).not.toHaveBeenCalled();
     });
 
+    it('should queue disk original and sidecar cleanup when post-create processing fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: 'fake_path/asset_1.heic',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const sidecarFile = {
+        uuid: 'random-sidecar-uuid',
+        originalPath: 'fake_path/asset_1.xmp',
+        mimeType: 'application/xml',
+        checksum: Buffer.from('sidecar hash', 'utf8'),
+        originalName: 'asset_1.xmp',
+        size: 12,
+      };
+      const error = new Error('failed after sidecar create');
+
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(error);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, file, sidecarFile)).rejects.toThrow(error);
+
+      expect(mocks.asset.upsertFile).toHaveBeenCalledWith({
+        assetId: assetEntity.id,
+        path: sidecarFile.originalPath,
+        type: AssetFileType.Sidecar,
+      });
+      expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: [file.originalPath, sidecarFile.originalPath] },
+      });
+      expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+    });
+
     it('should delete uploaded S3 originals when post-upload processing fails', async () => {
       const file = {
         uuid: 'random-uuid',
@@ -452,6 +489,42 @@ describe(AssetMediaService.name, () => {
           contentType: 'application/octet-stream',
         });
         expect(mocks.asset.update).toHaveBeenCalledWith({ id: assetEntity.id, originalPath: expectedKey });
+        expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+        expect(s3Backend.delete).toHaveBeenCalledWith(expectedKey);
+        expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+        (StorageService as any).writeBackendType = previousWriteBackendType;
+      }
+    });
+
+    it('should preserve the original upload error when S3 rollback deletion fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: '/dev/null',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const error = new Error('failed after s3 upload');
+      const deleteError = new Error('s3 delete failed');
+      const expectedKey = 'upload/user-id/id/_1/id_1';
+      const s3Backend = {
+        put: vi.fn().mockResolvedValue(void 0),
+        delete: vi.fn().mockRejectedValue(deleteError),
+      };
+      const previousS3Backend = (StorageService as any).s3Backend;
+      const previousWriteBackendType = (StorageService as any).writeBackendType;
+
+      (StorageService as any).s3Backend = s3Backend;
+      (StorageService as any).writeBackendType = 's3';
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.event.emit.mockRejectedValue(error);
+
+      try {
+        await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toThrow(error);
+
         expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
         expect(s3Backend.delete).toHaveBeenCalledWith(expectedKey);
         expect(mocks.user.updateUsage).not.toHaveBeenCalled();

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -397,6 +397,47 @@ describe(AssetMediaService.name, () => {
       expect(mocks.user.updateUsage).not.toHaveBeenCalled();
     });
 
+    it('should allow the same file to upload again after post-create processing fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: 'fake_path/asset_1.heic',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const error = new Error('failed after asset create');
+      let incompleteRowExists = false;
+
+      mocks.asset.create.mockImplementation(() => {
+        if (incompleteRowExists) {
+          const duplicateError = new Error('unique key violation');
+          (duplicateError as any).constraint_name = ASSET_CHECKSUM_CONSTRAINT;
+          return Promise.reject(duplicateError);
+        }
+
+        incompleteRowExists = true;
+        return Promise.resolve(assetEntity);
+      });
+      mocks.asset.remove.mockImplementation(() => {
+        incompleteRowExists = false;
+        return Promise.resolve();
+      });
+      mocks.event.emit.mockRejectedValueOnce(error);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toThrow(error);
+      await expect(sut.uploadAsset(authStub.user1, createDto, file)).resolves.toEqual({
+        id: assetEntity.id,
+        status: AssetMediaStatus.CREATED,
+      });
+
+      expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+      expect(mocks.asset.create).toHaveBeenCalledTimes(2);
+      expect(mocks.asset.getUploadAssetIdByChecksum).not.toHaveBeenCalled();
+      expect(mocks.user.updateUsage).toHaveBeenCalledTimes(1);
+      expect(mocks.user.updateUsage).toHaveBeenCalledWith(authStub.user1.user.id, file.size);
+    });
+
     it('should keep uploaded disk files when removing the incomplete asset row fails', async () => {
       const file = {
         uuid: 'random-uuid',

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -373,6 +373,178 @@ describe(AssetMediaService.name, () => {
       );
     });
 
+    it('should remove the asset row when post-create processing fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: 'fake_path/asset_1.heic',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const error = new Error('failed after asset create');
+
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(error);
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toThrow(error);
+
+      expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: [file.originalPath, undefined] },
+      });
+      expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+    });
+
+    it('should keep uploaded disk files when removing the incomplete asset row fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: 'fake_path/asset_1.heic',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const error = new Error('failed after asset create');
+
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertExif.mockRejectedValue(error);
+      mocks.asset.remove.mockRejectedValue(new Error('remove failed'));
+
+      await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toThrow(error);
+
+      expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: [file.originalPath, undefined] },
+      });
+      expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+    });
+
+    it('should delete uploaded S3 originals when post-upload processing fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: '/dev/null',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const error = new Error('failed after s3 upload');
+      const expectedKey = 'upload/user-id/id/_1/id_1';
+      const s3Backend = {
+        put: vi.fn().mockResolvedValue(void 0),
+        delete: vi.fn().mockResolvedValue(void 0),
+      };
+      const previousS3Backend = (StorageService as any).s3Backend;
+      const previousWriteBackendType = (StorageService as any).writeBackendType;
+
+      (StorageService as any).s3Backend = s3Backend;
+      (StorageService as any).writeBackendType = 's3';
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.event.emit.mockRejectedValue(error);
+
+      try {
+        await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toThrow(error);
+
+        expect(s3Backend.put).toHaveBeenCalledWith(expectedKey, expect.anything(), {
+          contentType: 'application/octet-stream',
+        });
+        expect(mocks.asset.update).toHaveBeenCalledWith({ id: assetEntity.id, originalPath: expectedKey });
+        expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+        expect(s3Backend.delete).toHaveBeenCalledWith(expectedKey);
+        expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+        (StorageService as any).writeBackendType = previousWriteBackendType;
+      }
+    });
+
+    it('should delete uploaded S3 sidecars when sidecar post-processing fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: '/dev/null',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const sidecarFile = {
+        uuid: 'random-sidecar-uuid',
+        originalPath: '/dev/null',
+        mimeType: 'application/xml',
+        checksum: Buffer.from('sidecar hash', 'utf8'),
+        originalName: 'asset_1.xmp',
+        size: 12,
+      };
+      const error = new Error('failed after s3 sidecar upload');
+      const expectedOriginalKey = 'upload/user-id/id/_1/id_1';
+      const expectedSidecarKey = 'upload/user-id/id/_1/id_1.xmp';
+      const s3Backend = {
+        put: vi.fn().mockResolvedValue(void 0),
+        delete: vi.fn().mockResolvedValue(void 0),
+      };
+      const previousS3Backend = (StorageService as any).s3Backend;
+      const previousWriteBackendType = (StorageService as any).writeBackendType;
+
+      (StorageService as any).s3Backend = s3Backend;
+      (StorageService as any).writeBackendType = 's3';
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.asset.upsertFile.mockResolvedValueOnce(void 0).mockRejectedValueOnce(error);
+
+      try {
+        await expect(sut.uploadAsset(authStub.user1, createDto, file, sidecarFile)).rejects.toThrow(error);
+
+        expect(s3Backend.put).toHaveBeenCalledWith(expectedOriginalKey, expect.anything(), {
+          contentType: 'application/octet-stream',
+        });
+        expect(s3Backend.put).toHaveBeenCalledWith(expectedSidecarKey, expect.anything());
+        expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+        expect(s3Backend.delete).toHaveBeenCalledWith(expectedOriginalKey);
+        expect(s3Backend.delete).toHaveBeenCalledWith(expectedSidecarKey);
+        expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+        (StorageService as any).writeBackendType = previousWriteBackendType;
+      }
+    });
+
+    it('should delete uploaded S3 originals directly when the temp cleanup queue fails', async () => {
+      const file = {
+        uuid: 'random-uuid',
+        originalPath: '/dev/null',
+        mimeType: 'image/heic',
+        checksum: Buffer.from('file hash', 'utf8'),
+        originalName: 'asset_1.HEIC',
+        size: 42,
+      };
+      const error = new Error('job queue unavailable');
+      const expectedKey = 'upload/user-id/id/_1/id_1';
+      const s3Backend = {
+        put: vi.fn().mockResolvedValue(void 0),
+        delete: vi.fn().mockResolvedValue(void 0),
+      };
+      const previousS3Backend = (StorageService as any).s3Backend;
+      const previousWriteBackendType = (StorageService as any).writeBackendType;
+
+      (StorageService as any).s3Backend = s3Backend;
+      (StorageService as any).writeBackendType = 's3';
+      mocks.asset.create.mockResolvedValue(assetEntity);
+      mocks.job.queue.mockRejectedValueOnce(error);
+
+      try {
+        await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toThrow(error);
+
+        expect(s3Backend.delete).toHaveBeenCalledWith(expectedKey);
+        expect(mocks.asset.remove).toHaveBeenCalledWith({ id: assetEntity.id });
+        expect(mocks.user.updateUsage).not.toHaveBeenCalled();
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+        (StorageService as any).writeBackendType = previousWriteBackendType;
+      }
+    });
+
     it('should handle a duplicate', async () => {
       const file = {
         uuid: 'random-uuid',

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -30,6 +30,7 @@ import {
   Permission,
   StorageFolder,
 } from 'src/enum';
+import { StorageBackend } from 'src/interfaces/storage-backend.interface';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { BaseService } from 'src/services/base.service';
 import { StorageService } from 'src/services/storage.service';
@@ -44,6 +45,17 @@ import { fromChecksum } from 'src/utils/request';
 export interface AssetMediaRedirectResponse {
   targetSize: AssetMediaSize | 'original';
 }
+
+const SKIP_UPLOAD_FILE_CLEANUP = Symbol('skipUploadFileCleanup');
+
+const markUploadFileCleanupSkipped = (error: Error | any) => {
+  if (error && typeof error === 'object') {
+    error[SKIP_UPLOAD_FILE_CLEANUP] = true;
+  }
+};
+
+const shouldSkipUploadFileCleanup = (error: Error | any) =>
+  !!(error && typeof error === 'object' && error[SKIP_UPLOAD_FILE_CLEANUP]);
 
 @Injectable()
 export class AssetMediaService extends BaseService {
@@ -287,10 +299,12 @@ export class AssetMediaService extends BaseService {
     sidecarFile?: UploadFile,
   ): Promise<AssetMediaResponseDto> {
     // clean up files
-    await this.jobRepository.queue({
-      name: JobName.FileDelete,
-      data: { files: [file.originalPath, sidecarFile?.originalPath] },
-    });
+    if (!shouldSkipUploadFileCleanup(error)) {
+      await this.jobRepository.queue({
+        name: JobName.FileDelete,
+        data: { files: [file.originalPath, sidecarFile?.originalPath] },
+      });
+    }
 
     // handle duplicates with a success response
     if (isAssetChecksumConstraint(error)) {
@@ -333,58 +347,86 @@ export class AssetMediaService extends BaseService {
       originalFileName: dto.filename || file.originalName,
     });
 
-    if (dto.metadata?.length) {
-      await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
-    }
+    const backendFiles: string[] = [];
+    let writeBackend: StorageBackend | undefined;
 
-    if (sidecarFile) {
-      await this.assetRepository.upsertFile({
-        assetId: asset.id,
-        path: sidecarFile.originalPath,
-        type: AssetFileType.Sidecar,
-      });
-      await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
-    }
-    await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
-    await this.assetRepository.upsertExif(
-      { assetId: asset.id, fileSizeInByte: file.size },
-      { lockedPropertiesBehavior: 'override' },
-    );
-
-    // If S3 backend, upload the file and update the path
-    const writeBackend = StorageService.getWriteBackend();
-    if (!(writeBackend instanceof DiskStorageBackend)) {
-      const relativeKey = StorageCore.getRelativeNestedPath(
-        StorageFolder.Upload,
-        ownerId,
-        `${asset.id}${getFilenameExtension(file.originalPath)}`,
-      );
-      const stream = createReadStream(file.originalPath);
-      await writeBackend.put(relativeKey, stream, {
-        contentType: mimeTypes.lookup(file.originalPath),
-      });
-      await this.assetRepository.update({ id: asset.id, originalPath: relativeKey });
-      // Clean up the temp local file
-      await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [file.originalPath] } });
+    try {
+      if (dto.metadata?.length) {
+        await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
+      }
 
       if (sidecarFile) {
-        const sidecarKey = StorageCore.getRelativeNestedPath(StorageFolder.Upload, ownerId, `${asset.id}.xmp`);
-        await writeBackend.put(sidecarKey, createReadStream(sidecarFile.originalPath));
         await this.assetRepository.upsertFile({
           assetId: asset.id,
-          path: sidecarKey,
+          path: sidecarFile.originalPath,
           type: AssetFileType.Sidecar,
         });
-        await this.jobRepository.queue({
-          name: JobName.FileDelete,
-          data: { files: [sidecarFile.originalPath] },
-        });
+        await this.storageRepository.utimes(sidecarFile.originalPath, new Date(), new Date(dto.fileModifiedAt));
       }
+      await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
+      await this.assetRepository.upsertExif(
+        { assetId: asset.id, fileSizeInByte: file.size },
+        { lockedPropertiesBehavior: 'override' },
+      );
+
+      // If S3 backend, upload the file and update the path
+      writeBackend = StorageService.getWriteBackend();
+      if (!(writeBackend instanceof DiskStorageBackend)) {
+        const relativeKey = StorageCore.getRelativeNestedPath(
+          StorageFolder.Upload,
+          ownerId,
+          `${asset.id}${getFilenameExtension(file.originalPath)}`,
+        );
+        const stream = createReadStream(file.originalPath);
+        await writeBackend.put(relativeKey, stream, {
+          contentType: mimeTypes.lookup(file.originalPath),
+        });
+        backendFiles.push(relativeKey);
+        await this.assetRepository.update({ id: asset.id, originalPath: relativeKey });
+        // Clean up the temp local file
+        await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [file.originalPath] } });
+
+        if (sidecarFile) {
+          const sidecarKey = StorageCore.getRelativeNestedPath(StorageFolder.Upload, ownerId, `${asset.id}.xmp`);
+          await writeBackend.put(sidecarKey, createReadStream(sidecarFile.originalPath));
+          backendFiles.push(sidecarKey);
+          await this.assetRepository.upsertFile({
+            assetId: asset.id,
+            path: sidecarKey,
+            type: AssetFileType.Sidecar,
+          });
+          await this.jobRepository.queue({
+            name: JobName.FileDelete,
+            data: { files: [sidecarFile.originalPath] },
+          });
+        }
+      }
+
+      await this.eventRepository.emit('AssetCreate', { asset });
+
+      await this.jobRepository.queue({ name: JobName.AssetExtractMetadata, data: { id: asset.id, source: 'upload' } });
+    } catch (error: Error | any) {
+      try {
+        await this.assetRepository.remove({ id: asset.id });
+        if (backendFiles.length > 0) {
+          for (const file of backendFiles) {
+            try {
+              await writeBackend?.delete(file);
+            } catch (deleteError: Error | any) {
+              this.logger.error(
+                `Failed to delete incomplete upload file ${file} for asset ${asset.id}: ${deleteError}`,
+                deleteError?.stack,
+              );
+            }
+          }
+        }
+      } catch (deleteError: Error | any) {
+        this.logger.error(`Failed to remove incomplete upload asset ${asset.id}: ${deleteError}`, deleteError?.stack);
+        markUploadFileCleanupSkipped(error);
+      }
+
+      throw error;
     }
-
-    await this.eventRepository.emit('AssetCreate', { asset });
-
-    await this.jobRepository.queue({ name: JobName.AssetExtractMetadata, data: { id: asset.id, source: 'upload' } });
 
     return asset;
   }


### PR DESCRIPTION
## Reason
The reported broken asset has a leading `/data/upload/...` original path, which means the database row still points at the disk upload staging/original path rather than a finalized S3-relative key. Our working suspicion is that upload post-processing failed during the disk-to-S3 handoff or another post-create step, but the asset row was already committed. That leaves a hanging asset record whose checksum then makes mobile believe the local photo is already uploaded.

This tightens that path so incomplete uploads do not leave database rows behind, while preserving recoverability if the row rollback itself fails.

## Summary
- roll back newly-created asset rows when upload post-processing fails
- avoid deleting disk originals if the row rollback fails, preserving recoverability
- directly delete S3 originals/sidecars written before a later upload failure

## Tests
- pnpm --dir server test asset-media.service.spec.ts --run
- pnpm --dir server exec eslint src/services/asset-media.service.ts src/services/asset-media.service.spec.ts --max-warnings 0
- pnpm --dir server check
- git diff --check

Fixes #568