### PR TITLE
fix(server): link merged person faces to identity

### DIFF
--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -1345,6 +1345,38 @@ set
 returning
   *
 
+-- FaceIdentityRepository.linkPersonFaces
+insert into
+  "face_identity_face" (
+    "assetFaceId",
+    "identityId",
+    "source",
+    "confidence"
+  )
+select
+  "asset_face"."id" as "assetFaceId",
+  $1 as "identityId",
+  $2 as "source",
+  $3 as "confidence"
+from
+  "asset_face"
+  inner join "asset" on "asset"."id" = "asset_face"."assetId"
+  left join "face_identity_face" on "face_identity_face"."assetFaceId" = "asset_face"."id"
+where
+  "asset_face"."personId" = $4
+  and "asset_face"."deletedAt" is null
+  and "asset_face"."isVisible" = $5
+  and "asset"."deletedAt" is null
+  and (
+    "face_identity_face"."identityId" is null
+    or "face_identity_face"."identityId" != $6
+  )
+on conflict ("assetFaceId") do update
+set
+  "identityId" = $7,
+  "source" = $8,
+  "confidence" = $9
+
 -- FaceIdentityRepository.updateRepresentativeFace
 update "face_identity"
 set

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -27,6 +27,12 @@ export type LinkFaceInput = {
   confidence?: number | null;
 };
 
+export type LinkPersonFacesInput = {
+  personId: string;
+  identityId: string;
+  source: FaceIdentityFaceSource;
+};
+
 export type BackfillResult = {
   processed: number;
   nextCursor?: string;
@@ -1982,6 +1988,43 @@ export class FaceIdentityRepository {
       )
       .returningAll()
       .executeTakeFirstOrThrow();
+  }
+
+  @GenerateSql({ params: [{ personId: DummyValue.UUID, identityId: DummyValue.UUID, source: 'manual' }] })
+  async linkPersonFaces(input: LinkPersonFacesInput): Promise<void> {
+    await this.db
+      .insertInto('face_identity_face')
+      .columns(['assetFaceId', 'identityId', 'source', 'confidence'])
+      .expression((eb) =>
+        eb
+          .selectFrom('asset_face')
+          .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+          .leftJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+          .select((eb) => [
+            'asset_face.id as assetFaceId',
+            eb.val(input.identityId).as('identityId'),
+            eb.val(input.source).as('source'),
+            eb.val(null).as('confidence'),
+          ])
+          .where('asset_face.personId', '=', input.personId)
+          .where('asset_face.deletedAt', 'is', null)
+          .where('asset_face.isVisible', '=', true)
+          .where('asset.deletedAt', 'is', null)
+          .where((eb) =>
+            eb.or([
+              eb('face_identity_face.identityId', 'is', null),
+              eb('face_identity_face.identityId', '!=', input.identityId),
+            ]),
+          ),
+      )
+      .onConflict((oc) =>
+        oc.column('assetFaceId').doUpdateSet({
+          identityId: input.identityId,
+          source: input.source,
+          confidence: null,
+        }),
+      )
+      .execute();
   }
 
   @GenerateSql({ params: [{ identityId: DummyValue.UUID, assetFaceId: DummyValue.UUID }] })

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -1172,6 +1172,11 @@ export class PersonService extends BaseService {
         const targetIdentity = await this.faceIdentityRepository.ensurePersonIdentity(id);
         const sourceIdentity = await this.faceIdentityRepository.ensurePersonIdentity(mergeId);
         await this.personRepository.reassignFaces(mergeData);
+        await this.faceIdentityRepository.linkPersonFaces({
+          personId: id,
+          identityId: targetIdentity.id,
+          source: 'manual',
+        });
         await this.removeAllPeople([mergePerson]);
         await this.faceIdentityRepository.mergeIdentities({
           targetIdentityId: targetIdentity.id,

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetFaceCreateDto } from 'src/dtos/person.dto';
-import { JobName } from 'src/enum';
+import { AssetVisibility, JobName } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetEditRepository } from 'src/repositories/asset-edit.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
@@ -39,6 +39,58 @@ beforeAll(async () => {
 });
 
 describe(PersonService.name, () => {
+  describe('mergePerson', () => {
+    it('links reassigned faces to the target identity for identity-filtered timelines', async () => {
+      const { sut, ctx } = setup();
+      const assetRepo = ctx.get(AssetRepository);
+      const faceIdentityRepo = ctx.get(FaceIdentityRepository);
+      const { user } = await ctx.newUser();
+      const { person: target } = await ctx.newPerson({ ownerId: user.id, name: 'Target' });
+      const { person: source } = await ctx.newPerson({ ownerId: user.id, name: 'Source' });
+      const { asset: targetAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: sourceAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: targetFace } = await ctx.newAssetFace({ assetId: targetAsset.id, personId: target.id });
+      const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: sourceAsset.id, personId: source.id });
+      const existingTargetIdentity = await faceIdentityRepo.ensurePersonIdentity(target.id);
+      await faceIdentityRepo.replaceFaceIdentity({
+        assetFaceId: targetFace.id,
+        identityId: existingTargetIdentity.id,
+        source: 'owner-person',
+      });
+
+      await sut.mergePerson(factory.auth({ user }), target.id, { ids: [source.id] });
+
+      const targetIdentity = await ctx.database
+        .selectFrom('person')
+        .select('identityId')
+        .where('id', '=', target.id)
+        .executeTakeFirstOrThrow();
+
+      expect(targetIdentity.identityId).toBe(existingTargetIdentity.id);
+
+      const links = await ctx.database
+        .selectFrom('face_identity_face')
+        .select(['assetFaceId', 'identityId', 'source'])
+        .where('assetFaceId', 'in', [targetFace.id, sourceFace.id])
+        .execute();
+
+      expect(links).toEqual(
+        expect.arrayContaining([
+          { assetFaceId: targetFace.id, identityId: targetIdentity.identityId!, source: 'owner-person' },
+          { assetFaceId: sourceFace.id, identityId: targetIdentity.identityId!, source: 'manual' },
+        ]),
+      );
+
+      const buckets = await assetRepo.getTimeBuckets({
+        identityIds: [targetIdentity.identityId!],
+        userIds: [user.id],
+        visibility: AssetVisibility.Timeline,
+      });
+
+      expect(buckets.reduce((total, bucket) => total + Number(bucket.count), 0)).toBe(2);
+    });
+  });
+
   describe('delete', () => {
     it('should throw an error when there is no access', async () => {
       const { sut } = setup();

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetFaceCreateDto } from 'src/dtos/person.dto';
-import { AssetVisibility, JobName } from 'src/enum';
+import { AssetVisibility, JobName, JobStatus } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetEditRepository } from 'src/repositories/asset-edit.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
@@ -88,6 +88,56 @@ describe(PersonService.name, () => {
       });
 
       expect(buckets.reduce((total, bucket) => total + Number(bucket.count), 0)).toBe(2);
+    });
+
+    it('repairs previously merged faces when people identity maintenance runs', async () => {
+      const { sut, ctx } = setup();
+      const assetRepo = ctx.get(AssetRepository);
+      const faceIdentityRepo = ctx.get(FaceIdentityRepository);
+      const jobMock = ctx.getMock(JobRepository);
+      const { user } = await ctx.newUser();
+      const { person: target } = await ctx.newPerson({ ownerId: user.id, name: 'Target' });
+      const { person: source } = await ctx.newPerson({ ownerId: user.id, name: 'Source' });
+      const { asset: targetAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: sourceAsset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace: targetFace } = await ctx.newAssetFace({ assetId: targetAsset.id, personId: target.id });
+      const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: sourceAsset.id, personId: source.id });
+      const targetIdentity = await faceIdentityRepo.ensurePersonIdentity(target.id);
+      await faceIdentityRepo.replaceFaceIdentity({
+        assetFaceId: targetFace.id,
+        identityId: targetIdentity.id,
+        source: 'owner-person',
+      });
+      await ctx.database
+        .updateTable('asset_face')
+        .set({ personId: target.id })
+        .where('id', '=', sourceFace.id)
+        .execute();
+      await ctx.database.deleteFrom('person').where('id', '=', source.id).execute();
+
+      const bucketsBeforeRepair = await assetRepo.getTimeBuckets({
+        identityIds: [targetIdentity.id],
+        userIds: [user.id],
+        visibility: AssetVisibility.Timeline,
+      });
+      expect(bucketsBeforeRepair.reduce((total, bucket) => total + Number(bucket.count), 0)).toBe(1);
+
+      jobMock.queue.mockResolvedValue();
+      await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
+
+      const sourceLink = await ctx.database
+        .selectFrom('face_identity_face')
+        .select(['identityId', 'source'])
+        .where('assetFaceId', '=', sourceFace.id)
+        .executeTakeFirstOrThrow();
+      expect(sourceLink).toEqual({ identityId: targetIdentity.id, source: 'backfill' });
+
+      const bucketsAfterRepair = await assetRepo.getTimeBuckets({
+        identityIds: [targetIdentity.id],
+        userIds: [user.id],
+        visibility: AssetVisibility.Timeline,
+      });
+      expect(bucketsAfterRepair.reduce((total, bucket) => total + Number(bucket.count), 0)).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Summary
- Link faces reassigned during person merge to the target face identity
- Preserve existing target-face identity links while repairing missing or mismatched links
- Add a medium regression for identity-filtered person timelines after merge

## Existing data
Previously merged people are recoverable. The old merge already moved affected rows in `asset_face.personId` to the target person; the missing data is only the `face_identity_face` link.

After this is deployed, app bootstrap detects that as face identity backfill work and queues People Identity Maintenance automatically. Admins can also run People Identity Maintenance manually via the `face-identity-backfill` job or the `peopleBackfill` queue. That maintenance job should auto-repair old broken merges without users needing to unmerge or remerge people.

## Test plan
- pnpm --filter immich exec vitest --config test/vitest.config.mjs --run src/services/person.service.spec.ts
- pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs --run test/medium/specs/services/person.service.spec.ts
- pnpm --filter immich check
- pnpm --filter immich build
- pnpm --filter immich sync:sql
- pnpm --filter immich exec eslint src/repositories/face-identity.repository.ts src/services/person.service.ts test/medium/specs/services/person.service.spec.ts --max-warnings 0
- pnpm --filter immich exec prettier --check src/repositories/face-identity.repository.ts src/services/person.service.ts test/medium/specs/services/person.service.spec.ts
- git diff --check

Fixes #570