### PR TITLE
fix(web): cap sampled queue job counts

### DIFF
--- a/web/src/lib/services/queue.service.spec.ts
+++ b/web/src/lib/services/queue.service.spec.ts
@@ -1,4 +1,4 @@
-import { getQueueJobTypeLabel } from '$lib/services/queue.service';
+import { formatSampledJobTypeCount, getQueueJobTypeLabel } from '$lib/services/queue.service';
 import { JobName } from '@immich/sdk';
 import { describe, expect, it } from 'vitest';
 
@@ -7,5 +7,13 @@ describe('queue service', () => {
     expect(getQueueJobTypeLabel(JobName.SharedSpaceFaceMatchPage)).toBe('Shared space face matching');
     expect(getQueueJobTypeLabel(JobName.SharedSpacePersonDedup)).toBe('Shared space people dedup');
     expect(getQueueJobTypeLabel(JobName.FacialRecognition)).toBe('Facial recognition');
+  });
+
+  it('formats sampled job type counts as capped values above the sampling limit', () => {
+    const formatNumber = (count: number) => count.toLocaleString('de-DE');
+
+    expect(formatSampledJobTypeCount(999, formatNumber)).toBe('999');
+    expect(formatSampledJobTypeCount(1000, formatNumber)).toBe('1.000');
+    expect(formatSampledJobTypeCount(1001, formatNumber)).toBe('1.000+');
   });
 });

--- a/web/src/lib/services/queue.service.ts
+++ b/web/src/lib/services/queue.service.ts
@@ -55,6 +55,10 @@ type QueueItem = {
 
 export type QueueJobTypeCounts = QueueJobTypeCountsDto;
 
+export const formatSampledJobTypeCount = (count: number, formatNumber: (count: number) => string) => {
+  return count > 1000 ? `${formatNumber(1000)}+` : formatNumber(count);
+};
+
 export const getQueueJobTypeLabel = (name: JobName) => {
   switch (name) {
     case JobName.FacialRecognition:

--- a/web/src/routes/admin/queues/QueueCard.svelte
+++ b/web/src/routes/admin/queues/QueueCard.svelte
@@ -4,7 +4,12 @@
   import QueueCardButton from './QueueCardButton.svelte';
   import Badge from '$lib/elements/Badge.svelte';
   import { Route } from '$lib/route';
-  import { asQueueItem, getQueueJobTypeLabel, type QueueJobTypeCounts } from '$lib/services/queue.service';
+  import {
+    asQueueItem,
+    formatSampledJobTypeCount,
+    getQueueJobTypeLabel,
+    type QueueJobTypeCounts,
+  } from '$lib/services/queue.service';
   import { locale } from '$lib/stores/preferences.store';
   import { transformToTitleCase } from '$lib/utils';
   import { QueueCommand, type QueueCommandDto, type QueueResponseDto } from '@immich/sdk';
@@ -152,11 +157,22 @@
         <div
           class="mt-2 flex w-full max-w-xl flex-col divide-y divide-gray-200 rounded-lg bg-white/70 text-sm text-gray-700 dark:divide-gray-700 dark:bg-black/20 dark:text-gray-200"
         >
+          <div
+            class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-4 px-4 py-2 text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
+          >
+            <span>Job type</span>
+            <span class="text-end">In progress</span>
+            <span class="text-end">Queued</span>
+          </div>
           {#each jobTypeRows as row (row.label)}
             <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-4 px-4 py-2">
               <span class="min-w-0 truncate">{row.label}</span>
-              <span class="tabular-nums">{row.active.toLocaleString($locale)}</span>
-              <span class="tabular-nums text-gray-500 dark:text-gray-400">{row.pending.toLocaleString($locale)}</span>
+              <span class="tabular-nums">
+                {formatSampledJobTypeCount(row.active, (count) => count.toLocaleString($locale))}
+              </span>
+              <span class="tabular-nums text-gray-500 dark:text-gray-400">
+                {formatSampledJobTypeCount(row.pending, (count) => count.toLocaleString($locale))}
+              </span>
             </div>
           {/each}
         </div>

--- a/web/src/routes/admin/queues/QueueCard.svelte
+++ b/web/src/routes/admin/queues/QueueCard.svelte
@@ -65,6 +65,7 @@
   });
 
   const commonClasses = 'flex place-items-center justify-between w-full py-2 sm:py-4 pe-4 ps-6';
+  const jobTypeGridClasses = 'grid grid-cols-[minmax(0,1fr)_8rem_5rem] items-center gap-4 px-4 py-2';
 </script>
 
 <div class="flex flex-col overflow-hidden rounded-2xl bg-gray-100 dark:bg-immich-dark-gray sm:flex-row sm:rounded-9">
@@ -157,20 +158,18 @@
         <div
           class="mt-2 flex w-full max-w-xl flex-col divide-y divide-gray-200 rounded-lg bg-white/70 text-sm text-gray-700 dark:divide-gray-700 dark:bg-black/20 dark:text-gray-200"
         >
-          <div
-            class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-4 px-4 py-2 text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
-          >
+          <div class={cleanClass(jobTypeGridClasses, 'text-xs font-medium uppercase text-gray-500 dark:text-gray-400')}>
             <span>Job type</span>
-            <span class="text-end">In progress</span>
-            <span class="text-end">Queued</span>
+            <span class="justify-self-end text-end">In progress</span>
+            <span class="justify-self-end text-end">Queued</span>
           </div>
           {#each jobTypeRows as row (row.label)}
-            <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-4 px-4 py-2">
+            <div class={jobTypeGridClasses}>
               <span class="min-w-0 truncate">{row.label}</span>
-              <span class="tabular-nums">
+              <span class="justify-self-end tabular-nums">
                 {formatSampledJobTypeCount(row.active, (count) => count.toLocaleString($locale))}
               </span>
-              <span class="tabular-nums text-gray-500 dark:text-gray-400">
+              <span class="justify-self-end tabular-nums text-gray-500 dark:text-gray-400">
                 {formatSampledJobTypeCount(row.pending, (count) => count.toLocaleString($locale))}
               </span>
             </div>


### PR DESCRIPTION
## Summary

Cap sampled job-type counts in the admin queue card so large sampled values do not look exact. The per-type table now shows explicit headings and values above the sampling limit render as `1000+`.

## Why

The queue overview already shows exact queue totals. The per-job-type breakdown is sampled for display, so it should not present counts like `1001` as if they were exact totals.

## Verification

- `vitest --run src/lib/services/queue.service.spec.ts`
- `svelte-check --no-tsconfig --fail-on-warnings --compiler-warnings 'state_referenced_locally:ignore'`
