### PR TITLE
fix(server): merge Keywords with HierarchicalSubject for tag import

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -595,10 +595,9 @@ describe(MetadataService.name, () => {
 
       await sut.handleMetadataExtraction({ id: asset.id });
 
-      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
-        expect.objectContaining({ tags: ['Archive', 'Flat'] }),
-        { lockedPropertiesBehavior: 'skip' },
-      );
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(expect.objectContaining({ tags: ['Archive', 'Flat'] }), {
+        lockedPropertiesBehavior: 'skip',
+      });
     });
 
     it('should deduplicate merged Keywords and HierarchicalSubject', async () => {
@@ -608,10 +607,9 @@ describe(MetadataService.name, () => {
 
       await sut.handleMetadataExtraction({ id: asset.id });
 
-      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
-        expect.objectContaining({ tags: ['Archive', 'Flat'] }),
-        { lockedPropertiesBehavior: 'skip' },
-      );
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(expect.objectContaining({ tags: ['Archive', 'Flat'] }), {
+        lockedPropertiesBehavior: 'skip',
+      });
     });
 
     it('should use only Keywords when HierarchicalSubject is absent', async () => {

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -596,7 +596,7 @@ describe(MetadataService.name, () => {
       await sut.handleMetadataExtraction({ id: asset.id });
 
       expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
-        expect.objectContaining({ tags: expect.arrayContaining(['Archive', 'Flat']) }),
+        expect.objectContaining({ tags: ['Archive', 'Flat'] }),
         { lockedPropertiesBehavior: 'skip' },
       );
     });
@@ -610,6 +610,32 @@ describe(MetadataService.name, () => {
 
       expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
         expect.objectContaining({ tags: ['Archive', 'Flat'] }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+    });
+
+    it('should use only Keywords when HierarchicalSubject is absent', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ Keywords: ['Trip2026', 'Landscape'] });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ['Trip2026', 'Landscape'] }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+    });
+
+    it('should apply | to / conversion when merging HierarchicalSubject with Keywords', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ HierarchicalSubject: ['Parent|Child'], Keywords: ['Vacation'] });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ['Parent/Child', 'Vacation'] }),
         { lockedPropertiesBehavior: 'skip' },
       );
     });

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -588,6 +588,32 @@ describe(MetadataService.name, () => {
       });
     });
 
+    it('should merge Keywords with HierarchicalSubject when both are present', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ HierarchicalSubject: ['Archive'], Keywords: ['Flat'] });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: expect.arrayContaining(['Archive', 'Flat']) }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+    });
+
+    it('should deduplicate merged Keywords and HierarchicalSubject', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ HierarchicalSubject: ['Archive'], Keywords: ['Archive', 'Flat'] });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ['Archive', 'Flat'] }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+    });
+
     it('should remove existing tags', async () => {
       const asset = AssetFactory.create();
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -630,29 +630,27 @@ export class MetadataService extends BaseService {
   }
 
   private getTagList(exifTags: ImmichTags): string[] {
-    let tags: string[];
     if (exifTags.TagsList) {
-      tags = exifTags.TagsList.map(String);
-    } else if (exifTags.HierarchicalSubject) {
-      tags = exifTags.HierarchicalSubject.map((tag) =>
-        // convert | to /
-        typeof tag === 'number'
-          ? String(tag)
-          : tag
-              .split('|')
-              .map((tag) => tag.replaceAll('/', '|'))
-              .join('/'),
-      );
-    } else if (exifTags.Keywords) {
-      let keywords = exifTags.Keywords;
-      if (!Array.isArray(keywords)) {
-        keywords = [keywords];
-      }
-      tags = keywords.map(String);
-    } else {
-      tags = [];
+      return exifTags.TagsList.map(String);
     }
-    return tags;
+
+    const hierarchical = (exifTags.HierarchicalSubject ?? []).map((tag) =>
+      // convert | to /
+      typeof tag === 'number'
+        ? String(tag)
+        : tag
+            .split('|')
+            .map((t) => t.replaceAll('/', '|'))
+            .join('/'),
+    );
+
+    let keywords = exifTags.Keywords ?? [];
+    if (!Array.isArray(keywords)) {
+      keywords = [keywords];
+    }
+    const flat = keywords.map(String);
+
+    return [...new Set([...hierarchical, ...flat])];
   }
 
   private async applyTagList({ id, ownerId }: { id: string; ownerId: string }) {


### PR DESCRIPTION
Fixes #406

## Summary

- `getTagList` previously used if/else logic — when `HierarchicalSubject` was present, `IPTC:Keywords` was silently dropped
- This caused Lightroom flat tags (written only to `Keywords`, not `HierarchicalSubject`) to be lost on metadata extraction
- Fixed by merging both fields and deduplicating via `Set`
- `TagsList` (ExifTool's composite field) still takes full precedence when present — no behaviour change for that path

## Test plan

- [ ] Two new unit tests: one for the merge, one for deduplication — both assert on `upsertExif`'s `tags` argument (the actual `getTagList` output)
- [ ] All existing metadata service tests pass (TagsList priority, hierarchical `|`→`/` conversion, single-field paths)
- [ ] TypeScript type-check clean