### PR TITLE
ci: harden e2e readiness diagnostics

### DIFF
--- a/.github/scripts/wait-for-url.mjs
+++ b/.github/scripts/wait-for-url.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function waitForUrl(
+  url,
+  {
+    fetchImpl = fetch,
+    intervalMs = 2_000,
+    sleep = defaultSleep,
+    timeoutMs = 120_000,
+  } = {},
+) {
+  const startedAt = Date.now();
+  let attempts = 0;
+  let lastFailure = "no attempts made";
+
+  do {
+    attempts += 1;
+
+    try {
+      const response = await fetchImpl(url);
+      if (response.ok) {
+        return { attempts };
+      }
+
+      lastFailure = `HTTP ${response.status}`;
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      break;
+    }
+
+    await sleep(intervalMs);
+  } while (true);
+
+  throw new Error(
+    `Timed out waiting for ${url} after ${attempts} attempts. Last failure: ${lastFailure}`,
+  );
+}
+
+async function main() {
+  const [url] = process.argv.slice(2);
+  if (!url) {
+    console.error("Usage: wait-for-url.mjs <url>");
+    process.exitCode = 2;
+    return;
+  }
+
+  const timeoutMs = Number(process.env.WAIT_FOR_URL_TIMEOUT_MS ?? 120_000);
+  const intervalMs = Number(process.env.WAIT_FOR_URL_INTERVAL_MS ?? 2_000);
+
+  try {
+    const { attempts } = await waitForUrl(url, { intervalMs, timeoutMs });
+    console.log(`Reached ${url} after ${attempts} attempt(s)`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/.github/scripts/wait-for-url.test.mjs
+++ b/.github/scripts/wait-for-url.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { waitForUrl } from "./wait-for-url.mjs";
+
+describe("waitForUrl", () => {
+  it("retries until the URL returns a successful response", async () => {
+    let attempts = 0;
+
+    const result = await waitForUrl("http://127.0.0.1:2285/api/server/ping", {
+      fetchImpl: async () => ({
+        ok: ++attempts === 3,
+        status: attempts === 3 ? 200 : 503,
+      }),
+      intervalMs: 1,
+      sleep: async () => {},
+      timeoutMs: 100,
+    });
+
+    assert.equal(result.attempts, 3);
+  });
+
+  it("throws with the last failure when the timeout expires", async () => {
+    await assert.rejects(
+      waitForUrl("http://127.0.0.1:2285/api/server/ping", {
+        fetchImpl: async () => {
+          throw new Error("connect ECONNREFUSED 127.0.0.1:2285");
+        },
+        intervalMs: 1,
+        sleep: async () => {},
+        timeoutMs: 0,
+      }),
+      /Timed out waiting for http:\/\/127\.0\.0\.1:2285\/api\/server\/ping.*ECONNREFUSED/s,
+    );
+  });
+});

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,43 +417,49 @@ jobs:
       - name: Run setup typescript-sdk
         run: pnpm install --frozen-lockfile && pnpm build
         working-directory: ./open-api/typescript-sdk
-        if: ${{ !cancelled() }}
       - name: Run setup web
         run: pnpm install --frozen-lockfile && pnpm exec svelte-kit sync
         working-directory: ./web
-        if: ${{ !cancelled() }}
       - name: Run setup cli
         run: pnpm install --frozen-lockfile && pnpm build
         working-directory: ./cli
-        if: ${{ !cancelled() }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: ${{ !cancelled() }}
       - name: Start Docker Compose
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
-        if: ${{ !cancelled() }}
+      - name: Wait for e2e server
+        run: node ../.github/scripts/wait-for-url.mjs http://127.0.0.1:2285/api/server/ping
       - name: Run e2e tests (api & cli)
         env:
           VITEST_DISABLE_DOCKER_SETUP: true
         run: pnpm test
-        if: ${{ !cancelled() }}
       - name: Run e2e tests (maintenance)
         env:
           VITEST_DISABLE_DOCKER_SETUP: true
         run: pnpm test:maintenance
-        if: ${{ !cancelled() }}
+      - name: Capture Docker diagnostics
+        if: always()
+        run: |
+          docker compose ps -a > docker-compose-ps.txt || true
+          docker inspect immich-e2e-server immich-e2e-auth-server immich-e2e-postgres immich-e2e-redis > docker-inspect.json 2> docker-inspect.err || true
+          node ../.github/scripts/wait-for-url.mjs http://127.0.0.1:2285/api/server/ping > e2e-server-final-ping.txt 2>&1 || true
       - name: Capture Docker logs
         if: always()
-        run: docker compose logs --no-color > docker-compose-logs.txt
+        run: docker compose logs --no-color > docker-compose-logs.txt 2>&1 || true
         working-directory: ./e2e
       - name: Archive Docker logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: e2e-server-docker-logs-${{ matrix.runner }}
-          path: e2e/docker-compose-logs.txt
+          path: |
+            e2e/docker-compose-logs.txt
+            e2e/docker-compose-ps.txt
+            e2e/docker-inspect.json
+            e2e/docker-inspect.err
+            e2e/e2e-server-final-ping.txt
   e2e-tests-web:
     name: End-to-End Tests (Web)
     needs: pre-job
@@ -488,23 +494,20 @@ jobs:
       - name: Run setup typescript-sdk
         run: pnpm install --frozen-lockfile && pnpm build
         working-directory: ./open-api/typescript-sdk
-        if: ${{ !cancelled() }}
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        if: ${{ !cancelled() }}
       - name: Install Playwright Browsers
         run: pnpm exec playwright install chromium --only-shell
-        if: ${{ !cancelled() }}
       - name: Docker build
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: docker compose up -d --build --renew-anon-volumes --force-recreate --remove-orphans --wait --wait-timeout 300
-        if: ${{ !cancelled() }}
+      - name: Wait for e2e server
+        run: node ../.github/scripts/wait-for-url.mjs http://127.0.0.1:2285/api/server/ping
       - name: Run e2e tests (web)
         env:
           PLAYWRIGHT_DISABLE_WEBSERVER: true
         run: pnpm test:web
-        if: ${{ !cancelled() }}
       - name: Archive e2e test (web) results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
@@ -515,7 +518,6 @@ jobs:
         env:
           PLAYWRIGHT_DISABLE_WEBSERVER: true
         run: pnpm test:web:ui
-        if: ${{ !cancelled() }}
       - name: Archive ui test (web) results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
@@ -526,23 +528,33 @@ jobs:
         env:
           PLAYWRIGHT_DISABLE_WEBSERVER: true
         run: pnpm test:web:maintenance
-        if: ${{ !cancelled() }}
       - name: Archive maintenance tests (web) results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: e2e-maintenance-isolated-test-results-${{ matrix.runner }}
           path: e2e/playwright-report/
+      - name: Capture Docker diagnostics
+        if: always()
+        run: |
+          docker compose ps -a > docker-compose-ps.txt || true
+          docker inspect immich-e2e-server immich-e2e-auth-server immich-e2e-postgres immich-e2e-redis > docker-inspect.json 2> docker-inspect.err || true
+          node ../.github/scripts/wait-for-url.mjs http://127.0.0.1:2285/api/server/ping > e2e-server-final-ping.txt 2>&1 || true
       - name: Capture Docker logs
         if: always()
-        run: docker compose logs --no-color > docker-compose-logs.txt
+        run: docker compose logs --no-color > docker-compose-logs.txt 2>&1 || true
         working-directory: ./e2e
       - name: Archive Docker logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: e2e-web-docker-logs-${{ matrix.runner }}
-          path: e2e/docker-compose-logs.txt
+          path: |
+            e2e/docker-compose-logs.txt
+            e2e/docker-compose-ps.txt
+            e2e/docker-inspect.json
+            e2e/docker-inspect.err
+            e2e/e2e-server-final-ping.txt
   success-check-e2e:
     name: End-to-End Tests Success
     needs: [e2e-tests-server-cli, e2e-tests-web]


### PR DESCRIPTION
## Summary
- stop e2e setup/test steps from continuing after earlier failures
- add an explicit server readiness wait after docker compose startup
- archive compose state, container inspect output, and final ping diagnostics for e2e jobs

## Validation
- node --test .github/scripts/wait-for-url.test.mjs
- pnpm --dir .github exec prettier --check scripts/wait-for-url.mjs scripts/wait-for-url.test.mjs workflows/test.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'\n- git diff --check