### PR TITLE
fix(server): guard against null jobs in getJobTypes queue scan

### DIFF
--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -182,6 +182,9 @@ export class JobRepository {
     for (const status of statuses) {
       const jobs = await this.getQueue(name).getJobs(status, 0, 1000, true);
       for (const job of jobs) {
+        if (!job) {
+          continue;
+        }
         const actualStatus = typeof job.getState === 'function' ? await job.getState() : status;
         if (!statuses.includes(actualStatus as (typeof statuses)[number])) {
           continue;


### PR DESCRIPTION
## Summary

- `getJobTypes()` iterates the array returned by BullMQ's `getJobs()` and reads `job.getState` on each entry
- BullMQ fetches jobs in two steps: list IDs from Redis, then fetch data per ID — a job that completes or is removed between these two steps leaves a `null`/`undefined` slot in the result array
- Accessing `job.getState` on that slot throws `TypeError: Cannot read properties of undefined (reading 'getState')`, which the error interceptor surfaces as HTTP 500 on the jobs/queues page
- Fix: skip null/undefined entries with an early `continue`

The intermittent nature matches the pattern in the logs — bursts of 500s during periods of active job processing (metadata extraction runs, etc.).

## Test plan

- [ ] All existing unit tests pass (4366 tests, 0 failures)
- [ ] Jobs page loads without 500 errors when jobs are actively processing