### PR TITLE
fix(mobile): preserve birth date when serializing date fields

### DIFF
--- a/mobile/openapi/lib/model/people_update_item.dart
+++ b/mobile/openapi/lib/model/people_update_item.dart
@@ -94,7 +94,7 @@ class PeopleUpdateItem {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -193,4 +193,3 @@ class PeopleUpdateItem {
     'id',
   };
 }
-

--- a/mobile/openapi/lib/model/people_update_item.dart
+++ b/mobile/openapi/lib/model/people_update_item.dart
@@ -193,3 +193,4 @@ class PeopleUpdateItem {
     'id',
   };
 }
+

--- a/mobile/openapi/lib/model/person_create_dto.dart
+++ b/mobile/openapi/lib/model/person_create_dto.dart
@@ -76,7 +76,7 @@ class PersonCreateDto {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -166,4 +166,3 @@ class PersonCreateDto {
   static const requiredKeys = <String>{
   };
 }
-

--- a/mobile/openapi/lib/model/person_create_dto.dart
+++ b/mobile/openapi/lib/model/person_create_dto.dart
@@ -166,3 +166,4 @@ class PersonCreateDto {
   static const requiredKeys = <String>{
   };
 }
+

--- a/mobile/openapi/lib/model/person_response_dto.dart
+++ b/mobile/openapi/lib/model/person_response_dto.dart
@@ -267,3 +267,4 @@ class PersonResponseDto {
     'thumbnailPath',
   };
 }
+

--- a/mobile/openapi/lib/model/person_response_dto.dart
+++ b/mobile/openapi/lib/model/person_response_dto.dart
@@ -144,7 +144,7 @@ class PersonResponseDto {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -267,4 +267,3 @@ class PersonResponseDto {
     'thumbnailPath',
   };
 }
-

--- a/mobile/openapi/lib/model/person_update_dto.dart
+++ b/mobile/openapi/lib/model/person_update_dto.dart
@@ -88,7 +88,7 @@ class PersonUpdateDto {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -184,4 +184,3 @@ class PersonUpdateDto {
   static const requiredKeys = <String>{
   };
 }
-

--- a/mobile/openapi/lib/model/person_update_dto.dart
+++ b/mobile/openapi/lib/model/person_update_dto.dart
@@ -184,3 +184,4 @@ class PersonUpdateDto {
   static const requiredKeys = <String>{
   };
 }
+

--- a/mobile/openapi/lib/model/person_with_faces_response_dto.dart
+++ b/mobile/openapi/lib/model/person_with_faces_response_dto.dart
@@ -161,7 +161,7 @@ class PersonWithFacesResponseDto {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -293,4 +293,3 @@ class PersonWithFacesResponseDto {
     'thumbnailPath',
   };
 }
-

--- a/mobile/openapi/lib/model/person_with_faces_response_dto.dart
+++ b/mobile/openapi/lib/model/person_with_faces_response_dto.dart
@@ -293,3 +293,4 @@ class PersonWithFacesResponseDto {
     'thumbnailPath',
   };
 }
+

--- a/mobile/openapi/lib/model/shared_space_person_response_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_person_response_dto.dart
@@ -124,7 +124,7 @@ class SharedSpacePersonResponseDto {
     }
       json[r'assetCount'] = this.assetCount;
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -233,6 +233,7 @@ class SharedSpacePersonResponseDto {
   };
 }
 
+
 /// Representative face source
 class SharedSpacePersonResponseDtoRepresentativeFaceSourceEnum {
   /// Instantiate a new enum with the provided [value].
@@ -305,5 +306,3 @@ class SharedSpacePersonResponseDtoRepresentativeFaceSourceEnumTypeTransformer {
   /// Singleton [SharedSpacePersonResponseDtoRepresentativeFaceSourceEnumTypeTransformer] instance.
   static SharedSpacePersonResponseDtoRepresentativeFaceSourceEnumTypeTransformer? _instance;
 }
-
-

--- a/mobile/openapi/lib/model/shared_space_person_response_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_person_response_dto.dart
@@ -233,7 +233,6 @@ class SharedSpacePersonResponseDto {
   };
 }
 
-
 /// Representative face source
 class SharedSpacePersonResponseDtoRepresentativeFaceSourceEnum {
   /// Instantiate a new enum with the provided [value].
@@ -306,3 +305,5 @@ class SharedSpacePersonResponseDtoRepresentativeFaceSourceEnumTypeTransformer {
   /// Singleton [SharedSpacePersonResponseDtoRepresentativeFaceSourceEnumTypeTransformer] instance.
   static SharedSpacePersonResponseDtoRepresentativeFaceSourceEnumTypeTransformer? _instance;
 }
+
+

--- a/mobile/openapi/lib/model/shared_space_person_update_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_person_update_dto.dart
@@ -64,7 +64,7 @@ class SharedSpacePersonUpdateDto {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (this.birthDate != null) {
-      json[r'birthDate'] = _dateFormatter.format(this.birthDate!.toUtc());
+      json[r'birthDate'] = _dateFormatter.format(this.birthDate!);
     } else {
     //  json[r'birthDate'] = null;
     }
@@ -148,4 +148,3 @@ class SharedSpacePersonUpdateDto {
   static const requiredKeys = <String>{
   };
 }
-

--- a/mobile/openapi/lib/model/shared_space_person_update_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_person_update_dto.dart
@@ -148,3 +148,4 @@ class SharedSpacePersonUpdateDto {
   static const requiredKeys = <String>{
   };
 }
+

--- a/mobile/test/openapi/person_update_dto_test.dart
+++ b/mobile/test/openapi/person_update_dto_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openapi/api.dart';
+
+void main() {
+  test('serializes person birthDate as the selected civil date', () {
+    final dto = PersonUpdateDto(birthDate: DateTime(1975, 3, 8));
+
+    expect(dto.toJson()['birthDate'], '1975-03-08');
+  });
+}

--- a/open-api/templates/mobile/serialization/native/native_class.mustache
+++ b/open-api/templates/mobile/serialization/native/native_class.mustache
@@ -78,10 +78,10 @@ class {{{classname}}} {
       {{#pattern}}
       json[r'{{{baseName}}}'] = _isEpochMarker(r'{{{pattern}}}')
         ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
-        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}});
       {{/pattern}}
       {{^pattern}}
-      json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
+      json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}});
       {{/pattern}}
     {{/isDate}}
     {{^isDateTime}}

--- a/open-api/templates/mobile/serialization/native/native_class.mustache.patch
+++ b/open-api/templates/mobile/serialization/native/native_class.mustache.patch
@@ -1,5 +1,18 @@
 --- native_class.mustache	2025-07-01 08:29:23.968133163 +0800
 +++ native_class_temp.mustache	2025-07-01 08:29:44.225850583 +0800
+@@ -78,10 +78,10 @@
+       {{#pattern}}
+       json[r'{{{baseName}}}'] = _isEpochMarker(r'{{{pattern}}}')
+         ? this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.millisecondsSinceEpoch
+-        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
++        : _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}});
+       {{/pattern}}
+       {{^pattern}}
+-      json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}}.toUtc());
++      json[r'{{{baseName}}}'] = _dateFormatter.format(this.{{{name}}}{{#isNullable}}!{{/isNullable}}{{^isNullable}}{{^required}}{{^defaultValue}}!{{/defaultValue}}{{/required}}{{/isNullable}});
+       {{/pattern}}
+     {{/isDate}}
+     {{^isDateTime}}
 @@ -91,14 +91,14 @@
      {{/isDateTime}}
      {{#isNullable}}


### PR DESCRIPTION
## Summary
- serialize generated mobile OpenAPI date fields as civil dates without UTC conversion
- update the mobile OpenAPI generation template so regenerated date models keep the same behavior
- add a regression test for a birthday selected in Europe/Berlin

Fixes #582

## Test plan
- RED check: old serializer returned `1975-03-07` for `DateTime(1975, 3, 8)` under `Europe/Berlin`
- `TZ=Europe/Berlin mise exec flutter@3.41.7 -- flutter test test/openapi/person_update_dto_test.dart`
- `pnpm --dir server test -- person.controller.spec.ts`
- `git diff --check`