### PR TITLE
fix(server): fetch queue job types in parallel, drop per-job getState calls

### DIFF
--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -200,11 +200,7 @@ describe(JobRepository.name, () => {
 
   it('does not double-count paused jobs that BullMQ also returns as waiting jobs', async () => {
     const { sut, queue } = setup();
-    const pausedJob = {
-      id: 'paused-job-1',
-      name: JobName.FaceIdentityBackfill,
-      getState: vitest.fn().mockResolvedValue('paused'),
-    };
+    const pausedJob = { id: 'paused-job-1', name: JobName.FaceIdentityBackfill };
     queue.getJobs.mockImplementation((status) => {
       const jobs = {
         active: [],

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -175,30 +175,33 @@ export class JobRepository {
   }
 
   async getJobTypes(name: QueueName): Promise<JobTypeCounts[]> {
-    const statuses = ['active', 'waiting', 'delayed', 'paused'] as const;
-    const counts = new Map<JobName, JobTypeCounts>();
-    const seenJobs = new Set<string>();
+    // Process 'paused' before 'waiting': BullMQ may include the same job in both lists
+    // when a queue is paused. ID-based dedup then correctly attributes it to 'paused'.
+    const statusOrder = ['active', 'delayed', 'paused', 'waiting'] as const;
+    type Status = (typeof statusOrder)[number];
 
-    for (const status of statuses) {
-      const jobs = await this.getQueue(name).getJobs(status, 0, 1000, true);
+    const results = await Promise.all(
+      statusOrder.map(async (status) => ({ status, jobs: await this.getQueue(name).getJobs(status, 0, 1000, true) })),
+    );
+
+    const counts = new Map<JobName, JobTypeCounts>();
+    const seenJobIds = new Set<string>();
+
+    for (const { status, jobs } of results) {
       for (const job of jobs) {
         if (!job) {
           continue;
         }
-        const actualStatus = typeof job.getState === 'function' ? await job.getState() : status;
-        if (!statuses.includes(actualStatus as (typeof statuses)[number])) {
-          continue;
+        if (job.id) {
+          if (seenJobIds.has(job.id)) {
+            continue;
+          }
+          seenJobIds.add(job.id);
         }
-
-        const jobKey = job.id ?? `${job.name}:${actualStatus}:${seenJobs.size}`;
-        if (seenJobs.has(jobKey)) {
-          continue;
-        }
-        seenJobs.add(jobKey);
 
         const jobName = job.name as JobName;
         const count = counts.get(jobName) ?? { name: jobName, active: 0, waiting: 0, delayed: 0, paused: 0 };
-        count[actualStatus as (typeof statuses)[number]]++;
+        count[status as Status]++;
         counts.set(jobName, count);
       }
     }

--- a/web/src/routes/admin/queues/QueueCard.svelte
+++ b/web/src/routes/admin/queues/QueueCard.svelte
@@ -64,6 +64,9 @@
       .sort((a, b) => b.active - a.active || b.pending - a.pending || a.label.localeCompare(b.label));
   });
 
+  let jobTypesSampled = $derived(jobTypeRows.reduce((sum, r) => sum + r.active + r.pending, 0));
+  let jobTypesTruncated = $derived(jobTypesSampled < statistics.active + waitingCount);
+
   const commonClasses = 'flex place-items-center justify-between w-full py-2 sm:py-4 pe-4 ps-6';
   const jobTypeGridClasses = 'grid grid-cols-[minmax(0,1fr)_8rem_5rem] items-center gap-4 px-4 py-2';
 </script>
@@ -174,6 +177,11 @@
               </span>
             </div>
           {/each}
+          {#if jobTypesTruncated}
+            <p class="px-4 py-2 text-xs text-gray-400 dark:text-gray-500">
+              Sampled from first {jobTypesSampled.toLocaleString($locale)} jobs
+            </p>
+          {/if}
         </div>
       {/if}
     </div>


### PR DESCRIPTION
## Problem

`GET /queues` (polled every 3 s by the admin queues page) was slow and occasionally returning 500s after #559 introduced the job type breakdown.

**Root cause in `getJobTypes`:**
1. The 4 status fetches (`active`, `waiting`, `delayed`, `paused`) were made **sequentially** — stacking 4 Redis round-trips in series
2. For **every job returned**, it called `job.getState()` — an individual Redis round-trip per job

With 22 queues polled every 3 seconds, this meant O(N × queues) Redis operations per request. A queue with 500 jobs would generate 500+ extra Redis calls per poll.

**Secondary bug:** the per-job-type breakdown counts fluctuated between `1000` and `999` even with 41k+ jobs queued, with no indication that the numbers were sampled/capped.

## Fix

### `job.repository.ts` — parallel fetches, drop `getState()`

- Use `Promise.all` to fetch all 4 status lists concurrently instead of sequentially
- Remove all `job.getState()` calls — use the status we fetched the job under directly
- Handle the BullMQ paused/waiting overlap (same job returned in both lists) via processing order + ID-based dedup: process `paused` before `waiting`, so the first time we see a job ID it gets attributed to the correct state

### `QueueCard.svelte` — truncation indicator

- Detect when the breakdown sample is smaller than the actual queue statistics
- Show "Sampled from first N jobs" at the bottom of the breakdown table when truncated, so fluctuating counts are clearly labelled as partial

## Tests

All existing tests pass (4,366 tests). The paused-job dedup test still exercises correct behavior — now via ID-based dedup instead of `getState`.

## Checklist
- [x] `pnpm test` green (4,366 tests, server)
- [x] `tsc --noEmit` clean (server)