### PR TITLE
fix(release): attach docker-compose.yml and example.env to every release

### DIFF
--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -517,7 +517,9 @@ jobs:
             --target "$SHA" \
             --title "$VERSION" \
             --latest \
-            --notes "$notes"
+            --notes "$notes" \
+            docker/docker-compose.yml \
+            docker/example.env
 
           echo "Released $VERSION (server-only)"
 

--- a/.github/workflows/gallery-release.yml
+++ b/.github/workflows/gallery-release.yml
@@ -348,6 +348,17 @@ jobs:
 
           git push origin "$VERSION" "v${major}" "release" --force
 
+      - name: Upload config files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ needs.discover.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release upload "$VERSION" --repo "$REPO" --clobber \
+            docker/docker-compose.yml \
+            docker/example.env
+
       - name: Promote draft release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- `gallery-release.yml` (2-phase mobile+server): adds an \"Upload config files\" step in the `tag` job before promoting the draft, using `--clobber` for idempotency on re-runs
- `gallery-release-server-only.yml`: appends the two files as positional arguments to the existing `gh release create` call

Both `docker/docker-compose.yml` and `docker/example.env` are now attached as assets to every release, fixing broken \"Download the configuration files\" links on the install page.

`v4.56.6` was patched manually with the same files.

## Test plan

- [ ] CI checks pass (workflow YAML lint)
- [ ] Next release includes both files as assets