### PR TITLE
docs: remove personal instance references from CLAUDE.md and plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Upstream Immich references are rewritten to Gallery at build time by `branding/a
 ## Releases & Deploys
 
 - **Release workflow** (`.github/workflows/gallery-release.yml`): manual-only (`workflow_dispatch`) — a maintainer triggers it from the Actions tab or via `gh workflow run gallery-release.yml`. It builds `gallery-server`, `gallery-ml`, and `gallery-ml:*-cuda` in parallel, computes the next semver from commit prefixes / PR labels since the last tag (`feat:` → minor, `BREAKING CHANGE` → major, anything else → patch, `changelog:skip` → no release), and pushes to `ghcr.io/open-noodle/*`.
-- **Deploy targets**: `demo.opennoodle.de` (demo), `pierre.opennoodle.de` (personal), `opennoodle.de` (marketing Astro site), `test.opennoodle.de` (marketing staging), `docs.opennoodle.de` (Docusaurus). Each has a corresponding skill in `.claude/skills/` (see `/deploy-gallery-*` slash commands).
+- **Deploy targets**: `demo.opennoodle.de` (demo), `docs.opennoodle.de` (Docusaurus). Each has a corresponding skill in `.claude/skills/` (see `/deploy-gallery-*` slash commands).
 - **RC builds**: `rc-personal` skill ships a tagged server image to the personal instance via a compose override — remember to remove the override after merge or release deploys will ship stale RC images.
 
 ## Contributing & Docs

--- a/docs/plans/2026-04-11-library-user-access-backfill-plan.md
+++ b/docs/plans/2026-04-11-library-user-access-backfill-plan.md
@@ -2119,7 +2119,7 @@ Summary: new `library_user (userId, libraryId, createId, createdAt)` denormaliza
 - [ ] New unit tests in `sync.repository.spec.ts` for `LibrarySync.getCreatedAfter`
 - [ ] New E2E cases in `sync-library.e2e-spec.ts`
 - [ ] Existing `sync-library*.spec.ts`, `library-audit-triggers.spec.ts`, and `sync-library.e2e-spec.ts` continue to pass
-- [ ] Deploy to `pierre.opennoodle.de` via RC build and manually verify: viewer re-added to Google Takeout space sees photos on next sync without app restart
+- [ ] Deploy to `personal instance` via RC build and manually verify: viewer re-added to Google Takeout space sees photos on next sync without app restart
 
 ## Rollback
 
@@ -2176,4 +2176,4 @@ EOF
 - **Medium tests need a real Postgres** — make sure your local stack has the test DB available (`make dev` or the test container setup). If `newMediumService` blows up on startup, that's a stack/env issue, not a code issue.
 - **Schema tool boilerplate is fiddly** — the `migration_overrides` JSON-encoded SQL strings must escape quotes and newlines exactly as shown. Copy-paste from `1778200000000-LibraryAuditTables.ts` as a template.
 - **If the `sql-tools` decorator library doesn't support exactly the decorator form shown** for `@CreateIdColumn({ index: false })`, fall back to the raw migration index and just use `@CreateIdColumn()` in the table definition. The plan adapts — don't get stuck on that detail.
-- **Don't merge to main until the full E2E + regression sweep is green** and the fix is manually verified on `pierre.opennoodle.de` via an RC build.
+- **Don't merge to main until the full E2E + regression sweep is green** and the fix is manually verified on `personal instance` via an RC build.

--- a/docs/plans/2026-04-16-open-in-app-prompt-design.md
+++ b/docs/plans/2026-04-16-open-in-app-prompt-design.md
@@ -6,7 +6,7 @@
 ## Problem
 
 When a user opens a Gallery web link on their mobile device (e.g. a friend shares
-`https://pierre.opennoodle.de/photos/<uuid>` in a chat), the user lands in mobile
+`https://<your-gallery>/photos/<uuid>` in a chat), the user lands in mobile
 Safari/Chrome. They have the Gallery app installed but the web isn't telling them
 that opening it in the app would be a better experience.
 

--- a/docs/plans/2026-04-17-cmdk-followups-plan.md
+++ b/docs/plans/2026-04-17-cmdk-followups-plan.md
@@ -708,7 +708,7 @@ Design doc: `docs/plans/2026-04-17-cmdk-followups-design.md`
 - [ ] Trigger an `onerror` (e.g. delete a person and re-open recents that
       still reference it): row falls back to the grey placeholder
       circle without breaking layout.
-- [ ] On `pierre.opennoodle.de` (real photo library): browse a few
+- [ ] On `personal instance` (real photo library): browse a few
       arrowed-through people in the People section to confirm the row
       thumbnail and the preview pane both update correctly per person.
 EOF

--- a/docs/plans/2026-04-21-s3-relative-path-audit-plan.md
+++ b/docs/plans/2026-04-21-s3-relative-path-audit-plan.md
@@ -1053,9 +1053,9 @@ If it reports issues, run `pnpm format` and commit as `chore: prettier`.
 
 - (none — use the `/rc-personal` skill)
 
-**Step 1: Push the branch** and invoke the `/rc-personal` skill to ship this branch to `pierre.opennoodle.de`.
+**Step 1: Push the branch** and invoke the `/rc-personal` skill to ship this branch to `personal instance`.
 
-**Step 2: Manually verify on pierre.opennoodle.de:**
+**Step 2: Manually verify on personal instance:**
 
 - Upload a short video; wait ~30s; confirm a `smart_search` row appears for the asset (query the DB directly via the instance's psql or admin UI).
 - Duplicate an asset with an XMP sidecar via the UI; confirm the target sidecar object exists in the S3 bucket.
@@ -1102,7 +1102,7 @@ Design: `docs/plans/2026-04-21-s3-relative-path-audit-design.md`
 - [ ] Type-check green (`make check-server`)
 - [ ] Lint zero warnings (`cd server && pnpm lint --max-warnings 0`)
 - [ ] Nightly storage-migration workflow passes with the two new phases
-- [ ] Manual smoke on pierre.opennoodle.de: video upload → `smart_search` row appears; asset duplicate with sidecar → target sidecar in S3
+- [ ] Manual smoke on personal instance: video upload → `smart_search` row appears; asset duplicate with sidecar → target sidecar in S3
 
 ## Verifications
 

--- a/docs/plans/2026-04-22-s3-orphan-cleanup-user-delete-design.md
+++ b/docs/plans/2026-04-22-s3-orphan-cleanup-user-delete-design.md
@@ -139,7 +139,7 @@ Wire into `.github/workflows/storage-migration-tests.yml` after `phaseCopyAssetS
 
 ### Manual smoke (via `/rc-personal`)
 
-1. Create a disposable user on pierre.opennoodle.de, upload 2–3 photos, wait for thumbs.
+1. Create a disposable user on personal instance, upload 2–3 photos, wait for thumbs.
 2. Admin delete with `force: true`.
 3. `docker logs gallery-server | grep 'Cleaned S3 prefix'` → see 4 lines.
 4. Wasabi console → confirm `upload/<deleted-uuid>/` returns 0 objects.


### PR DESCRIPTION
## Summary

- Remove `pierre.opennoodle.de` (personal), `opennoodle.de` (marketing Astro site), and `test.opennoodle.de` (marketing staging) from the Deploy targets list in `CLAUDE.md`
- Replace all remaining `pierre.opennoodle.de` occurrences in `docs/plans/` with generic alternatives (`personal instance` / `<your-gallery>`)

## Test plan

- [ ] `CLAUDE.md` deploy targets line lists only `demo.opennoodle.de` and `docs.opennoodle.de`
- [ ] `grep -r "pierre.opennoodle.de"` returns no results