### PR TITLE
feat(server): auto-queue People Identity Maintenance after Facial Recognition drains

### DIFF
--- a/mobile/openapi/lib/model/job_name.dart
+++ b/mobile/openapi/lib/model/job_name.dart
@@ -43,6 +43,7 @@ class JobName {
   static const facialRecognitionQueueAll = JobName._(r'FacialRecognitionQueueAll');
   static const facialRecognition = JobName._(r'FacialRecognition');
   static const faceIdentityBackfill = JobName._(r'FaceIdentityBackfill');
+  static const faceIdentityMaintenanceAfterRecognition = JobName._(r'FaceIdentityMaintenanceAfterRecognition');
   static const fileDelete = JobName._(r'FileDelete');
   static const fileMigrationQueueAll = JobName._(r'FileMigrationQueueAll');
   static const libraryDeleteCheck = JobName._(r'LibraryDeleteCheck');
@@ -116,6 +117,7 @@ class JobName {
     facialRecognitionQueueAll,
     facialRecognition,
     faceIdentityBackfill,
+    faceIdentityMaintenanceAfterRecognition,
     fileDelete,
     fileMigrationQueueAll,
     libraryDeleteCheck,
@@ -224,6 +226,7 @@ class JobNameTypeTransformer {
         case r'FacialRecognitionQueueAll': return JobName.facialRecognitionQueueAll;
         case r'FacialRecognition': return JobName.facialRecognition;
         case r'FaceIdentityBackfill': return JobName.faceIdentityBackfill;
+        case r'FaceIdentityMaintenanceAfterRecognition': return JobName.faceIdentityMaintenanceAfterRecognition;
         case r'FileDelete': return JobName.fileDelete;
         case r'FileMigrationQueueAll': return JobName.fileMigrationQueueAll;
         case r'LibraryDeleteCheck': return JobName.libraryDeleteCheck;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -22718,6 +22718,7 @@
           "FacialRecognitionQueueAll",
           "FacialRecognition",
           "FaceIdentityBackfill",
+          "FaceIdentityMaintenanceAfterRecognition",
           "FileDelete",
           "FileMigrationQueueAll",
           "LibraryDeleteCheck",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -8805,6 +8805,7 @@ export enum JobName {
     FacialRecognitionQueueAll = "FacialRecognitionQueueAll",
     FacialRecognition = "FacialRecognition",
     FaceIdentityBackfill = "FaceIdentityBackfill",
+    FaceIdentityMaintenanceAfterRecognition = "FaceIdentityMaintenanceAfterRecognition",
     FileDelete = "FileDelete",
     FileMigrationQueueAll = "FileMigrationQueueAll",
     LibraryDeleteCheck = "LibraryDeleteCheck",

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -725,6 +725,7 @@ export enum JobName {
   FacialRecognitionQueueAll = 'FacialRecognitionQueueAll',
   FacialRecognition = 'FacialRecognition',
   FaceIdentityBackfill = 'FaceIdentityBackfill',
+  FaceIdentityMaintenanceAfterRecognition = 'FaceIdentityMaintenanceAfterRecognition',
 
   FileDelete = 'FileDelete',
   FileMigrationQueueAll = 'FileMigrationQueueAll',

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -351,6 +351,13 @@ export class JobRepository {
         }
         return { jobId: 'face-identity-backfill/root', removeOnFail: true };
       }
+      case JobName.FaceIdentityMaintenanceAfterRecognition: {
+        const data = item.data as { delay?: number };
+        if (data.delay !== undefined) {
+          return { delay: data.delay, removeOnFail: true };
+        }
+        return { jobId: 'face-identity-maintenance-after-recognition', removeOnFail: true };
+      }
       case JobName.VersionCheck: {
         return { jobId: JobName.VersionCheck };
       }

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1653,6 +1653,184 @@ describe(PersonService.name, () => {
         }
       });
     });
+
+    it('force recognition queues the terminal maintenance marker after FacialRecognition and SharedSpaceFaceMatchAll jobs', async () => {
+      const face = AssetFaceFactory.from().person().build();
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+      mocks.person.getAll.mockReturnValue(makeStream([face.person!]));
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+      mocks.person.unassignFaces.mockResolvedValue();
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['space-1']);
+
+      await sut.handleQueueRecognizeFaces({ force: true });
+
+      const queueAllCalls = mocks.job.queueAll.mock;
+      const recognitionIdx = queueAllCalls.calls.findIndex((call) =>
+        call[0].some((job: any) => job.name === JobName.FacialRecognition),
+      );
+      const spaceMatchIdx = queueAllCalls.calls.findIndex((call) =>
+        call[0].some((job: any) => job.name === JobName.SharedSpaceFaceMatchAll),
+      );
+      const markerIdx = mocks.job.queue.mock.calls.findIndex(
+        (call) => call[0].name === JobName.FaceIdentityMaintenanceAfterRecognition,
+      );
+
+      expect(recognitionIdx).toBeGreaterThanOrEqual(0);
+      expect(spaceMatchIdx).toBeGreaterThanOrEqual(0);
+      expect(markerIdx).toBeGreaterThanOrEqual(0);
+
+      const markerOrder = mocks.job.queue.mock.invocationCallOrder[markerIdx];
+      expect(markerOrder).toBeGreaterThan(queueAllCalls.invocationCallOrder[recognitionIdx]);
+      expect(markerOrder).toBeGreaterThan(queueAllCalls.invocationCallOrder[spaceMatchIdx]);
+    });
+
+    it('non-force recognition queues the terminal maintenance marker after FacialRecognition jobs when recognition jobs were queued', async () => {
+      const face = AssetFaceFactory.create();
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+
+      await sut.handleQueueRecognizeFaces({ force: false });
+
+      const queueAllCalls = mocks.job.queueAll.mock;
+      const recognitionIdx = queueAllCalls.calls.findIndex((call) =>
+        call[0].some((job: any) => job.name === JobName.FacialRecognition),
+      );
+      const markerIdx = mocks.job.queue.mock.calls.findIndex(
+        (call) => call[0].name === JobName.FaceIdentityMaintenanceAfterRecognition,
+      );
+
+      expect(recognitionIdx).toBeGreaterThanOrEqual(0);
+      expect(markerIdx).toBeGreaterThanOrEqual(0);
+      expect(mocks.job.queue.mock.invocationCallOrder[markerIdx]).toBeGreaterThan(
+        queueAllCalls.invocationCallOrder[recognitionIdx],
+      );
+    });
+
+    it('nightly skip does not queue the terminal maintenance marker', async () => {
+      const lastRun = new Date();
+      mocks.systemMetadata.get.mockResolvedValue({ lastRun: lastRun.toISOString() });
+      mocks.person.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1).toISOString());
+
+      await sut.handleQueueRecognizeFaces({ force: false, nightly: true });
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: expect.anything(),
+      });
+    });
+  });
+
+  describe('handleFaceIdentityMaintenanceAfterRecognition', () => {
+    it('queues FaceIdentityBackfill when FacialRecognition queue is drained', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+      mocks.job.searchJobs.mockResolvedValue([]);
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: expect.anything(),
+      });
+    });
+
+    it('requeues itself with a delay when FacialRecognition has waiting jobs', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 5,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: { delay: expect.any(Number) },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+    });
+
+    it('requeues itself with a delay when FacialRecognition has delayed jobs', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 3,
+      });
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: { delay: expect.any(Number) },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+    });
+
+    it('requeues itself with a delay when there is other active FacialRecognition work', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 3,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: { delay: expect.any(Number) },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+    });
+
+    it('does not queue duplicate FaceIdentityBackfill if PeopleBackfill already has one active/waiting/delayed/paused', async () => {
+      mocks.job.getJobCounts.mockResolvedValue({
+        active: 1,
+        waiting: 0,
+        paused: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 0,
+      });
+      mocks.job.searchJobs.mockResolvedValue([{ id: '1', name: JobName.FaceIdentityBackfill, timestamp: 0, data: {} }]);
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+    });
   });
 
   describe('handleDetectFaces', () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -860,8 +860,44 @@ export class PersonService extends BaseService {
       );
     }
 
+    await this.jobRepository.queue({ name: JobName.FaceIdentityMaintenanceAfterRecognition, data: {} });
+
     await this.systemMetadataRepository.set(SystemMetadataKey.FacialRecognitionState, { lastRun });
 
+    return JobStatus.Success;
+  }
+
+  @OnJob({ name: JobName.FaceIdentityMaintenanceAfterRecognition, queue: QueueName.FacialRecognition })
+  async handleFaceIdentityMaintenanceAfterRecognition(
+    _data: JobOf<JobName.FaceIdentityMaintenanceAfterRecognition>,
+  ): Promise<JobStatus> {
+    const counts = await this.jobRepository.getJobCounts(QueueName.FacialRecognition);
+
+    if (counts.waiting > 0 || counts.delayed > 0 || counts.paused > 0) {
+      await this.jobRepository.queue({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: { delay: 10_000 },
+      });
+      return JobStatus.Success;
+    }
+
+    // active=1 means only this marker is running — queue has drained
+    if (counts.active > 1) {
+      await this.jobRepository.queue({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: { delay: 10_000 },
+      });
+      return JobStatus.Success;
+    }
+
+    const activeBackfills = await this.jobRepository.searchJobs(QueueName.PeopleBackfill, {
+      status: [QueueJobStatus.Active, QueueJobStatus.Delayed, QueueJobStatus.Paused, QueueJobStatus.Waiting],
+    });
+    if (activeBackfills.some((job) => job.name === JobName.FaceIdentityBackfill)) {
+      return JobStatus.Skipped;
+    }
+
+    await this.jobRepository.queue({ name: JobName.FaceIdentityBackfill, data: {} });
     return JobStatus.Success;
   }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -421,6 +421,7 @@ export type JobItem =
   | { name: JobName.FacialRecognitionQueueAll; data: INightlyJob }
   | { name: JobName.FacialRecognition; data: IFacialRecognitionJob }
   | { name: JobName.FaceIdentityBackfill; data: IFaceIdentityBackfillJob }
+  | { name: JobName.FaceIdentityMaintenanceAfterRecognition; data: IDelayedJob }
   | { name: JobName.PersonGenerateThumbnail; data: IEntityJob }
 
   // Smart Search


### PR DESCRIPTION
## Summary

- Adds a `FaceIdentityMaintenanceAfterRecognition` terminal marker job queued at the end of `handleQueueRecognizeFaces` (for all cases that actually queue recognition jobs — force, non-force, and nightly runs — but not when skipped)
- The marker runs on the `FacialRecognition` queue so it naturally sits behind all recognition work; it polls `getJobCounts` and requeues itself with a 10s delay if the queue hasn't drained yet
- Once the queue is quiet (waiting + delayed + paused = 0, active ≤ 1 counting only itself), it checks whether `FaceIdentityBackfill` is already active/waiting/delayed/paused on `PeopleBackfill` and only queues it if not already running
- Stable jobId (`face-identity-maintenance-after-recognition`) prevents duplicate markers accumulating; `removeOnFail: true` ensures failed/stale markers don't permanently block future scheduling

## Motivation

After a force Facial Recognition reset, the personal instance had many duplicate people until People Identity Maintenance was manually queued. The `AppBootstrap` fallback only fires on worker restart, not after recognition completes.

## Test plan

- [x] 8 new unit tests covering: force queues marker after all FacialRecognition + SharedSpaceFaceMatchAll jobs; non-force queues marker after recognition jobs; nightly skip does not queue marker; marker queues FaceIdentityBackfill when queue drained; marker requeues on waiting/delayed jobs; marker requeues on other active work; no duplicate FaceIdentityBackfill if already queued
- [x] All 4387 server unit tests pass
- [x] TypeScript type check clean
- [x] Format and lint clean
- [x] Server build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)