### PR TITLE
fix(server): removeOnComplete for FaceIdentityBackfill root job to allow re-trigger

### DIFF
--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -253,6 +253,7 @@ describe(JobRepository.name, () => {
       {
         jobId: 'face-identity-backfill/root',
         removeOnFail: true,
+        removeOnComplete: true,
       },
     );
     expect(queue.add).toHaveBeenCalledWith(
@@ -261,6 +262,7 @@ describe(JobRepository.name, () => {
       {
         jobId: 'face-identity-backfill/root',
         removeOnFail: true,
+        removeOnComplete: true,
       },
     );
     expect(queue.add).toHaveBeenCalledWith(
@@ -312,6 +314,27 @@ describe(JobRepository.name, () => {
       JobName.SharedSpacePersonMetadataBackfill,
       { identityId: 'identity-1', cursor: 'cursor-2', limit: 1000 },
       { jobId: 'shared-space-person-metadata-backfill/identity/identity-1/cursor-2', removeOnFail: true },
+    );
+  });
+
+  it('sets removeOnComplete on the root backfill so it can be re-triggered after recognition drains', async () => {
+    // BullMQ deduplicates by jobId: a completed job whose hash is still in Redis
+    // makes a same-jobId add a no-op (handleDuplicatedJob). Without removeOnComplete,
+    // the onBootstrap pass leaves face-identity-backfill/root behind and the
+    // FaceIdentityMaintenanceAfterRecognition marker can never queue a fresh backfill.
+    const { sut, queue } = setup();
+    setHandlers(sut, [JobName.FaceIdentityBackfill]);
+
+    await sut.queue({ name: JobName.FaceIdentityBackfill, data: {} });
+
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FaceIdentityBackfill,
+      {},
+      {
+        jobId: 'face-identity-backfill/root',
+        removeOnFail: true,
+        removeOnComplete: true,
+      },
     );
   });
 

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -352,7 +352,7 @@ export class JobRepository {
         if (data.continuationId) {
           return { jobId: `face-identity-backfill/continuation/${data.continuationId}`, removeOnFail: true };
         }
-        return { jobId: 'face-identity-backfill/root', removeOnFail: true };
+        return { jobId: 'face-identity-backfill/root', removeOnFail: true, removeOnComplete: true };
       }
       case JobName.FaceIdentityMaintenanceAfterRecognition: {
         const data = item.data as { delay?: number };


### PR DESCRIPTION
## Summary

- Adds `removeOnComplete: true` to the `FaceIdentityBackfill` root job options in `job.repository.ts`
- Without this, BullMQ's `handleDuplicatedJob` silently blocks re-queuing: when the `onBootstrap` backfill completes its initial pass, its job hash (`face-identity-backfill/root`) stays in Redis; the `FaceIdentityMaintenanceAfterRecognition` marker then tries to queue a fresh backfill after recognition drains, but BullMQ sees the existing hash key and emits a "duplicated" event without adding the new job
- With `removeOnComplete: true`, the hash is cleaned up after each run, allowing the marker (from #589) to schedule a new backfill correctly

## Root cause trace

Observed on the personal instance after a force facial recognition reset:
1. Worker restarts → `onBootstrap` queues `FaceIdentityBackfill` (root, stable jobId `face-identity-backfill/root`) — runs for ~4s on empty data, completes
2. Recognition + SharedSpaceFaceMatchAll run for ~45 min
3. `FaceIdentityMaintenanceAfterRecognition` marker polls until queue drains, then calls `jobRepository.queue({ name: JobName.FaceIdentityBackfill, data: {} })`
4. BullMQ's `addStandardJob` Lua script detects `EXISTS face-identity-backfill/root == 1`, calls `handleDuplicatedJob`, emits "duplicated" event, returns early — backfill never runs

## Test plan

- [ ] Trigger a force facial recognition reset on the personal instance and confirm `FaceIdentityBackfill` runs after recognition + SharedSpaceFaceMatchAll finish
- [ ] No duplicate backfill if one is already active/waiting (deduplication still works for non-completed states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)