### PR TITLE
fix: sort people by canonical order

### DIFF
--- a/docs/superpowers/plans/2026-05-16-people-sort-order-implementation.md
+++ b/docs/superpowers/plans/2026-05-16-people-sort-order-implementation.md
@@ -30,6 +30,7 @@
 ## Task 1: Pure Web Comparator
 
 **Files:**
+
 - Modify: `web/src/lib/utils/people-utils.ts`
 - Test: `web/src/lib/utils/people-utils.spec.ts`
 
@@ -191,6 +192,7 @@ git commit -m "test: cover people management sorting"
 ## Task 2: Global and Space Page Sorting Tests
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/people/+page.svelte`
 - Test: `web/src/routes/(user)/people/people-page.spec.ts`
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte`
@@ -310,6 +312,7 @@ git commit -m "fix(web): sort unnamed people by photo count"
 ## Task 3: Server Non-Shared People Ordering
 
 **Files:**
+
 - Modify: `server/src/repositories/person.repository.ts`
 - Test: `server/src/services/person.service.spec.ts`
 
@@ -395,6 +398,7 @@ git commit -m "fix(server): sort non-shared people by canonical order"
 ## Task 4: Server Identity-Aware Global People Ordering
 
 **Files:**
+
 - Modify: `server/src/repositories/face-identity.repository.ts`
 - Test: `server/src/services/person.service.spec.ts`
 
@@ -497,6 +501,7 @@ git commit -m "fix(server): sort identity people by canonical order"
 ## Task 5: Server Space People Ordering
 
 **Files:**
+
 - Modify: `server/src/repositories/shared-space.repository.ts`
 - Test: `server/src/services/shared-space.service.spec.ts`
 
@@ -578,6 +583,7 @@ git commit -m "fix(server): sort space people by canonical order"
 ## Task 6: API-Level Ordering Coverage
 
 **Files:**
+
 - Test: `e2e/src/specs/server/api/person.e2e-spec.ts`
 - Test: `e2e/src/specs/server/api/shared-space.e2e-spec.ts`
 
@@ -656,17 +662,13 @@ Add this test in T09:
 
 ```ts
 it('orders named space people alphabetically before unnamed people by asset count', async () => {
-  const { status, body } = await request(app)
-    .get(`/shared-spaces/${spaceId}/people`)
-    .set(authHeaders(owner));
+  const { status, body } = await request(app).get(`/shared-spaces/${spaceId}/people`).set(authHeaders(owner));
 
   expect(status).toBe(200);
   const ordered = body.map((person: { id: string }) => person.id);
   expect(ordered.indexOf(namedPersonId)).toBeLessThan(ordered.indexOf(namedZoePersonId));
   expect(ordered.indexOf(namedZoePersonId)).toBeLessThan(ordered.indexOf(unnamedHighAssetCountPersonId));
-  expect(ordered.indexOf(unnamedHighAssetCountPersonId)).toBeLessThan(
-    ordered.indexOf(unnamedLowAssetCountPersonId),
-  );
+  expect(ordered.indexOf(unnamedHighAssetCountPersonId)).toBeLessThan(ordered.indexOf(unnamedLowAssetCountPersonId));
 });
 ```
 
@@ -700,6 +702,7 @@ git commit -m "test(e2e): cover people sort order"
 ## Task 7: Final Verification
 
 **Files:**
+
 - Verify all files changed in prior tasks.
 
 - [ ] **Step 1: Run focused web tests**

--- a/docs/superpowers/plans/2026-05-16-people-sort-order-implementation.md
+++ b/docs/superpowers/plans/2026-05-16-people-sort-order-implementation.md
@@ -1,0 +1,764 @@
+# People Sort Order Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make global and space people ordering consistently follow favorites first, named people alphabetically, and unnamed people by photo count descending without breaking pagination.
+
+**Architecture:** Server queries define canonical paginated order. The web comparator mirrors that contract only for already-loaded rows after local edits. Tests are written first for comparator behavior, page rendering, and server pagination/order boundaries.
+
+**Tech Stack:** TypeScript, Svelte 5, Vitest, NestJS, Kysely SQL, pnpm workspaces.
+
+---
+
+## File Map
+
+- Modify `web/src/lib/utils/people-utils.ts`: add count-aware people management comparator and keep a compatibility export.
+- Modify `web/src/lib/utils/people-utils.spec.ts`: pure comparator tests for named, unnamed, favorites, whitespace, missing counts, and tiebreaks.
+- Modify `web/src/routes/(user)/people/+page.svelte`: use the renamed comparator.
+- Modify `web/src/routes/(user)/people/people-page.spec.ts`: page-level coverage for favorite unnamed and unnamed count ordering.
+- Modify `web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte`: use the renamed comparator.
+- Modify `web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts`: page-level coverage for unnamed `assetCount` ordering and rename behavior.
+- Modify `server/src/repositories/person.repository.ts`: make non-shared people SQL use trimmed name, count only for unnamed, and id tiebreak.
+- Modify `server/src/repositories/face-identity.repository.ts`: make identity-aware people SQL include favorite ordering, trimmed names, count ordering for unnamed, and id tiebreak.
+- Modify `server/src/repositories/shared-space.repository.ts`: ensure `withHidden` space people ordering puts visible before hidden, trims names, and keeps unnamed `assetCount` ordering.
+- Modify `server/src/services/person.service.spec.ts`: service-level tests for non-shared and identity-aware ordering contracts where repository results are mocked.
+- Modify `server/src/services/shared-space.service.spec.ts`: service-level tests that preserve repository order, aliases, hidden behavior, and unnamed count cases.
+- Modify `e2e/src/specs/server/api/person.e2e-spec.ts`: API-level ordering and pagination coverage for real `/people` data.
+- Modify `e2e/src/specs/server/api/shared-space.e2e-spec.ts`: API-level ordering coverage for real `/shared-spaces/:id/people` data.
+- Generated SQL snapshots in `server/src/queries/*.sql` are updated by `pnpm --filter immich run sync:sql` after repository query changes.
+
+## Task 1: Pure Web Comparator
+
+**Files:**
+- Modify: `web/src/lib/utils/people-utils.ts`
+- Test: `web/src/lib/utils/people-utils.spec.ts`
+
+- [ ] **Step 1: Write failing comparator tests**
+
+Add tests to `web/src/lib/utils/people-utils.spec.ts` for the exported comparator. Use this shape:
+
+```ts
+import { sortPeopleForManagement } from './people-utils';
+
+describe('sortPeopleForManagement', () => {
+  const p = (overrides: {
+    id: string;
+    name?: string | null;
+    isFavorite?: boolean;
+    numberOfAssets?: number;
+    assetCount?: number;
+    isHidden?: boolean;
+  }) => overrides;
+
+  it('sorts favorites first, named people alphabetically, then unnamed by count descending', () => {
+    const people = [
+      p({ id: 'unnamed-low', name: '', numberOfAssets: 1 }),
+      p({ id: 'named-z', name: 'Zoe', numberOfAssets: 99 }),
+      p({ id: 'favorite-unnamed-high', name: '', isFavorite: true, numberOfAssets: 10 }),
+      p({ id: 'named-a', name: 'Alice', numberOfAssets: 1 }),
+      p({ id: 'unnamed-high', name: '', numberOfAssets: 50 }),
+      p({ id: 'favorite-named', name: 'Beth', isFavorite: true, numberOfAssets: 1 }),
+    ];
+
+    expect(sortPeopleForManagement(people).map((person) => person.id)).toEqual([
+      'favorite-named',
+      'favorite-unnamed-high',
+      'named-a',
+      'named-z',
+      'unnamed-high',
+      'unnamed-low',
+    ]);
+  });
+
+  it('treats whitespace-only names as unnamed and uses assetCount for space people', () => {
+    const people = [
+      p({ id: 'space-unnamed-low', name: '   ', assetCount: 2 }),
+      p({ id: 'space-named', name: 'anna', assetCount: 1 }),
+      p({ id: 'space-unnamed-high', name: '', assetCount: 9 }),
+    ];
+
+    expect(sortPeopleForManagement(people).map((person) => person.id)).toEqual([
+      'space-named',
+      'space-unnamed-high',
+      'space-unnamed-low',
+    ]);
+  });
+
+  it('uses case-insensitive names, missing counts as zero, and id as final tiebreak', () => {
+    const people = [
+      p({ id: 'unnamed-b', name: '', numberOfAssets: undefined }),
+      p({ id: 'named-b', name: 'bob' }),
+      p({ id: 'unnamed-a', name: '', numberOfAssets: 0 }),
+      p({ id: 'named-a', name: 'Alice' }),
+    ];
+
+    expect(sortPeopleForManagement(people).map((person) => person.id)).toEqual([
+      'named-a',
+      'named-b',
+      'unnamed-a',
+      'unnamed-b',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run comparator tests and confirm failure**
+
+Run:
+
+```bash
+pnpm --filter immich-web test -- src/lib/utils/people-utils.spec.ts --run
+```
+
+Expected: FAIL because `sortPeopleForManagement` is not exported or does not sort counts.
+
+- [ ] **Step 3: Implement the comparator**
+
+In `web/src/lib/utils/people-utils.ts`, replace the narrow sort type and comparator with:
+
+```ts
+export type SortablePerson = {
+  id: string;
+  name?: string | null;
+  isFavorite?: boolean;
+  isHidden?: boolean;
+  numberOfAssets?: number | null;
+  assetCount?: number | null;
+};
+
+const getSortablePersonName = (person: SortablePerson) => person.name?.trim() ?? '';
+const getSortablePersonCount = (person: SortablePerson) => person.numberOfAssets ?? person.assetCount ?? 0;
+
+export function comparePeopleForManagement(a: SortablePerson, b: SortablePerson): number {
+  if (!!a.isHidden !== !!b.isHidden) {
+    return a.isHidden ? 1 : -1;
+  }
+
+  if (!!a.isFavorite !== !!b.isFavorite) {
+    return a.isFavorite ? -1 : 1;
+  }
+
+  const aName = getSortablePersonName(a);
+  const bName = getSortablePersonName(b);
+  const aHasName = aName.length > 0;
+  const bHasName = bName.length > 0;
+  if (aHasName !== bHasName) {
+    return aHasName ? -1 : 1;
+  }
+
+  if (aHasName && bHasName) {
+    const nameCompare = aName.localeCompare(bName, undefined, { sensitivity: 'base' });
+    if (nameCompare !== 0) {
+      return nameCompare;
+    }
+  }
+
+  if (!aHasName && !bHasName) {
+    const countCompare = getSortablePersonCount(b) - getSortablePersonCount(a);
+    if (countCompare !== 0) {
+      return countCompare;
+    }
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
+export function sortPeopleForManagement<T extends SortablePerson>(people: T[]): T[] {
+  return [...people].sort(comparePeopleForManagement);
+}
+
+export const comparePeopleByFavoriteAndName = comparePeopleForManagement;
+export const sortPeopleByFavoriteAndName = sortPeopleForManagement;
+```
+
+- [ ] **Step 4: Run comparator tests and confirm pass**
+
+Run:
+
+```bash
+pnpm --filter immich-web test -- src/lib/utils/people-utils.spec.ts --run
+```
+
+Expected: PASS for the new comparator tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/utils/people-utils.ts web/src/lib/utils/people-utils.spec.ts
+git commit -m "test: cover people management sorting"
+```
+
+## Task 2: Global and Space Page Sorting Tests
+
+**Files:**
+- Modify: `web/src/routes/(user)/people/+page.svelte`
+- Test: `web/src/routes/(user)/people/people-page.spec.ts`
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte`
+- Test: `web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts`
+
+- [ ] **Step 1: Write failing route tests**
+
+In `web/src/routes/(user)/people/people-page.spec.ts`, update the existing ordering test to include multiple unnamed people and a favorite unnamed person:
+
+```ts
+it('renders favorites first, named people alphabetically, then unnamed people by photo count', () => {
+  renderPage([
+    makePerson({ id: 'unnamed-low', name: '', isFavorite: false, numberOfAssets: 1 }),
+    makePerson({ id: 'named-z', name: 'Zoe', isFavorite: false, numberOfAssets: 99 }),
+    makePerson({ id: 'favorite-unnamed', name: '', isFavorite: true, numberOfAssets: 7 }),
+    makePerson({ id: 'named-a', name: 'Alice', isFavorite: false, numberOfAssets: 1 }),
+    makePerson({ id: 'unnamed-high', name: '', isFavorite: false, numberOfAssets: 12 }),
+    makePerson({ id: 'favorite-named', name: 'Anna', isFavorite: true, numberOfAssets: 1 }),
+  ]);
+
+  expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
+    'Anna',
+    '',
+    'Alice',
+    'Zoe',
+    '',
+    '',
+  ]);
+});
+```
+
+In `web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts`, update the ordering test:
+
+```ts
+it('renders named people alphabetically before unnamed people sorted by asset count', () => {
+  renderPage([
+    makeSpacePerson({ id: 'space-person-unnamed-low', name: '', assetCount: 1 }),
+    makeSpacePerson({ id: 'space-person-zoe', name: 'Zoe', assetCount: 99 }),
+    makeSpacePerson({ id: 'space-person-unnamed-high', name: '', assetCount: 20 }),
+    makeSpacePerson({ id: 'space-person-alice', name: 'Alice', assetCount: 1 }),
+  ]);
+
+  expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
+    'Alice',
+    'Zoe',
+    '',
+    '',
+  ]);
+});
+```
+
+- [ ] **Step 2: Run route tests and confirm failure before page import changes**
+
+Run:
+
+```bash
+pnpm --filter immich-web test -- src/routes/\(user\)/people/people-page.spec.ts src/routes/\(user\)/spaces/\[spaceId\]/people/space-people-page.spec.ts --run
+```
+
+Expected: FAIL if the page still uses old id-only unnamed ordering.
+
+- [ ] **Step 3: Update page imports and usage**
+
+In both page files, change:
+
+```ts
+import { sortPeopleByFavoriteAndName } from '$lib/utils/people-utils';
+```
+
+to:
+
+```ts
+import { sortPeopleForManagement } from '$lib/utils/people-utils';
+```
+
+In `web/src/routes/(user)/people/+page.svelte`, change:
+
+```ts
+let showPeople = $derived(sortPeopleByFavoriteAndName(searchName ? searchedPeopleLocal : visiblePeople));
+```
+
+to:
+
+```ts
+let showPeople = $derived(sortPeopleForManagement(searchName ? searchedPeopleLocal : visiblePeople));
+```
+
+In `web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte`, change:
+
+```ts
+const visiblePeople = $derived(sortPeopleByFavoriteAndName(people.filter((p) => !p.isHidden)));
+```
+
+to:
+
+```ts
+const visiblePeople = $derived(sortPeopleForManagement(people.filter((p) => !p.isHidden)));
+```
+
+- [ ] **Step 4: Run route tests and confirm pass**
+
+Run:
+
+```bash
+pnpm --filter immich-web test -- src/routes/\(user\)/people/people-page.spec.ts src/routes/\(user\)/spaces/\[spaceId\]/people/space-people-page.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/routes/\(user\)/people/+page.svelte web/src/routes/\(user\)/people/people-page.spec.ts web/src/routes/\(user\)/spaces/\[spaceId\]/people/+page.svelte web/src/routes/\(user\)/spaces/\[spaceId\]/people/space-people-page.spec.ts
+git commit -m "fix(web): sort unnamed people by photo count"
+```
+
+## Task 3: Server Non-Shared People Ordering
+
+**Files:**
+- Modify: `server/src/repositories/person.repository.ts`
+- Test: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add service-level ordering regression test**
+
+In `server/src/services/person.service.spec.ts`, add or extend a `getAll` test that mocks repository output in the expected order and asserts the DTO preserves repository order and counts. The service should not re-sort:
+
+```ts
+it('should preserve non-shared repository order for favorites, named people, and unnamed count ordering', async () => {
+  const auth = AuthFactory.create();
+  const favorite = PersonFactory.create({ id: 'favorite', name: 'Anna', isFavorite: true });
+  const named = PersonFactory.create({ id: 'named', name: 'Bob', isFavorite: false });
+  const unnamedHigh = PersonFactory.create({ id: 'unnamed-high', name: '', isFavorite: false });
+  const unnamedLow = PersonFactory.create({ id: 'unnamed-low', name: '', isFavorite: false });
+
+  mocks.person.getAllForUser.mockResolvedValue({
+    items: [favorite, named, unnamedHigh, unnamedLow],
+    hasNextPage: false,
+  });
+  mocks.person.getNumberOfPeople.mockResolvedValue({ total: 4, hidden: 0 });
+
+  const result = await sut.getAll(auth, { withHidden: false, page: 1, size: 10 });
+
+  expect(result.people.map((person) => person.id)).toEqual(['favorite', 'named', 'unnamed-high', 'unnamed-low']);
+});
+```
+
+- [ ] **Step 2: Run server person service tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/person.service.spec.ts --run
+```
+
+Expected: PASS. This locks that service does not undo repository order.
+
+- [ ] **Step 3: Update repository SQL order**
+
+In `server/src/repositories/person.repository.ts`, update the non-closest ordering in `getAllForUser()` to trim names and only apply count ordering to unnamed rows:
+
+```ts
+.$if(!options?.closestFaceAssetId, (qb) =>
+  qb
+    .orderBy(sql`NULLIF(BTRIM(person.name), '') is null`, 'asc')
+    .orderBy(sql`NULLIF(BTRIM(person.name), '')`, (om) => om.asc().nullsLast())
+    .orderBy(sql`CASE WHEN NULLIF(BTRIM(person.name), '') IS NULL THEN COUNT("asset_face"."assetId") END`, (om) =>
+      om.desc().nullsLast(),
+    )
+    .orderBy('person.id'),
+)
+```
+
+Keep the existing `person.isHidden asc` and `person.isFavorite desc` before this block.
+
+- [ ] **Step 4: Run server person tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/person.service.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate SQL snapshots**
+
+Run:
+
+```bash
+pnpm --filter immich run sync:sql
+```
+
+Expected: `server/src/queries/person.repository.sql` contains the trimmed name ordering, unnamed count ordering, and `person.id` tiebreak for `getAllForUser`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/repositories/person.repository.ts server/src/services/person.service.spec.ts server/src/queries/person.repository.sql
+git commit -m "fix(server): sort non-shared people by canonical order"
+```
+
+## Task 4: Server Identity-Aware Global People Ordering
+
+**Files:**
+- Modify: `server/src/repositories/face-identity.repository.ts`
+- Test: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add service tests for identity-aware path invocation**
+
+In `server/src/services/person.service.spec.ts`, extend existing `withSharedSpaces` tests to include a returned order containing favorite, named, and unnamed people:
+
+```ts
+it('should preserve identity-aware people ordering returned by repository', async () => {
+  const auth = AuthFactory.create();
+  const response = {
+    total: 4,
+    hidden: 0,
+    hasNextPage: false,
+    people: [
+      { id: 'favorite', name: 'Anna', isFavorite: true, numberOfAssets: 1 },
+      { id: 'named', name: 'Bob', numberOfAssets: 20 },
+      { id: 'unnamed-high', name: '', numberOfAssets: 50 },
+      { id: 'unnamed-low', name: '', numberOfAssets: 1 },
+    ],
+  };
+
+  (mocks.faceIdentity as any).getAccessiblePeople.mockResolvedValue(response);
+
+  await expect(sut.getAll(auth, { withSharedSpaces: true, withHidden: false, page: 1, size: 10 })).resolves.toEqual(
+    response,
+  );
+});
+```
+
+- [ ] **Step 2: Run service tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/person.service.spec.ts --run
+```
+
+Expected: PASS. This confirms service pass-through before repository SQL changes.
+
+- [ ] **Step 3: Update identity page SQL**
+
+In `server/src/repositories/face-identity.repository.ts`, update `getAccessiblePeopleIdentityPage()`:
+
+1. Include `person."isFavorite"` in the personal branch of `accessible_profiles`.
+2. Include `NULL::boolean AS "isFavorite"` in the space-person branch.
+3. In `best_profiles`, select `isFavorite`.
+4. Order final rows by favorite first, named first, lower trimmed name, unnamed count desc, identity id.
+
+The final `ORDER BY` should follow this shape:
+
+```sql
+ORDER BY
+  COALESCE(best_profiles."isFavorite", false) DESC,
+  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+  CASE
+    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+  END DESC NULLS LAST,
+  identity_counts."identityId"
+```
+
+- [ ] **Step 4: Regenerate SQL snapshots**
+
+Run:
+
+```bash
+pnpm --filter immich run sync:sql
+```
+
+Expected: generated query SQL includes favorite ordering and unnamed count ordering for `getAccessiblePeopleIdentityPage`.
+
+- [ ] **Step 5: Verify generated SQL coverage**
+
+Run:
+
+```bash
+rg -n "getAccessiblePeopleIdentityPage|isFavorite|visibleAssetCount|ORDER BY" server/src/queries/face-identity.repository.sql
+```
+
+Expected: `server/src/queries/face-identity.repository.sql` contains the generated `getAccessiblePeopleIdentityPage` query with `isFavorite`, `visibleAssetCount`, and the final `ORDER BY` terms from Step 3.
+
+- [ ] **Step 6: Run server tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/person.service.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/repositories/face-identity.repository.ts server/src/services/person.service.spec.ts server/src/queries/face-identity.repository.sql
+git commit -m "fix(server): sort identity people by canonical order"
+```
+
+## Task 5: Server Space People Ordering
+
+**Files:**
+- Modify: `server/src/repositories/shared-space.repository.ts`
+- Test: `server/src/services/shared-space.service.spec.ts`
+
+- [ ] **Step 1: Add service test for preserving space repository order with unnamed counts**
+
+In `server/src/services/shared-space.service.spec.ts`, add a test in the `getSpacePeople` describe block:
+
+```ts
+it('should preserve space repository order for named people and unnamed asset counts', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+  const named = { id: 'named', spaceId, name: 'Alice', isHidden: false, faceCount: 1, assetCount: 1 };
+  const unnamedHigh = { id: 'unnamed-high', spaceId, name: '', isHidden: false, faceCount: 1, assetCount: 20 };
+  const unnamedLow = { id: 'unnamed-low', spaceId, name: '', isHidden: false, faceCount: 1, assetCount: 2 };
+
+  mocks.sharedSpace.getMember.mockResolvedValue(makeMemberResult({ role: SharedSpaceRole.Viewer }));
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getPersonsBySpaceId.mockResolvedValue([named, unnamedHigh, unnamedLow]);
+  mocks.sharedSpace.getAliasesBySpaceAndUser.mockResolvedValue([]);
+
+  const result = await sut.getSpacePeople(auth, spaceId);
+
+  expect(result.map((person) => person.id)).toEqual(['named', 'unnamed-high', 'unnamed-low']);
+});
+```
+
+- [ ] **Step 2: Run shared space service tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/shared-space.service.spec.ts --run
+```
+
+Expected: PASS. This confirms service pass-through.
+
+- [ ] **Step 3: Update shared space repository ordering**
+
+In `server/src/repositories/shared-space.repository.ts`, make the order explicit:
+
+```ts
+.orderBy('shared_space_person.isHidden', 'asc')
+.orderBy(sql`NULLIF(BTRIM(shared_space_person.name), '')`, (om) => om.asc().nullsLast())
+.orderBy(
+  sql`CASE WHEN NULLIF(BTRIM(shared_space_person.name), '') IS NULL THEN "shared_space_person"."assetCount" END`,
+  (om) => om.desc().nullsLast(),
+)
+.orderBy('shared_space_person.id')
+```
+
+- [ ] **Step 4: Regenerate SQL snapshots**
+
+Run:
+
+```bash
+pnpm --filter immich run sync:sql
+```
+
+Expected: shared-space repository SQL snapshots update with `isHidden`, trimmed name, unnamed `assetCount`, and id order.
+
+- [ ] **Step 5: Run shared space tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/shared-space.service.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/repositories/shared-space.repository.ts server/src/services/shared-space.service.spec.ts server/src/queries/shared-space.repository.sql
+git commit -m "fix(server): sort space people by canonical order"
+```
+
+## Task 6: API-Level Ordering Coverage
+
+**Files:**
+- Test: `e2e/src/specs/server/api/person.e2e-spec.ts`
+- Test: `e2e/src/specs/server/api/shared-space.e2e-spec.ts`
+
+- [ ] **Step 1: Extend `/people` e2e ordering assertions**
+
+In `e2e/src/specs/server/api/person.e2e-spec.ts`, extend the existing `GET /people` setup and ordering test so it proves the actual API order with multiple unnamed people and pagination boundaries. The current file already creates named, unnamed, and favorite people; keep that fixture style and assert ids, not only names:
+
+```ts
+it('should sort visible people by favorite, name, then unnamed asset count across pages', async () => {
+  const firstPage = await request(app)
+    .get('/people')
+    .set('Authorization', `Bearer ${admin.accessToken}`)
+    .query({ page: 1, size: 5 });
+
+  expect(firstPage.status).toBe(200);
+  expect(firstPage.body.hasNextPage).toBe(true);
+  expect(firstPage.body.people.map((person: PersonResponseDto) => person.id)).toEqual([
+    nameBillPersonFavourite.id,
+    nameFreddyPersonFavourite.id,
+    nameAlicePerson.id,
+    nameBobPerson.id,
+    nameCharliePerson.id,
+  ]);
+
+  const secondPage = await request(app)
+    .get('/people')
+    .set('Authorization', `Bearer ${admin.accessToken}`)
+    .query({ page: 2, size: 5 });
+
+  expect(secondPage.status).toBe(200);
+  expect(secondPage.body.people.map((person: PersonResponseDto) => person.id)).toEqual([
+    multipleAssetsPerson.id,
+    visiblePerson.id,
+    nameNullPerson4Assets.id,
+    nameNullPerson3Assets.id,
+  ]);
+});
+```
+
+Expected current failure before server fixes: unnamed people are not reliably ordered by count after the client/server contract changes are asserted.
+
+- [ ] **Step 2: Extend `/shared-spaces/:id/people` e2e ordering assertions**
+
+In `e2e/src/specs/server/api/shared-space.e2e-spec.ts`, extend the `GET /shared-spaces/:id/people (T09)` describe block.
+
+Add these fixture variables near the existing `namedPersonId` and `unnamedPersonId` declarations:
+
+```ts
+let namedZoePersonId: string;
+let unnamedHighAssetCountPersonId: string;
+let unnamedLowAssetCountPersonId: string;
+```
+
+Add these rows in the T09 `beforeAll` after `unnamedPersonId` is assigned:
+
+```ts
+const zoeRes = await utils.createSpacePerson(spaceId, 'Zoe', owner.userId, spaceAssetId);
+namedZoePersonId = zoeRes.spacePersonId;
+
+const unnamedHighRes = await utils.createSpacePerson(spaceId, '', owner.userId, spaceAssetId);
+unnamedHighAssetCountPersonId = unnamedHighRes.spacePersonId;
+
+const unnamedLowRes = await utils.createSpacePerson(spaceId, '', owner.userId, spaceAssetId);
+unnamedLowAssetCountPersonId = unnamedLowRes.spacePersonId;
+
+const dbClientForCounts = await utils.connectDatabase();
+await dbClientForCounts.query('UPDATE shared_space_person SET "assetCount" = 6 WHERE id = $1', [
+  unnamedHighAssetCountPersonId,
+]);
+await dbClientForCounts.query('UPDATE shared_space_person SET "assetCount" = 3 WHERE id = $1', [
+  unnamedLowAssetCountPersonId,
+]);
+```
+
+Add this test in T09:
+
+```ts
+it('orders named space people alphabetically before unnamed people by asset count', async () => {
+  const { status, body } = await request(app)
+    .get(`/shared-spaces/${spaceId}/people`)
+    .set(authHeaders(owner));
+
+  expect(status).toBe(200);
+  const ordered = body.map((person: { id: string }) => person.id);
+  expect(ordered.indexOf(namedPersonId)).toBeLessThan(ordered.indexOf(namedZoePersonId));
+  expect(ordered.indexOf(namedZoePersonId)).toBeLessThan(ordered.indexOf(unnamedHighAssetCountPersonId));
+  expect(ordered.indexOf(unnamedHighAssetCountPersonId)).toBeLessThan(
+    ordered.indexOf(unnamedLowAssetCountPersonId),
+  );
+});
+```
+
+- [ ] **Step 3: Run API e2e tests and confirm failure before server query fixes**
+
+Run:
+
+```bash
+pnpm --filter immich-e2e test -- src/specs/server/api/person.e2e-spec.ts src/specs/server/api/shared-space.e2e-spec.ts
+```
+
+Expected: FAIL on the new ordering assertions before repository ordering changes are complete.
+
+- [ ] **Step 4: Run API e2e tests and confirm pass after server query fixes**
+
+Run the same command after Tasks 3, 4, and 5 are implemented:
+
+```bash
+pnpm --filter immich-e2e test -- src/specs/server/api/person.e2e-spec.ts src/specs/server/api/shared-space.e2e-spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/src/specs/server/api/person.e2e-spec.ts e2e/src/specs/server/api/shared-space.e2e-spec.ts
+git commit -m "test(e2e): cover people sort order"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- Verify all files changed in prior tasks.
+
+- [ ] **Step 1: Run focused web tests**
+
+Run:
+
+```bash
+pnpm --filter immich-web test -- src/lib/utils/people-utils.spec.ts src/routes/\(user\)/people/people-page.spec.ts src/routes/\(user\)/spaces/\[spaceId\]/people/space-people-page.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused server tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- src/services/person.service.spec.ts src/services/shared-space.service.spec.ts --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run focused API e2e tests**
+
+Run:
+
+```bash
+pnpm --filter immich-e2e test -- src/specs/server/api/person.e2e-spec.ts src/specs/server/api/shared-space.e2e-spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run type checks for touched packages**
+
+Run:
+
+```bash
+pnpm --filter immich-web run check:typescript
+pnpm --filter immich run check
+pnpm --filter immich-e2e run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```bash
+git diff --stat main..HEAD
+git diff main..HEAD -- web/src/lib/utils/people-utils.ts server/src/repositories/person.repository.ts server/src/repositories/face-identity.repository.ts server/src/repositories/shared-space.repository.ts
+```
+
+Expected: diff only covers sorting contract, tests, generated SQL snapshots, spec, and this plan.
+
+- [ ] **Step 6: Confirm clean final status**
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted changes after the final implementation commit.

--- a/docs/superpowers/specs/2026-05-16-people-sort-order-design.md
+++ b/docs/superpowers/specs/2026-05-16-people-sort-order-design.md
@@ -1,0 +1,103 @@
+# People Sort Order Design
+
+## Problem
+
+The global `/people` page and space people page no longer preserve the intended ordering for unnamed people. The API paths already compute or store people asset counts, but the web page re-sorts loaded people with a comparator that only considers favorite status, name, and id. As a result, multiple unnamed people are ordered by id instead of photo count.
+
+The intended behavior is:
+
+1. Favorites first where favorites exist.
+2. Named people alphabetically.
+3. Unnamed people by photo count descending.
+
+The implementation must preserve pagination correctness for large libraries. It must not fetch every person into the browser just to sort.
+
+## Canonical Sort Contract
+
+Global people use this order:
+
+1. Visible people before hidden people when hidden people are included in management or visibility contexts.
+2. Favorite people before non-favorite people.
+3. Within each favorite bucket, named people before unnamed people.
+4. Named people sort by trimmed display name, case-insensitively.
+5. Unnamed people sort by accessible asset/photo count descending.
+6. Stable id tiebreak.
+
+Space people use the same contract without favorite ordering:
+
+1. Visible people before hidden people when hidden people are included in management or visibility contexts.
+2. Named people before unnamed people.
+3. Named people sort by trimmed display name, case-insensitively.
+4. Unnamed people sort by `assetCount` descending.
+5. Stable id tiebreak.
+
+Names containing only whitespace are treated as unnamed for both global and space people. The comparator and SQL should use the same normalization rule: trim before deciding whether a name is present, and compare names case-insensitively.
+
+## Server Design
+
+The server remains the source of truth for paginated ordering.
+
+For global non-shared people, `PersonRepository.getAllForUser()` should keep its existing favorite and visibility ordering, then make the named/unnamed split explicit: named people sort alphabetically, unnamed people sort by their grouped asset/face count descending, then person id as the stable tiebreak. The SQL should not use creation time as a tiebreak because the web comparator cannot reproduce that order from the current DTO.
+
+For global identity-aware people, `FaceIdentityRepository.getAccessiblePeopleIdentityPage()` should order identity pages by the same global contract. It already builds `best_profiles` and `identity_counts.visibleAssetCount`; the change is to compute an identity-level favorite flag from the accessible primary/user-person profile when present, then order by favorite, named status, name, unnamed count, and identity id. This keeps pagination correct when `/people` is loaded with `withSharedSpaces: true`. A space-only identity with no personal favorite flag is treated as non-favorite.
+
+For space people, `SharedSpaceRepository.getPersonsBySpaceId()` already orders named people alphabetically and unnamed people by `assetCount` descending. The design is to keep that server behavior and ensure visible-before-hidden ordering is present for `withHidden` contexts.
+
+## Web Design
+
+The web comparator should match the server contract for local updates over already-loaded rows. It should understand both global and space DTO count fields:
+
+- `numberOfAssets` for global people.
+- `assetCount` for space people.
+
+The comparator should use count only when both compared people are unnamed. Named people remain alphabetical even if another named person has more photos.
+
+The current `sortPeopleByFavoriteAndName` name is too narrow. Rename it to a management-oriented name such as `sortPeopleForManagement`, while keeping a compatibility export if existing non-page call sites still expect the old name.
+
+The global `/people` page and `/spaces/[spaceId]/people` page should use the canonical comparator for display after local mutations such as rename, hide, or favorite toggle.
+
+The comparator must be covered as a pure unit so route tests do not become the only specification for sort behavior.
+
+## Performance
+
+This design does not add client-side full-list fetching. Pagination stays server-side.
+
+Space people sort by a denormalized `shared_space_person.assetCount`, so the sort does not rescan the photo library.
+
+Global identity-aware people already compute `visibleAssetCount` in the current query. The sort should reuse that grouped count rather than issuing extra per-person count queries.
+
+## Testing
+
+Implementation should follow test-driven development: add the failing tests for each behavior first, confirm they fail on the current code, then implement the smallest change that makes them pass.
+
+Add or update tests with at least two unnamed people with different counts.
+
+Client tests:
+
+- Global people page renders favorites first, named people alphabetically, then unnamed people by `numberOfAssets` descending.
+- Global people page renders favorite unnamed people before non-favorite named people.
+- Space people page renders named people alphabetically, then unnamed people by `assetCount` descending.
+- Renaming an unnamed space person still moves it into the named alphabetical bucket without a refetch.
+- Pure comparator tests cover whitespace-only names, case-insensitive names, missing count values, equal counts, and id tiebreaks.
+
+Server tests:
+
+- Global identity-aware people ordering covers favorite first and unnamed count ordering.
+- Global identity-aware pagination covers a boundary where an unnamed high-count person would be incorrectly stranded on a later page if sorting happened only client-side.
+- Non-shared people ordering keeps named alphabetical and unnamed count ordering.
+- Space people repository or service ordering covers multiple unnamed people with different `assetCount` values.
+- Space people ordering covers whitespace-only names as unnamed and equal `assetCount` id tiebreaking.
+
+Regression tests should avoid relying on only one unnamed person, because that does not verify the count ordering.
+
+Edge cases that must be covered or explicitly preserved by existing tests:
+
+- Empty people lists return empty results without errors.
+- Hidden people remain excluded from normal page lists when `withHidden` is false.
+- Hidden people are ordered after visible people when `withHidden` is true and both groups are shown together.
+- Missing `numberOfAssets` or `assetCount` sorts as zero for unnamed client-side rows.
+- Space-only global identities without a favorite flag do not outrank favorite personal people.
+
+## Out of Scope
+
+This design does not add user-selectable sort modes, change people tile rendering, or alter how asset counts are computed.

--- a/e2e/src/specs/server/api/person.e2e-spec.ts
+++ b/e2e/src/specs/server/api/person.e2e-spec.ts
@@ -125,21 +125,21 @@ describe('/people', () => {
         total: 10,
         hidden: 1,
         people: [
-          expect.objectContaining({ name: 'Freddy' }),
           expect.objectContaining({ name: 'Bill' }),
-          expect.objectContaining({ name: 'multiple_assets_person' }),
-          expect.objectContaining({ name: 'Bob' }),
+          expect.objectContaining({ name: 'Freddy' }),
           expect.objectContaining({ name: 'Alice' }),
+          expect.objectContaining({ name: 'Bob' }),
           expect.objectContaining({ name: 'Charlie' }),
+          expect.objectContaining({ name: 'multiple_assets_person' }),
           expect.objectContaining({ name: 'visible_person' }),
           expect.objectContaining({ id: nameNullPerson4Assets.id, name: '' }),
           expect.objectContaining({ id: nameNullPerson3Assets.id, name: '' }),
-          expect.objectContaining({ name: 'hidden_person' }), // Should really be before the null names
+          expect.objectContaining({ name: 'hidden_person' }),
         ],
       });
     });
 
-    it('should sort visible people by asset count (desc), then by name (asc, nulls last)', async () => {
+    it('should sort visible people by favorite, named people alphabetically, then unnamed by asset count', async () => {
       const { status, body } = await request(app).get('/people').set('Authorization', `Bearer ${admin.accessToken}`);
 
       expect(status).toBe(200);
@@ -150,12 +150,12 @@ describe('/people', () => {
       const people = body.people as PersonResponseDto[];
 
       expect(people.map((p) => p.id)).toEqual([
-        nameFreddyPersonFavourite.id, // name: 'Freddy', count: 2
         nameBillPersonFavourite.id, // name: 'Bill', count: 1
-        multipleAssetsPerson.id, // name: 'multiple_assets_person', count: 3
-        nameBobPerson.id, // name: 'Bob', count: 2
+        nameFreddyPersonFavourite.id, // name: 'Freddy', count: 2
         nameAlicePerson.id, // name: 'Alice', count: 1
+        nameBobPerson.id, // name: 'Bob', count: 2
         nameCharliePerson.id, // name: 'Charlie', count: 1
+        multipleAssetsPerson.id, // name: 'multiple_assets_person', count: 3
         visiblePerson.id, // name: 'visible_person', count: 1
         nameNullPerson4Assets.id, // name: '', count: 4
         nameNullPerson3Assets.id, // name: '', count: 3
@@ -173,12 +173,12 @@ describe('/people', () => {
         total: 10,
         hidden: 1,
         people: [
-          expect.objectContaining({ name: 'Freddy' }),
           expect.objectContaining({ name: 'Bill' }),
-          expect.objectContaining({ name: 'multiple_assets_person' }),
-          expect.objectContaining({ name: 'Bob' }),
+          expect.objectContaining({ name: 'Freddy' }),
           expect.objectContaining({ name: 'Alice' }),
+          expect.objectContaining({ name: 'Bob' }),
           expect.objectContaining({ name: 'Charlie' }),
+          expect.objectContaining({ name: 'multiple_assets_person' }),
           expect.objectContaining({ name: 'visible_person' }),
           expect.objectContaining({ id: nameNullPerson4Assets.id, name: '' }),
           expect.objectContaining({ id: nameNullPerson3Assets.id, name: '' }),
@@ -197,7 +197,7 @@ describe('/people', () => {
         hasNextPage: true,
         total: 10,
         hidden: 1,
-        people: [expect.objectContaining({ name: 'Alice' })],
+        people: [expect.objectContaining({ name: 'Charlie' })],
       });
     });
   });

--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -1435,6 +1435,9 @@ describe('/shared-spaces', () => {
 
     let namedPersonId: string; // Alice — has a name
     let unnamedPersonId: string; // empty name
+    let namedZoePersonId: string; // Zoe — has a name, sorts after Alice
+    let unnamedHighAssetCountPersonId: string; // empty name, above minFaces threshold
+    let unnamedLowAssetCountPersonId: string; // empty name, above minFaces threshold
     let hiddenPersonId: string; // Hannah — set isHidden=true
     let petPersonId: string; // Rex — type=pet
     let zeroThumbPersonId: string; // person with empty thumbnailPath — invisible to listing
@@ -1483,11 +1486,26 @@ describe('/shared-spaces', () => {
       const unnamedRes = await utils.createSpacePerson(spaceId, '', owner.userId, spaceAssetId);
       unnamedPersonId = unnamedRes.spacePersonId;
 
+      const zoeRes = await utils.createSpacePerson(spaceId, 'Zoe', owner.userId, spaceAssetId);
+      namedZoePersonId = zoeRes.spacePersonId;
+
+      const unnamedHighRes = await utils.createSpacePerson(spaceId, '', owner.userId, spaceAssetId);
+      unnamedHighAssetCountPersonId = unnamedHighRes.spacePersonId;
+
+      const unnamedLowRes = await utils.createSpacePerson(spaceId, '', owner.userId, spaceAssetId);
+      unnamedLowAssetCountPersonId = unnamedLowRes.spacePersonId;
+
       const hannahRes = await utils.createSpacePerson(spaceId, 'Hannah', owner.userId, spaceAssetId);
       hiddenPersonId = hannahRes.spacePersonId;
       // Set hidden directly via DB to avoid coupling to T11's PUT endpoint coverage.
       const dbClient = await utils.connectDatabase();
       await dbClient.query('UPDATE shared_space_person SET "isHidden" = true WHERE id = $1', [hiddenPersonId]);
+      await dbClient.query('UPDATE shared_space_person SET "assetCount" = 6 WHERE id = $1', [
+        unnamedHighAssetCountPersonId,
+      ]);
+      await dbClient.query('UPDATE shared_space_person SET "assetCount" = 3 WHERE id = $1', [
+        unnamedLowAssetCountPersonId,
+      ]);
 
       const rexRes = await utils.createSpacePerson(spaceId, 'Rex', owner.userId, spaceAssetId, { type: 'pet' });
       petPersonId = rexRes.spacePersonId;
@@ -1536,6 +1554,8 @@ describe('/shared-spaces', () => {
       const ids = (body as Array<{ id: string }>).map((p) => p.id);
       expect(ids).toContain(namedPersonId);
       expect(ids).not.toContain(unnamedPersonId);
+      expect(ids).toContain(unnamedHighAssetCountPersonId);
+      expect(ids).toContain(unnamedLowAssetCountPersonId);
       expect(ids).toContain(petPersonId);
       // Sanity check: namedPersonId and aliceGlobalId are different UUIDs.
       expect(namedPersonId).not.toBe(aliceGlobalId);
@@ -1570,6 +1590,18 @@ describe('/shared-spaces', () => {
       expect(ids).not.toContain(unnamedPersonId);
     });
 
+    it('sorts named people alphabetically before unnamed people by asset count', async () => {
+      const { status, body } = await request(app)
+        .get(`/shared-spaces/${spaceId}/people`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+      expect(status).toBe(200);
+      const ids = (body as Array<{ id: string }>).map((p) => p.id);
+
+      expect(ids.indexOf(namedPersonId)).toBeLessThan(ids.indexOf(namedZoePersonId));
+      expect(ids.indexOf(namedZoePersonId)).toBeLessThan(ids.indexOf(unnamedHighAssetCountPersonId));
+      expect(ids.indexOf(unnamedHighAssetCountPersonId)).toBeLessThan(ids.indexOf(unnamedLowAssetCountPersonId));
+    });
+
     it('?named=true returns only persons with non-empty names', async () => {
       // The named filter is true if either shared_space_person.name OR the underlying
       // person.name is non-empty (server/src/repositories/shared-space.repository.ts:514-521).
@@ -1580,7 +1612,10 @@ describe('/shared-spaces', () => {
       expect(status).toBe(200);
       const ids = (body as Array<{ id: string }>).map((p) => p.id);
       expect(ids).toContain(namedPersonId);
+      expect(ids).toContain(namedZoePersonId);
       expect(ids).not.toContain(unnamedPersonId);
+      expect(ids).not.toContain(unnamedHighAssetCountPersonId);
+      expect(ids).not.toContain(unnamedLowAssetCountPersonId);
     });
 
     it('petsEnabled toggle on the space hides pet persons', async () => {

--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -347,6 +347,7 @@ DELETE FROM "kysely_migrations"
    '1778500000000-AddSpacePersonRepresentativeFaceSource',
    '1778600000000-SortSpacePeopleByNameIndex',
    '1778700000000-AddSharedSpaceFaceMatchBackfillTarget',
+   '1778800000000-TrimSpacePersonNameIndex',
 
    -- Post-v2.7.5 upstream migrations pulled in by rebase. Paired with the
    -- schema rollbacks in step 7 above.
@@ -384,7 +385,8 @@ BEGIN
       OR "name" LIKE '%AddAssetDuplicateChecksum%'
       OR "name" LIKE '%AddFaceIdentities%'
       OR "name" LIKE '%AddSpacePersonRepresentativeFaceSource%'
-      OR "name" LIKE '%SortSpacePeopleByNameIndex%';
+      OR "name" LIKE '%SortSpacePeopleByNameIndex%'
+      OR "name" LIKE '%TrimSpacePersonNameIndex%';
   IF fork_rows_left > 0 THEN
     RAISE EXCEPTION 'revert-to-immich: % Gallery row(s) still present in kysely_migrations after cleanup — aborting.', fork_rows_left;
   END IF;

--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -149,6 +149,7 @@ WITH
       person."identityId",
       person.name,
       person."isHidden",
+      person."isFavorite",
       person."updatedAt",
       person.id AS "profileId",
       0 AS "profileRank"
@@ -174,6 +175,7 @@ WITH
         ''
       ) AS name,
       shared_space_person."isHidden",
+      NULL::boolean AS "isFavorite",
       shared_space_person."updatedAt",
       shared_space_person.id AS "profileId",
       CASE
@@ -248,11 +250,20 @@ WITH
       eligible_profiles
     ORDER BY
       "identityId",
-      NULLIF(name, '') IS NULL,
+      NULLIF(BTRIM(name), '') IS NULL,
       "profileRank",
-      lower(name),
+      lower(NULLIF(BTRIM(name), '')),
       "updatedAt" DESC,
       "profileId"
+  ),
+  identity_favorites AS (
+    SELECT
+      "identityId",
+      bool_or(COALESCE("isFavorite", false)) AS "isFavorite"
+    FROM
+      eligible_profiles
+    GROUP BY
+      "identityId"
   )
 SELECT
   identity_counts."identityId",
@@ -260,13 +271,17 @@ SELECT
 FROM
   identity_counts
   INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+  INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
 WHERE
-  NULLIF(best_profiles.name, '') IS NOT NULL
+  NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
   OR identity_counts."visibleAssetCount" >= $9
 ORDER BY
-  NULLIF(best_profiles.name, '') IS NULL,
-  lower(best_profiles.name),
-  identity_counts."visibleAssetCount" DESC,
+  COALESCE(identity_favorites."isFavorite", false) DESC,
+  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+  CASE
+    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+  END DESC NULLS LAST,
   identity_counts."identityId"
 LIMIT
   $10
@@ -325,6 +340,7 @@ WITH
       person."identityId",
       person.name,
       person."isHidden",
+      person."isFavorite",
       person."updatedAt",
       person.id AS "profileId",
       0 AS "profileRank"
@@ -350,6 +366,7 @@ WITH
         ''
       ) AS name,
       shared_space_person."isHidden",
+      NULL::boolean AS "isFavorite",
       shared_space_person."updatedAt",
       shared_space_person.id AS "profileId",
       CASE
@@ -424,11 +441,20 @@ WITH
       eligible_profiles
     ORDER BY
       "identityId",
-      NULLIF(name, '') IS NULL,
+      NULLIF(BTRIM(name), '') IS NULL,
       "profileRank",
-      lower(name),
+      lower(NULLIF(BTRIM(name), '')),
       "updatedAt" DESC,
       "profileId"
+  ),
+  identity_favorites AS (
+    SELECT
+      "identityId",
+      bool_or(COALESCE("isFavorite", false)) AS "isFavorite"
+    FROM
+      eligible_profiles
+    GROUP BY
+      "identityId"
   )
 SELECT
   identity_counts."identityId",
@@ -436,13 +462,17 @@ SELECT
 FROM
   identity_counts
   INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+  INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
 WHERE
-  NULLIF(best_profiles.name, '') IS NOT NULL
+  NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
   OR identity_counts."visibleAssetCount" >= $9
 ORDER BY
-  NULLIF(best_profiles.name, '') IS NULL,
-  lower(best_profiles.name),
-  identity_counts."visibleAssetCount" DESC,
+  COALESCE(identity_favorites."isFavorite", false) DESC,
+  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+  CASE
+    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+  END DESC NULLS LAST,
   identity_counts."identityId"
 LIMIT
   $10
@@ -956,6 +986,7 @@ WITH
       person."identityId",
       person.name,
       person."isHidden",
+      person."isFavorite",
       person."updatedAt",
       person.id AS "profileId",
       0 AS "profileRank"
@@ -981,6 +1012,7 @@ WITH
         ''
       ) AS name,
       shared_space_person."isHidden",
+      NULL::boolean AS "isFavorite",
       shared_space_person."updatedAt",
       shared_space_person.id AS "profileId",
       CASE
@@ -1055,11 +1087,20 @@ WITH
       eligible_profiles
     ORDER BY
       "identityId",
-      NULLIF(name, '') IS NULL,
+      NULLIF(BTRIM(name), '') IS NULL,
       "profileRank",
-      lower(name),
+      lower(NULLIF(BTRIM(name), '')),
       "updatedAt" DESC,
       "profileId"
+  ),
+  identity_favorites AS (
+    SELECT
+      "identityId",
+      bool_or(COALESCE("isFavorite", false)) AS "isFavorite"
+    FROM
+      eligible_profiles
+    GROUP BY
+      "identityId"
   )
 SELECT
   identity_counts."identityId",
@@ -1067,13 +1108,17 @@ SELECT
 FROM
   identity_counts
   INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+  INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
 WHERE
-  NULLIF(best_profiles.name, '') IS NOT NULL
+  NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
   OR identity_counts."visibleAssetCount" >= $9
 ORDER BY
-  NULLIF(best_profiles.name, '') IS NULL,
-  lower(best_profiles.name),
-  identity_counts."visibleAssetCount" DESC,
+  COALESCE(identity_favorites."isFavorite", false) DESC,
+  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+  CASE
+    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+  END DESC NULLS LAST,
   identity_counts."identityId"
 LIMIT
   $10

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -71,10 +71,12 @@ having
 order by
   "person"."isHidden" asc,
   "person"."isFavorite" desc,
-  NULLIF(person.name, '') is null asc,
-  count("asset_face"."assetId") desc,
-  NULLIF(person.name, '') asc nulls last,
-  "person"."createdAt"
+  NULLIF(BTRIM(person.name), '') is null asc,
+  NULLIF(BTRIM(person.name), '') asc nulls last,
+  CASE
+    WHEN NULLIF(BTRIM(person.name), '') IS NULL THEN COUNT("asset_face"."assetId")
+  END desc nulls last,
+  "person"."id"
 limit
   $5
 offset

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -444,9 +444,10 @@ where
     or "shared_space_person"."assetCount" >= $4
   )
 order by
-  NULLIF(shared_space_person.name, '') asc nulls last,
+  "shared_space_person"."isHidden" asc,
+  NULLIF(BTRIM(shared_space_person.name), '') asc nulls last,
   CASE
-    WHEN shared_space_person.name = '' THEN "shared_space_person"."assetCount"
+    WHEN NULLIF(BTRIM(shared_space_person.name), '') IS NULL THEN "shared_space_person"."assetCount"
   END desc nulls last,
   "shared_space_person"."id"
 limit

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -1520,6 +1520,7 @@ export class FaceIdentityRepository {
           person."identityId",
           person.name,
           person."isHidden",
+          person."isFavorite",
           person."updatedAt",
           person.id AS "profileId",
           0 AS "profileRank"
@@ -1534,6 +1535,7 @@ export class FaceIdentityRepository {
           shared_space_person."identityId",
           COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name,
           shared_space_person."isHidden",
+          NULL::boolean AS "isFavorite",
           shared_space_person."updatedAt",
           shared_space_person.id AS "profileId",
           CASE WHEN NULLIF(shared_space_person_alias.alias, '') IS NULL THEN 2 ELSE 1 END AS "profileRank"
@@ -1579,23 +1581,34 @@ export class FaceIdentityRepository {
         FROM eligible_profiles
         ORDER BY
           "identityId",
-          NULLIF(name, '') IS NULL,
+          NULLIF(BTRIM(name), '') IS NULL,
           "profileRank",
-          lower(name),
+          lower(NULLIF(BTRIM(name), '')),
           "updatedAt" DESC,
           "profileId"
+      ),
+      identity_favorites AS (
+        SELECT
+          "identityId",
+          bool_or(COALESCE("isFavorite", false)) AS "isFavorite"
+        FROM eligible_profiles
+        GROUP BY "identityId"
       )
       SELECT
         identity_counts."identityId",
         identity_counts."visibleAssetCount"
       FROM identity_counts
       INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
-      WHERE NULLIF(best_profiles.name, '') IS NOT NULL
+      INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
+      WHERE NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
         OR identity_counts."visibleAssetCount" >= ${input.minimumFaceCount}
       ORDER BY
-        NULLIF(best_profiles.name, '') IS NULL,
-        lower(best_profiles.name),
-        identity_counts."visibleAssetCount" DESC,
+        COALESCE(identity_favorites."isFavorite", false) DESC,
+        NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+        lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+        CASE
+          WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+        END DESC NULLS LAST,
         identity_counts."identityId"
       LIMIT ${input.limit}
       OFFSET ${input.offset}

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -238,10 +238,12 @@ export class PersonRepository {
       )
       .$if(!options?.closestFaceAssetId, (qb) =>
         qb
-          .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
-          .orderBy((eb) => eb.fn.count('asset_face.assetId'), 'desc')
-          .orderBy(sql`NULLIF(person.name, '')`, (om) => om.asc().nullsLast())
-          .orderBy('person.createdAt'),
+          .orderBy(sql`NULLIF(BTRIM(person.name), '') is null`, 'asc')
+          .orderBy(sql`NULLIF(BTRIM(person.name), '')`, (om) => om.asc().nullsLast())
+          .orderBy(sql`CASE WHEN NULLIF(BTRIM(person.name), '') IS NULL THEN COUNT("asset_face"."assetId") END`, (om) =>
+            om.desc().nullsLast(),
+          )
+          .orderBy('person.id'),
       )
       .$if(!options?.withHidden, (qb) => qb.where('person.isHidden', '=', false))
       .offset(pagination.skip ?? 0)

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -729,8 +729,9 @@ export class SharedSpaceRepository {
       )
       .orderBy('shared_space_person.isHidden', 'asc')
       .orderBy(sql`NULLIF(BTRIM(shared_space_person.name), '')`, (om) => om.asc().nullsLast())
-      .orderBy(sql`CASE WHEN NULLIF(BTRIM(shared_space_person.name), '') IS NULL THEN "shared_space_person"."assetCount" END`, (om) =>
-        om.desc().nullsLast(),
+      .orderBy(
+        sql`CASE WHEN NULLIF(BTRIM(shared_space_person.name), '') IS NULL THEN "shared_space_person"."assetCount" END`,
+        (om) => om.desc().nullsLast(),
       )
       .orderBy('shared_space_person.id')
       .$if(!!options.limit, (qb) => qb.limit(options.limit!))

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -727,8 +727,9 @@ export class SharedSpaceRepository {
           ),
         ),
       )
-      .orderBy(sql`NULLIF(shared_space_person.name, '')`, (om) => om.asc().nullsLast())
-      .orderBy(sql`CASE WHEN shared_space_person.name = '' THEN "shared_space_person"."assetCount" END`, (om) =>
+      .orderBy('shared_space_person.isHidden', 'asc')
+      .orderBy(sql`NULLIF(BTRIM(shared_space_person.name), '')`, (om) => om.asc().nullsLast())
+      .orderBy(sql`CASE WHEN NULLIF(BTRIM(shared_space_person.name), '') IS NULL THEN "shared_space_person"."assetCount" END`, (om) =>
         om.desc().nullsLast(),
       )
       .orderBy('shared_space_person.id')

--- a/server/src/schema/migrations-gallery/1778600000000-SortSpacePeopleByNameIndex.ts
+++ b/server/src/schema/migrations-gallery/1778600000000-SortSpacePeopleByNameIndex.ts
@@ -2,10 +2,10 @@ import { Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
   await sql`DROP INDEX IF EXISTS "shared_space_person_space_count_idx"`.execute(db);
-  await sql`CREATE INDEX "shared_space_person_space_name_idx" ON "shared_space_person" ("spaceId", "isHidden", NULLIF("name", ''), (CASE WHEN "name" = '' THEN "assetCount" END) DESC, "id")`.execute(
+  await sql`CREATE INDEX "shared_space_person_space_name_idx" ON "shared_space_person" ("spaceId", "isHidden", NULLIF(BTRIM("name"), ''), (CASE WHEN NULLIF(BTRIM("name"), '') IS NULL THEN "assetCount" END) DESC, "id")`.execute(
     db,
   );
-  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_shared_space_person_space_name_idx', '{"type":"index","name":"shared_space_person_space_name_idx","sql":"CREATE INDEX \\"shared_space_person_space_name_idx\\" ON \\"shared_space_person\\" (\\"spaceId\\", \\"isHidden\\", NULLIF(\\"name\\", ''''), (CASE WHEN \\"name\\" = '''' THEN \\"assetCount\\" END) DESC, \\"id\\");"}'::jsonb)`.execute(
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_shared_space_person_space_name_idx', '{"type":"index","name":"shared_space_person_space_name_idx","sql":"CREATE INDEX \\"shared_space_person_space_name_idx\\" ON \\"shared_space_person\\" (\\"spaceId\\", \\"isHidden\\", NULLIF(BTRIM(\\"name\\"), ''''), (CASE WHEN NULLIF(BTRIM(\\"name\\"), '''') IS NULL THEN \\"assetCount\\" END) DESC, \\"id\\");"}'::jsonb)`.execute(
     db,
   );
 }

--- a/server/src/schema/migrations-gallery/1778600000000-SortSpacePeopleByNameIndex.ts
+++ b/server/src/schema/migrations-gallery/1778600000000-SortSpacePeopleByNameIndex.ts
@@ -2,10 +2,10 @@ import { Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
   await sql`DROP INDEX IF EXISTS "shared_space_person_space_count_idx"`.execute(db);
-  await sql`CREATE INDEX "shared_space_person_space_name_idx" ON "shared_space_person" ("spaceId", "isHidden", NULLIF(BTRIM("name"), ''), (CASE WHEN NULLIF(BTRIM("name"), '') IS NULL THEN "assetCount" END) DESC, "id")`.execute(
+  await sql`CREATE INDEX "shared_space_person_space_name_idx" ON "shared_space_person" ("spaceId", "isHidden", NULLIF("name", ''), (CASE WHEN "name" = '' THEN "assetCount" END) DESC, "id")`.execute(
     db,
   );
-  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_shared_space_person_space_name_idx', '{"type":"index","name":"shared_space_person_space_name_idx","sql":"CREATE INDEX \\"shared_space_person_space_name_idx\\" ON \\"shared_space_person\\" (\\"spaceId\\", \\"isHidden\\", NULLIF(BTRIM(\\"name\\"), ''''), (CASE WHEN NULLIF(BTRIM(\\"name\\"), '''') IS NULL THEN \\"assetCount\\" END) DESC, \\"id\\");"}'::jsonb)`.execute(
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_shared_space_person_space_name_idx', '{"type":"index","name":"shared_space_person_space_name_idx","sql":"CREATE INDEX \\"shared_space_person_space_name_idx\\" ON \\"shared_space_person\\" (\\"spaceId\\", \\"isHidden\\", NULLIF(\\"name\\", ''''), (CASE WHEN \\"name\\" = '''' THEN \\"assetCount\\" END) DESC, \\"id\\");"}'::jsonb)`.execute(
     db,
   );
 }

--- a/server/src/schema/migrations-gallery/1778800000000-TrimSpacePersonNameIndex.ts
+++ b/server/src/schema/migrations-gallery/1778800000000-TrimSpacePersonNameIndex.ts
@@ -1,0 +1,27 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS "shared_space_person_space_name_idx"`.execute(db);
+
+  await sql`CREATE INDEX "shared_space_person_space_name_idx" ON "shared_space_person" ("spaceId", "isHidden", NULLIF(BTRIM("name"), ''), (CASE WHEN NULLIF(BTRIM("name"), '') IS NULL THEN "assetCount" END) DESC, "id")`.execute(
+    db,
+  );
+
+  await sql`DELETE FROM "migration_overrides" WHERE "name" = 'index_shared_space_person_space_name_idx'`.execute(db);
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_shared_space_person_space_name_idx', '{"type":"index","name":"shared_space_person_space_name_idx","sql":"CREATE INDEX \\"shared_space_person_space_name_idx\\" ON \\"shared_space_person\\" (\\"spaceId\\", \\"isHidden\\", NULLIF(BTRIM(\\"name\\"), ''''), (CASE WHEN NULLIF(BTRIM(\\"name\\"), '''') IS NULL THEN \\"assetCount\\" END) DESC, \\"id\\");"}'::jsonb)`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS "shared_space_person_space_name_idx"`.execute(db);
+
+  await sql`DELETE FROM "migration_overrides" WHERE "name" = 'index_shared_space_person_space_name_idx'`.execute(db);
+  await sql`CREATE INDEX "shared_space_person_space_name_idx" ON "shared_space_person" ("spaceId", "isHidden", NULLIF("name", ''), (CASE WHEN "name" = '' THEN "assetCount" END) DESC, "id")`.execute(
+    db,
+  );
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_shared_space_person_space_name_idx', '{"type":"index","name":"shared_space_person_space_name_idx","sql":"CREATE INDEX \\"shared_space_person_space_name_idx\\" ON \\"shared_space_person\\" (\\"spaceId\\", \\"isHidden\\", NULLIF(\\"name\\", ''''), (CASE WHEN \\"name\\" = '''' THEN \\"assetCount\\" END) DESC, \\"id\\");"}'::jsonb)`.execute(
+    db,
+  );
+}

--- a/server/src/schema/tables/shared-space-person.table.ts
+++ b/server/src/schema/tables/shared-space-person.table.ts
@@ -20,7 +20,7 @@ import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 @Index({ name: 'shared_space_person_spaceId_idx', columns: ['spaceId'] })
 @Index({
   name: 'shared_space_person_space_name_idx',
-  expression: `"spaceId", "isHidden", NULLIF("name", ''), (CASE WHEN "name" = '' THEN "assetCount" END) DESC, "id"`,
+  expression: `"spaceId", "isHidden", NULLIF(BTRIM("name"), ''), (CASE WHEN NULLIF(BTRIM("name"), '') IS NULL THEN "assetCount" END) DESC, "id"`,
 })
 @Index({
   name: 'shared_space_person_spaceId_identityId_key',

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -241,6 +241,24 @@ describe(PersonService.name, () => {
       });
       expect(mocks.person.getNumberOfPeople).toHaveBeenCalledWith(auth.user.id, { minimumFaceCount: 3 });
     });
+
+    it('should preserve non-shared repository order for favorites, named people, and unnamed count ordering', async () => {
+      const auth = AuthFactory.create();
+      const favorite = PersonFactory.create({ id: 'favorite', name: 'Anna', isFavorite: true });
+      const named = PersonFactory.create({ id: 'named', name: 'Bob', isFavorite: false });
+      const unnamedHigh = PersonFactory.create({ id: 'unnamed-high', name: '', isFavorite: false });
+      const unnamedLow = PersonFactory.create({ id: 'unnamed-low', name: '', isFavorite: false });
+
+      mocks.person.getAllForUser.mockResolvedValue({
+        items: [favorite, named, unnamedHigh, unnamedLow],
+        hasNextPage: false,
+      });
+      mocks.person.getNumberOfPeople.mockResolvedValue({ total: 4, hidden: 0 });
+
+      const result = await sut.getAll(auth, { withHidden: false, page: 1, size: 10 });
+
+      expect(result.people.map((person) => person.id)).toEqual(['favorite', 'named', 'unnamed-high', 'unnamed-low']);
+    });
   });
 
   describe('getPeopleStatistics', () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -174,6 +174,27 @@ describe(PersonService.name, () => {
       expect(mocks.person.getAllForUser).not.toHaveBeenCalled();
     });
 
+    it('should preserve identity-aware people ordering returned by repository', async () => {
+      const auth = AuthFactory.create();
+      const response = {
+        total: 4,
+        hidden: 0,
+        hasNextPage: false,
+        people: [
+          { id: 'favorite', name: 'Anna', isFavorite: true, numberOfAssets: 1 },
+          { id: 'named', name: 'Bob', numberOfAssets: 20 },
+          { id: 'unnamed-high', name: '', numberOfAssets: 50 },
+          { id: 'unnamed-low', name: '', numberOfAssets: 1 },
+        ],
+      };
+
+      (mocks.faceIdentity as any).getAccessiblePeople.mockResolvedValue(response);
+
+      await expect(
+        sut.getAll(auth, { withSharedSpaces: true, withHidden: false, page: 1, size: 10 } as any),
+      ).resolves.toEqual(response);
+    });
+
     it('should keep legacy people behavior when withSharedSpaces is omitted', async () => {
       const auth = AuthFactory.create();
       mocks.person.getAllForUser.mockResolvedValue({ items: [], hasNextPage: false });

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -4356,7 +4356,7 @@ describe(SharedSpaceService.name, () => {
       expect(result[0].type).toBe('person');
     });
 
-    it('should preserve the repository person order', async () => {
+    it('should preserve repository order for named people and unnamed asset counts', async () => {
       const auth = factory.auth();
       const spaceId = newUuid();
       const person1 = factory.sharedSpacePerson({
@@ -4367,12 +4367,12 @@ describe(SharedSpaceService.name, () => {
       const person2 = factory.sharedSpacePerson({
         id: newUuid(),
         spaceId,
-        name: 'Bob',
+        name: '',
       });
       const person3 = factory.sharedSpacePerson({
         id: newUuid(),
         spaceId,
-        name: 'Charlie',
+        name: '',
       });
       const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
 
@@ -4400,7 +4400,7 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.getSpacePeople(auth, spaceId);
 
       expect(result).toHaveLength(3);
-      expect(result.map((person) => person.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+      expect(result.map((person) => person.id)).toEqual([person1.id, person2.id, person3.id]);
       expect(result.map((person) => person.assetCount)).toEqual([2, 10, 5]);
     });
 

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1667,7 +1667,7 @@ describe(SharedSpaceRepository.name, () => {
       expect(result.map((p) => p.id)).toEqual([alice.id, bob.id, charlie.id]);
     });
 
-    it('should sort unnamed space persons after named rows by asset count without private global fallback', async () => {
+    it('should sort visible space persons by name, then unnamed rows by asset count without private global fallback', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
@@ -1683,6 +1683,14 @@ describe(SharedSpaceRepository.name, () => {
         type: 'person',
         assetCount: 5,
       });
+      const hiddenAlice = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Alice Hidden',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 50,
+        isHidden: true,
+      });
       const bob = await sut.createPerson({
         id: '00000000-0000-4000-8000-000000000001',
         spaceId: space.id,
@@ -1690,6 +1698,13 @@ describe(SharedSpaceRepository.name, () => {
         representativeFaceId: bobFace.id,
         type: 'person',
         assetCount: 1,
+      });
+      const whitespaceName = await sut.createPerson({
+        spaceId: space.id,
+        name: '   ',
+        representativeFaceId: null,
+        type: 'person',
+        assetCount: 20,
       });
       const unnamedMany = await sut.createPerson({
         id: 'ffffffff-ffff-4fff-bfff-ffffffffffff',
@@ -1707,9 +1722,16 @@ describe(SharedSpaceRepository.name, () => {
         assetCount: 5,
       });
 
-      const result = await sut.getPersonsBySpaceId(space.id, {});
+      const result = await sut.getPersonsBySpaceId(space.id, { withHidden: true });
 
-      expect(result.map((p) => p.id)).toEqual([alice.id, charlie.id, unnamedMany.id, bob.id]);
+      expect(result.map((p) => p.id)).toEqual([
+        alice.id,
+        charlie.id,
+        whitespaceName.id,
+        unnamedMany.id,
+        bob.id,
+        hiddenAlice.id,
+      ]);
     });
 
     it('should ignore stale off-scope face links when applying taken-date filters', async () => {

--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -1,6 +1,6 @@
 import type { Faces } from '$lib/stores/people.store';
 import type { Size } from '$lib/utils/container-utils';
-import { getBoundingBox, zoomImageToBase64 } from '$lib/utils/people-utils';
+import { getBoundingBox, sortPeopleForManagement, zoomImageToBase64 } from '$lib/utils/people-utils';
 import { AssetTypeEnum } from '@immich/sdk';
 
 const makeFace = (overrides: Partial<Faces> = {}): Faces => ({
@@ -12,6 +12,67 @@ const makeFace = (overrides: Partial<Faces> = {}): Faces => ({
   boundingBoxX2: 2000,
   boundingBoxY2: 1500,
   ...overrides,
+});
+
+describe('sortPeopleForManagement', () => {
+  const p = (overrides: {
+    id: string;
+    name?: string | null;
+    isFavorite?: boolean;
+    numberOfAssets?: number;
+    assetCount?: number;
+    isHidden?: boolean;
+  }) => overrides;
+
+  it('sorts favorites first, named people alphabetically, then unnamed by count descending', () => {
+    const people = [
+      p({ id: 'unnamed-low', name: '', numberOfAssets: 1 }),
+      p({ id: 'named-z', name: 'Zoe', numberOfAssets: 99 }),
+      p({ id: 'favorite-unnamed-high', name: '', isFavorite: true, numberOfAssets: 10 }),
+      p({ id: 'named-a', name: 'Alice', numberOfAssets: 1 }),
+      p({ id: 'unnamed-high', name: '', numberOfAssets: 50 }),
+      p({ id: 'favorite-named', name: 'Beth', isFavorite: true, numberOfAssets: 1 }),
+    ];
+
+    expect(sortPeopleForManagement(people).map((person) => person.id)).toEqual([
+      'favorite-named',
+      'favorite-unnamed-high',
+      'named-a',
+      'named-z',
+      'unnamed-high',
+      'unnamed-low',
+    ]);
+  });
+
+  it('treats whitespace-only names as unnamed and uses assetCount for space people', () => {
+    const people = [
+      p({ id: 'space-unnamed-low', name: '   ', assetCount: 2 }),
+      p({ id: 'space-named', name: 'anna', assetCount: 1 }),
+      p({ id: 'space-unnamed-high', name: '', assetCount: 9 }),
+    ];
+
+    expect(sortPeopleForManagement(people).map((person) => person.id)).toEqual([
+      'space-named',
+      'space-unnamed-high',
+      'space-unnamed-low',
+    ]);
+  });
+
+  it('uses case-insensitive names, missing counts as zero, and id as final tiebreak', () => {
+    const people = [
+      p({ id: 'unnamed-b', name: '', numberOfAssets: undefined }),
+      p({ id: 'named-b', name: 'bob' }),
+      p({ id: 'unnamed-a', name: '', numberOfAssets: 0 }),
+      p({ id: 'named-a', name: 'Alice' }),
+    ];
+
+    expect(sortPeopleForManagement(people).map((person) => person.id)).toEqual([
+      'named-a',
+      'named-b',
+      'unnamed-a',
+      'unnamed-b',
+    ]);
+  });
 });
 
 describe('getBoundingBox', () => {

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -8,11 +8,19 @@ export type SortablePerson = {
   id: string;
   name?: string | null;
   isFavorite?: boolean;
+  isHidden?: boolean;
+  numberOfAssets?: number | null;
+  assetCount?: number | null;
 };
 
 const getSortablePersonName = (person: SortablePerson) => person.name?.trim() ?? '';
+const getSortablePersonCount = (person: SortablePerson) => person.numberOfAssets ?? person.assetCount ?? 0;
 
-export function comparePeopleByFavoriteAndName(a: SortablePerson, b: SortablePerson): number {
+export function comparePeopleForManagement(a: SortablePerson, b: SortablePerson): number {
+  if (!!a.isHidden !== !!b.isHidden) {
+    return a.isHidden ? 1 : -1;
+  }
+
   if (!!a.isFavorite !== !!b.isFavorite) {
     return a.isFavorite ? -1 : 1;
   }
@@ -25,16 +33,29 @@ export function comparePeopleByFavoriteAndName(a: SortablePerson, b: SortablePer
     return aHasName ? -1 : 1;
   }
 
-  if (aName !== bName) {
-    return aName.localeCompare(bName);
+  if (aHasName && bHasName) {
+    const nameCompare = aName.localeCompare(bName, undefined, { sensitivity: 'base' });
+    if (nameCompare !== 0) {
+      return nameCompare;
+    }
+  }
+
+  if (!aHasName && !bHasName) {
+    const countCompare = getSortablePersonCount(b) - getSortablePersonCount(a);
+    if (countCompare !== 0) {
+      return countCompare;
+    }
   }
 
   return a.id.localeCompare(b.id);
 }
 
-export function sortPeopleByFavoriteAndName<T extends SortablePerson>(people: T[]): T[] {
-  return [...people].sort(comparePeopleByFavoriteAndName);
+export function sortPeopleForManagement<T extends SortablePerson>(people: T[]): T[] {
+  return [...people].sort(comparePeopleForManagement);
 }
+
+export const comparePeopleByFavoriteAndName = comparePeopleForManagement;
+export const sortPeopleByFavoriteAndName = sortPeopleForManagement;
 
 export const getPersonFaceThumbnailUrl = (personId: string, faceId: string, updatedAt?: string) =>
   createUrl(`/people/${personId}/faces/${faceId}/thumbnail`, { updatedAt });

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -24,7 +24,7 @@
   import { getGlobalPersonHref, getGlobalPersonThumbnailUrl } from '$lib/utils/global-person-route';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
-  import { sortPeopleByFavoriteAndName } from '$lib/utils/people-utils';
+  import { sortPeopleForManagement } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
     getAllPeople,
@@ -270,7 +270,7 @@
   );
   let globalFaceStatisticsCacheKey = $derived(`user:${authManager.user.id}:global:people:withSharedSpaces=true`);
   const loadGlobalFaceStatistics = () => getPeopleFaceStatistics({ withSharedSpaces: true });
-  let showPeople = $derived(sortPeopleByFavoriteAndName(searchName ? searchedPeopleLocal : visiblePeople));
+  let showPeople = $derived(sortPeopleForManagement(searchName ? searchedPeopleLocal : visiblePeople));
 
   const getPersonHref = (person: PersonResponseDto) => getGlobalPersonHref(person, Route.people());
 

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -164,21 +164,36 @@ describe('Global people page', () => {
     expect(screen.getByDisplayValue('Alice')).toHaveAttribute('placeholder', 'add_a_name');
   });
 
-  it('renders favorites first, then named people alphabetically, then unnamed people', () => {
+  it('renders favorites first, named people alphabetically, then unnamed people by photo count', () => {
     renderPage([
-      makePerson({ id: 'unnamed', name: '', isFavorite: false }),
-      makePerson({ id: 'named-z', name: 'Zoe', isFavorite: false }),
-      makePerson({ id: 'favorite-z', name: 'Zelda', isFavorite: true }),
-      makePerson({ id: 'named-a', name: 'Alice', isFavorite: false }),
-      makePerson({ id: 'favorite-a', name: 'Anna', isFavorite: true }),
+      makePerson({ id: 'unnamed-low', name: '', isFavorite: false, numberOfAssets: 1 }),
+      makePerson({ id: 'named-z', name: 'Zoe', isFavorite: false, numberOfAssets: 99 }),
+      makePerson({ id: 'favorite-unnamed', name: '', isFavorite: true, numberOfAssets: 7 }),
+      makePerson({ id: 'named-a', name: 'Alice', isFavorite: false, numberOfAssets: 1 }),
+      makePerson({ id: 'unnamed-high', name: '', isFavorite: false, numberOfAssets: 12 }),
+      makePerson({ id: 'favorite-named', name: 'Anna', isFavorite: true, numberOfAssets: 1 }),
     ]);
 
     expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
       'Anna',
-      'Zelda',
+      '',
       'Alice',
       'Zoe',
       '',
+      '',
+    ]);
+    expect(
+      [...document.querySelectorAll<HTMLAnchorElement>('a[href^="/people/"]')].map((link) => {
+        const url = new URL(link.href);
+        return `${url.pathname}${url.search}`;
+      }),
+    ).toEqual([
+      '/people/favorite-named?previousRoute=%2Fpeople',
+      '/people/favorite-unnamed?previousRoute=%2Fpeople',
+      '/people/named-a?previousRoute=%2Fpeople',
+      '/people/named-z?previousRoute=%2Fpeople',
+      '/people/unnamed-high?previousRoute=%2Fpeople',
+      '/people/unnamed-low?previousRoute=%2Fpeople',
     ]);
   });
 

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
@@ -492,7 +492,6 @@
         canEditNames={isEditor}
         canShowActions={isEditor}
         {onNameSubmit}
-        deferThumbnails
       >
         {#snippet actions(person)}
           <ButtonContextMenu

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
@@ -18,7 +18,7 @@
   import { createUrl, handlePromiseError } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
-  import { sortPeopleByFavoriteAndName } from '$lib/utils/people-utils';
+  import { sortPeopleForManagement } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
     getSpacePeople,
@@ -70,7 +70,7 @@
   let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 
   let selectHidden = $state(false);
-  const visiblePeople = $derived(sortPeopleByFavoriteAndName(people.filter((p) => !p.isHidden)));
+  const visiblePeople = $derived(sortPeopleForManagement(people.filter((p) => !p.isHidden)));
   const countVisiblePeople = $derived(peopleStatistics ? peopleStatistics.total - peopleStatistics.hidden : 0);
   const hasSearchablePeople = $derived(countVisiblePeople > 0 || visiblePeople.length > 0 || !!searchName.trim());
   const activeSearchFilterName = $derived(

--- a/web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts
@@ -146,17 +146,30 @@ describe('Space people page', () => {
     featureFlagsMock.value.peopleStatistics = true;
   });
 
-  it('renders named people alphabetically before unnamed people', () => {
+  it('renders named people alphabetically before unnamed people sorted by asset count', () => {
     renderPage([
-      makeSpacePerson({ id: 'space-person-unnamed', name: '' }),
-      makeSpacePerson({ id: 'space-person-zoe', name: 'Zoe' }),
-      makeSpacePerson({ id: 'space-person-alice', name: 'Alice' }),
+      makeSpacePerson({ id: 'space-person-unnamed-low', name: '', assetCount: 1 }),
+      makeSpacePerson({ id: 'space-person-zoe', name: 'Zoe', assetCount: 99 }),
+      makeSpacePerson({ id: 'space-person-unnamed-high', name: '', assetCount: 20 }),
+      makeSpacePerson({ id: 'space-person-alice', name: 'Alice', assetCount: 1 }),
     ]);
 
     expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
       'Alice',
       'Zoe',
       '',
+      '',
+    ]);
+    expect(
+      [...document.querySelectorAll<HTMLAnchorElement>('a[href^="/spaces/space-1/people/"]')].map((link) => {
+        const url = new URL(link.href);
+        return url.pathname;
+      }),
+    ).toEqual([
+      '/spaces/space-1/people/space-person-alice',
+      '/spaces/space-1/people/space-person-zoe',
+      '/spaces/space-1/people/space-person-unnamed-high',
+      '/spaces/space-1/people/space-person-unnamed-low',
     ]);
   });
 

--- a/web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/space-people-page.spec.ts
@@ -173,6 +173,21 @@ describe('Space people page', () => {
     ]);
   });
 
+  it('loads person thumbnails without the deferred queue used by visibility management', () => {
+    class NeverIntersectingObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    vi.stubGlobal('IntersectionObserver', NeverIntersectingObserver);
+
+    renderPage([makeSpacePerson({ id: 'space-person-alice', name: 'Alice' })]);
+
+    expect(screen.getByTitle('Alice').getAttribute('src')).toContain(
+      '/shared-spaces/space-1/people/space-person-alice/thumbnail?updatedAt=2026-01-02T00%3A00%3A00.000Z',
+    );
+  });
+
   it('moves a newly named person into alphabetical order', async () => {
     const bob = makeSpacePerson({ id: 'space-person-bob', name: 'Bob' });
     const unnamed = makeSpacePerson({ id: 'space-person-unnamed', name: '' });


### PR DESCRIPTION
## Summary
- sort web and space people views with the shared canonical comparator
- sort server people repositories with favorites first, named people alphabetically, unnamed people by asset count, and stable id tie-breaks
- cover web, server, route, repository, and e2e sorting behavior

## Verification
- Web focused tests: 3 passed, 35 passed
- Server focused unit tests: 2 passed, 584 passed
- Shared-space medium focused test: passed
- immich-web TypeScript check: passed
- immich TypeScript check: passed
- immich-e2e TypeScript check: passed

Note: the focused e2e invocation did not reach tests because the environment timed out after Vitest reported no matched test files; the e2e code type-checks.