### PR TITLE
fix(server): route EXIF and backfill space face matching through PeopleBackfill queue

### DIFF
--- a/mobile/openapi/lib/model/job_name.dart
+++ b/mobile/openapi/lib/model/job_name.dart
@@ -87,6 +87,7 @@ class JobName {
   static const sharedSpaceFaceMatch = JobName._(r'SharedSpaceFaceMatch');
   static const sharedSpaceFaceMatchAll = JobName._(r'SharedSpaceFaceMatchAll');
   static const sharedSpaceFaceMatchPage = JobName._(r'SharedSpaceFaceMatchPage');
+  static const sharedSpaceFaceMatchFromBackfill = JobName._(r'SharedSpaceFaceMatchFromBackfill');
   static const sharedSpaceLibraryFaceSync = JobName._(r'SharedSpaceLibraryFaceSync');
   static const sharedSpaceIdentityReconciliation = JobName._(r'SharedSpaceIdentityReconciliation');
   static const sharedSpacePersonDedup = JobName._(r'SharedSpacePersonDedup');
@@ -161,6 +162,7 @@ class JobName {
     sharedSpaceFaceMatch,
     sharedSpaceFaceMatchAll,
     sharedSpaceFaceMatchPage,
+    sharedSpaceFaceMatchFromBackfill,
     sharedSpaceLibraryFaceSync,
     sharedSpaceIdentityReconciliation,
     sharedSpacePersonDedup,
@@ -270,6 +272,7 @@ class JobNameTypeTransformer {
         case r'SharedSpaceFaceMatch': return JobName.sharedSpaceFaceMatch;
         case r'SharedSpaceFaceMatchAll': return JobName.sharedSpaceFaceMatchAll;
         case r'SharedSpaceFaceMatchPage': return JobName.sharedSpaceFaceMatchPage;
+        case r'SharedSpaceFaceMatchFromBackfill': return JobName.sharedSpaceFaceMatchFromBackfill;
         case r'SharedSpaceLibraryFaceSync': return JobName.sharedSpaceLibraryFaceSync;
         case r'SharedSpaceIdentityReconciliation': return JobName.sharedSpaceIdentityReconciliation;
         case r'SharedSpacePersonDedup': return JobName.sharedSpacePersonDedup;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -22762,6 +22762,7 @@
           "SharedSpaceFaceMatch",
           "SharedSpaceFaceMatchAll",
           "SharedSpaceFaceMatchPage",
+          "SharedSpaceFaceMatchFromBackfill",
           "SharedSpaceLibraryFaceSync",
           "SharedSpaceIdentityReconciliation",
           "SharedSpacePersonDedup",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -8849,6 +8849,7 @@ export enum JobName {
     SharedSpaceFaceMatch = "SharedSpaceFaceMatch",
     SharedSpaceFaceMatchAll = "SharedSpaceFaceMatchAll",
     SharedSpaceFaceMatchPage = "SharedSpaceFaceMatchPage",
+    SharedSpaceFaceMatchFromBackfill = "SharedSpaceFaceMatchFromBackfill",
     SharedSpaceLibraryFaceSync = "SharedSpaceLibraryFaceSync",
     SharedSpaceIdentityReconciliation = "SharedSpaceIdentityReconciliation",
     SharedSpacePersonDedup = "SharedSpacePersonDedup",

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -793,6 +793,7 @@ export enum JobName {
   SharedSpaceFaceMatch = 'SharedSpaceFaceMatch',
   SharedSpaceFaceMatchAll = 'SharedSpaceFaceMatchAll',
   SharedSpaceFaceMatchPage = 'SharedSpaceFaceMatchPage',
+  SharedSpaceFaceMatchFromBackfill = 'SharedSpaceFaceMatchFromBackfill',
   SharedSpaceLibraryFaceSync = 'SharedSpaceLibraryFaceSync',
   SharedSpaceIdentityReconciliation = 'SharedSpaceIdentityReconciliation',
   SharedSpacePersonDedup = 'SharedSpacePersonDedup',

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -377,6 +377,12 @@ export class JobRepository {
           removeOnComplete: true,
         };
       }
+      case JobName.SharedSpaceFaceMatchFromBackfill: {
+        return {
+          jobId: `shared-space-face-match/from-backfill/${item.data.spaceId}/${item.data.assetId}`,
+          removeOnComplete: true,
+        };
+      }
       case JobName.SharedSpaceFaceMatchAll: {
         return {
           jobId: `shared-space-face-match-all/${item.data.spaceId}`,
@@ -443,7 +449,8 @@ export class JobRepository {
     return (
       name === JobName.SharedSpaceFaceMatch ||
       name === JobName.SharedSpaceFaceMatchAll ||
-      name === JobName.SharedSpaceFaceMatchPage
+      name === JobName.SharedSpaceFaceMatchPage ||
+      name === JobName.SharedSpaceFaceMatchFromBackfill
     );
   }
 

--- a/server/src/repositories/tag.repository.ts
+++ b/server/src/repositories/tag.repository.ts
@@ -36,7 +36,7 @@ export class TagRepository {
   async upsertValue({ userId, value, parentId: _parentId }: { userId: string; value: string; parentId?: string }) {
     const parentId = _parentId ?? null;
     return this.db.transaction().execute(async (tx) => {
-      const tag = await this.db
+      const tag = await tx
         .insertInto('tag')
         .values({ userId, value, parentId })
         .onConflict((oc) => oc.columns(['userId', 'value']).doUpdateSet({ parentId }))
@@ -55,7 +55,7 @@ export class TagRepository {
           .insertInto('tag_closure')
           .columns(['id_ancestor', 'id_descendant'])
           .expression(
-            this.db
+            tx
               .selectFrom('tag_closure')
               .select(['id_ancestor', sql.raw<string>(`'${tag.id}'`).as('id_descendant')])
               .where('id_descendant', '=', parentId),

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1459,7 +1459,7 @@ describe(MetadataService.name, () => {
       expect(mocks.sharedSpace.getSpaceIdsForAsset).toHaveBeenCalledWith(asset.id);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
           data: { spaceId: 'space-1', assetId: asset.id },
         },
       ]);

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -945,6 +945,30 @@ describe(MetadataService.name, () => {
       });
     });
 
+    it('should skip motion photo extraction when corrupted metadata yields a negative read position', async () => {
+      const asset = AssetFactory.create();
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mocks.storage.stat.mockResolvedValue({
+        size: 100,
+        mtime: asset.fileModifiedAt,
+        mtimeMs: asset.fileModifiedAt.valueOf(),
+        birthtimeMs: asset.fileCreatedAt.valueOf(),
+      } as Stats);
+      mockReadTags({
+        Directory: 'foo/bar/',
+        MotionPhoto: 1,
+        MicroVideo: 1,
+        // Larger than the file size, so position = size - length - padding is negative.
+        MicroVideoOffset: 723_621,
+      });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.storage.readFile).not.toHaveBeenCalled();
+      expect(mocks.asset.create).not.toHaveBeenCalled();
+      expect(mocks.logger.warn).toHaveBeenCalledWith(expect.stringContaining('negative read position'));
+    });
+
     it('should delete old motion photo video assets if they do not match what is extracted', async () => {
       const motionAsset = AssetFactory.create({ type: AssetType.Video, visibility: AssetVisibility.Hidden });
       const asset = AssetFactory.create({ livePhotoVideoId: motionAsset.id });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -997,7 +997,7 @@ export class MetadataService extends BaseService {
       if (spaceIds.length > 0) {
         await this.jobRepository.queueAll(
           spaceIds.map(({ spaceId }) => ({
-            name: JobName.SharedSpaceFaceMatch as const,
+            name: JobName.SharedSpaceFaceMatchFromBackfill as const,
             data: { spaceId, assetId: asset.id },
           })),
         );

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -719,6 +719,15 @@ export class MetadataService extends BaseService {
       }
       // Default video extraction
       else {
+        // Corrupted Samsung motion-photo metadata can report length + padding
+        // larger than the file, yielding a negative read position that throws
+        // RangeError. Skip extraction for these assets instead.
+        if (position < 0) {
+          this.logger.warn(
+            `Skipping motion photo extraction for ${asset.id}: ${asset.originalPath}: computed negative read position (${position})`,
+          );
+          return;
+        }
         video = await this.storageRepository.readFile(effectiveOriginalPath, {
           buffer: Buffer.alloc(length),
           position,

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -2100,7 +2100,7 @@ describe(PersonService.name, () => {
       });
       expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill })]),
       );
       expect(mocks.job.queue).not.toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
@@ -2197,12 +2197,12 @@ describe(PersonService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: { spaceId: 'space-1', assetId: 'asset-1' },
         },
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId: 'space-2', assetId: 'asset-2', source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: { spaceId: 'space-2', assetId: 'asset-2' },
         },
       ]);
       expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
@@ -2241,12 +2241,12 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: { spaceId: 'space-1', assetId: 'asset-1' },
         },
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId: 'space-1', assetId: 'asset-2', source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: { spaceId: 'space-1', assetId: 'asset-2' },
         },
       ]);
     });
@@ -2279,8 +2279,8 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId: pendingTarget.spaceId, assetId: pendingTarget.assetId, source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: { spaceId: pendingTarget.spaceId, assetId: pendingTarget.assetId },
         },
       ]);
       expect((mocks.faceIdentity as any).deletePendingSharedSpaceFaceMatchBackfillTargets).toHaveBeenCalledWith([
@@ -2383,8 +2383,8 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { ...target, source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: target,
         },
       ]);
     });
@@ -2413,8 +2413,8 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { ...remainingTarget, source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: remainingTarget,
         },
       ]);
     });
@@ -2435,8 +2435,8 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
+          name: JobName.SharedSpaceFaceMatchFromBackfill,
+          data: { spaceId: 'space-1', assetId: 'asset-1' },
         },
       ]);
       expect(mocks.job.queue).not.toHaveBeenCalledWith({

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -604,8 +604,8 @@ export class PersonService extends BaseService {
     let jobs: JobItem[] = [];
     for (const { spaceId, assetId } of uniqueTargets) {
       jobs.push({
-        name: JobName.SharedSpaceFaceMatch as const,
-        data: { spaceId, assetId, source: 'identity-backfill' },
+        name: JobName.SharedSpaceFaceMatchFromBackfill as const,
+        data: { spaceId, assetId },
       });
 
       if (jobs.length >= JOBS_ASSET_PAGINATION_SIZE) {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3901,6 +3901,109 @@ describe(SharedSpaceService.name, () => {
     });
   });
 
+  describe('handleSharedSpaceFaceMatchFromBackfill', () => {
+    it('runs on PeopleBackfill queue, not FacialRecognition', () => {
+      const reflector = new Reflector();
+      expect(reflector.get(MetadataKey.JobConfig, sut.handleSharedSpaceFaceMatchFromBackfill)).toEqual({
+        name: JobName.SharedSpaceFaceMatchFromBackfill,
+        queue: QueueName.PeopleBackfill,
+      });
+    });
+
+    it('should skip when space not found', async () => {
+      mocks.sharedSpace.getById.mockResolvedValue(void 0);
+
+      const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId: 'space-1', assetId: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+    });
+
+    it('should skip when face recognition is disabled on the space', async () => {
+      const space = factory.sharedSpace({ faceRecognitionEnabled: false });
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+
+      const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId: space.id, assetId: 'asset-1' });
+
+      expect(result).toBe(JobStatus.Skipped);
+    });
+
+    it('should queue dedup pass after successful face match', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([]);
+
+      await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId, assetId });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonDedup, data: { spaceId } });
+    });
+
+    it('should queue identity reconciliation for affected space people', async () => {
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: 'space-1', faceRecognitionEnabled: true }));
+      mockOneAffectedSpacePerson();
+
+      await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId: 'space-1', assetId: 'asset-1' });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpaceIdentityReconciliation,
+        data: { spaceId: 'space-1', spacePersonId: 'space-person-1' },
+      });
+    });
+
+    it('always refreshes inherited metadata for exact assignments (refreshExactMetadata is unconditional)', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      const faceId = newUuid();
+      const identityId = newUuid();
+      const spacePersonId = newUuid();
+      const sourcePersonId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+      const spacePerson = factory.sharedSpacePerson({ id: spacePersonId, spaceId, identityId, nameSource: 'none' });
+
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([
+        { id: faceId, assetId, personId: newUuid(), identityId, type: 'person', embedding: '[1,2,3]' },
+      ]);
+      mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([
+        { personId: spacePersonId, identityId, type: 'person' },
+      ]);
+      mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(spacePerson);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: sourcePersonId,
+          sourceProfileType: 'user-person',
+          sourceProfileId: sourcePersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Inherited Alice',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 1,
+          isAssetAdder: false,
+        },
+      ]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId, assetId });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(
+        spacePersonId,
+        expect.objectContaining({
+          name: 'Inherited Alice',
+          nameSource: 'inherited',
+          nameSourceProfileId: sourcePersonId,
+        }),
+      );
+    });
+  });
+
   describe('handleSharedSpaceFaceMatchAll', () => {
     it('keeps shared-space face pipeline handlers on the facial-recognition queue', () => {
       const reflector = new Reflector();

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1530,6 +1530,31 @@ export class SharedSpaceService extends BaseService {
     return JobStatus.Success;
   }
 
+  @OnJob({ name: JobName.SharedSpaceFaceMatchFromBackfill, queue: QueueName.PeopleBackfill })
+  async handleSharedSpaceFaceMatchFromBackfill({
+    spaceId,
+    assetId,
+  }: JobOf<JobName.SharedSpaceFaceMatchFromBackfill>): Promise<JobStatus> {
+    const space = await this.sharedSpaceRepository.getById(spaceId);
+    if (!space || !space.faceRecognitionEnabled) {
+      return JobStatus.Skipped;
+    }
+
+    const affectedPersonIds = await this.processSpaceFaceMatch(spaceId, assetId, {
+      refreshExactMetadata: true,
+    });
+    for (const spacePersonId of affectedPersonIds) {
+      await this.queueSpaceIdentityReconciliation({ spaceId, spacePersonId });
+    }
+
+    await this.jobRepository.queue({
+      name: JobName.SharedSpacePersonDedup,
+      data: { spaceId },
+    });
+
+    return JobStatus.Success;
+  }
+
   @OnJob({ name: JobName.SharedSpaceLibraryFaceSync, queue: QueueName.FacialRecognition })
   async handleSharedSpaceLibraryFaceSync(job: JobOf<JobName.SharedSpaceLibraryFaceSync>): Promise<JobStatus> {
     const space = await this.sharedSpaceRepository.getById(job.spaceId);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -492,6 +492,7 @@ export type JobItem =
   | { name: JobName.SharedSpaceFaceMatch; data: ISharedSpaceFaceMatchJob }
   | { name: JobName.SharedSpaceFaceMatchAll; data: ISharedSpaceFaceMatchAllJob }
   | { name: JobName.SharedSpaceFaceMatchPage; data: ISharedSpaceFaceMatchPageJob }
+  | { name: JobName.SharedSpaceFaceMatchFromBackfill; data: ISharedSpaceFaceMatchJob }
   | { name: JobName.SharedSpaceLibraryFaceSync; data: ISharedSpaceLibraryFaceSyncJob }
   | { name: JobName.SharedSpaceIdentityReconciliation; data: ISharedSpaceIdentityReconciliationJob }
   | { name: JobName.SharedSpacePersonDedup; data: ISharedSpacePersonDedupJob }

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -531,8 +531,8 @@ describe(MetadataService.name, () => {
       expect(backfillCtx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll).toHaveBeenCalledWith(
         expect.arrayContaining([
           {
-            name: JobName.SharedSpaceFaceMatch,
-            data: { spaceId: space.id, assetId: asset.id, source: 'identity-backfill' },
+            name: JobName.SharedSpaceFaceMatchFromBackfill,
+            data: { spaceId: space.id, assetId: asset.id },
           },
         ]),
       );


### PR DESCRIPTION
## Summary

- `SharedSpaceFaceMatch` (the job that creates `shared_space_person` rows) was on `QueueName.FacialRecognition`. With that queue paused — e.g. when testing EXIF-only import without ML — space persons were never created and the Space People view stayed empty, even after running People Identity Maintenance.
- Adds `SharedSpaceFaceMatchFromBackfill` on `QueueName.PeopleBackfill` so that space person creation for EXIF-imported faces and People Identity Maintenance completes regardless of whether the Facial Recognition queue is active.
- `applyTaggedFaces` (EXIF import) and `FaceIdentityBackfill` (People Identity Maintenance) now use the new job. ML-triggered matching (`handleRecognizeFaces`) keeps using `SharedSpaceFaceMatch` on `FacialRecognition` since ordering relative to recognition matters there.

**No double-work risk:** `FaceIdentityMaintenanceAfterRecognition` waits for the Facial Recognition queue to fully drain before queuing `FaceIdentityBackfill`, so `SharedSpaceFaceMatchAll` always completes before any `SharedSpaceFaceMatchFromBackfill` jobs are queued. If everything was already matched, `getSharedSpaceFaceMatchBackfillTargets` returns empty and no backfill jobs are queued at all.

## Test plan

- [ ] Six new unit tests for `handleSharedSpaceFaceMatchFromBackfill`: queue routing (PeopleBackfill, not FacialRecognition), skip gates, dedup queued, reconciliation queued, `refreshExactMetadata` always-on
- [ ] Existing person service tests updated: `queueSharedSpaceFaceMatchTargets` now asserts `SharedSpaceFaceMatchFromBackfill`
- [ ] Existing metadata service test updated: EXIF import asserts `SharedSpaceFaceMatchFromBackfill`
- [ ] RC deployed to pierre.opennoodle.de (`fix-exif-space-people-rc1`) and verified healthy