### PR TITLE
test: cover face identity queue trigger contracts

### DIFF
--- a/docs/superpowers/plans/2026-05-17-face-identity-trigger-contract-coverage.md
+++ b/docs/superpowers/plans/2026-05-17-face-identity-trigger-contract-coverage.md
@@ -28,6 +28,10 @@
   - Owns duplicate-resolution keeper propagation and retryable queue-failure trigger contracts.
 - Modify: `server/src/services/pet-detection.service.spec.ts`
   - Owns pet detection queue-root and per-asset trigger contracts.
+- Audit/Modify: `server/src/services/person.service.spec.ts`
+  - Owns app bootstrap identity backfill trigger contracts from the trigger matrix.
+- Audit: `server/src/repositories/job.repository.spec.ts`
+  - Owns stable job id behavior for duplicate root backfill jobs and retrigger dedupe; do not edit unless the audit finds missing coverage.
 
 ## Execution Preflight
 
@@ -55,10 +59,58 @@ codex/face-queues-test-plan
 Run:
 
 ```bash
-pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts
+pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts src/services/person.service.spec.ts
 ```
 
 Expected: all targeted specs pass before new tests are added. If a pre-existing failure appears, stop and investigate before adding coverage.
+
+- [ ] **Step 3: Audit existing stable-job dedupe coverage**
+
+Run:
+
+```bash
+rg -n "FaceIdentityBackfill|SharedSpacePersonMetadataBackfill|stable|jobId" server/src/repositories/job.repository.spec.ts
+```
+
+Expected: output includes root, cursor, continuation, and metadata-backfill stable job id coverage. If those cases are missing, add `server/src/repositories/job.repository.spec.ts` to this plan before implementation and cover manual retrigger dedupe there.
+
+## TDD Protocol For This Coverage Slice
+
+This is primarily a test-coverage slice. Most behavior may already be implemented. Use this protocol for every task:
+
+- [ ] **Step 1: Write tests before production code**
+
+Add the new service-spec assertions first. Do not edit service implementation before the new test exists.
+
+- [ ] **Step 2: Run the smallest targeted test selection**
+
+Use either the full spec command in the task or a focused `-t` selector for the new test name. Expected result:
+
+- FAIL if the current implementation does not satisfy the contract.
+- PASS if the contract was already implemented and this is coverage-only.
+
+- [ ] **Step 3: If a test fails, make the minimal production fix**
+
+Only change production code for a failing contract test. Do not combine unrelated queue behavior changes in this slice.
+
+- [ ] **Step 4: Prove the assertion can fail**
+
+For at least one new assertion per touched spec file, temporarily change one expected `JobName` or `force` value to an intentionally wrong value, run the focused test and confirm it fails, then restore the correct expectation before committing. This prevents adding a vacuous test that cannot catch regressions.
+
+## Spec Coverage Map
+
+- Upload and thumbnail completion: Task 2 covers upload, non-upload, hidden upload, missing asset, image, and video job contracts.
+- Manual asset jobs: Task 2 covers multi-asset refresh faces and access failure no-op.
+- Admin queue starts: Task 1 covers face detection, facial recognition, people backfill, active recognition start behavior, and unrelated queues.
+- Nightly jobs: Task 1 covers `PersonCleanup`, missing thumbnails, non-force `clusterNewFaces`, disabled switches, and issue #597 scheduled-trigger boundaries. Stuck recognition queue mutation behavior belongs to Slice 3 and full overnight composition belongs to Slice 8.
+- Manual job endpoint: Task 2 covers identity backfill, shared-space metadata backfill, person cleanup, invalid jobs, and root-only side effects. Stable backfill job id dedupe remains in `job.repository.spec.ts`; audit that file before execution and only add a job repository test if coverage is missing.
+- App bootstrap: Task 7 covers root backfill queueing, no-work no-op, active/waiting/delayed/paused dedupe query, and no direct projection fan-out.
+- Metadata face import: Task 4 covers disabled import, no-space import, multi-space targeted backfill, identity linking, and thumbnail queueing.
+- Library sync and link: Task 3 covers scheduled scan roots and linked-library asset import; Task 5 covers link, duplicate link, unlink cleanup, and disabled face-recognition link behavior.
+- Shared-space membership and asset changes: Task 5 covers face-recognition toggle, add/remove members, add/remove assets, delete space, queue bulk add, and bulk-add handler behavior.
+- Duplicate resolution: Task 6 covers keeper propagation, no editable spaces, no keepers, add failure, queue failure retry, and downstream disabled-space skip behavior.
+- Pet detection: Task 6 covers disabled queue root, force fan-out, missing asset or preview, hidden asset, new species, existing species, first thumbnail, and no-pet no-op.
+- Manual people and face operations: intentionally deferred to Slice 7; they are destructive user operations rather than Slice 1 queue-trigger roots.
 
 ## Task 1: QueueService Scheduled And Admin Triggers
 
@@ -129,7 +181,54 @@ it.each([
 });
 ```
 
-- [ ] **Step 4: Run QueueService tests**
+- [ ] **Step 4: Add explicit nightly cleanup trigger coverage**
+
+In `describe('handleNightlyJobs')`, add:
+
+```ts
+it('should queue PersonCleanup only when nightly database cleanup is enabled', async () => {
+  await sut.handleNightlyJobs();
+  expect(mocks.job.queueAll.mock.calls[0][0]).toContainEqual({ name: JobName.PersonCleanup });
+
+  mocks.job.queueAll.mockClear();
+  mocks.systemMetadata.get.mockResolvedValue({
+    nightlyTasks: {
+      ...defaults.nightlyTasks,
+      databaseCleanup: false,
+    },
+  });
+
+  await sut.handleNightlyJobs();
+
+  expect(mocks.job.queueAll.mock.calls[0][0]).not.toContainEqual({ name: JobName.PersonCleanup });
+});
+```
+
+- [ ] **Step 5: Add unrelated queue start no-face coverage**
+
+In `describe('handleCommand')`, add:
+
+```ts
+it.each([
+  QueueName.VideoConversion,
+  QueueName.SmartSearch,
+  QueueName.MetadataExtraction,
+  QueueName.Sidecar,
+  QueueName.ThumbnailGeneration,
+  QueueName.Library,
+] as const)('should not enqueue face identity roots when starting unrelated queue %s', async (queueName) => {
+  mocks.job.isActive.mockResolvedValue(false);
+  mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+
+  await sut.runCommandLegacy(queueName, { command: QueueCommand.Start, force: false });
+
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
+});
+```
+
+- [ ] **Step 6: Run QueueService tests**
 
 Run:
 
@@ -139,7 +238,7 @@ pnpm --filter immich test -- --run src/services/queue.service.spec.ts
 
 Expected: PASS. If a new test fails, fix only the trigger contract that failed.
 
-- [ ] **Step 5: Commit Task 1**
+- [ ] **Step 7: Commit Task 1**
 
 Run:
 
@@ -193,7 +292,46 @@ it.each([
 });
 ```
 
-- [ ] **Step 3: Strengthen manual refresh-faces multi-asset coverage**
+- [ ] **Step 3: Add invalid manual job no-queue coverage**
+
+In `server/src/services/job.service.spec.ts`, extend the invalid manual job test with explicit queue assertions:
+
+```ts
+it('should not queue anything for an invalid manual job name', async () => {
+  await expect(sut.create({ name: 'invalid-job' as ManualJobName })).rejects.toThrow(BadRequestException);
+
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 4: Add hidden upload queue-decision coverage**
+
+In `server/src/services/job.service.spec.ts`, inside `describe('onDone - AssetGenerateThumbnails')`, add:
+
+```ts
+it('should still queue upload follow-up jobs for hidden assets while suppressing upload notifications', async () => {
+  mocks.job.run.mockResolvedValue(JobStatus.Success);
+  const id = newUuid();
+  const asset = AssetFactory.create({ id, visibility: AssetVisibility.Hidden });
+  mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue([asset] as any);
+
+  await sut.onJobRun(QueueName.ThumbnailGeneration, {
+    name: JobName.AssetGenerateThumbnails,
+    data: { id, source: 'upload' },
+  });
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SmartSearch, data: { id, source: 'upload' } },
+    { name: JobName.AssetDetectFaces, data: { id, source: 'upload' } },
+    { name: JobName.Ocr, data: { id, source: 'upload' } },
+    { name: JobName.PetDetection, data: { id, source: 'upload' } },
+  ]);
+  expect(mocks.websocket.clientSend).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 5: Strengthen manual refresh-faces multi-asset coverage**
 
 In `server/src/services/asset.service.spec.ts`, inside `describe('run')`, add:
 
@@ -212,7 +350,16 @@ it('should queue only per-asset face detection jobs for manual refresh faces', a
 });
 ```
 
-- [ ] **Step 4: Run JobService and AssetService tests**
+- [ ] **Step 6: Add manual refresh-faces access failure no-queue assertion**
+
+In `server/src/services/asset.service.spec.ts`, extend the existing access failure test with:
+
+```ts
+expect(mocks.job.queue).not.toHaveBeenCalled();
+expect(mocks.job.queueAll).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 7: Run JobService and AssetService tests**
 
 Run:
 
@@ -222,7 +369,7 @@ pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit Task 2**
+- [ ] **Step 8: Commit Task 2**
 
 Run:
 
@@ -244,6 +391,7 @@ In `describe('onConfigInit')`, add:
 ```ts
 it('should schedule library scan cron to queue only the library scan root', async () => {
   mocks.cron.create.mockResolvedValue();
+  mocks.job.queue.mockResolvedValue(undefined as any);
 
   await sut.onConfigInit({ newConfig: defaults });
 
@@ -332,7 +480,19 @@ it('should queue sidecar refresh and targeted space face match for imported link
 });
 ```
 
-- [ ] **Step 4: Run LibraryService tests**
+- [ ] **Step 4: Strengthen linked-library disabled and no-space coverage**
+
+In `describe('handleSyncFiles')`, inside `describe('space face matching')`, extend the existing no-space and disabled-space tests with exact queue assertions:
+
+```ts
+expect(mocks.job.queueAll).toHaveBeenCalledWith([
+  { name: JobName.SidecarCheck, data: { id: expect.any(String), source: 'upload' } },
+]);
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+```
+
+- [ ] **Step 5: Run LibraryService tests**
 
 Run:
 
@@ -342,7 +502,7 @@ pnpm --filter immich test -- --run src/services/library.service.spec.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit Task 3**
+- [ ] **Step 6: Commit Task 3**
 
 Run:
 
@@ -508,7 +668,106 @@ expect(mocks.job.queue).toHaveBeenCalledWith({
 });
 ```
 
-- [ ] **Step 5: Run SharedSpaceService tests**
+- [ ] **Step 5: Strengthen face-recognition toggle assertions**
+
+In `describe('update')`, extend the false-to-true, true-to-false, and already-true face-recognition tests with exact queue count assertions:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpaceFaceMatchAll,
+  data: { spaceId: space.id },
+});
+```
+
+For the true-to-false and already-true tests, use:
+
+```ts
+expect(mocks.job.queue).not.toHaveBeenCalledWith(
+  expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+);
+```
+
+- [ ] **Step 6: Strengthen delete-space and remove-member metadata backfill assertions**
+
+In `describe('remove')`, extend the delete-space metadata test with:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpacePersonMetadataBackfill,
+  data: {},
+});
+```
+
+In `describe('removeMember')`, extend both member-removal metadata tests with:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpacePersonMetadataBackfill,
+  data: {},
+});
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+```
+
+- [ ] **Step 7: Strengthen remove-assets and bulk-add trigger assertions**
+
+In `describe('removeAssets')`, extend the metadata backfill test with:
+
+```ts
+expect(mocks.sharedSpace.removePersonFacesByAssetIds).toHaveBeenCalledWith(spaceId, [assetId]);
+expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpacePersonMetadataBackfill,
+  data: {},
+});
+```
+
+In `describe('queueBulkAdd')`, extend the editor and owner tests with:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpaceBulkAddAssets,
+  data: { spaceId, userId: auth.user.id },
+});
+```
+
+In `describe('handleSharedSpaceBulkAddAssets')`, extend the count-zero and disabled tests with:
+
+```ts
+expect(mocks.job.queue).not.toHaveBeenCalledWith(
+  expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+);
+```
+
+For the enabled test, keep the exact positive assertion:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpaceFaceMatchAll,
+  data: { spaceId },
+});
+```
+
+- [ ] **Step 8: Strengthen link-library trigger assertions**
+
+In `describe('linkLibrary')`, extend the enabled test with:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpaceLibraryFaceSync,
+  data: { spaceId: space.id, libraryId: library.id },
+});
+```
+
+For disabled and duplicate-link tests, use:
+
+```ts
+expect(mocks.job.queue).not.toHaveBeenCalledWith(
+  expect.objectContaining({ name: JobName.SharedSpaceLibraryFaceSync }),
+);
+```
+
+- [ ] **Step 9: Run SharedSpaceService tests**
 
 Run:
 
@@ -518,7 +777,7 @@ pnpm --filter immich test -- --run src/services/shared-space.service.spec.ts
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit Task 5**
+- [ ] **Step 10: Commit Task 5**
 
 Run:
 
@@ -630,7 +889,86 @@ git add server/src/services/duplicate.service.spec.ts server/src/services/pet-de
 git commit -m "test: cover duplicate and pet face trigger contracts"
 ```
 
-## Task 7: Final Slice Verification
+## Task 7: PersonService App Bootstrap Trigger Audit
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Strengthen bootstrap backfill trigger status coverage**
+
+In `server/src/services/person.service.spec.ts`, update the import from `src/enum` to include `QueueJobStatus`:
+
+```ts
+import {
+  AssetFileType,
+  AssetVisibility,
+  CacheControl,
+  JobName,
+  JobStatus,
+  MetadataKey,
+  QueueJobStatus,
+  QueueName,
+  SourceType,
+  SystemMetadataKey,
+} from 'src/enum';
+```
+
+Then add this test inside `describe('onBootstrap')`:
+
+```ts
+it('should not queue a duplicate identity backfill root while any backfill job is active, waiting, delayed, or paused', async () => {
+  (mocks.faceIdentity as any).hasBackfillWork.mockResolvedValue(true);
+  mocks.job.searchJobs.mockResolvedValue([
+    {
+      id: 'face-identity-backfill/root',
+      name: JobName.FaceIdentityBackfill,
+      timestamp: Date.now(),
+      data: {},
+    },
+  ]);
+
+  await sut.onBootstrap();
+
+  expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
+    status: [QueueJobStatus.Active, QueueJobStatus.Delayed, QueueJobStatus.Paused, QueueJobStatus.Waiting],
+  });
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Assert bootstrap does not start projection fan-out directly**
+
+Extend the existing positive bootstrap test with:
+
+```ts
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+expect(mocks.job.queue).not.toHaveBeenCalledWith(
+  expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill }),
+);
+expect(mocks.job.queueAll).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 3: Run PersonService bootstrap tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/person.service.spec.ts -t "onBootstrap"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 7**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts
+git commit -m "test: cover bootstrap identity trigger contract"
+```
+
+## Task 8: Final Slice Verification
 
 **Files:**
 
@@ -641,7 +979,7 @@ git commit -m "test: cover duplicate and pet face trigger contracts"
 Run:
 
 ```bash
-pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts
+pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts src/services/person.service.spec.ts
 ```
 
 Expected: PASS.
@@ -669,10 +1007,10 @@ Expected: `git diff --check` emits no output. `git status --short` lists only in
 
 - [ ] **Step 4: Commit any remaining verification-only adjustments**
 
-If Task 7 changed files, commit them:
+If final verification changed files, commit them:
 
 ```bash
-git add server/src/services/job.service.spec.ts server/src/services/queue.service.spec.ts server/src/services/asset.service.spec.ts server/src/services/library.service.spec.ts server/src/services/metadata.service.spec.ts server/src/services/duplicate.service.spec.ts server/src/services/shared-space.service.spec.ts server/src/services/pet-detection.service.spec.ts
+git add server/src/services/job.service.spec.ts server/src/services/queue.service.spec.ts server/src/services/asset.service.spec.ts server/src/services/library.service.spec.ts server/src/services/metadata.service.spec.ts server/src/services/duplicate.service.spec.ts server/src/services/shared-space.service.spec.ts server/src/services/pet-detection.service.spec.ts server/src/services/person.service.spec.ts
 git commit -m "test: complete face trigger contract coverage"
 ```
 
@@ -685,8 +1023,9 @@ Expected: clean worktree after the final commit.
 - [ ] External library scan cron is asserted to queue only the library scan root directly.
 - [ ] Manual face refresh queues one `AssetDetectFaces` per requested asset with no coordinator shortcut.
 - [ ] Manual identity/backfill job endpoint queues only the requested root job.
+- [ ] App bootstrap identity backfill queues one root job only when work exists and no backfill job is active, waiting, delayed, or paused.
 - [ ] EXIF face import queues thumbnails, identity links, and targeted shared-space backfill only when applicable.
-- [ ] Shared-space add/remove/member/link/unlink/bulk triggers have explicit enabled and disabled assertions.
+- [ ] Shared-space toggle/member/add/remove/delete/link/unlink/bulk triggers have explicit enabled and disabled assertions.
 - [ ] Duplicate keeper propagation covers no spaces, no keepers, add failure, and queue failure retry.
 - [ ] Pet queue root covers disabled, force, and per-asset fan-out.
 - [ ] No test in this slice requires real ML, Redis workers, filesystem scanning, or medium DB fixtures.

--- a/docs/superpowers/plans/2026-05-17-face-identity-trigger-contract-coverage.md
+++ b/docs/superpowers/plans/2026-05-17-face-identity-trigger-contract-coverage.md
@@ -171,14 +171,17 @@ it.each([
   [QueueName.FacialRecognition, false, { name: JobName.FacialRecognitionQueueAll, data: { force: false } }],
   [QueueName.FacialRecognition, true, { name: JobName.FacialRecognitionQueueAll, data: { force: true } }],
   [QueueName.PeopleBackfill, false, { name: JobName.FaceIdentityBackfill, data: {} }],
-] as const)('should queue %s start with force=%s as the expected face identity root', async (queueName, force, expected) => {
-  mocks.job.isActive.mockResolvedValue(false);
-  mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+] as const)(
+  'should queue %s start with force=%s as the expected face identity root',
+  async (queueName, force, expected) => {
+    mocks.job.isActive.mockResolvedValue(false);
+    mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
 
-  await sut.runCommandLegacy(queueName, { command: QueueCommand.Start, force });
+    await sut.runCommandLegacy(queueName, { command: QueueCommand.Start, force });
 
-  expect(mocks.job.queue).toHaveBeenCalledWith(expected);
-});
+    expect(mocks.job.queue).toHaveBeenCalledWith(expected);
+  },
+);
 ```
 
 - [ ] **Step 4: Add explicit nightly cleanup trigger coverage**
@@ -223,7 +226,9 @@ it.each([
   await sut.runCommandLegacy(queueName, { command: QueueCommand.Start, force: false });
 
   expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
-  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(
+    expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+  );
   expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
 });
 ```
@@ -682,9 +687,7 @@ expect(mocks.job.queue).toHaveBeenCalledWith({
 For the true-to-false and already-true tests, use:
 
 ```ts
-expect(mocks.job.queue).not.toHaveBeenCalledWith(
-  expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
-);
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
 ```
 
 - [ ] **Step 6: Strengthen delete-space and remove-member metadata backfill assertions**
@@ -734,9 +737,7 @@ expect(mocks.job.queue).toHaveBeenCalledWith({
 In `describe('handleSharedSpaceBulkAddAssets')`, extend the count-zero and disabled tests with:
 
 ```ts
-expect(mocks.job.queue).not.toHaveBeenCalledWith(
-  expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
-);
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
 ```
 
 For the enabled test, keep the exact positive assertion:
@@ -762,9 +763,7 @@ expect(mocks.job.queue).toHaveBeenCalledWith({
 For disabled and duplicate-link tests, use:
 
 ```ts
-expect(mocks.job.queue).not.toHaveBeenCalledWith(
-  expect.objectContaining({ name: JobName.SharedSpaceLibraryFaceSync }),
-);
+expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceLibraryFaceSync }));
 ```
 
 - [ ] **Step 9: Run SharedSpaceService tests**

--- a/docs/superpowers/plans/2026-05-17-face-identity-trigger-contract-coverage.md
+++ b/docs/superpowers/plans/2026-05-17-face-identity-trigger-contract-coverage.md
@@ -1,0 +1,692 @@
+# Face Identity Trigger Contract Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add focused small-service tests proving every Slice 1 face identity trigger queues the expected jobs, queues nothing when disabled or unauthorized, and never turns scheduled overnight work into destructive face identity work.
+
+**Architecture:** This slice is test-only unless a trigger contract test exposes a real bug. Keep coverage in the service spec that owns each trigger, assert exact job names and job data, and avoid medium DB tests. Issue #597 is represented here only as scheduled-trigger coverage: nightly `clusterNewFaces` must queue non-force recognition, and scheduled missing-thumbnail/library-scan roots must not directly queue destructive face work.
+
+**Tech Stack:** TypeScript, NestJS service unit tests, Vitest, Gallery small test mocks, BullMQ job names.
+
+---
+
+## File Structure
+
+- Modify: `server/src/services/queue.service.spec.ts`
+  - Owns admin queue starts, nightly task fan-out, and issue #597 scheduled recognition trigger contracts.
+- Modify: `server/src/services/job.service.spec.ts`
+  - Owns thumbnail-completion follow-up jobs and manual job endpoint contracts.
+- Modify: `server/src/services/asset.service.spec.ts`
+  - Owns user-triggered asset job contracts such as `AssetJobName.REFRESH_FACES`.
+- Modify: `server/src/services/library.service.spec.ts`
+  - Owns scheduled external library scan roots and linked-library sync trigger contracts.
+- Modify: `server/src/services/metadata.service.spec.ts`
+  - Owns EXIF face import queue contracts.
+- Modify: `server/src/services/shared-space.service.spec.ts`
+  - Owns shared-space member, asset, bulk-add, delete, link, and unlink trigger contracts.
+- Modify: `server/src/services/duplicate.service.spec.ts`
+  - Owns duplicate-resolution keeper propagation and retryable queue-failure trigger contracts.
+- Modify: `server/src/services/pet-detection.service.spec.ts`
+  - Owns pet detection queue-root and per-asset trigger contracts.
+
+## Execution Preflight
+
+- [ ] **Step 1: Confirm the implementation worktree is isolated and clean**
+
+Run:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+```
+
+Expected:
+
+```text
+/home/pierre/dev/gallery/.worktrees/face-queues-test-plan
+codex/face-queues-test-plan
+```
+
+`git status --short` should be empty before editing server tests. If it is not empty, inspect every listed file and preserve user-owned work.
+
+- [ ] **Step 2: Run the Slice 1 baseline suite**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts
+```
+
+Expected: all targeted specs pass before new tests are added. If a pre-existing failure appears, stop and investigate before adding coverage.
+
+## Task 1: QueueService Scheduled And Admin Triggers
+
+**Files:**
+
+- Modify: `server/src/services/queue.service.spec.ts`
+
+- [ ] **Step 1: Add explicit nightly recognition contract coverage**
+
+In `describe('handleNightlyJobs')`, add:
+
+```ts
+it('should queue nightly face clustering as non-force recognition only', async () => {
+  await sut.handleNightlyJobs();
+
+  const jobs = mocks.job.queueAll.mock.calls[0][0];
+  expect(jobs).toContainEqual({
+    name: JobName.FacialRecognitionQueueAll,
+    data: { force: false, nightly: true },
+  });
+  expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
+  expect(jobs).not.toContainEqual(
+    expect.objectContaining({
+      name: JobName.FacialRecognitionQueueAll,
+      data: expect.objectContaining({ force: true }),
+    }),
+  );
+});
+```
+
+This pins the Slice 1 part of issue #597: the scheduled trigger must not request a forced recognition wipe.
+
+- [ ] **Step 2: Add explicit missing-thumbnail scheduled root coverage**
+
+In the same `describe('handleNightlyJobs')`, add:
+
+```ts
+it('should queue missing thumbnails without direct face detection work', async () => {
+  await sut.handleNightlyJobs();
+
+  const jobs = mocks.job.queueAll.mock.calls[0][0];
+  expect(jobs).toContainEqual({
+    name: JobName.AssetGenerateThumbnailsQueueAll,
+    data: { force: false },
+  });
+  expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
+});
+```
+
+- [ ] **Step 3: Add table-driven admin face queue start coverage**
+
+In `describe('handleCommand')`, add:
+
+```ts
+it.each([
+  [QueueName.FaceDetection, false, { name: JobName.AssetDetectFacesQueueAll, data: { force: false } }],
+  [QueueName.FaceDetection, true, { name: JobName.AssetDetectFacesQueueAll, data: { force: true } }],
+  [QueueName.FacialRecognition, false, { name: JobName.FacialRecognitionQueueAll, data: { force: false } }],
+  [QueueName.FacialRecognition, true, { name: JobName.FacialRecognitionQueueAll, data: { force: true } }],
+  [QueueName.PeopleBackfill, false, { name: JobName.FaceIdentityBackfill, data: {} }],
+] as const)('should queue %s start with force=%s as the expected face identity root', async (queueName, force, expected) => {
+  mocks.job.isActive.mockResolvedValue(false);
+  mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+
+  await sut.runCommandLegacy(queueName, { command: QueueCommand.Start, force });
+
+  expect(mocks.job.queue).toHaveBeenCalledWith(expected);
+});
+```
+
+- [ ] **Step 4: Run QueueService tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/queue.service.spec.ts
+```
+
+Expected: PASS. If a new test fails, fix only the trigger contract that failed.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add server/src/services/queue.service.spec.ts
+git commit -m "test: cover scheduled face queue triggers"
+```
+
+## Task 2: JobService And AssetService Manual Entry Points
+
+**Files:**
+
+- Modify: `server/src/services/job.service.spec.ts`
+- Modify: `server/src/services/asset.service.spec.ts`
+
+- [ ] **Step 1: Add generated-thumbnail no-op coverage for scheduled thumbnail roots**
+
+In `server/src/services/job.service.spec.ts`, inside `describe('onDone - AssetGenerateThumbnails')`, add:
+
+```ts
+it('should not queue face detection for generated thumbnail jobs without upload or notify markers', async () => {
+  mocks.job.run.mockResolvedValue(JobStatus.Success);
+  const id = newUuid();
+
+  await sut.onJobRun(QueueName.ThumbnailGeneration, {
+    name: JobName.AssetGenerateThumbnails,
+    data: { id },
+  });
+
+  expect(mocks.asset.getByIdsWithAllRelationsButStacks).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.AssetDetectFaces }));
+});
+```
+
+- [ ] **Step 2: Add manual identity job side-effect coverage**
+
+In `server/src/services/job.service.spec.ts`, inside `describe('create')`, add:
+
+```ts
+it.each([
+  [ManualJobName.FaceIdentityBackfill, { name: JobName.FaceIdentityBackfill, data: {} }],
+  [ManualJobName.SharedSpacePersonMetadataBackfill, { name: JobName.SharedSpacePersonMetadataBackfill, data: {} }],
+  [ManualJobName.PersonCleanup, { name: JobName.PersonCleanup }],
+] as const)('should queue only the manual %s root job', async (manualName, expected) => {
+  await sut.create({ name: manualName });
+
+  expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queue).toHaveBeenCalledWith(expected);
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Strengthen manual refresh-faces multi-asset coverage**
+
+In `server/src/services/asset.service.spec.ts`, inside `describe('run')`, add:
+
+```ts
+it('should queue only per-asset face detection jobs for manual refresh faces', async () => {
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1', 'asset-2']));
+
+  await sut.run(authStub.admin, { assetIds: ['asset-1', 'asset-2'], name: AssetJobName.REFRESH_FACES });
+
+  expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.AssetDetectFaces, data: { id: 'asset-1' } },
+    { name: JobName.AssetDetectFaces, data: { id: 'asset-2' } },
+  ]);
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 4: Run JobService and AssetService tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/asset.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add server/src/services/job.service.spec.ts server/src/services/asset.service.spec.ts
+git commit -m "test: cover manual face trigger contracts"
+```
+
+## Task 3: LibraryService Scheduled Scan And Linked Library Triggers
+
+**Files:**
+
+- Modify: `server/src/services/library.service.spec.ts`
+
+- [ ] **Step 1: Add scheduled library scan cron root coverage**
+
+In `describe('onConfigInit')`, add:
+
+```ts
+it('should schedule library scan cron to queue only the library scan root', async () => {
+  mocks.cron.create.mockResolvedValue();
+
+  await sut.onConfigInit({ newConfig: defaults });
+
+  expect(mocks.cron.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: CronJob.LibraryScan,
+      expression: defaults.library.scan.cronExpression,
+      start: defaults.library.scan.enabled,
+      onTick: expect.any(Function),
+    }),
+  );
+
+  const onTick = mocks.cron.create.mock.calls[0][0].onTick;
+  onTick();
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.LibraryScanQueueAll });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Strengthen all-library scan root coverage**
+
+In `describe('handleQueueAllScan')`, extend the existing refresh test or add:
+
+```ts
+it('should queue library sync roots without direct face identity work', async () => {
+  const library = factory.library();
+
+  mocks.library.getAll.mockResolvedValue([library]);
+
+  await expect(sut.handleQueueScanAll()).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.LibraryDeleteCheck,
+    data: {},
+  });
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.LibrarySyncFilesQueueAll, data: { id: library.id } },
+  ]);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.LibrarySyncAssetsQueueAll, data: { id: library.id } },
+  ]);
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+  );
+});
+```
+
+- [ ] **Step 3: Strengthen linked-library new asset coverage**
+
+In `describe('handleSyncFiles')`, inside `describe('space face matching')`, add:
+
+```ts
+it('should queue sidecar refresh and targeted space face match for imported linked-library assets', async () => {
+  const libraryId = newUuid();
+  const spaceId = newUuid();
+  const library = factory.library({ id: libraryId });
+  const assetId = newUuid();
+
+  mocks.library.get.mockResolvedValue(library);
+  mocks.asset.createAll.mockResolvedValue([assetId]);
+  mocks.sharedSpace.getSpacesLinkedToLibrary.mockResolvedValue([
+    {
+      spaceId,
+      libraryId,
+      addedById: null,
+      createdAt: newDate(),
+      updatedAt: newDate(),
+      createId: newUuid(),
+      updateId: newUuid(),
+      faceRecognitionEnabled: true,
+    },
+  ]);
+
+  await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SidecarCheck, data: { id: assetId, source: 'upload' } },
+  ]);
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.SharedSpaceFaceMatch,
+    data: { spaceId, assetId },
+  });
+});
+```
+
+- [ ] **Step 4: Run LibraryService tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/library.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add server/src/services/library.service.spec.ts
+git commit -m "test: cover library face trigger contracts"
+```
+
+## Task 4: MetadataService EXIF Face Import Triggers
+
+**Files:**
+
+- Modify: `server/src/services/metadata.service.spec.ts`
+
+- [ ] **Step 1: Add disabled import no-queue coverage**
+
+Near the existing metadata face import tests, add:
+
+```ts
+it('should not queue face identity jobs when metadata face import is disabled', async () => {
+  const asset = AssetFactory.create();
+  mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+  mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: false } } });
+  mockReadTags(makeFaceTags({ Name: 'Person 1' }));
+
+  await sut.handleMetadataExtraction({ id: asset.id });
+
+  expect(mocks.person.getDistinctNames).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill })]),
+  );
+});
+```
+
+- [ ] **Step 2: Add imported-face no-space coverage**
+
+Near `should queue shared-space matching for imported metadata faces`, add:
+
+```ts
+it('should not queue shared-space matching for imported metadata faces when the asset is in no spaces', async () => {
+  const asset = AssetFactory.create();
+  const person = PersonFactory.create();
+
+  mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+  mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
+  mockReadTags(makeFaceTags({ Name: person.name }));
+  mocks.person.getDistinctNames.mockResolvedValue([]);
+  mocks.person.createAll.mockResolvedValue([person.id]);
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+  mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([]);
+
+  await sut.handleMetadataExtraction({ id: asset.id });
+
+  expect(mocks.sharedSpace.getSpaceIdsForAsset).toHaveBeenCalledWith(asset.id);
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill })]),
+  );
+});
+```
+
+- [ ] **Step 3: Add multi-space imported-face fan-out coverage**
+
+Near the same shared-space import tests, add:
+
+```ts
+it('should queue one backfill face match per space for imported metadata faces', async () => {
+  const asset = AssetFactory.create();
+  const person = PersonFactory.create();
+
+  mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+  mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
+  mockReadTags(makeFaceTags({ Name: person.name }));
+  mocks.person.getDistinctNames.mockResolvedValue([]);
+  mocks.person.createAll.mockResolvedValue([person.id]);
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+  mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }, { spaceId: 'space-2' }]);
+
+  await sut.handleMetadataExtraction({ id: asset.id });
+
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SharedSpaceFaceMatchFromBackfill, data: { spaceId: 'space-1', assetId: asset.id } },
+    { name: JobName.SharedSpaceFaceMatchFromBackfill, data: { spaceId: 'space-2', assetId: asset.id } },
+  ]);
+});
+```
+
+- [ ] **Step 4: Run MetadataService tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/metadata.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+Run:
+
+```bash
+git add server/src/services/metadata.service.spec.ts
+git commit -m "test: cover metadata face import triggers"
+```
+
+## Task 5: SharedSpaceService Trigger Contracts
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.spec.ts`
+
+- [ ] **Step 1: Strengthen add-member enabled-face-recognition assertion**
+
+In `describe('addMember')`, extend the existing enabled face materialization test with:
+
+```ts
+expect(queuedJobs).toContainEqual({
+  name: JobName.SharedSpacePersonMetadataBackfill,
+  data: {},
+});
+expect(queuedJobs).toContainEqual({
+  name: JobName.SharedSpaceFaceMatchAll,
+  data: { spaceId },
+});
+expect(queuedJobs).toContainEqual({
+  name: JobName.SharedSpaceIdentityReconciliation,
+  data: { spaceId, userId },
+});
+```
+
+- [ ] **Step 2: Strengthen add-member disabled-face-recognition assertion**
+
+In `describe('addMember')`, extend the existing disabled face materialization test with:
+
+```ts
+expect(queuedJobs).toContainEqual({
+  name: JobName.SharedSpacePersonMetadataBackfill,
+  data: {},
+});
+expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+```
+
+- [ ] **Step 3: Strengthen add-assets disabled-face-recognition assertion**
+
+In `describe('addAssets')`, extend the existing disabled face match test with:
+
+```ts
+expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+  expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+);
+```
+
+- [ ] **Step 4: Strengthen unlink-library cleanup assertion**
+
+In `describe('unlinkLibrary cleanup')`, extend the cleanup test with:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpacePersonMetadataBackfill,
+  data: {},
+});
+```
+
+- [ ] **Step 5: Run SharedSpaceService tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/shared-space.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 5**
+
+Run:
+
+```bash
+git add server/src/services/shared-space.service.spec.ts
+git commit -m "test: cover shared space face trigger contracts"
+```
+
+## Task 6: DuplicateService And PetDetectionService Trigger Contracts
+
+**Files:**
+
+- Modify: `server/src/services/duplicate.service.spec.ts`
+- Modify: `server/src/services/pet-detection.service.spec.ts`
+
+- [ ] **Step 1: Add duplicate queue-failure retry coverage**
+
+In `server/src/services/duplicate.service.spec.ts`, inside `describe('shared space sync')`, add:
+
+```ts
+it('reports queue failure after keeper insertion so retry can queue face matches idempotently', async () => {
+  const asset1 = AssetFactory.create();
+  const asset2 = AssetFactory.create();
+  setupBaseDuplicate(asset1, asset2);
+  mocks.sharedSpace.getEditableByAssetIds.mockResolvedValue(new Set([spaceX]));
+  mocks.sharedSpace.addAssets.mockResolvedValue([]);
+  mocks.job.queueAll.mockRejectedValueOnce(new Error('queue unavailable')).mockResolvedValue(undefined as any);
+
+  const first = await sut.resolve(authStub.admin, {
+    groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id], trashAssetIds: [asset2.id] }],
+  });
+
+  expect(first[0].success).toBe(false);
+  expect(first[0].error).toBe(BulkIdErrorReason.UNKNOWN);
+  expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+    { spaceId: spaceX, assetId: asset1.id, addedById: authStub.admin.user.id },
+  ]);
+
+  const second = await sut.resolve(authStub.admin, {
+    groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id], trashAssetIds: [asset2.id] }],
+  });
+
+  expect(second[0].success).toBe(true);
+  expect(mocks.sharedSpace.addAssets).toHaveBeenCalledTimes(2);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith(
+    expect.arrayContaining([{ name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } }]),
+  );
+});
+```
+
+- [ ] **Step 2: Strengthen duplicate no-keeper coverage**
+
+Extend the existing no-keeper shared-space sync test with:
+
+```ts
+expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+  expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+);
+```
+
+- [ ] **Step 3: Add pet queue disabled no-op coverage**
+
+In `server/src/services/pet-detection.service.spec.ts`, inside `describe('handleQueuePetDetection')`, add:
+
+```ts
+it('should not queue pet jobs when pet detection is disabled', async () => {
+  expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Skipped);
+
+  expect(mocks.assetJob.streamForPetDetectionJob).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 4: Add pet queue force fan-out coverage**
+
+In the same describe block, add:
+
+```ts
+it('should queue pet detection jobs with force asset selection when force is true', async () => {
+  const asset = AssetFactory.create();
+  mocks.systemMetadata.get.mockResolvedValue({
+    machineLearning: { enabled: true, petDetection: { enabled: true } },
+  });
+  mocks.assetJob.streamForPetDetectionJob.mockReturnValue(makeStream([asset]));
+
+  expect(await sut.handleQueuePetDetection({ force: true })).toEqual(JobStatus.Success);
+
+  expect(mocks.assetJob.streamForPetDetectionJob).toHaveBeenCalledWith(true);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.PetDetection, data: { id: asset.id } }]);
+});
+```
+
+- [ ] **Step 5: Run DuplicateService and PetDetectionService tests**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/duplicate.service.spec.ts src/services/pet-detection.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 6**
+
+Run:
+
+```bash
+git add server/src/services/duplicate.service.spec.ts server/src/services/pet-detection.service.spec.ts
+git commit -m "test: cover duplicate and pet face trigger contracts"
+```
+
+## Task 7: Final Slice Verification
+
+**Files:**
+
+- Verify all modified Slice 1 service specs.
+
+- [ ] **Step 1: Run the full Slice 1 small-test suite**
+
+Run:
+
+```bash
+pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run static server checks**
+
+Run:
+
+```bash
+pnpm --filter immich check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check formatting and changed files**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: `git diff --check` emits no output. `git status --short` lists only intended Slice 1 test files if final commits have not yet been made.
+
+- [ ] **Step 4: Commit any remaining verification-only adjustments**
+
+If Task 7 changed files, commit them:
+
+```bash
+git add server/src/services/job.service.spec.ts server/src/services/queue.service.spec.ts server/src/services/asset.service.spec.ts server/src/services/library.service.spec.ts server/src/services/metadata.service.spec.ts server/src/services/duplicate.service.spec.ts server/src/services/shared-space.service.spec.ts server/src/services/pet-detection.service.spec.ts
+git commit -m "test: complete face trigger contract coverage"
+```
+
+Expected: clean worktree after the final commit.
+
+## Review Checklist
+
+- [ ] Nightly `clusterNewFaces` is asserted as `{ force: false, nightly: true }`.
+- [ ] Scheduled missing-thumbnail generation is asserted not to directly queue face detection.
+- [ ] External library scan cron is asserted to queue only the library scan root directly.
+- [ ] Manual face refresh queues one `AssetDetectFaces` per requested asset with no coordinator shortcut.
+- [ ] Manual identity/backfill job endpoint queues only the requested root job.
+- [ ] EXIF face import queues thumbnails, identity links, and targeted shared-space backfill only when applicable.
+- [ ] Shared-space add/remove/member/link/unlink/bulk triggers have explicit enabled and disabled assertions.
+- [ ] Duplicate keeper propagation covers no spaces, no keepers, add failure, and queue failure retry.
+- [ ] Pet queue root covers disabled, force, and per-asset fan-out.
+- [ ] No test in this slice requires real ML, Redis workers, filesystem scanning, or medium DB fixtures.

--- a/docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md
+++ b/docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md
@@ -16,6 +16,25 @@ The face pipeline is not one queue. It spans:
 
 The triggering surface is broad. Upload thumbnail completion, manual asset refresh, admin queue starts, nightly jobs, metadata face imports, linked-library sync, shared-space membership changes, duplicate resolution, pet detection, manual face edits, people merge/delete/reassign operations, and identity backfill can all touch the same people and face identity state.
 
+## Production Regression Focus
+
+Issue #597 reports an overnight state transition where Facial Recognition was stuck with about 87,000 waiting jobs, then by morning had about 274,000 waiting jobs and all Shared Space persons were empty while 359,274 faces still existed. The reported setup had EXIF face import enabled, ML facial recognition enabled, and no user interaction between the evening and morning observations.
+
+This plan treats that as a first-class regression scenario. The relevant scheduled entry points are:
+
+- nightly tasks at `nightlyTasks.startTime`, default `00:00`
+- external library scan cron, default every day at midnight
+
+The destructive shared-space wipe is not itself a scheduled branch. In the current code it is only in forced `FacialRecognitionQueueAll` handling. The scheduled nightly recognition job is `force=false` and `nightly=true`, so the tests must prove it never reaches the forced wipe path when a large or stuck Facial Recognition queue already exists.
+
+Regression coverage must prove:
+
+- scheduled `clusterNewFaces` queues only non-force `FacialRecognitionQueueAll`
+- a non-force nightly coordinator with waiting, delayed, paused, or active recognition work skips before `unassignFaces`, `unlinkFacesBySourceType`, `deleteAllPersonFaces`, or `deleteAllPersons`
+- recovered or retried non-force queue coordinators do not expand the queue with duplicate full-recognition fan-out while old work is still waiting
+- an already-pending force-recognition follow-up is the only path allowed to clear `shared_space_person` state, and it must queue the full shared-space rebuild before maintenance/backfill
+- library scans and EXIF face imports running on the same overnight window may add or repair projection work, but must not empty existing shared-space people without the forced recognition path
+
 ## Goals
 
 - Build an extremely thorough test plan before implementation.
@@ -160,9 +179,11 @@ Source: `QueueService.handleNightlyJobs`.
 Coverage:
 
 - database cleanup queues `PersonCleanup`
-- missing thumbnails queues `AssetGenerateThumbnailsQueueAll`, which may later trigger face detection through thumbnail completion
+- missing thumbnails queues `AssetGenerateThumbnailsQueueAll`; those generated thumbnail jobs are not upload/notify jobs and must not trigger face detection through thumbnail completion
 - cluster new faces queues `FacialRecognitionQueueAll` with `nightly=true` and `force=false`
 - nightly recognition skip with no new faces does not queue maintenance, backfill, or destructive reset work
+- nightly recognition with existing waiting, delayed, paused, or active recognition work skips before any destructive reset or shared-space wipe
+- nightly recognition recovered after a stuck queue does not enqueue duplicate full-recognition fan-out while old work is still waiting
 - disabled nightly switches do not enqueue corresponding face jobs
 
 ### Manual Job Endpoint
@@ -210,6 +231,8 @@ Sources: `LibraryService.handleSyncFiles`, `SharedSpaceService.linkLibrary`, `Sh
 Coverage:
 
 - importing new library assets queues normal post-sync jobs and shared-space face matches for enabled linked spaces
+- scheduled library scan queues only library sync roots directly; any face identity effects must come from later sidecar, metadata, thumbnail, EXIF import, or shared-space projection handlers
+- overnight library scan plus EXIF face import with pre-existing shared-space people does not empty shared-space people and queues only targeted projection/metadata repair work
 - no linked spaces queues no shared-space face work
 - disabled linked space queues no shared-space face work from library sync
 - linking a library to an enabled space queues `SharedSpaceLibraryFaceSync`
@@ -361,6 +384,8 @@ Add tests for:
 
 - waits for thumbnail and face detection queues before queueing recognition work
 - nightly skip happens before queue drain and before destructive reset
+- non-force nightly run with a large existing waiting queue skips before personal unassign, identity unlink, shared-space person-face delete, shared-space person delete, maintenance marker, and backfill
+- recovered or retried non-force coordinator with stale waiting recognition work remains idempotent and does not multiply full-queue fan-out
 - non-force run skips if recognition jobs are waiting
 - force run drains pending recognition work before deleting assignments
 - force run unassigns ML faces, unlinks ML identity links, cleans orphaned people, vacuums without vector reindex, clears shared-space person state, deletes unreferenced identities, queues per-face jobs with `skipSharedSpaceMatch`, queues `SharedSpaceFaceMatchAll`, queues maintenance marker, and writes last-run state
@@ -525,6 +550,9 @@ Add tests for:
 
 - upload-like chain: thumbnail completion, face detection, recognition, shared-space projection, dedup, metadata backfill
 - force detection followed by force recognition on a populated user and enabled shared space
+- issue #597 chain: overnight `clusterNewFaces` fires while a large non-force Facial Recognition queue is stuck or waiting; the coordinator skips without clearing shared-space people, does not multiply recognition jobs, and leaves EXIF-backed space people visible
+- issue #597 force-follow-up chain: if a force recognition follow-up was already pending before the overnight window, it is the only allowed wipe path; it clears shared-space people, queues full-space rematch after personal recognition jobs, and the final state has rebuilt space people rather than remaining empty after the queue drains
+- overnight library-scan chain: scheduled library scan, sidecar/metadata refresh, EXIF face import, targeted shared-space backfill, dedup, and metadata backfill preserve pre-existing shared-space people and do not convert all faces to unassigned
 - metadata EXIF import followed by targeted shared-space backfill projection
 - library link followed by library face sync, identity reconciliation, dedup, and global people visibility
 - duplicate keeper propagation followed by shared-space face match and stats repair

--- a/docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md
+++ b/docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md
@@ -1,0 +1,629 @@
+# Face Identity Queue Testing Plan Design
+
+Date: 2026-05-17
+
+## Context
+
+Gallery has several independent paths that create, remove, reassign, or project face data. A bug in any one of these paths can be destructive: named people can be deleted, manual or EXIF faces can be overwritten, shared-space people can be wiped, identity links can merge incorrectly, and queued work can run after the data it was built for has changed.
+
+The face pipeline is not one queue. It spans:
+
+- `QueueName.FaceDetection`: `AssetDetectFacesQueueAll`, `AssetDetectFaces`
+- `QueueName.FacialRecognition`: `FacialRecognitionQueueAll`, `FacialRecognition`, shared-space face matching, shared-space identity reconciliation, shared-space person deduplication
+- `QueueName.PeopleBackfill`: `FaceIdentityBackfill`, `SharedSpaceFaceMatchFromBackfill`, `SharedSpacePersonMetadataBackfill`
+- `QueueName.ThumbnailGeneration`: `PersonGenerateThumbnail`
+- `QueueName.BackgroundTask`: `PersonCleanup`, `SharedSpaceBulkAddAssets`
+
+The triggering surface is broad. Upload thumbnail completion, manual asset refresh, admin queue starts, nightly jobs, metadata face imports, linked-library sync, shared-space membership changes, duplicate resolution, pet detection, manual face edits, people merge/delete/reassign operations, and identity backfill can all touch the same people and face identity state.
+
+## Goals
+
+- Build an extremely thorough test plan before implementation.
+- Test every known path that queues face detection, face recognition, identity backfill, shared-space face matching, shared-space metadata backfill, person cleanup, or person thumbnail generation.
+- Test manually triggered jobs when users already have populated data: named people, hidden people, manual faces, EXIF faces, pet faces, linked libraries, shared spaces, merged identities, and pending jobs.
+- Pin destructive invariants so future queue changes cannot silently delete or corrupt user-managed people state.
+- Break the implementation into independent slices that can be assigned, reviewed, and merged separately.
+- Prefer deterministic service and medium database tests over real ML, real filesystem scans, or browser tests.
+- Keep each test focused on one behavior and one failure mode.
+
+## Non-Goals
+
+- Do not change queue behavior as part of this spec.
+- Do not add real ML inference tests.
+- Do not add slow full-stack UI tests for the queue graph.
+- Do not rework face clustering, identity merge rules, or shared-space access semantics.
+- Do not rely on production Redis state or real background workers for correctness assertions.
+
+## Current Coverage Snapshot
+
+The current suite already has substantial coverage:
+
+- Server small suite baseline passes with 4,388 tests and 9 skipped tests.
+- `person.service.spec.ts` covers detection queueing, force recognition reset ordering, per-face recognition branches, maintenance marker behavior, face identity backfill pagination, pending targets, and metadata fallback.
+- `shared-space.service.spec.ts` covers face-recognition toggle fan-out, asset-level face matching, identity-backed and legacy space person creation, pet faces, full-space paging, library face sync, dedup, and metadata inheritance.
+- `job.repository.spec.ts` covers stable job ids, facial-recognition force replacement, shared-space face-match job ids, and paused stable job replacement.
+- `queue.service.spec.ts` covers manual queue starts and nightly queueing.
+- Medium specs cover many real database identity, shared-space, RBAC, linked-library, and backfill invariants.
+
+The missing work is not "add first tests." The missing work is a deliberate matrix that proves all trigger paths compose safely and that destructive manual or forced reruns preserve the right data while intentionally removing only the right data.
+
+## Testing Approach
+
+Use three layers.
+
+### Layer 1: Service Contract Tests
+
+Use existing small service specs to assert queue decisions, branch behavior, and call ordering. These tests should not need Postgres, Redis, real ML, or real files.
+
+Examples:
+
+- `server/src/services/person.service.spec.ts`
+- `server/src/services/shared-space.service.spec.ts`
+- `server/src/services/job.service.spec.ts`
+- `server/src/services/queue.service.spec.ts`
+- `server/src/repositories/job.repository.spec.ts`
+- `server/src/services/asset.service.spec.ts`
+- `server/src/services/library.service.spec.ts`
+- `server/src/services/metadata.service.spec.ts`
+- `server/src/services/duplicate.service.spec.ts`
+- `server/src/services/pet-detection.service.spec.ts`
+
+### Layer 2: Medium Database Tests
+
+Use medium tests when correctness depends on SQL constraints, cascades, identity projection, statistics, visibility scope, or destructive writes. These tests should use real repositories and compact fixtures.
+
+Examples:
+
+- `server/test/medium/specs/services/person.service.spec.ts`
+- `server/test/medium/specs/services/people-identity-rbac.spec.ts`
+- `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+- `server/test/medium/specs/repositories/person.repository.spec.ts`
+- `server/test/medium/specs/repositories/shared-space-face-matching.spec.ts`
+
+### Layer 3: End-to-End Queue-Chain Simulations
+
+Add a small number of medium tests that invoke service handlers in queue order with mocked ML and mocked queue repository calls. These are not full worker tests. They prove that the final database state is correct after a realistic chain.
+
+Examples:
+
+- upload thumbnail completion queues face detection, then detection creates faces, then recognition assigns people, then shared-space matching materializes space people
+- force face recognition with populated personal and shared-space data clears only ML-derived state, rebuilds personal people, rebuilds shared-space projections, and leaves manual/EXIF data in the expected state
+- identity backfill repairs identities, queues targeted shared-space rematches, and metadata backfill runs only after projection state is safe
+
+## Destructive Invariants
+
+Every slice must include tests for these invariants where relevant.
+
+- Manual faces are never deleted by ML face detection refresh unless the explicit operation targets them.
+- EXIF/imported faces are not deleted by ML face detection refresh; matching ML detections may add embeddings to them.
+- Force face detection deletes only machine-learning faces before rerunning detection.
+- Force facial recognition unassigns machine-learning faces, unlinks machine-learning identity links, clears shared-space person state by design, and then rebuilds shared-space projections.
+- Nightly recognition skip must happen before any destructive reset.
+- Non-force recognition must not clear people, shared-space people, or identity links.
+- A queued job that runs after an asset, space, library link, member, or face has been removed must skip or repair idempotently.
+- Disabled shared-space face recognition must stop new shared-space matching work and must make already queued shared-space face jobs skip without mutation.
+- Stable job ids must dedupe pending duplicate work but must not block legitimate future work after completion.
+- Failed jobs that represent correctness work must remain visible unless there is a specific remove-on-fail design.
+- Identity merges must check personal-profile and space-profile conflicts before merging.
+- Shared-space metadata backfill must not publish stale inherited names or birth dates after membership removal, asset removal, person deletion, or identity detachment.
+- Person cleanup must not delete named people that still have faces through another source.
+- Orphan cleanup may delete faceless people and their thumbnails, and that deletion must queue metadata backfill when identity-scoped visibility can change.
+- Pet faces must not merge into human people, and human faces must not merge into pet people.
+
+## Trigger Matrix
+
+This matrix defines every trigger that should have explicit coverage.
+
+### Upload And Thumbnail Completion
+
+Source: `JobService.onDone(AssetGenerateThumbnails)`.
+
+Coverage:
+
+- upload image queues `SmartSearch`, `AssetDetectFaces`, `Ocr`, and `PetDetection`
+- upload video additionally queues `AssetEncodeVideo`
+- non-upload and non-notify thumbnail generation does not queue face detection
+- generated thumbnail for a missing asset logs and stops without face jobs
+- hidden or non-timeline upload notifications do not alter face queue decisions unexpectedly
+
+### Manual Asset Jobs
+
+Source: `AssetService.run`.
+
+Coverage:
+
+- `AssetJobName.REFRESH_FACES` queues one `AssetDetectFaces` per selected asset
+- multiple selected assets preserve per-asset queue data
+- access failure queues nothing
+- populated asset with manual, EXIF, and ML faces is covered by downstream detection tests
+
+### Admin Queue Starts
+
+Source: `QueueService.start`.
+
+Coverage:
+
+- starting `QueueName.FaceDetection` queues `AssetDetectFacesQueueAll` with `force=false`
+- starting `QueueName.FaceDetection` with `force=true` queues destructive forced detection
+- starting `QueueName.FacialRecognition` queues `FacialRecognitionQueueAll`
+- starting `QueueName.FacialRecognition` with `force=true` is allowed while one recognition job is active and replaces pending work
+- non-force recognition start while active is rejected
+- starting `QueueName.PeopleBackfill` queues `FaceIdentityBackfill`
+- starting unrelated queues does not enqueue face jobs
+- paused queues and failed job clearing do not silently lose stable face pipeline jobs
+
+### Nightly Jobs
+
+Source: `QueueService.handleNightlyJobs`.
+
+Coverage:
+
+- database cleanup queues `PersonCleanup`
+- missing thumbnails queues `AssetGenerateThumbnailsQueueAll`, which may later trigger face detection through thumbnail completion
+- cluster new faces queues `FacialRecognitionQueueAll` with `nightly=true` and `force=false`
+- nightly recognition skip with no new faces does not queue maintenance, backfill, or destructive reset work
+- disabled nightly switches do not enqueue corresponding face jobs
+
+### Manual Job Endpoint
+
+Source: `JobService.create`.
+
+Coverage:
+
+- manual `face-identity-backfill` queues `FaceIdentityBackfill`
+- manual `shared-space-person-metadata-backfill` queues `SharedSpacePersonMetadataBackfill`
+- manual `person-cleanup` queues `PersonCleanup`
+- invalid manual job queues nothing
+- manual retrigger while a stable backfill job is active or pending dedupes correctly
+
+### App Bootstrap
+
+Source: `PersonService.onBootstrap`.
+
+Coverage:
+
+- backfill work queues one root `FaceIdentityBackfill`
+- no backfill work queues nothing
+- active, waiting, delayed, or paused backfill job prevents duplicate root queueing
+- bootstrap does not start projection fan-out directly
+
+### Metadata Face Import
+
+Source: `MetadataService.applyTaggedFaces`.
+
+Coverage:
+
+- face import disabled skips face import
+- no `RegionInfo` or unnamed regions skip face creation
+- new names create people, create EXIF faces, link identities, and queue person thumbnails
+- existing names attach EXIF faces to existing people and identities
+- existing EXIF faces for the asset are removed before imported replacements are added
+- imported faces queue `SharedSpaceFaceMatchFromBackfill` for spaces containing the asset
+- imported faces on linked-library assets are covered by projection/backfill tests
+- malformed or rotated face regions use existing orientation tests and do not corrupt face boxes
+
+### Library Sync And Link
+
+Sources: `LibraryService.handleSyncFiles`, `SharedSpaceService.linkLibrary`, `SharedSpaceService.unlinkLibrary`, `SharedSpaceService.handleSharedSpaceLibraryFaceSync`.
+
+Coverage:
+
+- importing new library assets queues normal post-sync jobs and shared-space face matches for enabled linked spaces
+- no linked spaces queues no shared-space face work
+- disabled linked space queues no shared-space face work from library sync
+- linking a library to an enabled space queues `SharedSpaceLibraryFaceSync`
+- duplicate library link queues nothing
+- unlink removes linked-library person-face rows, deletes orphaned space people, and queues metadata backfill
+- queued library sync rechecks that the link still exists before every batch
+- library sync with no affected people still queues or skips dedup according to current behavior and has an explicit test
+
+### Shared Space Membership And Asset Changes
+
+Sources: `SharedSpaceService`.
+
+Coverage:
+
+- toggling face recognition from false to true queues `SharedSpaceFaceMatchAll`
+- toggling true to false queues no rebuild and makes queued face jobs skip
+- adding a member queues metadata backfill, full-space face match when enabled, and member-scoped identity reconciliation
+- removing a member queues metadata backfill and removes global accessibility for that member in medium tests
+- adding assets queues one `SharedSpaceFaceMatch` per asset when enabled
+- adding assets to a disabled space queues no face matches
+- bulk add queues one stable `SharedSpaceBulkAddAssets` job
+- bulk add handler queues `SharedSpaceFaceMatchAll` only when assets were added and face recognition is enabled
+- removing assets removes selected-space person-face rows, deletes orphaned space people, and queues metadata backfill
+- deleting a space queues metadata backfill and leaves no accessible stale space profiles
+
+### Duplicate Resolution
+
+Source: `DuplicateService.resolve`.
+
+Coverage:
+
+- keeper assets are added to editable spaces that contained trashed duplicate assets
+- shared-space face matches are queued for keepers in each editable space
+- no editable spaces queues no face matches
+- no keepers skips the space sync branch
+- `addAssets` failure prevents downstream destructive mutation
+- queue failure after keeper insertion is reported as failure and retry remains idempotent
+- disabled spaces are handled by the downstream shared-space face-match skip contract
+
+### Pet Detection
+
+Source: `PetDetectionService`.
+
+Coverage:
+
+- disabled pet detection skips
+- missing asset or preview fails safely
+- hidden asset skips
+- new pet species creates a pet person and pet face
+- existing species reuses the existing pet person
+- first pet face queues `PersonGenerateThumbnail`
+- pet faces can later project into shared spaces without human/pet type confusion
+- no pet face identities are required for legacy pet matching
+
+### Manual People And Face Operations
+
+Sources: `PersonService` and `SharedSpaceService`.
+
+Coverage:
+
+- creating a manual face links the face to the target identity and may queue thumbnail generation
+- deleting a face unlinks identity membership and respects soft versus force delete
+- reassigning faces links them to the target identity with manual source
+- reassigning a representative face queues thumbnail generation and updates identity representative face
+- updating person name or birth date queues scoped shared-space metadata backfill
+- deleting people queues file deletion and metadata backfill only when people existed
+- merging personal people reassigns faces, links target identity, removes source person, merges identities, and queues metadata backfill
+- merging scoped people enforces accessibility and scoped-profile conflict guards before merging identities
+- detaching scoped people enforces repairability before moving profile evidence
+- deleting shared-space people queues metadata backfill for identity-backed people
+- merging shared-space people reassigns faces, merges compatible identities, inherits metadata, recounts, queues dedup, and rejects cross-type merges
+- deduplicating shared-space people queues `SharedSpacePersonDedup` and requires owner access
+
+## Independent Implementation Slices
+
+Each slice below can be implemented independently. A slice should include its tests, focused verification command, and any minimal production fix revealed by the tests.
+
+### Slice 1: Trigger Contract Coverage
+
+Purpose: prove every trigger queues the expected face-related jobs and does not queue them when disabled or unauthorized.
+
+Primary files:
+
+- `server/src/services/job.service.spec.ts`
+- `server/src/services/queue.service.spec.ts`
+- `server/src/services/asset.service.spec.ts`
+- `server/src/services/library.service.spec.ts`
+- `server/src/services/metadata.service.spec.ts`
+- `server/src/services/duplicate.service.spec.ts`
+- `server/src/services/shared-space.service.spec.ts`
+- `server/src/services/pet-detection.service.spec.ts`
+
+Add tests for:
+
+- upload thumbnail completion and non-upload no-op
+- manual asset refresh faces with multiple assets
+- admin queue starts for face detection, facial recognition, and people backfill
+- nightly `PersonCleanup`, missing thumbnails, and cluster-new-faces trigger combinations
+- manual job endpoint for identity and metadata backfills
+- shared-space add member, add assets, bulk add, remove assets, delete space, link library, unlink library
+- duplicate keeper propagation and queue-failure retry behavior
+
+Completion criteria:
+
+- every trigger in the trigger matrix has at least one explicit test
+- access failure and disabled config paths queue nothing
+- tests assert exact job names and data
+
+### Slice 2: Face Detection Safety
+
+Purpose: pin `AssetDetectFacesQueueAll` and `AssetDetectFaces`, especially destructive refresh behavior.
+
+Primary files:
+
+- `server/src/services/person.service.spec.ts`
+- `server/test/medium/specs/services/person.service.spec.ts`
+- `server/test/medium/specs/repositories/person.repository.spec.ts`
+
+Add tests for:
+
+- `force=true`, `force=false`, and omitted `force`
+- force detection deletes only machine-learning faces and unlinks removed face identities
+- force detection preserves manual and EXIF faces
+- non-force detection does not delete people or shared-space people globally
+- missing asset, no preview, multiple preview files, hidden asset, and ML-disabled skips
+- no detected faces removes stale ML faces but not manual/EXIF faces
+- matching detection adds embeddings to existing EXIF/manual face instead of creating a duplicate
+- changed image dimensions and IOU matching preserve existing faces when boxes still overlap
+- job status `facesRecognizedAt` is written only for successful processed assets
+- new faces queue `FacialRecognitionQueueAll` plus per-face recognition when non-force
+- new faces queue only forced `FacialRecognitionQueueAll` when force detection created them
+
+Destructive medium tests:
+
+- populated user with named people, manual faces, EXIF faces, ML faces, and shared-space projections
+- force detection removes ML faces, leaves manual/EXIF faces and people expected to survive, deletes only orphaned people, and leaves identity projection repairable
+
+### Slice 3: Recognition Coordinator
+
+Purpose: pin `FacialRecognitionQueueAll` ordering, force replacement, nightly skip, and final maintenance behavior.
+
+Primary files:
+
+- `server/src/services/person.service.spec.ts`
+- `server/src/repositories/job.repository.spec.ts`
+- `server/src/services/queue.service.spec.ts`
+
+Add tests for:
+
+- waits for thumbnail and face detection queues before queueing recognition work
+- nightly skip happens before queue drain and before destructive reset
+- non-force run skips if recognition jobs are waiting
+- force run drains pending recognition work before deleting assignments
+- force run unassigns ML faces, unlinks ML identity links, cleans orphaned people, vacuums without vector reindex, clears shared-space person state, deletes unreferenced identities, queues per-face jobs with `skipSharedSpaceMatch`, queues `SharedSpaceFaceMatchAll`, queues maintenance marker, and writes last-run state
+- force run with enabled and disabled spaces queues rebuild only for enabled spaces
+- marker requeues itself while recognition jobs are waiting, delayed, paused, or active
+- marker queues `FaceIdentityBackfill` only when recognition is drained and no backfill is already active or pending
+- failed or paused stable jobs do not permanently block legitimate future coordinator work
+
+Destructive medium tests:
+
+- force recognition over populated data rebuilds ML assignments while preserving manual/EXIF identity evidence according to source semantics
+- running force recognition twice is idempotent and does not compound deletes or duplicate shared-space projections
+
+### Slice 4: Per-Face Recognition
+
+Purpose: pin `FacialRecognition` behavior for every face state.
+
+Primary files:
+
+- `server/src/services/person.service.spec.ts`
+- `server/test/medium/specs/services/person.service.spec.ts`
+- `server/test/medium/specs/services/people-identity-rbac.spec.ts`
+
+Add tests for:
+
+- missing face or missing asset fails safely
+- non-ML source skips
+- missing embedding fails
+- already assigned face repairs identity link and queues shared-space face matches unless `skipSharedSpaceMatch` is set
+- min-face threshold skips self-only matches
+- non-core faces defer once and preserve `skipSharedSpaceMatch`
+- deferred non-core face can still attach to an existing person when evidence exists
+- core face creates a new person, queues thumbnail generation, reassigns face, and links owner identity
+- existing person match reassigns without creating a new person
+- accessible shared identity match can merge identities only after conflict checks pass
+- same-owner and same-space conflicts prevent automatic identity merge
+- archive or hidden visibility does not create core people unexpectedly
+- spaces for the asset queue `SharedSpaceFaceMatch` exactly once per space for successful incremental recognition
+
+Destructive medium tests:
+
+- member private upload after joining a space merges with accessible shared evidence only when strict conflict guards pass
+- repeated recognition of already assigned faces does not create duplicate people or duplicate identity links
+
+### Slice 5: Shared-Space Projection Pipeline
+
+Purpose: pin `SharedSpaceFaceMatch`, `SharedSpaceFaceMatchFromBackfill`, `SharedSpaceLibraryFaceSync`, `SharedSpaceFaceMatchAll`, and `SharedSpaceFaceMatchPage`.
+
+Primary files:
+
+- `server/src/services/shared-space.service.spec.ts`
+- `server/src/repositories/job.repository.spec.ts`
+- `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- `server/test/medium/specs/repositories/shared-space-face-matching.spec.ts`
+
+Add tests for:
+
+- missing or disabled space skips without mutation
+- asset removed from space before job execution skips mutation but remains safe
+- identity-backed face attaches to existing compatible space person
+- identity-backed face creates a new compatible space person when none exists
+- identity-backed face does not merge into a nearby different identity just because embeddings are close
+- stale selected-space assignment is removed and replaced by the identity-correct person
+- exact assignment from backfill refreshes inherited metadata
+- legacy face with person but no identity uses legacy embedding path
+- face with no person waits and does not create a space person
+- pet face creates or reuses pet space person and never attaches to a human person
+- type-incompatible existing identity-backed space person causes skip or compatible repair, not cross-type assignment
+- affected people queue `SharedSpaceIdentityReconciliation`
+- successful asset match queues `SharedSpacePersonDedup`
+- from-backfill jobs run on `QueueName.PeopleBackfill`
+- all other shared-space face pipeline jobs remain on `QueueName.FacialRecognition`
+- full-space dispatcher queues only first page
+- pages use keyset lookahead, process exactly the page, and queue final dedup/reconciliation once
+- disabled space between pages stops the page chain without final follow-ups
+- library face sync rechecks link existence between batches and stops after unlink
+- library face sync creates one identity-backed space person across multiple linked libraries
+
+Destructive medium tests:
+
+- full-space rematch repairs missing, stale, and wrong-identity selected-space assignments without inflating counts
+- linked-library relink rebuilds identity-backed selected-space assignments
+- removing assets or unlinking libraries removes selected-space face rows and deletes orphaned space people
+- same asset direct plus linked-library path materializes only one selected-space face assignment
+
+### Slice 6: Identity Backfill And Metadata
+
+Purpose: pin `FaceIdentityBackfill`, `SharedSpaceFaceMatchFromBackfill`, and `SharedSpacePersonMetadataBackfill`.
+
+Primary files:
+
+- `server/src/services/person.service.spec.ts`
+- `server/src/services/shared-space.service.spec.ts`
+- `server/src/repositories/job.repository.spec.ts`
+- `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+- `server/test/medium/specs/services/people-identity-rbac.spec.ts`
+
+Add tests for:
+
+- personal identity page with cursor queues only next personal page
+- space-person identity page with cursor queues only next space-person page
+- identity work remaining after final pages requeues backfill without projection fan-out
+- projection work queues exact targeted `SharedSpaceFaceMatchFromBackfill` jobs
+- pending durable targets from earlier pages are retained until queueing succeeds
+- queueing failure does not delete pending targets
+- duplicate targets from repair and projection discovery dedupe to one job
+- no projection targets queues metadata backfill exactly once
+- metadata backfill pages by cursor and scope
+- metadata backfill inherits only from accessible and type-compatible candidates
+- same-priority metadata conflicts leave existing metadata unchanged
+- asset-adder metadata wins when priority is otherwise tied
+- manual names and birth dates keep their manual source unless explicitly changed
+
+Destructive medium tests:
+
+- legacy identities are hydrated across global people, space people, filters, search, map, and album scope after backfill
+- removing membership or disabling timeline prevents stale inherited metadata from surfacing in global people
+- detach and scoped merge operations update metadata visibility without leaking inaccessible profiles
+
+### Slice 7: Manual People Operations With Populated Data
+
+Purpose: test destructive user operations while realistic people data already exists.
+
+Primary files:
+
+- `server/src/services/person.service.spec.ts`
+- `server/src/services/shared-space.service.spec.ts`
+- `server/test/medium/specs/services/person.service.spec.ts`
+- `server/test/medium/specs/services/people-identity-rbac.spec.ts`
+
+Add tests for:
+
+- merge personal people where target has name and source has birth date
+- merge personal people where source has representative face and target does not
+- merge personal people with shared identity evidence and space metadata backfill
+- delete named person with manual, EXIF, and ML faces
+- delete faceless person and confirm thumbnail file deletion job
+- reassign faces from one named person to another and repair identity links
+- create manual face on edited asset and identity-link it
+- delete manual face and confirm identity unlink
+- update representative face and identity representative face
+- shared-space person merge with aliases, manual representative face, identity merge, and dedup follow-up
+- shared-space person delete with identity metadata backfill
+- scoped merge and detach with inaccessible backing profiles rejected before mutation
+
+Destructive medium tests:
+
+- personal and shared-space people remain separated when identities cannot safely merge
+- manual representative faces survive dedup and metadata backfill unless explicitly changed
+- deleting a source person after merge does not leave face identity links pointing at the deleted profile
+
+### Slice 8: Cross-Slice Queue-Chain Scenarios
+
+Purpose: prove independently tested slices compose safely.
+
+Primary files:
+
+- a new medium spec such as `server/test/medium/specs/services/face-queue-pipeline.spec.ts`
+- existing medium helper factories
+
+Add tests for:
+
+- upload-like chain: thumbnail completion, face detection, recognition, shared-space projection, dedup, metadata backfill
+- force detection followed by force recognition on a populated user and enabled shared space
+- metadata EXIF import followed by targeted shared-space backfill projection
+- library link followed by library face sync, identity reconciliation, dedup, and global people visibility
+- duplicate keeper propagation followed by shared-space face match and stats repair
+- member removal while queued reconciliation exists; queued job must not leak metadata after membership removal
+- space disabled while page rebuild is pending; queued page must skip mutation and not queue final follow-ups
+- failed projection job retry remains idempotent and does not create duplicate selected-space assignments
+
+Completion criteria:
+
+- every scenario asserts final database state, not only queued job calls
+- tests include populated data and at least one stale or already-existing row
+- tests assert no duplicate face assignments, no stale accessible profiles, and no unintended people deletes
+
+## Suggested Implementation Order
+
+1. Slice 1: trigger contract coverage. This gives a complete map and catches missing queue paths early.
+2. Slice 2: face detection safety. This covers the most direct destructive face-row mutations.
+3. Slice 3: recognition coordinator. This covers force reset ordering and pending job replacement.
+4. Slice 4: per-face recognition. This covers person creation, assignment, and identity merge safety.
+5. Slice 5: shared-space projection. This covers space data integrity and linked-library behavior.
+6. Slice 6: identity backfill and metadata. This covers repair, fan-out, and inherited metadata.
+7. Slice 7: manual people operations. This covers user-initiated destructive operations over populated state.
+8. Slice 8: cross-slice queue-chain scenarios. This is last because it relies on the contracts from the earlier slices.
+
+The slices are independent enough to implement in parallel if each worker owns a distinct spec file or test group. Medium tests that share fixtures should coordinate on helper changes to avoid conflicts.
+
+## Fixture Requirements
+
+Use compact, explicit fixtures. Each destructive medium test should state which rows are expected to survive.
+
+Canonical populated fixture:
+
+```text
+owner user U1
+member user U2
+space S, faceRecognitionEnabled = true
+optional disabled space S2
+library L1 linked to S
+library L2 linked to S
+asset A1 owned by U1 in timeline
+asset A2 owned by U1 archived
+asset A3 hidden or offline
+ML face F1 on A1 with embedding and identity I1
+EXIF face F2 on A1 assigned to named person P2
+manual face F3 on A1 assigned to named person P3
+pet face F4 on A1 assigned to pet person P4
+shared_space_person SP1 for I1
+stale shared_space_person SP_STALE for wrong or missing identity
+selected-space face rows including one correct row and one stale row
+pending or failed stable queue jobs when queue behavior is under test
+```
+
+Assertions should include:
+
+- `asset_face` rows by `sourceType`
+- `face_identity_face` rows by identity and source
+- `person.identityId`, `person.faceAssetId`, and `person.thumbnailPath`
+- `shared_space_person.identityId`, type, hidden state, representative face, and face count
+- `shared_space_person_face` uniqueness by `(spaceId, assetFaceId)`
+- global people statistics, space people statistics, and detailed face statistics when visibility can change
+- queued job names, data, stable ids, and remove-on-complete or remove-on-fail behavior where relevant
+
+## Verification Commands
+
+For doc-only changes:
+
+```bash
+git diff --check
+rg -n "T[B]D|TO[D]O|FIX[M]E|place[ ]holder|\\?\\?\\?" docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md
+```
+
+For Slice 1:
+
+```bash
+pnpm --filter immich test -- --run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts
+```
+
+For Slices 2 through 7, run the targeted small spec first, then the adjacent medium spec if database state is touched.
+
+For Slice 8:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/face-queue-pipeline.spec.ts
+```
+
+Before merging any slice:
+
+```bash
+pnpm --filter immich check
+pnpm --filter immich test -- --run <targeted-small-specs>
+pnpm --filter immich test:medium -- --run <targeted-medium-specs>
+```
+
+## Review Checklist
+
+- Every trigger in the trigger matrix is assigned to a slice.
+- Every destructive invariant has at least one slice that can test it.
+- Every slice has a clear primary file ownership boundary.
+- Medium tests are reserved for database behavior and destructive-state assertions.
+- Service tests cover queue contracts and call ordering.
+- No slice requires real ML inference, real Redis workers, or browser automation.
+- Cross-slice scenarios are last and depend on earlier contracts rather than duplicating them.

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1437,6 +1437,7 @@ describe(AssetService.name, () => {
         sut.run(authStub.admin, { assetIds: ['asset-1'], name: AssetJobName.REFRESH_FACES }),
       ).rejects.toBeInstanceOf(BadRequestException);
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
@@ -1451,15 +1452,13 @@ describe(AssetService.name, () => {
       ]);
     });
 
-    it('should only enqueue asset face detection for manual face refresh on populated assets', async () => {
-      const existingAsset = AssetFactory.from().face().build({ id: 'asset-1' });
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([existingAsset.id]));
+    it('should only enqueue the requested asset face detection job for manual face refresh', async () => {
+      const assetId = 'asset-1';
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
 
-      await sut.run(authStub.admin, { assetIds: [existingAsset.id], name: AssetJobName.REFRESH_FACES });
+      await sut.run(authStub.admin, { assetIds: [assetId], name: AssetJobName.REFRESH_FACES });
 
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        { name: JobName.AssetDetectFaces, data: { id: existingAsset.id } },
-      ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetDetectFaces, data: { id: assetId } }]);
       const queuedJobNames = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs.map((job) => job.name));
       expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(queuedJobNames).not.toContain(JobName.AssetDetectFacesQueueAll);

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1458,7 +1458,8 @@ describe(AssetService.name, () => {
 
       await sut.run(authStub.admin, { assetIds: [assetId], name: AssetJobName.REFRESH_FACES });
 
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.AssetDetectFaces, data: { id: assetId } }]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll.mock.calls[0][0]).toEqual([{ name: JobName.AssetDetectFaces, data: { id: assetId } }]);
       const queuedJobNames = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs.map((job) => job.name));
       expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(queuedJobNames).not.toContain(JobName.AssetDetectFacesQueueAll);

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1450,6 +1450,26 @@ describe(AssetService.name, () => {
         { name: JobName.AssetDetectFaces, data: { id: 'asset-2' } },
       ]);
     });
+
+    it('should only enqueue asset face detection for manual face refresh on populated assets', async () => {
+      const existingAsset = AssetFactory.from().face().build({ id: 'asset-1' });
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([existingAsset.id]));
+
+      await sut.run(authStub.admin, { assetIds: [existingAsset.id], name: AssetJobName.REFRESH_FACES });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetDetectFaces, data: { id: existingAsset.id } },
+      ]);
+      const queuedJobNames = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs.map((job) => job.name));
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(queuedJobNames).not.toContain(JobName.AssetDetectFacesQueueAll);
+      expect(queuedJobNames).not.toContain(JobName.FacialRecognitionQueueAll);
+      expect(queuedJobNames).not.toContain(JobName.FaceIdentityBackfill);
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+      expect(mocks.person.delete).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
+    });
   });
 
   describe('upsertMetadata', () => {

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1446,10 +1446,21 @@ describe(AssetService.name, () => {
 
       await sut.run(authStub.admin, { assetIds: ['asset-1', 'asset-2'], name: AssetJobName.REFRESH_FACES });
 
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll.mock.calls[0][0]).toEqual([
         { name: JobName.AssetDetectFaces, data: { id: 'asset-1' } },
         { name: JobName.AssetDetectFaces, data: { id: 'asset-2' } },
       ]);
+      const queuedJobNames = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs.map((job) => job.name));
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(queuedJobNames).not.toContain(JobName.AssetDetectFacesQueueAll);
+      expect(queuedJobNames).not.toContain(JobName.FacialRecognitionQueueAll);
+      expect(queuedJobNames).not.toContain(JobName.FaceIdentityBackfill);
+      expect(queuedJobNames).not.toContain(JobName.PersonCleanup);
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+      expect(mocks.person.delete).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
     });
 
     it('should only enqueue the requested asset face detection job for manual face refresh', async () => {

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -483,7 +483,23 @@ describe(DuplicateService.name, () => {
           .flat()
           .flat()
           .filter((j: any) => j?.name === JobName.SharedSpaceFaceMatch);
-        expect(queuedFaceJobs).toHaveLength(2);
+        expect(queuedFaceJobs).toEqual([
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceY, assetId: asset1.id } },
+        ]);
+        expect(mocks.job.queueAll).toHaveBeenCalledWith([
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceY, assetId: asset1.id } },
+        ]);
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+            expect.objectContaining({ name: JobName.AssetDetectFaces }),
+            expect.objectContaining({ name: JobName.FacialRecognition }),
+          ]),
+        );
       });
 
       it('skips the space sync branch entirely when there are no keepers', async () => {
@@ -578,6 +594,8 @@ describe(DuplicateService.name, () => {
         expect(mocks.album.addAssetIdsToAlbums).not.toHaveBeenCalled();
         expect(mocks.tag.replaceAssetTags).not.toHaveBeenCalled();
         expect(mocks.asset.updateAllExif).not.toHaveBeenCalled();
+        expect(mocks.job.queueAll).not.toHaveBeenCalled();
+        expect(mocks.event.emit).not.toHaveBeenCalled();
 
         // The trash step must NOT have run.
         const trashCalls = mocks.asset.updateAll.mock.calls.filter(

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -27,6 +27,24 @@ const hasDupe = {
   duplicateId: 'duplicate-id',
 };
 
+const globalFaceJobNames = [
+  JobName.AssetDetectFacesQueueAll,
+  JobName.FacialRecognitionQueueAll,
+  JobName.FaceIdentityBackfill,
+];
+
+const destructiveFaceJobNames = [...globalFaceJobNames, JobName.AssetDetectFaces, JobName.FacialRecognition];
+
+const getQueuedJobNames = (mocks: ServiceMocks) =>
+  mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs).map((job) => job.name);
+
+const expectNoQueuedJobNames = (mocks: ServiceMocks, names: JobName[]) => {
+  const queuedJobNames = getQueuedJobNames(mocks);
+  for (const name of names) {
+    expect(queuedJobNames).not.toContain(name);
+  }
+};
+
 describe(DuplicateService.name, () => {
   let sut: DuplicateService;
   let mocks: ServiceMocks;
@@ -416,13 +434,7 @@ describe(DuplicateService.name, () => {
         expect(queuedJobs).toEqual([
           { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
         ]);
-        expect(queuedJobs).not.toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          ]),
-        );
+        expectNoQueuedJobNames(mocks, globalFaceJobNames);
       });
 
       it('does not call addAssets when the user has no editable spaces containing the group', async () => {
@@ -445,13 +457,7 @@ describe(DuplicateService.name, () => {
         expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
           expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
         );
-        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-          expect.arrayContaining([
-            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          ]),
-        );
+        expectNoQueuedJobNames(mocks, globalFaceJobNames);
       });
 
       it('adds keeper to multiple editable spaces', async () => {
@@ -491,15 +497,7 @@ describe(DuplicateService.name, () => {
           { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
           { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceY, assetId: asset1.id } },
         ]);
-        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-          expect.arrayContaining([
-            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-            expect.objectContaining({ name: JobName.AssetDetectFaces }),
-            expect.objectContaining({ name: JobName.FacialRecognition }),
-          ]),
-        );
+        expectNoQueuedJobNames(mocks, destructiveFaceJobNames);
       });
 
       it('skips the space sync branch entirely when there are no keepers', async () => {
@@ -518,13 +516,7 @@ describe(DuplicateService.name, () => {
         expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
           expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
         );
-        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-          expect.arrayContaining([
-            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          ]),
-        );
+        expectNoQueuedJobNames(mocks, globalFaceJobNames);
       });
 
       it('reports queue failure after keeper insertion so retry can queue face matches idempotently', async () => {
@@ -564,13 +556,7 @@ describe(DuplicateService.name, () => {
           { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
           { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
         ]);
-        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-          expect.arrayContaining([
-            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          ]),
-        );
+        expectNoQueuedJobNames(mocks, globalFaceJobNames);
       });
 
       it('reports failure cleanly if addAssets throws, and NO downstream mutation runs', async () => {

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -411,6 +411,18 @@ describe(DuplicateService.name, () => {
             { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
           ]),
         );
+
+        const queuedJobs = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+        expect(queuedJobs).toEqual([
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
+        ]);
+        expect(queuedJobs).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          ]),
+        );
       });
 
       it('does not call addAssets when the user has no editable spaces containing the group', async () => {
@@ -430,6 +442,16 @@ describe(DuplicateService.name, () => {
           .flat()
           .filter((j: any) => j?.name === JobName.SharedSpaceFaceMatch);
         expect(faceMatchCalls).toHaveLength(0);
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+        );
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          ]),
+        );
       });
 
       it('adds keeper to multiple editable spaces', async () => {
@@ -477,6 +499,62 @@ describe(DuplicateService.name, () => {
         expect(result[0].success).toBe(true);
         expect(mocks.sharedSpace.getEditableByAssetIds).not.toHaveBeenCalled();
         expect(mocks.sharedSpace.addAssets).not.toHaveBeenCalled();
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+        );
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          ]),
+        );
+      });
+
+      it('reports queue failure after keeper insertion so retry can queue face matches idempotently', async () => {
+        const asset1 = AssetFactory.create();
+        const asset2 = AssetFactory.create();
+        setupBaseDuplicate(asset1, asset2);
+        mocks.sharedSpace.getEditableByAssetIds.mockResolvedValue(new Set([spaceX]));
+        mocks.sharedSpace.addAssets.mockResolvedValue([]);
+        mocks.job.queueAll.mockRejectedValueOnce(new Error('queue unavailable')).mockResolvedValue(undefined as any);
+
+        const first = await sut.resolve(authStub.admin, {
+          groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id], trashAssetIds: [asset2.id] }],
+        });
+
+        expect(first[0].success).toBe(false);
+        expect(first[0].error).toBe(BulkIdErrorReason.UNKNOWN);
+        expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+          { spaceId: spaceX, assetId: asset1.id, addedById: authStub.admin.user.id },
+        ]);
+
+        const second = await sut.resolve(authStub.admin, {
+          groups: [{ duplicateId: 'group-1', keepAssetIds: [asset1.id], trashAssetIds: [asset2.id] }],
+        });
+
+        expect(second[0].success).toBe(true);
+        expect(mocks.sharedSpace.addAssets).toHaveBeenCalledTimes(2);
+        expect(mocks.job.queueAll).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
+          ]),
+        );
+
+        const faceMatchCalls = mocks.job.queueAll.mock.calls
+          .flatMap(([jobs]) => jobs)
+          .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+        expect(faceMatchCalls).toEqual([
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
+          { name: JobName.SharedSpaceFaceMatch, data: { spaceId: spaceX, assetId: asset1.id } },
+        ]);
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+            expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+            expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          ]),
+        );
       });
 
       it('reports failure cleanly if addAssets throws, and NO downstream mutation runs', async () => {

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -1,13 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import {
-  AssetType,
-  AssetVisibility,
-  ImmichWorker,
-  JobName,
-  JobStatus,
-  ManualJobName,
-  QueueName,
-} from 'src/enum';
+import { AssetType, AssetVisibility, ImmichWorker, JobName, JobStatus, ManualJobName, QueueName } from 'src/enum';
 import { JobService } from 'src/services/job.service';
 import { JobItem } from 'src/types';
 import { AssetFactory } from 'test/factories/asset.factory';

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -6,11 +6,9 @@ import {
   JobName,
   JobStatus,
   ManualJobName,
-  QueueCommand,
   QueueName,
 } from 'src/enum';
 import { JobService } from 'src/services/job.service';
-import { QueueService } from 'src/services/queue.service';
 import { JobItem } from 'src/types';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { factory, newUuid } from 'test/small.factory';
@@ -70,7 +68,7 @@ describe(JobService.name, () => {
     });
 
     it('should queue a FaceIdentityBackfill job', async () => {
-      await sut.create({ name: 'face-identity-backfill' as ManualJobName });
+      await sut.create({ name: ManualJobName.FaceIdentityBackfill });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
@@ -78,7 +76,7 @@ describe(JobService.name, () => {
     });
 
     it('should queue a SharedSpacePersonMetadataBackfill job', async () => {
-      await sut.create({ name: 'shared-space-person-metadata-backfill' as ManualJobName });
+      await sut.create({ name: ManualJobName.SharedSpacePersonMetadataBackfill });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonMetadataBackfill, data: {} });
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
@@ -90,77 +88,6 @@ describe(JobService.name, () => {
 
       expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('manual face identity queue routes', () => {
-    let queueSut: QueueService;
-
-    beforeEach(() => {
-      ({ sut: queueSut, mocks } = newTestService(QueueService));
-
-      mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
-      mocks.job.isActive.mockResolvedValue(false);
-      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
-      mocks.job.isPaused.mockResolvedValue(false);
-    });
-
-    it.each([
-      {
-        queue: QueueName.FaceDetection,
-        force: false,
-        expected: { name: JobName.AssetDetectFacesQueueAll, data: { force: false } },
-      },
-      {
-        queue: QueueName.FaceDetection,
-        force: true,
-        expected: { name: JobName.AssetDetectFacesQueueAll, data: { force: true } },
-      },
-      {
-        queue: QueueName.FacialRecognition,
-        force: false,
-        expected: { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
-      },
-      {
-        queue: QueueName.FacialRecognition,
-        force: true,
-        expected: { name: JobName.FacialRecognitionQueueAll, data: { force: true } },
-      },
-      {
-        queue: QueueName.PeopleBackfill,
-        force: false,
-        expected: { name: JobName.FaceIdentityBackfill, data: {} },
-      },
-    ])('queues $expected.name for manual $queue start with force=$force', async ({ queue, force, expected }) => {
-      await queueSut.runCommandLegacy(queue, { command: QueueCommand.Start, force });
-
-      expect(mocks.job.queue).toHaveBeenCalledWith(expected);
-      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queueAll).not.toHaveBeenCalled();
-    });
-
-    it.each([
-      {
-        queue: QueueName.FaceDetection,
-        force: true,
-        unrelated: [JobName.FacialRecognitionQueueAll, JobName.FaceIdentityBackfill],
-      },
-      {
-        queue: QueueName.FacialRecognition,
-        force: true,
-        unrelated: [JobName.AssetDetectFacesQueueAll, JobName.FaceIdentityBackfill],
-      },
-      {
-        queue: QueueName.PeopleBackfill,
-        force: false,
-        unrelated: [JobName.AssetDetectFacesQueueAll, JobName.FacialRecognitionQueueAll],
-      },
-    ])('does not enqueue unrelated face identity roots for manual $queue starts', async ({ queue, force, unrelated }) => {
-      await queueSut.runCommandLegacy(queue, { command: QueueCommand.Start, force });
-
-      for (const name of unrelated) {
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name }));
-      }
     });
   });
 

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -1,6 +1,16 @@
 import { BadRequestException } from '@nestjs/common';
-import { AssetType, AssetVisibility, ImmichWorker, JobName, JobStatus, ManualJobName, QueueName } from 'src/enum';
+import {
+  AssetType,
+  AssetVisibility,
+  ImmichWorker,
+  JobName,
+  JobStatus,
+  ManualJobName,
+  QueueCommand,
+  QueueName,
+} from 'src/enum';
 import { JobService } from 'src/services/job.service';
+import { QueueService } from 'src/services/queue.service';
 import { JobItem } from 'src/types';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { factory, newUuid } from 'test/small.factory';
@@ -71,6 +81,77 @@ describe(JobService.name, () => {
 
     it('should throw BadRequestException for an invalid job name', async () => {
       await expect(sut.create({ name: 'invalid-job' as ManualJobName })).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('manual face identity queue routes', () => {
+    let queueSut: QueueService;
+
+    beforeEach(() => {
+      ({ sut: queueSut, mocks } = newTestService(QueueService));
+
+      mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+      mocks.job.isActive.mockResolvedValue(false);
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.job.isPaused.mockResolvedValue(false);
+    });
+
+    it.each([
+      {
+        queue: QueueName.FaceDetection,
+        force: false,
+        expected: { name: JobName.AssetDetectFacesQueueAll, data: { force: false } },
+      },
+      {
+        queue: QueueName.FaceDetection,
+        force: true,
+        expected: { name: JobName.AssetDetectFacesQueueAll, data: { force: true } },
+      },
+      {
+        queue: QueueName.FacialRecognition,
+        force: false,
+        expected: { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+      },
+      {
+        queue: QueueName.FacialRecognition,
+        force: true,
+        expected: { name: JobName.FacialRecognitionQueueAll, data: { force: true } },
+      },
+      {
+        queue: QueueName.PeopleBackfill,
+        force: false,
+        expected: { name: JobName.FaceIdentityBackfill, data: {} },
+      },
+    ])('queues $expected.name for manual $queue start with force=$force', async ({ queue, force, expected }) => {
+      await queueSut.runCommandLegacy(queue, { command: QueueCommand.Start, force });
+
+      expect(mocks.job.queue).toHaveBeenCalledWith(expected);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        queue: QueueName.FaceDetection,
+        force: true,
+        unrelated: [JobName.FacialRecognitionQueueAll, JobName.FaceIdentityBackfill],
+      },
+      {
+        queue: QueueName.FacialRecognition,
+        force: true,
+        unrelated: [JobName.AssetDetectFacesQueueAll, JobName.FaceIdentityBackfill],
+      },
+      {
+        queue: QueueName.PeopleBackfill,
+        force: false,
+        unrelated: [JobName.AssetDetectFacesQueueAll, JobName.FacialRecognitionQueueAll],
+      },
+    ])('does not enqueue unrelated face identity roots for manual $queue starts', async ({ queue, force, unrelated }) => {
+      await queueSut.runCommandLegacy(queue, { command: QueueCommand.Start, force });
+
+      for (const name of unrelated) {
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name }));
+      }
     });
   });
 

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -41,6 +41,8 @@ describe(JobService.name, () => {
       await sut.create({ name: ManualJobName.PersonCleanup });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.PersonCleanup });
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should queue a UserDeleteCheck job', async () => {
@@ -71,16 +73,23 @@ describe(JobService.name, () => {
       await sut.create({ name: 'face-identity-backfill' as ManualJobName });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should queue a SharedSpacePersonMetadataBackfill job', async () => {
       await sut.create({ name: 'shared-space-person-metadata-backfill' as ManualJobName });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonMetadataBackfill, data: {} });
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should throw BadRequestException for an invalid job name', async () => {
       await expect(sut.create({ name: 'invalid-job' as ManualJobName })).rejects.toThrow(BadRequestException);
+
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
   });
 
@@ -544,6 +553,20 @@ describe(JobService.name, () => {
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
+    it('should not queue jobs for generated thumbnails without upload or notify markers', async () => {
+      mocks.job.run.mockResolvedValue(JobStatus.Success);
+      const id = newUuid();
+
+      await sut.onJobRun(QueueName.ThumbnailGeneration, {
+        name: JobName.AssetGenerateThumbnails,
+        data: { id },
+      });
+
+      expect(mocks.asset.getByIdsWithAllRelationsButStacks).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
     it('should proceed when notify is true even without source upload', async () => {
       mocks.job.run.mockResolvedValue(JobStatus.Success);
       const id = newUuid();
@@ -649,7 +672,7 @@ describe(JobService.name, () => {
       expect(mocks.websocket.clientSend).toHaveBeenCalledWith('on_upload_success', ownerId, expect.anything());
     });
 
-    it('should not send websocket events for Hidden visibility assets', async () => {
+    it('should queue upload follow-up jobs for hidden assets while suppressing notifications', async () => {
       mocks.job.run.mockResolvedValue(JobStatus.Success);
       const id = newUuid();
       const ownerId = newUuid();
@@ -661,6 +684,13 @@ describe(JobService.name, () => {
         data: { id, source: 'upload' },
       });
 
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SmartSearch, data: { id, source: 'upload' } },
+        { name: JobName.AssetDetectFaces, data: { id, source: 'upload' } },
+        { name: JobName.Ocr, data: { id, source: 'upload' } },
+        { name: JobName.PetDetection, data: { id, source: 'upload' } },
+      ]);
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.websocket.clientSend).not.toHaveBeenCalled();
     });
 

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -772,30 +772,28 @@ describe(LibraryService.name, () => {
       it('should not queue face match jobs when library is not linked to any space', async () => {
         const libraryId = newUuid();
         const library = factory.library({ id: libraryId });
+        const assetId = newUuid();
 
         mocks.library.get.mockResolvedValue(library);
-        mocks.asset.createAll.mockResolvedValue([newUuid()]);
+        mocks.asset.createAll.mockResolvedValue([assetId]);
         mocks.sharedSpace.getSpacesLinkedToLibrary.mockResolvedValue([]);
 
         await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
 
+        expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
         expect(mocks.job.queueAll).toHaveBeenCalledWith([
-          { name: JobName.SidecarCheck, data: { id: expect.any(String), source: 'upload' } },
+          { name: JobName.SidecarCheck, data: { id: assetId, source: 'upload' } },
         ]);
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
-        );
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
-        );
+        expect(mocks.job.queue).not.toHaveBeenCalled();
       });
 
       it('should not queue face match jobs when linked space has face recognition disabled', async () => {
         const libraryId = newUuid();
         const library = factory.library({ id: libraryId });
+        const assetId = newUuid();
 
         mocks.library.get.mockResolvedValue(library);
-        mocks.asset.createAll.mockResolvedValue([newUuid()]);
+        mocks.asset.createAll.mockResolvedValue([assetId]);
         mocks.sharedSpace.getSpacesLinkedToLibrary.mockResolvedValue([
           {
             spaceId: newUuid(),
@@ -811,15 +809,38 @@ describe(LibraryService.name, () => {
 
         await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
 
+        expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
         expect(mocks.job.queueAll).toHaveBeenCalledWith([
-          { name: JobName.SidecarCheck, data: { id: expect.any(String), source: 'upload' } },
+          { name: JobName.SidecarCheck, data: { id: assetId, source: 'upload' } },
         ]);
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
-        );
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
-        );
+        expect(mocks.job.queue).not.toHaveBeenCalled();
+      });
+
+      it('should not queue face match jobs when linked library import has no new assets', async () => {
+        const libraryId = newUuid();
+        const spaceId = newUuid();
+        const library = factory.library({ id: libraryId });
+
+        mocks.library.get.mockResolvedValue(library);
+        mocks.asset.createAll.mockResolvedValue([]);
+        mocks.sharedSpace.getSpacesLinkedToLibrary.mockResolvedValue([
+          {
+            spaceId,
+            libraryId,
+            addedById: null,
+            createdAt: newDate(),
+            updatedAt: newDate(),
+            createId: newUuid(),
+            updateId: newUuid(),
+            faceRecognitionEnabled: true,
+          },
+        ]);
+
+        await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
+
+        expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+        expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
+        expect(mocks.job.queue).not.toHaveBeenCalled();
       });
     });
   });
@@ -1423,6 +1444,7 @@ describe(LibraryService.name, () => {
         name: JobName.LibrarySyncAssetsQueueAll,
         data: { id: library.id },
       });
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -63,6 +63,33 @@ describe(LibraryService.name, () => {
       });
     });
 
+    it('should schedule library scan cron to queue only the library scan root', async () => {
+      mocks.cron.create.mockResolvedValue();
+      mocks.job.queue.mockResolvedValue(undefined as any);
+
+      await sut.onConfigInit({ newConfig: defaults });
+
+      expect(mocks.cron.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: CronJob.LibraryScan,
+          expression: defaults.library.scan.cronExpression,
+          start: defaults.library.scan.enabled,
+          onTick: expect.any(Function),
+        }),
+      );
+
+      const onTick = mocks.cron.create.mock.calls[0][0].onTick;
+      onTick();
+
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.LibraryScanQueueAll });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
     it('should initialize watcher for all external libraries', async () => {
       const library1 = factory.library({ importPaths: ['/foo', '/bar'] });
       const library2 = factory.library({ importPaths: ['/xyz', '/asdf'] });
@@ -661,6 +688,43 @@ describe(LibraryService.name, () => {
         });
       });
 
+      it('should queue sidecar refresh and targeted space face match for imported linked-library assets', async () => {
+        const libraryId = newUuid();
+        const spaceId = newUuid();
+        const library = factory.library({ id: libraryId });
+        const assetId = newUuid();
+
+        mocks.library.get.mockResolvedValue(library);
+        mocks.asset.createAll.mockResolvedValue([assetId]);
+        mocks.sharedSpace.getSpacesLinkedToLibrary.mockResolvedValue([
+          {
+            spaceId,
+            libraryId,
+            addedById: null,
+            createdAt: newDate(),
+            updatedAt: newDate(),
+            createId: newUuid(),
+            updateId: newUuid(),
+            faceRecognitionEnabled: true,
+          },
+        ]);
+
+        await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
+
+        expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+        expect(mocks.job.queueAll).toHaveBeenCalledWith([
+          { name: JobName.SidecarCheck, data: { id: assetId, source: 'upload' } },
+        ]);
+        expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+        expect(mocks.job.queue).toHaveBeenCalledWith({
+          name: JobName.SharedSpaceFaceMatch,
+          data: { spaceId, assetId },
+        });
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+        );
+      });
+
       it('should queue jobs for multiple spaces if library is linked to more than one', async () => {
         const libraryId = newUuid();
         const space1 = newUuid();
@@ -715,8 +779,14 @@ describe(LibraryService.name, () => {
 
         await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
 
+        expect(mocks.job.queueAll).toHaveBeenCalledWith([
+          { name: JobName.SidecarCheck, data: { id: expect.any(String), source: 'upload' } },
+        ]);
         expect(mocks.job.queue).not.toHaveBeenCalledWith(
           expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
         );
       });
 
@@ -741,8 +811,14 @@ describe(LibraryService.name, () => {
 
         await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
 
+        expect(mocks.job.queueAll).toHaveBeenCalledWith([
+          { name: JobName.SidecarCheck, data: { id: expect.any(String), source: 'upload' } },
+        ]);
         expect(mocks.job.queue).not.toHaveBeenCalledWith(
           expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
         );
       });
     });
@@ -1365,6 +1441,34 @@ describe(LibraryService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.LibrarySyncFilesQueueAll, data: { id: library.id } },
       ]);
+    });
+
+    it('should queue library sync roots without direct face identity work', async () => {
+      const library = factory.library();
+
+      mocks.library.getAll.mockResolvedValue([library]);
+
+      await expect(sut.handleQueueScanAll()).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.LibraryDeleteCheck,
+        data: {},
+      });
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(2);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.LibrarySyncFilesQueueAll, data: { id: library.id } },
+      ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.LibrarySyncAssetsQueueAll, data: { id: library.id } },
+      ]);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+      );
     });
   });
 

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -850,7 +850,9 @@ describe(LibraryService.name, () => {
         expect(mocks.job.queue).not.toHaveBeenCalledWith(
           expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
         );
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+        );
         expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
           expect.arrayContaining([expect.objectContaining({ name: JobName.SidecarCheck })]),
         );

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -838,9 +838,34 @@ describe(LibraryService.name, () => {
 
         await sut.handleSyncFiles({ libraryId, paths: ['/photos/test.jpg'], progressCounter: 1, totalAssets: 1 });
 
-        expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
-        expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
-        expect(mocks.job.queue).not.toHaveBeenCalled();
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.SidecarCheck })]),
+        );
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),
+        );
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll })]),
+        );
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.FacialRecognitionQueueAll })]),
+        );
+        expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ name: JobName.FaceIdentityBackfill })]),
+        );
       });
     });
   });

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -85,11 +85,21 @@ describe(MetadataService.name, () => {
   });
 
   const expectNoGlobalFaceIdentityRootJobs = () => {
-    const queuedJobs = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs ?? []);
+    const globalFaceIdentityRoots = [
+      JobName.AssetDetectFacesQueueAll,
+      JobName.FacialRecognitionQueueAll,
+      JobName.FaceIdentityBackfill,
+      JobName.SharedSpaceFaceMatchAll,
+      JobName.SharedSpacePersonMetadataBackfill,
+    ];
+    const queuedJobs = [
+      ...mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs ?? []),
+      ...mocks.job.queue.mock.calls.map(([job]) => job),
+    ];
 
-    expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
-    expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
-    expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
+    for (const name of globalFaceIdentityRoots) {
+      expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name }));
+    }
   };
 
   afterEach(async () => {
@@ -197,6 +207,9 @@ describe(MetadataService.name, () => {
       expect(mocks.asset.upsertExif).not.toHaveBeenCalled();
       expect(mocks.asset.update).not.toHaveBeenCalled();
       expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
@@ -1377,7 +1390,9 @@ describe(MetadataService.name, () => {
       await sut.handleMetadataExtraction({ id: asset.id });
       expect(mocks.person.getDistinctNames).not.toHaveBeenCalled();
       expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
       expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
@@ -1389,7 +1404,9 @@ describe(MetadataService.name, () => {
       await sut.handleMetadataExtraction({ id: asset.id });
       expect(mocks.person.getDistinctNames).not.toHaveBeenCalled();
       expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
       expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
@@ -1405,7 +1422,9 @@ describe(MetadataService.name, () => {
       expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
       expect(mocks.person.updateAll).not.toHaveBeenCalled();
       expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
       expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
@@ -1421,7 +1440,9 @@ describe(MetadataService.name, () => {
       expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
       expect(mocks.person.updateAll).not.toHaveBeenCalled();
       expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
       expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
@@ -1572,7 +1593,10 @@ describe(MetadataService.name, () => {
     });
 
     it('should remove existing exif faces before adding new ones', async () => {
-      const asset = AssetFactory.from().face({ id: 'face-1', sourceType: SourceType.Exif }).build();
+      const asset = AssetFactory.from()
+        .face({ id: 'face-1', sourceType: SourceType.Exif })
+        .face({ id: 'face-2', sourceType: SourceType.MachineLearning })
+        .build();
       const person = PersonFactory.create();
 
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(asset as any);
@@ -1584,6 +1608,7 @@ describe(MetadataService.name, () => {
       await sut.handleMetadataExtraction({ id: asset.id });
 
       expect(mocks.person.refreshFaces).toHaveBeenCalledWith(expect.any(Array), ['face-1']);
+      expect(mocks.person.refreshFaces).not.toHaveBeenCalledWith(expect.any(Array), expect.arrayContaining(['face-2']));
       expectNoGlobalFaceIdentityRootJobs();
     });
 

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -84,6 +84,14 @@ describe(MetadataService.name, () => {
     delete process.env.TZ;
   });
 
+  const expectNoGlobalFaceIdentityRootJobs = () => {
+    const queuedJobs = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs ?? []);
+
+    expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
+    expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
+    expect(queuedJobs).not.toContainEqual(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
+  };
+
   afterEach(async () => {
     await sut.onShutdown();
   });
@@ -188,6 +196,8 @@ describe(MetadataService.name, () => {
       expect(mocks.assetJob.getForMetadataExtraction).toHaveBeenCalledWith('non-existent');
       expect(mocks.asset.upsertExif).not.toHaveBeenCalled();
       expect(mocks.asset.update).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should handle a date in a sidecar file', async () => {
@@ -1366,6 +1376,9 @@ describe(MetadataService.name, () => {
       mockReadTags(makeFaceTags({ Name: 'Person 1' }));
       await sut.handleMetadataExtraction({ id: asset.id });
       expect(mocks.person.getDistinctNames).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should skip importing metadata face for assets without tags.RegionInfo', async () => {
@@ -1375,6 +1388,9 @@ describe(MetadataService.name, () => {
       mockReadTags();
       await sut.handleMetadataExtraction({ id: asset.id });
       expect(mocks.person.getDistinctNames).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should skip importing faces without name', async () => {
@@ -1388,6 +1404,9 @@ describe(MetadataService.name, () => {
       expect(mocks.person.createAll).not.toHaveBeenCalled();
       expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
       expect(mocks.person.updateAll).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should skip importing faces with empty name', async () => {
@@ -1401,6 +1420,9 @@ describe(MetadataService.name, () => {
       expect(mocks.person.createAll).not.toHaveBeenCalled();
       expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
       expect(mocks.person.updateAll).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should apply metadata face tags creating new people', async () => {
@@ -1443,6 +1465,8 @@ describe(MetadataService.name, () => {
           data: { id: person.id },
         },
       ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expectNoGlobalFaceIdentityRootJobs();
     });
 
     it('should link imported metadata faces to identity-backed people', async () => {
@@ -1464,6 +1488,7 @@ describe(MetadataService.name, () => {
         identityId: 'identity-1',
         source: 'import',
       });
+      expectNoGlobalFaceIdentityRootJobs();
     });
 
     it('should queue shared-space matching for imported metadata faces', async () => {
@@ -1487,6 +1512,63 @@ describe(MetadataService.name, () => {
           data: { spaceId: 'space-1', assetId: asset.id },
         },
       ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(2);
+      expectNoGlobalFaceIdentityRootJobs();
+    });
+
+    it('should not queue shared-space matching for imported metadata faces when the asset is in no spaces', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
+      mockReadTags(makeFaceTags({ Name: person.name }));
+      mocks.person.getDistinctNames.mockResolvedValue([]);
+      mocks.person.createAll.mockResolvedValue([person.id]);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([]);
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).toHaveBeenCalledWith(asset.id);
+      expect(mocks.job.queueAll).toHaveBeenCalledExactlyOnceWith([
+        {
+          name: JobName.PersonGenerateThumbnail,
+          data: { id: person.id },
+        },
+      ]);
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill })]),
+      );
+      expectNoGlobalFaceIdentityRootJobs();
+    });
+
+    it('should queue one backfill face match per space for imported metadata faces', async () => {
+      const asset = AssetFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mocks.systemMetadata.get.mockResolvedValue({ metadata: { faces: { import: true } } });
+      mockReadTags(makeFaceTags({ Name: person.name }));
+      mocks.person.getDistinctNames.mockResolvedValue([]);
+      mocks.person.createAll.mockResolvedValue([person.id]);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }, { spaceId: 'space-2' }]);
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.job.queueAll).toHaveBeenNthCalledWith(1, [
+        {
+          name: JobName.PersonGenerateThumbnail,
+          data: { id: person.id },
+        },
+      ]);
+      expect(mocks.job.queueAll).toHaveBeenNthCalledWith(2, [
+        { name: JobName.SharedSpaceFaceMatchFromBackfill, data: { spaceId: 'space-1', assetId: asset.id } },
+        { name: JobName.SharedSpaceFaceMatchFromBackfill, data: { spaceId: 'space-2', assetId: asset.id } },
+      ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(2);
+      expectNoGlobalFaceIdentityRootJobs();
     });
 
     it('should remove existing exif faces before adding new ones', async () => {
@@ -1502,6 +1584,7 @@ describe(MetadataService.name, () => {
       await sut.handleMetadataExtraction({ id: asset.id });
 
       expect(mocks.person.refreshFaces).toHaveBeenCalledWith(expect.any(Array), ['face-1']);
+      expectNoGlobalFaceIdentityRootJobs();
     });
 
     it('should assign metadata face tags to existing persons', async () => {
@@ -1536,7 +1619,14 @@ describe(MetadataService.name, () => {
         [],
       );
       expect(mocks.person.updateAll).not.toHaveBeenCalled();
-      expect(mocks.job.queueAll).not.toHaveBeenCalledWith();
+      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(person.id);
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: 'random-uuid',
+        identityId: 'identity-1',
+        source: 'import',
+      });
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expectNoGlobalFaceIdentityRootJobs();
     });
 
     describe('handleFaceTagOrientation', () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -11,6 +11,7 @@ import {
   JobName,
   JobStatus,
   MetadataKey,
+  QueueJobStatus,
   QueueName,
   SourceType,
   SystemMetadataKey,
@@ -87,11 +88,19 @@ describe(PersonService.name, () => {
 
       await sut.onBootstrap();
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FaceIdentityBackfill,
         data: {},
       });
-      expect(mocks.job.searchJobs).toHaveBeenCalledWith('peopleBackfill', expect.any(Object));
+      expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, expect.any(Object));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill }),
+      );
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should skip identity backfill when no identity work remains', async () => {
@@ -100,6 +109,8 @@ describe(PersonService.name, () => {
       await sut.onBootstrap();
 
       expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.job.searchJobs).not.toHaveBeenCalled();
     });
 
     it('should not queue a new identity backfill root while another backfill page is pending', async () => {
@@ -115,6 +126,25 @@ describe(PersonService.name, () => {
 
       await sut.onBootstrap();
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
+
+    it('should not queue a duplicate identity backfill root while any backfill job is active, waiting, delayed, or paused', async () => {
+      (mocks.faceIdentity as any).hasBackfillWork.mockResolvedValue(true);
+      mocks.job.searchJobs.mockResolvedValue([
+        {
+          id: 'face-identity-backfill/root',
+          name: JobName.FaceIdentityBackfill,
+          timestamp: Date.now(),
+          data: {},
+        },
+      ]);
+
+      await sut.onBootstrap();
+
+      expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
+        status: [QueueJobStatus.Active, QueueJobStatus.Delayed, QueueJobStatus.Paused, QueueJobStatus.Waiting],
+      });
       expect(mocks.job.queue).not.toHaveBeenCalled();
     });
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -129,25 +129,6 @@ describe(PersonService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalled();
     });
 
-    it('should not queue a duplicate identity backfill root while any backfill job is active, waiting, delayed, or paused', async () => {
-      (mocks.faceIdentity as any).hasBackfillWork.mockResolvedValue(true);
-      mocks.job.searchJobs.mockResolvedValue([
-        {
-          id: 'face-identity-backfill/root',
-          name: JobName.FaceIdentityBackfill,
-          timestamp: Date.now(),
-          data: {},
-        },
-      ]);
-
-      await sut.onBootstrap();
-
-      expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
-        status: [QueueJobStatus.Active, QueueJobStatus.Delayed, QueueJobStatus.Paused, QueueJobStatus.Waiting],
-      });
-      expect(mocks.job.queue).not.toHaveBeenCalled();
-    });
-
     it('should not queue a new identity backfill root while the root backfill is active', async () => {
       (mocks.faceIdentity as any).hasBackfillWork.mockResolvedValue(true);
       mocks.job.searchJobs.mockResolvedValue([
@@ -161,6 +142,15 @@ describe(PersonService.name, () => {
 
       await sut.onBootstrap();
 
+      expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
+        status: expect.arrayContaining([
+          QueueJobStatus.Active,
+          QueueJobStatus.Delayed,
+          QueueJobStatus.Paused,
+          QueueJobStatus.Waiting,
+        ]),
+      });
+      expect(mocks.job.searchJobs.mock.calls[0][1]?.status).toHaveLength(4);
       expect(mocks.job.queue).not.toHaveBeenCalled();
     });
   });

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -94,9 +94,15 @@ describe(PersonService.name, () => {
         data: {},
       });
       expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, expect.any(Object));
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }));
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchFromBackfill }),
       );

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -130,12 +130,16 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handlePetDetection({ id: '123' })).toEqual(JobStatus.Skipped);
 
       expect(mocks.machineLearning.detectPets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
     it('should skip if pet detection is disabled (default)', async () => {
       expect(await sut.handlePetDetection({ id: '123' })).toEqual(JobStatus.Skipped);
 
       expect(mocks.machineLearning.detectPets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
     it('should fail if asset not found', async () => {
@@ -145,6 +149,8 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handlePetDetection({ id: 'non-existent' })).toEqual(JobStatus.Failed);
 
       expect(mocks.machineLearning.detectPets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
     it('should fail if asset has no preview file', async () => {
@@ -158,6 +164,8 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handlePetDetection({ id: '123' })).toEqual(JobStatus.Failed);
 
       expect(mocks.machineLearning.detectPets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
     it('should skip hidden assets', async () => {
@@ -171,6 +179,8 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handlePetDetection({ id: '123' })).toEqual(JobStatus.Skipped);
 
       expect(mocks.machineLearning.detectPets).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
     it('should create new pet person when none exists for species', async () => {
@@ -239,6 +249,38 @@ describe(PetDetectionService.name, () => {
       expect(mocks.person.update).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
       expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should generate the first thumbnail for an existing pet species without a face asset', async () => {
+      const asset = AssetFactory.create();
+      mocks.systemMetadata.get.mockResolvedValue(enabledConfig);
+      mocks.machineLearning.detectPets.mockResolvedValue({
+        imageHeight: 100,
+        imageWidth: 200,
+        pets: [{ boundingBox: { x1: 10, y1: 20, x2: 30, y2: 40 }, score: 0.9, label: 'cat' }],
+      });
+      mocks.person.getByOwnerAndSpecies.mockResolvedValue(makePerson({ id: 'existing-cat', faceAssetId: null }));
+      mocks.person.createAssetFace.mockResolvedValue('new-face-id');
+      mocks.person.getById.mockResolvedValue(makePerson({ id: 'existing-cat', faceAssetId: null }));
+      mocks.person.update.mockResolvedValue({} as any);
+
+      expect(await sut.handlePetDetection({ id: asset.id })).toEqual(JobStatus.Success);
+
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.createAssetFace).toHaveBeenCalledWith(expect.objectContaining({ personId: 'existing-cat' }));
+      expect(mocks.person.update).toHaveBeenCalledWith({ id: 'existing-cat', faceAssetId: 'new-face-id' });
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.PersonGenerateThumbnail, data: { id: 'existing-cat' } },
+      ]);
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        ]),
+      );
     });
 
     it('should reuse same person for multiple detections of same species in one photo', async () => {

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -23,6 +23,23 @@ const makePerson = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const petFaceIsolationJobNames = [
+  JobName.AssetDetectFacesQueueAll,
+  JobName.FacialRecognitionQueueAll,
+  JobName.FaceIdentityBackfill,
+  JobName.SharedSpaceFaceMatch,
+];
+
+const getQueuedJobNames = (mocks: ServiceMocks) =>
+  mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs).map((job) => job.name);
+
+const expectNoQueuedJobNames = (mocks: ServiceMocks, names: JobName[]) => {
+  const queuedJobNames = getQueuedJobNames(mocks);
+  for (const name of names) {
+    expect(queuedJobNames).not.toContain(name);
+  }
+};
+
 describe(PetDetectionService.name, () => {
   let sut: PetDetectionService;
   let mocks: ServiceMocks;
@@ -71,14 +88,7 @@ describe(PetDetectionService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.PetDetection, data: { id: asset.id } }]);
       expect(mocks.assetJob.streamForPetDetectionJob).toHaveBeenCalledWith(false);
-      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
-        ]),
-      );
+      expectNoQueuedJobNames(mocks, petFaceIsolationJobNames);
     });
 
     it('should pass force flag when queuing assets', async () => {
@@ -105,14 +115,7 @@ describe(PetDetectionService.name, () => {
       expect(mocks.assetJob.streamForPetDetectionJob).toHaveBeenCalledWith(true);
       expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.PetDetection, data: { id: asset.id } }]);
-      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
-        ]),
-      );
+      expectNoQueuedJobNames(mocks, petFaceIsolationJobNames);
     });
   });
 
@@ -220,14 +223,7 @@ describe(PetDetectionService.name, () => {
         { name: JobName.PersonGenerateThumbnail, data: { id: 'person-id' } },
       ]);
       expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
-        ]),
-      );
+      expectNoQueuedJobNames(mocks, petFaceIsolationJobNames);
     });
 
     it('should reuse existing pet person for same species', async () => {
@@ -273,14 +269,7 @@ describe(PetDetectionService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.PersonGenerateThumbnail, data: { id: 'existing-cat' } },
       ]);
-      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
-          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
-        ]),
-      );
+      expectNoQueuedJobNames(mocks, petFaceIsolationJobNames);
     });
 
     it('should reuse same person for multiple detections of same species in one photo', async () => {

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -388,6 +388,9 @@ describe(PetDetectionService.name, () => {
 
         expect(mocks.person.create).not.toHaveBeenCalled();
         expect(mocks.person.createAssetFace).not.toHaveBeenCalled();
+        expect(mocks.job.queueAll).not.toHaveBeenCalled();
+        expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+        expect(mocks.event.emit).not.toHaveBeenCalled();
       });
 
       it('should handle out of memory errors during inference', async () => {
@@ -398,6 +401,9 @@ describe(PetDetectionService.name, () => {
         expect(await sut.handlePetDetection({ id: asset.id })).toEqual(JobStatus.Failed);
 
         expect(mocks.person.create).not.toHaveBeenCalled();
+        expect(mocks.job.queueAll).not.toHaveBeenCalled();
+        expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+        expect(mocks.event.emit).not.toHaveBeenCalled();
       });
 
       it('should handle model loading timeout errors', async () => {
@@ -406,6 +412,10 @@ describe(PetDetectionService.name, () => {
         mocks.machineLearning.detectPets.mockRejectedValue(new Error('model load timeout'));
 
         expect(await sut.handlePetDetection({ id: asset.id })).toEqual(JobStatus.Failed);
+
+        expect(mocks.job.queueAll).not.toHaveBeenCalled();
+        expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+        expect(mocks.event.emit).not.toHaveBeenCalled();
       });
     });
   });

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -53,6 +53,13 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Skipped);
     });
 
+    it('should not queue pet jobs when pet detection is disabled', async () => {
+      expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Skipped);
+
+      expect(mocks.assetJob.streamForPetDetectionJob).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
     it('should queue assets for pet detection', async () => {
       const asset = AssetFactory.create();
       mocks.systemMetadata.get.mockResolvedValue({
@@ -64,6 +71,14 @@ describe(PetDetectionService.name, () => {
 
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.PetDetection, data: { id: asset.id } }]);
       expect(mocks.assetJob.streamForPetDetectionJob).toHaveBeenCalledWith(false);
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        ]),
+      );
     });
 
     it('should pass force flag when queuing assets', async () => {
@@ -76,6 +91,28 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handleQueuePetDetection({ force: true })).toEqual(JobStatus.Success);
 
       expect(mocks.assetJob.streamForPetDetectionJob).toHaveBeenCalledWith(true);
+    });
+
+    it('should queue pet detection jobs with force asset selection when force is true', async () => {
+      const asset = AssetFactory.create();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { enabled: true, petDetection: { enabled: true } },
+      });
+      mocks.assetJob.streamForPetDetectionJob.mockReturnValue(makeStream([asset]));
+
+      expect(await sut.handleQueuePetDetection({ force: true })).toEqual(JobStatus.Success);
+
+      expect(mocks.assetJob.streamForPetDetectionJob).toHaveBeenCalledWith(true);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.PetDetection, data: { id: asset.id } }]);
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        ]),
+      );
     });
   });
 
@@ -172,6 +209,15 @@ describe(PetDetectionService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.PersonGenerateThumbnail, data: { id: 'person-id' } },
       ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+          expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+          expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        ]),
+      );
     });
 
     it('should reuse existing pet person for same species', async () => {
@@ -192,6 +238,7 @@ describe(PetDetectionService.name, () => {
       expect(mocks.person.createAssetFace).toHaveBeenCalledWith(expect.objectContaining({ personId: 'existing-cat' }));
       expect(mocks.person.update).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
     });
 
     it('should reuse same person for multiple detections of same species in one photo', async () => {
@@ -283,6 +330,7 @@ describe(PetDetectionService.name, () => {
       expect(mocks.person.create).not.toHaveBeenCalled();
       expect(mocks.person.createAssetFace).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).toHaveBeenCalledWith([]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith(
         expect.objectContaining({ assetId: asset.id, petsDetectedAt: expect.any(Date) }),
       );

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -692,6 +692,7 @@ describe(QueueService.name, () => {
 
       expect(mocks.job.queue).toHaveBeenCalledWith(expected);
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -645,6 +645,21 @@ describe(QueueService.name, () => {
     });
 
     it.each([
+      { queue: QueueName.FaceDetection, force: true },
+      { queue: QueueName.PeopleBackfill, force: false },
+    ])('still rejects active destructive face-root starts for $queue with force=$force', async ({ queue, force }) => {
+      mocks.job.isActive.mockResolvedValue(true);
+
+      await expect(sut.runCommandLegacy(queue, { command: QueueCommand.Start, force })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+
+      expect(mocks.job.empty).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
+    it.each([
       {
         queue: QueueName.FaceDetection,
         force: false,

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -338,8 +338,13 @@ describe(QueueService.name, () => {
         name: JobName.FacialRecognitionQueueAll,
         data: { force: false, nightly: true },
       });
-      expect(jobs).not.toContainEqual({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
-      expect(jobs).not.toContainEqual({ name: JobName.AssetDetectFacesQueueAll, data: expect.anything() });
+      expect(jobs).not.toContainEqual(
+        expect.objectContaining({
+          name: JobName.FacialRecognitionQueueAll,
+          data: expect.objectContaining({ force: true }),
+        }),
+      );
+      expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
     });
 
     it('should keep missing thumbnails from directly queueing face detection or recognition roots', async () => {
@@ -360,8 +365,8 @@ describe(QueueService.name, () => {
         { name: JobName.AssetGenerateThumbnailsQueueAll, data: { force: false } },
       ]);
       const jobs = mocks.job.queueAll.mock.calls[0][0];
-      expect(jobs).not.toContainEqual({ name: JobName.AssetDetectFacesQueueAll, data: expect.anything() });
-      expect(jobs).not.toContainEqual({ name: JobName.FacialRecognitionQueueAll, data: expect.anything() });
+      expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
+      expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
     });
 
     it.each([
@@ -682,14 +687,13 @@ describe(QueueService.name, () => {
       await runStartCommand(queue, false);
 
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.AssetDetectFacesQueueAll,
-        data: expect.anything(),
-      });
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.FacialRecognitionQueueAll,
-        data: expect.anything(),
-      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
     });
 
     it('should handle a start video conversion command', async () => {

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -330,6 +330,64 @@ describe(QueueService.name, () => {
       ]);
     });
 
+    it('should queue nightly facial recognition without forcing recognition or face detection', async () => {
+      await sut.handleNightlyJobs();
+
+      const jobs = mocks.job.queueAll.mock.calls[0][0];
+      expect(jobs).toContainEqual({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: false, nightly: true },
+      });
+      expect(jobs).not.toContainEqual({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+      expect(jobs).not.toContainEqual({ name: JobName.AssetDetectFacesQueueAll, data: expect.anything() });
+    });
+
+    it('should keep missing thumbnails from directly queueing face detection or recognition roots', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({
+        nightlyTasks: {
+          startTime: '00:00',
+          databaseCleanup: false,
+          generateMemories: false,
+          syncQuotaUsage: false,
+          missingThumbnails: true,
+          clusterNewFaces: false,
+        },
+      });
+
+      await sut.handleNightlyJobs();
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetGenerateThumbnailsQueueAll, data: { force: false } },
+      ]);
+      const jobs = mocks.job.queueAll.mock.calls[0][0];
+      expect(jobs).not.toContainEqual({ name: JobName.AssetDetectFacesQueueAll, data: expect.anything() });
+      expect(jobs).not.toContainEqual({ name: JobName.FacialRecognitionQueueAll, data: expect.anything() });
+    });
+
+    it.each([
+      { databaseCleanup: true, expected: 'queues' },
+      { databaseCleanup: false, expected: 'skips' },
+    ])(
+      'should explicitly $expected nightly person cleanup when database cleanup is $databaseCleanup',
+      async ({ databaseCleanup }) => {
+        mocks.systemMetadata.get.mockResolvedValue({
+          nightlyTasks: {
+            ...defaults.nightlyTasks,
+            databaseCleanup,
+          },
+        });
+
+        await sut.handleNightlyJobs();
+
+        const jobs = mocks.job.queueAll.mock.calls[0][0];
+        if (databaseCleanup) {
+          expect(jobs).toContainEqual({ name: JobName.PersonCleanup });
+        } else {
+          expect(jobs).not.toContainEqual({ name: JobName.PersonCleanup });
+        }
+      },
+    );
+
     it('should skip database cleanup when disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue({
         nightlyTasks: {
@@ -482,6 +540,13 @@ describe(QueueService.name, () => {
   });
 
   describe('handleCommand', () => {
+    const runStartCommand = async (name: QueueName, force = false) => {
+      mocks.job.isActive.mockResolvedValue(false);
+      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+
+      await sut.runCommandLegacy(name, { command: QueueCommand.Start, force });
+    };
+
     it('should handle a pause command', async () => {
       mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
 
@@ -572,6 +637,59 @@ describe(QueueService.name, () => {
 
       expect(mocks.job.empty).not.toHaveBeenCalled();
       expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        queue: QueueName.FaceDetection,
+        force: false,
+        expected: { name: JobName.AssetDetectFacesQueueAll, data: { force: false } },
+      },
+      {
+        queue: QueueName.FaceDetection,
+        force: true,
+        expected: { name: JobName.AssetDetectFacesQueueAll, data: { force: true } },
+      },
+      {
+        queue: QueueName.FacialRecognition,
+        force: false,
+        expected: { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+      },
+      {
+        queue: QueueName.FacialRecognition,
+        force: true,
+        expected: { name: JobName.FacialRecognitionQueueAll, data: { force: true } },
+      },
+      {
+        queue: QueueName.PeopleBackfill,
+        force: false,
+        expected: { name: JobName.FaceIdentityBackfill, data: {} },
+      },
+    ])('should queue face identity root for $queue with force=$force', async ({ queue, force, expected }) => {
+      await runStartCommand(queue, force);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith(expected);
+    });
+
+    it.each([
+      QueueName.VideoConversion,
+      QueueName.SmartSearch,
+      QueueName.MetadataExtraction,
+      QueueName.Sidecar,
+      QueueName.ThumbnailGeneration,
+      QueueName.Library,
+    ])('should not enqueue face roots when starting %s', async (queue) => {
+      await runStartCommand(queue, false);
+
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.AssetDetectFacesQueueAll,
+        data: expect.anything(),
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: expect.anything(),
+      });
     });
 
     it('should handle a start video conversion command', async () => {
@@ -704,7 +822,7 @@ describe(QueueService.name, () => {
       mocks.job.isActive.mockResolvedValue(false);
       mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
 
-      await sut.runCommandLegacy('peopleBackfill' as QueueName, { command: QueueCommand.Start, force: false });
+      await sut.runCommandLegacy(QueueName.PeopleBackfill, { command: QueueCommand.Start, force: false });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
     });

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -344,6 +344,7 @@ describe(QueueService.name, () => {
           data: expect.objectContaining({ force: true }),
         }),
       );
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
     });
 
@@ -364,6 +365,7 @@ describe(QueueService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.AssetGenerateThumbnailsQueueAll, data: { force: false } },
       ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       const jobs = mocks.job.queueAll.mock.calls[0][0];
       expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }));
       expect(jobs).not.toContainEqual(expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }));
@@ -689,6 +691,7 @@ describe(QueueService.name, () => {
       await runStartCommand(queue, force);
 
       expect(mocks.job.queue).toHaveBeenCalledWith(expected);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
     });
 
     it.each([

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -1589,7 +1589,7 @@ describe(SharedSpaceService.name, () => {
       await sut.addMember(auth, spaceId, { userId });
 
       expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: 'SharedSpaceIdentityReconciliation',
+        name: JobName.SharedSpaceIdentityReconciliation,
         data: { spaceId, userId },
       });
     });
@@ -2102,7 +2102,10 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId1, assetId2]));
-      mocks.sharedSpace.addAssets.mockResolvedValue([]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([
+        { spaceId, assetId: assetId1, addedById: auth.user.id },
+        { spaceId, assetId: assetId2, addedById: auth.user.id },
+      ] as any);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -30,6 +30,7 @@ const sharedSpaceFaceIdentityJobNames = new Set<JobName>([
   JobName.AssetDetectFacesQueueAll,
   JobName.FaceIdentityBackfill,
   JobName.FacialRecognitionQueueAll,
+  JobName.PersonCleanup,
   JobName.SharedSpaceFaceMatchAll,
   JobName.SharedSpaceIdentityReconciliation,
   JobName.SharedSpacePersonMetadataBackfill,
@@ -2273,7 +2274,7 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
-      mocks.sharedSpace.addAssets.mockResolvedValue([]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([{ spaceId, assetId, addedById: auth.user.id }] as any);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
@@ -2284,6 +2285,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
       );
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
   });
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -26,6 +26,13 @@ import { ImmichFileResponse, ImmichStreamResponse } from 'src/utils/file';
 import { factory, newDate, newUuid } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
 
+const sharedSpaceFaceIdentityJobNames = new Set<JobName>([
+  JobName.FaceIdentityBackfill,
+  JobName.SharedSpaceFaceMatchAll,
+  JobName.SharedSpaceIdentityReconciliation,
+  JobName.SharedSpacePersonMetadataBackfill,
+]);
+
 /** Helper to build a joined member result (member + user fields from the repo join). */
 const makeMemberResult = (overrides: any = {}) => ({
   ...factory.sharedSpaceMember(),
@@ -1274,6 +1281,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.update(auth, space.id, { faceRecognitionEnabled: true });
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpaceFaceMatchAll,
         data: { spaceId: space.id },
@@ -1292,6 +1300,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.update(auth, space.id, { faceRecognitionEnabled: false });
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
       );
@@ -1309,6 +1318,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.update(auth, space.id, { faceRecognitionEnabled: true });
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
       );
@@ -1367,6 +1377,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.remove(auth, spaceId);
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
@@ -1598,6 +1609,28 @@ describe(SharedSpaceService.name, () => {
         name: JobName.SharedSpaceFaceMatchAll,
         data: { spaceId },
       });
+      expect(queuedJobs).toContainEqual({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
+      });
+      expect(queuedJobs).toContainEqual({
+        name: JobName.SharedSpaceIdentityReconciliation,
+        data: { spaceId, userId },
+      });
+      expect(queuedJobs.filter((job) => sharedSpaceFaceIdentityJobNames.has(job.name))).toEqual([
+        {
+          name: JobName.SharedSpacePersonMetadataBackfill,
+          data: {},
+        },
+        {
+          name: JobName.SharedSpaceFaceMatchAll,
+          data: { spaceId },
+        },
+        {
+          name: JobName.SharedSpaceIdentityReconciliation,
+          data: { spaceId, userId },
+        },
+      ]);
     });
 
     it('should not queue space face materialization when face recognition is disabled', async () => {
@@ -1617,9 +1650,23 @@ describe(SharedSpaceService.name, () => {
       const queuedJobs = mocks.job.queue.mock.calls.map(([job]) => job);
       expect(queuedJobs.some((job) => job.name === JobName.SharedSpaceFaceMatchAll)).toBe(false);
       expect(queuedJobs).toContainEqual({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
+      });
+      expect(queuedJobs).toContainEqual({
         name: JobName.SharedSpaceIdentityReconciliation,
         data: { spaceId, userId },
       });
+      expect(queuedJobs.filter((job) => sharedSpaceFaceIdentityJobNames.has(job.name))).toEqual([
+        {
+          name: JobName.SharedSpacePersonMetadataBackfill,
+          data: {},
+        },
+        {
+          name: JobName.SharedSpaceIdentityReconciliation,
+          data: { spaceId, userId },
+        },
+      ]);
     });
   });
 
@@ -2003,10 +2050,14 @@ describe(SharedSpaceService.name, () => {
 
       await sut.removeMember(auth, 'space-1', 'user-1');
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
     });
 
     it('should queue metadata backfill when an owner removes a member', async () => {
@@ -2019,10 +2070,14 @@ describe(SharedSpaceService.name, () => {
 
       await sut.removeMember(auth, 'space-1', 'other-user');
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
     });
   });
 
@@ -2208,6 +2263,9 @@ describe(SharedSpaceService.name, () => {
       await sut.addAssets(auth, spaceId, { assetIds: [assetId] });
 
       expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
+      );
     });
   });
 
@@ -2461,6 +2519,8 @@ describe(SharedSpaceService.name, () => {
 
       await sut.removeAssets(auth, spaceId, { assetIds: [assetId] });
 
+      expect(mocks.sharedSpace.removePersonFacesByAssetIds).toHaveBeenCalledWith(spaceId, [assetId]);
+      expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
@@ -6922,6 +6982,7 @@ describe(SharedSpaceService.name, () => {
 
       await expect(sut.linkLibrary(auth, space.id, { libraryId: library.id })).resolves.not.toThrow();
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceLibraryFaceSync }),
       );
@@ -6997,6 +7058,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.linkLibrary(auth, space.id, { libraryId: library.id });
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpaceLibraryFaceSync,
         data: { spaceId: space.id, libraryId: library.id },
@@ -7022,6 +7084,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.linkLibrary(auth, space.id, { libraryId: library.id });
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceLibraryFaceSync }),
       );
@@ -7162,6 +7225,7 @@ describe(SharedSpaceService.name, () => {
         expect(mocks.sharedSpace.removeLibrary).toHaveBeenCalledWith(spaceId, libraryId);
         expect(mocks.sharedSpace.removePersonFacesByLibrary).toHaveBeenCalledWith(spaceId, libraryId);
         expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
+        expect(mocks.job.queue).toHaveBeenCalledTimes(1);
         expect(mocks.job.queue).toHaveBeenCalledWith({
           name: JobName.SharedSpacePersonMetadataBackfill,
           data: {},
@@ -8450,6 +8514,9 @@ describe(SharedSpaceService.name, () => {
 
       expect(mocks.sharedSpace.logActivity).not.toHaveBeenCalled();
       expect(mocks.sharedSpace.update).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
     });
 
     it('should NOT send notification when count is 0', async () => {
@@ -8492,6 +8559,7 @@ describe(SharedSpaceService.name, () => {
 
       await sut.handleSharedSpaceBulkAddAssets({ spaceId, userId });
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpaceFaceMatchAll,
         data: { spaceId },

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2246,7 +2246,10 @@ describe(SharedSpaceService.name, () => {
 
       mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId1, assetId2]));
-      mocks.sharedSpace.addAssets.mockResolvedValue([]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([
+        { spaceId, assetId: assetId1, addedById: auth.user.id },
+        { spaceId, assetId: assetId2, addedById: auth.user.id },
+      ] as any);
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.update.mockResolvedValue(space);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -27,11 +27,21 @@ import { factory, newDate, newUuid } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
 
 const sharedSpaceFaceIdentityJobNames = new Set<JobName>([
+  JobName.AssetDetectFacesQueueAll,
   JobName.FaceIdentityBackfill,
+  JobName.FacialRecognitionQueueAll,
   JobName.SharedSpaceFaceMatchAll,
   JobName.SharedSpaceIdentityReconciliation,
   JobName.SharedSpacePersonMetadataBackfill,
 ]);
+
+const expectNoSharedSpaceFaceIdentityRootJobs = (mocks: ServiceMocks) => {
+  const queuedJobs = mocks.job.queue.mock.calls.map(([job]) => job);
+  const queuedBulkJobs = mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+
+  expect(queuedJobs.filter((job) => sharedSpaceFaceIdentityJobNames.has(job.name))).toEqual([]);
+  expect(queuedBulkJobs.filter((job) => sharedSpaceFaceIdentityJobNames.has(job.name))).toEqual([]);
+};
 
 /** Helper to build a joined member result (member + user fields from the repo join). */
 const makeMemberResult = (overrides: any = {}) => ({
@@ -2240,10 +2250,12 @@ describe(SharedSpaceService.name, () => {
 
       await sut.addAssets(auth, spaceId, { assetIds: [assetId1, assetId2] });
 
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: assetId1 } },
         { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: assetId2 } },
       ]);
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should not queue SharedSpaceFaceMatch jobs when faceRecognitionEnabled is false', async () => {
@@ -2521,10 +2533,23 @@ describe(SharedSpaceService.name, () => {
 
       expect(mocks.sharedSpace.removePersonFacesByAssetIds).toHaveBeenCalledWith(spaceId, [assetId]);
       expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+      );
     });
   });
 
@@ -5994,10 +6019,16 @@ describe(SharedSpaceService.name, () => {
           nameSourceProfileId: personId,
         }),
       );
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: { identityId: 'identity-1' },
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
+      });
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should update space-scoped birth date and mark it manual', async () => {
@@ -6052,10 +6083,16 @@ describe(SharedSpaceService.name, () => {
 
       await sut.updateSpacePerson(auth, spaceId, personId, { isHidden: true });
 
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: { identityId: 'identity-1' },
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
+      });
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should reject representativeFaceId that does not belong to an asset in the space', async () => {
@@ -6176,10 +6213,16 @@ describe(SharedSpaceService.name, () => {
       await sut.deleteSpacePerson(auth, spaceId, personId);
 
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith(personId);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: { identityId: 'identity-1' },
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: {},
+      });
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });
 
     it('should log activity when deleting a person', async () => {
@@ -8385,6 +8428,8 @@ describe(SharedSpaceService.name, () => {
 
       expect(result).toBe(JobStatus.Skipped);
       expect(mocks.sharedSpace.bulkAddUserAssets).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should skip when user has been demoted to viewer', async () => {
@@ -8398,6 +8443,8 @@ describe(SharedSpaceService.name, () => {
 
       expect(result).toBe(JobStatus.Skipped);
       expect(mocks.sharedSpace.bulkAddUserAssets).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should skip when space is deleted', async () => {
@@ -8412,6 +8459,8 @@ describe(SharedSpaceService.name, () => {
 
       expect(result).toBe(JobStatus.Skipped);
       expect(mocks.sharedSpace.bulkAddUserAssets).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should call bulkAddUserAssets with correct spaceId and userId', async () => {
@@ -8517,6 +8566,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
       );
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should NOT send notification when count is 0', async () => {
@@ -8593,6 +8643,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
       );
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should send websocket notification on completion', async () => {
@@ -8642,6 +8693,8 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.handleSharedSpaceBulkAddAssets({ spaceId, userId });
 
       expect(result).toBe(JobStatus.Failed);
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
 
     it('should return JobStatus.Success on happy path', async () => {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2549,9 +2549,7 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll }),
       );
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.FaceIdentityBackfill }),
-      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.AssetDetectFacesQueueAll }),
       );


### PR DESCRIPTION
## Summary
- add the committed face identity queue trigger testing spec and implementation plan
- cover scheduled, manual, library, metadata, shared-space, duplicate, pet, and bootstrap trigger contracts
- add destructive-root/no-op assertions for face detection, recognition, people backfill, shared-space matching, and identity metadata jobs

## Test plan
- pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/job.service.spec.ts src/services/queue.service.spec.ts src/services/asset.service.spec.ts src/services/library.service.spec.ts src/services/metadata.service.spec.ts src/services/duplicate.service.spec.ts src/services/shared-space.service.spec.ts src/services/pet-detection.service.spec.ts src/services/person.service.spec.ts