### PR TITLE
fix(server): keep force recognition scoped to ML faces

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1344,7 +1344,7 @@ describe(PersonService.name, () => {
       expect(mocks.person.vacuum).not.toHaveBeenCalled();
     });
 
-    it('should queue all assets', async () => {
+    it('should queue all machine-learning faces on force reset', async () => {
       const face = AssetFaceFactory.create();
       mocks.job.getJobCounts.mockResolvedValue({
         active: 1,
@@ -1363,7 +1363,9 @@ describe(PersonService.name, () => {
 
       await sut.handleQueueRecognizeFaces({ force: true });
 
-      expect(mocks.person.getAllFaces).toHaveBeenCalledWith(undefined);
+      expect(mocks.person.getAllFaces).toHaveBeenCalledWith({
+        sourceType: SourceType.MachineLearning,
+      });
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.FacialRecognition,
@@ -1390,6 +1392,7 @@ describe(PersonService.name, () => {
       expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(
         QueueName.ThumbnailGeneration,
         QueueName.FaceDetection,
+        QueueName.PeopleBackfill,
       );
       expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
       expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -777,7 +777,11 @@ export class PersonService extends BaseService {
       return JobStatus.Skipped;
     }
 
-    await this.jobRepository.waitForQueueCompletion(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
+    await this.jobRepository.waitForQueueCompletion(
+      QueueName.ThumbnailGeneration,
+      QueueName.FaceDetection,
+      ...(force ? [QueueName.PeopleBackfill] : []),
+    );
 
     if (nightly) {
       const [state, latestFaceDate] = await Promise.all([
@@ -820,7 +824,7 @@ export class PersonService extends BaseService {
 
     const lastRun = new Date().toISOString();
     const facePagination = this.personRepository.getAllFaces(
-      force ? undefined : { personId: null, sourceType: SourceType.MachineLearning },
+      force ? { sourceType: SourceType.MachineLearning } : { personId: null, sourceType: SourceType.MachineLearning },
     );
 
     let jobs: {


### PR DESCRIPTION
## Summary

- wait for PeopleBackfill before a force Facial Recognition reset clears people/shared-space state
- keep force Facial Recognition queueing scoped to machine-learning faces
- rely on the existing forced SharedSpaceFaceMatchAll rebuild for EXIF/manual faces instead of enqueueing them only to skip

## Context

Follow-up to #597 and Hagen's log analysis showing 36,972 `Skipping face ... due to source exif` entries during force Facial Recognition. The EXIF skip path was noisy and avoidable; the actual shared-space clearing comes from the force reset itself. This keeps the force recognition queue focused on ML faces and reduces the race window with People Identity Maintenance.

## Test plan

- `cd server && pnpm exec vitest --config test/vitest.config.mjs --run src/services/person.service.spec.ts`
- `cd server && pnpm exec vitest --config test/vitest.config.mjs --run`
- `cd server && pnpm check`
