### PR TITLE
test: cover face detection identity safety

### DIFF
--- a/docs/superpowers/plans/2026-05-17-face-detection-safety.md
+++ b/docs/superpowers/plans/2026-05-17-face-detection-safety.md
@@ -389,7 +389,93 @@ it('should remove only stale machine-learning faces and unlink only those identi
 });
 ```
 
-- [ ] **Step 2: Add manual-face matching coverage**
+- [ ] **Step 2: Add populated forced per-asset detection coverage**
+
+Add:
+
+```ts
+it('forced per-asset detection removes stale ML faces while preserving manual and EXIF evidence', async () => {
+  const assetId = newUuid();
+  const staleMlFace = AssetFaceFactory.create({
+    assetId,
+    id: 'stale-ml-face',
+    sourceType: SourceType.MachineLearning,
+    boundingBoxX1: 700,
+    boundingBoxY1: 500,
+    boundingBoxX2: 900,
+    boundingBoxY2: 700,
+  });
+  const exifFace = AssetFaceFactory.create({
+    assetId,
+    id: 'force-exif-face',
+    sourceType: SourceType.Exif,
+    boundingBoxX1: 10,
+    boundingBoxY1: 10,
+    boundingBoxX2: 40,
+    boundingBoxY2: 40,
+  });
+  const manualFace = AssetFaceFactory.create({
+    assetId,
+    id: 'force-manual-face',
+    sourceType: SourceType.Manual,
+    boundingBoxX1: 300,
+    boundingBoxY1: 300,
+    boundingBoxX2: 350,
+    boundingBoxY2: 350,
+  });
+  const asset = AssetFactory.from({ id: assetId })
+    .face(staleMlFace)
+    .face(exifFace)
+    .face(manualFace)
+    .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+    .exif()
+    .build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.crypto.randomUUID.mockReturnValue('force-new-ml-face');
+  mocks.machineLearning.detectFaces.mockResolvedValue({
+    imageHeight: 500,
+    imageWidth: 400,
+    faces: [
+      {
+        boundingBox: { x1: 100, y1: 80, x2: 250, y2: 200 },
+        embedding: '[1, 2, 3, 4]',
+        score: 0.99,
+      },
+    ],
+  });
+
+  await expect(sut.handleDetectFaces({ id: asset.id, force: true })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+    [
+      expect.objectContaining({
+        id: 'force-new-ml-face',
+        assetId: asset.id,
+        boundingBoxX1: 100,
+        boundingBoxY1: 80,
+        boundingBoxX2: 250,
+        boundingBoxY2: 200,
+      }),
+    ],
+    [staleMlFace.id],
+    [{ faceId: 'force-new-ml-face', embedding: '[1, 2, 3, 4]' }],
+  );
+  expect(mocks.faceIdentity.unlinkFaces).toHaveBeenCalledWith([staleMlFace.id]);
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([exifFace.id]));
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([manualFace.id]));
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FacialRecognitionQueueAll,
+    data: { force: true },
+  });
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+    assetId: asset.id,
+    facesRecognizedAt: expect.any(Date),
+  });
+});
+```
+
+- [ ] **Step 3: Add manual-face matching coverage**
 
 Existing tests cover EXIF matching. Add the manual equivalent:
 
@@ -417,7 +503,35 @@ it('should add an embedding to a matching manual face instead of creating a dupl
 });
 ```
 
-- [ ] **Step 3: Add changed-image-dimensions IOU preservation coverage**
+- [ ] **Step 4: Add matching existing ML face coverage**
+
+Add:
+
+```ts
+it('should keep a matching existing ML face without adding a duplicate or unlinking identities', async () => {
+  const mlFace = AssetFaceFactory.create({ sourceType: SourceType.MachineLearning });
+  const asset = AssetFactory.from({ id: mlFace.assetId })
+    .face(mlFace)
+    .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+    .exif()
+    .build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(mlFace));
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+  expect(mocks.crypto.randomUUID).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+  expectNoRecognitionFanout();
+  expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+    assetId: asset.id,
+    facesRecognizedAt: expect.any(Date),
+  });
+});
+```
+
+- [ ] **Step 5: Add changed-image-dimensions IOU preservation coverage**
 
 Add:
 
@@ -464,7 +578,7 @@ it('should preserve an existing metadata face when scaled detection boxes still 
 
 The detected box is in a half-size preview coordinate space, while the existing EXIF face is in the full-size original coordinate space. These boxes represent the same face and should overlap after scaling. If this test fails, make the minimal production fix in `handleDetectFaces()` so IOU comparison scales detection boxes from ML image dimensions into existing face dimensions.
 
-- [ ] **Step 4: Add changed-dimensions non-overlap coverage**
+- [ ] **Step 6: Add changed-dimensions non-overlap coverage**
 
 Add:
 
@@ -525,17 +639,17 @@ it('should create a new ML face when scaled detection boxes do not overlap exist
 });
 ```
 
-- [ ] **Step 5: Run focused matching tests**
+- [ ] **Step 7: Run focused matching tests**
 
 Run:
 
 ```bash
-pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "matching manual face|scaled detection|stale machine-learning"
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "matching manual face|matching existing ML face|scaled detection|stale machine-learning|forced per-asset detection"
 ```
 
 Expected: the focused tests pass or expose one minimal production fix.
 
-- [ ] **Step 6: Commit Task 3**
+- [ ] **Step 8: Commit Task 3**
 
 Run:
 
@@ -678,6 +792,7 @@ import { MachineLearningRepository } from 'src/repositories/machine-learning.rep
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
 import { clearConfigCache } from 'src/utils/config';
+import { Mocked } from 'vitest';
 ```
 
 Add this setup helper near the existing `setup()`:
@@ -752,6 +867,7 @@ describe('handleQueueDetectFaces safety', () => {
     const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
     await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: 'preview.jpg' });
     await ctx.newExif({ assetId: asset.id, exifImageWidth: 200, exifImageHeight: 200 });
+    await ctx.newJobStatus({ assetId: asset.id });
     const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
     const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
     const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
@@ -908,6 +1024,9 @@ it('non-force detection removes stale ML faces without deleting manual or EXIF p
   await expect(ctx.get(PersonRepository).getById(exifPerson.id)).resolves.toEqual(
     expect.objectContaining({ id: exifPerson.id }),
   );
+  await expect(ctx.get(PersonRepository).getById(mlPerson.id)).resolves.toEqual(
+    expect.objectContaining({ id: mlPerson.id }),
+  );
   await expect(
     ctx.database
       .selectFrom('asset_job_status')
@@ -923,7 +1042,7 @@ it('non-force detection removes stale ML faces without deleting manual or EXIF p
 Add:
 
 ```ts
-it('non-force detection preserves existing shared-space people for manual and EXIF identities', async () => {
+it('non-force detection preserves existing shared-space people for manual, EXIF, and stale ML identities', async () => {
   const { sut, ctx } = setupFaceDetection();
   const machineLearningMock = ctx.getMock<MachineLearningRepository, Mocked<MachineLearningRepository>>(
     MachineLearningRepository,
@@ -936,8 +1055,14 @@ it('non-force detection preserves existing shared-space people for manual and EX
   await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
   await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: 'preview.jpg' });
   await ctx.newExif({ assetId: asset.id, exifImageWidth: 200, exifImageHeight: 200 });
+  const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
   const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
   const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
+  const { result: mlFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: mlPerson.id,
+    sourceType: SourceType.MachineLearning,
+  });
   const { result: manualFaceId } = await ctx.newAssetFace({
     assetId: asset.id,
     personId: manualPerson.id,
@@ -948,8 +1073,14 @@ it('non-force detection preserves existing shared-space people for manual and EX
     personId: exifPerson.id,
     sourceType: SourceType.Exif,
   });
+  const mlIdentity = await faceIdentityRepo.ensurePersonIdentity(mlPerson.id);
   const manualIdentity = await faceIdentityRepo.ensurePersonIdentity(manualPerson.id);
   const exifIdentity = await faceIdentityRepo.ensurePersonIdentity(exifPerson.id);
+  await faceIdentityRepo.replaceFaceIdentity({
+    assetFaceId: mlFaceId,
+    identityId: mlIdentity.id,
+    source: 'ml',
+  });
   await faceIdentityRepo.replaceFaceIdentity({
     assetFaceId: manualFaceId,
     identityId: manualIdentity.id,
@@ -960,11 +1091,13 @@ it('non-force detection preserves existing shared-space people for manual and EX
     identityId: exifIdentity.id,
     source: 'import',
   });
+  const mlSpacePersonId = factory.uuid();
   const manualSpacePersonId = factory.uuid();
   const exifSpacePersonId = factory.uuid();
   await ctx.database
     .insertInto('shared_space_person')
     .values([
+      { id: mlSpacePersonId, spaceId: space.id, identityId: mlIdentity.id, name: 'ML', type: 'person' },
       { id: manualSpacePersonId, spaceId: space.id, identityId: manualIdentity.id, name: 'Manual', type: 'person' },
       { id: exifSpacePersonId, spaceId: space.id, identityId: exifIdentity.id, name: 'EXIF', type: 'person' },
     ])
@@ -972,6 +1105,7 @@ it('non-force detection preserves existing shared-space people for manual and EX
   await ctx.database
     .insertInto('shared_space_person_face')
     .values([
+      { personId: mlSpacePersonId, assetFaceId: mlFaceId },
       { personId: manualSpacePersonId, assetFaceId: manualFaceId },
       { personId: exifSpacePersonId, assetFaceId: exifFaceId },
     ])
@@ -984,21 +1118,27 @@ it('non-force detection preserves existing shared-space people for manual and EX
     ctx.database
       .selectFrom('shared_space_person')
       .select(['id', 'identityId', 'name'])
-      .where('id', 'in', [manualSpacePersonId, exifSpacePersonId])
+      .where('id', 'in', [mlSpacePersonId, manualSpacePersonId, exifSpacePersonId])
       .orderBy('name')
       .execute(),
   ).resolves.toEqual([
     { id: exifSpacePersonId, identityId: exifIdentity.id, name: 'EXIF' },
+    { id: mlSpacePersonId, identityId: mlIdentity.id, name: 'ML' },
     { id: manualSpacePersonId, identityId: manualIdentity.id, name: 'Manual' },
   ]);
-  await expect(
-    ctx.database
-      .selectFrom('shared_space_person_face')
-      .select(['personId', 'assetFaceId'])
-      .where('personId', 'in', [manualSpacePersonId, exifSpacePersonId])
-      .orderBy('personId')
-      .execute(),
-  ).resolves.toHaveLength(2);
+  const remainingSpaceFaceLinks = await ctx.database
+    .selectFrom('shared_space_person_face')
+    .select(['personId', 'assetFaceId'])
+    .where('personId', 'in', [mlSpacePersonId, manualSpacePersonId, exifSpacePersonId])
+    .execute();
+  expect(remainingSpaceFaceLinks).toEqual(
+    expect.arrayContaining([
+      { personId: manualSpacePersonId, assetFaceId: manualFaceId },
+      { personId: exifSpacePersonId, assetFaceId: exifFaceId },
+    ]),
+  );
+  expect(remainingSpaceFaceLinks.map((link) => link.personId)).not.toContain(mlSpacePersonId);
+  expect(remainingSpaceFaceLinks.map((link) => link.assetFaceId)).not.toContain(mlFaceId);
 });
 ```
 
@@ -1241,10 +1381,12 @@ Verify the final diff covers each Slice 2 invariant:
 - removed ML faces lose identity links
 - manual and EXIF `asset_face` rows survive force and non-force paths
 - manual and EXIF `face_identity_face` rows survive
-- non-force detection does not delete people or shared-space people globally
+- non-force stale-face detection does not delete personal people or shared-space people globally, including ML-backed people whose stale face rows were removed
+- populated per-asset `force=true` detection removes only stale ML face ids, preserves manual/EXIF evidence, and queues only the forced recognition coordinator
 - missing asset, no preview, multiple preview files, hidden asset, ML-disabled, ML-error, refresh-error, and queue-error paths do not write `facesRecognizedAt`
 - no detected faces removes stale ML faces but not manual/EXIF faces
 - matching detection adds embeddings to existing EXIF/manual faces instead of creating duplicates
+- matching detection keeps existing ML faces without deleting, recreating, or duplicating them
 - changed dimensions with high IOU preserve existing metadata faces
 - changed dimensions with low IOU create new ML faces
 - successful non-force new faces queue `FacialRecognitionQueueAll(force:false)` and per-face `FacialRecognition`

--- a/docs/superpowers/plans/2026-05-17-face-detection-safety.md
+++ b/docs/superpowers/plans/2026-05-17-face-detection-safety.md
@@ -1,0 +1,1275 @@
+# Face Detection Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add thorough Slice 2 coverage proving face detection queue roots and per-asset detection mutate only the intended machine-learning face rows, preserve manual and EXIF identity evidence, and queue recognition follow-ups safely.
+
+**Architecture:** This slice is mostly test-only. Use small `PersonService` unit tests for queue contracts, no-op/error paths, ML matching decisions, and job-status writes; use medium DB tests only where destructive row-level behavior must be proven. If a new test exposes a real bug, make the smallest production fix in `server/src/services/person.service.ts` or `server/src/repositories/person.repository.ts` and keep it in the same task commit.
+
+**Tech Stack:** TypeScript, NestJS service tests, Vitest, Gallery small test factories, Gallery medium DB test harness, Kysely, BullMQ job names.
+
+---
+
+## File Structure
+
+- Modify: `server/src/services/person.service.spec.ts`
+  - Owns small unit coverage for `handleQueueDetectFaces()` and `handleDetectFaces()` job contracts, skip/error paths, ML face matching, source-type preservation, recognition fan-out, and `facesRecognizedAt` writes.
+- Modify: `server/test/medium/specs/services/person.service.spec.ts`
+  - Owns DB-backed destructive-state coverage for populated users: force detection, no-face detection, manual/EXIF preservation, identity-link cascade behavior, shared-space projection preservation, and successful asset job-status writes.
+- Modify: `server/test/medium/specs/repositories/person.repository.spec.ts`
+  - Owns repository-level `refreshFaces()` safety: deletes only explicitly supplied face ids, cascades only those identity links, inserts new ML faces and embeddings atomically, and preserves manual/EXIF rows.
+- Modify only if a new failing test proves a bug:
+  - `server/src/services/person.service.ts`
+  - `server/src/repositories/person.repository.ts`
+
+## Execution Preflight
+
+- [ ] **Step 1: Confirm the worktree is isolated and clean**
+
+Run:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+```
+
+Expected:
+
+```text
+/home/pierre/dev/gallery/.worktrees/face-trigger-slice-2-plan
+codex/face-trigger-slice-2-plan
+```
+
+`git status --short` must be empty before editing. If it is not empty, inspect every listed file and preserve user-owned work.
+
+- [ ] **Step 2: Run the Slice 2 baseline small spec**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts
+```
+
+Expected: `person.service.spec.ts` passes before new tests are added.
+
+- [ ] **Step 3: Run the Slice 2 baseline medium specs**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/person.service.spec.ts test/medium/specs/repositories/person.repository.spec.ts
+```
+
+Expected: both medium specs pass before new DB-backed tests are added. If local Docker or test-asset setup blocks the run, record the environment failure and still run the focused small spec before editing.
+
+## TDD Protocol For This Slice
+
+- [ ] **Step 1: Write the failing or coverage test first**
+
+Add the test before editing production code. For coverage of existing behavior, it may pass immediately.
+
+- [ ] **Step 2: Run the smallest focused selector**
+
+Run the specific `-t` selector for the new test. Expected result:
+
+- FAIL when the current implementation violates the contract.
+- PASS when the contract already exists and this is coverage-only.
+
+- [ ] **Step 3: Make the smallest production fix only if needed**
+
+Do not refactor unrelated recognition or shared-space logic. Slice 3 owns recognition coordinator reset ordering; Slice 4 owns per-face recognition assignment; Slice 8 owns overnight queue-chain composition.
+
+- [ ] **Step 4: Prove assertions can fail**
+
+For each touched spec file, temporarily change one expected `JobName`, `SourceType`, or persisted face id to a wrong value, run the focused test and confirm it fails, then restore the correct expectation before committing.
+
+## Shared Small-Spec Helpers
+
+Add these helpers near the top of `server/src/services/person.service.spec.ts`, after `beforeEach()` or immediately before `describe('handleQueueDetectFaces')` if local scope is preferred:
+
+```ts
+const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
+
+const expectNoFaceDetectionMutation = () => {
+  expect(mocks.machineLearning.detectFaces).not.toHaveBeenCalled();
+  expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+};
+
+const expectNoRecognitionFanout = () => {
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(
+    expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+  );
+  expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
+  expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
+};
+```
+
+These helpers intentionally flatten `queueAll` calls and assert each forbidden job name separately so a single forbidden job cannot slip through a multi-entry `arrayContaining` negation.
+
+## Task 1: Small Queue-Root Face Detection Contracts
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Strengthen `force=false` and omitted-force queue-root tests**
+
+In `describe('handleQueueDetectFaces')`, add or replace the current non-force/omitted-force assertions with:
+
+```ts
+it.each([
+  ['force=false', false],
+  ['force omitted', undefined],
+] as const)('should queue per-asset detection without destructive cleanup when %s', async (_label, force) => {
+  const asset1 = AssetFactory.create();
+  const asset2 = AssetFactory.create();
+  mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset1, asset2]));
+
+  await expect(sut.handleQueueDetectFaces({ force })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(force);
+  expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+  expect(mocks.person.delete).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
+  expect(mocks.person.vacuum).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.AssetDetectFaces, data: { id: asset1.id } },
+    { name: JobName.AssetDetectFaces, data: { id: asset2.id } },
+  ]);
+
+  if (force === undefined) {
+    expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+    expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.PersonCleanup });
+  } else {
+    expect(mocks.job.queue).not.toHaveBeenCalled();
+  }
+});
+```
+
+This pins the distinction between user/admin refresh without `force`, explicit non-force detection, and destructive force detection.
+
+- [ ] **Step 2: Strengthen force queue-root destructive cleanup scope**
+
+Add a force-root test that asserts only ML source cleanup is requested and every queued asset job carries `force: true`:
+
+```ts
+it('should force-detect all assets after deleting only machine-learning faces', async () => {
+  const asset1 = AssetFactory.create();
+  const asset2 = AssetFactory.create();
+  const orphan = PersonFactory.create();
+  mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset1, asset2]));
+  mocks.person.getAllWithoutFaces.mockResolvedValue([orphan]);
+  mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
+
+  await expect(sut.handleQueueDetectFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.deleteFaces).toHaveBeenCalledTimes(1);
+  expect(mocks.person.deleteFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
+  expect(mocks.person.deleteFaces).not.toHaveBeenCalledWith({ sourceType: SourceType.Manual });
+  expect(mocks.person.deleteFaces).not.toHaveBeenCalledWith({ sourceType: SourceType.Exif });
+  expect(mocks.person.delete).toHaveBeenCalledWith([orphan.id]);
+  expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalledTimes(1);
+  expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: true });
+  expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.AssetDetectFaces, data: { id: asset1.id, force: true } },
+    { name: JobName.AssetDetectFaces, data: { id: asset2.id, force: true } },
+  ]);
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FileDelete,
+    data: { files: [orphan.thumbnailPath] },
+  });
+});
+```
+
+- [ ] **Step 3: Add no-assets root behavior coverage**
+
+Add this test to prevent empty streams from becoming destructive shortcuts:
+
+```ts
+it('should not enqueue recognition or cleanup shortcuts when the detection stream is empty', async () => {
+  mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([]));
+
+  await expect(sut.handleQueueDetectFaces({ force: false })).resolves.toBe(JobStatus.Success);
+
+  expect(queuedBatchJobs()).toEqual([]);
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+  expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
+  expectNoRecognitionFanout();
+});
+```
+
+- [ ] **Step 4: Run focused queue-root tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "handleQueueDetectFaces"
+```
+
+Expected: new `handleQueueDetectFaces` tests pass or expose one minimal production fix.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover face detection queue root safety"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 2: Small Per-Asset Skip, Error, And Status Safety
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add table-driven no-op/error coverage**
+
+In `describe('handleDetectFaces')`, add:
+
+```ts
+it.each([
+  {
+    label: 'missing asset',
+    asset: undefined,
+    expected: JobStatus.Failed,
+  },
+  {
+    label: 'asset without preview file',
+    asset: AssetFactory.from().exif().build(),
+    expected: JobStatus.Failed,
+  },
+  {
+    label: 'asset with multiple preview files',
+    asset: AssetFactory.from()
+      .file({ type: AssetFileType.Preview, path: '/preview-1.jpg' })
+      .file({ type: AssetFileType.Preview, path: '/preview-2.jpg' })
+      .exif()
+      .build(),
+    expected: JobStatus.Failed,
+  },
+  {
+    label: 'hidden asset with preview file',
+    asset: AssetFactory.from({ visibility: AssetVisibility.Hidden })
+      .file({ type: AssetFileType.Preview, path: '/hidden-preview.jpg' })
+      .exif()
+      .build(),
+    expected: JobStatus.Skipped,
+  },
+] as const)('should not mutate faces or status for $label', async ({ asset, expected }) => {
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(asset ? getForDetectedFaces(asset) : undefined);
+
+  await expect(sut.handleDetectFaces({ id: asset?.id ?? 'missing-asset' })).resolves.toBe(expected);
+
+  expectNoFaceDetectionMutation();
+});
+```
+
+This covers missing asset, no preview, multiple preview files, and hidden asset. The expected difference is return status only; all mutation and queue side effects must remain absent.
+
+- [ ] **Step 2: Strengthen ML-disabled per-asset skip coverage**
+
+Extend the existing ML-disabled test with:
+
+```ts
+expect(mocks.assetJob.getForDetectFacesJob).not.toHaveBeenCalled();
+expect(mocks.machineLearning.detectFaces).not.toHaveBeenCalled();
+expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+expect(mocks.job.queue).not.toHaveBeenCalled();
+expect(mocks.job.queueAll).not.toHaveBeenCalled();
+expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 3: Add ML inference failure status coverage**
+
+Add:
+
+```ts
+it('should not write facesRecognizedAt or queue recognition when ML face detection throws', async () => {
+  const asset = AssetFactory.from().file({ type: AssetFileType.Preview, path: '/preview.jpg' }).exif().build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.machineLearning.detectFaces.mockRejectedValue(new Error('ml unavailable'));
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).rejects.toThrow('ml unavailable');
+
+  expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 4: Strengthen successful no-face status coverage**
+
+Update the existing no-results test so it also proves no stale non-ML faces are removed when there are no existing ML faces:
+
+```ts
+expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+expect(mocks.job.queue).not.toHaveBeenCalled();
+expect(mocks.job.queueAll).not.toHaveBeenCalled();
+expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+  assetId: asset.id,
+  facesRecognizedAt: expect.any(Date),
+});
+```
+
+- [ ] **Step 5: Run focused skip/error tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "handleDetectFaces"
+```
+
+Expected: all per-asset skip/error tests pass or expose one minimal production fix.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover face detection skip and error safety"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 3: Small Per-Asset Source Preservation And IOU Matching
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add stale ML removal with manual/EXIF preservation**
+
+Add:
+
+```ts
+it('should remove only stale machine-learning faces and unlink only those identity links', async () => {
+  const assetId = newUuid();
+  const mlFace = AssetFaceFactory.create({ assetId, id: 'ml-face', sourceType: SourceType.MachineLearning });
+  const exifFace = AssetFaceFactory.create({ assetId, id: 'exif-face', sourceType: SourceType.Exif });
+  const manualFace = AssetFaceFactory.create({ assetId, id: 'manual-face', sourceType: SourceType.Manual });
+  const asset = AssetFactory.from({ id: assetId })
+    .face(mlFace)
+    .face(exifFace)
+    .face(manualFace)
+    .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+    .exif()
+    .build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.machineLearning.detectFaces.mockResolvedValue({ imageHeight: 500, imageWidth: 400, faces: [] });
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.refreshFaces).toHaveBeenCalledWith([], [mlFace.id], []);
+  expect(mocks.faceIdentity.unlinkFaces).toHaveBeenCalledTimes(1);
+  expect(mocks.faceIdentity.unlinkFaces).toHaveBeenCalledWith([mlFace.id]);
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([exifFace.id]));
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([manualFace.id]));
+  expectNoRecognitionFanout();
+  expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+    assetId: asset.id,
+    facesRecognizedAt: expect.any(Date),
+  });
+});
+```
+
+- [ ] **Step 2: Add manual-face matching coverage**
+
+Existing tests cover EXIF matching. Add the manual equivalent:
+
+```ts
+it('should add an embedding to a matching manual face instead of creating a duplicate', async () => {
+  const manualFace = AssetFaceFactory.create({ sourceType: SourceType.Manual });
+  const asset = AssetFactory.from({ id: manualFace.assetId })
+    .face(manualFace)
+    .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+    .exif()
+    .build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(manualFace));
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+    [],
+    [],
+    [{ faceId: manualFace.id, embedding: '[1, 2, 3, 4]' }],
+  );
+  expect(mocks.crypto.randomUUID).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+  expectNoRecognitionFanout();
+});
+```
+
+- [ ] **Step 3: Add changed-image-dimensions IOU preservation coverage**
+
+Add:
+
+```ts
+it('should preserve an existing metadata face when scaled detection boxes still overlap', async () => {
+  const assetId = newUuid();
+  const exifFace = AssetFaceFactory.create({
+    assetId,
+    id: 'scaled-exif-face',
+    sourceType: SourceType.Exif,
+    imageWidth: 1000,
+    imageHeight: 800,
+    boundingBoxX1: 200,
+    boundingBoxY1: 160,
+    boundingBoxX2: 500,
+    boundingBoxY2: 400,
+  });
+  const asset = AssetFactory.from({ id: assetId })
+    .face(exifFace)
+    .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+    .exif()
+    .build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.machineLearning.detectFaces.mockResolvedValue({
+    imageWidth: 500,
+    imageHeight: 400,
+    faces: [
+      {
+        boundingBox: { x1: 100, y1: 80, x2: 250, y2: 200 },
+        embedding: '[1, 2, 3, 4]',
+        score: 0.99,
+      },
+    ],
+  });
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.refreshFaces).toHaveBeenCalledWith([], [], [{ faceId: exifFace.id, embedding: '[1, 2, 3, 4]' }]);
+  expect(mocks.crypto.randomUUID).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+  expectNoRecognitionFanout();
+});
+```
+
+The detected box is in a half-size preview coordinate space, while the existing EXIF face is in the full-size original coordinate space. These boxes represent the same face and should overlap after scaling. If this test fails, make the minimal production fix in `handleDetectFaces()` so IOU comparison scales detection boxes from ML image dimensions into existing face dimensions.
+
+- [ ] **Step 4: Add changed-dimensions non-overlap coverage**
+
+Add:
+
+```ts
+it('should create a new ML face when scaled detection boxes do not overlap existing manual or EXIF faces', async () => {
+  const assetId = newUuid();
+  const exifFace = AssetFaceFactory.create({
+    assetId,
+    id: 'far-exif-face',
+    sourceType: SourceType.Exif,
+    imageWidth: 1000,
+    imageHeight: 800,
+    boundingBoxX1: 700,
+    boundingBoxY1: 500,
+    boundingBoxX2: 900,
+    boundingBoxY2: 700,
+  });
+  const asset = AssetFactory.from({ id: assetId })
+    .face(exifFace)
+    .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+    .exif()
+    .build();
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.crypto.randomUUID.mockReturnValue('new-ml-face');
+  mocks.machineLearning.detectFaces.mockResolvedValue({
+    imageWidth: 500,
+    imageHeight: 400,
+    faces: [
+      {
+        boundingBox: { x1: 100, y1: 80, x2: 250, y2: 200 },
+        embedding: '[1, 2, 3, 4]',
+        score: 0.99,
+      },
+    ],
+  });
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+    [
+      expect.objectContaining({
+        id: 'new-ml-face',
+        assetId: asset.id,
+        boundingBoxX1: 100,
+        boundingBoxY1: 80,
+        boundingBoxX2: 250,
+        boundingBoxY2: 200,
+      }),
+    ],
+    [],
+    [{ faceId: 'new-ml-face', embedding: '[1, 2, 3, 4]' }],
+  );
+  expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+    { name: JobName.FacialRecognition, data: { id: 'new-ml-face' } },
+  ]);
+});
+```
+
+- [ ] **Step 5: Run focused matching tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "matching manual face|scaled detection|stale machine-learning"
+```
+
+Expected: the focused tests pass or expose one minimal production fix.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover face detection source preservation"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 4: Small Recognition Fan-Out And `facesRecognizedAt` Contracts
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Strengthen non-force new-face fan-out**
+
+Update the non-force new-face tests so they assert exact queue calls and no direct force coordinator:
+
+```ts
+expect(mocks.job.queue).not.toHaveBeenCalled();
+expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+expect(mocks.job.queueAll).toHaveBeenCalledWith([
+  { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+  { name: JobName.FacialRecognition, data: { id: face.id } },
+]);
+expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+  assetId: asset.id,
+  facesRecognizedAt: expect.any(Date),
+});
+```
+
+- [ ] **Step 2: Strengthen force-created new-face fan-out**
+
+Update the forced detection test so it proves forced per-asset detection never queues immediate per-face recognition:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.FacialRecognitionQueueAll,
+  data: { force: true },
+});
+expect(mocks.job.queueAll).not.toHaveBeenCalled();
+expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+  assetId: asset.id,
+  facesRecognizedAt: expect.any(Date),
+});
+```
+
+- [ ] **Step 3: Add queue failure status guard**
+
+Add:
+
+```ts
+it('should not write facesRecognizedAt when recognition fan-out queueing fails', async () => {
+  const asset = AssetFactory.from().file({ type: AssetFileType.Preview, path: '/preview.jpg' }).exif().build();
+  const face = AssetFaceFactory.create({ assetId: asset.id });
+  mocks.crypto.randomUUID.mockReturnValue(face.id);
+  mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.person.refreshFaces.mockResolvedValue();
+  mocks.job.queueAll.mockRejectedValue(new Error('redis unavailable'));
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).rejects.toThrow('redis unavailable');
+
+  expect(mocks.person.refreshFaces).toHaveBeenCalled();
+  expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+});
+```
+
+This pins the order: status is written only after face refresh and recognition fan-out have succeeded.
+
+- [ ] **Step 4: Add refresh failure status guard**
+
+Add:
+
+```ts
+it('should not queue recognition or write facesRecognizedAt when refreshFaces fails', async () => {
+  const asset = AssetFactory.from().file({ type: AssetFileType.Preview, path: '/preview.jpg' }).exif().build();
+  const face = AssetFaceFactory.create({ assetId: asset.id });
+  mocks.crypto.randomUUID.mockReturnValue(face.id);
+  mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+  mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+  mocks.person.refreshFaces.mockRejectedValue(new Error('refresh failed'));
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).rejects.toThrow('refresh failed');
+
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 5: Run focused fan-out tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "fan-out|facesRecognizedAt|force recognition coordinator|refreshFaces fails"
+```
+
+Expected: the focused tests pass or expose one minimal production fix.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover face detection recognition fanout"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 5: Medium Service Destructive-State Tests
+
+**Files:**
+
+- Modify: `server/test/medium/specs/services/person.service.spec.ts`
+- Modify only if tests expose a bug: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Add medium face-detection setup**
+
+In `server/test/medium/specs/services/person.service.spec.ts`, extend imports:
+
+```ts
+import {
+  AssetFileType,
+  AssetVisibility,
+  JobName,
+  JobStatus,
+  SharedSpaceRole,
+  SourceType,
+  SystemMetadataKey,
+} from 'src/enum';
+import { AssetJobRepository } from 'src/repositories/asset-job.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { MachineLearningRepository } from 'src/repositories/machine-learning.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
+import { clearConfigCache } from 'src/utils/config';
+```
+
+Add this setup helper near the existing `setup()`:
+
+```ts
+const setupFaceDetection = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(PersonService, {
+    database: db || defaultDatabase,
+    real: [
+      AccessRepository,
+      AssetRepository,
+      AssetJobRepository,
+      ConfigRepository,
+      DatabaseRepository,
+      FaceIdentityRepository,
+      PersonRepository,
+      SharedSpaceRepository,
+    ],
+    mock: [JobRepository, LoggingRepository, MachineLearningRepository, StorageRepository, SystemMetadataRepository],
+  });
+
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queue.mockResolvedValue();
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll.mockResolvedValue();
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockImplementation(async (key) => {
+      if (key === SystemMetadataKey.SystemConfig) {
+        return { machineLearning: { facialRecognition: { minFaces: 1 } } } as any;
+      }
+      return undefined as any;
+    });
+
+  return { sut, ctx };
+};
+```
+
+- [ ] **Step 2: Add helper queries for face rows and identity links**
+
+Add below the setup helper:
+
+```ts
+const getAssetFaces = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], assetId: string) =>
+  ctx.database
+    .selectFrom('asset_face')
+    .select(['id', 'assetId', 'personId', 'sourceType'])
+    .where('assetId', '=', assetId)
+    .orderBy('id')
+    .execute();
+
+const getIdentityLinks = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], faceIds: string[]) =>
+  ctx.database
+    .selectFrom('face_identity_face')
+    .select(['assetFaceId', 'identityId', 'source'])
+    .where('assetFaceId', 'in', faceIds)
+    .orderBy('assetFaceId')
+    .execute();
+```
+
+- [ ] **Step 3: Add force root preservation medium test**
+
+Add a new `describe('handleQueueDetectFaces safety')` block:
+
+```ts
+describe('handleQueueDetectFaces safety', () => {
+  it('force detection deletes ML faces and identity links while preserving manual and EXIF evidence', async () => {
+    const { sut, ctx } = setupFaceDetection();
+    const faceIdentityRepo = ctx.get(FaceIdentityRepository);
+    const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: 'preview.jpg' });
+    await ctx.newExif({ assetId: asset.id, exifImageWidth: 200, exifImageHeight: 200 });
+    const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
+    const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
+    const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
+    const { result: mlFaceId } = await ctx.newAssetFace({
+      assetId: asset.id,
+      personId: mlPerson.id,
+      sourceType: SourceType.MachineLearning,
+    });
+    const { result: manualFaceId } = await ctx.newAssetFace({
+      assetId: asset.id,
+      personId: manualPerson.id,
+      sourceType: SourceType.Manual,
+    });
+    const { result: exifFaceId } = await ctx.newAssetFace({
+      assetId: asset.id,
+      personId: exifPerson.id,
+      sourceType: SourceType.Exif,
+    });
+    const mlIdentity = await faceIdentityRepo.ensurePersonIdentity(mlPerson.id);
+    const manualIdentity = await faceIdentityRepo.ensurePersonIdentity(manualPerson.id);
+    const exifIdentity = await faceIdentityRepo.ensurePersonIdentity(exifPerson.id);
+    await faceIdentityRepo.replaceFaceIdentity({ assetFaceId: mlFaceId, identityId: mlIdentity.id, source: 'ml' });
+    await faceIdentityRepo.replaceFaceIdentity({
+      assetFaceId: manualFaceId,
+      identityId: manualIdentity.id,
+      source: 'manual',
+    });
+    await faceIdentityRepo.replaceFaceIdentity({
+      assetFaceId: exifFaceId,
+      identityId: exifIdentity.id,
+      source: 'import',
+    });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const mlSpacePersonId = factory.uuid();
+    const manualSpacePersonId = factory.uuid();
+    const exifSpacePersonId = factory.uuid();
+    await ctx.database
+      .insertInto('shared_space_person')
+      .values([
+        { id: mlSpacePersonId, spaceId: space.id, identityId: mlIdentity.id, name: 'ML', type: 'person' },
+        { id: manualSpacePersonId, spaceId: space.id, identityId: manualIdentity.id, name: 'Manual', type: 'person' },
+        { id: exifSpacePersonId, spaceId: space.id, identityId: exifIdentity.id, name: 'EXIF', type: 'person' },
+      ])
+      .execute();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values([
+        { personId: mlSpacePersonId, assetFaceId: mlFaceId },
+        { personId: manualSpacePersonId, assetFaceId: manualFaceId },
+        { personId: exifSpacePersonId, assetFaceId: exifFaceId },
+      ])
+      .execute();
+
+    await expect(sut.handleQueueDetectFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+    await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: manualFaceId, sourceType: SourceType.Manual }),
+        expect.objectContaining({ id: exifFaceId, sourceType: SourceType.Exif }),
+      ]),
+    );
+    const remainingFaces = await getAssetFaces(ctx, asset.id);
+    expect(remainingFaces.map((face) => face.id)).not.toContain(mlFaceId);
+    await expect(getIdentityLinks(ctx, [mlFaceId, manualFaceId, exifFaceId])).resolves.toEqual(
+      expect.arrayContaining([
+        { assetFaceId: manualFaceId, identityId: manualIdentity.id, source: 'manual' },
+        { assetFaceId: exifFaceId, identityId: exifIdentity.id, source: 'import' },
+      ]),
+    );
+    const remainingLinks = await getIdentityLinks(ctx, [mlFaceId, manualFaceId, exifFaceId]);
+    expect(remainingLinks.map((link) => link.assetFaceId)).not.toContain(mlFaceId);
+    await expect(ctx.get(PersonRepository).getById(manualPerson.id)).resolves.toEqual(
+      expect.objectContaining({ id: manualPerson.id }),
+    );
+    await expect(ctx.get(PersonRepository).getById(exifPerson.id)).resolves.toEqual(
+      expect.objectContaining({ id: exifPerson.id }),
+    );
+    await expect(ctx.get(PersonRepository).getById(mlPerson.id)).resolves.toBeUndefined();
+    await expect(
+      ctx.database
+        .selectFrom('shared_space_person')
+        .select(['id', 'identityId', 'name'])
+        .where('id', 'in', [mlSpacePersonId, manualSpacePersonId, exifSpacePersonId])
+        .orderBy('name')
+        .execute(),
+    ).resolves.toEqual([
+      { id: exifSpacePersonId, identityId: exifIdentity.id, name: 'EXIF' },
+      { id: manualSpacePersonId, identityId: manualIdentity.id, name: 'Manual' },
+    ]);
+    const remainingSpaceFaceLinks = await ctx.database
+      .selectFrom('shared_space_person_face')
+      .select(['personId', 'assetFaceId'])
+      .where('personId', 'in', [mlSpacePersonId, manualSpacePersonId, exifSpacePersonId])
+      .execute();
+    expect(remainingSpaceFaceLinks).toEqual(
+      expect.arrayContaining([
+        { personId: manualSpacePersonId, assetFaceId: manualFaceId },
+        { personId: exifSpacePersonId, assetFaceId: exifFaceId },
+      ]),
+    );
+    expect(remainingSpaceFaceLinks.map((link) => link.personId)).not.toContain(mlSpacePersonId);
+    expect(jobMock.queueAll.mock.calls.flatMap(([jobs]) => jobs)).toContainEqual({
+      name: JobName.AssetDetectFaces,
+      data: { id: asset.id, force: true },
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Add non-force no-detected-faces medium test**
+
+Add:
+
+```ts
+it('non-force detection removes stale ML faces without deleting manual or EXIF people', async () => {
+  const { sut, ctx } = setupFaceDetection();
+  const machineLearningMock = ctx.getMock<MachineLearningRepository, Mocked<MachineLearningRepository>>(
+    MachineLearningRepository,
+  );
+  const { user } = await ctx.newUser();
+  const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+  await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: 'preview.jpg' });
+  await ctx.newExif({ assetId: asset.id, exifImageWidth: 200, exifImageHeight: 200 });
+  const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
+  const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
+  const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
+  const { result: mlFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: mlPerson.id,
+    sourceType: SourceType.MachineLearning,
+  });
+  const { result: manualFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: manualPerson.id,
+    sourceType: SourceType.Manual,
+  });
+  const { result: exifFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: exifPerson.id,
+    sourceType: SourceType.Exif,
+  });
+  machineLearningMock.detectFaces.mockResolvedValue({ imageWidth: 200, imageHeight: 200, faces: [] });
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  const remainingFaces = await getAssetFaces(ctx, asset.id);
+  expect(remainingFaces.map((face) => face.id)).toEqual(expect.arrayContaining([manualFaceId, exifFaceId]));
+  expect(remainingFaces.map((face) => face.id)).not.toContain(mlFaceId);
+  await expect(ctx.get(PersonRepository).getById(manualPerson.id)).resolves.toEqual(
+    expect.objectContaining({ id: manualPerson.id }),
+  );
+  await expect(ctx.get(PersonRepository).getById(exifPerson.id)).resolves.toEqual(
+    expect.objectContaining({ id: exifPerson.id }),
+  );
+  await expect(
+    ctx.database
+      .selectFrom('asset_job_status')
+      .select('facesRecognizedAt')
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow(),
+  ).resolves.toEqual({ facesRecognizedAt: expect.any(Date) });
+});
+```
+
+- [ ] **Step 5: Add shared-space projection preservation medium test**
+
+Add:
+
+```ts
+it('non-force detection preserves existing shared-space people for manual and EXIF identities', async () => {
+  const { sut, ctx } = setupFaceDetection();
+  const machineLearningMock = ctx.getMock<MachineLearningRepository, Mocked<MachineLearningRepository>>(
+    MachineLearningRepository,
+  );
+  const faceIdentityRepo = ctx.get(FaceIdentityRepository);
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: 'preview.jpg' });
+  await ctx.newExif({ assetId: asset.id, exifImageWidth: 200, exifImageHeight: 200 });
+  const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
+  const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
+  const { result: manualFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: manualPerson.id,
+    sourceType: SourceType.Manual,
+  });
+  const { result: exifFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    personId: exifPerson.id,
+    sourceType: SourceType.Exif,
+  });
+  const manualIdentity = await faceIdentityRepo.ensurePersonIdentity(manualPerson.id);
+  const exifIdentity = await faceIdentityRepo.ensurePersonIdentity(exifPerson.id);
+  await faceIdentityRepo.replaceFaceIdentity({
+    assetFaceId: manualFaceId,
+    identityId: manualIdentity.id,
+    source: 'manual',
+  });
+  await faceIdentityRepo.replaceFaceIdentity({
+    assetFaceId: exifFaceId,
+    identityId: exifIdentity.id,
+    source: 'import',
+  });
+  const manualSpacePersonId = factory.uuid();
+  const exifSpacePersonId = factory.uuid();
+  await ctx.database
+    .insertInto('shared_space_person')
+    .values([
+      { id: manualSpacePersonId, spaceId: space.id, identityId: manualIdentity.id, name: 'Manual', type: 'person' },
+      { id: exifSpacePersonId, spaceId: space.id, identityId: exifIdentity.id, name: 'EXIF', type: 'person' },
+    ])
+    .execute();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values([
+      { personId: manualSpacePersonId, assetFaceId: manualFaceId },
+      { personId: exifSpacePersonId, assetFaceId: exifFaceId },
+    ])
+    .execute();
+  machineLearningMock.detectFaces.mockResolvedValue({ imageWidth: 200, imageHeight: 200, faces: [] });
+
+  await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+  await expect(
+    ctx.database
+      .selectFrom('shared_space_person')
+      .select(['id', 'identityId', 'name'])
+      .where('id', 'in', [manualSpacePersonId, exifSpacePersonId])
+      .orderBy('name')
+      .execute(),
+  ).resolves.toEqual([
+    { id: exifSpacePersonId, identityId: exifIdentity.id, name: 'EXIF' },
+    { id: manualSpacePersonId, identityId: manualIdentity.id, name: 'Manual' },
+  ]);
+  await expect(
+    ctx.database
+      .selectFrom('shared_space_person_face')
+      .select(['personId', 'assetFaceId'])
+      .where('personId', 'in', [manualSpacePersonId, exifSpacePersonId])
+      .orderBy('personId')
+      .execute(),
+  ).resolves.toHaveLength(2);
+});
+```
+
+- [ ] **Step 6: Run focused medium service tests**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/person.service.spec.ts -t "face detection"
+```
+
+Expected: the new medium tests pass or expose a real destructive-state bug.
+
+- [ ] **Step 7: Commit Task 5**
+
+Run:
+
+```bash
+git add server/test/medium/specs/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover face detection destructive state"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 6: Medium Repository `refreshFaces()` Safety
+
+**Files:**
+
+- Modify: `server/test/medium/specs/repositories/person.repository.spec.ts`
+- Modify only if tests expose a bug: `server/src/repositories/person.repository.ts`
+
+- [ ] **Step 1: Add repository `refreshFaces()` import coverage**
+
+At the top of `server/test/medium/specs/repositories/person.repository.spec.ts`, ensure these imports exist:
+
+```ts
+import { SourceType } from 'src/enum';
+import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
+import { newEmbedding } from 'test/small.factory';
+```
+
+`FaceIdentityRepository` is already imported in this file; only add missing imports.
+
+- [ ] **Step 2: Add `refreshFaces()` preservation test**
+
+Add this near existing face repository tests:
+
+```ts
+describe('refreshFaces', () => {
+  it('deletes only requested ML faces, cascades only those identity links, and preserves manual and EXIF evidence', async () => {
+    const { ctx, sut } = setup();
+    const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
+    const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
+    const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
+    const { result: mlFaceId } = await ctx.newAssetFace({
+      assetId: asset.id,
+      personId: mlPerson.id,
+      sourceType: SourceType.MachineLearning,
+    });
+    const { result: manualFaceId } = await ctx.newAssetFace({
+      assetId: asset.id,
+      personId: manualPerson.id,
+      sourceType: SourceType.Manual,
+    });
+    const { result: exifFaceId } = await ctx.newAssetFace({
+      assetId: asset.id,
+      personId: exifPerson.id,
+      sourceType: SourceType.Exif,
+    });
+    const mlIdentity = await faceIdentityRepository.ensurePersonIdentity(mlPerson.id);
+    const manualIdentity = await faceIdentityRepository.ensurePersonIdentity(manualPerson.id);
+    const exifIdentity = await faceIdentityRepository.ensurePersonIdentity(exifPerson.id);
+    await faceIdentityRepository.replaceFaceIdentity({
+      assetFaceId: mlFaceId,
+      identityId: mlIdentity.id,
+      source: 'ml',
+    });
+    await faceIdentityRepository.replaceFaceIdentity({
+      assetFaceId: manualFaceId,
+      identityId: manualIdentity.id,
+      source: 'manual',
+    });
+    await faceIdentityRepository.replaceFaceIdentity({
+      assetFaceId: exifFaceId,
+      identityId: exifIdentity.id,
+      source: 'import',
+    });
+    const newFaceId = '11111111-1111-4111-8111-111111111111';
+    const embedding = newEmbedding();
+
+    await sut.refreshFaces(
+      [
+        {
+          id: newFaceId,
+          assetId: asset.id,
+          imageWidth: 200,
+          imageHeight: 200,
+          boundingBoxX1: 10,
+          boundingBoxY1: 10,
+          boundingBoxX2: 60,
+          boundingBoxY2: 60,
+        },
+      ],
+      [mlFaceId],
+      [{ faceId: newFaceId, embedding }],
+    );
+
+    const faceRows = await ctx.database
+      .selectFrom('asset_face')
+      .select(['id', 'sourceType'])
+      .where('assetId', '=', asset.id)
+      .execute();
+    expect(faceRows).toEqual(
+      expect.arrayContaining([
+        { id: manualFaceId, sourceType: SourceType.Manual },
+        { id: exifFaceId, sourceType: SourceType.Exif },
+        { id: newFaceId, sourceType: SourceType.MachineLearning },
+      ]),
+    );
+    expect(faceRows.map((face) => face.id)).not.toContain(mlFaceId);
+
+    const links = await ctx.database
+      .selectFrom('face_identity_face')
+      .select(['assetFaceId', 'identityId', 'source'])
+      .where('assetFaceId', 'in', [mlFaceId, manualFaceId, exifFaceId])
+      .execute();
+    expect(links).toEqual(
+      expect.arrayContaining([
+        { assetFaceId: manualFaceId, identityId: manualIdentity.id, source: 'manual' },
+        { assetFaceId: exifFaceId, identityId: exifIdentity.id, source: 'import' },
+      ]),
+    );
+    expect(links.map((link) => link.assetFaceId)).not.toContain(mlFaceId);
+    await expect(
+      ctx.database.selectFrom('face_search').select(['faceId']).where('faceId', '=', newFaceId).executeTakeFirst(),
+    ).resolves.toEqual({ faceId: newFaceId });
+  });
+});
+```
+
+- [ ] **Step 3: Add empty-input no-op coverage**
+
+Add:
+
+```ts
+it('does not mutate face rows when refreshFaces receives no inserts, removals, or embeddings', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { result: manualFaceId } = await ctx.newAssetFace({
+    assetId: asset.id,
+    sourceType: SourceType.Manual,
+  });
+
+  await sut.refreshFaces([], [], []);
+
+  await expect(
+    ctx.database.selectFrom('asset_face').select(['id', 'sourceType']).where('assetId', '=', asset.id).execute(),
+  ).resolves.toEqual([{ id: manualFaceId, sourceType: SourceType.Manual }]);
+});
+```
+
+- [ ] **Step 4: Run focused repository tests**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/repositories/person.repository.spec.ts -t "refreshFaces"
+```
+
+Expected: focused repository tests pass.
+
+- [ ] **Step 5: Commit Task 6**
+
+Run:
+
+```bash
+git add server/test/medium/specs/repositories/person.repository.spec.ts server/src/repositories/person.repository.ts
+git commit -m "test: cover refreshFaces row safety"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 7: Final Verification And Review
+
+**Files:**
+
+- Verify: all Slice 2 touched files.
+
+- [ ] **Step 1: Run small spec**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts
+```
+
+Expected: all `person.service.spec.ts` small tests pass.
+
+- [ ] **Step 2: Run medium specs**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/person.service.spec.ts test/medium/specs/repositories/person.repository.spec.ts
+```
+
+Expected: both medium specs pass. If local environment fails for Docker, Postgres client limits, or missing submodule test assets, capture the exact failure and require CI confirmation before merge.
+
+- [ ] **Step 3: Run type and formatting checks**
+
+Run:
+
+```bash
+pnpm --filter immich check
+pnpm --dir server exec prettier --check src/services/person.service.spec.ts test/medium/specs/services/person.service.spec.ts test/medium/specs/repositories/person.repository.spec.ts
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 4: Run placeholder scan on this plan**
+
+Run:
+
+```bash
+rg -n "T[B]D|TO[D]O|FIX[M]E|place[ ]holder|\\?\\?\\?" docs/superpowers/plans/2026-05-17-face-detection-safety.md
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Review destructive invariant coverage**
+
+Verify the final diff covers each Slice 2 invariant:
+
+- `force=true`, `force=false`, and omitted `force`
+- force root deletes only `SourceType.MachineLearning` faces
+- removed ML faces lose identity links
+- manual and EXIF `asset_face` rows survive force and non-force paths
+- manual and EXIF `face_identity_face` rows survive
+- non-force detection does not delete people or shared-space people globally
+- missing asset, no preview, multiple preview files, hidden asset, ML-disabled, ML-error, refresh-error, and queue-error paths do not write `facesRecognizedAt`
+- no detected faces removes stale ML faces but not manual/EXIF faces
+- matching detection adds embeddings to existing EXIF/manual faces instead of creating duplicates
+- changed dimensions with high IOU preserve existing metadata faces
+- changed dimensions with low IOU create new ML faces
+- successful non-force new faces queue `FacialRecognitionQueueAll(force:false)` and per-face `FacialRecognition`
+- successful force new faces queue only `FacialRecognitionQueueAll(force:true)`
+- medium repository tests prove `refreshFaces()` deletes only supplied ids and preserves unrelated rows
+
+- [ ] **Step 6: Commit final verification notes if needed**
+
+No commit is needed for verification-only work. If a formatting-only fix is required, commit it separately:
+
+```bash
+git add server/src/services/person.service.spec.ts server/test/medium/specs/services/person.service.spec.ts server/test/medium/specs/repositories/person.repository.spec.ts
+git commit -m "test: format face detection safety specs"
+```
+
+## Execution Notes
+
+- Keep Slice 2 scoped to face detection safety. Recognition queue draining, force recognition reset ordering, and overnight stuck-queue behavior belong to Slice 3 and Slice 8.
+- Prefer small tests for service call contracts. Use medium tests only when the assertion requires real DB cascades or real row preservation.
+- Any production change must be justified by a failing test from this plan.
+- When using `queueAll` negative assertions, flatten jobs and assert each forbidden job name individually.
+- When adding medium tests that depend on config, call `clearConfigCache()` in the setup helper before constructing the service.
+
+## Self-Review
+
+- Spec coverage: every Slice 2 bullet from `docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md` maps to Task 1 through Task 7.
+- Placeholder scan: this plan avoids unresolved placeholders and includes exact commands, file paths, and test code shapes.
+- Type consistency: all snippets use existing `PersonService`, repository, factory, enum, and job names observed in the current codebase.

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1974,6 +1974,36 @@ describe(PersonService.name, () => {
       expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
+    it('should not write facesRecognizedAt when recognition fan-out queueing fails', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview, path: '/preview.jpg' }).exif().build();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.crypto.randomUUID.mockReturnValue(face.id);
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.person.refreshFaces.mockResolvedValue();
+      mocks.job.queueAll.mockRejectedValue(new Error('redis unavailable'));
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).rejects.toThrow('redis unavailable');
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+    });
+
+    it('should not queue recognition or write facesRecognizedAt when refreshFaces fails', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview, path: '/preview.jpg' }).exif().build();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.crypto.randomUUID.mockReturnValue(face.id);
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(face));
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.person.refreshFaces.mockRejectedValue(new Error('refresh failed'));
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).rejects.toThrow('refresh failed');
+
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+    });
+
     it('should create a face with no person and queue recognition job', async () => {
       const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).exif().build();
       const face = AssetFaceFactory.create({ assetId: asset.id });
@@ -1990,10 +2020,16 @@ describe(PersonService.name, () => {
         [],
         [{ faceId: face.id, embedding: '[1, 2, 3, 4]' }],
       );
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
         { name: JobName.FacialRecognition, data: { id: face.id } },
       ]);
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
       expect(mocks.person.reassignFace).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
     });
@@ -2019,6 +2055,10 @@ describe(PersonService.name, () => {
       });
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
     });
 
     it('non-force detection keeps immediate incremental recognition for new faces', async () => {
@@ -2031,10 +2071,16 @@ describe(PersonService.name, () => {
 
       await sut.handleDetectFaces({ id: asset.id, force: false });
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
         { name: JobName.FacialRecognition, data: { id: face.id } },
       ]);
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
     });
 
     it('keeps old pre-deploy asset-detection jobs without force on the incremental path', async () => {
@@ -2047,10 +2093,16 @@ describe(PersonService.name, () => {
 
       await sut.handleDetectFaces({ id: asset.id });
 
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
         { name: JobName.FacialRecognition, data: { id: face.id } },
       ]);
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
     });
 
     it('should delete an existing face not among the new detected faces', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1245,6 +1245,7 @@ describe(PersonService.name, () => {
       expect(mocks.person.delete).toHaveBeenCalledWith([orphan.id]);
       expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalledTimes(1);
       expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: true });
+      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(true);
       expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         { name: JobName.AssetDetectFaces, data: { id: asset1.id, force: true } },

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1178,6 +1178,17 @@ describe(PersonService.name, () => {
   });
 
   describe('handleQueueDetectFaces', () => {
+    const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+    const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
+
+    const expectNoRecognitionFanout = () => {
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+      );
+      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
+      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
+    };
+
     it('should skip if machine learning is disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
 
@@ -1187,122 +1198,74 @@ describe(PersonService.name, () => {
       expect(mocks.systemMetadata.get).toHaveBeenCalled();
     });
 
-    it('should queue missing assets', async () => {
-      const asset = AssetFactory.create();
-      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
-
-      await sut.handleQueueDetectFaces({ force: false });
-
-      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(false);
-      expect(mocks.person.vacuum).not.toHaveBeenCalled();
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.AssetDetectFaces,
-          data: { id: asset.id },
-        },
-      ]);
-    });
-
-    it('should queue all assets', async () => {
-      const asset = AssetFactory.create();
-      const person = PersonFactory.create();
-
-      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
-      mocks.person.getAllWithoutFaces.mockResolvedValue([person]);
-      mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
-
-      await sut.handleQueueDetectFaces({ force: true });
-
-      expect(mocks.person.deleteFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
-      expect(mocks.person.delete).toHaveBeenCalledWith([person.id]);
-      expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalled();
-      expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: true });
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.FileDelete,
-        data: { files: [person.thumbnailPath] },
-      });
-      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(true);
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.AssetDetectFaces,
-          data: { id: asset.id, force: true },
-        },
-      ]);
-    });
-
-    it('marks force-created asset face-detection jobs so recognition fan-out can be suppressed', async () => {
+    it.each([
+      ['force=false', false],
+      ['force omitted', undefined],
+    ] as const)('should queue per-asset detection without destructive cleanup when %s', async (_label, force) => {
       const asset1 = AssetFactory.create();
       const asset2 = AssetFactory.create();
-      const person = PersonFactory.create();
+      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset1, asset2]));
+
+      await expect(sut.handleQueueDetectFaces({ force })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(force);
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+      expect(mocks.person.delete).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
+      expect(mocks.person.vacuum).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetDetectFaces, data: { id: asset1.id } },
+        { name: JobName.AssetDetectFaces, data: { id: asset2.id } },
+      ]);
+
+      if (force === undefined) {
+        expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+        expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.PersonCleanup });
+      } else {
+        expect(mocks.job.queue).not.toHaveBeenCalled();
+      }
+    });
+
+    it('should force-detect all assets after deleting only machine-learning faces', async () => {
+      const asset1 = AssetFactory.create();
+      const asset2 = AssetFactory.create();
+      const orphan = PersonFactory.create();
 
       mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset1, asset2]));
-      mocks.person.getAllWithoutFaces.mockResolvedValue([person]);
+      mocks.person.getAllWithoutFaces.mockResolvedValue([orphan]);
       mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
 
-      await sut.handleQueueDetectFaces({ force: true });
+      await expect(sut.handleQueueDetectFaces({ force: true })).resolves.toBe(JobStatus.Success);
 
-      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(true);
+      expect(mocks.person.deleteFaces).toHaveBeenCalledTimes(1);
+      expect(mocks.person.deleteFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalledWith({ sourceType: SourceType.Manual });
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalledWith({ sourceType: SourceType.Exif });
+      expect(mocks.person.delete).toHaveBeenCalledWith([orphan.id]);
+      expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalledTimes(1);
+      expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: true });
+      expect(mocks.job.queueAll).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.AssetDetectFaces,
-          data: { id: asset1.id, force: true },
-        },
-        {
-          name: JobName.AssetDetectFaces,
-          data: { id: asset2.id, force: true },
-        },
+        { name: JobName.AssetDetectFaces, data: { id: asset1.id, force: true } },
+        { name: JobName.AssetDetectFaces, data: { id: asset2.id, force: true } },
       ]);
-    });
-
-    it('should refresh all assets', async () => {
-      const asset = AssetFactory.create();
-      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
-
-      await sut.handleQueueDetectFaces({ force: undefined });
-
-      expect(mocks.person.delete).not.toHaveBeenCalled();
-      expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
-      expect(mocks.person.vacuum).not.toHaveBeenCalled();
-      expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
-      expect(mocks.storage.unlink).not.toHaveBeenCalled();
-      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(undefined);
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.AssetDetectFaces,
-          data: { id: asset.id },
-        },
-      ]);
-      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.PersonCleanup });
-    });
-
-    it('should delete existing people and faces if forced', async () => {
-      const asset = AssetFactory.create();
-      const face = AssetFaceFactory.from().person().build();
-      const person = PersonFactory.create();
-
-      mocks.person.getAll.mockReturnValue(makeStream([face.person!, person]));
-      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
-      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([asset]));
-      mocks.person.getAllWithoutFaces.mockResolvedValue([person]);
-      mocks.person.deleteFaces.mockResolvedValue();
-      mocks.sharedSpace.deleteAllOrphanedPersons.mockResolvedValue(void 0 as any);
-
-      await sut.handleQueueDetectFaces({ force: true });
-
-      expect(mocks.assetJob.streamForDetectFacesJob).toHaveBeenCalledWith(true);
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.AssetDetectFaces,
-          data: { id: asset.id, force: true },
-        },
-      ]);
-      expect(mocks.person.delete).toHaveBeenCalledWith([person.id]);
-      expect(mocks.sharedSpace.deleteAllOrphanedPersons).toHaveBeenCalled();
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FileDelete,
-        data: { files: [person.thumbnailPath] },
+        data: { files: [orphan.thumbnailPath] },
       });
-      expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: true });
+    });
+
+    it('should not enqueue recognition or cleanup shortcuts when the detection stream is empty', async () => {
+      mocks.assetJob.streamForDetectFacesJob.mockReturnValue(makeStream([]));
+
+      await expect(sut.handleQueueDetectFaces({ force: false })).resolves.toBe(JobStatus.Success);
+
+      expect(queuedBatchJobs()).toEqual([]);
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.person.deleteFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllOrphanedPersons).not.toHaveBeenCalled();
+      expectNoRecognitionFanout();
     });
   });
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1872,6 +1872,17 @@ describe(PersonService.name, () => {
   });
 
   describe('handleDetectFaces', () => {
+    const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+    const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
+
+    const expectNoRecognitionFanout = () => {
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+      );
+      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
+      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
+    };
+
     it('should skip if machine learning is disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
 
@@ -2053,6 +2064,257 @@ describe(PersonService.name, () => {
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
       expect(mocks.person.reassignFace).not.toHaveBeenCalled();
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    });
+
+    it('should remove only stale machine-learning faces and unlink only those identity links', async () => {
+      const assetId = newUuid();
+      const mlFace = AssetFaceFactory.create({ assetId, id: 'ml-face', sourceType: SourceType.MachineLearning });
+      const exifFace = AssetFaceFactory.create({ assetId, id: 'exif-face', sourceType: SourceType.Exif });
+      const manualFace = AssetFaceFactory.create({ assetId, id: 'manual-face', sourceType: SourceType.Manual });
+      const asset = AssetFactory.from({ id: assetId })
+        .face(mlFace)
+        .face(exifFace)
+        .face(manualFace)
+        .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+        .exif()
+        .build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.machineLearning.detectFaces.mockResolvedValue({ imageHeight: 500, imageWidth: 400, faces: [] });
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalledWith([], [mlFace.id], []);
+      expect(mocks.faceIdentity.unlinkFaces).toHaveBeenCalledTimes(1);
+      expect(mocks.faceIdentity.unlinkFaces).toHaveBeenCalledWith([mlFace.id]);
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([exifFace.id]));
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([manualFace.id]));
+      expectNoRecognitionFanout();
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
+    });
+
+    it('forced per-asset detection removes stale ML faces while preserving manual and EXIF evidence', async () => {
+      const assetId = newUuid();
+      const staleMlFace = AssetFaceFactory.create({
+        assetId,
+        id: 'stale-ml-face',
+        sourceType: SourceType.MachineLearning,
+        boundingBoxX1: 700,
+        boundingBoxY1: 500,
+        boundingBoxX2: 900,
+        boundingBoxY2: 700,
+      });
+      const exifFace = AssetFaceFactory.create({
+        assetId,
+        id: 'force-exif-face',
+        sourceType: SourceType.Exif,
+        boundingBoxX1: 10,
+        boundingBoxY1: 10,
+        boundingBoxX2: 40,
+        boundingBoxY2: 40,
+      });
+      const manualFace = AssetFaceFactory.create({
+        assetId,
+        id: 'force-manual-face',
+        sourceType: SourceType.Manual,
+        boundingBoxX1: 300,
+        boundingBoxY1: 300,
+        boundingBoxX2: 350,
+        boundingBoxY2: 350,
+      });
+      const asset = AssetFactory.from({ id: assetId })
+        .face(staleMlFace)
+        .face(exifFace)
+        .face(manualFace)
+        .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+        .exif()
+        .build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.crypto.randomUUID.mockReturnValue('force-new-ml-face');
+      mocks.machineLearning.detectFaces.mockResolvedValue({
+        imageHeight: 500,
+        imageWidth: 400,
+        faces: [
+          {
+            boundingBox: { x1: 100, y1: 80, x2: 250, y2: 200 },
+            embedding: '[1, 2, 3, 4]',
+            score: 0.99,
+          },
+        ],
+      });
+
+      await expect(sut.handleDetectFaces({ id: asset.id, force: true })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            id: 'force-new-ml-face',
+            assetId: asset.id,
+            boundingBoxX1: 100,
+            boundingBoxY1: 80,
+            boundingBoxX2: 250,
+            boundingBoxY2: 200,
+          }),
+        ],
+        [staleMlFace.id],
+        [{ faceId: 'force-new-ml-face', embedding: '[1, 2, 3, 4]' }],
+      );
+      expect(mocks.faceIdentity.unlinkFaces).toHaveBeenCalledWith([staleMlFace.id]);
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([exifFace.id]));
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalledWith(expect.arrayContaining([manualFace.id]));
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FacialRecognitionQueueAll,
+        data: { force: true },
+      });
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
+    });
+
+    it('should add an embedding to a matching manual face instead of creating a duplicate', async () => {
+      const manualFace = AssetFaceFactory.create({ sourceType: SourceType.Manual });
+      const asset = AssetFactory.from({ id: manualFace.assetId })
+        .face(manualFace)
+        .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+        .exif()
+        .build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(manualFace));
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+        [],
+        [],
+        [{ faceId: manualFace.id, embedding: '[1, 2, 3, 4]' }],
+      );
+      expect(mocks.crypto.randomUUID).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+      expectNoRecognitionFanout();
+    });
+
+    it('should keep a matching existing ML face without adding a duplicate or unlinking identities', async () => {
+      const mlFace = AssetFaceFactory.create({ sourceType: SourceType.MachineLearning });
+      const asset = AssetFactory.from({ id: mlFace.assetId })
+        .face(mlFace)
+        .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+        .exif()
+        .build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.machineLearning.detectFaces.mockResolvedValue(getAsDetectedFace(mlFace));
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+      expect(mocks.crypto.randomUUID).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+      expectNoRecognitionFanout();
+      expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
+        assetId: asset.id,
+        facesRecognizedAt: expect.any(Date),
+      });
+    });
+
+    it('should preserve an existing metadata face when scaled detection boxes still overlap', async () => {
+      const assetId = newUuid();
+      const exifFace = AssetFaceFactory.create({
+        assetId,
+        id: 'scaled-exif-face',
+        sourceType: SourceType.Exif,
+        imageWidth: 1000,
+        imageHeight: 800,
+        boundingBoxX1: 200,
+        boundingBoxY1: 160,
+        boundingBoxX2: 500,
+        boundingBoxY2: 400,
+      });
+      const asset = AssetFactory.from({ id: assetId })
+        .face(exifFace)
+        .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+        .exif()
+        .build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.machineLearning.detectFaces.mockResolvedValue({
+        imageWidth: 500,
+        imageHeight: 400,
+        faces: [
+          {
+            boundingBox: { x1: 100, y1: 80, x2: 250, y2: 200 },
+            embedding: '[1, 2, 3, 4]',
+            score: 0.99,
+          },
+        ],
+      });
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+        [],
+        [],
+        [{ faceId: exifFace.id, embedding: '[1, 2, 3, 4]' }],
+      );
+      expect(mocks.crypto.randomUUID).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+      expectNoRecognitionFanout();
+    });
+
+    it('should create a new ML face when scaled detection boxes do not overlap existing manual or EXIF faces', async () => {
+      const assetId = newUuid();
+      const exifFace = AssetFaceFactory.create({
+        assetId,
+        id: 'far-exif-face',
+        sourceType: SourceType.Exif,
+        imageWidth: 1000,
+        imageHeight: 800,
+        boundingBoxX1: 700,
+        boundingBoxY1: 500,
+        boundingBoxX2: 900,
+        boundingBoxY2: 700,
+      });
+      const asset = AssetFactory.from({ id: assetId })
+        .face(exifFace)
+        .file({ type: AssetFileType.Preview, path: '/preview.jpg' })
+        .exif()
+        .build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.crypto.randomUUID.mockReturnValue('new-ml-face');
+      mocks.machineLearning.detectFaces.mockResolvedValue({
+        imageWidth: 500,
+        imageHeight: 400,
+        faces: [
+          {
+            boundingBox: { x1: 100, y1: 80, x2: 250, y2: 200 },
+            embedding: '[1, 2, 3, 4]',
+            score: 0.99,
+          },
+        ],
+      });
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.refreshFaces).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            id: 'new-ml-face',
+            assetId: asset.id,
+            boundingBoxX1: 100,
+            boundingBoxY1: 80,
+            boundingBoxX2: 250,
+            boundingBoxY2: 200,
+          }),
+        ],
+        [],
+        [{ faceId: 'new-ml-face', embedding: '[1, 2, 3, 4]' }],
+      );
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.FacialRecognitionQueueAll, data: { force: false } },
+        { name: JobName.FacialRecognition, data: { id: 'new-ml-face' } },
+      ]);
     });
 
     it('should add new face and delete an existing face not among the new detected faces', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -86,6 +86,17 @@ describe(PersonService.name, () => {
     expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
   };
 
+  const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+  const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
+
+  const expectNoRecognitionFanout = () => {
+    expect(mocks.job.queue).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+    );
+    expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
+    expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
+  };
+
   it('should be defined', () => {
     expect(sut).toBeDefined();
   });
@@ -1187,17 +1198,6 @@ describe(PersonService.name, () => {
   });
 
   describe('handleQueueDetectFaces', () => {
-    const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
-    const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
-
-    const expectNoRecognitionFanout = () => {
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-      );
-      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
-      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
-    };
-
     it('should skip if machine learning is disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
 
@@ -1872,17 +1872,6 @@ describe(PersonService.name, () => {
   });
 
   describe('handleDetectFaces', () => {
-    const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
-    const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
-
-    const expectNoRecognitionFanout = () => {
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
-      );
-      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
-      expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
-    };
-
     it('should skip if machine learning is disabled', async () => {
       mocks.systemMetadata.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -77,6 +77,15 @@ describe(PersonService.name, () => {
     mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
   });
 
+  const expectNoFaceDetectionMutation = () => {
+    expect(mocks.machineLearning.detectFaces).not.toHaveBeenCalled();
+    expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+    expect(mocks.job.queue).not.toHaveBeenCalled();
+    expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
+  };
+
   it('should be defined', () => {
     expect(sut).toBeDefined();
   });
@@ -1869,6 +1878,44 @@ describe(PersonService.name, () => {
       await expect(sut.handleDetectFaces({ id: 'foo' })).resolves.toBe(JobStatus.Skipped);
       expect(mocks.asset.getByIds).not.toHaveBeenCalled();
       expect(mocks.systemMetadata.get).toHaveBeenCalled();
+      expect(mocks.assetJob.getForDetectFacesJob).not.toHaveBeenCalled();
+      expectNoFaceDetectionMutation();
+    });
+
+    it.each([
+      {
+        label: 'missing asset',
+        asset: undefined,
+        expected: JobStatus.Failed,
+      },
+      {
+        label: 'asset without preview file',
+        asset: AssetFactory.from().exif().build(),
+        expected: JobStatus.Failed,
+      },
+      {
+        label: 'asset with multiple preview files',
+        asset: AssetFactory.from()
+          .file({ type: AssetFileType.Preview, path: '/preview-1.jpg' })
+          .file({ type: AssetFileType.Preview, path: '/preview-2.jpg' })
+          .exif()
+          .build(),
+        expected: JobStatus.Failed,
+      },
+      {
+        label: 'hidden asset with preview file',
+        asset: AssetFactory.from({ visibility: AssetVisibility.Hidden })
+          .file({ type: AssetFileType.Preview, path: '/hidden-preview.jpg' })
+          .exif()
+          .build(),
+        expected: JobStatus.Skipped,
+      },
+    ] as const)('should not mutate faces or status for $label', async ({ asset, expected }) => {
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(asset ? getForDetectedFaces(asset) : undefined);
+
+      await expect(sut.handleDetectFaces({ id: asset?.id ?? 'missing-asset' })).resolves.toBe(expected);
+
+      expectNoFaceDetectionMutation();
     });
 
     it('should skip when no resize path', async () => {
@@ -1891,6 +1938,8 @@ describe(PersonService.name, () => {
       );
       expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
 
       expect(mocks.asset.upsertJobStatus).toHaveBeenCalledWith({
         assetId: asset.id,
@@ -1898,6 +1947,20 @@ describe(PersonService.name, () => {
       });
       const facesRecognizedAt = mocks.asset.upsertJobStatus.mock.calls[0][0].facesRecognizedAt as Date;
       expect(facesRecognizedAt.getTime()).toBeGreaterThan(start);
+    });
+
+    it('should not write facesRecognizedAt or queue recognition when ML face detection throws', async () => {
+      const asset = AssetFactory.from().file({ type: AssetFileType.Preview, path: '/preview.jpg' }).exif().build();
+      mocks.assetJob.getForDetectFacesJob.mockResolvedValue(getForDetectedFaces(asset));
+      mocks.machineLearning.detectFaces.mockRejectedValue(new Error('ml unavailable'));
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).rejects.toThrow('ml unavailable');
+
+      expect(mocks.person.refreshFaces).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.unlinkFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+      expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
     });
 
     it('should create a face with no person and queue recognition job', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -694,16 +694,19 @@ export class PersonService extends BaseService {
       }
     }
 
-    const heightScale = imageHeight / (asset.faces[0]?.imageHeight || 1);
-    const widthScale = imageWidth / (asset.faces[0]?.imageWidth || 1);
     for (const { boundingBox, embedding } of faces) {
-      const scaledBox = {
-        x1: boundingBox.x1 * widthScale,
-        y1: boundingBox.y1 * heightScale,
-        x2: boundingBox.x2 * widthScale,
-        y2: boundingBox.y2 * heightScale,
-      };
-      const match = asset.faces.find((face) => this.iou(face, scaledBox) > 0.5);
+      const match = asset.faces.find((face) => {
+        const heightScale = face.imageHeight / imageHeight;
+        const widthScale = face.imageWidth / imageWidth;
+        const scaledBox = {
+          x1: boundingBox.x1 * widthScale,
+          y1: boundingBox.y1 * heightScale,
+          x2: boundingBox.x2 * widthScale,
+          y2: boundingBox.y2 * heightScale,
+        };
+
+        return this.iou(face, scaledBox) > 0.5;
+      });
 
       if (match && !mlFaceIds.delete(match.id)) {
         embeddings.push({ faceId: match.id, embedding });

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -1,11 +1,12 @@
-import { Kysely } from 'kysely';
-import { AssetFileType, AssetVisibility } from 'src/enum';
+import { Kysely, sql } from 'kysely';
+import { AssetFileType, AssetVisibility, SourceType } from 'src/enum';
 import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
 import { DB } from 'src/schema';
 import { BaseService } from 'src/services/base.service';
 import { newMediumService } from 'test/medium.factory';
+import { newEmbedding } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
 
 let defaultDatabase: Kysely<DB>;
@@ -554,6 +555,156 @@ describe(PersonRepository.name, () => {
       await expect(
         sut.getRepresentativeFaceForUpdate({ personId: targetPerson.id, assetFaceId: faceId }),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('refreshFaces', () => {
+    it('deletes only requested ML faces, cascades only those identity links, and preserves manual and EXIF evidence', async () => {
+      const { ctx, sut } = setup();
+      const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
+      const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
+      const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
+      const { result: mlFaceId } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: mlPerson.id,
+        sourceType: SourceType.MachineLearning,
+      });
+      const { result: manualFaceId } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: manualPerson.id,
+        sourceType: SourceType.Manual,
+      });
+      const { result: exifFaceId } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: exifPerson.id,
+        sourceType: SourceType.Exif,
+      });
+      const mlIdentity = await faceIdentityRepository.ensurePersonIdentity(mlPerson.id);
+      const manualIdentity = await faceIdentityRepository.ensurePersonIdentity(manualPerson.id);
+      const exifIdentity = await faceIdentityRepository.ensurePersonIdentity(exifPerson.id);
+      await faceIdentityRepository.replaceFaceIdentity({
+        assetFaceId: mlFaceId,
+        identityId: mlIdentity.id,
+        source: 'ml',
+      });
+      await faceIdentityRepository.replaceFaceIdentity({
+        assetFaceId: manualFaceId,
+        identityId: manualIdentity.id,
+        source: 'manual',
+      });
+      await faceIdentityRepository.replaceFaceIdentity({
+        assetFaceId: exifFaceId,
+        identityId: exifIdentity.id,
+        source: 'import',
+      });
+      const newFaceId = '11111111-1111-4111-8111-111111111111';
+      const embedding = newEmbedding();
+
+      await sut.refreshFaces(
+        [
+          {
+            id: newFaceId,
+            assetId: asset.id,
+            imageWidth: 200,
+            imageHeight: 200,
+            boundingBoxX1: 10,
+            boundingBoxY1: 10,
+            boundingBoxX2: 60,
+            boundingBoxY2: 60,
+          },
+        ],
+        [mlFaceId],
+        [{ faceId: newFaceId, embedding }],
+      );
+
+      const faceRows = await ctx.database
+        .selectFrom('asset_face')
+        .select(['id', 'sourceType'])
+        .where('assetId', '=', asset.id)
+        .execute();
+      expect(faceRows).toEqual(
+        expect.arrayContaining([
+          { id: manualFaceId, sourceType: SourceType.Manual },
+          { id: exifFaceId, sourceType: SourceType.Exif },
+          { id: newFaceId, sourceType: SourceType.MachineLearning },
+        ]),
+      );
+      expect(faceRows).toHaveLength(3);
+      expect(faceRows.map((face) => face.id)).not.toContain(mlFaceId);
+
+      const links = await ctx.database
+        .selectFrom('face_identity_face')
+        .select(['assetFaceId', 'identityId', 'source'])
+        .where('assetFaceId', 'in', [mlFaceId, manualFaceId, exifFaceId])
+        .execute();
+      expect(links).toEqual(
+        expect.arrayContaining([
+          { assetFaceId: manualFaceId, identityId: manualIdentity.id, source: 'manual' },
+          { assetFaceId: exifFaceId, identityId: exifIdentity.id, source: 'import' },
+        ]),
+      );
+      expect(links).toHaveLength(2);
+      expect(links.map((link) => link.assetFaceId)).not.toContain(mlFaceId);
+
+      await expect(
+        ctx.database
+          .selectFrom('face_search')
+          .select(['faceId', sql<number>`vector_dims(embedding)`.as('dimensions')])
+          .where('faceId', '=', newFaceId)
+          .executeTakeFirst(),
+      ).resolves.toEqual({ faceId: newFaceId, dimensions: 512 });
+    });
+
+    it('does not mutate face rows when refreshFaces receives no inserts, removals, or embeddings', async () => {
+      const { ctx, sut } = setup();
+      const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { result: manualFaceId } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: person.id,
+        sourceType: SourceType.Manual,
+      });
+      const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
+      await faceIdentityRepository.replaceFaceIdentity({
+        assetFaceId: manualFaceId,
+        identityId: identity.id,
+        source: 'manual',
+      });
+
+      const before = {
+        faces: await ctx.database
+          .selectFrom('asset_face')
+          .select(['id', 'sourceType'])
+          .where('assetId', '=', asset.id)
+          .execute(),
+        links: await ctx.database
+          .selectFrom('face_identity_face')
+          .select(['assetFaceId', 'identityId', 'source'])
+          .where('assetFaceId', '=', manualFaceId)
+          .execute(),
+        embeddings: await ctx.database.selectFrom('face_search').select(['faceId']).execute(),
+      };
+
+      await sut.refreshFaces([], [], []);
+
+      await expect(
+        ctx.database.selectFrom('asset_face').select(['id', 'sourceType']).where('assetId', '=', asset.id).execute(),
+      ).resolves.toEqual(before.faces);
+      await expect(
+        ctx.database
+          .selectFrom('face_identity_face')
+          .select(['assetFaceId', 'identityId', 'source'])
+          .where('assetFaceId', '=', manualFaceId)
+          .execute(),
+      ).resolves.toEqual(before.links);
+      await expect(ctx.database.selectFrom('face_search').select(['faceId']).execute()).resolves.toEqual(
+        before.embeddings,
+      );
     });
   });
 });

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -672,7 +672,7 @@ describe(PersonRepository.name, () => {
       ).resolves.toEqual({ faceId: newFaceId, dimensions: 512 });
       const embeddingDistance = await ctx.database
         .selectFrom('face_search')
-        .select(sql<number>`face_search.embedding <=> ${embedding}`.as('distance'))
+        .select(sql<number>`face_search.embedding <-> ${embedding}`.as('distance'))
         .where('faceId', '=', newFaceId)
         .executeTakeFirstOrThrow();
       expect(embeddingDistance.distance).toBeCloseTo(0);

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -670,6 +670,12 @@ describe(PersonRepository.name, () => {
           .where('faceId', '=', newFaceId)
           .executeTakeFirst(),
       ).resolves.toEqual({ faceId: newFaceId, dimensions: 512 });
+      const embeddingDistance = await ctx.database
+        .selectFrom('face_search')
+        .select(sql<number>`face_search.embedding <=> ${embedding}`.as('distance'))
+        .where('faceId', '=', newFaceId)
+        .executeTakeFirstOrThrow();
+      expect(embeddingDistance.distance).toBeCloseTo(0);
     });
 
     it('does not mutate face rows when refreshFaces receives no inserts, removals, or embeddings', async () => {

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -565,11 +565,17 @@ describe(PersonRepository.name, () => {
       const { user } = await ctx.newUser();
       const { asset } = await ctx.newAsset({ ownerId: user.id });
       const { person: mlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'ML' });
+      const { person: retainedMlPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Retained ML' });
       const { person: manualPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Manual' });
       const { person: exifPerson } = await ctx.newPerson({ ownerId: user.id, name: 'EXIF' });
       const { result: mlFaceId } = await ctx.newAssetFace({
         assetId: asset.id,
         personId: mlPerson.id,
+        sourceType: SourceType.MachineLearning,
+      });
+      const { result: retainedMlFaceId } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: retainedMlPerson.id,
         sourceType: SourceType.MachineLearning,
       });
       const { result: manualFaceId } = await ctx.newAssetFace({
@@ -583,11 +589,17 @@ describe(PersonRepository.name, () => {
         sourceType: SourceType.Exif,
       });
       const mlIdentity = await faceIdentityRepository.ensurePersonIdentity(mlPerson.id);
+      const retainedMlIdentity = await faceIdentityRepository.ensurePersonIdentity(retainedMlPerson.id);
       const manualIdentity = await faceIdentityRepository.ensurePersonIdentity(manualPerson.id);
       const exifIdentity = await faceIdentityRepository.ensurePersonIdentity(exifPerson.id);
       await faceIdentityRepository.replaceFaceIdentity({
         assetFaceId: mlFaceId,
         identityId: mlIdentity.id,
+        source: 'ml',
+      });
+      await faceIdentityRepository.replaceFaceIdentity({
+        assetFaceId: retainedMlFaceId,
+        identityId: retainedMlIdentity.id,
         source: 'ml',
       });
       await faceIdentityRepository.replaceFaceIdentity({
@@ -627,26 +639,28 @@ describe(PersonRepository.name, () => {
         .execute();
       expect(faceRows).toEqual(
         expect.arrayContaining([
+          { id: retainedMlFaceId, sourceType: SourceType.MachineLearning },
           { id: manualFaceId, sourceType: SourceType.Manual },
           { id: exifFaceId, sourceType: SourceType.Exif },
           { id: newFaceId, sourceType: SourceType.MachineLearning },
         ]),
       );
-      expect(faceRows).toHaveLength(3);
+      expect(faceRows).toHaveLength(4);
       expect(faceRows.map((face) => face.id)).not.toContain(mlFaceId);
 
       const links = await ctx.database
         .selectFrom('face_identity_face')
         .select(['assetFaceId', 'identityId', 'source'])
-        .where('assetFaceId', 'in', [mlFaceId, manualFaceId, exifFaceId])
+        .where('assetFaceId', 'in', [mlFaceId, retainedMlFaceId, manualFaceId, exifFaceId])
         .execute();
       expect(links).toEqual(
         expect.arrayContaining([
+          { assetFaceId: retainedMlFaceId, identityId: retainedMlIdentity.id, source: 'ml' },
           { assetFaceId: manualFaceId, identityId: manualIdentity.id, source: 'manual' },
           { assetFaceId: exifFaceId, identityId: exifIdentity.id, source: 'import' },
         ]),
       );
-      expect(links).toHaveLength(2);
+      expect(links).toHaveLength(3);
       expect(links.map((link) => link.assetFaceId)).not.toContain(mlFaceId);
 
       await expect(

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -97,10 +97,7 @@ const getIdentityLinks = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], fac
     .orderBy('assetFaceId')
     .execute();
 
-const createAssetReadyForFaceDetection = async (
-  ctx: ReturnType<typeof setupFaceDetection>['ctx'],
-  ownerId: string,
-) => {
+const createAssetReadyForFaceDetection = async (ctx: ReturnType<typeof setupFaceDetection>['ctx'], ownerId: string) => {
   const { asset } = await ctx.newAsset({ ownerId, visibility: AssetVisibility.Timeline, width: 200, height: 200 });
   await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: `/preview/${asset.id}.webp` });
   await ctx.newExif({ assetId: asset.id, exifImageHeight: 200, exifImageWidth: 200 });
@@ -231,9 +228,9 @@ describe(PersonService.name, () => {
           }),
         ]),
       );
-      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toHaveLength(
-        2,
-      );
+      await expect(
+        getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id]),
+      ).resolves.toHaveLength(2);
       await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
         expect.arrayContaining([
           { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
@@ -411,11 +408,7 @@ describe(PersonService.name, () => {
       await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
 
       await expect(
-        ctx.database
-          .selectFrom('asset_face')
-          .select('id')
-          .where('id', '=', ml.assetFace.id)
-          .execute(),
+        ctx.database.selectFrom('asset_face').select('id').where('id', '=', ml.assetFace.id).execute(),
       ).resolves.toEqual([]);
       await expect(
         ctx.database

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -254,13 +254,13 @@ describe(PersonService.name, () => {
       await expect(
         ctx.database
           .selectFrom('shared_space_person')
-          .select(['id', 'name'])
+          .select(['id', 'identityId', 'name'])
           .where('id', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
           .orderBy('name')
           .execute(),
       ).resolves.toEqual([
-        { id: exifSpacePerson.id, name: 'Exif Space' },
-        { id: manualSpacePerson.id, name: 'Manual Space' },
+        { id: exifSpacePerson.id, identityId: exif.identity.id, name: 'Exif Space' },
+        { id: manualSpacePerson.id, identityId: manual.identity.id, name: 'Manual Space' },
       ]);
       await expect(
         ctx.database
@@ -420,14 +420,14 @@ describe(PersonService.name, () => {
       await expect(
         ctx.database
           .selectFrom('shared_space_person')
-          .select(['id', 'name'])
+          .select(['id', 'identityId', 'name'])
           .where('id', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
           .orderBy('name')
           .execute(),
       ).resolves.toEqual([
-        { id: exifSpacePerson.id, name: 'Exif Space' },
-        { id: mlSpacePerson.id, name: 'Machine Space' },
-        { id: manualSpacePerson.id, name: 'Manual Space' },
+        { id: exifSpacePerson.id, identityId: exif.identity.id, name: 'Exif Space' },
+        { id: mlSpacePerson.id, identityId: ml.identity.id, name: 'Machine Space' },
+        { id: manualSpacePerson.id, identityId: manual.identity.id, name: 'Manual Space' },
       ]);
       await expect(
         ctx.database

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -412,6 +412,13 @@ describe(PersonService.name, () => {
 
       await expect(
         ctx.database
+          .selectFrom('asset_face')
+          .select('id')
+          .where('id', '=', ml.assetFace.id)
+          .execute(),
+      ).resolves.toEqual([]);
+      await expect(
+        ctx.database
           .selectFrom('shared_space_person')
           .select(['id', 'name'])
           .where('id', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -1,21 +1,36 @@
 import { Kysely } from 'kysely';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetFaceCreateDto } from 'src/dtos/person.dto';
-import { AssetVisibility, JobName, JobStatus } from 'src/enum';
+import {
+  AssetFileType,
+  AssetVisibility,
+  JobName,
+  JobStatus,
+  SharedSpaceRole,
+  SourceType,
+  SystemMetadataKey,
+} from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetEditRepository } from 'src/repositories/asset-edit.repository';
+import { AssetJobRepository } from 'src/repositories/asset-job.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
 import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
 import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
+import { MachineLearningRepository } from 'src/repositories/machine-learning.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
+import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
 import { DB } from 'src/schema';
 import { PersonService } from 'src/services/person.service';
+import { clearConfigCache } from 'src/utils/config';
 import { newMediumService } from 'test/medium.factory';
 import { factory } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
+import { Mocked } from 'vitest';
 
 let defaultDatabase: Kysely<DB>;
 
@@ -34,11 +49,410 @@ const setup = (db?: Kysely<DB>) => {
   });
 };
 
+const setupFaceDetection = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(PersonService, {
+    database: db || defaultDatabase,
+    real: [
+      AccessRepository,
+      AssetRepository,
+      AssetJobRepository,
+      ConfigRepository,
+      DatabaseRepository,
+      FaceIdentityRepository,
+      PersonRepository,
+      SharedSpaceRepository,
+    ],
+    mock: [JobRepository, LoggingRepository, MachineLearningRepository, StorageRepository, SystemMetadataRepository],
+  });
+
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queue.mockResolvedValue();
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll.mockResolvedValue();
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockImplementation(async (key) => {
+      if (key === SystemMetadataKey.SystemConfig) {
+        return { machineLearning: { facialRecognition: { enabled: true, minFaces: 1 } } } as any;
+      }
+      return undefined as any;
+    });
+
+  return { sut, ctx };
+};
+
+const getAssetFaces = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], assetId: string) =>
+  ctx.database
+    .selectFrom('asset_face')
+    .select(['id', 'assetId', 'personId', 'sourceType'])
+    .where('assetId', '=', assetId)
+    .orderBy('id')
+    .execute();
+
+const getIdentityLinks = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], faceIds: string[]) =>
+  ctx.database
+    .selectFrom('face_identity_face')
+    .select(['assetFaceId', 'identityId', 'source'])
+    .where('assetFaceId', 'in', faceIds)
+    .orderBy('assetFaceId')
+    .execute();
+
+const createAssetReadyForFaceDetection = async (
+  ctx: ReturnType<typeof setupFaceDetection>['ctx'],
+  ownerId: string,
+) => {
+  const { asset } = await ctx.newAsset({ ownerId, visibility: AssetVisibility.Timeline, width: 200, height: 200 });
+  await ctx.newAssetFile({ assetId: asset.id, type: AssetFileType.Preview, path: `/preview/${asset.id}.webp` });
+  await ctx.newExif({ assetId: asset.id, exifImageHeight: 200, exifImageWidth: 200 });
+  return asset;
+};
+
+const createPersonFaceIdentity = async (
+  ctx: ReturnType<typeof setupFaceDetection>['ctx'],
+  input: {
+    ownerId: string;
+    assetId: string;
+    name: string;
+    sourceType: SourceType;
+    linkSource: 'ml' | 'manual' | 'import';
+  },
+) => {
+  const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+  const { result: person } = await ctx.newPerson({ ownerId: input.ownerId, name: input.name });
+  const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
+  const { assetFace } = await ctx.newAssetFace({
+    assetId: input.assetId,
+    personId: person.id,
+    sourceType: input.sourceType,
+  });
+  await faceIdentityRepository.replaceFaceIdentity({
+    assetFaceId: assetFace.id,
+    identityId: identity.id,
+    source: input.linkSource,
+  });
+
+  return { person, identity, assetFace };
+};
+
+const createSpacePersonFace = async (
+  ctx: ReturnType<typeof setupFaceDetection>['ctx'],
+  input: { spaceId: string; identityId: string; assetFaceId: string; name: string },
+) => {
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: input.spaceId,
+      identityId: input.identityId,
+      name: input.name,
+      type: 'person',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: input.assetFaceId })
+    .execute();
+
+  return spacePerson;
+};
+
 beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
 
 describe(PersonService.name, () => {
+  describe('handleQueueDetectFaces safety', () => {
+    it('preserves manual and EXIF roots while force face detection removes stale machine-learning state', async () => {
+      const { sut, ctx } = setupFaceDetection();
+      const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+      const { user } = await ctx.newUser();
+      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+      await ctx.newJobStatus({ assetId: asset.id });
+
+      const ml = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Machine',
+        sourceType: SourceType.MachineLearning,
+        linkSource: 'ml',
+      });
+      const manual = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Manual',
+        sourceType: SourceType.Manual,
+        linkSource: 'manual',
+      });
+      const exif = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Exif',
+        sourceType: SourceType.Exif,
+        linkSource: 'import',
+      });
+
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const mlSpacePerson = await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: ml.identity.id,
+        assetFaceId: ml.assetFace.id,
+        name: 'Machine Space',
+      });
+      const manualSpacePerson = await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: manual.identity.id,
+        assetFaceId: manual.assetFace.id,
+        name: 'Manual Space',
+      });
+      const exifSpacePerson = await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: exif.identity.id,
+        assetFaceId: exif.assetFace.id,
+        name: 'Exif Space',
+      });
+
+      await expect(sut.handleQueueDetectFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+      await expect(getAssetFaces(ctx, asset.id)).resolves.toHaveLength(2);
+      await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: exif.assetFace.id,
+            personId: exif.person.id,
+            sourceType: SourceType.Exif,
+          }),
+          expect.objectContaining({
+            id: manual.assetFace.id,
+            personId: manual.person.id,
+            sourceType: SourceType.Manual,
+          }),
+        ]),
+      );
+      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toHaveLength(
+        2,
+      );
+      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+        expect.arrayContaining([
+          { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+          { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+        ]),
+      );
+      await expect(
+        ctx.database
+          .selectFrom('person')
+          .select(['id', 'name'])
+          .where('id', 'in', [ml.person.id, manual.person.id, exif.person.id])
+          .orderBy('name')
+          .execute(),
+      ).resolves.toEqual([
+        { id: exif.person.id, name: 'Exif' },
+        { id: manual.person.id, name: 'Manual' },
+      ]);
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'name'])
+          .where('id', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
+          .orderBy('name')
+          .execute(),
+      ).resolves.toEqual([
+        { id: exifSpacePerson.id, name: 'Exif Space' },
+        { id: manualSpacePerson.id, name: 'Manual Space' },
+      ]);
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person_face')
+          .select(['personId', 'assetFaceId'])
+          .where('personId', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
+          .orderBy('personId')
+          .execute(),
+      ).resolves.toHaveLength(2);
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person_face')
+          .select(['personId', 'assetFaceId'])
+          .where('personId', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
+          .orderBy('personId')
+          .execute(),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          { personId: manualSpacePerson.id, assetFaceId: manual.assetFace.id },
+          { personId: exifSpacePerson.id, assetFaceId: exif.assetFace.id },
+        ]),
+      );
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person_face')
+          .select(['personId', 'assetFaceId'])
+          .where('personId', '=', mlSpacePerson.id)
+          .execute(),
+      ).resolves.toEqual([]);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        { name: JobName.AssetDetectFaces, data: { id: asset.id, force: true } },
+      ]);
+    });
+  });
+
+  describe('handleDetectFaces face detection safety', () => {
+    it('removes stale machine-learning faces without deleting people on non-force no-detected-faces runs', async () => {
+      const { sut, ctx } = setupFaceDetection();
+      const machineLearningMock = ctx.getMock<MachineLearningRepository, Mocked<MachineLearningRepository>>(
+        MachineLearningRepository,
+      );
+      const { user } = await ctx.newUser();
+      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+      const ml = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Machine',
+        sourceType: SourceType.MachineLearning,
+        linkSource: 'ml',
+      });
+      const manual = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Manual',
+        sourceType: SourceType.Manual,
+        linkSource: 'manual',
+      });
+      const exif = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Exif',
+        sourceType: SourceType.Exif,
+        linkSource: 'import',
+      });
+      machineLearningMock.detectFaces.mockResolvedValue({ imageWidth: 200, imageHeight: 200, faces: [] });
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      await expect(getAssetFaces(ctx, asset.id)).resolves.toHaveLength(2);
+      await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: exif.assetFace.id, sourceType: SourceType.Exif }),
+          expect.objectContaining({ id: manual.assetFace.id, sourceType: SourceType.Manual }),
+        ]),
+      );
+      await expect(
+        ctx.database
+          .selectFrom('person')
+          .select(['id', 'name'])
+          .where('id', 'in', [ml.person.id, manual.person.id, exif.person.id])
+          .orderBy('name')
+          .execute(),
+      ).resolves.toEqual([
+        { id: exif.person.id, name: 'Exif' },
+        { id: ml.person.id, name: 'Machine' },
+        { id: manual.person.id, name: 'Manual' },
+      ]);
+      await expect(
+        ctx.database
+          .selectFrom('asset_job_status')
+          .select('facesRecognizedAt')
+          .where('assetId', '=', asset.id)
+          .executeTakeFirstOrThrow(),
+      ).resolves.toEqual({ facesRecognizedAt: expect.any(Date) });
+    });
+
+    it('preserves manual and EXIF shared-space projections while removing stale machine-learning face links', async () => {
+      const { sut, ctx } = setupFaceDetection();
+      const machineLearningMock = ctx.getMock<MachineLearningRepository, Mocked<MachineLearningRepository>>(
+        MachineLearningRepository,
+      );
+      const { user } = await ctx.newUser();
+      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const ml = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Machine',
+        sourceType: SourceType.MachineLearning,
+        linkSource: 'ml',
+      });
+      const manual = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Manual',
+        sourceType: SourceType.Manual,
+        linkSource: 'manual',
+      });
+      const exif = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Exif',
+        sourceType: SourceType.Exif,
+        linkSource: 'import',
+      });
+      const mlSpacePerson = await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: ml.identity.id,
+        assetFaceId: ml.assetFace.id,
+        name: 'Machine Space',
+      });
+      const manualSpacePerson = await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: manual.identity.id,
+        assetFaceId: manual.assetFace.id,
+        name: 'Manual Space',
+      });
+      const exifSpacePerson = await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: exif.identity.id,
+        assetFaceId: exif.assetFace.id,
+        name: 'Exif Space',
+      });
+      machineLearningMock.detectFaces.mockResolvedValue({ imageWidth: 200, imageHeight: 200, faces: [] });
+
+      await expect(sut.handleDetectFaces({ id: asset.id })).resolves.toBe(JobStatus.Success);
+
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'name'])
+          .where('id', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
+          .orderBy('name')
+          .execute(),
+      ).resolves.toEqual([
+        { id: exifSpacePerson.id, name: 'Exif Space' },
+        { id: mlSpacePerson.id, name: 'Machine Space' },
+        { id: manualSpacePerson.id, name: 'Manual Space' },
+      ]);
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person_face')
+          .select(['personId', 'assetFaceId'])
+          .where('personId', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
+          .orderBy('personId')
+          .execute(),
+      ).resolves.toHaveLength(2);
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person_face')
+          .select(['personId', 'assetFaceId'])
+          .where('personId', 'in', [mlSpacePerson.id, manualSpacePerson.id, exifSpacePerson.id])
+          .orderBy('personId')
+          .execute(),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          { personId: manualSpacePerson.id, assetFaceId: manual.assetFace.id },
+          { personId: exifSpacePerson.id, assetFaceId: exif.assetFace.id },
+        ]),
+      );
+      await expect(
+        ctx.database
+          .selectFrom('shared_space_person_face')
+          .select(['personId', 'assetFaceId'])
+          .where('personId', '=', mlSpacePerson.id)
+          .execute(),
+      ).resolves.toEqual([]);
+    });
+  });
+
   describe('mergePerson', () => {
     it('links reassigned faces to the target identity for identity-filtered timelines', async () => {
       const { sut, ctx } = setup();

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -71,7 +71,7 @@ const setupFaceDetection = (db?: Kysely<DB>) => {
   ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queueAll.mockResolvedValue();
   ctx
     .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
-    .get.mockImplementation(async (key) => {
+    .get.mockImplementation((key) => {
       if (key === SystemMetadataKey.SystemConfig) {
         return { machineLearning: { facialRecognition: { enabled: true, minFaces: 1 } } } as any;
       }


### PR DESCRIPTION
## Summary
- add Slice 2 unit coverage for face-detection queue roots, per-asset skip/error behavior, source preservation, and recognition fanout
- add medium coverage for destructive face-detection and refreshFaces row safety across manual, EXIF, and machine-learning faces
- fix face matching by scaling each ML detection into each existing face's coordinate space before IOU comparison

## Verification
- pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts
- pnpm --filter immich test:medium --run test/medium/specs/services/person.service.spec.ts test/medium/specs/repositories/person.repository.spec.ts
- pnpm --dir server exec prettier --check src/services/person.service.spec.ts test/medium/specs/services/person.service.spec.ts test/medium/specs/repositories/person.repository.spec.ts
- pnpm --filter immich check