### PR TITLE
fix(web): stop space person merge from reloading the deleted person

### DIFF
--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -236,7 +236,8 @@
         sharedSpacePersonMergeDto: { ids: [person.id] },
       });
       toastManager.success($t('spaces_people_merged'));
-      await invalidateAll();
+      // The current route person is the merge source and no longer exists; navigate
+      // straight to the surviving suggested person instead of reloading a deleted route.
       await goto(getSpacePersonRoute(suggestedPerson.id), { replaceState: true });
     } catch (error) {
       handleError(error, $t('cannot_merge_people'));
@@ -305,7 +306,9 @@
         }));
 
     toastManager.success($t('spaces_people_merged'));
-    return person;
+    // Return the surviving target, not the page's route person — after an auto-swap
+    // the route person is a merged-away source and would 404 on reload.
+    return targetPerson;
   };
 
   const handleBack = async () => {
@@ -333,11 +336,30 @@
   }
 
   async function handleMergeComplete(updatedPerson: ScopedMergeCandidate) {
-    if (isSharedSpacePerson(updatedPerson)) {
-      setPerson(updatedPerson);
-    }
     setAction(null);
-    await invalidateAll();
+
+    const targetRef = toScopedPersonRef(updatedPerson);
+    const targetIsCurrentSpacePerson =
+      targetRef.type === ScopedPersonProfileType.SpacePerson &&
+      (targetRef.spaceId ?? space.id) === space.id &&
+      targetRef.id === person.id;
+
+    if (targetIsCurrentSpacePerson) {
+      // The route person survived as the merge target — refresh it in place.
+      if (isSharedSpacePerson(updatedPerson)) {
+        setPerson(updatedPerson);
+      }
+      await invalidateAll();
+      return;
+    }
+
+    // The route person was a merged-away source; navigate to the surviving target
+    // instead of reloading a deleted route (which 400s with "Person not found").
+    const destination =
+      targetRef.type === ScopedPersonProfileType.SpacePerson
+        ? Route.viewSpacePerson(targetRef.spaceId ?? space.id, targetRef.id, previousRouteParams)
+        : Route.viewPerson({ id: targetRef.id }, previousRouteParams);
+    await goto(destination, { replaceState: true });
   }
 
   async function openBirthDateModal() {

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -95,7 +95,7 @@ vi.mock('$lib/components/assets/thumbnail/image-thumbnail.svelte', async () => {
 });
 
 vi.mock('$lib/components/people/people-merge-selector.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/people-merge-selector.stub.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/space-people-merge-selector.stub.svelte');
   return { default: MockComponent };
 });
 

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -508,4 +508,38 @@ describe('Spaces person detail page', () => {
     });
     expect(invalidateAllMock).toHaveBeenCalled();
   });
+
+  it('navigates to the surviving person after an autosuggest merge without reloading the deleted route', async () => {
+    const person = makePerson({ id: 'person-1', name: '' });
+    const existingPerson = makePerson({ id: 'person-2', name: 'Alice Existing' });
+    sdkMock.getSpacePeople.mockResolvedValue([existingPerson]);
+    vi.mocked(modalManager.showDialog).mockResolvedValue(true);
+    renderPage({ person });
+
+    await userEvent.click(screen.getByText('add_a_name'));
+    await userEvent.type(screen.getByPlaceholderText('add_a_name'), 'Ali');
+    await userEvent.click(await screen.findByRole('button', { name: 'Alice Existing' }));
+
+    await waitFor(() => {
+      expect(sdkMock.mergeSpacePeople).toHaveBeenCalledWith({
+        id: 'space-1',
+        personId: 'person-2',
+        sharedSpacePersonMergeDto: { ids: ['person-1'] },
+      });
+    });
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-1/people/person-2', { replaceState: true });
+    expect(invalidateAllMock).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the surviving target after a swapped merge instead of reloading the deleted route person', async () => {
+    renderPage({ action: 'merge' });
+
+    await userEvent.click(screen.getByTestId('merge-swapped-space-candidate'));
+
+    await waitFor(() => {
+      expect(sdkMock.mergeScopedPeople).toHaveBeenCalled();
+    });
+    expect(gotoMock).toHaveBeenCalledWith('/spaces/space-2/people/space-person-candidate', { replaceState: true });
+    expect(invalidateAllMock).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/test-data/mocks/people-merge-selector.stub.svelte
+++ b/web/src/test-data/mocks/people-merge-selector.stub.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
+  type Candidate = { id: string; [key: string]: unknown };
+
   interface Props {
     person: { id: string };
-    mergePeople?: (person: { id: string }, selectedPeople: Array<{ id: string; [key: string]: unknown }>) => void;
-    onSwapPerson?: (person: { id: string; [key: string]: unknown }) => void;
+    mergePeople?: (person: { id: string }, selectedPeople: Candidate[]) => Promise<Candidate | void> | Candidate | void;
+    onMerge?: (person: Candidate) => void;
+    onSwapPerson?: (person: Candidate) => void;
     searchPeople?: (name: string) => void;
   }
 
-  let { person, mergePeople = () => {}, onSwapPerson = () => {}, searchPeople = () => {} }: Props = $props();
+  let {
+    person,
+    mergePeople = () => {},
+    onMerge = () => {},
+    onSwapPerson = () => {},
+    searchPeople = () => {},
+  }: Props = $props();
 
   const personalCandidate = {
     id: 'person-candidate',
@@ -19,20 +28,26 @@
     name: 'Space Candidate',
     primaryProfile: { type: 'space-person', id: 'space-person-candidate', spaceId: 'space-2' },
   };
+
+  // Mirror the real selector: after merging, hand the surviving person to onMerge.
+  const runMerge = async (target: Candidate, sources: Candidate[]) => {
+    const merged = await mergePeople(target, sources);
+    onMerge(merged ?? target);
+  };
 </script>
 
 <div data-testid="people-merge-selector" data-person-id={person.id}>
   choose_matching_people_to_merge
-  <button type="button" data-testid="merge-personal-candidate" onclick={() => mergePeople(person, [personalCandidate])}>
+  <button type="button" data-testid="merge-personal-candidate" onclick={() => void runMerge(person, [personalCandidate])}>
     merge personal candidate
   </button>
-  <button type="button" data-testid="merge-space-candidate" onclick={() => mergePeople(person, [spaceCandidate])}>
+  <button type="button" data-testid="merge-space-candidate" onclick={() => void runMerge(person, [spaceCandidate])}>
     merge space candidate
   </button>
   <button
     type="button"
     data-testid="merge-swapped-space-candidate"
-    onclick={() => mergePeople(spaceCandidate, [person])}
+    onclick={() => void runMerge(spaceCandidate, [person])}
   >
     merge swapped space candidate
   </button>

--- a/web/src/test-data/mocks/people-merge-selector.stub.svelte
+++ b/web/src/test-data/mocks/people-merge-selector.stub.svelte
@@ -1,21 +1,12 @@
 <script lang="ts">
-  type Candidate = { id: string; [key: string]: unknown };
-
   interface Props {
     person: { id: string };
-    mergePeople?: (person: { id: string }, selectedPeople: Candidate[]) => Promise<Candidate | void> | Candidate | void;
-    onMerge?: (person: Candidate) => void;
-    onSwapPerson?: (person: Candidate) => void;
+    mergePeople?: (person: { id: string }, selectedPeople: Array<{ id: string; [key: string]: unknown }>) => void;
+    onSwapPerson?: (person: { id: string; [key: string]: unknown }) => void;
     searchPeople?: (name: string) => void;
   }
 
-  let {
-    person,
-    mergePeople = () => {},
-    onMerge = () => {},
-    onSwapPerson = () => {},
-    searchPeople = () => {},
-  }: Props = $props();
+  let { person, mergePeople = () => {}, onSwapPerson = () => {}, searchPeople = () => {} }: Props = $props();
 
   const personalCandidate = {
     id: 'person-candidate',
@@ -28,26 +19,20 @@
     name: 'Space Candidate',
     primaryProfile: { type: 'space-person', id: 'space-person-candidate', spaceId: 'space-2' },
   };
-
-  // Mirror the real selector: after merging, hand the surviving person to onMerge.
-  const runMerge = async (target: Candidate, sources: Candidate[]) => {
-    const merged = await mergePeople(target, sources);
-    onMerge(merged ?? target);
-  };
 </script>
 
 <div data-testid="people-merge-selector" data-person-id={person.id}>
   choose_matching_people_to_merge
-  <button type="button" data-testid="merge-personal-candidate" onclick={() => void runMerge(person, [personalCandidate])}>
+  <button type="button" data-testid="merge-personal-candidate" onclick={() => mergePeople(person, [personalCandidate])}>
     merge personal candidate
   </button>
-  <button type="button" data-testid="merge-space-candidate" onclick={() => void runMerge(person, [spaceCandidate])}>
+  <button type="button" data-testid="merge-space-candidate" onclick={() => mergePeople(person, [spaceCandidate])}>
     merge space candidate
   </button>
   <button
     type="button"
     data-testid="merge-swapped-space-candidate"
-    onclick={() => void runMerge(spaceCandidate, [person])}
+    onclick={() => mergePeople(spaceCandidate, [person])}
   >
     merge swapped space candidate
   </button>

--- a/web/src/test-data/mocks/space-people-merge-selector.stub.svelte
+++ b/web/src/test-data/mocks/space-people-merge-selector.stub.svelte
@@ -41,7 +41,11 @@
 
 <div data-testid="people-merge-selector" data-person-id={person.id}>
   choose_matching_people_to_merge
-  <button type="button" data-testid="merge-personal-candidate" onclick={() => void runMerge(person, [personalCandidate])}>
+  <button
+    type="button"
+    data-testid="merge-personal-candidate"
+    onclick={() => void runMerge(person, [personalCandidate])}
+  >
     merge personal candidate
   </button>
   <button type="button" data-testid="merge-space-candidate" onclick={() => void runMerge(person, [spaceCandidate])}>

--- a/web/src/test-data/mocks/space-people-merge-selector.stub.svelte
+++ b/web/src/test-data/mocks/space-people-merge-selector.stub.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  // Like people-merge-selector.stub.svelte, but mirrors the real selector by
+  // handing the surviving person to onMerge after a merge. Used by the spaces
+  // person detail spec to exercise handleMergeComplete. Kept separate so the
+  // global people spec keeps the original no-onMerge stub behavior.
+  type Candidate = { id: string; [key: string]: unknown };
+
+  interface Props {
+    person: { id: string };
+    mergePeople?: (person: { id: string }, selectedPeople: Candidate[]) => Promise<Candidate | void> | Candidate | void;
+    onMerge?: (person: Candidate) => void;
+    onSwapPerson?: (person: Candidate) => void;
+    searchPeople?: (name: string) => void;
+  }
+
+  let {
+    person,
+    mergePeople = () => {},
+    onMerge = () => {},
+    onSwapPerson = () => {},
+    searchPeople = () => {},
+  }: Props = $props();
+
+  const personalCandidate = {
+    id: 'person-candidate',
+    name: 'Personal Candidate',
+    primaryProfile: { type: 'user-person', id: 'person-candidate' },
+  };
+
+  const spaceCandidate = {
+    id: 'space-person-candidate',
+    name: 'Space Candidate',
+    primaryProfile: { type: 'space-person', id: 'space-person-candidate', spaceId: 'space-2' },
+  };
+
+  const runMerge = async (target: Candidate, sources: Candidate[]) => {
+    const merged = await mergePeople(target, sources);
+    onMerge(merged ?? target);
+  };
+</script>
+
+<div data-testid="people-merge-selector" data-person-id={person.id}>
+  choose_matching_people_to_merge
+  <button type="button" data-testid="merge-personal-candidate" onclick={() => void runMerge(person, [personalCandidate])}>
+    merge personal candidate
+  </button>
+  <button type="button" data-testid="merge-space-candidate" onclick={() => void runMerge(person, [spaceCandidate])}>
+    merge space candidate
+  </button>
+  <button
+    type="button"
+    data-testid="merge-swapped-space-candidate"
+    onclick={() => void runMerge(spaceCandidate, [person])}
+  >
+    merge swapped space candidate
+  </button>
+  <button type="button" data-testid="swap-space-candidate" onclick={() => onSwapPerson(spaceCandidate)}>
+    swap space candidate
+  </button>
+  <button type="button" data-testid="search-merge-candidates" onclick={() => searchPeople('Alice')}>search</button>
+</div>


### PR DESCRIPTION
## Problem

Reported by a user: merging two people inside a shared space (as admin) briefly flashes an **"Person not found (HTTP 400)"** error before the page recovers.

The stacktrace pointed at the route loader's `Promise.all` **index 2**, which is exactly `getSpacePerson(...)` in `+page.ts`. Root cause: after a merge, the page reloaded the route of a person the merge had **just deleted**.

Two paths were affected:

1. **`selectSuggestedPerson`** (the name-edit autosuggest merge, from #481): the current route person is the merge *source* and gets deleted, but the code called `invalidateAll()` — re-running `load` for the now-deleted `personId` → `getSpacePerson` 400 — *before* navigating to the surviving suggested person. The subsequent `goto` is why it only flashed for a moment.

2. **`mergePeople` + `handleMergeComplete`** (the "Merge people" overflow flow): `mergePeople` always returned the page's route person. When the merge-selector auto-swaps (an **unnamed** route person — common for EXIF-imported people — becomes a source), the route person is deleted, but `handleMergeComplete` then `setPerson(deletedPerson)` + `invalidateAll()` with **no navigation**, leaving the 400 error stuck.

## Fix

- `selectSuggestedPerson` skips the redundant `invalidateAll()` and navigates straight to the surviving suggested person (matching the global people page's `handleMergeSuggestion` pattern).
- `mergePeople` now returns the surviving **target** instead of the page's route person.
- `handleMergeComplete` navigates to the surviving target (space person → space route, otherwise the global person route), only refreshing in place via `invalidateAll()` when the route person actually survived as the merge target.

## Tests (TDD)

Added two failing-first tests to `space-person-detail-page.spec.ts`:

- autosuggest merge navigates to the surviving person and does **not** reload the deleted route.
- swapped merge navigates to the surviving target instead of reloading the deleted route person.

The merge-selector stub now mirrors the real component by invoking `onMerge` with the surviving person, so the full page flow is exercised. Full web unit suite green; `make check-web` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)