### PR TITLE
fix(server): recover timezone from uploaded instant for zone-less EXIF

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -316,6 +316,78 @@ describe(MetadataService.name, () => {
       );
     });
 
+    // Issue #607: Android cameras omit OffsetTimeOriginal, so the EXIF wall-clock
+    // time has no timezone. Recover the offset from the upload-supplied
+    // fileCreatedAt instant instead of assuming UTC.
+    it('should recover a positive timezone offset from the uploaded fileCreatedAt instant', async () => {
+      // Photo taken at 16:51 local time in UTC+2 -> true instant 14:51Z
+      const asset = AssetFactory.create({ fileCreatedAt: new Date('2026-05-18T14:51:00.000Z') });
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ DateTimeOriginal: '2026:05:18 16:51:00' });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dateTimeOriginal: new Date('2026-05-18T14:51:00.000Z'),
+          timeZone: 'UTC+2',
+        }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileCreatedAt: new Date('2026-05-18T14:51:00.000Z'),
+          localDateTime: new Date('2026-05-18T16:51:00.000Z'),
+        }),
+      );
+    });
+
+    it('should recover a negative timezone offset from the uploaded fileCreatedAt instant', async () => {
+      // Photo taken at 12:00 local time in UTC-4 -> true instant 16:00Z
+      const asset = AssetFactory.create({ fileCreatedAt: new Date('2026-05-18T16:00:00.000Z') });
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ DateTimeOriginal: '2026:05:18 12:00:00' });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dateTimeOriginal: new Date('2026-05-18T16:00:00.000Z'),
+          timeZone: 'UTC-4',
+        }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileCreatedAt: new Date('2026-05-18T16:00:00.000Z'),
+          localDateTime: new Date('2026-05-18T12:00:00.000Z'),
+        }),
+      );
+    });
+
+    it('should not invent a timezone when the uploaded instant matches the EXIF wall clock', async () => {
+      // Clients (web/immich-go) that derive fileCreatedAt from the same zone-less
+      // EXIF must keep the existing UTC behaviour, not gain a fake offset.
+      const asset = AssetFactory.create({ fileCreatedAt: new Date('2026-05-18T16:51:00.000Z') });
+      mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));
+      mockReadTags({ DateTimeOriginal: '2026:05:18 16:51:00' });
+
+      await sut.handleMetadataExtraction({ id: asset.id });
+
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dateTimeOriginal: new Date('2026-05-18T16:51:00.000Z'),
+          timeZone: null,
+        }),
+        { lockedPropertiesBehavior: 'skip' },
+      );
+      expect(mocks.asset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          localDateTime: new Date('2026-05-18T16:51:00.000Z'),
+        }),
+      );
+    });
+
     it('should handle lists of numbers', async () => {
       const asset = AssetFactory.create();
       mocks.assetJob.getForMetadataExtraction.mockResolvedValue(getForMetadataExtraction(asset));

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ContainerDirectoryItem, ExifDateTime, Tags } from 'exiftool-vendored';
 import { Insertable } from 'kysely';
 import _ from 'lodash';
-import { DateTime, Duration } from 'luxon';
+import { DateTime, Duration, FixedOffsetZone } from 'luxon';
 import { Stats } from 'node:fs';
 import { constants } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -85,6 +85,33 @@ export function firstDateTime(tags: ImmichTags) {
     }
   }
 }
+
+/**
+ * Recover a UTC offset for a zone-less EXIF capture time (issue #607).
+ *
+ * Android cameras commonly omit `OffsetTimeOriginal`, so the EXIF wall-clock
+ * time has no timezone and would otherwise be assumed to be UTC. Clients upload
+ * `fileCreatedAt` derived from the true capture instant, so the gap between the
+ * wall clock (read as UTC) and that instant is the original offset.
+ *
+ * Returns a Luxon fixed-offset zone string (e.g. `UTC+2`, `UTC-4`) or null when
+ * the gap is zero or does not resolve to a real-world offset — in which case
+ * the caller keeps the existing UTC behaviour.
+ */
+const deriveTimeZoneFromUploadedInstant = (exifLocalAsUtc: DateTime, fileCreatedAt: Date): string | null => {
+  if (!exifLocalAsUtc.isValid || Number.isNaN(fileCreatedAt.getTime())) {
+    return null;
+  }
+
+  const offsetMinutes = (exifLocalAsUtc.toMillis() - fileCreatedAt.getTime()) / 60_000;
+  // Real-world UTC offsets are whole multiples of 15 minutes within ±14:00.
+  const snapped = Math.round(offsetMinutes / 15) * 15;
+  if (snapped === 0 || Math.abs(snapped) > 14 * 60 || Math.abs(offsetMinutes - snapped) > 2) {
+    return null;
+  }
+
+  return FixedOffsetZone.instance(snapped).name;
+};
 
 const validate = <T>(value: T): NonNullable<T> | null => {
   // handle lists of numbers
@@ -1051,6 +1078,21 @@ export class MetadataService extends BaseService {
     // do not let JavaScript use local timezone
     if (dateTimeOriginal && !dateTime?.hasZone) {
       dateTimeOriginal = dateTimeOriginal.setZone('UTC', { keepLocalTime: true });
+
+      // EXIF has a wall-clock capture time but no offset (Android cameras omit
+      // OffsetTimeOriginal, unlike iOS). Recover the original offset from the
+      // upload-supplied fileCreatedAt instant so the timestamp is not shifted
+      // into UTC on sync. Issue #607.
+      if (timeZone == null) {
+        const derived = deriveTimeZoneFromUploadedInstant(dateTimeOriginal, asset.fileCreatedAt);
+        if (derived) {
+          timeZone = derived;
+          dateTimeOriginal = dateTimeOriginal.setZone(derived, { keepLocalTime: true });
+          this.logger.verbose(
+            `Derived timezone ${timeZone} from fileCreatedAt for asset ${asset.id}: ${asset.originalPath}`,
+          );
+        }
+      }
     }
 
     // align with whatever timeZone we chose


### PR DESCRIPTION
## Problem

Closes #607. Photos taken on Android show the correct timezone (e.g. `4:51 PM GMT+02:00`) until upload completes, then shift to `4:51 PM GMT+00:00` — a different real-world instant. Reproduces on both the Immich and Gallery Android apps; iOS is unaffected.

## Root cause

The Android app uploads the correct UTC instant in `fileCreatedAt` (sourced from MediaStore `DATE_TAKEN`). But `metadata.service.ts` `getDates()` discards it and uses the EXIF `DateTimeOriginal` wall-clock time. Android cameras omit `OffsetTimeOriginal`, so that EXIF time has no zone → the server assumes UTC, shifting the instant by the device's offset. iOS writes `OffsetTimeOriginal`, so it never hits this path.

## Fix

When EXIF has a zone-less capture time, derive the original offset from the gap between that wall-clock time (read as UTC) and the upload-supplied `fileCreatedAt` instant, snap it to a real-world offset (multiple of 15 min, within ±14:00), and apply it.

- **Client-agnostic** — fixes the Gallery *and* Immich Android apps, plus any client that uploads a correct instant. No API/OpenAPI change.
- **Degrades safely** — if a client's `fileCreatedAt` matches the zone-less EXIF (web / immich-go), the gap is 0 → no offset invented → exactly today's behaviour.
- **Idempotent** on re-extraction; does not touch the upstream iOS code path.
- **Known limitation:** recovers a fixed UTC offset (e.g. `UTC+2`), not a named IANA zone — consistent with how Immich already handles offset-only sources.

## Tests

- 3 new tests in `metadata.service.spec.ts`: positive offset (`UTC+2`), negative offset (`UTC-4`), and no-op when the uploaded instant matches the EXIF wall clock.
- Full server unit suite green (4441 passed); `tsc --noEmit` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)