### PR TITLE
test: combine face recognition safety slices

### DIFF
--- a/docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
+++ b/docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
@@ -1,0 +1,1099 @@
+# Face Recognition Coordinator Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Slice 3 coverage proving the facial-recognition coordinator skips, drains, resets, queues, and hands off maintenance work without destructive surprises, especially for overnight issue #597-style queue states.
+
+**Architecture:** Keep most coverage in small unit specs for `PersonService` and `JobRepository`, because Slice 3 is primarily queue orchestration and call ordering. Add medium database tests only for the destructive force-recognition reset over populated face identity state. Production changes are allowed only when the new TDD tests prove a real coordinator bug; expected candidate fixes are limited to `server/src/services/person.service.ts` and `server/src/repositories/job.repository.ts`.
+
+**Tech Stack:** TypeScript, NestJS service tests, Vitest, Gallery small test factories, Gallery medium DB test harness, Kysely, BullMQ job names, BullMQ queue states.
+
+---
+
+## File Structure
+
+- Modify: `server/src/services/person.service.spec.ts`
+  - Owns small unit coverage for `handleQueueRecognizeFaces()` ordering, skip behavior, force-reset scope, per-face job fan-out, shared-space full-rebuild fan-out, maintenance marker ordering, and `handleFaceIdentityMaintenanceAfterRecognition()`.
+- Modify only if a new failing small test proves a coordinator bug: `server/src/services/person.service.ts`
+  - Owns the actual recognition coordinator and maintenance marker implementations.
+- Modify: `server/src/repositories/job.repository.spec.ts`
+  - Owns stable job replacement and dedupe coverage for `FacialRecognitionQueueAll` and its force follow-up stable job.
+- Modify only if a new failing repository test proves a stable-job bug: `server/src/repositories/job.repository.ts`
+  - Owns BullMQ stable-job replacement behavior.
+- Modify: `server/test/medium/specs/services/person.service.spec.ts`
+  - Owns DB-backed destructive-state coverage for force recognition over populated ML, manual, EXIF, and shared-space identity data.
+
+## Execution Preflight
+
+- [ ] **Step 1: Confirm the worktree is isolated and clean**
+
+Run:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+```
+
+Expected:
+
+```text
+/home/pierre/dev/gallery/.worktrees/face-trigger-slice-3-plan
+codex/face-trigger-slice-3-plan
+```
+
+`git status --short` must be empty before editing. If it is not empty, inspect every listed file and preserve user-owned work.
+
+- [ ] **Step 2: Run the Slice 3 baseline small specs**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts src/repositories/job.repository.spec.ts src/services/queue.service.spec.ts
+```
+
+Expected: all three specs pass before new tests are added. The `queue.service.spec.ts` run confirms Slice 1 scheduled/admin trigger coverage still passes after the Slice 3 branch starts.
+
+- [ ] **Step 3: Run the Slice 3 baseline medium service spec**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium --run test/medium/specs/services/person.service.spec.ts
+```
+
+Expected: the medium service spec passes before new DB-backed recognition tests are added.
+
+## TDD Protocol For This Slice
+
+- [ ] **Step 1: Write the failing or coverage test first**
+
+Add the new test before editing production code. For coverage of existing behavior, it may pass immediately.
+
+- [ ] **Step 2: Run the smallest focused selector**
+
+Run the exact `-t` selector from each task. Expected result:
+
+- FAIL when the current implementation violates the Slice 3 contract.
+- PASS when the contract already exists and this is coverage-only.
+
+- [ ] **Step 3: Make the smallest production fix only after a failing test proves it**
+
+Do not change per-face recognition assignment, shared-space matching internals, identity backfill pagination, or manual people operations in this slice.
+
+- [ ] **Step 4: Prove assertions can fail**
+
+For each touched spec file, temporarily change one expected `QueueName`, `JobName`, `SourceType`, queue-state count, or persisted face id to an intentionally wrong value, run the focused test and confirm it fails, then restore the correct expectation before committing.
+
+## Spec Coverage Map
+
+- Nightly recognition skip before queue drains or destructive reset: Task 1.
+- Non-force recognition with waiting, delayed, paused, or extra active work skips without destructive work or duplicate fan-out: Task 2.
+- Force recognition waits for thumbnail, face detection, and people backfill prerequisites before draining and deleting assignments: Task 3.
+- Force recognition unassigns and unlinks only machine-learning faces, queues only ML face jobs, suppresses per-face shared-space matching, queues enabled-space full rebuild jobs, queues the terminal maintenance marker, and writes last-run state: Task 3 and Task 6.
+- Maintenance marker requeues while recognition work is waiting, delayed, paused, or still active; queues backfill only after the queue is drained and no backfill is active/pending: Task 4.
+- Failed or paused stable coordinator jobs do not permanently block legitimate future coordinator work: Task 5.
+- Force recognition over populated DB state preserves manual/EXIF asset faces and identity links, clears only intended ML assignment/link state, wipes shared-space people by design, and is idempotent over repeated force runs: Task 6.
+- Cross-slice overnight chains with library scan and EXIF import remain Slice 8. Per-face recognition assignment remains Slice 4.
+
+## Shared Small-Spec Helpers
+
+- [ ] **Step 1: Add coordinator helper functions**
+
+In `server/src/services/person.service.spec.ts`, add this import with the existing DTO imports:
+
+```ts
+import { QueueStatisticsDto } from 'src/dtos/queue.dto';
+```
+
+Then place these helpers near the existing top-level test helpers inside `describe(PersonService.name, () => { ... })`, after `expectNoRecognitionFanout()`:
+
+```ts
+const recognitionCounts = (overrides: Partial<QueueStatisticsDto> = {}) =>
+  factory.queueStatistics({
+    active: 1,
+    waiting: 0,
+    delayed: 0,
+    paused: 0,
+    completed: 0,
+    failed: 0,
+    ...overrides,
+  });
+
+const expectNoRecognitionCoordinatorMutation = () => {
+  expect(mocks.job.empty).not.toHaveBeenCalled();
+  expect(mocks.database.prewarm).not.toHaveBeenCalled();
+  expect(mocks.person.unassignFaces).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.unlinkFacesBySourceType).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
+  expect((mocks.faceIdentity as any).deleteUnreferencedIdentities).not.toHaveBeenCalled();
+  expect(mocks.person.vacuum).not.toHaveBeenCalled();
+  expect(mocks.job.queueAll).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.FaceIdentityMaintenanceAfterRecognition,
+    data: expect.anything(),
+  });
+  expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
+};
+```
+
+- [ ] **Step 2: Run the helper compile check**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "handleQueueRecognizeFaces"
+```
+
+Expected: existing `handleQueueRecognizeFaces` tests still compile and pass before new tests are added.
+
+## Task 1: Nightly Recognition Skip Must Happen Before Queue Wait And Reset
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify only if the new test fails: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Write the failing early-skip tests**
+
+In `describe('handleQueueRecognizeFaces')`, add:
+
+```ts
+it.each([
+  ['scheduled non-force nightly', { force: false, nightly: true }],
+  ['defensive force+nightly payload', { force: true, nightly: true }],
+] as const)('skips %s before prerequisite waits or destructive reset when no new faces exist', async (_label, data) => {
+  const lastRun = new Date('2026-05-17T02:00:00.000Z');
+  mocks.systemMetadata.get.mockResolvedValue({ lastRun: lastRun.toISOString() });
+  mocks.person.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1_000).toISOString());
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ waiting: 25_000, delayed: 1_000, paused: 3 }));
+
+  await expect(sut.handleQueueRecognizeFaces(data)).resolves.toBe(JobStatus.Skipped);
+
+  expect(mocks.systemMetadata.get).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState);
+  expect(mocks.person.getLatestFaceDate).toHaveBeenCalledOnce();
+  expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+  expect(mocks.person.getAllFaces).not.toHaveBeenCalled();
+  expectNoRecognitionCoordinatorMutation();
+});
+```
+
+This is the Slice 3 issue #597 guard: a nightly skip must happen before waiting for queues and before any force-style wipe.
+
+- [ ] **Step 2: Run the focused test and observe the failure**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "skips .* before prerequisite waits"
+```
+
+Expected on current `origin/main`: FAIL because `handleQueueRecognizeFaces()` waits for thumbnail/face-detection queues before the nightly freshness skip.
+
+- [ ] **Step 3: Move the nightly freshness skip before prerequisite queue waits**
+
+In `server/src/services/person.service.ts`, move the existing `if (nightly) { ... }` block so it runs immediately after the facial-recognition-enabled check and before `waitForQueueCompletion(...)`.
+
+The resulting structure must be:
+
+```ts
+const { machineLearning } = await this.getConfig({ withCache: false });
+if (!isFacialRecognitionEnabled(machineLearning)) {
+  return JobStatus.Skipped;
+}
+
+if (nightly) {
+  const [state, latestFaceDate] = await Promise.all([
+    this.systemMetadataRepository.get(SystemMetadataKey.FacialRecognitionState),
+    this.personRepository.getLatestFaceDate(),
+  ]);
+
+  if (state?.lastRun && latestFaceDate && state.lastRun > latestFaceDate) {
+    this.logger.debug('Skipping facial recognition nightly since no face has been added since the last run');
+    return JobStatus.Skipped;
+  }
+}
+
+await this.jobRepository.waitForQueueCompletion(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
+```
+
+Do not change the skip comparison in this task.
+
+- [ ] **Step 4: Re-run the focused test**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "skips .* before prerequisite waits"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove the assertion can fail**
+
+Temporarily change `expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();` to `toHaveBeenCalled();`, run the focused selector, confirm it fails, then restore the correct assertion.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover nightly recognition early skip"
+```
+
+## Task 2: Non-Force Recognition Must Skip For All Pending Queue States
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify only if the new test fails: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Add table-driven pending-state skip coverage**
+
+In `describe('handleQueueRecognizeFaces')`, add:
+
+```ts
+it.each([
+  ['waiting jobs', { waiting: 87_000 }],
+  ['delayed jobs', { delayed: 42 }],
+  ['paused jobs', { paused: 9 }],
+  ['another active job besides the coordinator', { active: 2 }],
+] as const)('skips non-force recognition when FacialRecognition has %s', async (_label, counts) => {
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts(counts));
+  mocks.person.getAllFaces.mockReturnValue(makeStream([AssetFaceFactory.create()]));
+
+  await expect(sut.handleQueueRecognizeFaces({ force: false })).resolves.toBe(JobStatus.Skipped);
+
+  expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
+  expectNoRecognitionCoordinatorMutation();
+});
+```
+
+This test treats `active: 1` as the running coordinator itself and `active > 1` as additional recognition work that must block new non-force fan-out.
+
+- [ ] **Step 2: Add issue #597-sized nightly pending-state coverage**
+
+In the same `describe`, add:
+
+```ts
+it('does not expand a large stuck nightly queue or clear shared-space people', async () => {
+  mocks.systemMetadata.get.mockResolvedValue({ lastRun: '2026-05-16T00:00:00.000Z' });
+  mocks.person.getLatestFaceDate.mockResolvedValue('2026-05-17T00:00:00.000Z');
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ waiting: 87_000 }));
+  mocks.person.getAllFaces.mockReturnValue(makeStream([AssetFaceFactory.create()]));
+
+  await expect(sut.handleQueueRecognizeFaces({ force: false, nightly: true })).resolves.toBe(JobStatus.Skipped);
+
+  expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+    expect.arrayContaining([expect.objectContaining({ name: JobName.FacialRecognition })]),
+  );
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.FaceIdentityMaintenanceAfterRecognition,
+    data: expect.anything(),
+  });
+  expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
+  expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run the focused tests and observe failures**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "skips non-force recognition|large stuck nightly"
+```
+
+Expected on current `origin/main`: FAIL for delayed, paused, or extra-active cases if the coordinator only checks `waiting`.
+
+- [ ] **Step 4: Broaden the non-force pending guard**
+
+In `server/src/services/person.service.ts`, replace:
+
+```ts
+const { waiting } = await this.jobRepository.getJobCounts(QueueName.FacialRecognition);
+```
+
+with:
+
+```ts
+const { active, delayed, paused, waiting } = await this.jobRepository.getJobCounts(QueueName.FacialRecognition);
+const hasOtherActiveRecognitionWork = active > 1;
+const hasPendingRecognitionWork = waiting > 0 || delayed > 0 || paused > 0 || hasOtherActiveRecognitionWork;
+```
+
+Then replace the non-force guard:
+
+```ts
+} else if (waiting) {
+  this.logger.debug(
+    `Skipping facial recognition queueing because ${waiting} job${waiting > 1 ? 's are' : ' is'} already queued`,
+  );
+  return JobStatus.Skipped;
+}
+```
+
+with:
+
+```ts
+} else if (hasPendingRecognitionWork) {
+  this.logger.debug(
+    `Skipping facial recognition queueing because recognition work is already pending ` +
+      `(${active} active, ${waiting} waiting, ${delayed} delayed, ${paused} paused)`,
+  );
+  return JobStatus.Skipped;
+}
+```
+
+- [ ] **Step 5: Re-run the focused tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "skips non-force recognition|large stuck nightly"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Prove the assertion can fail**
+
+Temporarily change the paused row to expect `JobStatus.Success`, run the focused selector, confirm it fails, then restore `JobStatus.Skipped`.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover recognition pending-state skips"
+```
+
+## Task 3: Force Recognition Reset Ordering, Source Scope, And Full-Space Fan-Out
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify only if the new tests fail: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Strengthen prerequisite wait ordering**
+
+Replace the current force-reset wait assertion test with:
+
+```ts
+it('force recognition waits for thumbnail, face detection, and people backfill before draining and clearing identities', async () => {
+  const face = AssetFaceFactory.create();
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+  mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+  mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+  mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
+
+  await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(
+    QueueName.ThumbnailGeneration,
+    QueueName.FaceDetection,
+    QueueName.PeopleBackfill,
+  );
+  expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.job.empty.mock.invocationCallOrder[0],
+  );
+  expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.person.unassignFaces.mock.invocationCallOrder[0],
+  );
+  expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.faceIdentity.unlinkFacesBySourceType.mock.invocationCallOrder[0],
+  );
+  expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.sharedSpace.deleteAllPersonFaces.mock.invocationCallOrder[0],
+  );
+  expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.sharedSpace.deleteAllPersons.mock.invocationCallOrder[0],
+  );
+});
+```
+
+This prevents force recognition from wiping shared-space people while identity backfill still has work in flight.
+
+- [ ] **Step 2: Add ML-only force fan-out scope coverage**
+
+In the same `describe`, add:
+
+```ts
+it('force recognition queues only machine-learning faces and suppresses per-face shared-space matching', async () => {
+  const mlFace = AssetFaceFactory.from({ sourceType: SourceType.MachineLearning }).person().build();
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+  mocks.person.getAllFaces.mockReturnValue(makeStream([mlFace]));
+  mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+  mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
+
+  await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.person.getAllFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
+  expect(mocks.person.getAllFaces).not.toHaveBeenCalledWith(undefined);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.FacialRecognition,
+      data: { id: mlFace.id, deferred: false, skipSharedSpaceMatch: true },
+    },
+  ]);
+});
+```
+
+- [ ] **Step 3: Add enabled-space-only full rebuild coverage**
+
+In the same `describe`, add:
+
+```ts
+it('force recognition queues SharedSpaceFaceMatchAll only for enabled spaces after personal jobs', async () => {
+  const face = AssetFaceFactory.from({ sourceType: SourceType.MachineLearning }).person().build();
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+  mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+  mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+  mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['enabled-space-1', 'enabled-space-2']);
+
+  await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+  const queueAllCalls = mocks.job.queueAll.mock.calls;
+  const personalJobCall = queueAllCalls.findIndex((call) =>
+    call[0].some((job) => job.name === JobName.FacialRecognition),
+  );
+  const sharedSpaceCall = queueAllCalls.findIndex((call) =>
+    call[0].some((job) => job.name === JobName.SharedSpaceFaceMatchAll),
+  );
+
+  expect(personalJobCall).toBeGreaterThanOrEqual(0);
+  expect(sharedSpaceCall).toBeGreaterThan(personalJobCall);
+  expect(queueAllCalls[sharedSpaceCall][0]).toEqual([
+    { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'enabled-space-1' } },
+    { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'enabled-space-2' } },
+  ]);
+});
+```
+
+- [ ] **Step 4: Run focused tests and observe expected failures**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "force recognition waits|queues only machine-learning faces|enabled spaces"
+```
+
+Expected on current `origin/main`: FAIL for the `PeopleBackfill` prerequisite and ML-only `getAllFaces` scope if those production fixes are not present.
+
+- [ ] **Step 5: Make the minimal production fix**
+
+In `server/src/services/person.service.ts`, update the prerequisite wait:
+
+```ts
+await this.jobRepository.waitForQueueCompletion(
+  QueueName.ThumbnailGeneration,
+  QueueName.FaceDetection,
+  ...(force ? [QueueName.PeopleBackfill] : []),
+);
+```
+
+Then update the face pagination scope:
+
+```ts
+const facePagination = this.personRepository.getAllFaces(
+  force ? { sourceType: SourceType.MachineLearning } : { personId: null, sourceType: SourceType.MachineLearning },
+);
+```
+
+Do not change per-face `FacialRecognition` handler behavior in this task.
+
+- [ ] **Step 6: Re-run focused tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "force recognition waits|queues only machine-learning faces|enabled spaces"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Prove the assertion can fail**
+
+Temporarily change the expected `QueueName.PeopleBackfill` to `QueueName.BackgroundTask`, run the focused selector, confirm it fails, then restore `QueueName.PeopleBackfill`.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover force recognition reset scope"
+```
+
+## Task 4: Maintenance Marker Drains Recognition Work Before Backfill
+
+**Files:**
+
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify only if the new tests fail: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Add missing paused-state marker coverage**
+
+In `describe('handleFaceIdentityMaintenanceAfterRecognition')`, add:
+
+```ts
+it('requeues itself with a delay when FacialRecognition has paused jobs', async () => {
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ active: 1, paused: 2 }));
+
+  await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FaceIdentityMaintenanceAfterRecognition,
+    data: { delay: 10_000 },
+  });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+  expect(mocks.job.searchJobs).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Add failed-job non-blocking coverage**
+
+In the same `describe`, add:
+
+```ts
+it('ignores failed recognition jobs when deciding whether the queue has drained', async () => {
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ active: 1, failed: 12 }));
+  mocks.job.searchJobs.mockResolvedValue([]);
+
+  await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({
+    name: JobName.FaceIdentityMaintenanceAfterRecognition,
+    data: expect.anything(),
+  });
+});
+```
+
+- [ ] **Step 3: Strengthen PeopleBackfill dedupe status coverage**
+
+Replace the existing duplicate-backfill assertion with:
+
+```ts
+it('does not queue duplicate FaceIdentityBackfill if PeopleBackfill already has one active, waiting, delayed, or paused', async () => {
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ active: 1 }));
+  mocks.job.searchJobs.mockResolvedValue([{ id: '1', name: JobName.FaceIdentityBackfill, timestamp: 0, data: {} }]);
+
+  await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Skipped);
+
+  expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
+    status: [QueueJobStatus.Active, QueueJobStatus.Delayed, QueueJobStatus.Paused, QueueJobStatus.Waiting],
+  });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+});
+```
+
+Ensure `QueueJobStatus` is already imported in the spec. If it is not, import it from `src/enum` with the existing enum imports.
+
+- [ ] **Step 4: Run focused marker tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "handleFaceIdentityMaintenanceAfterRecognition"
+```
+
+Expected: PASS or expose one minimal marker fix.
+
+- [ ] **Step 5: Prove the assertion can fail**
+
+Temporarily change `delay: 10_000` to `delay: 1`, run the focused selector, confirm it fails, then restore `delay: 10_000`.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover recognition maintenance marker drains"
+```
+
+## Task 5: Stable FacialRecognitionQueueAll Replacement Edge Cases
+
+**Files:**
+
+- Modify: `server/src/repositories/job.repository.spec.ts`
+- Modify only if the new tests fail: `server/src/repositories/job.repository.ts`
+
+- [ ] **Step 1: Add failed force-follow-up replacement coverage**
+
+In `server/src/repositories/job.repository.spec.ts`, near the existing `FacialRecognitionQueueAll` stable-job tests, add:
+
+```ts
+it('removes a failed force follow-up coordinator before queueing a replacement follow-up', async () => {
+  const { sut, queue } = setup();
+  const activeNonForceCoordinator = {
+    data: { force: false },
+    getState: vi.fn().mockResolvedValue('active'),
+    remove: vi.fn().mockResolvedValue(void 0),
+    updateData: vi.fn().mockResolvedValue(void 0),
+  };
+  const failedForceFollowUp = {
+    data: { force: true },
+    getState: vi.fn().mockResolvedValue('failed'),
+    remove: vi.fn().mockResolvedValue(void 0),
+  };
+  queue.getJob.mockImplementation((jobId: string) =>
+    Promise.resolve(
+      jobId === JobName.FacialRecognitionQueueAll
+        ? activeNonForceCoordinator
+        : jobId === 'FacialRecognitionQueueAll/force'
+          ? failedForceFollowUp
+          : undefined,
+    ),
+  );
+  setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+  await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+  expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+  expect(queue.getJob).toHaveBeenCalledWith('FacialRecognitionQueueAll/force');
+  expect(failedForceFollowUp.getState).toHaveBeenCalled();
+  expect(failedForceFollowUp.remove).toHaveBeenCalled();
+  expect(queue.add).toHaveBeenCalledWith(
+    JobName.FacialRecognitionQueueAll,
+    { force: true },
+    {
+      jobId: 'FacialRecognitionQueueAll/force',
+      removeOnComplete: true,
+    },
+  );
+});
+```
+
+- [ ] **Step 2: Verify paused primary coordinator replacement is already covered**
+
+Run:
+
+```bash
+rg -n "replaces a pending .*paused.*FacialRecognitionQueueAll|waiting', 'delayed', 'paused" server/src/repositories/job.repository.spec.ts
+```
+
+Expected: output points to the existing table-driven test that removes waiting, delayed, and paused non-force primary coordinators when force is requested. Do not add a duplicate paused-primary test in this task.
+
+- [ ] **Step 3: Run focused repository tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/job.repository.spec.ts -t "force follow-up|facial-recognition coordinator"
+```
+
+Expected: PASS or expose one minimal stable-job replacement fix.
+
+- [ ] **Step 4: Prove the assertion can fail**
+
+Temporarily change the expected follow-up `jobId` to `JobName.FacialRecognitionQueueAll`, run the focused selector, confirm it fails, then restore `'FacialRecognitionQueueAll/force'`.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add server/src/repositories/job.repository.spec.ts server/src/repositories/job.repository.ts
+git commit -m "test: cover force recognition stable job replacement"
+```
+
+If no production file changed, omit it from `git add`.
+
+## Task 6: Medium Force Recognition Destructive-State Safety
+
+**Files:**
+
+- Modify: `server/test/medium/specs/services/person.service.spec.ts`
+- Modify only if a DB-backed test proves a bug: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Add a recognition-specific medium setup helper**
+
+In `server/test/medium/specs/services/person.service.spec.ts`, add `QueueName` to the existing enum imports and then add this helper after `setupFaceDetection`:
+
+```ts
+const setupFaceRecognition = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(PersonService, {
+    database: db || defaultDatabase,
+    real: [
+      AccessRepository,
+      AssetRepository,
+      ConfigRepository,
+      DatabaseRepository,
+      FaceIdentityRepository,
+      PersonRepository,
+      SharedSpaceRepository,
+    ],
+    mock: [JobRepository, LoggingRepository, MachineLearningRepository, StorageRepository, SystemMetadataRepository],
+  });
+
+  const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+  jobMock.waitForQueueCompletion.mockResolvedValue();
+  jobMock.empty.mockResolvedValue();
+  jobMock.queue.mockResolvedValue();
+  jobMock.queueAll.mockResolvedValue();
+  jobMock.getJobCounts.mockResolvedValue({
+    active: 1,
+    waiting: 0,
+    delayed: 0,
+    paused: 0,
+    completed: 0,
+    failed: 0,
+  });
+
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockImplementation((key) => {
+      if (key === SystemMetadataKey.SystemConfig) {
+        return { machineLearning: { facialRecognition: { enabled: true, minFaces: 1 } } } as any;
+      }
+      return undefined as any;
+    });
+
+  ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository).set.mockResolvedValue();
+
+  return { sut, ctx };
+};
+```
+
+- [ ] **Step 2: Add recognition DB query helpers**
+
+After `getIdentityLinks`, add:
+
+```ts
+const getPeopleByIds = (ctx: ReturnType<typeof setupFaceRecognition>['ctx'], ids: string[]) =>
+  ctx.database
+    .selectFrom('person')
+    .select(['id', 'name'])
+    .where('id', 'in', ids)
+    .orderBy('name')
+    .execute();
+
+const getSpacePeople = (ctx: ReturnType<typeof setupFaceRecognition>['ctx'], spaceIds: string[]) =>
+  ctx.database
+    .selectFrom('shared_space_person')
+    .select(['id', 'identityId', 'name', 'spaceId'])
+    .where('spaceId', 'in', spaceIds)
+    .orderBy('name')
+    .execute();
+```
+
+- [ ] **Step 3: Add force-recognition preservation medium test**
+
+Add a new `describe('handleQueueRecognizeFaces safety', () => { ... })` after the face-detection safety describe:
+
+```ts
+describe('handleQueueRecognizeFaces safety', () => {
+  it('preserves manual and EXIF identity evidence while force recognition resets ML assignments and queues rebuilds', async () => {
+    const { sut, ctx } = setupFaceRecognition();
+    const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+    const systemMetadataMock = ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(
+      SystemMetadataRepository,
+    );
+    const { user } = await ctx.newUser();
+    const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+
+    const ml = await createPersonFaceIdentity(ctx, {
+      ownerId: user.id,
+      assetId: asset.id,
+      name: 'Machine',
+      sourceType: SourceType.MachineLearning,
+      linkSource: 'ml',
+    });
+    const manual = await createPersonFaceIdentity(ctx, {
+      ownerId: user.id,
+      assetId: asset.id,
+      name: 'Manual',
+      sourceType: SourceType.Manual,
+      linkSource: 'manual',
+    });
+    const exif = await createPersonFaceIdentity(ctx, {
+      ownerId: user.id,
+      assetId: asset.id,
+      name: 'Exif',
+      sourceType: SourceType.Exif,
+      linkSource: 'import',
+    });
+
+    const { space: enabledSpace } = await ctx.newSharedSpace({
+      createdById: user.id,
+      faceRecognitionEnabled: true,
+    });
+    const { space: disabledSpace } = await ctx.newSharedSpace({
+      createdById: user.id,
+      faceRecognitionEnabled: false,
+    });
+    await ctx.newSharedSpaceMember({ spaceId: enabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: enabledSpace.id, assetId: asset.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
+    await createSpacePersonFace(ctx, {
+      spaceId: enabledSpace.id,
+      identityId: ml.identity.id,
+      assetFaceId: ml.assetFace.id,
+      name: 'Machine Enabled Space',
+    });
+    await createSpacePersonFace(ctx, {
+      spaceId: enabledSpace.id,
+      identityId: manual.identity.id,
+      assetFaceId: manual.assetFace.id,
+      name: 'Manual Enabled Space',
+    });
+    await createSpacePersonFace(ctx, {
+      spaceId: disabledSpace.id,
+      identityId: exif.identity.id,
+      assetFaceId: exif.assetFace.id,
+      name: 'Exif Disabled Space',
+    });
+
+    await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+    await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
+        expect.objectContaining({ id: manual.assetFace.id, personId: manual.person.id, sourceType: SourceType.Manual }),
+        expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
+      ]),
+    );
+    await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+      expect.arrayContaining([
+        { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+        { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+      ]),
+    );
+    await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
+    await expect(getPeopleByIds(ctx, [manual.person.id, exif.person.id])).resolves.toEqual([
+      { id: exif.person.id, name: 'Exif' },
+      { id: manual.person.id, name: 'Manual' },
+    ]);
+    await expect(getSpacePeople(ctx, [enabledSpace.id, disabledSpace.id])).resolves.toEqual([]);
+
+    const queuedJobs = jobMock.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+    expect(jobMock.waitForQueueCompletion).toHaveBeenCalledWith(
+      QueueName.ThumbnailGeneration,
+      QueueName.FaceDetection,
+      QueueName.PeopleBackfill,
+    );
+    expect(jobMock.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+    expect(jobMock.queueAll).toHaveBeenCalledWith([
+      {
+        name: JobName.FacialRecognition,
+        data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
+      },
+    ]);
+    expect(jobMock.queueAll).toHaveBeenCalledWith([
+      { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: enabledSpace.id } },
+    ]);
+    expect(queuedJobs).not.toContainEqual({ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: disabledSpace.id } });
+    expect(jobMock.queue).toHaveBeenCalledWith({
+      name: JobName.FaceIdentityMaintenanceAfterRecognition,
+      data: {},
+    });
+    expect(systemMetadataMock.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
+      lastRun: expect.any(String),
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Add repeated-force idempotency medium test**
+
+Inside the same `describe`, add:
+
+```ts
+it('keeps force recognition idempotent over repeated runs with populated manual and EXIF evidence', async () => {
+  const { sut, ctx } = setupFaceRecognition();
+  const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+  const { user } = await ctx.newUser();
+  const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+  const ml = await createPersonFaceIdentity(ctx, {
+    ownerId: user.id,
+    assetId: asset.id,
+    name: 'Machine',
+    sourceType: SourceType.MachineLearning,
+    linkSource: 'ml',
+  });
+  const manual = await createPersonFaceIdentity(ctx, {
+    ownerId: user.id,
+    assetId: asset.id,
+    name: 'Manual',
+    sourceType: SourceType.Manual,
+    linkSource: 'manual',
+  });
+  const exif = await createPersonFaceIdentity(ctx, {
+    ownerId: user.id,
+    assetId: asset.id,
+    name: 'Exif',
+    sourceType: SourceType.Exif,
+    linkSource: 'import',
+  });
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  await createSpacePersonFace(ctx, {
+    spaceId: space.id,
+    identityId: ml.identity.id,
+    assetFaceId: ml.assetFace.id,
+    name: 'Machine Space',
+  });
+
+  await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+  jobMock.queue.mockClear();
+  jobMock.queueAll.mockClear();
+  jobMock.empty.mockClear();
+
+  await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+  await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
+      expect.objectContaining({ id: manual.assetFace.id, personId: manual.person.id, sourceType: SourceType.Manual }),
+      expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
+    ]),
+  );
+  await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+    expect.arrayContaining([
+      { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+      { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+    ]),
+  );
+  await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
+  await expect(getSpacePeople(ctx, [space.id])).resolves.toEqual([]);
+  expect(jobMock.empty).toHaveBeenCalledTimes(1);
+  expect(jobMock.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.FacialRecognition,
+      data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
+    },
+  ]);
+  expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } }]);
+  expect(jobMock.queue).toHaveBeenCalledWith({
+    name: JobName.FaceIdentityMaintenanceAfterRecognition,
+    data: {},
+  });
+});
+```
+
+- [ ] **Step 5: Run focused medium recognition tests**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium --run test/medium/specs/services/person.service.spec.ts -t "handleQueueRecognizeFaces safety"
+```
+
+Expected: PASS or expose one minimal production fix.
+
+- [ ] **Step 6: Prove the DB assertion can fail**
+
+Temporarily change the manual identity-link expected source from `'manual'` to `'ml'`, run the focused selector, confirm it fails, then restore `'manual'`.
+
+- [ ] **Step 7: Commit Task 6**
+
+Run:
+
+```bash
+git add server/test/medium/specs/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: cover force recognition destructive state"
+```
+
+If no production file changed in this task, omit it from `git add`.
+
+## Task 7: Final Verification And Review
+
+- [ ] **Step 1: Run the small service and repository specs**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts src/repositories/job.repository.spec.ts src/services/queue.service.spec.ts
+```
+
+Expected: all targeted small specs pass.
+
+- [ ] **Step 2: Run the medium service spec**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium --run test/medium/specs/services/person.service.spec.ts
+```
+
+Expected: the medium service spec passes.
+
+- [ ] **Step 3: Run formatting and lint checks**
+
+Run:
+
+```bash
+pnpm --dir server exec prettier --check src/services/person.service.ts src/services/person.service.spec.ts src/repositories/job.repository.ts src/repositories/job.repository.spec.ts test/medium/specs/services/person.service.spec.ts
+pnpm --dir server lint
+```
+
+Expected: Prettier and ESLint pass.
+
+- [ ] **Step 4: Run typecheck**
+
+Run:
+
+```bash
+pnpm --filter immich check
+```
+
+Expected: `tsc --noEmit` passes.
+
+- [ ] **Step 5: Run placeholder scan on this plan**
+
+Run:
+
+```bash
+rg -n "T[B]D|TO[D]O|imple[m]ent later|fill in det[a]ils|Similar to Ta[s]k|appropriate error handl[i]ng|write tests for the ab[o]ve" docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 6: Review destructive invariant coverage**
+
+Before opening a PR, confirm these statements are true from test names and assertions:
+
+- Nightly no-new-face skip does not call `waitForQueueCompletion`, `empty`, reset methods, `queueAll`, maintenance marker queueing, or state writes.
+- Non-force recognition skips for waiting, delayed, paused, and extra active recognition work.
+- Force recognition waits for `ThumbnailGeneration`, `FaceDetection`, and `PeopleBackfill` before draining `FacialRecognition`.
+- Force recognition unassigns and unlinks only `SourceType.MachineLearning`.
+- Force recognition queues `FacialRecognition` jobs only for ML faces and always sets `skipSharedSpaceMatch: true`.
+- Force recognition queues `SharedSpaceFaceMatchAll` only for enabled shared spaces and only after personal recognition jobs.
+- The maintenance marker waits for waiting, delayed, paused, and extra active recognition work before queueing `FaceIdentityBackfill`.
+- Medium tests prove manual and EXIF asset faces and identity links survive force recognition.
+- Medium tests prove repeated force recognition does not duplicate shared-space person rows or delete preserved manual/EXIF evidence.
+
+- [ ] **Step 7: Commit final verification notes only if a tracked file changed**
+
+If verification required formatting changes, commit them:
+
+```bash
+git add server/src/services/person.service.spec.ts server/test/medium/specs/services/person.service.spec.ts
+git commit -m "test: format recognition coordinator specs"
+```
+
+If no files changed, do not create an empty commit.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md`.
+
+Two execution options:
+
+1. Subagent-Driven (recommended) - dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. Inline Execution - execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.

--- a/docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
+++ b/docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
@@ -93,7 +93,7 @@ For each touched spec file, temporarily change one expected `QueueName`, `JobNam
 - Force recognition unassigns and unlinks only machine-learning faces, queues only ML face jobs, suppresses per-face shared-space matching, queues enabled-space full rebuild jobs, queues the terminal maintenance marker, and writes last-run state: Task 3 and Task 6.
 - Maintenance marker requeues while recognition work is waiting, delayed, paused, or still active; queues backfill only after the queue is drained and no backfill is active/pending: Task 4.
 - Failed or paused stable coordinator jobs do not permanently block legitimate future coordinator work: Task 5.
-- Force recognition over populated DB state preserves manual/EXIF asset faces and identity links, clears only intended ML assignment/link state, wipes shared-space people by design, and is idempotent over repeated force runs: Task 6.
+- Force recognition over populated DB state preserves manual/EXIF asset faces and identity links, clears only intended ML assignment/link state, wipes shared-space people by design, and idempotently queues the coordinator rebuild handoff over repeated force runs: Task 6.
 - Cross-slice overnight chains with library scan and EXIF import remain Slice 8. Per-face recognition assignment remains Slice 4.
 
 ## Shared Small-Spec Helpers
@@ -134,6 +134,7 @@ const expectNoRecognitionCoordinatorMutation = () => {
     name: JobName.FaceIdentityMaintenanceAfterRecognition,
     data: expect.anything(),
   });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
   expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
 };
 ```
@@ -293,6 +294,7 @@ it('does not expand a large stuck nightly queue or clear shared-space people', a
     name: JobName.FaceIdentityMaintenanceAfterRecognition,
     data: expect.anything(),
   });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
   expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
   expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
   expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
@@ -419,7 +421,57 @@ it('force recognition waits for thumbnail, face detection, and people backfill b
 
 This prevents force recognition from wiping shared-space people while identity backfill still has work in flight.
 
-- [ ] **Step 2: Add ML-only force fan-out scope coverage**
+- [ ] **Step 2: Add full reset collaborator contract coverage**
+
+In the same `describe`, add:
+
+```ts
+it('force recognition performs the full ML reset and maintenance handoff contract', async () => {
+  const mlFace = AssetFaceFactory.from({ sourceType: SourceType.MachineLearning }).person().build();
+  const orphan = PersonFactory.create();
+  mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+  mocks.person.getAllFaces.mockReturnValue(makeStream([mlFace]));
+  mocks.person.getAllWithoutFaces.mockResolvedValue([orphan]);
+  mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+  mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['enabled-space']);
+
+  await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+  expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+  expect(mocks.person.unassignFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
+  expect(mocks.faceIdentity.unlinkFacesBySourceType).toHaveBeenCalledWith(SourceType.MachineLearning);
+  expect(mocks.person.delete).toHaveBeenCalledWith([orphan.id]);
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FileDelete,
+    data: { files: [orphan.thumbnailPath] },
+  });
+  expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: false });
+  expect(mocks.sharedSpace.deleteAllPersonFaces).toHaveBeenCalledOnce();
+  expect(mocks.sharedSpace.deleteAllPersons).toHaveBeenCalledOnce();
+  expect((mocks.faceIdentity as any).deleteUnreferencedIdentities).toHaveBeenCalledOnce();
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    {
+      name: JobName.FacialRecognition,
+      data: { id: mlFace.id, deferred: false, skipSharedSpaceMatch: true },
+    },
+  ]);
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'enabled-space' } },
+  ]);
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FaceIdentityMaintenanceAfterRecognition,
+    data: {},
+  });
+  expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
+    lastRun: expect.any(String),
+  });
+});
+```
+
+This test pins the complete force reset collaborator contract in the fast unit suite. The medium tests in Task 6 then prove the same reset does not destroy preserved DB evidence.
+
+- [ ] **Step 3: Add ML-only force fan-out scope coverage**
 
 In the same `describe`, add:
 
@@ -446,7 +498,7 @@ it('force recognition queues only machine-learning faces and suppresses per-face
 });
 ```
 
-- [ ] **Step 3: Add enabled-space-only full rebuild coverage**
+- [ ] **Step 4: Add enabled-space-only full rebuild coverage**
 
 In the same `describe`, add:
 
@@ -479,17 +531,17 @@ it('force recognition queues SharedSpaceFaceMatchAll only for enabled spaces aft
 });
 ```
 
-- [ ] **Step 4: Run focused tests and observe expected failures**
+- [ ] **Step 5: Run focused tests and observe expected failures**
 
 Run:
 
 ```bash
-pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "force recognition waits|queues only machine-learning faces|enabled spaces"
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "force recognition waits|full ML reset|queues only machine-learning faces|enabled spaces"
 ```
 
-Expected on current `origin/main`: FAIL for the `PeopleBackfill` prerequisite and ML-only `getAllFaces` scope if those production fixes are not present.
+Expected on current `origin/main`: FAIL for the `PeopleBackfill` prerequisite, ML-only `getAllFaces` scope, or full reset collaborator contract if those production fixes are not present.
 
-- [ ] **Step 5: Make the minimal production fix**
+- [ ] **Step 6: Make the minimal production fix**
 
 In `server/src/services/person.service.ts`, update the prerequisite wait:
 
@@ -511,21 +563,21 @@ const facePagination = this.personRepository.getAllFaces(
 
 Do not change per-face `FacialRecognition` handler behavior in this task.
 
-- [ ] **Step 6: Re-run focused tests**
+- [ ] **Step 7: Re-run focused tests**
 
 Run:
 
 ```bash
-pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "force recognition waits|queues only machine-learning faces|enabled spaces"
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "force recognition waits|full ML reset|queues only machine-learning faces|enabled spaces"
 ```
 
 Expected: PASS.
 
-- [ ] **Step 7: Prove the assertion can fail**
+- [ ] **Step 8: Prove the assertion can fail**
 
-Temporarily change the expected `QueueName.PeopleBackfill` to `QueueName.BackgroundTask`, run the focused selector, confirm it fails, then restore `QueueName.PeopleBackfill`.
+Temporarily change the expected `QueueName.PeopleBackfill` to `QueueName.BackgroundTask`, run the focused selector, confirm it fails, then restore `QueueName.PeopleBackfill`. Then temporarily change the full reset test's `reindexVectors: false` assertion to `reindexVectors: true`, run the focused selector, confirm it fails, and restore `reindexVectors: false`.
 
-- [ ] **Step 8: Commit Task 3**
+- [ ] **Step 9: Commit Task 3**
 
 Run:
 
@@ -716,6 +768,8 @@ If no production file changed, omit it from `git add`.
 
 - Modify: `server/test/medium/specs/services/person.service.spec.ts`
 - Modify only if a DB-backed test proves a bug: `server/src/services/person.service.ts`
+
+These medium tests intentionally stop at the coordinator boundary. They prove destructive DB side effects and queued rebuild handoffs, but they do not execute the queued per-face recognition or shared-space rematch jobs; final assignment and projection rebuild behavior remains covered by Slice 4 and the cross-queue Slice 8 chain.
 
 - [ ] **Step 1: Add a recognition-specific medium setup helper**
 
@@ -908,6 +962,8 @@ describe('handleQueueRecognizeFaces safety', () => {
 });
 ```
 
+This test proves the force coordinator preserves manual/EXIF evidence while resetting ML-owned state and queueing the rebuild work. It must not assert final rebuilt ML assignments or final shared-space projections, because those jobs are queued but not executed in this slice.
+
 - [ ] **Step 4: Add repeated-force idempotency medium test**
 
 Inside the same `describe`, add:
@@ -1075,8 +1131,9 @@ Before opening a PR, confirm these statements are true from test names and asser
 - Force recognition queues `FacialRecognition` jobs only for ML faces and always sets `skipSharedSpaceMatch: true`.
 - Force recognition queues `SharedSpaceFaceMatchAll` only for enabled shared spaces and only after personal recognition jobs.
 - The maintenance marker waits for waiting, delayed, paused, and extra active recognition work before queueing `FaceIdentityBackfill`.
-- Medium tests prove manual and EXIF asset faces and identity links survive force recognition.
-- Medium tests prove repeated force recognition does not duplicate shared-space person rows or delete preserved manual/EXIF evidence.
+- Medium tests prove manual and EXIF asset faces and identity links survive the force-recognition coordinator reset.
+- Medium tests prove repeated force-recognition coordinator runs do not duplicate shared-space person rows, delete preserved manual/EXIF evidence, or enqueue disabled-space rebuild jobs.
+- Medium tests do not claim final ML assignment or shared-space projection rebuilds are complete until the queued recognition and shared-space jobs run in later slices.
 
 - [ ] **Step 7: Commit final verification notes only if a tracked file changed**
 

--- a/docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
+++ b/docs/superpowers/plans/2026-05-17-face-recognition-coordinator-safety.md
@@ -816,7 +816,9 @@ const setupFaceRecognition = (db?: Kysely<DB>) => {
       return undefined as any;
     });
 
-  ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository).set.mockResolvedValue();
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .set.mockResolvedValue();
 
   return { sut, ctx };
 };
@@ -828,12 +830,7 @@ After `getIdentityLinks`, add:
 
 ```ts
 const getPeopleByIds = (ctx: ReturnType<typeof setupFaceRecognition>['ctx'], ids: string[]) =>
-  ctx.database
-    .selectFrom('person')
-    .select(['id', 'name'])
-    .where('id', 'in', ids)
-    .orderBy('name')
-    .execute();
+  ctx.database.selectFrom('person').select(['id', 'name']).where('id', 'in', ids).orderBy('name').execute();
 
 const getSpacePeople = (ctx: ReturnType<typeof setupFaceRecognition>['ctx'], spaceIds: string[]) =>
   ctx.database
@@ -950,7 +947,10 @@ describe('handleQueueRecognizeFaces safety', () => {
     expect(jobMock.queueAll).toHaveBeenCalledWith([
       { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: enabledSpace.id } },
     ]);
-    expect(queuedJobs).not.toContainEqual({ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: disabledSpace.id } });
+    expect(queuedJobs).not.toContainEqual({
+      name: JobName.SharedSpaceFaceMatchAll,
+      data: { spaceId: disabledSpace.id },
+    });
     expect(jobMock.queue).toHaveBeenCalledWith({
       name: JobName.FaceIdentityMaintenanceAfterRecognition,
       data: {},
@@ -1034,7 +1034,9 @@ it('keeps force recognition idempotent over repeated runs with populated manual 
       data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
     },
   ]);
-  expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } }]);
+  expect(jobMock.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } },
+  ]);
   expect(jobMock.queue).toHaveBeenCalledWith({
     name: JobName.FaceIdentityMaintenanceAfterRecognition,
     data: {},

--- a/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
+++ b/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
@@ -784,13 +784,14 @@ Add this test immediately after the strict personal-conflict test:
     };
 
     await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
-    const firstState = await readState();
 
     await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+    const assignedState = await readState();
+
     await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
     const repeatedState = await readState();
 
-    expect(repeatedState).toEqual(firstState);
+    expect(repeatedState).toEqual(assignedState);
     expect(repeatedState.memberPeople).toHaveLength(1);
     expect(repeatedState.faceLinks).toEqual([
       {

--- a/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
+++ b/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
@@ -94,6 +94,7 @@ Adjust the staged paths to the files touched by the task.
 ## Task 1: Safe Early Exits
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 
 - [ ] **Step 1: Add a local no-mutation assertion helper**
@@ -101,17 +102,17 @@ Adjust the staged paths to the files touched by the task.
 In the first `describe('handleRecognizeFaces')` block near `server/src/services/person.service.spec.ts:2864`, add this helper immediately after the `beforeEach()` block:
 
 ```ts
-    const expectNoRecognitionMutation = () => {
-      expect(mocks.search.searchFaces).not.toHaveBeenCalled();
-      expect(mocks.person.create).not.toHaveBeenCalled();
-      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
-      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalled();
-    };
+const expectNoRecognitionMutation = () => {
+  expect(mocks.search.searchFaces).not.toHaveBeenCalled();
+  expect(mocks.person.create).not.toHaveBeenCalled();
+  expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+};
 ```
 
 - [ ] **Step 2: Strengthen the missing face and missing asset tests**
@@ -119,20 +120,20 @@ In the first `describe('handleRecognizeFaces')` block near `server/src/services/
 Update the existing tests named `should fail if face does not exist` and `should fail if face does not have asset` to call the helper:
 
 ```ts
-    it('should fail if face does not exist', async () => {
-      expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Failed);
+it('should fail if face does not exist', async () => {
+  expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Failed);
 
-      expectNoRecognitionMutation();
-    });
+  expectNoRecognitionMutation();
+});
 
-    it('should fail if face does not have asset', async () => {
-      const face = AssetFaceFactory.create();
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, null));
+it('should fail if face does not have asset', async () => {
+  const face = AssetFaceFactory.create();
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, null));
 
-      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
+  expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
 
-      expectNoRecognitionMutation();
-    });
+  expectNoRecognitionMutation();
+});
 ```
 
 - [ ] **Step 3: Add safe source and missing-embedding tests to the same recognition block**
@@ -140,29 +141,29 @@ Update the existing tests named `should fail if face does not exist` and `should
 Add these tests immediately after the missing-asset test:
 
 ```ts
-    it('skips non-machine-learning faces without mutating identities or queues', async () => {
-      const asset = AssetFactory.create();
-      const face = AssetFaceFactory.create({ assetId: asset.id, sourceType: SourceType.Exif });
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+it('skips non-machine-learning faces without mutating identities or queues', async () => {
+  const asset = AssetFactory.create();
+  const face = AssetFaceFactory.create({ assetId: asset.id, sourceType: SourceType.Exif });
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
 
-      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+  expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
 
-      expectNoRecognitionMutation();
-    });
+  expectNoRecognitionMutation();
+});
 
-    it('fails when a machine-learning face has no embedding without mutating identities or queues', async () => {
-      const asset = AssetFactory.create();
-      const face = AssetFaceFactory.create({ assetId: asset.id });
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue({
-        ...face,
-        asset,
-        faceSearch: null,
-      } as any);
+it('fails when a machine-learning face has no embedding without mutating identities or queues', async () => {
+  const asset = AssetFactory.create();
+  const face = AssetFaceFactory.create({ assetId: asset.id });
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue({
+    ...face,
+    asset,
+    faceSearch: null,
+  } as any);
 
-      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
+  expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
 
-      expectNoRecognitionMutation();
-    });
+  expectNoRecognitionMutation();
+});
 ```
 
 - [ ] **Step 4: Run the focused safe-exit tests**
@@ -185,6 +186,7 @@ git commit -m "test: cover safe recognition early exits"
 ## Task 2: Shared-Space Fanout Is Suppressed Or Deduped
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 - Modify when red: `server/src/services/person.service.ts`
 
@@ -193,27 +195,27 @@ git commit -m "test: cover safe recognition early exits"
 In the first `describe('handleRecognizeFaces')` block, add this test after `should queue space face matching even when face already has a person assigned`:
 
 ```ts
-    it('queues shared-space face matching exactly once per space after repairing an assigned face', async () => {
-      const asset = AssetFactory.create();
-      const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
-      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
-      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
-        { spaceId: 'space-1' },
-        { spaceId: 'space-1' },
-        { spaceId: 'space-2' },
-      ]);
+it('queues shared-space face matching exactly once per space after repairing an assigned face', async () => {
+  const asset = AssetFactory.create();
+  const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+  mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
+    { spaceId: 'space-1' },
+    { spaceId: 'space-1' },
+    { spaceId: 'space-2' },
+  ]);
 
-      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+  expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
 
-      const sharedSpaceJobs = mocks.job.queue.mock.calls
-        .map(([job]) => job)
-        .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
-      expect(sharedSpaceJobs).toEqual([
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: face.assetId } },
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: face.assetId } },
-      ]);
-    });
+  const sharedSpaceJobs = mocks.job.queue.mock.calls
+    .map(([job]) => job)
+    .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+  expect(sharedSpaceJobs).toEqual([
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: face.assetId } },
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: face.assetId } },
+  ]);
+});
 ```
 
 - [ ] **Step 2: Add a red test for deduped fanout after successful incremental assignment**
@@ -221,37 +223,37 @@ In the first `describe('handleRecognizeFaces')` block, add this test after `shou
 Add this test after `should queue SharedSpaceFaceMatch for spaces containing the asset`:
 
 ```ts
-    it('queues one SharedSpaceFaceMatch job per unique space after assigning a face', async () => {
-      const asset = AssetFactory.create();
-      const [noPerson, primaryFace] = [
-        AssetFaceFactory.create({ assetId: asset.id }),
-        AssetFaceFactory.from().person().build(),
-      ];
-      const faces = [
-        { ...noPerson, distance: 0 },
-        { ...primaryFace, distance: 0.2 },
-      ] as FaceSearchResult[];
+it('queues one SharedSpaceFaceMatch job per unique space after assigning a face', async () => {
+  const asset = AssetFactory.create();
+  const [noPerson, primaryFace] = [
+    AssetFaceFactory.create({ assetId: asset.id }),
+    AssetFaceFactory.from().person().build(),
+  ];
+  const faces = [
+    { ...noPerson, distance: 0 },
+    { ...primaryFace, distance: 0.2 },
+  ] as FaceSearchResult[];
 
-      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-      mocks.search.searchFaces.mockResolvedValue(faces);
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
-      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
-      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
-        { spaceId: 'space-1' },
-        { spaceId: 'space-2' },
-        { spaceId: 'space-1' },
-      ]);
+  mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+  mocks.search.searchFaces.mockResolvedValue(faces);
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+  mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
+    { spaceId: 'space-1' },
+    { spaceId: 'space-2' },
+    { spaceId: 'space-1' },
+  ]);
 
-      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+  expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
 
-      const sharedSpaceJobs = mocks.job.queue.mock.calls
-        .map(([job]) => job)
-        .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
-      expect(sharedSpaceJobs).toEqual([
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: noPerson.assetId } },
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: noPerson.assetId } },
-      ]);
-    });
+  const sharedSpaceJobs = mocks.job.queue.mock.calls
+    .map(([job]) => job)
+    .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+  expect(sharedSpaceJobs).toEqual([
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: noPerson.assetId } },
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: noPerson.assetId } },
+  ]);
+});
 ```
 
 - [ ] **Step 3: Run the focused fanout tests and confirm they fail before the helper**
@@ -290,15 +292,15 @@ In `server/src/services/person.service.ts`, add this private helper after `handl
 In the already-assigned branch, replace the loop at `server/src/services/person.service.ts:942-950` with:
 
 ```ts
-      // Still queue space face matching because this face may belong to a space
-      // that was created or linked after the face was originally recognized.
-      await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
+// Still queue space face matching because this face may belong to a space
+// that was created or linked after the face was originally recognized.
+await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
 ```
 
 Near the end of `handleRecognizeFaces()`, replace the loop at `server/src/services/person.service.ts:1044-1051` with:
 
 ```ts
-    await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
+await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
 ```
 
 - [ ] **Step 6: Re-run the fanout tests**
@@ -321,6 +323,7 @@ git commit -m "test: dedupe recognition shared-space fanout"
 ## Task 3: Assignment Paths Link Identity And Avoid Spurious Work
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 
 - [ ] **Step 1: Add an explicit min-face self-only threshold test**
@@ -328,22 +331,22 @@ git commit -m "test: dedupe recognition shared-space fanout"
 In the first `describe('handleRecognizeFaces')` block, add this test after `should not queue face with no matches`:
 
 ```ts
-    it('skips self-only matches below the min-face threshold without deferring or assigning', async () => {
-      const asset = AssetFactory.create();
-      const face = AssetFaceFactory.create({ assetId: asset.id });
+it('skips self-only matches below the min-face threshold without deferring or assigning', async () => {
+  const asset = AssetFactory.create();
+  const face = AssetFaceFactory.create({ assetId: asset.id });
 
-      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
-      mocks.search.searchFaces.mockResolvedValue([{ ...face, distance: 0 }] as FaceSearchResult[]);
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+  mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
+  mocks.search.searchFaces.mockResolvedValue([{ ...face, distance: 0 }] as FaceSearchResult[]);
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
 
-      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+  expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
 
-      expect(mocks.search.searchFaces).toHaveBeenCalledTimes(1);
-      expect(mocks.person.create).not.toHaveBeenCalled();
-      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalled();
-      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
-    });
+  expect(mocks.search.searchFaces).toHaveBeenCalledTimes(1);
+  expect(mocks.person.create).not.toHaveBeenCalled();
+  expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+});
 ```
 
 - [ ] **Step 2: Strengthen the core-person creation test**
@@ -351,44 +354,44 @@ In the first `describe('handleRecognizeFaces')` block, add this test after `shou
 Update the existing test named `should create a new person if the face is a core point with no person` to include thumbnail and identity-link assertions:
 
 ```ts
-    it('should create a new person if the face is a core point with no person', async () => {
-      const asset = AssetFactory.create();
-      const [noPerson1, noPerson2] = [AssetFaceFactory.create({ assetId: asset.id }), AssetFaceFactory.create()];
-      const person = PersonFactory.create({ ownerId: asset.ownerId });
-      const sourceIdentityId = 'created-person-identity';
+it('should create a new person if the face is a core point with no person', async () => {
+  const asset = AssetFactory.create();
+  const [noPerson1, noPerson2] = [AssetFaceFactory.create({ assetId: asset.id }), AssetFaceFactory.create()];
+  const person = PersonFactory.create({ ownerId: asset.ownerId });
+  const sourceIdentityId = 'created-person-identity';
 
-      const faces = [
-        { ...noPerson1, distance: 0 },
-        { ...noPerson2, distance: 0.3 },
-      ] as FaceSearchResult[];
+  const faces = [
+    { ...noPerson1, distance: 0 },
+    { ...noPerson2, distance: 0.3 },
+  ] as FaceSearchResult[];
 
-      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-      mocks.search.searchFaces.mockResolvedValueOnce(faces).mockResolvedValueOnce([]);
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
-      mocks.person.create.mockResolvedValue(person);
-      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+  mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+  mocks.search.searchFaces.mockResolvedValueOnce(faces).mockResolvedValueOnce([]);
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
+  mocks.person.create.mockResolvedValue(person);
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
 
-      expect(await sut.handleRecognizeFaces({ id: noPerson1.id })).toBe(JobStatus.Success);
+  expect(await sut.handleRecognizeFaces({ id: noPerson1.id })).toBe(JobStatus.Success);
 
-      expect(mocks.person.create).toHaveBeenCalledWith({
-        ownerId: asset.ownerId,
-        faceAssetId: noPerson1.id,
-      });
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.PersonGenerateThumbnail,
-        data: { id: person.id },
-      });
-      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
-        faceIds: [noPerson1.id],
-        newPersonId: person.id,
-      });
-      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(person.id);
-      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
-        assetFaceId: noPerson1.id,
-        identityId: sourceIdentityId,
-        source: 'owner-person',
-      });
-    });
+  expect(mocks.person.create).toHaveBeenCalledWith({
+    ownerId: asset.ownerId,
+    faceAssetId: noPerson1.id,
+  });
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.PersonGenerateThumbnail,
+    data: { id: person.id },
+  });
+  expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+    faceIds: [noPerson1.id],
+    newPersonId: person.id,
+  });
+  expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(person.id);
+  expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+    assetFaceId: noPerson1.id,
+    identityId: sourceIdentityId,
+    source: 'owner-person',
+  });
+});
 ```
 
 - [ ] **Step 3: Add an existing-person no-thumbnail assertion**
@@ -396,38 +399,36 @@ Update the existing test named `should create a new person if the face is a core
 Add this test after `should link identity after recognition assigns an existing person`:
 
 ```ts
-    it('assigns an existing person without creating a person or thumbnail job', async () => {
-      const asset = AssetFactory.create();
-      const [noPerson, matchedFace] = [
-        AssetFaceFactory.create({ assetId: asset.id }),
-        AssetFaceFactory.from().person().build(),
-      ];
-      const faces = [
-        { ...noPerson, distance: 0 },
-        { ...matchedFace, distance: 0.2 },
-      ] as FaceSearchResult[];
+it('assigns an existing person without creating a person or thumbnail job', async () => {
+  const asset = AssetFactory.create();
+  const [noPerson, matchedFace] = [
+    AssetFaceFactory.create({ assetId: asset.id }),
+    AssetFaceFactory.from().person().build(),
+  ];
+  const faces = [
+    { ...noPerson, distance: 0 },
+    { ...matchedFace, distance: 0.2 },
+  ] as FaceSearchResult[];
 
-      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-      mocks.search.searchFaces.mockResolvedValue(faces);
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
-      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'matched-identity' } as any);
+  mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+  mocks.search.searchFaces.mockResolvedValue(faces);
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'matched-identity' } as any);
 
-      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+  expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
 
-      expect(mocks.person.create).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.PersonGenerateThumbnail }),
-      );
-      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
-        faceIds: [noPerson.id],
-        newPersonId: matchedFace.person!.id,
-      });
-      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
-        assetFaceId: noPerson.id,
-        identityId: 'matched-identity',
-        source: 'owner-person',
-      });
-    });
+  expect(mocks.person.create).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.PersonGenerateThumbnail }));
+  expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+    faceIds: [noPerson.id],
+    newPersonId: matchedFace.person!.id,
+  });
+  expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+    assetFaceId: noPerson.id,
+    identityId: 'matched-identity',
+    source: 'owner-person',
+  });
+});
 ```
 
 - [ ] **Step 4: Run focused assignment-path tests**
@@ -450,6 +451,7 @@ git commit -m "test: cover recognition assignment paths"
 ## Task 4: Non-Core, Archive, And Hidden Faces Never Fan Out Without Assignment
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 - Modify when red: `server/src/services/person.service.ts`
 
@@ -458,32 +460,34 @@ git commit -m "test: cover recognition assignment paths"
 In the first `describe('handleRecognizeFaces')` block, add this test after `should not assign person to deferred non-core face with no matching person`:
 
 ```ts
-    it.each([AssetVisibility.Archive, AssetVisibility.Hidden, AssetVisibility.Locked])(
-      'does not create a core person or queue shared-space matching for deferred %s assets without a person',
-      async (visibility) => {
-        const asset = AssetFactory.create({ visibility });
-        const face = AssetFaceFactory.create({ assetId: asset.id });
+it.each([AssetVisibility.Archive, AssetVisibility.Hidden, AssetVisibility.Locked])(
+  'does not create a core person or queue shared-space matching for deferred %s assets without a person',
+  async (visibility) => {
+    const asset = AssetFactory.create({ visibility });
+    const face = AssetFaceFactory.create({ assetId: asset.id });
 
-        mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-        mocks.search.searchFaces.mockResolvedValueOnce([{ ...face, distance: 0 }] as FaceSearchResult[]).mockResolvedValueOnce([]);
-        mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
-        (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
-          identityId: 'accessible-space-identity',
-          distance: 0.2,
-        });
-        mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+    mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+    mocks.search.searchFaces
+      .mockResolvedValueOnce([{ ...face, distance: 0 }] as FaceSearchResult[])
+      .mockResolvedValueOnce([]);
+    mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+    (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+      identityId: 'accessible-space-identity',
+      distance: 0.2,
+    });
+    mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
 
-        expect(await sut.handleRecognizeFaces({ id: face.id, deferred: true })).toBe(JobStatus.Skipped);
+    expect(await sut.handleRecognizeFaces({ id: face.id, deferred: true })).toBe(JobStatus.Skipped);
 
-        expect(mocks.person.create).not.toHaveBeenCalled();
-        expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-        expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
-        expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
-        expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
-        expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
-        expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
-      },
-    );
+    expect(mocks.person.create).not.toHaveBeenCalled();
+    expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+    expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+    expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+  },
+);
 ```
 
 - [ ] **Step 2: Run the focused archive/hidden test and confirm it fails before the guard**
@@ -501,40 +505,40 @@ Expected before implementation: FAIL if the current service returns `Success`, q
 In `server/src/services/person.service.ts`, after the `if (personId) { ... }` assignment block and before `if (skipSharedSpaceMatch)`, add:
 
 ```ts
-    if (!personId) {
-      this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
-      return JobStatus.Skipped;
-    }
+if (!personId) {
+  this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
+  return JobStatus.Skipped;
+}
 ```
 
 The final branch order must be:
 
 ```ts
-    if (personId) {
-      this.logger.debug(`Assigning face ${id} to person ${personId}`);
-      await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: personId });
-      const sourceIdentityId = await this.replaceFaceIdentity(personId, id, 'owner-person');
-      await this.mergeWithAccessibleSharedIdentity({
-        userId: face.asset.ownerId,
-        embedding: face.faceSearch.embedding,
-        maxDistance: machineLearning.facialRecognition.maxDistance,
-        sourceIdentityId,
-        match: personId === createdPersonId ? accessibleIdentityMatch : undefined,
-      });
-    }
+if (personId) {
+  this.logger.debug(`Assigning face ${id} to person ${personId}`);
+  await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: personId });
+  const sourceIdentityId = await this.replaceFaceIdentity(personId, id, 'owner-person');
+  await this.mergeWithAccessibleSharedIdentity({
+    userId: face.asset.ownerId,
+    embedding: face.faceSearch.embedding,
+    maxDistance: machineLearning.facialRecognition.maxDistance,
+    sourceIdentityId,
+    match: personId === createdPersonId ? accessibleIdentityMatch : undefined,
+  });
+}
 
-    if (!personId) {
-      this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
-      return JobStatus.Skipped;
-    }
+if (!personId) {
+  this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
+  return JobStatus.Skipped;
+}
 
-    if (skipSharedSpaceMatch) {
-      return JobStatus.Success;
-    }
+if (skipSharedSpaceMatch) {
+  return JobStatus.Success;
+}
 
-    await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
+await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
 
-    return JobStatus.Success;
+return JobStatus.Success;
 ```
 
 - [ ] **Step 4: Re-run non-core/deferred recognition tests**
@@ -557,6 +561,7 @@ git commit -m "test: block recognition fanout without assignment"
 ## Task 5: Accessible Shared Identity Merge Guards
 
 **Files:**
+
 - Modify: `server/src/services/person.service.spec.ts`
 
 - [ ] **Step 1: Add same-space conflict coverage**
@@ -564,43 +569,43 @@ git commit -m "test: block recognition fanout without assignment"
 In the first `describe('handleRecognizeFaces')` block, add this test after `skips accessible shared identity merge when same-owner personal conflicts exist`:
 
 ```ts
-    it('skips accessible shared identity merge when same-space conflicts exist', async () => {
-      const asset = AssetFactory.create();
-      const [noPerson, matchedFace] = [
-        AssetFaceFactory.create({ assetId: asset.id }),
-        AssetFaceFactory.from().person().build(),
-      ];
-      const faces = [
-        { ...noPerson, distance: 0 },
-        { ...matchedFace, distance: 0.2 },
-      ] as FaceSearchResult[];
-      const sourceIdentityId = 'source-identity';
-      const targetIdentityId = 'target-identity';
+it('skips accessible shared identity merge when same-space conflicts exist', async () => {
+  const asset = AssetFactory.create();
+  const [noPerson, matchedFace] = [
+    AssetFaceFactory.create({ assetId: asset.id }),
+    AssetFaceFactory.from().person().build(),
+  ];
+  const faces = [
+    { ...noPerson, distance: 0 },
+    { ...matchedFace, distance: 0.2 },
+  ] as FaceSearchResult[];
+  const sourceIdentityId = 'source-identity';
+  const targetIdentityId = 'target-identity';
 
-      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-      mocks.search.searchFaces.mockResolvedValue(faces);
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
-      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
-      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
-        identityId: targetIdentityId,
-        distance: 0.2,
-      });
-      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
-        personalProfileConflictCount: 0,
-        spaceProfileConflictCount: 1,
-      });
+  mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+  mocks.search.searchFaces.mockResolvedValue(faces);
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+  (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+    identityId: targetIdentityId,
+    distance: 0.2,
+  });
+  mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+    personalProfileConflictCount: 0,
+    spaceProfileConflictCount: 1,
+  });
 
-      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+  expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
 
-      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
-        targetIdentityId,
-        sourceIdentityIds: [sourceIdentityId],
-      });
-      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
-      );
-    });
+  expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+    targetIdentityId,
+    sourceIdentityIds: [sourceIdentityId],
+  });
+  expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(
+    expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+  );
+});
 ```
 
 - [ ] **Step 2: Add same-identity no-conflict-query coverage**
@@ -608,35 +613,35 @@ In the first `describe('handleRecognizeFaces')` block, add this test after `skip
 Add this test immediately after the same-space conflict test:
 
 ```ts
-    it('does not run conflict checks when accessible shared evidence already points at the source identity', async () => {
-      const asset = AssetFactory.create();
-      const [noPerson, matchedFace] = [
-        AssetFaceFactory.create({ assetId: asset.id }),
-        AssetFaceFactory.from().person().build(),
-      ];
-      const faces = [
-        { ...noPerson, distance: 0 },
-        { ...matchedFace, distance: 0.2 },
-      ] as FaceSearchResult[];
-      const sourceIdentityId = 'source-identity';
+it('does not run conflict checks when accessible shared evidence already points at the source identity', async () => {
+  const asset = AssetFactory.create();
+  const [noPerson, matchedFace] = [
+    AssetFaceFactory.create({ assetId: asset.id }),
+    AssetFaceFactory.from().person().build(),
+  ];
+  const faces = [
+    { ...noPerson, distance: 0 },
+    { ...matchedFace, distance: 0.2 },
+  ] as FaceSearchResult[];
+  const sourceIdentityId = 'source-identity';
 
-      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-      mocks.search.searchFaces.mockResolvedValue(faces);
-      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
-      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
-      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
-        identityId: sourceIdentityId,
-        distance: 0.1,
-      });
+  mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+  mocks.search.searchFaces.mockResolvedValue(faces);
+  mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+  mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+  (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+    identityId: sourceIdentityId,
+    distance: 0.1,
+  });
 
-      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+  expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
 
-      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
-      );
-    });
+  expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+  expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(
+    expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+  );
+});
 ```
 
 - [ ] **Step 3: Run focused merge-guard tests**
@@ -659,6 +664,7 @@ git commit -m "test: cover recognition shared identity merge guards"
 ## Task 6: Medium Destructive Identity Tests
 
 **Files:**
+
 - Modify: `server/test/medium/specs/services/people-identity-rbac.spec.ts`
 
 - [ ] **Step 1: Strengthen the existing post-join private upload pass case**
@@ -666,8 +672,8 @@ git commit -m "test: cover recognition shared identity merge guards"
 In the existing test named `links a post-join private upload to a linked-library space identity and preserves owned access after leave`, add this assertion after `uploadedPerson` is loaded:
 
 ```ts
-    const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
-    expect(uploadedPerson.identityId).toBe(targetIdentity.id);
+const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
+expect(uploadedPerson.identityId).toBe(targetIdentity.id);
 ```
 
 Expected behavior: a member private upload merges into accessible shared evidence only when the repository conflict guards allow the merge.
@@ -677,65 +683,65 @@ Expected behavior: a member private upload merges into accessible shared evidenc
 Add this test immediately after the strengthened pass case:
 
 ```ts
-  it('does not merge a post-join private upload when strict personal conflict guards fail', async () => {
-    const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
-    const embeddingRow = await fx.ctx.database
-      .selectFrom('face_search')
-      .select('embedding')
-      .where('faceId', '=', fx.face.faceId)
-      .executeTakeFirstOrThrow();
-    const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
+it('does not merge a post-join private upload when strict personal conflict guards fail', async () => {
+  const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
+  const embeddingRow = await fx.ctx.database
+    .selectFrom('face_search')
+    .select('embedding')
+    .where('faceId', '=', fx.face.faceId)
+    .executeTakeFirstOrThrow();
+  const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
 
-    const { result: memberConflictPerson } = await fx.ctx.newPerson({
-      ownerId: fx.member.id,
-      name: 'Member Existing Profile',
-    });
-    const memberConflictIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(memberConflictPerson.id);
-    await fx.faceIdentityRepository.mergeIdentities({
-      targetIdentityId: targetIdentity.id,
-      sourceIdentityIds: [memberConflictIdentity.id],
-      source: 'manual',
-    });
-
-    const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
-    const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
-    await fx.ctx.database
-      .insertInto('face_search')
-      .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
-      .execute();
-
-    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
-
-    const uploadedPerson = await fx.ctx.database
-      .selectFrom('asset_face')
-      .innerJoin('person', 'person.id', 'asset_face.personId')
-      .select(['person.id', 'person.identityId'])
-      .where('asset_face.id', '=', uploadedFaceId)
-      .executeTakeFirstOrThrow();
-    const uploadedLinks = await fx.ctx.database
-      .selectFrom('face_identity_face')
-      .select(['assetFaceId', 'identityId', 'source'])
-      .where('assetFaceId', '=', uploadedFaceId)
-      .execute();
-    const targetProfiles = await fx.ctx.database
-      .selectFrom('person')
-      .select(['id', 'ownerId', 'identityId'])
-      .where('identityId', '=', targetIdentity.id)
-      .orderBy('id')
-      .execute();
-
-    expect(uploadedPerson.id).not.toBe(memberConflictPerson.id);
-    expect(uploadedPerson.identityId).not.toBe(targetIdentity.id);
-    expect(uploadedLinks).toEqual([
-      { assetFaceId: uploadedFaceId, identityId: uploadedPerson.identityId, source: 'owner-person' },
-    ]);
-    expect(targetProfiles).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: memberConflictPerson.id, ownerId: fx.member.id, identityId: targetIdentity.id }),
-      ]),
-    );
-    expect(targetProfiles.map((profile) => profile.id)).not.toContain(uploadedPerson.id);
+  const { result: memberConflictPerson } = await fx.ctx.newPerson({
+    ownerId: fx.member.id,
+    name: 'Member Existing Profile',
   });
+  const memberConflictIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(memberConflictPerson.id);
+  await fx.faceIdentityRepository.mergeIdentities({
+    targetIdentityId: targetIdentity.id,
+    sourceIdentityIds: [memberConflictIdentity.id],
+    source: 'manual',
+  });
+
+  const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
+  const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
+  await fx.ctx.database
+    .insertInto('face_search')
+    .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+    .execute();
+
+  await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+
+  const uploadedPerson = await fx.ctx.database
+    .selectFrom('asset_face')
+    .innerJoin('person', 'person.id', 'asset_face.personId')
+    .select(['person.id', 'person.identityId'])
+    .where('asset_face.id', '=', uploadedFaceId)
+    .executeTakeFirstOrThrow();
+  const uploadedLinks = await fx.ctx.database
+    .selectFrom('face_identity_face')
+    .select(['assetFaceId', 'identityId', 'source'])
+    .where('assetFaceId', '=', uploadedFaceId)
+    .execute();
+  const targetProfiles = await fx.ctx.database
+    .selectFrom('person')
+    .select(['id', 'ownerId', 'identityId'])
+    .where('identityId', '=', targetIdentity.id)
+    .orderBy('id')
+    .execute();
+
+  expect(uploadedPerson.id).not.toBe(memberConflictPerson.id);
+  expect(uploadedPerson.identityId).not.toBe(targetIdentity.id);
+  expect(uploadedLinks).toEqual([
+    { assetFaceId: uploadedFaceId, identityId: uploadedPerson.identityId, source: 'owner-person' },
+  ]);
+  expect(targetProfiles).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ id: memberConflictPerson.id, ownerId: fx.member.id, identityId: targetIdentity.id }),
+    ]),
+  );
+  expect(targetProfiles.map((profile) => profile.id)).not.toContain(uploadedPerson.id);
+});
 ```
 
 This test exercises the repository-side strict guard that prevents an accessible shared identity from being offered to a new private upload when that target identity already has a profile for the uploader. It complements the small Task 5 mocked conflict tests, which directly prove `getMergeConflicts()` blocks automatic merges when a same-owner or same-space conflict is reported after a candidate match is found.
@@ -745,62 +751,62 @@ This test exercises the repository-side strict guard that prevents an accessible
 Add this test immediately after the strict personal-conflict test:
 
 ```ts
-  it('repeated recognition of an already assigned face preserves one person and one identity link', async () => {
-    const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
-    const embeddingRow = await fx.ctx.database
-      .selectFrom('face_search')
-      .select('embedding')
-      .where('faceId', '=', fx.face.faceId)
-      .executeTakeFirstOrThrow();
+it('repeated recognition of an already assigned face preserves one person and one identity link', async () => {
+  const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
+  const embeddingRow = await fx.ctx.database
+    .selectFrom('face_search')
+    .select('embedding')
+    .where('faceId', '=', fx.face.faceId)
+    .executeTakeFirstOrThrow();
 
-    const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
-    const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
-    await fx.ctx.database
-      .insertInto('face_search')
-      .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+  const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
+  const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
+  await fx.ctx.database
+    .insertInto('face_search')
+    .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+    .execute();
+
+  const readState = async () => {
+    const assignedPerson = await fx.ctx.database
+      .selectFrom('asset_face')
+      .innerJoin('person', 'person.id', 'asset_face.personId')
+      .select(['person.id as personId', 'person.identityId as identityId'])
+      .where('asset_face.id', '=', uploadedFaceId)
+      .executeTakeFirstOrThrow();
+    const memberPeople = await fx.ctx.database
+      .selectFrom('person')
+      .select(['id', 'identityId'])
+      .where('ownerId', '=', fx.member.id)
+      .orderBy('id')
+      .execute();
+    const faceLinks = await fx.ctx.database
+      .selectFrom('face_identity_face')
+      .select(['assetFaceId', 'identityId', 'source'])
+      .where('assetFaceId', '=', uploadedFaceId)
+      .orderBy('assetFaceId')
       .execute();
 
-    const readState = async () => {
-      const assignedPerson = await fx.ctx.database
-        .selectFrom('asset_face')
-        .innerJoin('person', 'person.id', 'asset_face.personId')
-        .select(['person.id as personId', 'person.identityId as identityId'])
-        .where('asset_face.id', '=', uploadedFaceId)
-        .executeTakeFirstOrThrow();
-      const memberPeople = await fx.ctx.database
-        .selectFrom('person')
-        .select(['id', 'identityId'])
-        .where('ownerId', '=', fx.member.id)
-        .orderBy('id')
-        .execute();
-      const faceLinks = await fx.ctx.database
-        .selectFrom('face_identity_face')
-        .select(['assetFaceId', 'identityId', 'source'])
-        .where('assetFaceId', '=', uploadedFaceId)
-        .orderBy('assetFaceId')
-        .execute();
+    return { assignedPerson, memberPeople, faceLinks };
+  };
 
-      return { assignedPerson, memberPeople, faceLinks };
-    };
+  await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
 
-    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+  await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+  const assignedState = await readState();
 
-    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
-    const assignedState = await readState();
+  await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+  const repeatedState = await readState();
 
-    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
-    const repeatedState = await readState();
-
-    expect(repeatedState).toEqual(assignedState);
-    expect(repeatedState.memberPeople).toHaveLength(1);
-    expect(repeatedState.faceLinks).toEqual([
-      {
-        assetFaceId: uploadedFaceId,
-        identityId: repeatedState.assignedPerson.identityId,
-        source: 'owner-person',
-      },
-    ]);
-  });
+  expect(repeatedState).toEqual(assignedState);
+  expect(repeatedState.memberPeople).toHaveLength(1);
+  expect(repeatedState.faceLinks).toEqual([
+    {
+      assetFaceId: uploadedFaceId,
+      identityId: repeatedState.assignedPerson.identityId,
+      source: 'owner-person',
+    },
+  ]);
+});
 ```
 
 - [ ] **Step 4: Run focused medium destructive tests**
@@ -823,6 +829,7 @@ git commit -m "test: cover recognition destructive identity cases"
 ## Task 7: Full Slice Verification
 
 **Files:**
+
 - Verify all modified files.
 
 - [ ] **Step 1: Run the full small recognition spec**

--- a/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
+++ b/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
@@ -1,0 +1,924 @@
+# Per-Face Recognition Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add thorough Slice 4 coverage proving each `FacialRecognition` job state assigns, repairs, merges, defers, skips, and fans out shared-space work without destructive identity side effects.
+
+**Architecture:** Keep most coverage in `PersonService` small tests because `handleRecognizeFaces()` is branch-heavy and already owns mocked repositories for each decision. Use DB-backed medium tests in `people-identity-rbac.spec.ts` only for destructive identity outcomes that mocks cannot prove: strict conflict guards on post-join uploads and repeated recognition idempotency. Make production changes only where a new red test exposes unsafe behavior, with the expected fixes limited to `server/src/services/person.service.ts`.
+
+**Tech Stack:** TypeScript, NestJS service tests, Vitest, Gallery small test factories, Gallery medium DB test harness, Kysely, BullMQ job names.
+
+---
+
+## File Structure
+
+- Modify: `server/src/services/person.service.spec.ts`
+  - Owns small unit coverage for safe no-op/failure states, already-assigned identity repair, shared-space fanout suppression and dedupe, min-face threshold behavior, non-core deferral, archive/hidden safety, core-person creation, existing-person assignment, and accessible shared identity conflict guards.
+- Modify only when a new failing test proves the current service is unsafe: `server/src/services/person.service.ts`
+  - Owns the shared-space fanout helper, no-fanout-without-assignment guard, and any minimal recognition branch fix required by Slice 4 tests.
+- Modify: `server/test/medium/specs/services/people-identity-rbac.spec.ts`
+  - Owns DB-backed destructive tests for member private uploads after joining a space, strict conflict guards, and repeated recognition idempotency.
+- Audit only: `server/test/medium/specs/services/person.service.spec.ts`
+  - This file owns face-detection medium fixtures and does not currently include a `SearchRepository`-backed recognition setup. Keep Slice 4 medium identity coverage in `people-identity-rbac.spec.ts` unless implementation discovers an existing recognition fixture here.
+
+## Execution Preflight
+
+- [ ] **Step 1: Confirm the worktree is isolated and clean**
+
+Run:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+```
+
+Expected:
+
+```text
+/home/pierre/dev/gallery/.worktrees/face-trigger-slice-4-plan
+codex/face-trigger-slice-4-plan
+```
+
+`git status --short` must be empty before implementation edits. If it lists files, inspect them and preserve user-owned work.
+
+- [ ] **Step 2: Run the Slice 4 small-spec baseline**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "handleRecognizeFaces"
+```
+
+Expected: all existing `handleRecognizeFaces` tests pass before new tests are added.
+
+- [ ] **Step 3: Run the Slice 4 medium baseline**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/people-identity-rbac.spec.ts -t "post-join private upload|repeated recognition|strict"
+```
+
+Expected: matching existing medium tests pass before new DB-backed tests are added. If the selector finds no existing repeated-recognition test, Vitest should still run the matching post-join upload tests.
+
+## TDD Protocol For This Slice
+
+- [ ] **Step 1: Write the failing or coverage test first**
+
+Add each test before editing `server/src/services/person.service.ts`. Coverage tests for existing behavior may pass immediately; destructive-safety fixes should start red.
+
+- [ ] **Step 2: Run the smallest focused selector**
+
+Use a specific `-t` selector for the new test name. Expected result is either a red failure proving an unsafe gap or a pass proving the behavior already exists.
+
+- [ ] **Step 3: Make the smallest production fix**
+
+Only edit `server/src/services/person.service.ts` when the new test fails for product behavior. Do not refactor detection, shared-space projection, backfill, or overnight queue coordination in this slice.
+
+- [ ] **Step 4: Re-run the focused selector**
+
+Expected: the focused test passes.
+
+- [ ] **Step 5: Commit each completed task**
+
+Use one commit per task:
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts server/test/medium/specs/services/people-identity-rbac.spec.ts
+git commit -m "test: cover per-face recognition safety"
+```
+
+Adjust the staged paths to the files touched by the task.
+
+## Task 1: Safe Early Exits
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add a local no-mutation assertion helper**
+
+In the first `describe('handleRecognizeFaces')` block near `server/src/services/person.service.spec.ts:2864`, add this helper immediately after the `beforeEach()` block:
+
+```ts
+    const expectNoRecognitionMutation = () => {
+      expect(mocks.search.searchFaces).not.toHaveBeenCalled();
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    };
+```
+
+- [ ] **Step 2: Strengthen the missing face and missing asset tests**
+
+Update the existing tests named `should fail if face does not exist` and `should fail if face does not have asset` to call the helper:
+
+```ts
+    it('should fail if face does not exist', async () => {
+      expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Failed);
+
+      expectNoRecognitionMutation();
+    });
+
+    it('should fail if face does not have asset', async () => {
+      const face = AssetFaceFactory.create();
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, null));
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
+
+      expectNoRecognitionMutation();
+    });
+```
+
+- [ ] **Step 3: Add safe source and missing-embedding tests to the same recognition block**
+
+Add these tests immediately after the missing-asset test:
+
+```ts
+    it('skips non-machine-learning faces without mutating identities or queues', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.create({ assetId: asset.id, sourceType: SourceType.Exif });
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+
+      expectNoRecognitionMutation();
+    });
+
+    it('fails when a machine-learning face has no embedding without mutating identities or queues', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue({
+        ...face,
+        asset,
+        faceSearch: null,
+      } as any);
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
+
+      expectNoRecognitionMutation();
+    });
+```
+
+- [ ] **Step 4: Run the focused safe-exit tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "face does not exist|face does not have asset|non-machine-learning faces|no embedding"
+```
+
+Expected: all selected tests pass. If `getMergeConflicts` is called during an early exit, the test should fail and the service must be fixed before continuing.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add server/src/services/person.service.spec.ts
+git commit -m "test: cover safe recognition early exits"
+```
+
+## Task 2: Shared-Space Fanout Is Suppressed Or Deduped
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify when red: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Add a red test for deduped fanout on already-assigned faces**
+
+In the first `describe('handleRecognizeFaces')` block, add this test after `should queue space face matching even when face already has a person assigned`:
+
+```ts
+    it('queues shared-space face matching exactly once per space after repairing an assigned face', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
+        { spaceId: 'space-1' },
+        { spaceId: 'space-1' },
+        { spaceId: 'space-2' },
+      ]);
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+
+      const sharedSpaceJobs = mocks.job.queue.mock.calls
+        .map(([job]) => job)
+        .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+      expect(sharedSpaceJobs).toEqual([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: face.assetId } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: face.assetId } },
+      ]);
+    });
+```
+
+- [ ] **Step 2: Add a red test for deduped fanout after successful incremental assignment**
+
+Add this test after `should queue SharedSpaceFaceMatch for spaces containing the asset`:
+
+```ts
+    it('queues one SharedSpaceFaceMatch job per unique space after assigning a face', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, primaryFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...primaryFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
+        { spaceId: 'space-1' },
+        { spaceId: 'space-2' },
+        { spaceId: 'space-1' },
+      ]);
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      const sharedSpaceJobs = mocks.job.queue.mock.calls
+        .map(([job]) => job)
+        .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+      expect(sharedSpaceJobs).toEqual([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: noPerson.assetId } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: noPerson.assetId } },
+      ]);
+    });
+```
+
+- [ ] **Step 3: Run the focused fanout tests and confirm they fail before the helper**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "exactly once per space|per unique space"
+```
+
+Expected before implementation: FAIL because the service queues duplicate `SharedSpaceFaceMatch` jobs when the repository returns duplicate `spaceId` rows.
+
+- [ ] **Step 4: Add a deduping fanout helper**
+
+In `server/src/services/person.service.ts`, add this private helper after `handleRecognizeFaces()` and before `replaceFaceIdentity()`:
+
+```ts
+  private async queueSharedSpaceFaceMatchesForAsset(assetId: string): Promise<void> {
+    const spaceIds = await this.sharedSpaceRepository.getSpaceIdsForAsset(assetId);
+    const queuedSpaceIds = new Set<string>();
+    for (const { spaceId } of spaceIds) {
+      if (queuedSpaceIds.has(spaceId)) {
+        continue;
+      }
+      queuedSpaceIds.add(spaceId);
+      await this.jobRepository.queue({
+        name: JobName.SharedSpaceFaceMatch,
+        data: { spaceId, assetId },
+      });
+    }
+  }
+```
+
+- [ ] **Step 5: Replace both raw shared-space fanout loops**
+
+In the already-assigned branch, replace the loop at `server/src/services/person.service.ts:942-950` with:
+
+```ts
+      // Still queue space face matching because this face may belong to a space
+      // that was created or linked after the face was originally recognized.
+      await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
+```
+
+Near the end of `handleRecognizeFaces()`, replace the loop at `server/src/services/person.service.ts:1044-1051` with:
+
+```ts
+    await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
+```
+
+- [ ] **Step 6: Re-run the fanout tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "exactly once per space|per unique space|skipSharedSpaceMatch|force jobs"
+```
+
+Expected: PASS. Existing `skipSharedSpaceMatch` tests must still prove `getSpaceIdsForAsset()` is not called when suppression is set.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: dedupe recognition shared-space fanout"
+```
+
+## Task 3: Assignment Paths Link Identity And Avoid Spurious Work
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add an explicit min-face self-only threshold test**
+
+In the first `describe('handleRecognizeFaces')` block, add this test after `should not queue face with no matches`:
+
+```ts
+    it('skips self-only matches below the min-face threshold without deferring or assigning', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
+      mocks.search.searchFaces.mockResolvedValue([{ ...face, distance: 0 }] as FaceSearchResult[]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+
+      expect(mocks.search.searchFaces).toHaveBeenCalledTimes(1);
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Strengthen the core-person creation test**
+
+Update the existing test named `should create a new person if the face is a core point with no person` to include thumbnail and identity-link assertions:
+
+```ts
+    it('should create a new person if the face is a core point with no person', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson1, noPerson2] = [AssetFaceFactory.create({ assetId: asset.id }), AssetFaceFactory.create()];
+      const person = PersonFactory.create({ ownerId: asset.ownerId });
+      const sourceIdentityId = 'created-person-identity';
+
+      const faces = [
+        { ...noPerson1, distance: 0 },
+        { ...noPerson2, distance: 0.3 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValueOnce(faces).mockResolvedValueOnce([]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
+      mocks.person.create.mockResolvedValue(person);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson1.id })).toBe(JobStatus.Success);
+
+      expect(mocks.person.create).toHaveBeenCalledWith({
+        ownerId: asset.ownerId,
+        faceAssetId: noPerson1.id,
+      });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.PersonGenerateThumbnail,
+        data: { id: person.id },
+      });
+      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+        faceIds: [noPerson1.id],
+        newPersonId: person.id,
+      });
+      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(person.id);
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: noPerson1.id,
+        identityId: sourceIdentityId,
+        source: 'owner-person',
+      });
+    });
+```
+
+- [ ] **Step 3: Add an existing-person no-thumbnail assertion**
+
+Add this test after `should link identity after recognition assigns an existing person`:
+
+```ts
+    it('assigns an existing person without creating a person or thumbnail job', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'matched-identity' } as any);
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.PersonGenerateThumbnail }),
+      );
+      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+        faceIds: [noPerson.id],
+        newPersonId: matchedFace.person!.id,
+      });
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: noPerson.id,
+        identityId: 'matched-identity',
+        source: 'owner-person',
+      });
+    });
+```
+
+- [ ] **Step 4: Run focused assignment-path tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "self-only matches|core point|existing person without creating"
+```
+
+Expected: PASS. A failure here means the service is creating people, thumbnails, or assignments in a branch that should be inert.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add server/src/services/person.service.spec.ts
+git commit -m "test: cover recognition assignment paths"
+```
+
+## Task 4: Non-Core, Archive, And Hidden Faces Never Fan Out Without Assignment
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+- Modify when red: `server/src/services/person.service.ts`
+
+- [ ] **Step 1: Add a red archive/hidden deferred test**
+
+In the first `describe('handleRecognizeFaces')` block, add this test after `should not assign person to deferred non-core face with no matching person`:
+
+```ts
+    it.each([AssetVisibility.Archive, AssetVisibility.Hidden])(
+      'does not create a core person or queue shared-space matching for deferred %s assets without a person',
+      async (visibility) => {
+        const asset = AssetFactory.create({ visibility });
+        const face = AssetFaceFactory.create({ assetId: asset.id });
+
+        mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+        mocks.search.searchFaces.mockResolvedValueOnce([{ ...face, distance: 0 }] as FaceSearchResult[]).mockResolvedValueOnce([]);
+        mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+        (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+          identityId: 'accessible-space-identity',
+          distance: 0.2,
+        });
+        mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+
+        expect(await sut.handleRecognizeFaces({ id: face.id, deferred: true })).toBe(JobStatus.Skipped);
+
+        expect(mocks.person.create).not.toHaveBeenCalled();
+        expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+        expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+        expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+        expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+        expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }));
+      },
+    );
+```
+
+- [ ] **Step 2: Run the focused archive/hidden test and confirm it fails before the guard**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "deferred .* assets without a person"
+```
+
+Expected before implementation: FAIL if the current service returns `Success`, queries spaces, or queues `SharedSpaceFaceMatch` after a deferred archive/hidden face resolves to no person.
+
+- [ ] **Step 3: Add the no-person no-fanout guard**
+
+In `server/src/services/person.service.ts`, after the `if (personId) { ... }` assignment block and before `if (skipSharedSpaceMatch)`, add:
+
+```ts
+    if (!personId) {
+      this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
+      return JobStatus.Skipped;
+    }
+```
+
+The final branch order must be:
+
+```ts
+    if (personId) {
+      this.logger.debug(`Assigning face ${id} to person ${personId}`);
+      await this.personRepository.reassignFaces({ faceIds: [id], newPersonId: personId });
+      const sourceIdentityId = await this.replaceFaceIdentity(personId, id, 'owner-person');
+      await this.mergeWithAccessibleSharedIdentity({
+        userId: face.asset.ownerId,
+        embedding: face.faceSearch.embedding,
+        maxDistance: machineLearning.facialRecognition.maxDistance,
+        sourceIdentityId,
+        match: personId === createdPersonId ? accessibleIdentityMatch : undefined,
+      });
+    }
+
+    if (!personId) {
+      this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
+      return JobStatus.Skipped;
+    }
+
+    if (skipSharedSpaceMatch) {
+      return JobStatus.Success;
+    }
+
+    await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
+
+    return JobStatus.Success;
+```
+
+- [ ] **Step 4: Re-run non-core/deferred recognition tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "deferred .* assets without a person|defer non-core|deferred non-core|skipSharedSpaceMatch"
+```
+
+Expected: PASS. Existing deferred tests must still prove one deferral, `skipSharedSpaceMatch` preservation, and assignment to an existing person when evidence exists.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add server/src/services/person.service.spec.ts server/src/services/person.service.ts
+git commit -m "test: block recognition fanout without assignment"
+```
+
+## Task 5: Accessible Shared Identity Merge Guards
+
+**Files:**
+- Modify: `server/src/services/person.service.spec.ts`
+
+- [ ] **Step 1: Add same-space conflict coverage**
+
+In the first `describe('handleRecognizeFaces')` block, add this test after `skips accessible shared identity merge when same-owner personal conflicts exist`:
+
+```ts
+    it('skips accessible shared identity merge when same-space conflicts exist', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+      const sourceIdentityId = 'source-identity';
+      const targetIdentityId = 'target-identity';
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+        identityId: targetIdentityId,
+        distance: 0.2,
+      });
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 1,
+      });
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
+      });
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonMetadataBackfill,
+        data: { identityId: targetIdentityId },
+      });
+    });
+```
+
+- [ ] **Step 2: Add same-identity no-conflict-query coverage**
+
+Add this test immediately after the same-space conflict test:
+
+```ts
+    it('does not run conflict checks when accessible shared evidence already points at the source identity', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+      const sourceIdentityId = 'source-identity';
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+        identityId: sourceIdentityId,
+        distance: 0.1,
+      });
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+      );
+    });
+```
+
+- [ ] **Step 3: Run focused merge-guard tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "accessible shared identity merge|same-space conflicts|same-owner personal conflicts|already points at the source identity"
+```
+
+Expected: PASS. If same-space conflict still merges identities or queues metadata backfill, fix `mergeWithAccessibleSharedIdentity()` before continuing.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add server/src/services/person.service.spec.ts
+git commit -m "test: cover recognition shared identity merge guards"
+```
+
+## Task 6: Medium Destructive Identity Tests
+
+**Files:**
+- Modify: `server/test/medium/specs/services/people-identity-rbac.spec.ts`
+
+- [ ] **Step 1: Strengthen the existing post-join private upload pass case**
+
+In the existing test named `links a post-join private upload to a linked-library space identity and preserves owned access after leave`, add this assertion after `uploadedPerson` is loaded:
+
+```ts
+    const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
+    expect(uploadedPerson.identityId).toBe(targetIdentity.id);
+```
+
+Expected behavior: a member private upload merges into accessible shared evidence only when the repository conflict guards allow the merge.
+
+- [ ] **Step 2: Add a strict personal-conflict blocked medium test**
+
+Add this test immediately after the strengthened pass case:
+
+```ts
+  it('does not merge a post-join private upload when strict personal conflict guards fail', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
+    const embeddingRow = await fx.ctx.database
+      .selectFrom('face_search')
+      .select('embedding')
+      .where('faceId', '=', fx.face.faceId)
+      .executeTakeFirstOrThrow();
+    const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
+
+    const { result: memberConflictPerson } = await fx.ctx.newPerson({
+      ownerId: fx.member.id,
+      name: 'Member Existing Profile',
+    });
+    const memberConflictIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(memberConflictPerson.id);
+    await fx.faceIdentityRepository.mergeIdentities({
+      targetIdentityId: targetIdentity.id,
+      sourceIdentityIds: [memberConflictIdentity.id],
+      source: 'manual',
+    });
+
+    const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
+    const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
+    await fx.ctx.database
+      .insertInto('face_search')
+      .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+      .execute();
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+
+    const uploadedPerson = await fx.ctx.database
+      .selectFrom('asset_face')
+      .innerJoin('person', 'person.id', 'asset_face.personId')
+      .select(['person.id', 'person.identityId'])
+      .where('asset_face.id', '=', uploadedFaceId)
+      .executeTakeFirstOrThrow();
+    const uploadedLinks = await fx.ctx.database
+      .selectFrom('face_identity_face')
+      .select(['assetFaceId', 'identityId', 'source'])
+      .where('assetFaceId', '=', uploadedFaceId)
+      .execute();
+    const targetProfiles = await fx.ctx.database
+      .selectFrom('person')
+      .select(['id', 'ownerId', 'identityId'])
+      .where('identityId', '=', targetIdentity.id)
+      .orderBy('id')
+      .execute();
+
+    expect(uploadedPerson.id).not.toBe(memberConflictPerson.id);
+    expect(uploadedPerson.identityId).not.toBe(targetIdentity.id);
+    expect(uploadedLinks).toEqual([
+      { assetFaceId: uploadedFaceId, identityId: uploadedPerson.identityId, source: 'owner-person' },
+    ]);
+    expect(targetProfiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: memberConflictPerson.id, ownerId: fx.member.id, identityId: targetIdentity.id }),
+      ]),
+    );
+  });
+```
+
+- [ ] **Step 3: Add repeated-recognition idempotency medium coverage**
+
+Add this test immediately after the strict personal-conflict test:
+
+```ts
+  it('repeated recognition of an already assigned face preserves one person and one identity link', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
+    const embeddingRow = await fx.ctx.database
+      .selectFrom('face_search')
+      .select('embedding')
+      .where('faceId', '=', fx.face.faceId)
+      .executeTakeFirstOrThrow();
+
+    const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
+    const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
+    await fx.ctx.database
+      .insertInto('face_search')
+      .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+      .execute();
+
+    const readState = async () => {
+      const assignedPerson = await fx.ctx.database
+        .selectFrom('asset_face')
+        .innerJoin('person', 'person.id', 'asset_face.personId')
+        .select(['person.id as personId', 'person.identityId as identityId'])
+        .where('asset_face.id', '=', uploadedFaceId)
+        .executeTakeFirstOrThrow();
+      const memberPeople = await fx.ctx.database
+        .selectFrom('person')
+        .select(['id', 'identityId'])
+        .where('ownerId', '=', fx.member.id)
+        .orderBy('id')
+        .execute();
+      const faceLinks = await fx.ctx.database
+        .selectFrom('face_identity_face')
+        .select(['assetFaceId', 'identityId', 'source'])
+        .where('assetFaceId', '=', uploadedFaceId)
+        .orderBy('assetFaceId')
+        .execute();
+
+      return { assignedPerson, memberPeople, faceLinks };
+    };
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+    const firstState = await readState();
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+    const repeatedState = await readState();
+
+    expect(repeatedState).toEqual(firstState);
+    expect(repeatedState.memberPeople).toHaveLength(1);
+    expect(repeatedState.faceLinks).toEqual([
+      {
+        assetFaceId: uploadedFaceId,
+        identityId: repeatedState.assignedPerson.identityId,
+        source: 'owner-person',
+      },
+    ]);
+  });
+```
+
+- [ ] **Step 4: Run focused medium destructive tests**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/people-identity-rbac.spec.ts -t "post-join private upload|strict personal conflict|repeated recognition"
+```
+
+Expected: PASS. The strict personal-conflict test must leave the uploaded person's identity separate from the accessible shared target. The repeated-recognition test must prove one member person row and one `face_identity_face` row for the uploaded face after multiple runs.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add server/test/medium/specs/services/people-identity-rbac.spec.ts
+git commit -m "test: cover recognition destructive identity cases"
+```
+
+## Task 7: Full Slice Verification
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Run the full small recognition spec**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/person.service.spec.ts -t "handleRecognizeFaces"
+```
+
+Expected: all `handleRecognizeFaces` tests pass.
+
+- [ ] **Step 2: Run the full people identity RBAC medium spec**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/people-identity-rbac.spec.ts
+```
+
+Expected: the full medium spec passes. If the local database or testcontainers environment blocks this run, capture the exact environment error and still run the focused medium selector from Task 6.
+
+- [ ] **Step 3: Run formatting on touched files**
+
+Run:
+
+```bash
+pnpm --dir server exec prettier --check src/services/person.service.ts src/services/person.service.spec.ts test/medium/specs/services/people-identity-rbac.spec.ts
+```
+
+Expected: Prettier reports all files are formatted.
+
+- [ ] **Step 4: Run typecheck if production code changed**
+
+Run when `server/src/services/person.service.ts` changed:
+
+```bash
+pnpm --dir server check
+```
+
+Expected: TypeScript check passes.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff -- server/src/services/person.service.ts server/src/services/person.service.spec.ts server/test/medium/specs/services/people-identity-rbac.spec.ts
+```
+
+Expected: diff contains only Slice 4 recognition safety tests and the minimal service helper/guard required by those tests.
+
+- [ ] **Step 6: Commit final verification metadata if needed**
+
+If formatting changes files after earlier commits, commit them:
+
+```bash
+git add server/src/services/person.service.ts server/src/services/person.service.spec.ts server/test/medium/specs/services/people-identity-rbac.spec.ts
+git commit -m "chore: format recognition safety tests"
+```
+
+If there are no formatting changes, do not create an empty commit.
+
+## Spec Coverage Checklist
+
+- [ ] Missing face and missing asset fail safely: Task 1.
+- [ ] Non-ML source skips safely: Task 1.
+- [ ] Missing embedding fails safely: Task 1.
+- [ ] Already assigned face repairs identity and queues shared-space matches unless `skipSharedSpaceMatch` is set: Tasks 2 and existing strengthened tests.
+- [ ] Min-face threshold skips self-only matches: Task 3.
+- [ ] Non-core faces defer once and preserve `skipSharedSpaceMatch`: Task 4 re-runs existing deferred coverage and protects it from regressions.
+- [ ] Deferred non-core face can still attach to an existing person when evidence exists: Task 4 re-runs existing focused coverage.
+- [ ] Core face creates a person, queues thumbnail generation, reassigns face, and links owner identity: Task 3.
+- [ ] Existing person match reassigns without creating a person: Task 3.
+- [ ] Accessible shared identity match can merge only after conflict checks pass: Tasks 5 and 6.
+- [ ] Same-owner and same-space conflicts prevent automatic identity merge: Tasks 5 and 6.
+- [ ] Archive or hidden visibility does not create core people unexpectedly: Task 4.
+- [ ] Spaces for the asset queue `SharedSpaceFaceMatch` exactly once per space for successful incremental recognition: Task 2.
+- [ ] Member private upload after joining a space merges with accessible shared evidence only when strict conflict guards pass: Task 6.
+- [ ] Repeated recognition of already assigned faces does not create duplicate people or duplicate identity links: Task 6.
+
+## Explicit Out Of Scope
+
+- Shared-space projection behavior inside `handleSharedSpaceFaceMatch*` belongs to Slice 5.
+- Full overnight chain composition, including issue #597 end-to-end scheduled recovery, belongs to Slice 8.
+- Face detection matching, stale ML-face deletion, and scaled detection matching belong to Slice 2.
+- Force recognition reset ordering and stuck queue behavior belong to Slice 3.
+
+## Self-Review Notes
+
+- Spec coverage: every Slice 4 bullet maps to a task in the checklist above.
+- Placeholder scan: this plan contains concrete file paths, test snippets, implementation snippets, commands, expected results, and commit commands.
+- Type consistency: snippets use existing imports and names from the current codebase: `AssetVisibility.Archive`, `AssetVisibility.Hidden`, `JobName.SharedSpaceFaceMatch`, `JobName.PersonGenerateThumbnail`, `JobName.SharedSpacePersonMetadataBackfill`, `SourceType.Exif`, `FaceSearchResult`, `getForFacialRecognitionJob`, `createLinkedLibraryIdentityFixture`, and `newEmbedding` fixtures already present in the target specs.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - dispatch a fresh subagent per task, review between tasks, and keep implementation commits small.
+
+**2. Inline Execution** - execute tasks in this session using `superpowers:executing-plans`, with checkpoints after each task.

--- a/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
+++ b/docs/superpowers/plans/2026-05-17-per-face-recognition-safety.md
@@ -458,7 +458,7 @@ git commit -m "test: cover recognition assignment paths"
 In the first `describe('handleRecognizeFaces')` block, add this test after `should not assign person to deferred non-core face with no matching person`:
 
 ```ts
-    it.each([AssetVisibility.Archive, AssetVisibility.Hidden])(
+    it.each([AssetVisibility.Archive, AssetVisibility.Hidden, AssetVisibility.Locked])(
       'does not create a core person or queue shared-space matching for deferred %s assets without a person',
       async (visibility) => {
         const asset = AssetFactory.create({ visibility });
@@ -597,10 +597,9 @@ In the first `describe('handleRecognizeFaces')` block, add this test after `skip
         sourceIdentityIds: [sourceIdentityId],
       });
       expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalledWith({
-        name: JobName.SharedSpacePersonMetadataBackfill,
-        data: { identityId: targetIdentityId },
-      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+      );
     });
 ```
 
@@ -735,8 +734,11 @@ Add this test immediately after the strengthened pass case:
         expect.objectContaining({ id: memberConflictPerson.id, ownerId: fx.member.id, identityId: targetIdentity.id }),
       ]),
     );
+    expect(targetProfiles.map((profile) => profile.id)).not.toContain(uploadedPerson.id);
   });
 ```
+
+This test exercises the repository-side strict guard that prevents an accessible shared identity from being offered to a new private upload when that target identity already has a profile for the uploader. It complements the small Task 5 mocked conflict tests, which directly prove `getMergeConflicts()` blocks automatic merges when a same-owner or same-space conflict is reported after a candidate match is found.
 
 - [ ] **Step 3: Add repeated-recognition idempotency medium coverage**
 
@@ -867,8 +869,8 @@ Expected: TypeScript check passes.
 Run:
 
 ```bash
-git diff --stat HEAD
-git diff -- server/src/services/person.service.ts server/src/services/person.service.spec.ts server/test/medium/specs/services/people-identity-rbac.spec.ts
+git diff --stat @{upstream}...HEAD
+git diff @{upstream}...HEAD -- server/src/services/person.service.ts server/src/services/person.service.spec.ts server/test/medium/specs/services/people-identity-rbac.spec.ts
 ```
 
 Expected: diff contains only Slice 4 recognition safety tests and the minimal service helper/guard required by those tests.
@@ -897,7 +899,7 @@ If there are no formatting changes, do not create an empty commit.
 - [ ] Existing person match reassigns without creating a person: Task 3.
 - [ ] Accessible shared identity match can merge only after conflict checks pass: Tasks 5 and 6.
 - [ ] Same-owner and same-space conflicts prevent automatic identity merge: Tasks 5 and 6.
-- [ ] Archive or hidden visibility does not create core people unexpectedly: Task 4.
+- [ ] Archive, hidden, or locked visibility does not create core people unexpectedly: Task 4.
 - [ ] Spaces for the asset queue `SharedSpaceFaceMatch` exactly once per space for successful incremental recognition: Task 2.
 - [ ] Member private upload after joining a space merges with accessible shared evidence only when strict conflict guards pass: Task 6.
 - [ ] Repeated recognition of already assigned faces does not create duplicate people or duplicate identity links: Task 6.

--- a/docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+++ b/docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
@@ -1,0 +1,1077 @@
+# Shared-Space Projection Pipeline Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Slice 5 safety coverage for shared-space face projection jobs so stale, missing, duplicate, disabled, and linked-library paths cannot corrupt selected-space people or identity-backed face assignments.
+
+**Architecture:** Keep queue metadata, stable job id, and handler branch coverage in small service/repository tests. Use DB-backed medium tests for destructive selected-space projection outcomes because correctness depends on real constraints, cascades, recounts, and repository cleanup. Make production changes only when a red test proves existing behavior is unsafe, and keep fixes limited to `server/src/services/shared-space.service.ts`, `server/src/repositories/shared-space.repository.ts`, or `server/src/repositories/job.repository.ts`.
+
+**Tech Stack:** TypeScript, NestJS service tests, Vitest, Gallery small factories, Gallery medium DB harness, Kysely, BullMQ job metadata, shared-space identity repositories.
+
+---
+
+## Slice 5 Source
+
+Spec: `docs/superpowers/specs/2026-05-17-face-identity-queue-testing-plan-design.md`
+
+Slice 5 purpose: pin `SharedSpaceFaceMatch`, `SharedSpaceFaceMatchFromBackfill`, `SharedSpaceLibraryFaceSync`, `SharedSpaceFaceMatchAll`, and `SharedSpaceFaceMatchPage`.
+
+Slice 4 status: already implemented on PR #604 (`codex/face-trigger-slice-4-plan`) and green as of the last babysit run. This Slice 5 plan is based on `origin/main` so it does not depend on the still-open Slice 4 branch.
+
+## Existing Coverage To Preserve
+
+`server/src/services/shared-space.service.spec.ts` already covers:
+
+- missing and disabled spaces for `SharedSpaceFaceMatch`, `SharedSpaceFaceMatchFromBackfill`, `SharedSpaceFaceMatchAll`, `SharedSpaceFaceMatchPage`, `SharedSpaceLibraryFaceSync`, and `SharedSpacePersonDedup`
+- targeted asset removed before execution for `SharedSpaceFaceMatch`
+- identity-backed face attach/create paths
+- nearby different identity does not override identity-backed matching
+- stale selected-space assignment replacement
+- wrong-identity selected-space assignment replacement
+- type-incompatible assignment removal
+- exact identity-backfill metadata refresh
+- legacy no-identity face path
+- no-person face wait path
+- pet matching and type setting
+- affected people queue `SharedSpaceIdentityReconciliation`
+- successful target match queues `SharedSpacePersonDedup`
+- `SharedSpaceFaceMatchFromBackfill` runs on `QueueName.PeopleBackfill`
+- other shared-space face pipeline jobs run on `QueueName.FacialRecognition`
+- full-space dispatcher queues only the first page
+- page lookahead, batch clamping, continuation, disabled-between-pages, and final follow-up behavior
+- library face sync link recheck and stop-after-unlink behavior
+
+`server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts` already covers:
+
+- linked-library full rematch assigns EXIF identity faces without embeddings
+- one identity-backed space person across multiple linked libraries
+- stale linked-library assignment repair
+- linked-library relink rebuild
+- no-identity pet legacy path
+- type-incompatible full rematch cleanup
+
+This plan fills the remaining high-risk gaps from Slice 5: `SharedSpaceFaceMatchFromBackfill` stable job ids, from-backfill asset-removal safety, identity-backed pet incompatibility in small tests, no-work linked-library follow-up suppression, and DB-backed destructive cleanup/duplication invariants.
+
+## File Structure
+
+- Modify: `server/src/repositories/job.repository.spec.ts`
+  - Owns stable job id and failed/paused job behavior for `SharedSpaceFaceMatchFromBackfill`.
+- Modify: `server/src/services/shared-space.service.spec.ts`
+  - Owns small handler coverage for from-backfill targeted asset removal, identity-backed pet incompatibility, and no-work library-sync follow-up behavior.
+- Modify only if a new red test proves unsafe behavior: `server/src/repositories/job.repository.ts`
+  - Owns `SharedSpaceFaceMatchFromBackfill` job id and stable shared-space face pipeline treatment.
+- Modify only if a new red test proves unsafe behavior: `server/src/services/shared-space.service.ts`
+  - Owns handler skip/follow-up behavior and shared-space projection repair orchestration.
+- Modify only if a new red test proves unsafe behavior: `server/src/repositories/shared-space.repository.ts`
+  - Owns selected-space assignment cleanup, orphan deletion, and asset/library face selection queries.
+- Modify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+  - Owns DB-backed destructive projection tests for missing, stale, wrong-identity, direct-plus-linked duplicate, direct asset removal, and library unlink cleanup.
+
+## Execution Preflight
+
+- [ ] **Step 1: Confirm the worktree is isolated and clean**
+
+Run:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+```
+
+Expected:
+
+```text
+/home/pierre/dev/gallery/.worktrees/face-trigger-slice-5-plan
+codex/face-trigger-slice-5-plan
+```
+
+`git status --short` must be empty before implementation edits. If it lists files, inspect them and preserve user-owned work.
+
+- [ ] **Step 2: Run the small Slice 5 baseline**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/shared-space.service.spec.ts -t "handleSharedSpaceFaceMatch|handleSharedSpaceFaceMatchFromBackfill|handleSharedSpaceFaceMatchAll|handleSharedSpaceFaceMatchPage|handleSharedSpaceLibraryFaceSync"
+```
+
+Expected: all matching existing small tests pass before new coverage is added.
+
+- [ ] **Step 3: Run the job repository baseline**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/job.repository.spec.ts -t "shared-space face pipeline|SharedSpaceFaceMatchFromBackfill|stable shared-space"
+```
+
+Expected: all matching existing job repository tests pass before new coverage is added.
+
+- [ ] **Step 4: Run the medium Slice 5 baseline**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+```
+
+Expected: existing linked-library face identity repair medium tests pass before adding new destructive scenarios.
+
+## TDD Protocol For This Slice
+
+- [ ] **Step 1: Write the test first**
+
+For each task, add the test before editing production code. If the test passes immediately, it still pins the behavior and should be committed as coverage.
+
+- [ ] **Step 2: Run the smallest focused selector**
+
+Use the exact `-t` selector shown in each task. Expected result is either a red failure proving an unsafe gap or a pass proving current behavior is safe.
+
+- [ ] **Step 3: Make the smallest production fix only for red product behavior**
+
+Only edit production files when the new test fails for product behavior. Do not refactor shared-space matching, identity reconciliation, metadata inheritance, or linked-library sync outside the failing branch.
+
+- [ ] **Step 4: Re-run the focused selector**
+
+Expected: the focused test passes.
+
+- [ ] **Step 5: Commit each completed task**
+
+Use one commit per task. Adjust staged paths to the files touched by the task.
+
+## Task 1: From-Backfill Stable Job Identity
+
+**Files:**
+
+- Modify: `server/src/repositories/job.repository.spec.ts`
+- Modify only if red: `server/src/repositories/job.repository.ts`
+
+- [ ] **Step 1: Add `SharedSpaceFaceMatchFromBackfill` to stable visible-failure job id coverage**
+
+In `server/src/repositories/job.repository.spec.ts`, update the test named `uses stable visible-failure job ids for shared-space face pipeline jobs`.
+
+Replace the `setHandlers()` array with:
+
+```ts
+setHandlers(sut, [
+  JobName.SharedSpaceFaceMatch,
+  JobName.SharedSpaceFaceMatchFromBackfill,
+  JobName.SharedSpaceFaceMatchAll,
+  JobName.SharedSpaceFaceMatchPage,
+  JobName.SharedSpacePersonDedup,
+  JobName.SharedSpaceIdentityReconciliation,
+]);
+```
+
+Replace the `queueAll()` input with:
+
+```ts
+await sut.queueAll([
+  { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+  { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+  { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: 'asset-1' } },
+  { name: JobName.SharedSpaceFaceMatchFromBackfill, data: { spaceId: 'space-1', assetId: 'asset-1' } },
+  { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-1' } },
+  { name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1' } },
+  { name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1', afterAssetId: 'asset-9' } },
+  { name: JobName.SharedSpacePersonDedup, data: { spaceId: 'space-1' } },
+  { name: JobName.SharedSpaceIdentityReconciliation, data: { spaceId: 'space-1' } },
+]);
+```
+
+Add this expectation after the existing `SharedSpaceFaceMatch` expectations:
+
+```ts
+expect(queue.add).toHaveBeenCalledWith(
+  JobName.SharedSpaceFaceMatchFromBackfill,
+  { spaceId: 'space-1', assetId: 'asset-1' },
+  {
+    jobId: 'shared-space-face-match/from-backfill/space-1/asset-1',
+    removeOnComplete: true,
+  },
+);
+```
+
+- [ ] **Step 2: Add failed-job visibility coverage for from-backfill jobs**
+
+Add this test after `does not remove failed stable shared-space jobs while queueing duplicates`:
+
+```ts
+it('does not remove failed from-backfill shared-space jobs while queueing duplicates', async () => {
+  const { sut, queue } = setup();
+  const failedJob = {
+    getState: vi.fn().mockResolvedValue('failed'),
+    remove: vi.fn().mockResolvedValue(void 0),
+  };
+  queue.getJob.mockResolvedValue(failedJob);
+  setHandlers(sut, [JobName.SharedSpaceFaceMatchFromBackfill]);
+
+  await sut.queue({
+    name: JobName.SharedSpaceFaceMatchFromBackfill,
+    data: { spaceId: 'space-1', assetId: 'asset-1' },
+  });
+
+  expect(queue.getJob).toHaveBeenCalledWith('shared-space-face-match/from-backfill/space-1/asset-1');
+  expect(failedJob.getState).toHaveBeenCalled();
+  expect(failedJob.remove).not.toHaveBeenCalled();
+  expect(queue.add).toHaveBeenCalledWith(
+    JobName.SharedSpaceFaceMatchFromBackfill,
+    { spaceId: 'space-1', assetId: 'asset-1' },
+    {
+      jobId: 'shared-space-face-match/from-backfill/space-1/asset-1',
+      removeOnComplete: true,
+    },
+  );
+});
+```
+
+- [ ] **Step 3: Add paused replacement coverage for from-backfill jobs**
+
+In the `it.each([...])('replaces paused stable %s jobs before requeueing them', ...)` table, add:
+
+```ts
+[
+  JobName.SharedSpaceFaceMatchFromBackfill,
+  { spaceId: 'space-1', assetId: 'asset-1' },
+  'shared-space-face-match/from-backfill/space-1/asset-1',
+],
+```
+
+- [ ] **Step 4: Run the focused job repository tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/job.repository.spec.ts -t "from-backfill shared-space|stable visible-failure job ids|replaces paused stable"
+```
+
+Expected: PASS. If it fails because `SharedSpaceFaceMatchFromBackfill` does not get stable shared-space pipeline handling, update `server/src/repositories/job.repository.ts` so `getJobOptions()` returns:
+
+```ts
+case JobName.SharedSpaceFaceMatchFromBackfill: {
+  return {
+    jobId: `shared-space-face-match/from-backfill/${item.data.spaceId}/${item.data.assetId}`,
+    removeOnComplete: true,
+  };
+}
+```
+
+and ensure `isSharedSpaceFacePipelineJob()` includes:
+
+```ts
+name === JobName.SharedSpaceFaceMatchFromBackfill;
+```
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add server/src/repositories/job.repository.spec.ts server/src/repositories/job.repository.ts
+git commit -m "test: cover from-backfill shared-space job ids"
+```
+
+If `server/src/repositories/job.repository.ts` was not changed, omit it from `git add`.
+
+## Task 2: From-Backfill Targeted Handler Safety
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+
+- [ ] **Step 1: Add asset-removed safety coverage for from-backfill jobs**
+
+In `server/src/services/shared-space.service.spec.ts`, inside `describe('handleSharedSpaceFaceMatchFromBackfill')`, add this test after `should skip when face recognition is disabled on the space`:
+
+```ts
+it('skips safely when a from-backfill asset is no longer in the space before execution', async () => {
+  const spaceId = newUuid();
+  const assetId = newUuid();
+
+  mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+  mocks.sharedSpace.isAssetInSpace.mockResolvedValue(false);
+
+  const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId, assetId });
+
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).not.toHaveBeenCalled();
+  expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonDedup, data: { spaceId } });
+});
+```
+
+- [ ] **Step 2: Strengthen missing/disabled from-backfill no-mutation assertions**
+
+Update the existing tests named `should skip when space not found` and `should skip when face recognition is disabled on the space` in the same describe block to include:
+
+```ts
+expect(mocks.sharedSpace.isAssetInSpace).not.toHaveBeenCalled();
+expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+expect(mocks.job.queue).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 3: Run the focused from-backfill safety tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/shared-space.service.spec.ts -t "from-backfill asset is no longer|handleSharedSpaceFaceMatchFromBackfill"
+```
+
+Expected: PASS. If the asset-removed test fails because the handler mutates after `isAssetInSpace=false`, ensure `processSpaceFaceMatch()` starts with:
+
+```ts
+const isAssetInSpace = await this.sharedSpaceRepository.isAssetInSpace(spaceId, assetId);
+if (!isAssetInSpace) {
+  return [];
+}
+```
+
+- [ ] **Step 4: Commit Task 2**
+
+```bash
+git add server/src/services/shared-space.service.spec.ts server/src/services/shared-space.service.ts
+git commit -m "test: cover from-backfill projection skips"
+```
+
+If `server/src/services/shared-space.service.ts` was not changed, omit it from `git add`.
+
+## Task 3: Identity-Backed Pet Projection Guards
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+
+- [ ] **Step 1: Add identity-backed pet incompatible-human guard**
+
+In `server/src/services/shared-space.service.spec.ts`, inside `describe('handleSharedSpaceFaceMatch')`, add this test near the existing pet tests:
+
+```ts
+it('does not attach an identity-backed pet face to an existing human space person for the same identity', async () => {
+  const spaceId = newUuid();
+  const assetId = newUuid();
+  const petFaceId = newUuid();
+  const petPersonId = newUuid();
+  const identityId = newUuid();
+  const humanSpacePersonId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+  mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([
+    { id: petFaceId, assetId, personId: petPersonId, identityId, type: 'pet' },
+  ]);
+  mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([]);
+  mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(
+    factory.sharedSpacePerson({ id: humanSpacePersonId, spaceId, identityId, type: 'person' }),
+  );
+
+  const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
+
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Add identity-backed pet stale-human assignment cleanup coverage**
+
+Add this test after the previous one:
+
+```ts
+it('removes a stale human selected-space assignment for an identity-backed pet face without cross-type reassignment', async () => {
+  const spaceId = newUuid();
+  const assetId = newUuid();
+  const petFaceId = newUuid();
+  const petPersonId = newUuid();
+  const identityId = newUuid();
+  const humanSpacePersonId = newUuid();
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+  mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([
+    { id: petFaceId, assetId, personId: petPersonId, identityId, type: 'pet' },
+  ]);
+  mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([
+    { personId: humanSpacePersonId, identityId, type: 'person' },
+  ]);
+  mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(
+    factory.sharedSpacePerson({ id: humanSpacePersonId, spaceId, identityId, type: 'person' }),
+  );
+  mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace.mockResolvedValue([humanSpacePersonId]);
+
+  const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
+
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).toHaveBeenCalledWith(spaceId, petFaceId);
+  expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+  expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([humanSpacePersonId]);
+  expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).toHaveBeenCalledWith(spaceId, [humanSpacePersonId]);
+});
+```
+
+- [ ] **Step 3: Run the focused pet projection tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/shared-space.service.spec.ts -t "identity-backed pet"
+```
+
+Expected: PASS. If these fail because a pet face attaches to a human person, keep the fix in `findOrCreateCompatibleSpacePersonForIdentity()`:
+
+```ts
+if (existingByIdentity) {
+  if (existingByIdentity.type && existingByIdentity.type !== input.type) {
+    return undefined;
+  }
+  return existingByIdentity;
+}
+```
+
+and verify both regular-face and pet-face branches remove stale selected-space rows before skipping incompatible assignment.
+
+- [ ] **Step 4: Commit Task 3**
+
+```bash
+git add server/src/services/shared-space.service.spec.ts server/src/services/shared-space.service.ts
+git commit -m "test: cover identity-backed pet projection guards"
+```
+
+If `server/src/services/shared-space.service.ts` was not changed, omit it from `git add`.
+
+## Task 4: Library Sync No-Work Follow-Up Contract
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+
+- [ ] **Step 1: Strengthen no-assets library sync behavior**
+
+In `server/src/services/shared-space.service.spec.ts`, inside `describe('handleSharedSpaceLibraryFaceSync')`, update the test named `should succeed with no work when library has no assets with faces` to include:
+
+```ts
+expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+expect(mocks.job.queue).toHaveBeenCalledWith({
+  name: JobName.SharedSpacePersonDedup,
+  data: { spaceId },
+});
+expect(mocks.job.queue).not.toHaveBeenCalledWith(
+  expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+);
+```
+
+- [ ] **Step 2: Add assets-with-no-affected-people behavior**
+
+Add this test after `should process library assets with faces in batches`:
+
+```ts
+it('does not queue identity reconciliation when library sync finds assets but changes no space people', async () => {
+  const spaceId = newUuid();
+  const libraryId = newUuid();
+  const assetId = newUuid();
+
+  mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+  mocks.sharedSpace.hasLibraryLink.mockResolvedValue(true);
+  mocks.asset.getByLibraryIdWithFaces.mockResolvedValueOnce([{ id: assetId }]).mockResolvedValueOnce([]);
+  mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
+  mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+  mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([]);
+
+  const result = await sut.handleSharedSpaceLibraryFaceSync({ spaceId, libraryId });
+
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.sharedSpace.getAssetFacesForMatching).toHaveBeenCalledWith(assetId);
+  expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.SharedSpacePersonDedup,
+    data: { spaceId },
+  });
+  expect(mocks.job.queue).not.toHaveBeenCalledWith(
+    expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+  );
+});
+```
+
+- [ ] **Step 3: Run focused library-sync follow-up tests**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/shared-space.service.spec.ts -t "library sync finds assets but changes no space people|no work when library has no assets"
+```
+
+Expected: PASS. If red because identity reconciliation is queued for no affected people, keep `handleSharedSpaceLibraryFaceSync()` gated by `affectedAny`:
+
+```ts
+if (affectedAny) {
+  await this.queueSpaceIdentityReconciliation({ spaceId: job.spaceId });
+}
+```
+
+- [ ] **Step 4: Commit Task 4**
+
+```bash
+git add server/src/services/shared-space.service.spec.ts server/src/services/shared-space.service.ts
+git commit -m "test: cover library sync no-work follow-ups"
+```
+
+If `server/src/services/shared-space.service.ts` was not changed, omit it from `git add`.
+
+## Task 5: Full-Space Rematch Repairs Missing, Stale, And Wrong Identity Rows
+
+**Files:**
+
+- Modify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+- Modify only if red: `server/src/repositories/shared-space.repository.ts`
+
+- [ ] **Step 1: Add a DB helper for selected-space face assignments**
+
+In `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`, after `drainSharedSpaceFaceJobs()`, add:
+
+```ts
+const getSelectedSpaceFaceRows = async (ctx: ReturnType<typeof setup>['ctx'], spaceId: string) =>
+  ctx.database
+    .selectFrom('shared_space_person_face as face')
+    .innerJoin('shared_space_person as person', 'person.id', 'face.personId')
+    .select([
+      'face.assetFaceId as assetFaceId',
+      'face.personId as personId',
+      'person.identityId as identityId',
+      'person.type as type',
+    ])
+    .where('person.spaceId', '=', spaceId)
+    .orderBy('face.assetFaceId')
+    .execute();
+```
+
+- [ ] **Step 2: Add the destructive full-space repair test**
+
+In the same file, add this test before `full-space rematch repairs stale selected-space face assignments from linked libraries`:
+
+```ts
+it('full-space rematch repairs missing stale and wrong-identity selected-space assignments without inflating counts', async () => {
+  const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+
+  const target = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    name: 'Alice',
+  });
+  const missing = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    personId: target.person.id,
+    identityId: target.identity.id,
+  });
+  const wrong = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    personId: target.person.id,
+    identityId: target.identity.id,
+  });
+  const stale = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    personId: target.person.id,
+    identityId: target.identity.id,
+  });
+
+  const correctPerson = await sharedSpaceRepository.createPerson({
+    spaceId: space.id,
+    identityId: target.identity.id,
+    name: '',
+    representativeFaceId: target.assetFace.id,
+    type: 'person',
+  });
+  await sharedSpaceRepository.addPersonFaces([{ personId: correctPerson.id, assetFaceId: target.assetFace.id }], {
+    skipRecount: true,
+  });
+
+  const { result: wrongOwnerPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Wrong Alice' });
+  const wrongIdentity = await faceIdentityRepository.ensurePersonIdentity(wrongOwnerPerson.id);
+  const wrongSpacePerson = await sharedSpaceRepository.createPerson({
+    spaceId: space.id,
+    identityId: wrongIdentity.id,
+    name: '',
+    representativeFaceId: wrong.assetFace.id,
+    type: 'person',
+  });
+  await sharedSpaceRepository.addPersonFaces([{ personId: wrongSpacePerson.id, assetFaceId: wrong.assetFace.id }], {
+    skipRecount: true,
+  });
+
+  const staleSpacePerson = await sharedSpaceRepository.createPerson({
+    spaceId: space.id,
+    name: '',
+    representativeFaceId: stale.assetFace.id,
+    type: 'person',
+  });
+  await sharedSpaceRepository.addPersonFaces([{ personId: staleSpacePerson.id, assetFaceId: stale.assetFace.id }], {
+    skipRecount: true,
+  });
+
+  await expect(sut.handleSharedSpaceFaceMatchAll({ spaceId: space.id })).resolves.toBe(JobStatus.Success);
+  await drainSharedSpaceFaceJobs(sut, jobs);
+
+  const repairedPerson = await ctx.database
+    .selectFrom('shared_space_person')
+    .selectAll()
+    .where('spaceId', '=', space.id)
+    .where('identityId', '=', target.identity.id)
+    .executeTakeFirstOrThrow();
+  expect(repairedPerson.id).toBe(correctPerson.id);
+
+  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([
+    {
+      assetFaceId: missing.assetFace.id,
+      personId: repairedPerson.id,
+      identityId: target.identity.id,
+      type: 'person',
+    },
+    {
+      assetFaceId: stale.assetFace.id,
+      personId: repairedPerson.id,
+      identityId: target.identity.id,
+      type: 'person',
+    },
+    {
+      assetFaceId: target.assetFace.id,
+      personId: repairedPerson.id,
+      identityId: target.identity.id,
+      type: 'person',
+    },
+    {
+      assetFaceId: wrong.assetFace.id,
+      personId: repairedPerson.id,
+      identityId: target.identity.id,
+      type: 'person',
+    },
+  ]);
+  await expect(sharedSpaceRepository.getPersonById(wrongSpacePerson.id)).resolves.toBeUndefined();
+  await expect(sharedSpaceRepository.getPersonById(staleSpacePerson.id)).resolves.toBeUndefined();
+  await expect(
+    sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+  ).resolves.toMatchObject({
+    detectedFaceCount: 4,
+    assignedVisibleFaceCount: 4,
+    assignedHiddenFaceCount: 0,
+    unassignedFaceCount: 0,
+  });
+});
+```
+
+- [ ] **Step 3: Run the focused destructive full-rematch test**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts -t "missing stale and wrong-identity"
+```
+
+Expected: PASS. If red because stale/wrong rows survive, keep the production fix scoped to the identity-backed branch in `processSpaceFaceMatch()`:
+
+```ts
+if (selectedSpaceAssignments.length > 0) {
+  const removedPersonIds = await this.sharedSpaceRepository.removePersonFaceAssignmentsForSpaceFace(spaceId, face.id);
+  for (const personId of removedPersonIds) {
+    recountPersonIds.add(personId);
+    stalePersonIds.add(personId);
+  }
+}
+```
+
+and ensure `deleteOrphanedPersonsByIds(spaceId, [...stalePersonIds])` runs after recounting.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts server/src/services/shared-space.service.ts server/src/repositories/shared-space.repository.ts
+git commit -m "test: cover full-space projection repair"
+```
+
+If production files were not changed, omit them from `git add`.
+
+## Task 6: Direct Asset Removal Cleans Projection Rows
+
+**Files:**
+
+- Modify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+- Modify only if red: `server/src/repositories/shared-space.repository.ts`
+
+- [ ] **Step 1: Add direct removal destructive cleanup coverage**
+
+In `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`, add this test after Task 5's test:
+
+```ts
+it('removing direct assets removes selected-space face rows and deletes orphaned space people', async () => {
+  const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+  const face = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    name: 'Alice',
+  });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: face.asset.id, addedById: user.id });
+
+  await expect(sut.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: face.asset.id })).resolves.toBe(
+    JobStatus.Success,
+  );
+  const projectedPerson = await ctx.database
+    .selectFrom('shared_space_person')
+    .selectAll()
+    .where('spaceId', '=', space.id)
+    .where('identityId', '=', face.identity.id)
+    .executeTakeFirstOrThrow();
+  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toHaveLength(1);
+
+  await sut.removeAssets(factory.auth({ user: { id: user.id } }), space.id, { assetIds: [face.asset.id] });
+
+  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([]);
+  await expect(sharedSpaceRepository.getPersonById(projectedPerson.id)).resolves.toBeUndefined();
+  await expect(
+    sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+  ).resolves.toMatchObject({
+    detectedFaceCount: 0,
+    assignedVisibleFaceCount: 0,
+    assignedHiddenFaceCount: 0,
+    unassignedFaceCount: 0,
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused direct removal test**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts -t "removing direct assets removes selected-space"
+```
+
+Expected: PASS. If red because selected-space rows remain after asset removal, keep the production fix in `SharedSpaceService.removeAssets()` after `removeAssets()`:
+
+```ts
+await this.sharedSpaceRepository.removePersonFacesByAssetIds(spaceId, dto.assetIds);
+await this.sharedSpaceRepository.deleteOrphanedPersons(spaceId);
+await this.queueSpacePersonMetadataBackfill();
+```
+
+- [ ] **Step 3: Commit Task 6**
+
+```bash
+git add server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts server/src/services/shared-space.service.ts server/src/repositories/shared-space.repository.ts
+git commit -m "test: cover direct asset projection cleanup"
+```
+
+If production files were not changed, omit them from `git add`.
+
+## Task 7: Linked Library Unlink Cleans Projection Rows
+
+**Files:**
+
+- Modify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+- Modify only if red: `server/src/repositories/shared-space.repository.ts`
+
+- [ ] **Step 1: Add linked-library unlink destructive cleanup coverage**
+
+In `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`, add this test after Task 6's test:
+
+```ts
+it('unlinking a library removes selected-space face rows and deletes orphaned space people', async () => {
+  const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+  const face = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    name: 'Alice',
+  });
+
+  await expect(sut.handleSharedSpaceLibraryFaceSync({ spaceId: space.id, libraryId: library.id })).resolves.toBe(
+    JobStatus.Success,
+  );
+  const projectedPerson = await ctx.database
+    .selectFrom('shared_space_person')
+    .selectAll()
+    .where('spaceId', '=', space.id)
+    .where('identityId', '=', face.identity.id)
+    .executeTakeFirstOrThrow();
+  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toHaveLength(1);
+
+  await sut.unlinkLibrary(factory.auth({ user: { id: user.id, isAdmin: true } }), space.id, library.id);
+
+  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([]);
+  await expect(sharedSpaceRepository.getPersonById(projectedPerson.id)).resolves.toBeUndefined();
+  await expect(
+    sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+  ).resolves.toMatchObject({
+    detectedFaceCount: 0,
+    assignedVisibleFaceCount: 0,
+    assignedHiddenFaceCount: 0,
+    unassignedFaceCount: 0,
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused unlink cleanup test**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts -t "unlinking a library removes selected-space"
+```
+
+Expected: PASS. If red because selected-space rows remain after unlink, keep the production fix in `SharedSpaceService.unlinkLibrary()` after `removeLibrary()`:
+
+```ts
+await this.sharedSpaceRepository.removePersonFacesByLibrary(spaceId, libraryId);
+await this.sharedSpaceRepository.deleteOrphanedPersons(spaceId);
+await this.queueSpacePersonMetadataBackfill();
+```
+
+- [ ] **Step 3: Commit Task 7**
+
+```bash
+git add server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts server/src/services/shared-space.service.ts server/src/repositories/shared-space.repository.ts
+git commit -m "test: cover linked-library projection cleanup"
+```
+
+If production files were not changed, omit them from `git add`.
+
+## Task 8: Direct Plus Linked Path Dedupes One Assignment
+
+**Files:**
+
+- Modify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- Modify only if red: `server/src/services/shared-space.service.ts`
+- Modify only if red: `server/src/repositories/shared-space.repository.ts`
+
+- [ ] **Step 1: Add direct-plus-linked duplicate protection coverage**
+
+In `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`, add this test after Task 7's test:
+
+```ts
+it('same asset direct plus linked-library path materializes only one selected-space face assignment', async () => {
+  const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+  const face = await createIdentityFace(ctx, faceIdentityRepository, {
+    ownerId: user.id,
+    libraryId: library.id,
+    name: 'Alice',
+  });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: face.asset.id, addedById: user.id });
+
+  await expect(sut.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: face.asset.id })).resolves.toBe(
+    JobStatus.Success,
+  );
+  await expect(sut.handleSharedSpaceLibraryFaceSync({ spaceId: space.id, libraryId: library.id })).resolves.toBe(
+    JobStatus.Success,
+  );
+
+  const people = await ctx.database
+    .selectFrom('shared_space_person')
+    .selectAll()
+    .where('spaceId', '=', space.id)
+    .where('identityId', '=', face.identity.id)
+    .execute();
+  expect(people).toHaveLength(1);
+  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([
+    {
+      assetFaceId: face.assetFace.id,
+      personId: people[0].id,
+      identityId: face.identity.id,
+      type: 'person',
+    },
+  ]);
+  await expect(
+    sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+  ).resolves.toMatchObject({
+    detectedFaceCount: 1,
+    assignedVisibleFaceCount: 1,
+    assignedHiddenFaceCount: 0,
+    unassignedFaceCount: 0,
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused direct-plus-linked dedupe test**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts -t "direct plus linked-library"
+```
+
+Expected: PASS. If red because duplicate `shared_space_person_face` rows appear, keep the production fix in repository insert semantics:
+
+```ts
+.onConflict((oc) => oc.columns(['personId', 'assetFaceId']).doNothing())
+```
+
+and ensure identity-backed exact selected-space assignments skip re-adding faces.
+
+- [ ] **Step 3: Commit Task 8**
+
+```bash
+git add server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts server/src/services/shared-space.service.ts server/src/repositories/shared-space.repository.ts
+git commit -m "test: cover direct and linked projection dedupe"
+```
+
+If production files were not changed, omit them from `git add`.
+
+## Task 9: Full Slice 5 Verification
+
+**Files:**
+
+- Verify: `server/src/repositories/job.repository.spec.ts`
+- Verify: `server/src/services/shared-space.service.spec.ts`
+- Verify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- Verify changed production files if any
+
+- [ ] **Step 1: Run the full job repository spec**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/job.repository.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full shared-space service small spec**
+
+Run:
+
+```bash
+pnpm --config.verify-deps-before-run=false --filter immich exec vitest --config test/vitest.config.mjs run src/services/shared-space.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full linked-library face identity repair medium spec**
+
+Run:
+
+```bash
+pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run formatting and type checks**
+
+Run:
+
+```bash
+pnpm --dir server exec prettier --check src/repositories/job.repository.spec.ts src/services/shared-space.service.spec.ts test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+pnpm --dir docs exec prettier --check superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+pnpm --dir server check
+git diff --check
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 5: Inspect the final diff**
+
+Run:
+
+```bash
+git diff @{upstream}...HEAD -- server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts server/src/services/shared-space.service.ts server/src/services/shared-space.service.spec.ts server/src/repositories/shared-space.repository.ts server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+```
+
+Expected: diff contains only Slice 5 shared-space projection tests, this plan, and any minimal production fixes directly proven by the new tests.
+
+- [ ] **Step 6: Commit final formatting if needed**
+
+If formatting commands changed files after earlier task commits, commit them:
+
+```bash
+git add server/src/repositories/job.repository.spec.ts server/src/services/shared-space.service.spec.ts server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+git commit -m "chore: format shared-space projection tests"
+```
+
+If formatting produced no changes, do not create an empty commit.
+
+## Spec Coverage Checklist
+
+- [ ] Missing or disabled space skips without mutation: existing small tests preserved; Task 2 strengthens from-backfill no-mutation assertions.
+- [ ] Asset removed from space before job execution skips mutation but remains safe: existing target-match test preserved; Task 2 adds from-backfill coverage.
+- [ ] Identity-backed face attaches to existing compatible space person: existing small tests preserved.
+- [ ] Identity-backed face creates new compatible space person when none exists: existing small tests preserved.
+- [ ] Identity-backed face does not merge into nearby different identity just because embeddings are close: existing small tests preserved.
+- [ ] Stale selected-space assignment is removed and replaced by the identity-correct person: existing small tests preserved; Task 5 adds DB-backed combined missing/stale/wrong coverage.
+- [ ] Exact assignment from backfill refreshes inherited metadata: existing small tests preserved.
+- [ ] Legacy face with person but no identity uses legacy embedding path: existing small tests preserved.
+- [ ] Face with no person waits and does not create a space person: existing small tests preserved.
+- [ ] Pet face creates or reuses pet space person and never attaches to a human person: existing small tests preserved; Task 3 adds identity-backed incompatible-human coverage.
+- [ ] Type-incompatible identity-backed space person causes skip or compatible repair, not cross-type assignment: existing small and medium tests preserved; Task 3 strengthens pet-side coverage.
+- [ ] Affected people queue `SharedSpaceIdentityReconciliation`: existing small tests preserved.
+- [ ] Successful asset match queues `SharedSpacePersonDedup`: existing small tests preserved.
+- [ ] From-backfill jobs run on `QueueName.PeopleBackfill`: existing small metadata test preserved.
+- [ ] Other shared-space face pipeline jobs remain on `QueueName.FacialRecognition`: existing small metadata test preserved.
+- [ ] Full-space dispatcher queues only first page: existing small tests preserved.
+- [ ] Pages use keyset lookahead, process exactly the page, and queue final dedup/reconciliation once: existing small tests preserved.
+- [ ] Disabled space between pages stops the page chain without final follow-ups: existing small tests preserved.
+- [ ] Library face sync rechecks link existence between batches and stops after unlink: existing small tests preserved.
+- [ ] Library face sync creates one identity-backed space person across multiple linked libraries: existing medium test preserved.
+- [ ] Full-space rematch repairs missing, stale, and wrong-identity selected-space assignments without inflating counts: Task 5.
+- [ ] Linked-library relink rebuilds identity-backed selected-space assignments: existing medium test preserved.
+- [ ] Removing assets or unlinking libraries removes selected-space face rows and deletes orphaned space people: Tasks 6 and 7.
+- [ ] Same asset direct plus linked-library path materializes only one selected-space face assignment: Task 8.
+- [ ] From-backfill jobs use stable visible-failure job ids and paused replacement like the rest of the shared-space face pipeline: Task 1.
+
+## Explicit Out Of Scope
+
+- Per-face recognition assignment and shared-space fanout belongs to Slice 4.
+- Identity backfill root pagination and metadata inheritance queue fanout belongs to Slice 6.
+- Manual person merge/delete/reassign operations belong to Slice 7.
+- Overnight end-to-end chain composition and issue #597 reproduction belongs to Slice 8.
+- Reworking identity reconciliation scoring, dedup thresholds, or metadata priority rules is not part of Slice 5.
+
+## Self-Review Notes
+
+- Spec coverage: every Slice 5 bullet maps to existing preserved coverage or to Tasks 1-8 above.
+- Placeholder scan: this plan contains exact file paths, concrete test snippets, focused commands, expected results, and commit commands.
+- Type consistency: snippets use existing project names and imports already present in target files: `JobName`, `JobStatus`, `QueueName`, `SharedSpaceRole`, `factory`, `newUuid`, `createIdentityFace`, `drainSharedSpaceFaceJobs`, `faceIdentityRepository`, `sharedSpaceRepository`, `jobs`, and `ctx.database`.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - dispatch fresh workers by task group, review after each worker, and keep implementation commits small.
+
+**2. Inline Execution** - execute tasks in this session using `superpowers:executing-plans`, with checkpoints after each task group.

--- a/docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+++ b/docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
@@ -50,6 +50,13 @@ Slice 4 status: already implemented on PR #604 (`codex/face-trigger-slice-4-plan
 - no-identity pet legacy path
 - type-incompatible full rematch cleanup
 
+`server/test/medium/specs/repositories/shared-space-face-matching.spec.ts` already covers repository-level selected-space face assignment behavior:
+
+- duplicate assignment attempts are idempotent
+- asset-face cascades remove selected-space face rows
+- selected-space orphan cleanup removes faceless space people
+- multiple-space and linked-library repository paths stay isolated
+
 This plan fills the remaining high-risk gaps from Slice 5: `SharedSpaceFaceMatchFromBackfill` stable job ids, from-backfill asset-removal safety, identity-backed pet incompatibility in small tests, no-work linked-library follow-up suppression, and DB-backed destructive cleanup/duplication invariants.
 
 ## File Structure
@@ -66,6 +73,8 @@ This plan fills the remaining high-risk gaps from Slice 5: `SharedSpaceFaceMatch
   - Owns selected-space assignment cleanup, orphan deletion, and asset/library face selection queries.
 - Modify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
   - Owns DB-backed destructive projection tests for missing, stale, wrong-identity, direct-plus-linked duplicate, direct asset removal, and library unlink cleanup.
+- Verify: `server/test/medium/specs/repositories/shared-space-face-matching.spec.ts`
+  - Preserves repository-level selected-space assignment idempotency, cascade cleanup, orphan cleanup, and linked-library isolation coverage required by the Slice 5 design.
 
 ## Execution Preflight
 
@@ -644,32 +653,36 @@ it('full-space rematch repairs missing stale and wrong-identity selected-space a
     .executeTakeFirstOrThrow();
   expect(repairedPerson.id).toBe(correctPerson.id);
 
-  await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([
-    {
-      assetFaceId: missing.assetFace.id,
-      personId: repairedPerson.id,
-      identityId: target.identity.id,
-      type: 'person',
-    },
-    {
-      assetFaceId: stale.assetFace.id,
-      personId: repairedPerson.id,
-      identityId: target.identity.id,
-      type: 'person',
-    },
-    {
-      assetFaceId: target.assetFace.id,
-      personId: repairedPerson.id,
-      identityId: target.identity.id,
-      type: 'person',
-    },
-    {
-      assetFaceId: wrong.assetFace.id,
-      personId: repairedPerson.id,
-      identityId: target.identity.id,
-      type: 'person',
-    },
-  ]);
+  const repairedRows = await getSelectedSpaceFaceRows(ctx, space.id);
+  expect(repairedRows).toHaveLength(4);
+  expect(repairedRows).toEqual(
+    expect.arrayContaining([
+      {
+        assetFaceId: missing.assetFace.id,
+        personId: repairedPerson.id,
+        identityId: target.identity.id,
+        type: 'person',
+      },
+      {
+        assetFaceId: stale.assetFace.id,
+        personId: repairedPerson.id,
+        identityId: target.identity.id,
+        type: 'person',
+      },
+      {
+        assetFaceId: target.assetFace.id,
+        personId: repairedPerson.id,
+        identityId: target.identity.id,
+        type: 'person',
+      },
+      {
+        assetFaceId: wrong.assetFace.id,
+        personId: repairedPerson.id,
+        identityId: target.identity.id,
+        type: 'person',
+      },
+    ]),
+  );
   await expect(sharedSpaceRepository.getPersonById(wrongSpacePerson.id)).resolves.toBeUndefined();
   await expect(sharedSpaceRepository.getPersonById(staleSpacePerson.id)).resolves.toBeUndefined();
   await expect(
@@ -960,6 +973,7 @@ If production files were not changed, omit them from `git add`.
 - Verify: `server/src/repositories/job.repository.spec.ts`
 - Verify: `server/src/services/shared-space.service.spec.ts`
 - Verify: `server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
+- Verify: `server/test/medium/specs/repositories/shared-space-face-matching.spec.ts`
 - Verify changed production files if any
 
 - [ ] **Step 1: Run the full job repository spec**
@@ -992,12 +1006,22 @@ pnpm --filter immich test:medium -- --run test/medium/specs/services/shared-spac
 
 Expected: PASS.
 
-- [ ] **Step 4: Run formatting and type checks**
+- [ ] **Step 4: Run the full shared-space face matching repository medium spec**
 
 Run:
 
 ```bash
-pnpm --dir server exec prettier --check src/repositories/job.repository.spec.ts src/services/shared-space.service.spec.ts test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+pnpm --filter immich test:medium -- --run test/medium/specs/repositories/shared-space-face-matching.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run formatting and type checks**
+
+Run:
+
+```bash
+pnpm --dir server exec prettier --check src/repositories/job.repository.spec.ts src/services/shared-space.service.spec.ts test/medium/specs/services/shared-space-face-identity-repair.spec.ts test/medium/specs/repositories/shared-space-face-matching.spec.ts
 pnpm --dir docs exec prettier --check superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
 pnpm --dir server check
 git diff --check
@@ -1005,22 +1029,22 @@ git diff --check
 
 Expected: all commands pass.
 
-- [ ] **Step 5: Inspect the final diff**
+- [ ] **Step 6: Inspect the final diff**
 
 Run:
 
 ```bash
-git diff @{upstream}...HEAD -- server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts server/src/services/shared-space.service.ts server/src/services/shared-space.service.spec.ts server/src/repositories/shared-space.repository.ts server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+git diff @{upstream}...HEAD -- server/src/repositories/job.repository.ts server/src/repositories/job.repository.spec.ts server/src/services/shared-space.service.ts server/src/services/shared-space.service.spec.ts server/src/repositories/shared-space.repository.ts server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts server/test/medium/specs/repositories/shared-space-face-matching.spec.ts docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
 ```
 
 Expected: diff contains only Slice 5 shared-space projection tests, this plan, and any minimal production fixes directly proven by the new tests.
 
-- [ ] **Step 6: Commit final formatting if needed**
+- [ ] **Step 7: Commit final formatting if needed**
 
 If formatting commands changed files after earlier task commits, commit them:
 
 ```bash
-git add server/src/repositories/job.repository.spec.ts server/src/services/shared-space.service.spec.ts server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
+git add server/src/repositories/job.repository.spec.ts server/src/services/shared-space.service.spec.ts server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts server/test/medium/specs/repositories/shared-space-face-matching.spec.ts docs/superpowers/plans/2026-05-18-shared-space-projection-pipeline-safety.md
 git commit -m "chore: format shared-space projection tests"
 ```
 
@@ -1049,6 +1073,7 @@ If formatting produced no changes, do not create an empty commit.
 - [ ] Library face sync rechecks link existence between batches and stops after unlink: existing small tests preserved.
 - [ ] Library face sync creates one identity-backed space person across multiple linked libraries: existing medium test preserved.
 - [ ] Full-space rematch repairs missing, stale, and wrong-identity selected-space assignments without inflating counts: Task 5.
+- [ ] Repository-level selected-space assignment idempotency, asset-face cascade cleanup, orphan cleanup, and multiple-space/linked-library isolation remain covered: existing `shared-space-face-matching.spec.ts`, verified in Task 9.
 - [ ] Linked-library relink rebuilds identity-backed selected-space assignments: existing medium test preserved.
 - [ ] Removing assets or unlinking libraries removes selected-space face rows and deletes orphaned space people: Tasks 6 and 7.
 - [ ] Same asset direct plus linked-library path materializes only one selected-space face assignment: Task 8.

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -540,6 +540,7 @@ describe(JobRepository.name, () => {
     const { sut, queue } = setup();
     setHandlers(sut, [
       JobName.SharedSpaceFaceMatch,
+      JobName.SharedSpaceFaceMatchFromBackfill,
       JobName.SharedSpaceFaceMatchAll,
       JobName.SharedSpaceFaceMatchPage,
       JobName.SharedSpacePersonDedup,
@@ -550,6 +551,7 @@ describe(JobRepository.name, () => {
       { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
       { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: 'asset-1' } },
       { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: 'asset-1' } },
+      { name: JobName.SharedSpaceFaceMatchFromBackfill, data: { spaceId: 'space-1', assetId: 'asset-1' } },
       { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'space-1' } },
       { name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1' } },
       { name: JobName.SharedSpaceFaceMatchPage, data: { spaceId: 'space-1', afterAssetId: 'asset-9' } },
@@ -571,6 +573,14 @@ describe(JobRepository.name, () => {
       { spaceId: 'space-2', assetId: 'asset-1' },
       {
         jobId: 'shared-space-face-match/space-2/asset-1',
+        removeOnComplete: true,
+      },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatchFromBackfill,
+      { spaceId: 'space-1', assetId: 'asset-1' },
+      {
+        jobId: 'shared-space-face-match/from-backfill/space-1/asset-1',
         removeOnComplete: true,
       },
     );
@@ -619,6 +629,33 @@ describe(JobRepository.name, () => {
     }
   });
 
+  it('does not remove failed from-backfill shared-space jobs while queueing duplicates', async () => {
+    const { sut, queue } = setup();
+    const failedJob = {
+      getState: vi.fn().mockResolvedValue('failed'),
+      remove: vi.fn().mockResolvedValue(void 0),
+    };
+    queue.getJob.mockResolvedValue(failedJob);
+    setHandlers(sut, [JobName.SharedSpaceFaceMatchFromBackfill]);
+
+    await sut.queue({
+      name: JobName.SharedSpaceFaceMatchFromBackfill,
+      data: { spaceId: 'space-1', assetId: 'asset-1' },
+    });
+
+    expect(queue.getJob).toHaveBeenCalledWith('shared-space-face-match/from-backfill/space-1/asset-1');
+    expect(failedJob.getState).toHaveBeenCalled();
+    expect(failedJob.remove).not.toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpaceFaceMatchFromBackfill,
+      { spaceId: 'space-1', assetId: 'asset-1' },
+      {
+        jobId: 'shared-space-face-match/from-backfill/space-1/asset-1',
+        removeOnComplete: true,
+      },
+    );
+  });
+
   it('uses distinct stable job ids for identity-backfill shared-space face matches', async () => {
     const { sut, queue } = setup();
     setHandlers(sut, [JobName.SharedSpaceFaceMatch]);
@@ -655,6 +692,11 @@ describe(JobRepository.name, () => {
       JobName.SharedSpaceFaceMatch,
       { spaceId: 'space-1', assetId: 'asset-1', source: 'identity-backfill' },
       'shared-space-face-match/identity-backfill/space-1/asset-1',
+    ],
+    [
+      JobName.SharedSpaceFaceMatchFromBackfill,
+      { spaceId: 'space-1', assetId: 'asset-1' },
+      'shared-space-face-match/from-backfill/space-1/asset-1',
     ],
     [JobName.SharedSpaceFaceMatchAll, { spaceId: 'space-1' }, 'shared-space-face-match-all/space-1'],
     [

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -470,6 +470,50 @@ describe(JobRepository.name, () => {
     );
   });
 
+  it('removes a failed force follow-up coordinator before queueing a replacement follow-up', async () => {
+    const { sut, queue } = setup();
+    const activeNonForceCoordinator = {
+      data: { force: false },
+      getState: vi.fn().mockResolvedValue('active'),
+      remove: vi.fn().mockResolvedValue(void 0),
+      updateData: vi.fn().mockResolvedValue(void 0),
+    };
+    const failedForceFollowUp = {
+      data: { force: true },
+      getState: vi.fn().mockResolvedValue('failed'),
+      remove: vi.fn().mockResolvedValue(void 0),
+    };
+    queue.getJob.mockImplementation((jobId: string) =>
+      Promise.resolve(
+        jobId === JobName.FacialRecognitionQueueAll
+          ? activeNonForceCoordinator
+          : jobId === 'FacialRecognitionQueueAll/force'
+            ? failedForceFollowUp
+            : void 0,
+      ),
+    );
+    setHandlers(sut, [JobName.FacialRecognitionQueueAll]);
+
+    await sut.queue({ name: JobName.FacialRecognitionQueueAll, data: { force: true } });
+
+    expect(queue.getJob).toHaveBeenCalledWith(JobName.FacialRecognitionQueueAll);
+    expect(queue.getJob).toHaveBeenCalledWith('FacialRecognitionQueueAll/force');
+    expect(activeNonForceCoordinator.getState).toHaveBeenCalled();
+    expect(activeNonForceCoordinator.remove).not.toHaveBeenCalled();
+    expect(activeNonForceCoordinator.updateData).not.toHaveBeenCalled();
+    expect(failedForceFollowUp.getState).toHaveBeenCalled();
+    expect(failedForceFollowUp.remove).toHaveBeenCalled();
+    expect(queue.drain).toHaveBeenCalledWith(true);
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.FacialRecognitionQueueAll,
+      { force: true },
+      {
+        jobId: 'FacialRecognitionQueueAll/force',
+        removeOnComplete: true,
+      },
+    );
+  });
+
   it('does not queue another coordinator when force recognition is already active', async () => {
     const { sut, queue } = setup();
     const existingJob = {

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -504,6 +504,7 @@ describe(JobRepository.name, () => {
     expect(failedForceFollowUp.getState).toHaveBeenCalled();
     expect(failedForceFollowUp.remove).toHaveBeenCalled();
     expect(queue.drain).toHaveBeenCalledWith(true);
+    expect(failedForceFollowUp.remove.mock.invocationCallOrder[0]).toBeLessThan(queue.add.mock.invocationCallOrder[0]);
     expect(queue.add).toHaveBeenCalledWith(
       JobName.FacialRecognitionQueueAll,
       { force: true },

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1449,7 +1449,7 @@ describe(PersonService.name, () => {
 
       await sut.handleQueueRecognizeFaces({ force: true });
 
-      expect(mocks.person.getAllFaces).toHaveBeenCalledWith(undefined);
+      expect(mocks.person.getAllFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
       expect(mocks.job.queueAll).toHaveBeenCalledWith([
         {
           name: JobName.FacialRecognition,
@@ -1462,22 +1462,22 @@ describe(PersonService.name, () => {
       expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: false });
     });
 
-    it('force recognition drains stale facial-recognition work after prerequisites and before clearing space people', async () => {
+    it('force recognition waits for thumbnail, face detection, and people backfill before draining and clearing identities', async () => {
       const face = AssetFaceFactory.create();
-      mocks.job.getJobCounts.mockResolvedValue(factory.queueStatistics());
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
       mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
       mocks.person.getAllWithoutFaces.mockResolvedValue([]);
       mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
       mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
       mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
 
-      await sut.handleQueueRecognizeFaces({ force: true });
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
 
       expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(
         QueueName.ThumbnailGeneration,
         QueueName.FaceDetection,
+        QueueName.PeopleBackfill,
       );
-      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
       expect(mocks.job.waitForQueueCompletion.mock.invocationCallOrder[0]).toBeLessThan(
         mocks.job.empty.mock.invocationCallOrder[0],
       );
@@ -1493,6 +1493,99 @@ describe(PersonService.name, () => {
       expect(mocks.job.empty.mock.invocationCallOrder[0]).toBeLessThan(
         mocks.sharedSpace.deleteAllPersons.mock.invocationCallOrder[0],
       );
+    });
+
+    it('force recognition performs the full ML reset and maintenance handoff contract', async () => {
+      const mlFace = AssetFaceFactory.from({ sourceType: SourceType.MachineLearning }).person().build();
+      const orphan = PersonFactory.create();
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([mlFace]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([orphan]);
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['enabled-space']);
+
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(mocks.person.unassignFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
+      expect(mocks.faceIdentity.unlinkFacesBySourceType).toHaveBeenCalledWith(SourceType.MachineLearning);
+      expect(mocks.person.delete).toHaveBeenCalledWith([orphan.id]);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: [orphan.thumbnailPath] },
+      });
+      expect(mocks.person.vacuum).toHaveBeenCalledWith({ reindexVectors: false });
+      expect(mocks.sharedSpace.deleteAllPersonFaces).toHaveBeenCalledOnce();
+      expect(mocks.sharedSpace.deleteAllPersons).toHaveBeenCalledOnce();
+      expect((mocks.faceIdentity as any).deleteUnreferencedIdentities).toHaveBeenCalledOnce();
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.FacialRecognition,
+          data: { id: mlFace.id, deferred: false, skipSharedSpaceMatch: true },
+        },
+      ]);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'enabled-space' } },
+      ]);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: {},
+      });
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
+        lastRun: expect.any(String),
+      });
+    });
+
+    it('force recognition queues only machine-learning faces and suppresses per-face shared-space matching', async () => {
+      const mlFace = AssetFaceFactory.from({ sourceType: SourceType.MachineLearning }).person().build();
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([mlFace]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([]);
+
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.person.getAllFaces).toHaveBeenCalledWith({ sourceType: SourceType.MachineLearning });
+      expect(mocks.person.getAllFaces).not.toHaveBeenCalledWith(undefined);
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.FacialRecognition,
+          data: { id: mlFace.id, deferred: false, skipSharedSpaceMatch: true },
+        },
+      ]);
+    });
+
+    it('force recognition queues SharedSpaceFaceMatchAll only for enabled spaces after personal jobs', async () => {
+      const face = AssetFaceFactory.from({ sourceType: SourceType.MachineLearning }).person().build();
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
+      mocks.person.getAllFaces.mockReturnValue(makeStream([face]));
+      mocks.person.getAllWithoutFaces.mockResolvedValue([]);
+      mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([
+        'enabled-space-1',
+        'enabled-space-2',
+      ]);
+
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+      const queueAllCalls = mocks.job.queueAll.mock.calls;
+      const personalJobCall = queueAllCalls.findIndex((call) =>
+        call[0].some((job) => job.name === JobName.FacialRecognition),
+      );
+      const sharedSpaceCall = queueAllCalls.findIndex((call) =>
+        call[0].some((job) => job.name === JobName.SharedSpaceFaceMatchAll),
+      );
+
+      expect(personalJobCall).toBeGreaterThanOrEqual(0);
+      expect(sharedSpaceCall).toBeGreaterThan(personalJobCall);
+      expect(queueAllCalls[sharedSpaceCall][0]).toEqual([
+        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'enabled-space-1' } },
+        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: 'enabled-space-2' } },
+      ]);
     });
 
     it('force recognition queues personal face jobs with shared-space matching suppressed', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1360,6 +1360,45 @@ describe(PersonService.name, () => {
       expectNoRecognitionCoordinatorMutation();
     });
 
+    it.each([
+      ['waiting jobs', { waiting: 87_000 }],
+      ['delayed jobs', { delayed: 42 }],
+      ['paused jobs', { paused: 9 }],
+      ['another active job besides the coordinator', { active: 2 }],
+    ] as const)('skips non-force recognition when FacialRecognition has %s', async (_label, counts) => {
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts(counts));
+      mocks.person.getAllFaces.mockReturnValue(makeStream([AssetFaceFactory.create()]));
+
+      await expect(sut.handleQueueRecognizeFaces({ force: false })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.job.waitForQueueCompletion).toHaveBeenCalledWith(
+        QueueName.ThumbnailGeneration,
+        QueueName.FaceDetection,
+      );
+      expectNoRecognitionCoordinatorMutation();
+    });
+
+    it('does not expand a large stuck nightly queue or clear shared-space people', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({ lastRun: '2026-05-16T00:00:00.000Z' });
+      mocks.person.getLatestFaceDate.mockResolvedValue('2026-05-17T00:00:00.000Z');
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ waiting: 87_000 }));
+      mocks.person.getAllFaces.mockReturnValue(makeStream([AssetFaceFactory.create()]));
+
+      await expect(sut.handleQueueRecognizeFaces({ force: false, nightly: true })).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: JobName.FacialRecognition })]),
+      );
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: expect.anything(),
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
+      expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
+    });
+
     it('should queue missing assets', async () => {
       const face = AssetFaceFactory.create();
       mocks.job.getJobCounts.mockResolvedValue({

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -38,6 +38,17 @@ import {
 import { factory, newDate, newUuid } from 'test/small.factory';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
 
+const recognitionCounts = (overrides: Partial<QueueStatisticsDto> = {}) =>
+  factory.queueStatistics({
+    active: 1,
+    waiting: 0,
+    delayed: 0,
+    paused: 0,
+    completed: 0,
+    failed: 0,
+    ...overrides,
+  });
+
 describe(PersonService.name, () => {
   let sut: PersonService;
   let mocks: ServiceMocks;
@@ -97,17 +108,6 @@ describe(PersonService.name, () => {
     expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
     expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
   };
-
-  const recognitionCounts = (overrides: Partial<QueueStatisticsDto> = {}) =>
-    factory.queueStatistics({
-      active: 1,
-      waiting: 0,
-      delayed: 0,
-      paused: 0,
-      completed: 0,
-      failed: 0,
-      ...overrides,
-    });
 
   const expectNoRecognitionCoordinatorMutation = () => {
     expect(mocks.job.empty).not.toHaveBeenCalled();
@@ -1345,20 +1345,23 @@ describe(PersonService.name, () => {
     it.each([
       ['scheduled non-force nightly', { force: false, nightly: true }],
       ['defensive force+nightly payload', { force: true, nightly: true }],
-    ] as const)('skips %s before prerequisite waits or destructive reset when no new faces exist', async (_label, data) => {
-      const lastRun = new Date('2026-05-17T02:00:00.000Z');
-      mocks.systemMetadata.get.mockResolvedValue({ lastRun: lastRun.toISOString() });
-      mocks.person.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1_000).toISOString());
-      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ waiting: 25_000, delayed: 1_000, paused: 3 }));
+    ] as const)(
+      'skips %s before prerequisite waits or destructive reset when no new faces exist',
+      async (_label, data) => {
+        const lastRun = new Date('2026-05-17T02:00:00.000Z');
+        mocks.systemMetadata.get.mockResolvedValue({ lastRun: lastRun.toISOString() });
+        mocks.person.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1000).toISOString());
+        mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ waiting: 25_000, delayed: 1000, paused: 3 }));
 
-      await expect(sut.handleQueueRecognizeFaces(data)).resolves.toBe(JobStatus.Skipped);
+        await expect(sut.handleQueueRecognizeFaces(data)).resolves.toBe(JobStatus.Skipped);
 
-      expect(mocks.systemMetadata.get).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState);
-      expect(mocks.person.getLatestFaceDate).toHaveBeenCalledOnce();
-      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
-      expect(mocks.person.getAllFaces).not.toHaveBeenCalled();
-      expectNoRecognitionCoordinatorMutation();
-    });
+        expect(mocks.systemMetadata.get).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState);
+        expect(mocks.person.getLatestFaceDate).toHaveBeenCalledOnce();
+        expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+        expect(mocks.person.getAllFaces).not.toHaveBeenCalled();
+        expectNoRecognitionCoordinatorMutation();
+      },
+    );
 
     it.each([
       ['waiting jobs', { waiting: 87_000 }],
@@ -1565,10 +1568,7 @@ describe(PersonService.name, () => {
       mocks.person.getAllWithoutFaces.mockResolvedValue([]);
       mocks.sharedSpace.deleteAllPersonFaces.mockResolvedValue(void 0 as any);
       mocks.sharedSpace.deleteAllPersons.mockResolvedValue(void 0 as any);
-      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue([
-        'enabled-space-1',
-        'enabled-space-2',
-      ]);
+      mocks.sharedSpace.getSpaceIdsWithFaceRecognitionEnabled.mockResolvedValue(['enabled-space-1', 'enabled-space-2']);
 
       await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
 
@@ -2067,12 +2067,7 @@ describe(PersonService.name, () => {
       await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Skipped);
 
       expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
-        status: [
-          QueueJobStatus.Active,
-          QueueJobStatus.Delayed,
-          QueueJobStatus.Paused,
-          QueueJobStatus.Waiting,
-        ],
+        status: [QueueJobStatus.Active, QueueJobStatus.Delayed, QueueJobStatus.Paused, QueueJobStatus.Waiting],
       });
       expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
     });

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1996,6 +1996,19 @@ describe(PersonService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
     });
 
+    it('requeues itself with a delay when FacialRecognition has paused jobs', async () => {
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ active: 1, paused: 2 }));
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: { delay: 10_000 },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.job.searchJobs).not.toHaveBeenCalled();
+    });
+
     it('requeues itself with a delay when FacialRecognition has delayed jobs', async () => {
       mocks.job.getJobCounts.mockResolvedValue({
         active: 1,
@@ -2034,19 +2047,33 @@ describe(PersonService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
     });
 
-    it('does not queue duplicate FaceIdentityBackfill if PeopleBackfill already has one active/waiting/delayed/paused', async () => {
-      mocks.job.getJobCounts.mockResolvedValue({
-        active: 1,
-        waiting: 0,
-        paused: 0,
-        completed: 0,
-        failed: 0,
-        delayed: 0,
+    it('ignores failed recognition jobs when deciding whether the queue has drained', async () => {
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ active: 1, failed: 12 }));
+      mocks.job.searchJobs.mockResolvedValue([]);
+
+      await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: expect.anything(),
       });
+    });
+
+    it('does not queue duplicate FaceIdentityBackfill if PeopleBackfill already has one active, waiting, delayed, or paused', async () => {
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts());
       mocks.job.searchJobs.mockResolvedValue([{ id: '1', name: JobName.FaceIdentityBackfill, timestamp: 0, data: {} }]);
 
       await expect(sut.handleFaceIdentityMaintenanceAfterRecognition({})).resolves.toBe(JobStatus.Skipped);
 
+      expect(mocks.job.searchJobs).toHaveBeenCalledWith(QueueName.PeopleBackfill, {
+        status: [
+          QueueJobStatus.Active,
+          QueueJobStatus.Delayed,
+          QueueJobStatus.Paused,
+          QueueJobStatus.Waiting,
+        ],
+      });
       expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
     });
   });

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -4,6 +4,7 @@ import { writeFile } from 'node:fs/promises';
 import { DiskStorageBackend } from 'src/backends/disk-storage.backend';
 import { BulkIdErrorReason } from 'src/dtos/asset-ids.response.dto';
 import { mapFaces, mapPerson } from 'src/dtos/person.dto';
+import { QueueStatisticsDto } from 'src/dtos/queue.dto';
 import {
   AssetFileType,
   AssetVisibility,
@@ -95,6 +96,35 @@ describe(PersonService.name, () => {
     );
     expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognitionQueueAll);
     expect(queuedBatchJobNames()).not.toContain(JobName.FacialRecognition);
+  };
+
+  const recognitionCounts = (overrides: Partial<QueueStatisticsDto> = {}) =>
+    factory.queueStatistics({
+      active: 1,
+      waiting: 0,
+      delayed: 0,
+      paused: 0,
+      completed: 0,
+      failed: 0,
+      ...overrides,
+    });
+
+  const expectNoRecognitionCoordinatorMutation = () => {
+    expect(mocks.job.empty).not.toHaveBeenCalled();
+    expect(mocks.database.prewarm).not.toHaveBeenCalled();
+    expect(mocks.person.unassignFaces).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.unlinkFacesBySourceType).not.toHaveBeenCalled();
+    expect(mocks.sharedSpace.deleteAllPersonFaces).not.toHaveBeenCalled();
+    expect(mocks.sharedSpace.deleteAllPersons).not.toHaveBeenCalled();
+    expect((mocks.faceIdentity as any).deleteUnreferencedIdentities).not.toHaveBeenCalled();
+    expect(mocks.person.vacuum).not.toHaveBeenCalled();
+    expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    expect(mocks.job.queue).not.toHaveBeenCalledWith({
+      name: JobName.FaceIdentityMaintenanceAfterRecognition,
+      data: expect.anything(),
+    });
+    expect(mocks.job.queue).not.toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+    expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
   };
 
   it('should be defined', () => {
@@ -1310,6 +1340,24 @@ describe(PersonService.name, () => {
       await expect(sut.handleQueueRecognizeFaces({})).resolves.toBe(JobStatus.Skipped);
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
       expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['scheduled non-force nightly', { force: false, nightly: true }],
+      ['defensive force+nightly payload', { force: true, nightly: true }],
+    ] as const)('skips %s before prerequisite waits or destructive reset when no new faces exist', async (_label, data) => {
+      const lastRun = new Date('2026-05-17T02:00:00.000Z');
+      mocks.systemMetadata.get.mockResolvedValue({ lastRun: lastRun.toISOString() });
+      mocks.person.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1_000).toISOString());
+      mocks.job.getJobCounts.mockResolvedValue(recognitionCounts({ waiting: 25_000, delayed: 1_000, paused: 3 }));
+
+      await expect(sut.handleQueueRecognizeFaces(data)).resolves.toBe(JobStatus.Skipped);
+
+      expect(mocks.systemMetadata.get).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState);
+      expect(mocks.person.getLatestFaceDate).toHaveBeenCalledOnce();
+      expect(mocks.job.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(mocks.person.getAllFaces).not.toHaveBeenCalled();
+      expectNoRecognitionCoordinatorMutation();
     });
 
     it('should queue missing assets', async () => {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -86,6 +86,18 @@ describe(PersonService.name, () => {
     expect(mocks.asset.upsertJobStatus).not.toHaveBeenCalled();
   };
 
+  const expectNoRecognitionMutation = () => {
+    expect(mocks.search.searchFaces).not.toHaveBeenCalled();
+    expect(mocks.person.create).not.toHaveBeenCalled();
+    expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+    expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+    expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+    expect(mocks.job.queue).not.toHaveBeenCalled();
+  };
+
   const queuedBatchJobs = () => mocks.job.queueAll.mock.calls.flatMap(([jobs]) => jobs);
   const queuedBatchJobNames = () => queuedBatchJobs().map((job) => job.name);
 
@@ -2874,18 +2886,6 @@ describe(PersonService.name, () => {
         spaceProfileConflictCount: 0,
       });
     });
-
-    const expectNoRecognitionMutation = () => {
-      expect(mocks.search.searchFaces).not.toHaveBeenCalled();
-      expect(mocks.person.create).not.toHaveBeenCalled();
-      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
-      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
-      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalled();
-    };
 
     it('should fail if face does not exist', async () => {
       expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Failed);

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -2875,11 +2875,22 @@ describe(PersonService.name, () => {
       });
     });
 
+    const expectNoRecognitionMutation = () => {
+      expect(mocks.search.searchFaces).not.toHaveBeenCalled();
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    };
+
     it('should fail if face does not exist', async () => {
       expect(await sut.handleRecognizeFaces({ id: 'unknown-face' })).toBe(JobStatus.Failed);
 
-      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-      expect(mocks.person.create).not.toHaveBeenCalled();
+      expectNoRecognitionMutation();
     });
 
     it('should fail if face does not have asset', async () => {
@@ -2888,8 +2899,31 @@ describe(PersonService.name, () => {
 
       expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
 
-      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
-      expect(mocks.person.create).not.toHaveBeenCalled();
+      expectNoRecognitionMutation();
+    });
+
+    it('skips non-machine-learning faces without mutating identities or queues', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.create({ assetId: asset.id, sourceType: SourceType.Exif });
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+
+      expectNoRecognitionMutation();
+    });
+
+    it('fails when a machine-learning face has no embedding without mutating identities or queues', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue({
+        ...face,
+        asset,
+        faceSearch: null,
+      } as any);
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Failed);
+
+      expectNoRecognitionMutation();
     });
 
     it('should skip if face already has an assigned person', async () => {
@@ -2916,6 +2950,28 @@ describe(PersonService.name, () => {
         name: JobName.SharedSpaceFaceMatch,
         data: { spaceId: 'space-1', assetId: face.assetId },
       });
+    });
+
+    it('queues shared-space face matching exactly once per space after repairing an assigned face', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.from({ assetId: asset.id }).person().build();
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
+        { spaceId: 'space-1' },
+        { spaceId: 'space-1' },
+        { spaceId: 'space-2' },
+      ]);
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+
+      const sharedSpaceJobs = mocks.job.queue.mock.calls
+        .map(([job]) => job)
+        .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+      expect(sharedSpaceJobs).toEqual([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: face.assetId } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: face.assetId } },
+      ]);
     });
 
     it('does not queue shared-space matching for force jobs when face already has a person', async () => {
@@ -3055,6 +3111,39 @@ describe(PersonService.name, () => {
       });
     });
 
+    it('assigns an existing person without creating a person or thumbnail job', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'matched-identity' } as any);
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.PersonGenerateThumbnail }),
+      );
+      expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
+        faceIds: [noPerson.id],
+        newPersonId: matchedFace.person!.id,
+      });
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: noPerson.id,
+        identityId: 'matched-identity',
+        source: 'owner-person',
+      });
+    });
+
     it('should merge an existing matched local person identity into an accessible shared identity', async () => {
       const asset = AssetFactory.create();
       const [noPerson, matchedFace] = [
@@ -3142,6 +3231,74 @@ describe(PersonService.name, () => {
         name: JobName.SharedSpacePersonMetadataBackfill,
         data: {},
       });
+    });
+
+    it('skips accessible shared identity merge when same-space conflicts exist', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+      const sourceIdentityId = 'source-identity';
+      const targetIdentityId = 'target-identity';
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+        identityId: targetIdentityId,
+        distance: 0.2,
+      });
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 1,
+      });
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      expect(mocks.faceIdentity.getMergeConflicts).toHaveBeenCalledWith({
+        targetIdentityId,
+        sourceIdentityIds: [sourceIdentityId],
+      });
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+      );
+    });
+
+    it('does not run conflict checks when accessible shared evidence already points at the source identity', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, matchedFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...matchedFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+      const sourceIdentityId = 'source-identity';
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
+      (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+        identityId: sourceIdentityId,
+        distance: 0.1,
+      });
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      expect(mocks.faceIdentity.getMergeConflicts).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+      );
     });
 
     it('does not queue shared-space matching for force jobs after assigning a person', async () => {
@@ -3263,7 +3420,8 @@ describe(PersonService.name, () => {
     it('should create a new person if the face is a core point with no person', async () => {
       const asset = AssetFactory.create();
       const [noPerson1, noPerson2] = [AssetFaceFactory.create({ assetId: asset.id }), AssetFaceFactory.create()];
-      const person = PersonFactory.create();
+      const person = PersonFactory.create({ ownerId: asset.ownerId });
+      const sourceIdentityId = 'created-person-identity';
 
       const faces = [
         { ...noPerson1, distance: 0 },
@@ -3271,19 +3429,30 @@ describe(PersonService.name, () => {
       ] as FaceSearchResult[];
 
       mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
-      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.search.searchFaces.mockResolvedValueOnce(faces).mockResolvedValueOnce([]);
       mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson1, asset));
       mocks.person.create.mockResolvedValue(person);
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: sourceIdentityId } as any);
 
-      await sut.handleRecognizeFaces({ id: noPerson1.id });
+      expect(await sut.handleRecognizeFaces({ id: noPerson1.id })).toBe(JobStatus.Success);
 
       expect(mocks.person.create).toHaveBeenCalledWith({
         ownerId: asset.ownerId,
         faceAssetId: noPerson1.id,
       });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.PersonGenerateThumbnail,
+        data: { id: person.id },
+      });
       expect(mocks.person.reassignFaces).toHaveBeenCalledWith({
         faceIds: [noPerson1.id],
         newPersonId: person.id,
+      });
+      expect(mocks.faceIdentity.ensurePersonIdentity).toHaveBeenCalledWith(person.id);
+      expect(mocks.faceIdentity.replaceFaceIdentity).toHaveBeenCalledWith({
+        assetFaceId: noPerson1.id,
+        identityId: sourceIdentityId,
+        source: 'owner-person',
       });
     });
 
@@ -3414,6 +3583,23 @@ describe(PersonService.name, () => {
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
     });
 
+    it('skips self-only matches below the min-face threshold without deferring or assigning', async () => {
+      const asset = AssetFactory.create();
+      const face = AssetFaceFactory.create({ assetId: asset.id });
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 3 } } });
+      mocks.search.searchFaces.mockResolvedValue([{ ...face, distance: 0 }] as FaceSearchResult[]);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+
+      expect(await sut.handleRecognizeFaces({ id: face.id })).toBe(JobStatus.Skipped);
+
+      expect(mocks.search.searchFaces).toHaveBeenCalledTimes(1);
+      expect(mocks.person.create).not.toHaveBeenCalled();
+      expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+    });
+
     it('preserves shared-space suppression when deferring a force-created face job', async () => {
       const asset = AssetFactory.create();
       const noPerson = AssetFaceFactory.create({ assetId: asset.id });
@@ -3476,6 +3662,37 @@ describe(PersonService.name, () => {
       expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
     });
 
+    it.each([AssetVisibility.Archive, AssetVisibility.Hidden, AssetVisibility.Locked])(
+      'does not create a core person or queue shared-space matching for deferred %s assets without a person',
+      async (visibility) => {
+        const asset = AssetFactory.create({ visibility });
+        const face = AssetFaceFactory.create({ assetId: asset.id });
+
+        mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+        mocks.search.searchFaces
+          .mockResolvedValueOnce([{ ...face, distance: 0 }] as FaceSearchResult[])
+          .mockResolvedValueOnce([]);
+        mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(face, asset));
+        (mocks.faceIdentity as any).findClosestAccessibleIdentityForFace.mockResolvedValue({
+          identityId: 'accessible-space-identity',
+          distance: 0.2,
+        });
+        mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([{ spaceId: 'space-1' }]);
+
+        expect(await sut.handleRecognizeFaces({ id: face.id, deferred: true })).toBe(JobStatus.Skipped);
+
+        expect(mocks.person.create).not.toHaveBeenCalled();
+        expect(mocks.person.reassignFaces).not.toHaveBeenCalled();
+        expect(mocks.faceIdentity.ensurePersonIdentity).not.toHaveBeenCalled();
+        expect(mocks.faceIdentity.replaceFaceIdentity).not.toHaveBeenCalled();
+        expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+        expect(mocks.sharedSpace.getSpaceIdsForAsset).not.toHaveBeenCalled();
+        expect(mocks.job.queue).not.toHaveBeenCalledWith(
+          expect.objectContaining({ name: JobName.SharedSpaceFaceMatch }),
+        );
+      },
+    );
+
     it('should queue SharedSpaceFaceMatch for spaces containing the asset', async () => {
       const asset = AssetFactory.create();
       const person = PersonFactory.create();
@@ -3508,6 +3725,38 @@ describe(PersonService.name, () => {
         name: JobName.SharedSpaceFaceMatch,
         data: { spaceId: 'space-2', assetId: noPerson1.assetId },
       });
+    });
+
+    it('queues one SharedSpaceFaceMatch job per unique space after assigning a face', async () => {
+      const asset = AssetFactory.create();
+      const [noPerson, primaryFace] = [
+        AssetFaceFactory.create({ assetId: asset.id }),
+        AssetFaceFactory.from().person().build(),
+      ];
+      const faces = [
+        { ...noPerson, distance: 0 },
+        { ...primaryFace, distance: 0.2 },
+      ] as FaceSearchResult[];
+
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: { facialRecognition: { minFaces: 1 } } });
+      mocks.search.searchFaces.mockResolvedValue(faces);
+      mocks.person.getFaceForFacialRecognitionJob.mockResolvedValue(getForFacialRecognitionJob(noPerson, asset));
+      mocks.faceIdentity.ensurePersonIdentity.mockResolvedValue({ id: 'identity-1' } as any);
+      mocks.sharedSpace.getSpaceIdsForAsset.mockResolvedValue([
+        { spaceId: 'space-1' },
+        { spaceId: 'space-2' },
+        { spaceId: 'space-1' },
+      ]);
+
+      expect(await sut.handleRecognizeFaces({ id: noPerson.id })).toBe(JobStatus.Success);
+
+      const sharedSpaceJobs = mocks.job.queue.mock.calls
+        .map(([job]) => job)
+        .filter((job) => job.name === JobName.SharedSpaceFaceMatch);
+      expect(sharedSpaceJobs).toEqual([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-1', assetId: noPerson.assetId } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId: 'space-2', assetId: noPerson.assetId } },
+      ]);
     });
 
     it('should not queue SharedSpaceFaceMatch when asset belongs to no spaces', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -939,15 +939,9 @@ export class PersonService extends BaseService {
         return JobStatus.Skipped;
       }
 
-      // Still queue space face matching — this face may belong to a space
-      // that was created/linked after the face was originally recognized.
-      const spaceIds = await this.sharedSpaceRepository.getSpaceIdsForAsset(face.assetId);
-      for (const { spaceId } of spaceIds) {
-        await this.jobRepository.queue({
-          name: JobName.SharedSpaceFaceMatch,
-          data: { spaceId, assetId: face.assetId },
-        });
-      }
+      // Still queue space face matching because this face may belong to a space
+      // that was created or linked after the face was originally recognized.
+      await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
 
       return JobStatus.Skipped;
     }
@@ -1037,20 +1031,33 @@ export class PersonService extends BaseService {
       });
     }
 
+    if (!personId) {
+      this.logger.debug(`Face ${id} did not resolve to a person, skipping shared-space face matching`);
+      return JobStatus.Skipped;
+    }
+
     if (skipSharedSpaceMatch) {
       return JobStatus.Success;
     }
 
-    // Queue shared space face matching for any spaces containing this asset
-    const spaceIds = await this.sharedSpaceRepository.getSpaceIdsForAsset(face.assetId);
-    for (const { spaceId } of spaceIds) {
-      await this.jobRepository.queue({
-        name: JobName.SharedSpaceFaceMatch,
-        data: { spaceId, assetId: face.assetId },
-      });
-    }
+    await this.queueSharedSpaceFaceMatchesForAsset(face.assetId);
 
     return JobStatus.Success;
+  }
+
+  private async queueSharedSpaceFaceMatchesForAsset(assetId: string): Promise<void> {
+    const spaceIds = await this.sharedSpaceRepository.getSpaceIdsForAsset(assetId);
+    const queuedSpaceIds = new Set<string>();
+    for (const { spaceId } of spaceIds) {
+      if (queuedSpaceIds.has(spaceId)) {
+        continue;
+      }
+      queuedSpaceIds.add(spaceId);
+      await this.jobRepository.queue({
+        name: JobName.SharedSpaceFaceMatch,
+        data: { spaceId, assetId },
+      });
+    }
   }
 
   private async replaceFaceIdentity(

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -780,8 +780,6 @@ export class PersonService extends BaseService {
       return JobStatus.Skipped;
     }
 
-    await this.jobRepository.waitForQueueCompletion(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
-
     if (nightly) {
       const [state, latestFaceDate] = await Promise.all([
         this.systemMetadataRepository.get(SystemMetadataKey.FacialRecognitionState),
@@ -793,6 +791,8 @@ export class PersonService extends BaseService {
         return JobStatus.Skipped;
       }
     }
+
+    await this.jobRepository.waitForQueueCompletion(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
 
     if (force) {
       await this.jobRepository.empty(QueueName.FacialRecognition, true);

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -830,9 +830,7 @@ export class PersonService extends BaseService {
 
     const lastRun = new Date().toISOString();
     const facePagination = this.personRepository.getAllFaces(
-      force
-        ? { sourceType: SourceType.MachineLearning }
-        : { personId: null, sourceType: SourceType.MachineLearning },
+      force ? { sourceType: SourceType.MachineLearning } : { personId: null, sourceType: SourceType.MachineLearning },
     );
 
     let jobs: {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -798,7 +798,9 @@ export class PersonService extends BaseService {
       await this.jobRepository.empty(QueueName.FacialRecognition, true);
     }
 
-    const { waiting } = await this.jobRepository.getJobCounts(QueueName.FacialRecognition);
+    const { active, delayed, paused, waiting } = await this.jobRepository.getJobCounts(QueueName.FacialRecognition);
+    const hasOtherActiveRecognitionWork = active > 1;
+    const hasPendingRecognitionWork = waiting > 0 || delayed > 0 || paused > 0 || hasOtherActiveRecognitionWork;
 
     if (force) {
       await this.personRepository.unassignFaces({ sourceType: SourceType.MachineLearning });
@@ -812,9 +814,10 @@ export class PersonService extends BaseService {
       await this.sharedSpaceRepository.deleteAllPersonFaces();
       await this.sharedSpaceRepository.deleteAllPersons();
       await this.faceIdentityRepository.deleteUnreferencedIdentities();
-    } else if (waiting) {
+    } else if (hasPendingRecognitionWork) {
       this.logger.debug(
-        `Skipping facial recognition queueing because ${waiting} job${waiting > 1 ? 's are' : ' is'} already queued`,
+        `Skipping facial recognition queueing because recognition work is already pending ` +
+          `(${active} active, ${waiting} waiting, ${delayed} delayed, ${paused} paused)`,
       );
       return JobStatus.Skipped;
     }

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -792,7 +792,11 @@ export class PersonService extends BaseService {
       }
     }
 
-    await this.jobRepository.waitForQueueCompletion(QueueName.ThumbnailGeneration, QueueName.FaceDetection);
+    await this.jobRepository.waitForQueueCompletion(
+      QueueName.ThumbnailGeneration,
+      QueueName.FaceDetection,
+      ...(force ? [QueueName.PeopleBackfill] : []),
+    );
 
     if (force) {
       await this.jobRepository.empty(QueueName.FacialRecognition, true);
@@ -826,7 +830,9 @@ export class PersonService extends BaseService {
 
     const lastRun = new Date().toISOString();
     const facePagination = this.personRepository.getAllFaces(
-      force ? undefined : { personId: null, sourceType: SourceType.MachineLearning },
+      force
+        ? { sourceType: SourceType.MachineLearning }
+        : { personId: null, sourceType: SourceType.MachineLearning },
     );
 
     let jobs: {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -4007,6 +4007,13 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId: 'space-1', assetId: 'asset-1' });
 
       expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.sharedSpace.isAssetInSpace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
     });
 
     it('should skip when face recognition is disabled on the space', async () => {
@@ -4016,6 +4023,34 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId: space.id, assetId: 'asset-1' });
 
       expect(result).toBe(JobStatus.Skipped);
+      expect(mocks.sharedSpace.isAssetInSpace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
+
+    it('skips safely when a from-backfill asset is no longer in the space before execution', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(false);
+
+      const result = await sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId, assetId });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetFacesForMatching).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getPetFacesForAsset).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.SharedSpacePersonDedup, data: { spaceId } });
     });
 
     it('should queue dedup pass after successful face match', async () => {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -7479,6 +7479,32 @@ describe(SharedSpaceService.name, () => {
       });
     });
 
+    it('does not queue identity reconciliation when library sync finds assets but changes no space people', async () => {
+      const spaceId = newUuid();
+      const libraryId = newUuid();
+      const assetId = newUuid();
+
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.hasLibraryLink.mockResolvedValue(true);
+      mocks.asset.getByLibraryIdWithFaces.mockResolvedValueOnce([{ id: assetId }]).mockResolvedValueOnce([]);
+      mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpaceLibraryFaceSync({ spaceId, libraryId });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getAssetFacesForMatching).toHaveBeenCalledWith(assetId);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId },
+      });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+      );
+    });
+
     it('should skip when space does not exist', async () => {
       mocks.sharedSpace.getById.mockResolvedValue(void 0);
       const result = await sut.handleSharedSpaceLibraryFaceSync({ spaceId: newUuid(), libraryId: newUuid() });
@@ -7508,10 +7534,14 @@ describe(SharedSpaceService.name, () => {
       mocks.asset.getByLibraryIdWithFaces.mockResolvedValue([]);
       const result = await sut.handleSharedSpaceLibraryFaceSync({ spaceId, libraryId });
       expect(result).toBe(JobStatus.Success);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonDedup,
         data: { spaceId },
       });
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpaceIdentityReconciliation }),
+      );
     });
 
     it('should stop syncing when library is unlinked during iteration', async () => {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3636,6 +3636,66 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).toHaveBeenCalledWith(spaceId, [petSpacePersonId]);
     });
 
+    it('does not attach an identity-backed pet face to an existing human space person for the same identity', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      const petFaceId = newUuid();
+      const petPersonId = newUuid();
+      const identityId = newUuid();
+      const humanSpacePersonId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([
+        { id: petFaceId, assetId, personId: petPersonId, identityId, type: 'pet' },
+      ]);
+      mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([]);
+      mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(
+        factory.sharedSpacePerson({ id: humanSpacePersonId, spaceId, identityId, type: 'person' }),
+      );
+
+      const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).not.toHaveBeenCalled();
+    });
+
+    it('removes a stale human selected-space assignment for an identity-backed pet face without cross-type reassignment', async () => {
+      const spaceId = newUuid();
+      const assetId = newUuid();
+      const petFaceId = newUuid();
+      const petPersonId = newUuid();
+      const identityId = newUuid();
+      const humanSpacePersonId = newUuid();
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getAssetFacesForMatching.mockResolvedValue([]);
+      mocks.sharedSpace.getPetFacesForAsset.mockResolvedValue([
+        { id: petFaceId, assetId, personId: petPersonId, identityId, type: 'pet' },
+      ]);
+      mocks.sharedSpace.getPersonFaceAssignmentsForSpace.mockResolvedValue([
+        { personId: humanSpacePersonId, identityId, type: 'person' },
+      ]);
+      mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(
+        factory.sharedSpacePerson({ id: humanSpacePersonId, spaceId, identityId, type: 'person' }),
+      );
+      mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace.mockResolvedValue([humanSpacePersonId]);
+
+      const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.removePersonFaceAssignmentsForSpaceFace).toHaveBeenCalledWith(spaceId, petFaceId);
+      expect(mocks.sharedSpace.addPersonFaces).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.createPerson).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([humanSpacePersonId]);
+      expect(mocks.sharedSpace.deleteOrphanedPersonsByIds).toHaveBeenCalledWith(spaceId, [humanSpacePersonId]);
+    });
+
     it('should not auto-repair or attach pre-existing stale rows for a face without source personId', async () => {
       const spaceId = newUuid();
       const assetId = newUuid();

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -647,6 +647,7 @@ describe('People identity RBAC projection', () => {
       .select(['person.id', 'person.identityId'])
       .where('asset_face.id', '=', uploadedFaceId)
       .executeTakeFirstOrThrow();
+    const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
     const withSpace = await fx.personService.getAll(authFor(fx.member), {
       withHidden: false,
       withSharedSpaces: true,
@@ -654,6 +655,7 @@ describe('People identity RBAC projection', () => {
       size: 50,
     } as any);
 
+    expect(uploadedPerson.identityId).toBe(targetIdentity.id);
     expect(withSpace.people).toEqual([
       expect.objectContaining({
         primaryProfile: { type: 'user-person', id: uploadedPerson.id },
@@ -681,6 +683,123 @@ describe('People identity RBAC projection', () => {
       }),
     ]);
     expect(JSON.stringify(afterLeave)).not.toContain(fx.spacePerson.id);
+  });
+
+  it('does not merge a post-join private upload when strict personal conflict guards fail', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
+    const embeddingRow = await fx.ctx.database
+      .selectFrom('face_search')
+      .select('embedding')
+      .where('faceId', '=', fx.face.faceId)
+      .executeTakeFirstOrThrow();
+    const targetIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(fx.face.person.id);
+
+    const { result: memberConflictPerson } = await fx.ctx.newPerson({
+      ownerId: fx.member.id,
+      name: 'Member Existing Profile',
+    });
+    const memberConflictIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(memberConflictPerson.id);
+    await fx.faceIdentityRepository.mergeIdentities({
+      targetIdentityId: targetIdentity.id,
+      sourceIdentityIds: [memberConflictIdentity.id],
+      source: 'manual',
+    });
+
+    const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
+    const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
+    await fx.ctx.database
+      .insertInto('face_search')
+      .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+      .execute();
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+
+    const uploadedPerson = await fx.ctx.database
+      .selectFrom('asset_face')
+      .innerJoin('person', 'person.id', 'asset_face.personId')
+      .select(['person.id', 'person.identityId'])
+      .where('asset_face.id', '=', uploadedFaceId)
+      .executeTakeFirstOrThrow();
+    const uploadedLinks = await fx.ctx.database
+      .selectFrom('face_identity_face')
+      .select(['assetFaceId', 'identityId', 'source'])
+      .where('assetFaceId', '=', uploadedFaceId)
+      .execute();
+    const targetProfiles = await fx.ctx.database
+      .selectFrom('person')
+      .select(['id', 'ownerId', 'identityId'])
+      .where('identityId', '=', targetIdentity.id)
+      .orderBy('id')
+      .execute();
+
+    expect(uploadedPerson.id).not.toBe(memberConflictPerson.id);
+    expect(uploadedPerson.identityId).not.toBe(targetIdentity.id);
+    expect(uploadedLinks).toEqual([
+      { assetFaceId: uploadedFaceId, identityId: uploadedPerson.identityId, source: 'owner-person' },
+    ]);
+    expect(targetProfiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: memberConflictPerson.id, ownerId: fx.member.id, identityId: targetIdentity.id }),
+      ]),
+    );
+    expect(targetProfiles.map((profile) => profile.id)).not.toContain(uploadedPerson.id);
+  });
+
+  it('repeated recognition of an already assigned face preserves one person and one identity link', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ personName: 'Library Source' });
+    const embeddingRow = await fx.ctx.database
+      .selectFrom('face_search')
+      .select('embedding')
+      .where('faceId', '=', fx.face.faceId)
+      .executeTakeFirstOrThrow();
+
+    const { asset } = await fx.ctx.newAsset({ ownerId: fx.member.id, visibility: AssetVisibility.Timeline });
+    const { result: uploadedFaceId } = await fx.ctx.newAssetFace({ assetId: asset.id });
+    await fx.ctx.database
+      .insertInto('face_search')
+      .values({ faceId: uploadedFaceId, embedding: embeddingRow.embedding })
+      .execute();
+
+    const readState = async () => {
+      const assignedPerson = await fx.ctx.database
+        .selectFrom('asset_face')
+        .innerJoin('person', 'person.id', 'asset_face.personId')
+        .select(['person.id as personId', 'person.identityId as identityId'])
+        .where('asset_face.id', '=', uploadedFaceId)
+        .executeTakeFirstOrThrow();
+      const memberPeople = await fx.ctx.database
+        .selectFrom('person')
+        .select(['id', 'identityId'])
+        .where('ownerId', '=', fx.member.id)
+        .orderBy('id')
+        .execute();
+      const faceLinks = await fx.ctx.database
+        .selectFrom('face_identity_face')
+        .select(['assetFaceId', 'identityId', 'source'])
+        .where('assetFaceId', '=', uploadedFaceId)
+        .orderBy('assetFaceId')
+        .execute();
+
+      return { assignedPerson, memberPeople, faceLinks };
+    };
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+    const assignedState = await readState();
+
+    await fx.personService.handleRecognizeFaces({ id: uploadedFaceId });
+    const repeatedState = await readState();
+
+    expect(repeatedState).toEqual(assignedState);
+    expect(repeatedState.memberPeople).toHaveLength(1);
+    expect(repeatedState.faceLinks).toEqual([
+      {
+        assetFaceId: uploadedFaceId,
+        identityId: repeatedState.assignedPerson.identityId,
+        source: 'owner-person',
+      },
+    ]);
   });
 
   it('reconciles a late member local person against linked-library space evidence', async () => {

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -352,198 +352,213 @@ describe(PersonService.name, () => {
 
   describe('handleQueueRecognizeFaces safety', () => {
     it('preserves manual and EXIF identity evidence while force recognition resets ML assignments and queues rebuilds', async () => {
-      const { sut, ctx } = setupFaceRecognition(await getKyselyDB());
-      const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
-      const systemMetadataMock = ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(
-        SystemMetadataRepository,
-      );
-      const { user } = await ctx.newUser();
-      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+      const db = await getKyselyDB();
+      try {
+        const { sut, ctx } = setupFaceRecognition(db);
+        const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+        const systemMetadataMock = ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(
+          SystemMetadataRepository,
+        );
+        const { user } = await ctx.newUser();
+        const asset = await createAssetReadyForFaceDetection(ctx, user.id);
 
-      const ml = await createPersonFaceIdentity(ctx, {
-        ownerId: user.id,
-        assetId: asset.id,
-        name: 'Machine',
-        sourceType: SourceType.MachineLearning,
-        linkSource: 'ml',
-      });
-      const manual = await createPersonFaceIdentity(ctx, {
-        ownerId: user.id,
-        assetId: asset.id,
-        name: 'Manual',
-        sourceType: SourceType.Manual,
-        linkSource: 'manual',
-      });
-      const exif = await createPersonFaceIdentity(ctx, {
-        ownerId: user.id,
-        assetId: asset.id,
-        name: 'Exif',
-        sourceType: SourceType.Exif,
-        linkSource: 'import',
-      });
+        const ml = await createPersonFaceIdentity(ctx, {
+          ownerId: user.id,
+          assetId: asset.id,
+          name: 'Machine',
+          sourceType: SourceType.MachineLearning,
+          linkSource: 'ml',
+        });
+        const manual = await createPersonFaceIdentity(ctx, {
+          ownerId: user.id,
+          assetId: asset.id,
+          name: 'Manual',
+          sourceType: SourceType.Manual,
+          linkSource: 'manual',
+        });
+        const exif = await createPersonFaceIdentity(ctx, {
+          ownerId: user.id,
+          assetId: asset.id,
+          name: 'Exif',
+          sourceType: SourceType.Exif,
+          linkSource: 'import',
+        });
 
-      const { space: enabledSpace } = await ctx.newSharedSpace({
-        createdById: user.id,
-        faceRecognitionEnabled: true,
-      });
-      const { space: disabledSpace } = await ctx.newSharedSpace({
-        createdById: user.id,
-        faceRecognitionEnabled: false,
-      });
-      await ctx.newSharedSpaceMember({ spaceId: enabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
-      await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
-      await ctx.newSharedSpaceAsset({ spaceId: enabledSpace.id, assetId: asset.id, addedById: user.id });
-      await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
-      await createSpacePersonFace(ctx, {
-        spaceId: enabledSpace.id,
-        identityId: ml.identity.id,
-        assetFaceId: ml.assetFace.id,
-        name: 'Machine Enabled Space',
-      });
-      await createSpacePersonFace(ctx, {
-        spaceId: enabledSpace.id,
-        identityId: manual.identity.id,
-        assetFaceId: manual.assetFace.id,
-        name: 'Manual Enabled Space',
-      });
-      await createSpacePersonFace(ctx, {
-        spaceId: disabledSpace.id,
-        identityId: exif.identity.id,
-        assetFaceId: exif.assetFace.id,
-        name: 'Exif Disabled Space',
-      });
+        const { space: enabledSpace } = await ctx.newSharedSpace({
+          createdById: user.id,
+          faceRecognitionEnabled: true,
+        });
+        const { space: disabledSpace } = await ctx.newSharedSpace({
+          createdById: user.id,
+          faceRecognitionEnabled: false,
+        });
+        await ctx.newSharedSpaceMember({ spaceId: enabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+        await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+        await ctx.newSharedSpaceAsset({ spaceId: enabledSpace.id, assetId: asset.id, addedById: user.id });
+        await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
+        await createSpacePersonFace(ctx, {
+          spaceId: enabledSpace.id,
+          identityId: ml.identity.id,
+          assetFaceId: ml.assetFace.id,
+          name: 'Machine Enabled Space',
+        });
+        await createSpacePersonFace(ctx, {
+          spaceId: enabledSpace.id,
+          identityId: manual.identity.id,
+          assetFaceId: manual.assetFace.id,
+          name: 'Manual Enabled Space',
+        });
+        await createSpacePersonFace(ctx, {
+          spaceId: disabledSpace.id,
+          identityId: exif.identity.id,
+          assetFaceId: exif.assetFace.id,
+          name: 'Exif Disabled Space',
+        });
 
-      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+        await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
 
-      await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
-          expect.objectContaining({
-            id: manual.assetFace.id,
-            personId: manual.person.id,
-            sourceType: SourceType.Manual,
-          }),
-          expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
-        ]),
-      );
-      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
-        expect.arrayContaining([
-          { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
-          { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
-        ]),
-      );
-      await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
-      await expect(getPeopleByIds(ctx, [manual.person.id, exif.person.id])).resolves.toEqual([
-        { id: exif.person.id, name: 'Exif' },
-        { id: manual.person.id, name: 'Manual' },
-      ]);
-      await expect(getSpacePeople(ctx, [enabledSpace.id, disabledSpace.id])).resolves.toEqual([]);
+        await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
+            expect.objectContaining({
+              id: manual.assetFace.id,
+              personId: manual.person.id,
+              sourceType: SourceType.Manual,
+            }),
+            expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
+          ]),
+        );
+        await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+          expect.arrayContaining([
+            { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+            { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+          ]),
+        );
+        await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
+        await expect(getPeopleByIds(ctx, [ml.person.id, manual.person.id, exif.person.id])).resolves.toEqual([
+          { id: exif.person.id, name: 'Exif' },
+          { id: manual.person.id, name: 'Manual' },
+        ]);
+        await expect(getSpacePeople(ctx, [enabledSpace.id, disabledSpace.id])).resolves.toEqual([]);
 
-      const queuedJobs = jobMock.queueAll.mock.calls.flatMap(([jobs]) => jobs);
-      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledWith(
-        QueueName.ThumbnailGeneration,
-        QueueName.FaceDetection,
-        QueueName.PeopleBackfill,
-      );
-      expect(jobMock.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
-      expect(jobMock.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.FacialRecognition,
-          data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
-        },
-      ]);
-      expect(jobMock.queueAll).toHaveBeenCalledWith([
-        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: enabledSpace.id } },
-      ]);
-      expect(queuedJobs).not.toContainEqual({
-        name: JobName.SharedSpaceFaceMatchAll,
-        data: { spaceId: disabledSpace.id },
-      });
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.FaceIdentityMaintenanceAfterRecognition,
-        data: {},
-      });
-      expect(systemMetadataMock.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
-        lastRun: expect.any(String),
-      });
+        const queuedJobs = jobMock.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+        expect(jobMock.waitForQueueCompletion).toHaveBeenCalledWith(
+          QueueName.ThumbnailGeneration,
+          QueueName.FaceDetection,
+          QueueName.PeopleBackfill,
+        );
+        expect(jobMock.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+        expect(jobMock.queueAll).toHaveBeenCalledWith([
+          {
+            name: JobName.FacialRecognition,
+            data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
+          },
+        ]);
+        expect(jobMock.queueAll).toHaveBeenCalledWith([
+          { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: enabledSpace.id } },
+        ]);
+        expect(queuedJobs).not.toContainEqual({
+          name: JobName.SharedSpaceFaceMatchAll,
+          data: { spaceId: disabledSpace.id },
+        });
+        expect(jobMock.queue).toHaveBeenCalledWith({
+          name: JobName.FaceIdentityMaintenanceAfterRecognition,
+          data: {},
+        });
+        expect(systemMetadataMock.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
+          lastRun: expect.any(String),
+        });
+      } finally {
+        await db.destroy();
+      }
     });
 
     it('keeps force recognition idempotent over repeated runs with populated manual and EXIF evidence', async () => {
-      const { sut, ctx } = setupFaceRecognition(await getKyselyDB());
-      const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
-      const { user } = await ctx.newUser();
-      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
-      const ml = await createPersonFaceIdentity(ctx, {
-        ownerId: user.id,
-        assetId: asset.id,
-        name: 'Machine',
-        sourceType: SourceType.MachineLearning,
-        linkSource: 'ml',
-      });
-      const manual = await createPersonFaceIdentity(ctx, {
-        ownerId: user.id,
-        assetId: asset.id,
-        name: 'Manual',
-        sourceType: SourceType.Manual,
-        linkSource: 'manual',
-      });
-      const exif = await createPersonFaceIdentity(ctx, {
-        ownerId: user.id,
-        assetId: asset.id,
-        name: 'Exif',
-        sourceType: SourceType.Exif,
-        linkSource: 'import',
-      });
-      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
-      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-      await createSpacePersonFace(ctx, {
-        spaceId: space.id,
-        identityId: ml.identity.id,
-        assetFaceId: ml.assetFace.id,
-        name: 'Machine Space',
-      });
+      const db = await getKyselyDB();
+      try {
+        const { sut, ctx } = setupFaceRecognition(db);
+        const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+        const { user } = await ctx.newUser();
+        const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+        const ml = await createPersonFaceIdentity(ctx, {
+          ownerId: user.id,
+          assetId: asset.id,
+          name: 'Machine',
+          sourceType: SourceType.MachineLearning,
+          linkSource: 'ml',
+        });
+        const manual = await createPersonFaceIdentity(ctx, {
+          ownerId: user.id,
+          assetId: asset.id,
+          name: 'Manual',
+          sourceType: SourceType.Manual,
+          linkSource: 'manual',
+        });
+        const exif = await createPersonFaceIdentity(ctx, {
+          ownerId: user.id,
+          assetId: asset.id,
+          name: 'Exif',
+          sourceType: SourceType.Exif,
+          linkSource: 'import',
+        });
+        const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+        await createSpacePersonFace(ctx, {
+          spaceId: space.id,
+          identityId: ml.identity.id,
+          assetFaceId: ml.assetFace.id,
+          name: 'Machine Space',
+        });
 
-      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
-      jobMock.queue.mockClear();
-      jobMock.queueAll.mockClear();
-      jobMock.empty.mockClear();
+        await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+        jobMock.queue.mockClear();
+        jobMock.queueAll.mockClear();
+        jobMock.empty.mockClear();
 
-      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+        await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
 
-      await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
-          expect.objectContaining({
-            id: manual.assetFace.id,
-            personId: manual.person.id,
-            sourceType: SourceType.Manual,
-          }),
-          expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
-        ]),
-      );
-      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
-        expect.arrayContaining([
-          { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
-          { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
-        ]),
-      );
-      await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
-      await expect(getSpacePeople(ctx, [space.id])).resolves.toEqual([]);
-      expect(jobMock.empty).toHaveBeenCalledTimes(1);
-      expect(jobMock.queueAll).toHaveBeenCalledWith([
-        {
-          name: JobName.FacialRecognition,
-          data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
-        },
-      ]);
-      expect(jobMock.queueAll).toHaveBeenCalledWith([
-        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } },
-      ]);
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.FaceIdentityMaintenanceAfterRecognition,
-        data: {},
-      });
+        await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
+            expect.objectContaining({
+              id: manual.assetFace.id,
+              personId: manual.person.id,
+              sourceType: SourceType.Manual,
+            }),
+            expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
+          ]),
+        );
+        await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+          expect.arrayContaining([
+            { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+            { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+          ]),
+        );
+        await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
+        await expect(getSpacePeople(ctx, [space.id])).resolves.toEqual([]);
+        expect(jobMock.empty).toHaveBeenCalledTimes(1);
+        expect(jobMock.queueAll).toHaveBeenCalledWith([
+          {
+            name: JobName.FacialRecognition,
+            data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
+          },
+        ]);
+        expect(jobMock.queueAll).toHaveBeenCalledWith([
+          { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } },
+        ]);
+        expect(
+          jobMock.queue.mock.calls.filter(
+            ([job]) => job.name === JobName.FaceIdentityMaintenanceAfterRecognition,
+          ),
+        ).toHaveLength(1);
+        expect(jobMock.queue).toHaveBeenCalledWith({
+          name: JobName.FaceIdentityMaintenanceAfterRecognition,
+          data: {},
+        });
+      } finally {
+        await db.destroy();
+      }
     });
   });
 

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -122,7 +122,9 @@ const setupFaceRecognition = (db?: Kysely<DB>) => {
       return undefined as any;
     });
 
-  ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository).set.mockResolvedValue();
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .set.mockResolvedValue();
 
   return { sut, ctx };
 };
@@ -548,9 +550,7 @@ describe(PersonService.name, () => {
           { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } },
         ]);
         expect(
-          jobMock.queue.mock.calls.filter(
-            ([job]) => job.name === JobName.FaceIdentityMaintenanceAfterRecognition,
-          ),
+          jobMock.queue.mock.calls.filter(([job]) => job.name === JobName.FaceIdentityMaintenanceAfterRecognition),
         ).toHaveLength(1);
         expect(jobMock.queue).toHaveBeenCalledWith({
           name: JobName.FaceIdentityMaintenanceAfterRecognition,

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -6,6 +6,7 @@ import {
   AssetVisibility,
   JobName,
   JobStatus,
+  QueueName,
   SharedSpaceRole,
   SourceType,
   SystemMetadataKey,
@@ -81,6 +82,51 @@ const setupFaceDetection = (db?: Kysely<DB>) => {
   return { sut, ctx };
 };
 
+const setupFaceRecognition = (db?: Kysely<DB>) => {
+  clearConfigCache();
+
+  const { sut, ctx } = newMediumService(PersonService, {
+    database: db || defaultDatabase,
+    real: [
+      AccessRepository,
+      AssetRepository,
+      ConfigRepository,
+      DatabaseRepository,
+      FaceIdentityRepository,
+      PersonRepository,
+      SharedSpaceRepository,
+    ],
+    mock: [JobRepository, LoggingRepository, MachineLearningRepository, StorageRepository, SystemMetadataRepository],
+  });
+
+  const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+  jobMock.waitForQueueCompletion.mockResolvedValue();
+  jobMock.empty.mockResolvedValue();
+  jobMock.queue.mockResolvedValue();
+  jobMock.queueAll.mockResolvedValue();
+  jobMock.getJobCounts.mockResolvedValue({
+    active: 1,
+    waiting: 0,
+    delayed: 0,
+    paused: 0,
+    completed: 0,
+    failed: 0,
+  });
+
+  ctx
+    .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
+    .get.mockImplementation((key) => {
+      if (key === SystemMetadataKey.SystemConfig) {
+        return { machineLearning: { facialRecognition: { enabled: true, minFaces: 1 } } } as any;
+      }
+      return undefined as any;
+    });
+
+  ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository).set.mockResolvedValue();
+
+  return { sut, ctx };
+};
+
 const getAssetFaces = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], assetId: string) =>
   ctx.database
     .selectFrom('asset_face')
@@ -95,6 +141,17 @@ const getIdentityLinks = (ctx: ReturnType<typeof setupFaceDetection>['ctx'], fac
     .select(['assetFaceId', 'identityId', 'source'])
     .where('assetFaceId', 'in', faceIds)
     .orderBy('assetFaceId')
+    .execute();
+
+const getPeopleByIds = (ctx: ReturnType<typeof setupFaceRecognition>['ctx'], ids: string[]) =>
+  ctx.database.selectFrom('person').select(['id', 'name']).where('id', 'in', ids).orderBy('name').execute();
+
+const getSpacePeople = (ctx: ReturnType<typeof setupFaceRecognition>['ctx'], spaceIds: string[]) =>
+  ctx.database
+    .selectFrom('shared_space_person')
+    .select(['id', 'identityId', 'name', 'spaceId'])
+    .where('spaceId', 'in', spaceIds)
+    .orderBy('name')
     .execute();
 
 const createAssetReadyForFaceDetection = async (ctx: ReturnType<typeof setupFaceDetection>['ctx'], ownerId: string) => {
@@ -290,6 +347,203 @@ describe(PersonService.name, () => {
       expect(jobMock.queueAll).toHaveBeenCalledWith([
         { name: JobName.AssetDetectFaces, data: { id: asset.id, force: true } },
       ]);
+    });
+  });
+
+  describe('handleQueueRecognizeFaces safety', () => {
+    it('preserves manual and EXIF identity evidence while force recognition resets ML assignments and queues rebuilds', async () => {
+      const { sut, ctx } = setupFaceRecognition(await getKyselyDB());
+      const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+      const systemMetadataMock = ctx.getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(
+        SystemMetadataRepository,
+      );
+      const { user } = await ctx.newUser();
+      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+
+      const ml = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Machine',
+        sourceType: SourceType.MachineLearning,
+        linkSource: 'ml',
+      });
+      const manual = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Manual',
+        sourceType: SourceType.Manual,
+        linkSource: 'manual',
+      });
+      const exif = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Exif',
+        sourceType: SourceType.Exif,
+        linkSource: 'import',
+      });
+
+      const { space: enabledSpace } = await ctx.newSharedSpace({
+        createdById: user.id,
+        faceRecognitionEnabled: true,
+      });
+      const { space: disabledSpace } = await ctx.newSharedSpace({
+        createdById: user.id,
+        faceRecognitionEnabled: false,
+      });
+      await ctx.newSharedSpaceMember({ spaceId: enabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: disabledSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: enabledSpace.id, assetId: asset.id, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: disabledSpace.id, assetId: asset.id, addedById: user.id });
+      await createSpacePersonFace(ctx, {
+        spaceId: enabledSpace.id,
+        identityId: ml.identity.id,
+        assetFaceId: ml.assetFace.id,
+        name: 'Machine Enabled Space',
+      });
+      await createSpacePersonFace(ctx, {
+        spaceId: enabledSpace.id,
+        identityId: manual.identity.id,
+        assetFaceId: manual.assetFace.id,
+        name: 'Manual Enabled Space',
+      });
+      await createSpacePersonFace(ctx, {
+        spaceId: disabledSpace.id,
+        identityId: exif.identity.id,
+        assetFaceId: exif.assetFace.id,
+        name: 'Exif Disabled Space',
+      });
+
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+      await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
+          expect.objectContaining({
+            id: manual.assetFace.id,
+            personId: manual.person.id,
+            sourceType: SourceType.Manual,
+          }),
+          expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
+        ]),
+      );
+      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+        expect.arrayContaining([
+          { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+          { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+        ]),
+      );
+      await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
+      await expect(getPeopleByIds(ctx, [manual.person.id, exif.person.id])).resolves.toEqual([
+        { id: exif.person.id, name: 'Exif' },
+        { id: manual.person.id, name: 'Manual' },
+      ]);
+      await expect(getSpacePeople(ctx, [enabledSpace.id, disabledSpace.id])).resolves.toEqual([]);
+
+      const queuedJobs = jobMock.queueAll.mock.calls.flatMap(([jobs]) => jobs);
+      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledWith(
+        QueueName.ThumbnailGeneration,
+        QueueName.FaceDetection,
+        QueueName.PeopleBackfill,
+      );
+      expect(jobMock.empty).toHaveBeenCalledWith(QueueName.FacialRecognition, true);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.FacialRecognition,
+          data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
+        },
+      ]);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: enabledSpace.id } },
+      ]);
+      expect(queuedJobs).not.toContainEqual({
+        name: JobName.SharedSpaceFaceMatchAll,
+        data: { spaceId: disabledSpace.id },
+      });
+      expect(jobMock.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: {},
+      });
+      expect(systemMetadataMock.set).toHaveBeenCalledWith(SystemMetadataKey.FacialRecognitionState, {
+        lastRun: expect.any(String),
+      });
+    });
+
+    it('keeps force recognition idempotent over repeated runs with populated manual and EXIF evidence', async () => {
+      const { sut, ctx } = setupFaceRecognition(await getKyselyDB());
+      const jobMock = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+      const { user } = await ctx.newUser();
+      const asset = await createAssetReadyForFaceDetection(ctx, user.id);
+      const ml = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Machine',
+        sourceType: SourceType.MachineLearning,
+        linkSource: 'ml',
+      });
+      const manual = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Manual',
+        sourceType: SourceType.Manual,
+        linkSource: 'manual',
+      });
+      const exif = await createPersonFaceIdentity(ctx, {
+        ownerId: user.id,
+        assetId: asset.id,
+        name: 'Exif',
+        sourceType: SourceType.Exif,
+        linkSource: 'import',
+      });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      await createSpacePersonFace(ctx, {
+        spaceId: space.id,
+        identityId: ml.identity.id,
+        assetFaceId: ml.assetFace.id,
+        name: 'Machine Space',
+      });
+
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+      jobMock.queue.mockClear();
+      jobMock.queueAll.mockClear();
+      jobMock.empty.mockClear();
+
+      await expect(sut.handleQueueRecognizeFaces({ force: true })).resolves.toBe(JobStatus.Success);
+
+      await expect(getAssetFaces(ctx, asset.id)).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: ml.assetFace.id, personId: null, sourceType: SourceType.MachineLearning }),
+          expect.objectContaining({
+            id: manual.assetFace.id,
+            personId: manual.person.id,
+            sourceType: SourceType.Manual,
+          }),
+          expect.objectContaining({ id: exif.assetFace.id, personId: exif.person.id, sourceType: SourceType.Exif }),
+        ]),
+      );
+      await expect(getIdentityLinks(ctx, [ml.assetFace.id, manual.assetFace.id, exif.assetFace.id])).resolves.toEqual(
+        expect.arrayContaining([
+          { assetFaceId: manual.assetFace.id, identityId: manual.identity.id, source: 'manual' },
+          { assetFaceId: exif.assetFace.id, identityId: exif.identity.id, source: 'import' },
+        ]),
+      );
+      await expect(getIdentityLinks(ctx, [ml.assetFace.id])).resolves.toEqual([]);
+      await expect(getSpacePeople(ctx, [space.id])).resolves.toEqual([]);
+      expect(jobMock.empty).toHaveBeenCalledTimes(1);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.FacialRecognition,
+          data: { id: ml.assetFace.id, deferred: false, skipSharedSpaceMatch: true },
+        },
+      ]);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.id } },
+      ]);
+      expect(jobMock.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityMaintenanceAfterRecognition,
+        data: {},
+      });
     });
   });
 

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -485,6 +485,52 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     });
   });
 
+  it('same asset direct plus linked-library path materializes only one selected-space face assignment', async () => {
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+    const face = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      name: 'Alice',
+    });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: face.asset.id, addedById: user.id });
+
+    await expect(sut.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: face.asset.id })).resolves.toBe(
+      JobStatus.Success,
+    );
+    await expect(sut.handleSharedSpaceLibraryFaceSync({ spaceId: space.id, libraryId: library.id })).resolves.toBe(
+      JobStatus.Success,
+    );
+
+    const people = await ctx.database
+      .selectFrom('shared_space_person')
+      .selectAll()
+      .where('spaceId', '=', space.id)
+      .where('identityId', '=', face.identity.id)
+      .execute();
+    expect(people).toHaveLength(1);
+    await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([
+      {
+        assetFaceId: face.assetFace.id,
+        personId: people[0].id,
+        identityId: face.identity.id,
+        type: 'person',
+      },
+    ]);
+    await expect(
+      sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+    ).resolves.toMatchObject({
+      detectedFaceCount: 1,
+      assignedVisibleFaceCount: 1,
+      assignedHiddenFaceCount: 0,
+      unassignedFaceCount: 0,
+    });
+  });
+
   it('full-space rematch repairs stale selected-space face assignments from linked libraries', async () => {
     const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -67,6 +67,20 @@ const drainSharedSpaceFaceJobs = async (sharedSpaceService: SharedSpaceService, 
   }
 };
 
+const getSelectedSpaceFaceRows = async (ctx: ReturnType<typeof setup>['ctx'], spaceId: string) =>
+  ctx.database
+    .selectFrom('shared_space_person_face as face')
+    .innerJoin('shared_space_person as person', 'person.id', 'face.personId')
+    .select([
+      'face.assetFaceId as assetFaceId',
+      'face.personId as personId',
+      'person.identityId as identityId',
+      'person.type as type',
+    ])
+    .where('person.spaceId', '=', spaceId)
+    .orderBy('face.assetFaceId')
+    .execute();
+
 beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
@@ -273,6 +287,125 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     expect(jobs.queue).toHaveBeenCalledWith({
       name: JobName.SharedSpaceIdentityReconciliation,
       data: { spaceId: space.id },
+    });
+  });
+
+  it('full-space rematch repairs missing stale and wrong-identity selected-space assignments without inflating counts', async () => {
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+
+    const target = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      name: 'Alice',
+    });
+    const missing = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      personId: target.person.id,
+      identityId: target.identity.id,
+    });
+    const wrong = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      personId: target.person.id,
+      identityId: target.identity.id,
+    });
+    const stale = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      personId: target.person.id,
+      identityId: target.identity.id,
+    });
+
+    const correctPerson = await sharedSpaceRepository.createPerson({
+      spaceId: space.id,
+      identityId: target.identity.id,
+      name: '',
+      representativeFaceId: target.assetFace.id,
+      type: 'person',
+    });
+    await sharedSpaceRepository.addPersonFaces([{ personId: correctPerson.id, assetFaceId: target.assetFace.id }], {
+      skipRecount: true,
+    });
+
+    const { result: wrongOwnerPerson } = await ctx.newPerson({ ownerId: user.id, name: 'Wrong Alice' });
+    const wrongIdentity = await faceIdentityRepository.ensurePersonIdentity(wrongOwnerPerson.id);
+    const wrongSpacePerson = await sharedSpaceRepository.createPerson({
+      spaceId: space.id,
+      identityId: wrongIdentity.id,
+      name: '',
+      representativeFaceId: wrong.assetFace.id,
+      type: 'person',
+    });
+    await sharedSpaceRepository.addPersonFaces([{ personId: wrongSpacePerson.id, assetFaceId: wrong.assetFace.id }], {
+      skipRecount: true,
+    });
+
+    const staleSpacePerson = await sharedSpaceRepository.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: stale.assetFace.id,
+      type: 'person',
+    });
+    await sharedSpaceRepository.addPersonFaces([{ personId: staleSpacePerson.id, assetFaceId: stale.assetFace.id }], {
+      skipRecount: true,
+    });
+
+    await expect(sut.handleSharedSpaceFaceMatchAll({ spaceId: space.id })).resolves.toBe(JobStatus.Success);
+    await drainSharedSpaceFaceJobs(sut, jobs);
+
+    const repairedPerson = await ctx.database
+      .selectFrom('shared_space_person')
+      .selectAll()
+      .where('spaceId', '=', space.id)
+      .where('identityId', '=', target.identity.id)
+      .executeTakeFirstOrThrow();
+    expect(repairedPerson.id).toBe(correctPerson.id);
+
+    const repairedRows = await getSelectedSpaceFaceRows(ctx, space.id);
+    expect(repairedRows).toHaveLength(4);
+    expect(repairedRows).toEqual(
+      expect.arrayContaining([
+        {
+          assetFaceId: missing.assetFace.id,
+          personId: repairedPerson.id,
+          identityId: target.identity.id,
+          type: 'person',
+        },
+        {
+          assetFaceId: stale.assetFace.id,
+          personId: repairedPerson.id,
+          identityId: target.identity.id,
+          type: 'person',
+        },
+        {
+          assetFaceId: target.assetFace.id,
+          personId: repairedPerson.id,
+          identityId: target.identity.id,
+          type: 'person',
+        },
+        {
+          assetFaceId: wrong.assetFace.id,
+          personId: repairedPerson.id,
+          identityId: target.identity.id,
+          type: 'person',
+        },
+      ]),
+    );
+    await expect(sharedSpaceRepository.getPersonById(wrongSpacePerson.id)).resolves.toBeUndefined();
+    await expect(sharedSpaceRepository.getPersonById(staleSpacePerson.id)).resolves.toBeUndefined();
+    await expect(
+      sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+    ).resolves.toMatchObject({
+      detectedFaceCount: 4,
+      assignedVisibleFaceCount: 4,
+      assignedHiddenFaceCount: 0,
+      unassignedFaceCount: 0,
     });
   });
 

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -409,6 +409,44 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     });
   });
 
+  it('removing direct assets removes selected-space face rows and deletes orphaned space people', async () => {
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    const face = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      name: 'Alice',
+    });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: face.asset.id, addedById: user.id });
+
+    await expect(sut.handleSharedSpaceFaceMatch({ spaceId: space.id, assetId: face.asset.id })).resolves.toBe(
+      JobStatus.Success,
+    );
+    const projectedPerson = await ctx.database
+      .selectFrom('shared_space_person')
+      .selectAll()
+      .where('spaceId', '=', space.id)
+      .where('identityId', '=', face.identity.id)
+      .executeTakeFirstOrThrow();
+    await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toHaveLength(1);
+
+    await sut.removeAssets(factory.auth({ user: { id: user.id } }), space.id, { assetIds: [face.asset.id] });
+
+    await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([]);
+    await expect(sharedSpaceRepository.getPersonById(projectedPerson.id)).resolves.toBeUndefined();
+    await expect(
+      sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+    ).resolves.toMatchObject({
+      detectedFaceCount: 0,
+      assignedVisibleFaceCount: 0,
+      assignedHiddenFaceCount: 0,
+      unassignedFaceCount: 0,
+    });
+  });
+
   it('full-space rematch repairs stale selected-space face assignments from linked libraries', async () => {
     const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -447,6 +447,44 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     });
   });
 
+  it('unlinking a library removes selected-space face rows and deletes orphaned space people', async () => {
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+    const face = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      name: 'Alice',
+    });
+
+    await expect(sut.handleSharedSpaceLibraryFaceSync({ spaceId: space.id, libraryId: library.id })).resolves.toBe(
+      JobStatus.Success,
+    );
+    const projectedPerson = await ctx.database
+      .selectFrom('shared_space_person')
+      .selectAll()
+      .where('spaceId', '=', space.id)
+      .where('identityId', '=', face.identity.id)
+      .executeTakeFirstOrThrow();
+    await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toHaveLength(1);
+
+    await sut.unlinkLibrary(factory.auth({ user: { id: user.id, isAdmin: true } }), space.id, library.id);
+
+    await expect(getSelectedSpaceFaceRows(ctx, space.id)).resolves.toEqual([]);
+    await expect(sharedSpaceRepository.getPersonById(projectedPerson.id)).resolves.toBeUndefined();
+    await expect(
+      sharedSpaceRepository.getPeopleFaceStatisticsBySpaceId(space.id, { minimumFaceCount: 1 }),
+    ).resolves.toMatchObject({
+      detectedFaceCount: 0,
+      assignedVisibleFaceCount: 0,
+      assignedHiddenFaceCount: 0,
+      unassignedFaceCount: 0,
+    });
+  });
+
   it('full-space rematch repairs stale selected-space face assignments from linked libraries', async () => {
     const { ctx, sut, faceIdentityRepository, sharedSpaceRepository, jobs } = setup();
     const { user } = await ctx.newUser();


### PR DESCRIPTION
## Summary
- combines the face recognition coordinator, per-face recognition, and shared-space projection safety slices into one branch
- supersedes #602, #604, and #605 so the code logic changes can be reviewed and merged together
- has been deployed as a personal RC using `ghcr.io/open-noodle/gallery-server:rc-face-trigger-slices-rc1`

## Verification
- `./node_modules/.bin/vitest --config test/vitest.config.mjs --run src/services/person.service.spec.ts src/services/shared-space.service.spec.ts src/repositories/job.repository.spec.ts`
- `./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/services/people-identity-rbac.spec.ts test/medium/specs/services/person.service.spec.ts test/medium/specs/services/shared-space-face-identity-repair.spec.ts`
- personal RC rollout completed and `/api/server/ping` returned HTTP 200

Supersedes #602
Supersedes #604
Supersedes #605