### PR TITLE
fix(web): stop broken space person face thumbnail for non-owner viewers

### DIFF
--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -231,7 +231,12 @@ describe(zoomImageToBase64.name, () => {
     }
 
     const drawImage = vi.fn();
-    const canvas = { width: 0, height: 0, getContext: () => ({ drawImage }), toDataURL: () => 'data:image/png;base64,face' };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage }),
+      toDataURL: () => 'data:image/png;base64,face',
+    };
     const originalCreateElement = document.createElement.bind(document);
     vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) =>
       tagName === 'canvas' ? canvas : originalCreateElement(tagName)) as typeof document.createElement);

--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -206,4 +206,68 @@ describe(zoomImageToBase64.name, () => {
       expect(operations[crossOriginIndex].value).toBe('anonymous');
     }
   });
+
+  it('crops from the loaded image even when the displayed photo has not decoded yet', async () => {
+    class TestImage extends EventTarget {
+      naturalWidth = 4000;
+      naturalHeight = 3000;
+      crossOrigin: string | null = null;
+      private source = '';
+
+      set src(value: string) {
+        this.source = value;
+      }
+
+      get src() {
+        return this.source;
+      }
+
+      override addEventListener(...args: Parameters<EventTarget['addEventListener']>) {
+        super.addEventListener(...args);
+        if (args[0] === 'load') {
+          queueMicrotask(() => this.dispatchEvent(new Event('load')));
+        }
+      }
+    }
+
+    const drawImage = vi.fn();
+    const canvas = { width: 0, height: 0, getContext: () => ({ drawImage }), toDataURL: () => 'data:image/png;base64,face' };
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) =>
+      tagName === 'canvas' ? canvas : originalCreateElement(tagName)) as typeof document.createElement);
+    vi.stubGlobal('Image', TestImage);
+
+    // The displayed <img> is bound but still decoding: naturalWidth/Height are 0.
+    const photoViewer = { naturalWidth: 0, naturalHeight: 0, src: 'http://localhost/preview.jpg' } as HTMLImageElement;
+
+    const result = await zoomImageToBase64(makeFace(), 'asset-1', AssetTypeEnum.Image, photoViewer);
+
+    // Must not emit a broken 0×0 "data:," thumbnail.
+    expect(result).toBe('data:image/png;base64,face');
+    expect(canvas.width).toBeGreaterThan(0);
+    expect(canvas.height).toBeGreaterThan(0);
+    // Crop rectangle must be scaled from the loaded clone (4000×3000), not the 0-sized element.
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 1000, 750, 1000, 750, 0, 0, 1000, 750);
+  });
+
+  it('returns null (so callers fall back) when the source image fails to load', async () => {
+    class BrokenImage extends EventTarget {
+      naturalWidth = 0;
+      naturalHeight = 0;
+      crossOrigin: string | null = null;
+      src = '';
+
+      override addEventListener(...args: Parameters<EventTarget['addEventListener']>) {
+        super.addEventListener(...args);
+        if (args[0] === 'error') {
+          queueMicrotask(() => this.dispatchEvent(new Event('error')));
+        }
+      }
+    }
+
+    vi.stubGlobal('Image', BrokenImage);
+    const photoViewer = { naturalWidth: 0, naturalHeight: 0, src: 'http://localhost/preview.jpg' } as HTMLImageElement;
+
+    await expect(zoomImageToBase64(makeFace(), 'asset-1', AssetTypeEnum.Image, photoViewer)).resolves.toBeNull();
+  });
 });

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -104,26 +104,39 @@ export const zoomImageToBase64 = async (
   if (!image) {
     return null;
   }
-  const { boundingBoxX1: x1, boundingBoxX2: x2, boundingBoxY1: y1, boundingBoxY2: y2, imageWidth, imageHeight } = face;
-
-  const coordinates = {
-    x1: (image.naturalWidth / imageWidth) * x1,
-    x2: (image.naturalWidth / imageWidth) * x2,
-    y1: (image.naturalHeight / imageHeight) * y1,
-    y2: (image.naturalHeight / imageHeight) * y2,
-  };
-
-  const faceWidth = coordinates.x2 - coordinates.x1;
-  const faceHeight = coordinates.y2 - coordinates.y1;
 
   const faceImage = new Image();
   faceImage.crossOrigin = 'anonymous';
   faceImage.src = image.src;
 
-  await new Promise((resolve) => {
-    faceImage.addEventListener('load', resolve);
-    faceImage.addEventListener('error', () => resolve(null));
+  const loaded = await new Promise<boolean>((resolve) => {
+    faceImage.addEventListener('load', () => resolve(true));
+    faceImage.addEventListener('error', () => resolve(false));
   });
+
+  // The displayed <img> is frequently still decoding when the detail panel
+  // renders (its naturalWidth/Height are then 0). Derive the crop from the
+  // freshly loaded clone instead, and bail out — so callers fall back to the
+  // person thumbnail — rather than emit a broken 0×0 "data:," image.
+  if (!loaded || faceImage.naturalWidth === 0 || faceImage.naturalHeight === 0) {
+    return null;
+  }
+
+  const { boundingBoxX1: x1, boundingBoxX2: x2, boundingBoxY1: y1, boundingBoxY2: y2, imageWidth, imageHeight } = face;
+  const widthScale = faceImage.naturalWidth / imageWidth;
+  const heightScale = faceImage.naturalHeight / imageHeight;
+  const coordinates = {
+    x1: widthScale * x1,
+    x2: widthScale * x2,
+    y1: heightScale * y1,
+    y2: heightScale * y2,
+  };
+
+  const faceWidth = coordinates.x2 - coordinates.x1;
+  const faceHeight = coordinates.y2 - coordinates.y1;
+  if (faceWidth <= 0 || faceHeight <= 0) {
+    return null;
+  }
 
   const canvas = document.createElement('canvas');
   canvas.width = faceWidth;


### PR DESCRIPTION
## Problem

Editors/viewers of a shared space saw a broken "square with a pattern" instead of the people face thumbnail in the asset detail panel; the owner saw it correctly.

## Investigation

Reproduced on a local dev stack (editor `b@b.com` viewing a space photo owned by `a@a.com`). Verified that **every server response is byte-identical for owner vs editor**:

- `GET /api/assets/:id?spaceId=…` → identical JSON (same person, same face, same bbox)
- `GET /api/assets/:id/thumbnail?size=preview|thumbnail` → identical media
- `GET /api/shared-spaces/:id/people/:spacePersonId/thumbnail` → identical md5, valid 250×250 face crop

So this is **not** a server/permissions/thumbnail-generation bug.

## Root cause

The detail-panel people strip's primary render is a client-side canvas crop of the displayed `<img>` (`assetViewerManager.imgRef`) via `zoomImageToBase64`. `imgRef` is bound when the element **mounts**, not when the image **loads**. The old code read `image.naturalWidth/Height` before any load wait — when the photo hadn't decoded yet those are `0`, so the canvas is `0×0` and `canvas.toDataURL()` returns the literal string `"data:,"`. That value is *truthy*, so `faceThumbnailUrl ?? fallbackThumbnailUrl` rendered the broken `"data:,"` instead of the correct person-thumbnail fallback, and the `{#await}` never re-ran. Owners had the preview cached/decoded in time; non-owners opening a space photo fresh hit the race — hence the intermittent, owner-vs-viewer appearance.

## Fix

Create the `faceImage` clone first, await its load, derive the crop scale from the **loaded clone's** `naturalWidth/Height`, and return `null` (so callers fall back to the correct person thumbnail) when it is not loaded / zero-dim / degenerate. It can never emit `"data:,"`. The video probe-image structure is preserved so the existing crossOrigin-before-src test still passes.

## Tests (TDD)

Added two `people-utils.spec.ts` tests (the not-yet-decoded race + load failure → `null`); confirmed red → green. Isolated `vitest run people-utils.spec.ts` → 10/10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)