### PR TITLE
ci: drop unreachable comment action from disabled docs-deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -197,14 +197,3 @@ jobs:
           TF_STATE_POSTGRES_CONN_STR: ${{ secrets.TF_STATE_POSTGRES_CONN_STR }}
         working-directory: 'deployment/modules/cloudflare/docs-release'
         run: 'mise run //deployment:tf apply'
-
-      - name: Comment
-        uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3.2.0
-        if: ${{ steps.parameters.outputs.event == 'pr' }}
-        with:
-          token: ${{ github.token }}
-          number: ${{ fromJson(needs.checks.outputs.parameters).pr_number }}
-          body: |
-            📖 Documentation deployed to [${{ steps.docs-output.outputs.subdomain }}](https://${{ steps.docs-output.outputs.subdomain }})
-          emojis: 'rocket'
-          body-include: '<!-- Docs PR URL -->'


### PR DESCRIPTION
## Problem

`actions-cool/maintain-one-comment` is no longer reachable on GitHub. Zizmor's `impostor-commit` audit scans **every** workflow file, tries to verify the pinned SHA against that repo, gets an HTTP 403, and treats it as fatal (`no audit was performed`). This makes the **Zizmor** check fail on `main` and on **every open PR** repo-wide (e.g. #615), unrelated to those PRs' contents.

## Fix

Remove the `Comment` step that used the action. It lives in `.github/workflows/docs-deploy.yml`, which is the **disabled upstream Immich workflow** (`name: Docs deploy (upstream — disabled)`, `workflow_dispatch`-only) — the fork replaced it with `gallery-docs-deploy.yml`. Removing this step has **zero functional impact**.

## Verification

- Zizmor check on this PR should pass (no longer references the unreachable action).
- Once merged, all open PRs can rebase onto `main` to clear Zizmor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)