### PR TITLE
fix(server): require all selected people in search filters

### DIFF
--- a/docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
+++ b/docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
@@ -1,0 +1,1247 @@
+# People Search AND Bugfix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make multiple selected people filter assets with AND semantics by default, while preserving explicit internal OR behavior through `personMatchAny`.
+
+**Architecture:** Keep the fix in server repository/query helpers so existing web URLs, SDK DTOs, and UI flows keep working. Add failing medium tests for real timeline result behavior first, then add unit SQL-shape tests for helper/query paths that are hard to exercise cheaply through services. Implement shared people-filter helpers in `server/src/utils/database.ts` and replace OR-only calls in asset/search repositories.
+
+**Tech Stack:** TypeScript, NestJS repositories/services, Kysely SQL builders, Vitest unit specs, Vitest medium specs with Postgres fixtures, generated SQL snapshots via `server/src/queries/*.sql`.
+
+---
+
+## Source Spec
+
+Design spec: `docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md`.
+
+Implementation rules from the spec:
+
+1. Write one failing test for the next behavior.
+2. Run the narrow test and confirm it fails for the expected OR-vs-AND reason.
+3. Write the minimal production code to make that test pass.
+4. Rerun the same focused test and keep it green.
+5. Commit before moving to the next independent behavior.
+
+No production code should be written before a failing test proves the behavior gap.
+
+## Files
+
+- Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
+  - Add real DB tests for timeline `personIds`, `spacePersonIds`, `identityIds`, hidden/deleted faces, duplicate IDs, and bucket counts.
+- Modify: `server/src/repositories/asset.repository.ts`
+  - Replace default OR people filters in `getTimeBuckets()` and `getTimeBucket()`.
+- Modify: `server/src/utils/database.ts`
+  - Normalize people-related filter IDs.
+  - Add `hasSpacePeople()`.
+  - Add reusable all/any people-filter helpers for `searchAssetBuilder()`.
+- Modify: `server/src/repositories/search.repository.ts`
+  - Use AND semantics for smart facet and suggestion filtered-asset builders.
+- Modify: `server/src/repositories/search.repository.spec.ts`
+  - Add SQL-shape tests for smart facets, suggestions, and `personMatchAny` preservation.
+- Modify generated SQL if changed by query decorators:
+  - `server/src/queries/asset.repository.sql`
+  - `server/src/queries/search.repository.sql`
+- Do not modify:
+  - Web source files.
+  - DTO schemas.
+  - OpenAPI or TypeScript SDK files.
+
+## Baseline
+
+- [ ] **Step 1: Confirm the isolated worktree is clean**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: branch is `fix/issue-628-people-search-and` and status is clean.
+
+- [ ] **Step 2: Run the focused unit baseline**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts src/services/timeline.service.spec.ts src/services/search.service.spec.ts src/services/shared-space.service.spec.ts
+```
+
+Expected: all selected unit specs pass before new tests are added.
+
+- [ ] **Step 3: Run the focused medium baseline**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts test/medium/specs/services/people-identity-rbac.spec.ts
+```
+
+Expected: all selected medium specs pass before new tests are added.
+
+---
+
+## Task 1: Timeline User-Person Filters Require Every Selected Person
+
+**Files:**
+
+- Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
+- Modify: `server/src/repositories/asset.repository.ts`
+- Modify: `server/src/utils/database.ts`
+
+- [ ] **Step 1: Write the failing `getTimeBucket()` user-person test**
+
+In `server/test/medium/specs/repositories/asset.repository.spec.ts`, inside the top-level `describe(AssetRepository.name)` block, add this helper near `interface TimeBucketAssets`:
+
+```ts
+const createTimelineAssetWithPeople = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  ownerId: string,
+  personIds: string[],
+  localDateTime = new Date('2026-03-15T12:00:00.000Z'),
+) => {
+  const { asset } = await ctx.newAsset({
+    ownerId,
+    visibility: AssetVisibility.Timeline,
+    fileCreatedAt: localDateTime,
+    localDateTime,
+  });
+  await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+  for (const personId of personIds) {
+    await ctx.newAssetFace({ assetId: asset.id, personId, isVisible: true });
+  }
+  return asset;
+};
+```
+
+Then add a new `describe('people filters use AND semantics')` block before the existing `describe('getTimeBucket with spacePersonIds')` block:
+
+```ts
+describe('people filters use AND semantics', () => {
+  it('requires every selected person for time bucket assets', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const auth = factory.auth({ user: { id: user.id } });
+    const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+    const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+
+    await createTimelineAssetWithPeople(ctx, user.id, [alice.id]);
+    await createTimelineAssetWithPeople(ctx, user.id, [bob.id]);
+    const both = await createTimelineAssetWithPeople(ctx, user.id, [alice.id, bob.id]);
+
+    const bucket = await sut.getTimeBucket(
+      '2026-03-01',
+      {
+        userIds: [user.id],
+        personIds: [alice.id, bob.id],
+        visibility: AssetVisibility.Timeline,
+      },
+      auth,
+    );
+
+    const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+    expect(assets.id).toEqual([both.id]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected person for time bucket assets"
+```
+
+Expected: FAIL because the current OR filter returns the Alice-only and Bob-only assets as well as the asset containing both people.
+
+- [ ] **Step 3: Implement minimal user-person AND for timeline bucket assets**
+
+In `server/src/repositories/asset.repository.ts`, update the imports from `src/utils/database`:
+
+```ts
+import {
+  anyUuid,
+  asUuid,
+  hasAnyFaceIdentity,
+  hasAnyPerson,
+  hasAnySpacePerson,
+  hasPeople,
+  isStaleAssetForeignKeyConstraint,
+  removeUndefinedKeys,
+  truncatedDate,
+  unnest,
+  withAnyTagId,
+  withDefaultVisibility,
+  withEdits,
+  withExif,
+  withFaces,
+  withFacesAndPeople,
+  withFiles,
+  withLibrary,
+  withOwner,
+  withSmartSearch,
+  withTags,
+} from 'src/utils/database';
+```
+
+Then replace only the `getTimeBucket()` person filter line:
+
+```ts
+.$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
+```
+
+Do not change `getTimeBuckets()`, `spacePersonIds`, or `identityIds` yet.
+
+- [ ] **Step 4: Run the focused test again**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected person for time bucket assets"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing `getTimeBuckets()` count test**
+
+Add this test in the same `people filters use AND semantics` block:
+
+```ts
+it('requires every selected person when counting time buckets', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+  const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+
+  await createTimelineAssetWithPeople(ctx, user.id, [alice.id]);
+  await createTimelineAssetWithPeople(ctx, user.id, [bob.id]);
+  await createTimelineAssetWithPeople(ctx, user.id, [alice.id, bob.id]);
+
+  await expect(
+    sut.getTimeBuckets({
+      userIds: [user.id],
+      personIds: [alice.id, bob.id],
+      visibility: AssetVisibility.Timeline,
+    }),
+  ).resolves.toEqual([{ count: 1, timeBucket: '2026-03-01' }]);
+});
+```
+
+- [ ] **Step 6: Run the failing bucket-count test**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected person when counting time buckets"
+```
+
+Expected: FAIL because `getTimeBuckets()` still uses `hasAnyPerson()` and counts all three assets.
+
+- [ ] **Step 7: Implement minimal user-person AND for timeline bucket counts**
+
+In `server/src/repositories/asset.repository.ts`, replace only the `getTimeBuckets()` person filter line:
+
+```ts
+.$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
+```
+
+- [ ] **Step 8: Run Task 1 tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected person"
+```
+
+Expected: PASS for both user-person AND tests.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```bash
+git add server/test/medium/specs/repositories/asset.repository.spec.ts server/src/repositories/asset.repository.ts
+git commit -m "fix(server): require all selected people in timeline buckets"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 2: Space-Person And Identity Timeline Filters Require Every Selected ID
+
+**Files:**
+
+- Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
+- Modify: `server/src/utils/database.ts`
+- Modify: `server/src/repositories/asset.repository.ts`
+
+- [ ] **Step 1: Write the failing space-person AND test**
+
+In `server/test/medium/specs/repositories/asset.repository.spec.ts`, add this test in the `people filters use AND semantics` block:
+
+```ts
+it('requires every selected space person for time bucket assets', async () => {
+  const { ctx, sut } = setup();
+  const sharedSpaceRepo = ctx.get(SharedSpaceRepository);
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({ user: { id: user.id } });
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  const bucketDate = new Date('2026-03-15T12:00:00.000Z');
+
+  const aliceOnly = await createTimelineAssetWithPeople(ctx, user.id, [], bucketDate);
+  const bobOnly = await createTimelineAssetWithPeople(ctx, user.id, [], bucketDate);
+  const both = await createTimelineAssetWithPeople(ctx, user.id, [], bucketDate);
+
+  const { assetFace: aliceOnlyFace } = await ctx.newAssetFace({ assetId: aliceOnly.id, isVisible: true });
+  const { assetFace: bobOnlyFace } = await ctx.newAssetFace({ assetId: bobOnly.id, isVisible: true });
+  const { assetFace: bothAliceFace } = await ctx.newAssetFace({ assetId: both.id, isVisible: true });
+  const { assetFace: bothBobFace } = await ctx.newAssetFace({ assetId: both.id, isVisible: true });
+
+  const alice = await sharedSpaceRepo.createPerson({
+    spaceId: space.id,
+    name: 'Alice',
+    representativeFaceId: aliceOnlyFace.id,
+    type: 'person',
+  });
+  const bob = await sharedSpaceRepo.createPerson({
+    spaceId: space.id,
+    name: 'Bob',
+    representativeFaceId: bobOnlyFace.id,
+    type: 'person',
+  });
+  await sharedSpaceRepo.addPersonFaces(
+    [
+      { personId: alice.id, assetFaceId: aliceOnlyFace.id },
+      { personId: bob.id, assetFaceId: bobOnlyFace.id },
+      { personId: alice.id, assetFaceId: bothAliceFace.id },
+      { personId: bob.id, assetFaceId: bothBobFace.id },
+    ],
+    { skipRecount: true },
+  );
+
+  const bucket = await sut.getTimeBucket(
+    '2026-03-01',
+    {
+      userIds: [user.id],
+      spacePersonIds: [alice.id, bob.id],
+      visibility: AssetVisibility.Timeline,
+    },
+    auth,
+  );
+
+  const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+  expect(assets.id).toEqual([both.id]);
+});
+```
+
+- [ ] **Step 2: Run the failing space-person test**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected space person for time bucket assets"
+```
+
+Expected: FAIL because `hasAnySpacePerson()` returns all assets that contain Alice or Bob.
+
+- [ ] **Step 3: Implement `hasSpacePeople()` and use it in `getTimeBucket()`**
+
+In `server/src/utils/database.ts`, add this helper after `hasAnySpacePerson()`:
+
+```ts
+export function hasSpacePeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spacePersonIds: string[]) {
+  if (spacePersonIds.length === 0) {
+    return qb;
+  }
+
+  return qb.where((eb) =>
+    eb.and(
+      spacePersonIds.map((spacePersonId) =>
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face')
+            .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('shared_space_person_face.personId', '=', asUuid(spacePersonId)),
+        ),
+      ),
+    ),
+  );
+}
+```
+
+In `server/src/repositories/asset.repository.ts`, import `hasSpacePeople` from `src/utils/database`, then replace only the `getTimeBucket()` space-person filter:
+
+```ts
+.$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
+```
+
+- [ ] **Step 4: Run the space-person test again**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected space person for time bucket assets"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing identity AND test**
+
+Add this test in the same `people filters use AND semantics` block:
+
+```ts
+it('requires every selected identity for time bucket assets', async () => {
+  const { ctx, sut } = setup();
+  const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({ user: { id: user.id } });
+  const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+  const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+  const aliceIdentity = await faceIdentityRepository.ensurePersonIdentity(alice.id);
+  const bobIdentity = await faceIdentityRepository.ensurePersonIdentity(bob.id);
+
+  const aliceOnly = await createTimelineAssetWithPeople(ctx, user.id, [], new Date('2026-03-15T12:00:00.000Z'));
+  const bobOnly = await createTimelineAssetWithPeople(ctx, user.id, [], new Date('2026-03-15T12:00:00.000Z'));
+  const both = await createTimelineAssetWithPeople(ctx, user.id, [], new Date('2026-03-15T12:00:00.000Z'));
+
+  const { assetFace: aliceOnlyFace } = await ctx.newAssetFace({ assetId: aliceOnly.id, personId: alice.id });
+  const { assetFace: bobOnlyFace } = await ctx.newAssetFace({ assetId: bobOnly.id, personId: bob.id });
+  const { assetFace: bothAliceFace } = await ctx.newAssetFace({ assetId: both.id, personId: alice.id });
+  const { assetFace: bothBobFace } = await ctx.newAssetFace({ assetId: both.id, personId: bob.id });
+
+  await faceIdentityRepository.linkFace({
+    assetFaceId: aliceOnlyFace.id,
+    identityId: aliceIdentity.id,
+    source: 'manual',
+  });
+  await faceIdentityRepository.linkFace({ assetFaceId: bobOnlyFace.id, identityId: bobIdentity.id, source: 'manual' });
+  await faceIdentityRepository.linkFace({ assetFaceId: bothAliceFace.id, identityId: aliceIdentity.id, source: 'manual' });
+  await faceIdentityRepository.linkFace({ assetFaceId: bothBobFace.id, identityId: bobIdentity.id, source: 'manual' });
+
+  const bucket = await sut.getTimeBucket(
+    '2026-03-01',
+    {
+      userIds: [user.id],
+      identityIds: [aliceIdentity.id, bobIdentity.id],
+      visibility: AssetVisibility.Timeline,
+    },
+    auth,
+  );
+
+  const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+  expect(assets.id).toEqual([both.id]);
+});
+```
+
+- [ ] **Step 6: Run the failing identity test**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "requires every selected identity for time bucket assets"
+```
+
+Expected: FAIL because `hasAnyFaceIdentity()` returns all assets linked to Alice or Bob.
+
+- [ ] **Step 7: Use AND identity and space-person helpers in both timeline queries**
+
+In `server/src/repositories/asset.repository.ts`, remove unused imports `hasAnyFaceIdentity`, `hasAnyPerson`, and `hasAnySpacePerson` if they are no longer used. Import `hasFaceIdentities`, `hasPeople`, and `hasSpacePeople`.
+
+Replace the people-related filter lines in both `getTimeBuckets()` and `getTimeBucket()` with:
+
+```ts
+.$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
+.$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
+.$if(!!options.identityIds?.length, (qb) => hasFaceIdentities(qb, options.identityIds!))
+```
+
+- [ ] **Step 8: Run Task 2 tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "people filters use AND semantics|spacePersonIds"
+```
+
+Expected: PASS. Existing single-space-person hidden/deleted test must still pass.
+
+- [ ] **Step 9: Commit Task 2**
+
+Run:
+
+```bash
+git add server/test/medium/specs/repositories/asset.repository.spec.ts server/src/repositories/asset.repository.ts server/src/utils/database.ts
+git commit -m "fix(server): require all selected scoped people in timeline buckets"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 3: Normalize Duplicate People IDs And Preserve Visible-Face Edge Cases
+
+**Files:**
+
+- Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
+- Modify: `server/src/utils/database.ts`
+
+- [ ] **Step 1: Write duplicate-ID tests for every people filter ID type**
+
+Add these tests in `people filters use AND semantics`:
+
+```ts
+it('treats duplicate selected person ids as one selected person', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({ user: { id: user.id } });
+  const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+  const asset = await createTimelineAssetWithPeople(ctx, user.id, [alice.id]);
+
+  const bucket = await sut.getTimeBucket(
+    '2026-03-01',
+    {
+      userIds: [user.id],
+      personIds: [alice.id, alice.id],
+      visibility: AssetVisibility.Timeline,
+    },
+    auth,
+  );
+
+  const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+  expect(assets.id).toEqual([asset.id]);
+});
+
+it('treats duplicate selected identity ids as one selected identity', async () => {
+  const { ctx, sut } = setup();
+  const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({ user: { id: user.id } });
+  const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+  const identity = await faceIdentityRepository.ensurePersonIdentity(alice.id);
+  const asset = await createTimelineAssetWithPeople(ctx, user.id, []);
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: alice.id, isVisible: true });
+  await faceIdentityRepository.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'manual' });
+
+  const bucket = await sut.getTimeBucket(
+    '2026-03-01',
+    {
+      userIds: [user.id],
+      identityIds: [identity.id, identity.id],
+      visibility: AssetVisibility.Timeline,
+    },
+    auth,
+  );
+
+  const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+  expect(assets.id).toEqual([asset.id]);
+});
+
+it('treats duplicate selected space person ids as one selected space person', async () => {
+  const { ctx, sut } = setup();
+  const sharedSpaceRepo = ctx.get(SharedSpaceRepository);
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({ user: { id: user.id } });
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  const asset = await createTimelineAssetWithPeople(ctx, user.id, []);
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, isVisible: true });
+  const alice = await sharedSpaceRepo.createPerson({
+    spaceId: space.id,
+    name: 'Alice',
+    representativeFaceId: assetFace.id,
+    type: 'person',
+  });
+  await sharedSpaceRepo.addPersonFaces([{ personId: alice.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+  const bucket = await sut.getTimeBucket(
+    '2026-03-01',
+    {
+      userIds: [user.id],
+      spacePersonIds: [alice.id, alice.id],
+      visibility: AssetVisibility.Timeline,
+    },
+    auth,
+  );
+
+  const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+  expect(assets.id).toEqual([asset.id]);
+});
+```
+
+- [ ] **Step 2: Run the duplicate-ID tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "treats duplicate selected .* ids as one selected"
+```
+
+Expected: FAIL after Tasks 1 and 2 because `hasPeople()` compares `count(distinct personId)` to the raw array length and `hasFaceIdentities()` compares `count(distinct identityId)` to the raw array length, so duplicate person and identity IDs become impossible. The space-person duplicate test may already pass because repeated `EXISTS` predicates are logically equivalent, but it remains required coverage.
+
+- [ ] **Step 3: Normalize IDs in people helpers**
+
+In `server/src/utils/database.ts`, add this helper near `anyUuid`:
+
+```ts
+const uniqueTruthyIds = (ids: string[] = []) => [...new Set(ids.filter(Boolean))];
+```
+
+Update `hasPeople()`, `hasAnyPerson()`, `hasFaceIdentities()`, `hasAnyFaceIdentity()`, `hasSpacePeople()`, and `hasAnySpacePerson()` to normalize first. `hasPeople()` must have this final shape:
+
+```ts
+export function hasPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, personIds: string[]) {
+  const ids = uniqueTruthyIds(personIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
+  return qb.innerJoin(
+    (eb) =>
+      eb
+        .selectFrom('asset_face')
+        .select('assetId')
+        .where('personId', '=', anyUuid(ids))
+        .where('deletedAt', 'is', null)
+        .where('isVisible', 'is', true)
+        .groupBy('assetId')
+        .having((eb) => eb.fn.count('personId').distinct(), '=', ids.length)
+        .as('has_people'),
+    (join) => join.onRef('has_people.assetId', '=', 'asset.id'),
+  );
+}
+```
+
+Make these exact edits in each remaining helper:
+
+1. In `hasAnyPerson()`, add `const ids = uniqueTruthyIds(personIds);` as the first statement.
+2. In `hasFaceIdentities()` and `hasAnyFaceIdentity()`, add `const ids = uniqueTruthyIds(identityIds);` as the first statement.
+3. In `hasSpacePeople()` and `hasAnySpacePerson()`, add `const ids = uniqueTruthyIds(spacePersonIds);` as the first statement.
+4. Add `if (ids.length === 0) { return qb; }` immediately after it.
+5. In `hasAnyPerson()`, replace `anyUuid(personIds)` with `anyUuid(ids)`.
+6. In `hasFaceIdentities()` and `hasAnyFaceIdentity()`, replace `anyUuid(identityIds)` with `anyUuid(ids)`.
+7. In `hasAnySpacePerson()`, replace `anyUuid(spacePersonIds)` with `anyUuid(ids)`.
+8. In `hasSpacePeople()`, iterate over `ids` instead of `spacePersonIds`.
+9. Replace the `hasFaceIdentities()` count comparison with `.having((eb) => eb.fn.count('face_identity_face.identityId').distinct(), '=', ids.length)`.
+
+- [ ] **Step 4: Run duplicate-ID tests again**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "treats duplicate selected .* ids as one selected"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add multiple-faces-same-person coverage**
+
+Add this test in `people filters use AND semantics`:
+
+```ts
+it('counts multiple visible faces for the same person as one selected person', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({ user: { id: user.id } });
+  const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+  const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+  const asset = await createTimelineAssetWithPeople(ctx, user.id, [alice.id, alice.id, bob.id]);
+
+  const bucket = await sut.getTimeBucket(
+    '2026-03-01',
+    {
+      userIds: [user.id],
+      personIds: [alice.id, bob.id],
+      visibility: AssetVisibility.Timeline,
+    },
+    auth,
+  );
+
+  const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+  expect(assets.id).toEqual([asset.id]);
+});
+```
+
+- [ ] **Step 6: Run all Task 3 tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "duplicate selected .* ids|multiple visible faces"
+```
+
+Expected: PASS. If the multiple-face test passes immediately, keep it as edge coverage.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add server/test/medium/specs/repositories/asset.repository.spec.ts server/src/utils/database.ts
+git commit -m "fix(server): normalize duplicate people filters"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 4: Search Builders Use AND By Default And Preserve Explicit OR
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.spec.ts`
+- Modify: `server/src/utils/database.ts`
+- Modify: `server/src/repositories/search.repository.ts`
+
+- [ ] **Step 1: Write failing SQL-shape tests for search and suggestion builders**
+
+In `server/src/repositories/search.repository.spec.ts`, add these tests.
+
+In the existing `describe('smart facets query shape')` block:
+
+```ts
+it('space person filters emit one EXISTS per selected space person for smart facet totals', () => {
+  const sql = buildFacetFilteredIdsSql(sut, {
+    ...baseOptions,
+    spacePersonIds: [
+      '00000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000002',
+    ],
+  });
+
+  expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
+  expect(sql).not.toMatch(/"shared_space_person_face"\."personId"\s*=\s*any\(/i);
+});
+```
+
+In the existing `describe('filter suggestions query shape')` block:
+
+```ts
+it('global person suggestion filters require every selected person', () => {
+  const sql = compileFilteredAssetIds(sut, {
+    personIds: [
+      '00000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000002',
+    ],
+  });
+
+  expect(sql).toContain('"has_people"');
+  expect(sql).toMatch(/having count\(distinct "personId"\) = \$\d+/i);
+});
+
+it('space person suggestion filters require every selected space person', () => {
+  const sql = compileFilteredAssetIds(sut, {
+    spaceId: '11111111-1111-1111-1111-111111111111',
+    personIds: [
+      '00000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000002',
+    ],
+  });
+
+  expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
+  expect(sql).not.toMatch(/"shared_space_person_face"\."personId"\s*=\s*any\(/i);
+});
+```
+
+In a new `describe('searchAssetBuilder people semantics')` block:
+
+```ts
+it('uses AND semantics for space person filters by default', () => {
+  const sql = buildAssetSearchSql({
+    userIds: ['00000000-0000-0000-0000-000000000000'],
+    spacePersonIds: [
+      '00000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000002',
+    ],
+  });
+
+  expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
+  expect(sql).not.toMatch(/"shared_space_person_face"\."personId"\s*=\s*any\(/i);
+});
+
+it('keeps personMatchAny as OR for identity and space person filters', () => {
+  const sql = buildAssetSearchSql({
+    userIds: ['00000000-0000-0000-0000-000000000000'],
+    personMatchAny: true,
+    personIds: ['00000000-0000-0000-0000-000000000001'],
+    identityIds: ['00000000-0000-0000-0000-000000000002'],
+    spacePersonIds: ['00000000-0000-0000-0000-000000000003'],
+  });
+
+  expect(sql).toMatch(/\bor\b/i);
+  expect(sql).toContain('"face_identity_face"');
+  expect(sql).toContain('"shared_space_person_face"');
+  expect(sql).not.toContain('"has_face_identities"');
+  expect(sql).not.toContain('"has_people"');
+});
+
+it('does not apply people predicates for empty people arrays', () => {
+  const sql = buildAssetSearchSql({
+    userIds: ['00000000-0000-0000-0000-000000000000'],
+    personIds: [],
+    identityIds: [],
+    spacePersonIds: [],
+  });
+
+  expect(sql).not.toContain('"asset_face"');
+  expect(sql).not.toContain('"face_identity_face"');
+  expect(sql).not.toContain('"shared_space_person_face"');
+});
+
+it('keeps mixed people categories cumulative by default', () => {
+  const sql = buildAssetSearchSql({
+    userIds: ['00000000-0000-0000-0000-000000000000'],
+    personIds: ['00000000-0000-0000-0000-000000000001'],
+    identityIds: ['00000000-0000-0000-0000-000000000002'],
+    spacePersonIds: ['00000000-0000-0000-0000-000000000003'],
+  });
+
+  expect(sql).toContain('"has_people"');
+  expect(sql).toContain('"has_face_identities"');
+  expect(sql).toContain('"shared_space_person_face"');
+  expect(sql).not.toMatch(/\bor\b/i);
+});
+```
+
+- [ ] **Step 2: Run the failing SQL-shape tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "space person filters emit one EXISTS|global person suggestion filters require every selected person|space person suggestion filters require every selected space person|searchAssetBuilder people semantics|empty people arrays|mixed people categories"
+```
+
+Expected: FAIL because current builders use `any(uuid[])` for space-person suggestions/facets, global suggestions use OR-style `EXISTS`, and `personMatchAny` does not include identity filters in a shared OR predicate. The empty-array and mixed-category tests may already pass; keep them as edge coverage.
+
+- [ ] **Step 3: Add reusable AND/OR people filter helpers**
+
+In `server/src/utils/database.ts`, add this type and helper after the individual people helpers:
+
+```ts
+type PeopleFilterIds = {
+  personIds?: string[];
+  identityIds?: string[];
+  spacePersonIds?: string[];
+};
+
+export function hasAllPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, filters: PeopleFilterIds) {
+  const personIds = uniqueTruthyIds(filters.personIds);
+  const identityIds = uniqueTruthyIds(filters.identityIds);
+  const spacePersonIds = uniqueTruthyIds(filters.spacePersonIds);
+
+  return qb
+    .$if(personIds.length > 0, (qb) => hasPeople(qb, personIds))
+    .$if(identityIds.length > 0, (qb) => hasFaceIdentities(qb, identityIds))
+    .$if(spacePersonIds.length > 0, (qb) => hasSpacePeople(qb, spacePersonIds));
+}
+
+export function hasAnyPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, filters: PeopleFilterIds) {
+  const personIds = uniqueTruthyIds(filters.personIds);
+  const identityIds = uniqueTruthyIds(filters.identityIds);
+  const spacePersonIds = uniqueTruthyIds(filters.spacePersonIds);
+
+  if (personIds.length === 0 && identityIds.length === 0 && spacePersonIds.length === 0) {
+    return qb;
+  }
+
+  return qb.where((eb) => {
+    const predicates: ReturnType<typeof eb.exists>[] = [];
+
+    if (personIds.length > 0) {
+      predicates.push(
+        eb.exists(
+          eb
+            .selectFrom('asset_face')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('asset_face.personId', '=', anyUuid(personIds)),
+        ),
+      );
+    }
+
+    if (identityIds.length > 0) {
+      predicates.push(
+        eb.exists(
+          eb
+            .selectFrom('asset_face')
+            .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('face_identity_face.identityId', '=', anyUuid(identityIds)),
+        ),
+      );
+    }
+
+    if (spacePersonIds.length > 0) {
+      predicates.push(
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face')
+            .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('shared_space_person_face.personId', '=', anyUuid(spacePersonIds)),
+        ),
+      );
+    }
+
+    return eb.or(predicates);
+  });
+}
+```
+
+- [ ] **Step 4: Use helpers in `searchAssetBuilder()`**
+
+In `server/src/utils/database.ts`, remove these separate people filter calls from `searchAssetBuilder()`:
+
+```ts
+.$if(!!options.spacePersonIds?.length, (qb) => hasAnySpacePerson(qb, options.spacePersonIds!))
+.$if(!!options.personIds && options.personIds.length > 0, (qb) =>
+  options.personMatchAny ? hasAnyPerson(qb, options.personIds!) : hasPeople(qb, options.personIds!),
+)
+.$if(!!options.identityIds && options.identityIds.length > 0, (qb) => hasFaceIdentities(qb, options.identityIds!))
+```
+
+Insert this combined people filter call in the same position where those removed filters were applied:
+
+```ts
+.$if(
+  !!options.personIds?.length || !!options.identityIds?.length || !!options.spacePersonIds?.length,
+  (qb) =>
+    options.personMatchAny
+      ? hasAnyPeople(qb, {
+          personIds: options.personIds,
+          identityIds: options.identityIds,
+          spacePersonIds: options.spacePersonIds,
+        })
+      : hasAllPeople(qb, {
+          personIds: options.personIds,
+          identityIds: options.identityIds,
+          spacePersonIds: options.spacePersonIds,
+        }),
+)
+```
+
+- [ ] **Step 5: Use AND helpers in search repository filtered builders**
+
+In `server/src/repositories/search.repository.ts`, update the import list from `src/utils/database`:
+
+- Add `hasSpacePeople`.
+- Remove `hasAnySpacePerson` after the replacements below if no references remain.
+
+In `buildSmartFacetFilteredAssetIds()`, replace:
+
+```ts
+.$if(exclude !== 'people' && !!options.spacePersonIds?.length, (qb) =>
+  hasAnySpacePerson(qb, options.spacePersonIds!),
+)
+```
+
+with:
+
+```ts
+.$if(exclude !== 'people' && !!options.spacePersonIds?.length, (qb) =>
+  hasSpacePeople(qb, options.spacePersonIds!),
+)
+```
+
+In `buildFilteredAssetIds()`, replace the two `personIds` blocks:
+
+```ts
+.$if(!!options.personIds?.length && !!options.spaceId, (qb) =>
+  qb.where((eb) =>
+    eb.exists(
+      eb
+        .selectFrom('shared_space_person_face')
+        .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+        .whereRef('asset_face.assetId', '=', 'asset.id')
+        .where('asset_face.deletedAt', 'is', null)
+        .where('asset_face.isVisible', 'is', true)
+        .where('shared_space_person_face.personId', '=', anyUuid(options.personIds!)),
+    ),
+  ),
+)
+.$if(!!options.personIds?.length && !options.spaceId, (qb) =>
+  qb.where((eb) =>
+    eb.exists(
+      eb
+        .selectFrom('asset_face')
+        .whereRef('asset_face.assetId', '=', 'asset.id')
+        .where('asset_face.personId', '=', anyUuid(options.personIds!)),
+    ),
+  ),
+)
+```
+
+with:
+
+```ts
+.$if(!!options.personIds?.length && !!options.spaceId, (qb) => hasSpacePeople(qb, options.personIds!))
+.$if(!!options.personIds?.length && !options.spaceId, (qb) => hasPeople(qb, options.personIds!))
+```
+
+- [ ] **Step 6: Run Task 4 tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "space person filters emit one EXISTS|global person suggestion filters require every selected person|space person suggestion filters require every selected space person|searchAssetBuilder people semantics|empty people arrays|mixed people categories"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full search repository unit spec**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts
+```
+
+Expected: PASS. This protects smart-search ordering constraints and existing explicit `personMatchAny` tests.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add server/src/repositories/search.repository.spec.ts server/src/repositories/search.repository.ts server/src/utils/database.ts
+git commit -m "fix(server): align people filters in search builders"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 5: Service-Level Regression Coverage For Scoped Resolution And OR Preservation
+
+**Files:**
+
+- Modify: `server/src/services/search.service.spec.ts`
+- Modify only if a failing test proves it: `server/src/services/search.service.ts`
+- Modify only if a failing test proves it: `server/src/services/shared-space.service.ts`
+
+- [ ] **Step 1: Add duplicate-token normalization coverage for resolved scoped filters**
+
+In `server/src/services/search.service.spec.ts`, add this test in the `searchMetadata` describe block:
+
+```ts
+it('deduplicates resolved scoped person filters before repository search', async () => {
+  const token = `person:${newUuid()}`;
+  mocks.search.searchMetadata.mockResolvedValue({ hasNextPage: false, items: [] });
+  (mocks.faceIdentity as any).resolveScopedPersonTokens.mockResolvedValue({
+    identityIds: ['00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000010'],
+    legacyPersonIds: ['00000000-0000-4000-8000-000000000020', '00000000-0000-4000-8000-000000000020'],
+    legacySpacePersonIds: ['00000000-0000-4000-8000-000000000030', '00000000-0000-4000-8000-000000000030'],
+    hasInaccessibleToken: false,
+  });
+
+  await sut.searchMetadata(authStub.user1, { withSharedSpaces: true, personIds: [token, token] });
+
+  expect(mocks.search.searchMetadata).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      identityIds: ['00000000-0000-4000-8000-000000000010'],
+      personIds: ['00000000-0000-4000-8000-000000000020'],
+      spacePersonIds: ['00000000-0000-4000-8000-000000000030'],
+    }),
+  );
+});
+```
+
+- [ ] **Step 2: Run the service duplicate test**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/services/search.service.spec.ts -t "deduplicates resolved scoped person filters before repository search"
+```
+
+Expected: FAIL if service-layer resolved arrays are not deduplicated before reaching repositories. If it passes because repository-level normalization is enough and service already dedupes `spacePersonIds`, keep it as coverage only.
+
+- [ ] **Step 3: Implement only if the test fails semantically**
+
+If the test fails, update `resolveScopedPersonFilters()` in `server/src/services/search.service.ts`:
+
+```ts
+const unique = <T>(items: T[]) => [...new Set(items)];
+
+return {
+  ...dto,
+  personIds: unique(resolution.legacyPersonIds),
+  identityIds: unique(resolution.identityIds),
+  spacePersonIds: unique([...(dto.spacePersonIds ?? []), ...resolution.legacySpacePersonIds]),
+  forceEmptyResult: dto.forceEmptyResult || resolution.hasInaccessibleToken,
+};
+```
+
+If the test passes, do not edit production code.
+
+- [ ] **Step 4: Run search and shared-space service OR preservation tests**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/services/shared-space.service.spec.ts -t "personMatchAny"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/services/search.service.spec.ts -t "spacePersonIds|scoped person"
+```
+
+Expected: PASS. These tests ensure map marker callers still pass `personMatchAny: true` and search endpoints still reject invalid `spacePersonIds` combinations.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add server/src/services/search.service.spec.ts server/src/services/search.service.ts server/src/services/shared-space.service.ts
+git commit -m "test(server): cover scoped people filter normalization"
+```
+
+Expected: commit succeeds. If no production files changed, commit only the spec file.
+
+---
+
+## Task 6: Regenerate SQL Snapshots And Run Focused Verification
+
+**Files:**
+
+- Modify if generated output changes:
+  - `server/src/queries/asset.repository.sql`
+  - `server/src/queries/search.repository.sql`
+
+- [ ] **Step 1: Regenerate SQL snapshots**
+
+Run:
+
+```bash
+pnpm --filter immich run sync:sql
+```
+
+Expected: generated SQL files update if query decorators cover changed methods. If the command reports no changes, continue.
+
+- [ ] **Step 2: Inspect generated SQL diffs**
+
+Run:
+
+```bash
+git diff -- server/src/queries/asset.repository.sql server/src/queries/search.repository.sql
+```
+
+Expected: any diff reflects AND semantics for people filters. Reject unrelated query churn.
+
+- [ ] **Step 3: Run focused unit verification**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts src/services/timeline.service.spec.ts src/services/search.service.spec.ts src/services/shared-space.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run focused medium verification**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts test/medium/specs/services/people-identity-rbac.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck or server check if SQL/code changes touched shared helpers**
+
+Run:
+
+```bash
+pnpm --filter immich run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit generated SQL and any final fixes**
+
+Run:
+
+```bash
+git status --short
+git add server/src/queries/asset.repository.sql server/src/queries/search.repository.sql
+git commit -m "chore(server): update people filter SQL snapshots"
+```
+
+Expected: commit succeeds if generated SQL changed. If no generated SQL changed, skip this commit.
+
+---
+
+## Task 7: Final Branch Verification
+
+**Files:**
+
+- No edits unless verification exposes a bug.
+
+- [ ] **Step 1: Run full server unit suite**
+
+Run:
+
+```bash
+pnpm --filter immich test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run all touched medium specs**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts test/medium/specs/services/people-identity-rbac.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review final diff**
+
+Run:
+
+```bash
+git diff main...HEAD -- server/src/utils/database.ts server/src/repositories/asset.repository.ts server/src/repositories/search.repository.ts server/test/medium/specs/repositories/asset.repository.spec.ts server/src/repositories/search.repository.spec.ts server/src/services/search.service.spec.ts docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
+```
+
+Expected: diff matches the spec. There are no DTO, OpenAPI, SDK, or web changes.
+
+- [ ] **Step 4: Confirm clean worktree**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted changes.
+
+---
+
+## Self-Review Notes
+
+Spec coverage:
+
+- Default AND semantics: Tasks 1, 2, and 4.
+- Explicit OR preservation: Task 4 and Task 5.
+- Legacy user-person IDs: Task 1.
+- Identity IDs: Task 2 and Task 4.
+- Shared-space person IDs: Task 2 and Task 4.
+- Duplicate IDs: Task 3 and Task 5.
+- Empty people arrays: Task 4.
+- Hidden/deleted faces: existing medium test is preserved and rerun in Task 2.
+- Mixed resolved categories: Task 4 default cumulative SQL test, Task 4 OR helper, and Task 5 service coverage.
+- No API/UI changes: file list and final diff check in Task 7.
+- Generated SQL consistency: Task 6.
+
+Completeness scan: every production change above has concrete snippets and commands.
+
+Type consistency: all new test snippets use existing `setup()`, `factory`, `AssetVisibility`, `SharedSpaceRepository`, `FaceIdentityRepository`, and `TimeBucketAssets` already present in `asset.repository.spec.ts`.

--- a/docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
+++ b/docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
@@ -419,7 +419,11 @@ it('requires every selected identity for time bucket assets', async () => {
     source: 'manual',
   });
   await faceIdentityRepository.linkFace({ assetFaceId: bobOnlyFace.id, identityId: bobIdentity.id, source: 'manual' });
-  await faceIdentityRepository.linkFace({ assetFaceId: bothAliceFace.id, identityId: aliceIdentity.id, source: 'manual' });
+  await faceIdentityRepository.linkFace({
+    assetFaceId: bothAliceFace.id,
+    identityId: aliceIdentity.id,
+    source: 'manual',
+  });
   await faceIdentityRepository.linkFace({ assetFaceId: bothBobFace.id, identityId: bobIdentity.id, source: 'manual' });
 
   const bucket = await sut.getTimeBucket(
@@ -721,10 +725,7 @@ In the existing `describe('smart facets query shape')` block:
 it('space person filters emit one EXISTS per selected space person for smart facet totals', () => {
   const sql = buildFacetFilteredIdsSql(sut, {
     ...baseOptions,
-    spacePersonIds: [
-      '00000000-0000-0000-0000-000000000001',
-      '00000000-0000-0000-0000-000000000002',
-    ],
+    spacePersonIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
   });
 
   expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
@@ -737,10 +738,7 @@ In the existing `describe('filter suggestions query shape')` block:
 ```ts
 it('global person suggestion filters require every selected person', () => {
   const sql = compileFilteredAssetIds(sut, {
-    personIds: [
-      '00000000-0000-0000-0000-000000000001',
-      '00000000-0000-0000-0000-000000000002',
-    ],
+    personIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
   });
 
   expect(sql).toContain('"has_people"');
@@ -750,10 +748,7 @@ it('global person suggestion filters require every selected person', () => {
 it('space person suggestion filters require every selected space person', () => {
   const sql = compileFilteredAssetIds(sut, {
     spaceId: '11111111-1111-1111-1111-111111111111',
-    personIds: [
-      '00000000-0000-0000-0000-000000000001',
-      '00000000-0000-0000-0000-000000000002',
-    ],
+    personIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
   });
 
   expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
@@ -767,10 +762,7 @@ In a new `describe('searchAssetBuilder people semantics')` block:
 it('uses AND semantics for space person filters by default', () => {
   const sql = buildAssetSearchSql({
     userIds: ['00000000-0000-0000-0000-000000000000'],
-    spacePersonIds: [
-      '00000000-0000-0000-0000-000000000001',
-      '00000000-0000-0000-0000-000000000002',
-    ],
+    spacePersonIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
   });
 
   expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);

--- a/docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
+++ b/docs/superpowers/plans/2026-05-25-people-search-and-bugfix.md
@@ -90,7 +90,7 @@ Expected: all selected medium specs pass before new tests are added.
 
 - [ ] **Step 1: Write the failing `getTimeBucket()` user-person test**
 
-In `server/test/medium/specs/repositories/asset.repository.spec.ts`, inside the top-level `describe(AssetRepository.name)` block, add this helper near `interface TimeBucketAssets`:
+In `server/test/medium/specs/repositories/asset.repository.spec.ts`, add this module-scope helper near `interface TimeBucketAssets` and `setup()`:
 
 ```ts
 const createTimelineAssetWithPeople = async (
@@ -489,9 +489,9 @@ Expected: commit succeeds.
 - Modify: `server/test/medium/specs/repositories/asset.repository.spec.ts`
 - Modify: `server/src/utils/database.ts`
 
-- [ ] **Step 1: Write duplicate-ID tests for every people filter ID type**
+- [ ] **Step 1: Write the failing duplicate user-person ID test**
 
-Add these tests in `people filters use AND semantics`:
+Add this test in `people filters use AND semantics`:
 
 ```ts
 it('treats duplicate selected person ids as one selected person', async () => {
@@ -514,7 +514,78 @@ it('treats duplicate selected person ids as one selected person', async () => {
   const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
   expect(assets.id).toEqual([asset.id]);
 });
+```
 
+- [ ] **Step 2: Run the duplicate user-person ID test**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "treats duplicate selected person ids as one selected person"
+```
+
+Expected: FAIL after Tasks 1 and 2 because `hasPeople()` compares `count(distinct personId)` to the raw array length, so duplicate person IDs become impossible.
+
+- [ ] **Step 3: Normalize IDs in people helpers**
+
+In `server/src/utils/database.ts`, add this helper near `anyUuid`:
+
+```ts
+const uniqueTruthyIds = (ids: string[] = []) => [...new Set(ids.filter(Boolean))];
+```
+
+Update `hasPeople()`, `hasAnyPerson()`, `hasFaceIdentities()`, `hasAnyFaceIdentity()`, `hasSpacePeople()`, and `hasAnySpacePerson()` to normalize first. `hasPeople()` must have this final shape:
+
+```ts
+export function hasPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, personIds: string[]) {
+  const ids = uniqueTruthyIds(personIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
+  return qb.innerJoin(
+    (eb) =>
+      eb
+        .selectFrom('asset_face')
+        .select('assetId')
+        .where('personId', '=', anyUuid(ids))
+        .where('deletedAt', 'is', null)
+        .where('isVisible', 'is', true)
+        .groupBy('assetId')
+        .having((eb) => eb.fn.count('personId').distinct(), '=', ids.length)
+        .as('has_people'),
+    (join) => join.onRef('has_people.assetId', '=', 'asset.id'),
+  );
+}
+```
+
+Make these exact edits in each remaining helper:
+
+1. In `hasAnyPerson()`, add `const ids = uniqueTruthyIds(personIds);` as the first statement.
+2. In `hasFaceIdentities()` and `hasAnyFaceIdentity()`, add `const ids = uniqueTruthyIds(identityIds);` as the first statement.
+3. In `hasSpacePeople()` and `hasAnySpacePerson()`, add `const ids = uniqueTruthyIds(spacePersonIds);` as the first statement.
+4. Add `if (ids.length === 0) { return qb; }` immediately after it.
+5. In `hasAnyPerson()`, replace `anyUuid(personIds)` with `anyUuid(ids)`.
+6. In `hasFaceIdentities()` and `hasAnyFaceIdentity()`, replace `anyUuid(identityIds)` with `anyUuid(ids)`.
+7. In `hasAnySpacePerson()`, replace `anyUuid(spacePersonIds)` with `anyUuid(ids)`.
+8. In `hasSpacePeople()`, iterate over `ids` instead of `spacePersonIds`.
+9. Replace the `hasFaceIdentities()` count comparison with `.having((eb) => eb.fn.count('face_identity_face.identityId').distinct(), '=', ids.length)`.
+
+- [ ] **Step 4: Run the duplicate user-person ID test again**
+
+Run:
+
+```bash
+pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "treats duplicate selected person ids as one selected person"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add identity and space-person duplicate-ID regression coverage**
+
+Add these tests in `people filters use AND semantics`:
+
+```ts
 it('treats duplicate selected identity ids as one selected identity', async () => {
   const { ctx, sut } = setup();
   const faceIdentityRepository = ctx.get(FaceIdentityRepository);
@@ -571,62 +642,7 @@ it('treats duplicate selected space person ids as one selected space person', as
 });
 ```
 
-- [ ] **Step 2: Run the duplicate-ID tests**
-
-Run:
-
-```bash
-pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts -t "treats duplicate selected .* ids as one selected"
-```
-
-Expected: FAIL after Tasks 1 and 2 because `hasPeople()` compares `count(distinct personId)` to the raw array length and `hasFaceIdentities()` compares `count(distinct identityId)` to the raw array length, so duplicate person and identity IDs become impossible. The space-person duplicate test may already pass because repeated `EXISTS` predicates are logically equivalent, but it remains required coverage.
-
-- [ ] **Step 3: Normalize IDs in people helpers**
-
-In `server/src/utils/database.ts`, add this helper near `anyUuid`:
-
-```ts
-const uniqueTruthyIds = (ids: string[] = []) => [...new Set(ids.filter(Boolean))];
-```
-
-Update `hasPeople()`, `hasAnyPerson()`, `hasFaceIdentities()`, `hasAnyFaceIdentity()`, `hasSpacePeople()`, and `hasAnySpacePerson()` to normalize first. `hasPeople()` must have this final shape:
-
-```ts
-export function hasPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, personIds: string[]) {
-  const ids = uniqueTruthyIds(personIds);
-  if (ids.length === 0) {
-    return qb;
-  }
-
-  return qb.innerJoin(
-    (eb) =>
-      eb
-        .selectFrom('asset_face')
-        .select('assetId')
-        .where('personId', '=', anyUuid(ids))
-        .where('deletedAt', 'is', null)
-        .where('isVisible', 'is', true)
-        .groupBy('assetId')
-        .having((eb) => eb.fn.count('personId').distinct(), '=', ids.length)
-        .as('has_people'),
-    (join) => join.onRef('has_people.assetId', '=', 'asset.id'),
-  );
-}
-```
-
-Make these exact edits in each remaining helper:
-
-1. In `hasAnyPerson()`, add `const ids = uniqueTruthyIds(personIds);` as the first statement.
-2. In `hasFaceIdentities()` and `hasAnyFaceIdentity()`, add `const ids = uniqueTruthyIds(identityIds);` as the first statement.
-3. In `hasSpacePeople()` and `hasAnySpacePerson()`, add `const ids = uniqueTruthyIds(spacePersonIds);` as the first statement.
-4. Add `if (ids.length === 0) { return qb; }` immediately after it.
-5. In `hasAnyPerson()`, replace `anyUuid(personIds)` with `anyUuid(ids)`.
-6. In `hasFaceIdentities()` and `hasAnyFaceIdentity()`, replace `anyUuid(identityIds)` with `anyUuid(ids)`.
-7. In `hasAnySpacePerson()`, replace `anyUuid(spacePersonIds)` with `anyUuid(ids)`.
-8. In `hasSpacePeople()`, iterate over `ids` instead of `spacePersonIds`.
-9. Replace the `hasFaceIdentities()` count comparison with `.having((eb) => eb.fn.count('face_identity_face.identityId').distinct(), '=', ids.length)`.
-
-- [ ] **Step 4: Run duplicate-ID tests again**
+- [ ] **Step 6: Run duplicate-ID regression tests**
 
 Run:
 
@@ -636,7 +652,7 @@ pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test
 
 Expected: PASS.
 
-- [ ] **Step 5: Add multiple-faces-same-person coverage**
+- [ ] **Step 7: Add multiple-faces-same-person coverage**
 
 Add this test in `people filters use AND semantics`:
 
@@ -664,7 +680,7 @@ it('counts multiple visible faces for the same person as one selected person', a
 });
 ```
 
-- [ ] **Step 6: Run all Task 3 tests**
+- [ ] **Step 8: Run all Task 3 tests**
 
 Run:
 
@@ -674,7 +690,7 @@ pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test
 
 Expected: PASS. If the multiple-face test passes immediately, keep it as edge coverage.
 
-- [ ] **Step 7: Commit Task 3**
+- [ ] **Step 9: Commit Task 3**
 
 Run:
 
@@ -695,9 +711,9 @@ Expected: commit succeeds.
 - Modify: `server/src/utils/database.ts`
 - Modify: `server/src/repositories/search.repository.ts`
 
-- [ ] **Step 1: Write failing SQL-shape tests for search and suggestion builders**
+- [ ] **Step 1: Write SQL-shape tests for search and suggestion builders one at a time**
 
-In `server/src/repositories/search.repository.spec.ts`, add these tests.
+In `server/src/repositories/search.repository.spec.ts`, use the tests below as a queue. Add only one test, run it by exact title, make the smallest corresponding production change from Steps 3-5, rerun that same title, and then move to the next test. Do not paste the whole queue before seeing the first failing test.
 
 In the existing `describe('smart facets query shape')` block:
 
@@ -805,15 +821,21 @@ it('keeps mixed people categories cumulative by default', () => {
 });
 ```
 
-- [ ] **Step 2: Run the failing SQL-shape tests**
+- [ ] **Step 2: Run each SQL-shape test at the red and green points**
 
-Run:
+Run each command when its matching test is added:
 
 ```bash
-pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "space person filters emit one EXISTS|global person suggestion filters require every selected person|space person suggestion filters require every selected space person|searchAssetBuilder people semantics|empty people arrays|mixed people categories"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "space person filters emit one EXISTS per selected space person for smart facet totals"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "global person suggestion filters require every selected person"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "space person suggestion filters require every selected space person"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "uses AND semantics for space person filters by default"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "keeps personMatchAny as OR for identity and space person filters"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "does not apply people predicates for empty people arrays"
+pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts -t "keeps mixed people categories cumulative by default"
 ```
 
-Expected: FAIL because current builders use `any(uuid[])` for space-person suggestions/facets, global suggestions use OR-style `EXISTS`, and `personMatchAny` does not include identity filters in a shared OR predicate. The empty-array and mixed-category tests may already pass; keep them as edge coverage.
+Expected red points: the smart facet, global suggestion, space suggestion, default space-person builder, and `personMatchAny` tests fail against current behavior. The empty-array and mixed-category tests may already pass; add them after the builder semantics are green and keep them as edge coverage.
 
 - [ ] **Step 3: Add reusable AND/OR people filter helpers**
 
@@ -847,7 +869,7 @@ export function hasAnyPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, filters:
   }
 
   return qb.where((eb) => {
-    const predicates: ReturnType<typeof eb.exists>[] = [];
+    const predicates: Expression<SqlBool>[] = [];
 
     if (personIds.length > 0) {
       predicates.push(
@@ -1033,6 +1055,7 @@ In `server/src/services/search.service.spec.ts`, add this test in the `searchMet
 ```ts
 it('deduplicates resolved scoped person filters before repository search', async () => {
   const token = `person:${newUuid()}`;
+  mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
   mocks.search.searchMetadata.mockResolvedValue({ hasNextPage: false, items: [] });
   (mocks.faceIdentity as any).resolveScopedPersonTokens.mockResolvedValue({
     identityIds: ['00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000010'],

--- a/docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md
+++ b/docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md
@@ -1,0 +1,108 @@
+# People Search AND Bugfix Design
+
+Status: pending written-spec review
+Date: 2026-05-25
+Worktree: `/Users/pierre/dev/gallery/.worktrees/issue-628-people-search-and`
+Branch: `fix/issue-628-people-search-and`
+Issue: https://github.com/open-noodle/gallery/issues/628
+
+## Problem
+
+When a user selects two or more people in Gallery search/filter flows, results can include assets containing any selected person. Issue #628 reports that Immich returns photos containing all selected people, while Gallery returns photos containing either selected person.
+
+This is a bugfix, not an OR/AND feature. The default meaning of multiple selected people should be "contains every selected person".
+
+## Goals
+
+- Make multi-person asset filtering use AND semantics by default.
+- Preserve the existing explicit OR escape hatch where code already passes `personMatchAny`.
+- Cover legacy user-person IDs, identity-group filters, and shared-space person filters.
+- Avoid API, URL, SDK, or UI changes.
+- Keep the fix server-side so every caller gets consistent behavior.
+
+## Non-Goals
+
+- Do not add a user-facing OR/AND toggle.
+- Do not add a new DTO field or query parameter.
+- Do not change tag, album, camera, location, rating, favorite, or media filters.
+- Do not refactor unrelated search or timeline code.
+
+## Current Behavior
+
+The search repository already has both semantics:
+
+- `hasPeople()` and `hasFaceIdentities()` require all selected people or identities.
+- `hasAnyPerson()` and `hasAnyFaceIdentity()` match any selected person or identity.
+- `searchAssetBuilder()` uses `personMatchAny` to choose OR, otherwise it uses AND for normal `personIds`.
+- Smart search also defaults to one visible-face `EXISTS` predicate per selected person unless `personMatchAny` is set.
+
+The inconsistent path is timeline browsing. `AssetRepository.getTimeBuckets()` and `AssetRepository.getTimeBucket()` currently use the OR helpers for `personIds`, `identityIds`, and `spacePersonIds`. That means URLs such as `/photos?people=a,b` can show timeline results containing either person.
+
+Shared-space person filters are also OR-only in the shared helper `hasAnySpacePerson()`, and `searchAssetBuilder()` currently applies that helper whenever `spacePersonIds` are present.
+
+## Design
+
+### Repository Semantics
+
+Default people filters should be AND:
+
+- `personIds`: use `hasPeople()`.
+- `identityIds`: use `hasFaceIdentities()`.
+- `spacePersonIds`: add and use a new `hasSpacePeople()` helper.
+
+`hasSpacePeople()` should mirror the existing `hasSpacePerson()` predicate for each selected shared-space person and combine those predicates with `AND`. This avoids relying on grouping across `shared_space_person_face` joins and keeps the intended semantics easy to read.
+
+Explicit OR should remain possible only through existing OR-specific helpers:
+
+- `personMatchAny` continues to select `hasAnyPerson()` in `searchAssetBuilder()`.
+- Existing callers that intentionally pass `personMatchAny: true` keep their behavior.
+
+There is no new public API flag.
+
+### Affected Query Paths
+
+Update these paths to use default AND semantics:
+
+- `searchAssetBuilder()` for `spacePersonIds`.
+- `AssetRepository.getTimeBuckets()` for `personIds`, `spacePersonIds`, and `identityIds`.
+- `AssetRepository.getTimeBucket()` for `personIds`, `spacePersonIds`, and `identityIds`.
+
+Metadata search and smart search already use AND for normal `personIds` and `identityIds`; they should be covered by regression tests, not redesigned.
+
+### Data Flow
+
+The frontend continues to serialize selected people as it does today:
+
+- Global photos filters put selected people in `personIds`.
+- Space pages pass selected space people as `spacePersonIds`.
+- Scoped tokens are resolved by service-layer logic into legacy person IDs, identity IDs, and/or space person IDs.
+
+After resolution reaches repositories, each selected people-related ID narrows the candidate asset set.
+
+### Error Handling
+
+No new error cases are introduced. Existing invalid-token, inaccessible-token, and empty-result behavior remains unchanged.
+
+If a selected scoped person token resolves to an inaccessible person, existing `forceEmptyResult` behavior still applies.
+
+### Testing
+
+Add focused tests that prove multi-person filters are AND:
+
+- Repository-level SQL shape tests for `getTimeBuckets()` and `getTimeBucket()` should no longer use `hasAnyPerson()`/`hasAnyFaceIdentity()` for default people filters.
+- Unit or medium tests should cover timeline filtering with two people where only assets containing both are returned.
+- Shared-space person filters should cover two selected space people and require both.
+- Existing tests for `personMatchAny` should continue proving explicit OR behavior.
+- Existing search repository tests for smart search and metadata search should continue passing.
+
+## Implementation Notes
+
+The likely implementation is small:
+
+1. Add `hasSpacePeople()` in `server/src/utils/database.ts`.
+2. Replace default timeline `hasAnyPerson()` calls with `hasPeople()`.
+3. Replace default timeline `hasAnyFaceIdentity()` calls with `hasFaceIdentities()`.
+4. Replace default `spacePersonIds` filters with `hasSpacePeople()`.
+5. Add tests around the changed paths.
+
+No generated OpenAPI or SDK updates are expected.

--- a/docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md
+++ b/docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md
@@ -120,18 +120,18 @@ Add focused tests in this order:
 
 Coverage must include these edge cases:
 
-| Edge Case | Expected Behavior |
-| --- | --- |
-| Empty or undefined people arrays | No people filter is applied. |
-| Single selected person | Same results as today for visible, non-deleted faces. |
-| Duplicate selected IDs | Deduplicate before applying AND. |
-| Multiple visible faces for the same person on one asset | Counts as satisfying that one selected person once. |
-| Hidden or deleted faces | Do not satisfy any people filter. |
-| One selected person has no visible matching face | Result set is empty unless another OR path was explicitly requested. |
-| Mixed `personIds`, `identityIds`, and `spacePersonIds` | Asset must satisfy every non-empty category by default. |
-| `personMatchAny: true` | Preserve intentional OR behavior for every people-related ID category in `searchAssetBuilder()` callers. |
-| Shared-space timeline opt-out or inaccessible token | Existing access filtering and `forceEmptyResult` behavior wins. |
-| Pagination, ordering, and bucket grouping | Existing order and grouping behavior stays unchanged after the narrower filter is applied. |
+| Edge Case                                               | Expected Behavior                                                                                        |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Empty or undefined people arrays                        | No people filter is applied.                                                                             |
+| Single selected person                                  | Same results as today for visible, non-deleted faces.                                                    |
+| Duplicate selected IDs                                  | Deduplicate before applying AND.                                                                         |
+| Multiple visible faces for the same person on one asset | Counts as satisfying that one selected person once.                                                      |
+| Hidden or deleted faces                                 | Do not satisfy any people filter.                                                                        |
+| One selected person has no visible matching face        | Result set is empty unless another OR path was explicitly requested.                                     |
+| Mixed `personIds`, `identityIds`, and `spacePersonIds`  | Asset must satisfy every non-empty category by default.                                                  |
+| `personMatchAny: true`                                  | Preserve intentional OR behavior for every people-related ID category in `searchAssetBuilder()` callers. |
+| Shared-space timeline opt-out or inaccessible token     | Existing access filtering and `forceEmptyResult` behavior wins.                                          |
+| Pagination, ordering, and bucket grouping               | Existing order and grouping behavior stays unchanged after the narrower filter is applied.               |
 
 Suggested verification commands:
 

--- a/docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md
+++ b/docs/superpowers/specs/2026-05-25-people-search-and-bugfix-design.md
@@ -1,6 +1,6 @@
 # People Search AND Bugfix Design
 
-Status: pending written-spec review
+Status: reviewed for TDD implementation planning; pending user approval
 Date: 2026-05-25
 Worktree: `/Users/pierre/dev/gallery/.worktrees/issue-628-people-search-and`
 Branch: `fix/issue-628-people-search-and`
@@ -36,9 +36,9 @@ The search repository already has both semantics:
 - `searchAssetBuilder()` uses `personMatchAny` to choose OR, otherwise it uses AND for normal `personIds`.
 - Smart search also defaults to one visible-face `EXISTS` predicate per selected person unless `personMatchAny` is set.
 
-The inconsistent path is timeline browsing. `AssetRepository.getTimeBuckets()` and `AssetRepository.getTimeBucket()` currently use the OR helpers for `personIds`, `identityIds`, and `spacePersonIds`. That means URLs such as `/photos?people=a,b` can show timeline results containing either person.
+The inconsistent result path is timeline browsing. `AssetRepository.getTimeBuckets()` and `AssetRepository.getTimeBucket()` currently use the OR helpers for `personIds`, `identityIds`, and `spacePersonIds`. That means URLs such as `/photos?people=a,b` can show timeline results containing either person.
 
-Shared-space person filters are also OR-only in the shared helper `hasAnySpacePerson()`, and `searchAssetBuilder()` currently applies that helper whenever `spacePersonIds` are present.
+Shared-space person filters are also OR-only in the shared helper `hasAnySpacePerson()`. `searchAssetBuilder()` and smart-search facet filtering currently apply that helper whenever `spacePersonIds` are present. Search/filter suggestion queries have their own filtered-asset builder and also need the same default semantics so counts and suggestions do not describe an OR-filtered result set.
 
 ## Design
 
@@ -50,11 +50,14 @@ Default people filters should be AND:
 - `identityIds`: use `hasFaceIdentities()`.
 - `spacePersonIds`: add and use a new `hasSpacePeople()` helper.
 
+Each people-related ID list should be normalized to unique, truthy IDs before applying AND helpers. This avoids the existing `count(distinct ...) = ids.length` pattern turning duplicate URL or typed-search IDs into an impossible filter.
+
 `hasSpacePeople()` should mirror the existing `hasSpacePerson()` predicate for each selected shared-space person and combine those predicates with `AND`. This avoids relying on grouping across `shared_space_person_face` joins and keeps the intended semantics easy to read.
 
 Explicit OR should remain possible only through existing OR-specific helpers:
 
-- `personMatchAny` continues to select `hasAnyPerson()` in `searchAssetBuilder()`.
+- `personMatchAny` continues to select OR matching in `searchAssetBuilder()`.
+- When `personMatchAny` is set, `personIds`, `identityIds`, and `spacePersonIds` should all use their OR helpers.
 - Existing callers that intentionally pass `personMatchAny: true` keep their behavior.
 
 There is no new public API flag.
@@ -63,11 +66,13 @@ There is no new public API flag.
 
 Update these paths to use default AND semantics:
 
-- `searchAssetBuilder()` for `spacePersonIds`.
+- `searchAssetBuilder()` for `spacePersonIds`, while preserving `personMatchAny` OR behavior for all people-related filters.
+- `SearchRepository.buildSmartFacetFilteredAssetIds()` for `spacePersonIds`.
+- `SearchRepository.buildFilteredAssetIds()` for filter/search suggestion queries that apply `personIds` in either global or space scope.
 - `AssetRepository.getTimeBuckets()` for `personIds`, `spacePersonIds`, and `identityIds`.
 - `AssetRepository.getTimeBucket()` for `personIds`, `spacePersonIds`, and `identityIds`.
 
-Metadata search and smart search already use AND for normal `personIds` and `identityIds`; they should be covered by regression tests, not redesigned.
+Metadata search and smart search already use AND for normal `personIds` and `identityIds`; they should be covered by regression tests and duplicate-ID normalization, not redesigned.
 
 ### Data Flow
 
@@ -79,30 +84,75 @@ The frontend continues to serialize selected people as it does today:
 
 After resolution reaches repositories, each selected people-related ID narrows the candidate asset set.
 
+Mixed resolved categories are cumulative. If a request resolves to `personIds`, `identityIds`, and `spacePersonIds`, an asset must satisfy every non-empty category unless the repository path was explicitly called with `personMatchAny`.
+
 ### Error Handling
 
 No new error cases are introduced. Existing invalid-token, inaccessible-token, and empty-result behavior remains unchanged.
 
 If a selected scoped person token resolves to an inaccessible person, existing `forceEmptyResult` behavior still applies.
 
+## TDD Requirements
+
+Implementation must follow red-green-refactor.
+
+1. Write one failing test for the next behavior.
+2. Run the narrow test command and confirm it fails for the expected OR-vs-AND reason.
+3. Implement the smallest production change that makes that test pass.
+4. Re-run the narrow test and keep it green.
+5. Repeat for the next edge case.
+
+Do not write production code for this bugfix before a failing test demonstrates the bug. Tests written after implementation are acceptable only as additional regression coverage, not as the first proof for a changed behavior.
+
 ### Testing
 
-Add focused tests that prove multi-person filters are AND:
+Add focused tests in this order:
 
-- Repository-level SQL shape tests for `getTimeBuckets()` and `getTimeBucket()` should no longer use `hasAnyPerson()`/`hasAnyFaceIdentity()` for default people filters.
-- Unit or medium tests should cover timeline filtering with two people where only assets containing both are returned.
-- Shared-space person filters should cover two selected space people and require both.
-- Existing tests for `personMatchAny` should continue proving explicit OR behavior.
-- Existing search repository tests for smart search and metadata search should continue passing.
+1. `AssetRepository.getTimeBucket()` with three assets: person A only, person B only, and A+B. Filtering by `[A, B]` must return only A+B. This should fail against the current OR implementation.
+2. `AssetRepository.getTimeBuckets()` with the same shape, using different bucket dates where useful, must count only assets that contain every selected person.
+3. `AssetRepository.getTimeBucket()` with two selected `spacePersonIds` must return only assets containing both space people.
+4. `AssetRepository.getTimeBucket()` with two selected `identityIds` must return only assets linked to both identities.
+5. `SearchRepository.buildSmartFacetFilteredAssetIds()` through `searchSmartFacets()` must apply selected `spacePersonIds` as AND so facet totals match result semantics.
+6. `SearchRepository.buildFilteredAssetIds()` through search/filter suggestion endpoints must apply selected people as AND in both global and space-scoped requests.
+7. Duplicate IDs such as `[A, A]` must behave like `[A]`, not as an impossible two-person filter.
+8. Existing explicit OR paths using `personMatchAny: true` must still return assets matching any selected `personIds`, `identityIds`, or `spacePersonIds`.
+9. Existing inaccessible scoped-token tests must continue returning empty results through `forceEmptyResult`.
+
+Coverage must include these edge cases:
+
+| Edge Case | Expected Behavior |
+| --- | --- |
+| Empty or undefined people arrays | No people filter is applied. |
+| Single selected person | Same results as today for visible, non-deleted faces. |
+| Duplicate selected IDs | Deduplicate before applying AND. |
+| Multiple visible faces for the same person on one asset | Counts as satisfying that one selected person once. |
+| Hidden or deleted faces | Do not satisfy any people filter. |
+| One selected person has no visible matching face | Result set is empty unless another OR path was explicitly requested. |
+| Mixed `personIds`, `identityIds`, and `spacePersonIds` | Asset must satisfy every non-empty category by default. |
+| `personMatchAny: true` | Preserve intentional OR behavior for every people-related ID category in `searchAssetBuilder()` callers. |
+| Shared-space timeline opt-out or inaccessible token | Existing access filtering and `forceEmptyResult` behavior wins. |
+| Pagination, ordering, and bucket grouping | Existing order and grouping behavior stays unchanged after the narrower filter is applied. |
+
+Suggested verification commands:
+
+```bash
+pnpm --filter immich test:medium -- asset.repository.spec.ts search.service.spec.ts people-identity-rbac.spec.ts
+pnpm --filter immich test -- search.repository.spec.ts timeline.service.spec.ts shared-space.service.spec.ts search.service.spec.ts
+```
+
+The exact narrow commands can be adjusted to match Vitest file filtering, but every new failing test must be run alone or in a small focused group before production code changes.
 
 ## Implementation Notes
 
 The likely implementation is small:
 
 1. Add `hasSpacePeople()` in `server/src/utils/database.ts`.
-2. Replace default timeline `hasAnyPerson()` calls with `hasPeople()`.
-3. Replace default timeline `hasAnyFaceIdentity()` calls with `hasFaceIdentities()`.
-4. Replace default `spacePersonIds` filters with `hasSpacePeople()`.
-5. Add tests around the changed paths.
+2. Normalize people-related ID arrays before count-based AND comparisons.
+3. Replace default timeline `hasAnyPerson()` calls with `hasPeople()`.
+4. Replace default timeline `hasAnyFaceIdentity()` calls with `hasFaceIdentities()`.
+5. Replace default `spacePersonIds` filters with `hasSpacePeople()`.
+6. Teach `searchAssetBuilder()` to honor `personMatchAny` for `identityIds` and `spacePersonIds`, preserving internal OR callers.
+7. Update smart-facet and suggestion filtering to use default AND semantics.
+8. Add the red-first tests listed above.
 
 No generated OpenAPI or SDK updates are expected.

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -173,7 +173,7 @@ from
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "shared_space_person_face"."personId" = any ($5::uuid[])
+          and "shared_space_person_face"."personId" = $5::uuid
       )
       and "asset"."fileCreatedAt" >= $6
       and "asset_exif"."lensModel" = $7

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -28,9 +28,9 @@ import { AssetTable } from 'src/schema/tables/asset.table';
 import {
   anyUuid,
   asUuid,
-  hasAnyFaceIdentity,
-  hasAnySpacePerson,
+  hasFaceIdentities,
   hasPeople,
+  hasSpacePeople,
   isStaleAssetForeignKeyConstraint,
   removeUndefinedKeys,
   truncatedDate,
@@ -947,8 +947,8 @@ export class AssetRepository {
             ),
           )
           .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
-          .$if(!!options.spacePersonIds?.length, (qb) => hasAnySpacePerson(qb, options.spacePersonIds!))
-          .$if(!!options.identityIds?.length, (qb) => hasAnyFaceIdentity(qb, options.identityIds!))
+          .$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
+          .$if(!!options.identityIds?.length, (qb) => hasFaceIdentities(qb, options.identityIds!))
           .$if(!!options.withStacked, (qb) =>
             qb
               .leftJoin('stack', (join) =>
@@ -1087,8 +1087,8 @@ export class AssetRepository {
             ),
           )
           .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
-          .$if(!!options.spacePersonIds?.length, (qb) => hasAnySpacePerson(qb, options.spacePersonIds!))
-          .$if(!!options.identityIds?.length, (qb) => hasAnyFaceIdentity(qb, options.identityIds!))
+          .$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
+          .$if(!!options.identityIds?.length, (qb) => hasFaceIdentities(qb, options.identityIds!))
           .$if(!!options.city, (qb) => qb.where('asset_exif.city', '=', options.city!))
           .$if(!!options.country, (qb) => qb.where('asset_exif.country', '=', options.country!))
           .$if(!!options.make, (qb) => qb.where('asset_exif.make', '=', options.make!))

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -29,8 +29,8 @@ import {
   anyUuid,
   asUuid,
   hasAnyFaceIdentity,
-  hasAnyPerson,
   hasAnySpacePerson,
+  hasPeople,
   isStaleAssetForeignKeyConstraint,
   removeUndefinedKeys,
   truncatedDate,
@@ -946,7 +946,7 @@ export class AssetRepository {
               ]),
             ),
           )
-          .$if(!!options.personIds?.length, (qb) => hasAnyPerson(qb, options.personIds!))
+          .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
           .$if(!!options.spacePersonIds?.length, (qb) => hasAnySpacePerson(qb, options.spacePersonIds!))
           .$if(!!options.identityIds?.length, (qb) => hasAnyFaceIdentity(qb, options.identityIds!))
           .$if(!!options.withStacked, (qb) =>
@@ -1086,7 +1086,7 @@ export class AssetRepository {
               ]),
             ),
           )
-          .$if(!!options.personIds?.length, (qb) => hasAnyPerson(qb, options.personIds!))
+          .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
           .$if(!!options.spacePersonIds?.length, (qb) => hasAnySpacePerson(qb, options.spacePersonIds!))
           .$if(!!options.identityIds?.length, (qb) => hasAnyFaceIdentity(qb, options.identityIds!))
           .$if(!!options.city, (qb) => qb.where('asset_exif.city', '=', options.city!))

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -210,6 +210,15 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"tag_asset"');
     });
 
+    it('space person filters emit one EXISTS per selected space person for smart facet totals', () => {
+      const sql = buildFacetFilteredIdsSql(sut, {
+        ...baseOptions,
+        spacePersonIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
+      });
+      expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
+      expect(sql).not.toMatch(/"shared_space_person_face"\."personId"\s*=\s*any\(/i);
+    });
+
     it('candidate query omits the distance threshold when maxDistance is disabled', () => {
       const sql = buildFacetCandidateSql(sut, { ...baseOptions, maxDistance: 0 });
 
@@ -408,6 +417,23 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"face_identity_face"."identityId"');
     });
 
+    it('global person suggestion filters require every selected person', () => {
+      const sql = compileFilteredAssetIds(sut, {
+        personIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
+      });
+      expect(sql).toContain('"has_people"');
+      expect(sql).toMatch(/having count\(distinct "personId"\) = \$\d+/i);
+    });
+
+    it('space person suggestion filters require every selected space person', () => {
+      const sql = compileFilteredAssetIds(sut, {
+        spaceId: '11111111-1111-1111-1111-111111111111',
+        personIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
+      });
+      expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
+      expect(sql).not.toMatch(/"shared_space_person_face"\."personId"\s*=\s*any\(/i);
+    });
+
     it('forceEmptyResult compiles to an impossible predicate', () => {
       const sql = compileFilteredAssetIds(sut, { forceEmptyResult: true });
 
@@ -508,6 +534,57 @@ describe(SearchRepository.name, () => {
       expect(sql).toMatch(/rating"?\s+is\s+null/i);
       expect(sql).not.toMatch(/rating"?\s*>=\s*\$\d+/i);
       expect(sql).not.toMatch(/rating"?\s*=\s*\$\d+/i);
+    });
+  });
+
+  describe('searchAssetBuilder people semantics', () => {
+    it('uses AND semantics for space person filters by default', () => {
+      const sql = buildAssetSearchSql({
+        userIds: ['00000000-0000-0000-0000-000000000000'],
+        spacePersonIds: ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002'],
+      });
+      expect(countMatches(sql, /exists\s*\(select\b[\s\S]+?from\s+"shared_space_person_face"/gi)).toBe(2);
+      expect(sql).not.toMatch(/"shared_space_person_face"\."personId"\s*=\s*any\(/i);
+    });
+
+    it('keeps personMatchAny as OR for identity and space person filters', () => {
+      const sql = buildAssetSearchSql({
+        userIds: ['00000000-0000-0000-0000-000000000000'],
+        personMatchAny: true,
+        personIds: ['00000000-0000-0000-0000-000000000001'],
+        identityIds: ['00000000-0000-0000-0000-000000000002'],
+        spacePersonIds: ['00000000-0000-0000-0000-000000000003'],
+      });
+      expect(sql).toMatch(/\bor\b/i);
+      expect(sql).toContain('"face_identity_face"');
+      expect(sql).toContain('"shared_space_person_face"');
+      expect(sql).not.toContain('"has_face_identities"');
+      expect(sql).not.toContain('"has_people"');
+    });
+
+    it('does not apply people predicates for empty people arrays', () => {
+      const sql = buildAssetSearchSql({
+        userIds: ['00000000-0000-0000-0000-000000000000'],
+        personIds: [],
+        identityIds: [],
+        spacePersonIds: [],
+      });
+      expect(sql).not.toContain('"asset_face"');
+      expect(sql).not.toContain('"face_identity_face"');
+      expect(sql).not.toContain('"shared_space_person_face"');
+    });
+
+    it('keeps mixed people categories cumulative by default', () => {
+      const sql = buildAssetSearchSql({
+        userIds: ['00000000-0000-0000-0000-000000000000'],
+        personIds: ['00000000-0000-0000-0000-000000000001'],
+        identityIds: ['00000000-0000-0000-0000-000000000002'],
+        spacePersonIds: ['00000000-0000-0000-0000-000000000003'],
+      });
+      expect(sql).toContain('"has_people"');
+      expect(sql).toContain('"has_face_identities"');
+      expect(sql).toContain('"shared_space_person_face"');
+      expect(sql).not.toMatch(/\bor\b/i);
     });
   });
 });

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -10,8 +10,8 @@ import { AssetExifTable } from 'src/schema/tables/asset-exif.table';
 import {
   anyUuid,
   asUuid,
-  hasAnySpacePerson,
   hasPeople,
+  hasSpacePeople,
   hasTags,
   searchAssetBuilder,
   truncatedDate,
@@ -674,7 +674,7 @@ export class SearchRepository {
         ),
       )
       .$if(exclude !== 'people' && !!options.spacePersonIds?.length, (qb) =>
-        hasAnySpacePerson(qb, options.spacePersonIds!),
+        hasSpacePeople(qb, options.spacePersonIds!),
       )
       .$if(exclude !== 'tags' && !!options.tagIds?.length, (qb) => hasTags(qb, options.tagIds!))
       .$if(exclude !== 'tags' && options.tagIds === null, (qb) =>
@@ -1315,29 +1315,8 @@ export class SearchRepository {
           .$if(!!options.model, (qb) => qb.where('asset_exif.model', '=', options.model!))
           .$if(!!options.rating, (qb) => qb.where('asset_exif.rating', '>=', options.rating!)),
       )
-      .$if(!!options.personIds?.length && !!options.spaceId, (qb) =>
-        qb.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('shared_space_person_face')
-              .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
-              .whereRef('asset_face.assetId', '=', 'asset.id')
-              .where('asset_face.deletedAt', 'is', null)
-              .where('asset_face.isVisible', 'is', true)
-              .where('shared_space_person_face.personId', '=', anyUuid(options.personIds!)),
-          ),
-        ),
-      )
-      .$if(!!options.personIds?.length && !options.spaceId, (qb) =>
-        qb.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('asset_face')
-              .whereRef('asset_face.assetId', '=', 'asset.id')
-              .where('asset_face.personId', '=', anyUuid(options.personIds!)),
-          ),
-        ),
-      )
+      .$if(!!options.personIds?.length && !!options.spaceId, (qb) => hasSpacePeople(qb, options.personIds!))
+      .$if(!!options.personIds?.length && !options.spaceId, (qb) => hasPeople(qb, options.personIds!))
       .$if(!!options.identityIds?.length, (qb) =>
         qb.where((eb) =>
           eb.and(

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1425,6 +1425,29 @@ describe(SearchService.name, () => {
         expect.objectContaining({ albumIds: [albumId], timelineSpaceIds: [spaceId] }),
       );
     });
+
+    it('deduplicates resolved scoped person filters before repository search', async () => {
+      const token = `person:${newUuid()}`;
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+      mocks.search.searchMetadata.mockResolvedValue({ hasNextPage: false, items: [] });
+      (mocks.faceIdentity as any).resolveScopedPersonTokens.mockResolvedValue({
+        identityIds: ['00000000-0000-4000-8000-000000000010', '00000000-0000-4000-8000-000000000010'],
+        legacyPersonIds: ['00000000-0000-4000-8000-000000000020', '00000000-0000-4000-8000-000000000020'],
+        legacySpacePersonIds: ['00000000-0000-4000-8000-000000000030', '00000000-0000-4000-8000-000000000030'],
+        hasInaccessibleToken: false,
+      });
+
+      await sut.searchMetadata(authStub.user1, { withSharedSpaces: true, personIds: [token, token] });
+
+      expect(mocks.search.searchMetadata).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          identityIds: ['00000000-0000-4000-8000-000000000010'],
+          personIds: ['00000000-0000-4000-8000-000000000020'],
+          spacePersonIds: ['00000000-0000-4000-8000-000000000030'],
+        }),
+      );
+    });
   });
 
   describe('searchStatistics', () => {

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -37,6 +37,8 @@ import { isSmartSearchEnabled } from 'src/utils/misc';
 // of env reads).
 const searchTimingEnabled = process.env.GALLERY_SEARCH_TIMING === 'true';
 
+const unique = <T>(items: T[]) => [...new Set(items)];
+
 type ResolvedSmartSearch = {
   options: Omit<SmartSearchDto, 'page' | 'size' | 'order'> & {
     embedding: string;
@@ -512,9 +514,9 @@ export class SearchService extends BaseService {
 
     return {
       ...dto,
-      personIds: resolution.legacyPersonIds,
-      identityIds: resolution.identityIds,
-      spacePersonIds: [...new Set([...(dto.spacePersonIds ?? []), ...resolution.legacySpacePersonIds])],
+      personIds: unique(resolution.legacyPersonIds),
+      identityIds: unique(resolution.identityIds),
+      spacePersonIds: unique([...(dto.spacePersonIds ?? []), ...resolution.legacySpacePersonIds]),
       forceEmptyResult: dto.forceEmptyResult || resolution.hasInaccessibleToken,
     };
   }

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -260,6 +260,28 @@ export function hasAnySpacePerson<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spa
   );
 }
 
+export function hasSpacePeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spacePersonIds: string[]) {
+  if (spacePersonIds.length === 0) {
+    return qb;
+  }
+
+  return qb.where((eb) =>
+    eb.and(
+      spacePersonIds.map((spacePersonId) =>
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face')
+            .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('shared_space_person_face.personId', '=', asUuid(spacePersonId)),
+        ),
+      ),
+    ),
+  );
+}
+
 export function inAlbums<O>(qb: SelectQueryBuilder<DB, 'asset', O>, albumIds: string[]) {
   return qb.innerJoin(
     (eb) =>

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -57,6 +57,8 @@ export const asUuid = (id: string | Expression<string>) => sql<string>`${id}::uu
 
 export const anyUuid = (ids: string[]) => sql<string>`any(${`{${ids}}`}::uuid[])`;
 
+const uniqueTruthyIds = (ids: string[] = []) => [...new Set(ids.filter(Boolean))];
+
 export const asVector = (embedding: number[]) => sql<string>`${`[${embedding}]`}::vector`;
 
 export const unnest = (array: string[]) => sql<Record<string, string>>`unnest(array[${sql.join(array)}]::text[])`;
@@ -169,28 +171,38 @@ export function withFacesAndPeople(
 }
 
 export function hasPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, personIds: string[]) {
+  const ids = uniqueTruthyIds(personIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
   return qb.innerJoin(
     (eb) =>
       eb
         .selectFrom('asset_face')
         .select('assetId')
-        .where('personId', '=', anyUuid(personIds!))
+        .where('personId', '=', anyUuid(ids))
         .where('deletedAt', 'is', null)
         .where('isVisible', 'is', true)
         .groupBy('assetId')
-        .having((eb) => eb.fn.count('personId').distinct(), '=', personIds.length)
+        .having((eb) => eb.fn.count('personId').distinct(), '=', ids.length)
         .as('has_people'),
     (join) => join.onRef('has_people.assetId', '=', 'asset.id'),
   );
 }
 
 export function hasAnyPerson<O>(qb: SelectQueryBuilder<DB, 'asset', O>, personIds: string[]) {
+  const ids = uniqueTruthyIds(personIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
   return qb.innerJoin(
     (eb) =>
       eb
         .selectFrom('asset_face')
         .select('assetId')
-        .where('personId', '=', anyUuid(personIds))
+        .where('personId', '=', anyUuid(ids))
         .where('deletedAt', 'is', null)
         .where('isVisible', 'is', true)
         .groupBy('assetId')
@@ -200,30 +212,40 @@ export function hasAnyPerson<O>(qb: SelectQueryBuilder<DB, 'asset', O>, personId
 }
 
 export function hasFaceIdentities<O>(qb: SelectQueryBuilder<DB, 'asset', O>, identityIds: string[]) {
+  const ids = uniqueTruthyIds(identityIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
   return qb.innerJoin(
     (eb) =>
       eb
         .selectFrom('asset_face')
         .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
         .select('asset_face.assetId')
-        .where('face_identity_face.identityId', '=', anyUuid(identityIds))
+        .where('face_identity_face.identityId', '=', anyUuid(ids))
         .where('asset_face.deletedAt', 'is', null)
         .where('asset_face.isVisible', 'is', true)
         .groupBy('asset_face.assetId')
-        .having((eb) => eb.fn.count('face_identity_face.identityId').distinct(), '=', identityIds.length)
+        .having((eb) => eb.fn.count('face_identity_face.identityId').distinct(), '=', ids.length)
         .as('has_face_identities'),
     (join) => join.onRef('has_face_identities.assetId', '=', 'asset.id'),
   );
 }
 
 export function hasAnyFaceIdentity<O>(qb: SelectQueryBuilder<DB, 'asset', O>, identityIds: string[]) {
+  const ids = uniqueTruthyIds(identityIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
   return qb.innerJoin(
     (eb) =>
       eb
         .selectFrom('asset_face')
         .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
         .select('asset_face.assetId')
-        .where('face_identity_face.identityId', '=', anyUuid(identityIds))
+        .where('face_identity_face.identityId', '=', anyUuid(ids))
         .where('asset_face.deletedAt', 'is', null)
         .where('asset_face.isVisible', 'is', true)
         .groupBy('asset_face.assetId')
@@ -247,6 +269,11 @@ export function hasSpacePerson<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spaceP
 }
 
 export function hasAnySpacePerson<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spacePersonIds: string[]) {
+  const ids = uniqueTruthyIds(spacePersonIds);
+  if (ids.length === 0) {
+    return qb;
+  }
+
   return qb.where((eb) =>
     eb.exists(
       eb
@@ -255,19 +282,20 @@ export function hasAnySpacePerson<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spa
         .whereRef('asset_face.assetId', '=', 'asset.id')
         .where('asset_face.deletedAt', 'is', null)
         .where('asset_face.isVisible', 'is', true)
-        .where('shared_space_person_face.personId', '=', anyUuid(spacePersonIds)),
+        .where('shared_space_person_face.personId', '=', anyUuid(ids)),
     ),
   );
 }
 
 export function hasSpacePeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spacePersonIds: string[]) {
-  if (spacePersonIds.length === 0) {
+  const ids = uniqueTruthyIds(spacePersonIds);
+  if (ids.length === 0) {
     return qb;
   }
 
   return qb.where((eb) =>
     eb.and(
-      spacePersonIds.map((spacePersonId) =>
+      ids.map((spacePersonId) =>
         eb.exists(
           eb
             .selectFrom('shared_space_person_face')

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -310,6 +310,72 @@ export function hasSpacePeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, spaceP
   );
 }
 
+type PeopleFilterIds = { personIds?: string[]; identityIds?: string[]; spacePersonIds?: string[] };
+
+export function hasAllPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, filters: PeopleFilterIds) {
+  return hasSpacePeople(
+    hasFaceIdentities(hasPeople(qb, filters.personIds ?? []), filters.identityIds ?? []),
+    filters.spacePersonIds ?? [],
+  );
+}
+
+export function hasAnyPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, filters: PeopleFilterIds) {
+  const personIds = uniqueTruthyIds(filters.personIds);
+  const identityIds = uniqueTruthyIds(filters.identityIds);
+  const spacePersonIds = uniqueTruthyIds(filters.spacePersonIds);
+
+  if (personIds.length === 0 && identityIds.length === 0 && spacePersonIds.length === 0) {
+    return qb;
+  }
+
+  return qb.where((eb) => {
+    const predicates: Expression<SqlBool>[] = [];
+
+    if (personIds.length > 0) {
+      predicates.push(
+        eb.exists(
+          eb
+            .selectFrom('asset_face')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('asset_face.personId', '=', anyUuid(personIds)),
+        ),
+      );
+    }
+
+    if (identityIds.length > 0) {
+      predicates.push(
+        eb.exists(
+          eb
+            .selectFrom('asset_face')
+            .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('face_identity_face.identityId', '=', anyUuid(identityIds)),
+        ),
+      );
+    }
+
+    if (spacePersonIds.length > 0) {
+      predicates.push(
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face')
+            .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+            .whereRef('asset_face.assetId', '=', 'asset.id')
+            .where('asset_face.deletedAt', 'is', null)
+            .where('asset_face.isVisible', 'is', true)
+            .where('shared_space_person_face.personId', '=', anyUuid(spacePersonIds)),
+        ),
+      );
+    }
+
+    return eb.or(predicates);
+  });
+}
+
 export function inAlbums<O>(qb: SelectQueryBuilder<DB, 'asset', O>, albumIds: string[]) {
   return qb.innerJoin(
     (eb) =>
@@ -492,17 +558,15 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
         ]),
       ),
     )
-    .$if(!!options.spacePersonIds?.length, (qb) => hasAnySpacePerson(qb, options.spacePersonIds!))
+    .$if(!!(options.personIds?.length || options.identityIds?.length || options.spacePersonIds?.length), (qb) =>
+      options.personMatchAny ? hasAnyPeople(qb, options) : hasAllPeople(qb, options),
+    )
     .$if(!!options.tagIds && options.tagIds.length > 0, (qb) =>
       options.tagMatchAny ? withAnyTagId(qb, options.tagIds!) : hasTags(qb, options.tagIds!),
     )
     .$if(options.tagIds === null, (qb) =>
       qb.where((eb) => eb.not(eb.exists((eb) => eb.selectFrom('tag_asset').whereRef('assetId', '=', 'asset.id')))),
     )
-    .$if(!!options.personIds && options.personIds.length > 0, (qb) =>
-      options.personMatchAny ? hasAnyPerson(qb, options.personIds!) : hasPeople(qb, options.personIds!),
-    )
-    .$if(!!options.identityIds && options.identityIds.length > 0, (qb) => hasFaceIdentities(qb, options.identityIds!))
     .$if(!!options.createdBefore, (qb) => qb.where('asset.createdAt', '<=', options.createdBefore!))
     .$if(!!options.createdAfter, (qb) => qb.where('asset.createdAt', '>=', options.createdAfter!))
     .$if(!!options.updatedBefore, (qb) => qb.where('asset.updatedAt', '<=', options.updatedBefore!))

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -545,6 +545,27 @@ describe(AssetRepository.name, () => {
       expect(assets.id).toEqual([both.id]);
     });
 
+    it('treats duplicate selected person ids as one selected person', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const asset = await createTimelineAssetWithPeople(ctx, user.id, [alice.id]);
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          personIds: [alice.id, alice.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([asset.id]);
+    });
+
     it('requires every selected space person for time bucket assets', async () => {
       const { ctx, sut } = setup();
       const sharedSpaceRepo = ctx.get(SharedSpaceRepository);
@@ -598,6 +619,36 @@ describe(AssetRepository.name, () => {
       expect(assets.id).toEqual([both.id]);
     });
 
+    it('treats duplicate selected space person ids as one selected space person', async () => {
+      const { ctx, sut } = setup();
+      const sharedSpaceRepo = ctx.get(SharedSpaceRepository);
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const asset = await createTimelineAssetWithPeople(ctx, user.id, []);
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, isVisible: true });
+      const alice = await sharedSpaceRepo.createPerson({
+        spaceId: space.id,
+        name: 'Alice',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+      });
+      await sharedSpaceRepo.addPersonFaces([{ personId: alice.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          spacePersonIds: [alice.id, alice.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([asset.id]);
+    });
+
     it('requires every selected identity for time bucket assets', async () => {
       const { ctx, sut } = setup();
       const faceIdentityRepository = ctx.get(FaceIdentityRepository);
@@ -638,6 +689,53 @@ describe(AssetRepository.name, () => {
 
       const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
       expect(assets.id).toEqual([both.id]);
+    });
+
+    it('treats duplicate selected identity ids as one selected identity', async () => {
+      const { ctx, sut } = setup();
+      const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const identity = await faceIdentityRepository.ensurePersonIdentity(alice.id);
+      const asset = await createTimelineAssetWithPeople(ctx, user.id, []);
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: alice.id, isVisible: true });
+      await faceIdentityRepository.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'manual' });
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          identityIds: [identity.id, identity.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([asset.id]);
+    });
+
+    it('counts multiple visible faces for the same person as one selected person', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+      const asset = await createTimelineAssetWithPeople(ctx, user.id, [alice.id, alice.id, bob.id]);
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          personIds: [alice.id, bob.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([asset.id]);
     });
 
     it('requires every selected person when counting time buckets', async () => {

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -545,6 +545,101 @@ describe(AssetRepository.name, () => {
       expect(assets.id).toEqual([both.id]);
     });
 
+    it('requires every selected space person for time bucket assets', async () => {
+      const { ctx, sut } = setup();
+      const sharedSpaceRepo = ctx.get(SharedSpaceRepository);
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const bucketDate = new Date('2026-03-15T12:00:00.000Z');
+
+      const aliceOnly = await createTimelineAssetWithPeople(ctx, user.id, [], bucketDate);
+      const bobOnly = await createTimelineAssetWithPeople(ctx, user.id, [], bucketDate);
+      const both = await createTimelineAssetWithPeople(ctx, user.id, [], bucketDate);
+
+      const { assetFace: aliceOnlyFace } = await ctx.newAssetFace({ assetId: aliceOnly.id, isVisible: true });
+      const { assetFace: bobOnlyFace } = await ctx.newAssetFace({ assetId: bobOnly.id, isVisible: true });
+      const { assetFace: bothAliceFace } = await ctx.newAssetFace({ assetId: both.id, isVisible: true });
+      const { assetFace: bothBobFace } = await ctx.newAssetFace({ assetId: both.id, isVisible: true });
+
+      const alice = await sharedSpaceRepo.createPerson({
+        spaceId: space.id,
+        name: 'Alice',
+        representativeFaceId: aliceOnlyFace.id,
+        type: 'person',
+      });
+      const bob = await sharedSpaceRepo.createPerson({
+        spaceId: space.id,
+        name: 'Bob',
+        representativeFaceId: bobOnlyFace.id,
+        type: 'person',
+      });
+      await sharedSpaceRepo.addPersonFaces(
+        [
+          { personId: alice.id, assetFaceId: aliceOnlyFace.id },
+          { personId: bob.id, assetFaceId: bobOnlyFace.id },
+          { personId: alice.id, assetFaceId: bothAliceFace.id },
+          { personId: bob.id, assetFaceId: bothBobFace.id },
+        ],
+        { skipRecount: true },
+      );
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          spacePersonIds: [alice.id, bob.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([both.id]);
+    });
+
+    it('requires every selected identity for time bucket assets', async () => {
+      const { ctx, sut } = setup();
+      const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+      const aliceIdentity = await faceIdentityRepository.ensurePersonIdentity(alice.id);
+      const bobIdentity = await faceIdentityRepository.ensurePersonIdentity(bob.id);
+
+      const aliceOnly = await createTimelineAssetWithPeople(ctx, user.id, [], new Date('2026-03-15T12:00:00.000Z'));
+      const bobOnly = await createTimelineAssetWithPeople(ctx, user.id, [], new Date('2026-03-15T12:00:00.000Z'));
+      const both = await createTimelineAssetWithPeople(ctx, user.id, [], new Date('2026-03-15T12:00:00.000Z'));
+
+      const { assetFace: aliceOnlyFace } = await ctx.newAssetFace({ assetId: aliceOnly.id, personId: alice.id });
+      const { assetFace: bobOnlyFace } = await ctx.newAssetFace({ assetId: bobOnly.id, personId: bob.id });
+      const { assetFace: bothAliceFace } = await ctx.newAssetFace({ assetId: both.id, personId: alice.id });
+      const { assetFace: bothBobFace } = await ctx.newAssetFace({ assetId: both.id, personId: bob.id });
+
+      await faceIdentityRepository.linkFace({
+        assetFaceId: aliceOnlyFace.id,
+        identityId: aliceIdentity.id,
+        source: 'manual',
+      });
+      await faceIdentityRepository.linkFace({ assetFaceId: bobOnlyFace.id, identityId: bobIdentity.id, source: 'manual' });
+      await faceIdentityRepository.linkFace({ assetFaceId: bothAliceFace.id, identityId: aliceIdentity.id, source: 'manual' });
+      await faceIdentityRepository.linkFace({ assetFaceId: bothBobFace.id, identityId: bobIdentity.id, source: 'manual' });
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          identityIds: [aliceIdentity.id, bobIdentity.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([both.id]);
+    });
+
     it('requires every selected person when counting time buckets', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -25,6 +25,25 @@ const setup = (db?: Kysely<DB>) => {
   return { ctx, sut: ctx.get(AssetRepository) };
 };
 
+const createTimelineAssetWithPeople = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  ownerId: string,
+  personIds: string[],
+  localDateTime = new Date('2026-03-15T12:00:00.000Z'),
+) => {
+  const { asset } = await ctx.newAsset({
+    ownerId,
+    visibility: AssetVisibility.Timeline,
+    fileCreatedAt: localDateTime,
+    localDateTime,
+  });
+  await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+  for (const personId of personIds) {
+    await ctx.newAssetFace({ assetId: asset.id, personId, isVisible: true });
+  }
+  return asset;
+};
+
 beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
@@ -497,6 +516,52 @@ describe(AssetRepository.name, () => {
           .where('assetId', '=', asset.id)
           .executeTakeFirstOrThrow(),
       ).resolves.toEqual({ lockedProperties: null });
+    });
+  });
+
+  describe('people filters use AND semantics', () => {
+    it('requires every selected person for time bucket assets', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+      const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+
+      await createTimelineAssetWithPeople(ctx, user.id, [alice.id]);
+      await createTimelineAssetWithPeople(ctx, user.id, [bob.id]);
+      const both = await createTimelineAssetWithPeople(ctx, user.id, [alice.id, bob.id]);
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [user.id],
+          personIds: [alice.id, bob.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        auth,
+      );
+
+      const assets = JSON.parse(bucket.assets) as TimeBucketAssets;
+      expect(assets.id).toEqual([both.id]);
+    });
+
+    it('requires every selected person when counting time buckets', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { person: alice } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const { person: bob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
+
+      await createTimelineAssetWithPeople(ctx, user.id, [alice.id]);
+      await createTimelineAssetWithPeople(ctx, user.id, [bob.id]);
+      await createTimelineAssetWithPeople(ctx, user.id, [alice.id, bob.id]);
+
+      await expect(
+        sut.getTimeBuckets({
+          userIds: [user.id],
+          personIds: [alice.id, bob.id],
+          visibility: AssetVisibility.Timeline,
+        }),
+      ).resolves.toEqual([{ count: 1, timeBucket: '2026-03-01' }]);
     });
   });
 

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -673,9 +673,21 @@ describe(AssetRepository.name, () => {
         identityId: aliceIdentity.id,
         source: 'manual',
       });
-      await faceIdentityRepository.linkFace({ assetFaceId: bobOnlyFace.id, identityId: bobIdentity.id, source: 'manual' });
-      await faceIdentityRepository.linkFace({ assetFaceId: bothAliceFace.id, identityId: aliceIdentity.id, source: 'manual' });
-      await faceIdentityRepository.linkFace({ assetFaceId: bothBobFace.id, identityId: bobIdentity.id, source: 'manual' });
+      await faceIdentityRepository.linkFace({
+        assetFaceId: bobOnlyFace.id,
+        identityId: bobIdentity.id,
+        source: 'manual',
+      });
+      await faceIdentityRepository.linkFace({
+        assetFaceId: bothAliceFace.id,
+        identityId: aliceIdentity.id,
+        source: 'manual',
+      });
+      await faceIdentityRepository.linkFace({
+        assetFaceId: bothBobFace.id,
+        identityId: bobIdentity.id,
+        source: 'manual',
+      });
 
       const bucket = await sut.getTimeBucket(
         '2026-03-01',


### PR DESCRIPTION
## Summary
- make timeline people filters require every selected person, identity, or space person by default
- align search builders, smart facets, and suggestion filtering with AND semantics
- preserve explicit personMatchAny OR behavior and normalize duplicate scoped people filters

## Verification
- mise exec -- pnpm --filter immich exec vitest --config test/vitest.config.mjs run src/repositories/search.repository.spec.ts src/services/timeline.service.spec.ts src/services/search.service.spec.ts src/services/shared-space.service.spec.ts
- mise exec -- pnpm --filter immich exec vitest --config test/vitest.config.medium.mjs run test/medium/specs/repositories/asset.repository.spec.ts test/medium/specs/services/people-identity-rbac.spec.ts test/medium/specs/services/search.service.spec.ts test/medium/specs/repositories/search.repository.spec.ts
- mise exec -- pnpm --filter immich check
- mise exec -- pnpm --filter immich test -- --run