### PR TITLE
fix(mobile): pin glance-appwidget to stable 1.1.1 to unblock Android release

### DIFF
--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -3,6 +3,20 @@ allprojects {
         google()
         mavenCentral()
     }
+
+    // The home_widget plugin requests `androidx.glance:glance-appwidget:1.+`, a dynamic
+    // version that resolves to the highest published 1.x — which now includes pre-release
+    // alphas. glance-appwidget 1.3.0-alpha01 (published 2026-05-19) and its transitive
+    // androidx.compose.remote require compileSdk 37 / AGP 9.1.0, which breaks our
+    // compileSdk 36 / AGP 8.11.2 release build (`:app:checkReleaseAarMetadata` fails).
+    // Pin to the stable version our version catalog already targets
+    // (mobile/android/gradle/libs.versions.toml: glance = "1.1.1") so the plugin's `1.+`
+    // selector can no longer drift into alpha releases.
+    configurations.all {
+        resolutionStrategy {
+            force "androidx.glance:glance-appwidget:1.1.1"
+        }
+    }
 }
 
 rootProject.buildDir = '../build'


### PR DESCRIPTION
## What broke

The **Release Mobile** workflow failed at *Build and sign Android* → step **Build signed Android App Bundle** ([run 26670193902](https://github.com/open-noodle/gallery/actions/runs/26670193902/job/78611756371)). Gradle's `:app:checkReleaseAarMetadata` rejected the build:

```
> Dependency 'androidx.glance:glance-appwidget:1.3.0-alpha01' requires ... compileSdk 37 or later
  ... Android Gradle plugin 9.1.0 or higher. This build uses AGP 8.11.2 / android-36.
> Dependency 'androidx.compose.remote:remote-creation-android:1.0.0-alpha11' requires ... compileSdk 37 ... AGP 9.1.0
```

## Root cause

Nothing in this repo changed — it was external dependency drift.

The `home_widget` plugin (v0.8.1) declares a **dynamic version** in its Android `build.gradle`:

```gradle
implementation "androidx.glance:glance-appwidget:1.+"
```

`1.+` resolves to the *highest* published 1.x, and Gradle's `+` selector accepts pre-releases. androidx published **`glance-appwidget:1.3.0-alpha01` on 2026-05-19** (`maven-metadata.xml` `lastUpdated=20260519170000`), so `1.+` started picking up that alpha — which transitively pulls `androidx.compose.remote:remote-creation-android:1.0.0-alpha11`. Both require compileSdk 37 / AGP 9.1.0.

Our version catalog pins `glance = "1.1.1"`, but the plugin's `1.+` outranks it (highest version wins in conflict resolution), so the whole graph drifted up to the alpha.

> Note: upstream Immich's `mobile/android/build.gradle` is byte-identical and has the same latent issue.

## The fix

Force `glance-appwidget` back to the stable `1.1.1` our catalog already targets, in the root `allprojects` block so it covers both `:app` and the `:home_widget` subproject:

```gradle
configurations.all {
    resolutionStrategy {
        force "androidx.glance:glance-appwidget:1.1.1"
    }
}
```

`1.1.1` is the latest *stable* 1.x (no stable 1.2.x exists) and is exactly what `1.+` resolved to before the alpha was published, so this restores the previously-working state.

## Verification

Reproduced and verified the resolution with **Gradle 8.14** (the wrapper version) against the real Google Maven repo — no Android SDK needed since this is purely a version-resolution issue:

| Configuration | Result |
|---|---|
| `1.+` + `1.1.1`, **no** force (pre-fix) | `glance-appwidget:1.3.0-alpha01` ❌ |
| `1.+` + `1.1.1`, **with** force (this PR) | `glance-appwidget:1.1.1` ✅ |

Full transitive audit under the force: all glance artifacts → `1.1.1`, `androidx.compose.remote` **gone**, and **zero** alpha/beta/rc deps in the 48-component graph.

Final confirmation is the re-run of the Release Mobile workflow after merge.

## Out of scope / follow-up

`home_widget` also declares `androidx.work:work-runtime-ktx:2.+`. It currently resolves to a stable 2.x and is **not** failing, so it's intentionally left untouched here (forcing it would risk an unvalidated downgrade). Worth pinning preemptively if `androidx.work` ever publishes an SDK-37-requiring alpha.