### PR TITLE
fix(server): collapse same-scope conflicts in scoped identity merge

### DIFF
--- a/docs/plans/2026-05-29-same-scope-merge-collapse-design.md
+++ b/docs/plans/2026-05-29-same-scope-merge-collapse-design.md
@@ -1,0 +1,219 @@
+# Same-Scope Merge Collapse Design
+
+## Problem
+
+Merging two duplicate people that already have separate profiles **in the same physical scope** fails. The manual scoped-merge endpoint (`POST /people/same-person` → `PersonService.mergeScopedPeople`) rejects the operation instead of combining the duplicates.
+
+Field evidence (tester report, `brainstorm-people-merge-propagation` line):
+
+- Merging two space people that are both visible in the **same shared space** always fails with `Cannot merge people that already have separate profiles in the same scope`. Reproduced across three independent person pairs; behaviour is 100% consistent.
+- Merging two personal duplicates from `/people` works **only** when both resolve to personal profiles (classic `mergePerson`). When either duplicate's accessible primary profile is a space person, the merge is routed to `mergeScopedPeople` and hits the same wall.
+
+The user intent is unambiguous: "these two entries are the same person, combine them." Refusing the merge is a defect, not a guard.
+
+## Background — Why It Fails Today
+
+There are three real merge paths, each with a distinct contract:
+
+| Path                        | Endpoint                                                       | Behaviour                                                                                                                                                  |
+| --------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Personal physical merge     | `POST /people/:id/merge` (`mergePerson`)                       | Reassign `asset_face.personId` source→target, **delete the source `person` row**, then `mergeIdentities`.                                                  |
+| Same-space physical merge   | `POST /spaces/:id/people/:personId/merge` (`mergeSpacePeople`) | Reassign `shared_space_person_face` source→target, recount, **delete the source `shared_space_person` row**, then `mergeIdentitiesForSpacePersonEvidence`. |
+| Cross-scope identity repair | `POST /people/same-person` (`mergeScopedPeople`)               | Resolve scoped refs, validate access/type, then `mergeIdentities`. **Never deletes a profile row.** Currently throws on any same-scope conflict.           |
+
+The two physical paths already use a **collapse-then-merge** sequence: they delete the duplicate row _before_ calling `mergeIdentities`. By the time `mergeIdentities` runs, there is no same-scope conflict, so its internal guard passes. This is why `mergePerson` (Test case A) works.
+
+`mergeScopedPeople` skips that collapse step. It calls `mergeIdentities` while **both** profile rows still exist. Two layers then refuse the operation, because a naive `identityId` reassignment would violate the partial-unique indexes `person_ownerId_identityId_key` and `shared_space_person_spaceId_identityId_key`:
+
+1. **Service gate** — `person.service.ts:177` throws `BadRequestException` when `resolveRepairRefs` reports `hasScopedProfileConflict`.
+2. **Repository no-op** — `face-identity.repository.ts` `mergeIdentities` preflights `countMergeConflicts` and **returns early doing nothing** when any conflict exists; its `person`/`shared_space_person` reassignments additionally carry `NOT EXISTS` guards that would otherwise leave the conflicting source row orphaned.
+
+Both layers were introduced to protect **cross-scope** merges (personal + space, or space + space across _different_ spaces) from clobbering two legitimately-separate profiles. They are too broad: two profiles in the **same** physical scope being merged is exactly the case where collapsing one **is** the correct merge.
+
+## Vocabulary
+
+- **Physical scope**: the uniqueness boundary for a profile row. For a `person` it is its `ownerId`; for a `shared_space_person` it is its `spaceId`.
+- **Scoped profile**: a `person` row or a `shared_space_person` row.
+- **Same-scope conflict**: two or more profiles that belong to the set of merged identities (target identity ∪ source identities) and share one physical scope.
+- **Collapse**: move all backing faces from a redundant profile onto the surviving profile in that scope, link those faces to the target identity, then delete the redundant row. Child rows that reference the deleted profile by foreign key — `shared_space_person_face`, `shared_space_person_alias`, and `person_face_suggestion` — are all `ON DELETE CASCADE`, so anything not explicitly moved first is removed with the row.
+- **Survivor**: the single profile that remains in a physical scope after collapse, carrying the target identity.
+
+## Design Direction
+
+Make `mergeScopedPeople` resolve same-scope conflicts by **collapsing** them, the same way the dedicated physical-merge endpoints already do, instead of refusing. The cross-scope identity repair becomes a universal manual merge: regardless of which physical tables the selected profiles live in, "merge these people" succeeds and yields one profile per physical scope plus one unified identity.
+
+The collapse runs **before** the identity link reassignment, inside the same database transaction as `mergeIdentities`, so the whole operation is atomic.
+
+This refines — it does not contradict — the existing merge-cases design (`docs/superpowers/specs/2026-05-05-accessible-identity-merge-cases-design.md`). That design's "reject same-scope conflict / do not delete a space person row in a cross-scope merge" rule exists to keep merges across _different_ scopes from deleting legitimately-separate profiles. Same-physical-scope collapse is the deliberately-excluded case where deletion is the intended outcome. The earlier design routed same-scope merges to the physical endpoints via the UI; this design centralises that responsibility on the server so every entry point (people detail page, person-merge suggestion modal, command palette, and any direct API caller) is correct without per-screen routing logic.
+
+## Collapse Semantics
+
+Let `I = {targetIdentityId} ∪ sourceIdentityIds`. After a successful merge:
+
+- Every face that backed any profile of an identity in `I` backs the target identity.
+- Within each physical scope, there is **exactly one** surviving profile, and it carries the target identity.
+- Source identities with no remaining profiles and no remaining face links are deleted.
+
+### Survivor selection (deterministic)
+
+Within one physical scope (one `ownerId`, or one `spaceId`), among all profiles whose identity is in `I`:
+
+1. Prefer the profile already on the **target** identity.
+2. Otherwise pick the lowest stable id, so re-runs and concurrent jobs converge on the same survivor.
+
+This also fixes a latent defect in the current `NOT EXISTS` reassignment: when two **source** identities each have a profile in a scope where the target identity has none, today's single `UPDATE` reassigns both to the target identity and violates the partial-unique index. Survivor selection over the full set `I` collapses those too.
+
+Each collapse mirrors the data steps of the matching physical-merge endpoint. Because the collapse runs inside the `mergeIdentities` transaction, those steps must be issued on the transaction handle, not via the existing `this.db`-based repository helpers (see [Transaction discipline](#transaction-discipline)); the helper names below identify the SQL to reuse, not methods to call directly.
+
+### Personal scope collapse
+
+For a scope keyed by `ownerId` where a non-survivor `person` row exists (mirrors `mergePerson`):
+
+- Before deleting, carry over display metadata only when the survivor lacks it (`name`, `birthDate`), matching `mergePerson`'s fill-if-empty behaviour.
+- Reassign `asset_face.personId` from the redundant person to the survivor (the SQL of `personRepository.reassignFaces`).
+- Link the survivor's faces to the target identity (the SQL of `faceIdentityRepository.linkPersonFaces`, `source: 'manual'`) so faces that had no prior `face_identity_face` row are covered — `mergeIdentities`' own face-link reassignment only moves rows that already point at a source identity.
+- Delete the redundant `person` row. Its pending `person_face_suggestion` rows cascade-delete with it (no relink); the survivor keeps its own feature photo (`faceAssetId`).
+
+Personal people counts are computed on read, so no recount is required.
+
+### Space scope collapse
+
+For a scope keyed by `spaceId` where a non-survivor `shared_space_person` row exists (mirrors `mergeSpacePeople`):
+
+- Reassign `shared_space_person_face` from the redundant space person to the survivor using the **conflict-safe** form (`sharedSpaceRepository.reassignPersonFacesSafe` — delete the face links that already exist on the survivor, then move the rest), because `(personId, assetFaceId)` is the table's primary key.
+- Resolve face suggestions for the moved faces (`resolveAssignedFace` per moved `assetFaceId`, as `resolveMovedSpacePersonFaces` does).
+- Delete the redundant `shared_space_person` row. Its `shared_space_person_alias` rows cascade-delete (matching today's `mergeSpacePeople`, which does not migrate aliases — see Non-Goals).
+- Recount the survivor (the SQL of `recountPersons`). Display metadata (name inheritance, representative face, thumbnail) is refreshed by the post-merge `SharedSpacePersonMetadataBackfill` job that `mergeScopedPeople` already queues — the survivor is the target row and keeps its own representative face until backfill runs, so no synchronous representative-face fix-up is needed.
+
+### Identity finalisation
+
+After every conflicted scope has exactly one surviving profile, the existing `mergeIdentities` body runs unchanged on the now conflict-free row set: surviving profiles still on a source identity are reassigned to the target identity (the `NOT EXISTS` guards now never fire because no scope holds two profiles from `I`), source-identity `face_identity_face` links are reassigned to the target identity, and source identities left with no profiles and no faces are deleted. `countMergeConflicts` returns zero after collapse, so the early-return no-op path is not taken.
+
+### Transaction discipline
+
+The collapse executes inside `mergeIdentities`' existing `this.db.transaction()`. Every collapse query **must** run on the transaction handle (`trx`). It must not call the existing `this.db`-based helpers (`reassignPersonFacesSafe`, `linkPersonFaces`, `recountPersons`, `resolveAssignedFace`, …) from inside the transaction: those issue queries on the base pool, and reserving a second connection while the transaction holds the first deadlocks against the 10-connection pool (the issue #595 failure mode — see `feedback_kysely_no_thisdb_in_transaction`). Implementation options, in order of preference:
+
+1. Parameterise the reused helpers with an optional executor (`db: Kysely<DB> | Transaction<DB> = this.db`) and pass `trx`. This keeps one definition of each SQL and lets both the physical endpoints and the collapse share it.
+2. Otherwise inline the equivalent SQL on `trx`.
+
+Secondary, idempotent cleanups that are not integrity-critical (face-suggestion resolution, display-metadata inheritance, thumbnails) may instead run after the transaction commits or be left to the already-queued `SharedSpacePersonMetadataBackfill`, provided the integrity-critical mutations — face reassignment, face→identity linking, profile-row deletion, identity-link reassignment, identity cleanup — all commit atomically in the one transaction.
+
+## Access and Permissions
+
+**Product rule (decided):** a user may merge **(a)** their own personal people and **(b)** space people in spaces where they are owner/editor. A merge must never require modifying a scope the actor does not control.
+
+Two gates enforce this. The first is unchanged; the second is **narrowed** from the current blanket attachment check.
+
+1. **Every selected ref must be repairable by the actor** — `resolveRepairRefs`/`resolveRepairProfile` already require `person.ownerId = actor` for a personal ref and owner/editor membership for a space ref. A selected ref that is inaccessible or that the actor cannot repair ⇒ `BadRequestException` (not found / no access). _Unchanged._
+2. **Every scope that requires a collapse must be repairable by the actor.** A collapse is required in a physical scope only when two or more of the merged identities (`I`) hold a separate profile there. For each such conflicted scope the actor must own it (personal `ownerId = actor`) or be owner/editor of the space. A required collapse in a scope the actor cannot repair ⇒ `ForbiddenException`. _This replaces the previous `allAttachedProfilesRepairable` rule._
+
+### Why narrow, not drop, the attachment gate
+
+The old `allAttachedProfilesRepairable` blocked the merge whenever **any** profile transitively attached to `I` lived in a space the actor could not edit — even a space not involved in any collision. That is what wrongly blocked a non-admin from merging their own duplicates (tester Part 1). The real invariant is narrower: completing a merge only requires editing a scope when that scope has a **same-scope conflict** (two profiles that must collapse to one to satisfy the partial-unique index). Reassigning a single profile's `identityId` (no deletion) is identity grouping, not space editing, and classic `mergePerson` already does it across view-only spaces today; matching that here keeps personal merges and editor-space merges working while still refusing to delete rows in a space the actor cannot edit.
+
+Concretely, after this change:
+
+- Two personal people the actor owns ⇒ merge succeeds; identity unification propagates into any spaces the identities appear in (collapsing nothing there unless both already appear separately in one space).
+- Two space people in a space the actor edits ⇒ merge succeeds (tester Test case B for a non-admin editor).
+- Two profiles whose identities **both** appear as separate space people in one space the actor can only **view** ⇒ refused with an actionable message (completing the merge would delete a row in that space). Defer to an editor of that space.
+- A profile attached to a view-only space with **no** collision there ⇒ does not block the merge.
+
+## Automatic Reconciliation Is Unaffected
+
+`mergeIdentities` is also called by automatic, best-effort paths that must **not** collapse rows on conflict:
+
+- `SharedSpaceService.applySharedSpaceIdentityReconciliationClaim` preflights `getMergeConflicts` and skips when any conflict exists.
+- `mergeIdentitiesForSpacePersonEvidence` runs only after a physical same-space merge has already removed the conflict.
+
+Collapse is therefore **opt-in**: `mergeIdentities` gains a `collapseScopedConflicts` option that defaults to `false` (today's behaviour: preflight counts, early-return no-op, `NOT EXISTS` guards). Only `mergeScopedPeople` passes `true`. `getMergeConflicts` and the early-return path are preserved for automatic callers. This keeps the existing reconciliation regression suites green.
+
+## Atomicity, Idempotency, Concurrency
+
+- The integrity-critical mutations execute in **one** `mergeIdentities` transaction (see Transaction discipline). A failure rolls back the whole merge — no half-collapsed state, no orphaned faces.
+- Re-running the same merge is a no-op: after the first run the source profiles/identities are gone, so `resolveRepairRefs` returns "not found" for the stale refs and no rows change.
+- Concurrency: today `mergeIdentities` runs no explicit row locks — it relies on transaction atomicity and the partial-unique indexes. To make a concurrent merge of an overlapping set deterministic rather than constraint-error-prone, the collapse transaction should `SELECT … FOR UPDATE` the candidate `face_identity` rows (target + sources) at the top of the transaction. The loser then either observes the merged state and no-ops, or fails its own transaction without corrupting state; a lost race must not hard-fail the user action. (This locking is a new requirement, not existing behaviour.)
+- After a successful merge, queue `SharedSpacePersonMetadataBackfill` for the target identity (already done by `mergeScopedPeople`) so thumbnails, labels, and space metadata refresh.
+
+## Error Handling
+
+`mergeScopedPeople` outcomes after this change:
+
+- Inaccessible / non-repairable **selected** profile ⇒ `BadRequestException` (unchanged).
+- Incompatible type (person vs pet) ⇒ `BadRequestException` (unchanged).
+- Same-scope conflict the actor **can** repair ⇒ **success with collapse** (was `BadRequestException`).
+- Same-scope conflict in a scope the actor **cannot** repair ⇒ `ForbiddenException` with an actionable message naming the space and the role required, e.g. _"«Alice» and «Alice (2)» both appear in shared space «Holidays», which you can only view. Ask an editor of «Holidays» to merge them."_ (was the opaque `inaccessible attached profiles`).
+- Stale / already-merged ref ⇒ not found / no-op (unchanged).
+
+## TDD Requirements
+
+Implementation is **test-first, red-green-refactor**. For each behaviour: add the smallest failing test, run it and confirm it fails _for the expected reason_, write the minimal production code to pass, re-run the focused test plus the nearest suite, then refactor on green. Do not add collapse production code before its red test has been observed failing. Commit history need not be one commit per test, but the working sequence must be test-first.
+
+Suggested order (each step red-first): (1) repository same-space collapse, (2) repository same-owner collapse, (3) repository survivor-selection / source–source and multi-source cases, (4) repository cross-scope non-conflict regressions, (5) `mergeIdentities` opt-in flag preserves legacy behaviour, (6) service same-scope success + permission narrowing, (7) service permission refusal, (8) route/e2e. Land the repository collapse before the service flips off the `hasScopedProfileConflict` throw, so the service never reaches an unimplemented collapse.
+
+### Repository (medium, real DB) — `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+Collapse correctness (each RED first):
+
+- Two `shared_space_person` profiles in the **same space** (`collapseScopedConflicts: true`) ⇒ one surviving space-person row on the target identity; all `shared_space_person_face` rows moved onto it (including the conflict-safe case where a face links to **both** rows — no PK violation, no duplicate link); source row deleted; emptied source identity deleted; survivor recounted.
+- Two `person` profiles owned by the **same owner** ⇒ one surviving person row on the target identity; `asset_face.personId` reassigned; **all** survivor faces linked to the target identity in `face_identity_face`, including a face that had no prior identity link (proves the `linkPersonFaces` step, which the bare `mergeIdentities` reassignment would miss); source person deleted; empty `name`/`birthDate` filled from the source.
+- Source person's pending `person_face_suggestion` rows are gone after collapse (cascade), and no stale suggestion points at a deleted person.
+- Survivor selection: when the **target** identity has a profile in the scope it is the survivor; when it does not, the lowest-id source profile survives and is reassigned to the target identity (deterministic).
+- Two **source** identities each with a profile in one scope where the target identity is absent ⇒ collapse to a single survivor without violating the partial-unique index (covers the latent multi-source defect).
+- Multi-source batch (target + ≥2 sources) where conflicts exist in **some** scopes and not others ⇒ each conflicted scope collapses to one survivor; non-conflicted scopes reassign with no deletion.
+- Collapse carries the entity `type` through (two **pet** space-people in one space collapse just like person profiles).
+- Hidden survivor/source: a manual collapse merges regardless of hidden state and the survivor's hidden flag is preserved (manual merge is user-directed; hidden is not a gate here, unlike automatic reconciliation).
+
+Cross-scope **non-conflict** regressions (must still pass, no row deleted):
+
+- personal `person` (owner A) + `shared_space_person` (space X) — different scopes ⇒ identity merge only; both rows survive on the target identity.
+- two `shared_space_person` rows in **different** spaces ⇒ both survive on the target identity.
+
+Legacy / opt-out and counting:
+
+- With `collapseScopedConflicts` defaulted/false, `mergeIdentities` keeps today's behaviour: `countMergeConflicts > 0` ⇒ early-return no-op, `NOT EXISTS` guards leave conflicting rows untouched.
+- `getMergeConflicts` still reports same-owner and same-space conflict counts.
+
+Idempotency & concurrency:
+
+- Re-running the collapsing merge over the now-merged set changes nothing.
+- (If feasible in medium tests) two overlapping collapsing merges do not both delete the same survivor or leave a duplicate; one wins, the other no-ops or errors without corrupting state.
+
+### Service (unit) — `server/src/services/person.service.spec.ts`
+
+- RED: `mergeScopedPeople` with two same-space space-person refs (actor is space editor) calls `mergeIdentities` with `collapseScopedConflicts: true` and **does not throw** (replaces the current `hasScopedProfileConflict` throw expectation).
+- RED (permission narrowing — tester Part 1): a non-admin merging two of their **own** personal people whose identities are also attached to a space they only **view**, with **no** collision in that space, **succeeds** (was `ForbiddenException`).
+- RED: merging two profiles whose identities **both** appear as separate space people in a **view-only** space ⇒ `ForbiddenException` carrying the actionable, space-named message.
+- RED: a mixed batch with a same-space conflict the actor **can** repair plus an attachment in an unrelated view-only space (no conflict there) ⇒ succeeds (only conflicted scopes gate).
+- Preserve: a selected ref the actor cannot access/repair ⇒ `BadRequestException`; incompatible type (person vs pet) ⇒ `BadRequestException`.
+- Preserve: a successful merge queues `SharedSpacePersonMetadataBackfill` for the target identity.
+
+### Automatic reconciliation regression — `server/src/services/shared-space.service.spec.ts`
+
+- Preserve: `applySharedSpaceIdentityReconciliationClaim` still preflights `getMergeConflicts`, skips on any conflict, and never passes `collapseScopedConflicts: true`.
+- Preserve: existing add-member / new-evidence / same-space dedup reconciliation tests stay green.
+- Preserve: `mergeSpacePeople` and `mergePerson` behaviour is unchanged (their own suites stay green); if their reassign/link helpers are parameterised with an executor for reuse, the default-arg call sites keep identical behaviour.
+
+### Route / end-to-end coverage — `e2e/`
+
+- `POST /people/same-person` merging two same-space duplicates returns success and the surviving identity resolves to one accessible person with the combined asset and face counts.
+- A **non-admin editor** of a space can merge two duplicates within that space via `POST /people/same-person` (tester Test case B for a non-admin).
+- A **non-admin** can merge two of their own personal duplicates that also appear (without collision) in a view-only space.
+- A **viewer** (non-editor) attempting to merge two profiles that both appear in that view-only space is refused with the space-named `ForbiddenException`.
+- Navigating to the collapsed source profile id afterward returns not-found (expected; the row is gone).
+
+## Web Follow-up (non-blocking)
+
+With the server collapse in place, the per-screen routing that currently decides between physical and scoped endpoints can be simplified to "personal-only batch ⇒ `mergePerson`; everything else ⇒ `mergeScopedPeople`," because the scoped endpoint now handles same-space and same-owner batches correctly. The dedicated `mergeSpacePeople` in-space flow stays as a fast path. This cleanup is optional and out of scope for the core fix; it should keep the existing web merge specs green.
+
+## Non-Goals
+
+- Do not change automatic reconciliation policy (it continues to skip conflicts it cannot physically resolve first).
+- Do not expose raw `face_identity.id` values.
+- Do not unmerge identities on access loss.
+- Do not allow a merge to delete or collapse a profile row in a scope the actor cannot edit (the narrowed gate still refuses this).
+- Do not migrate per-user `shared_space_person_alias` rows off a collapsed space person — they cascade-delete, matching today's `mergeSpacePeople`. (Alias migration is a possible follow-up; if added, apply it to `mergeSpacePeople` too so the two paths stay consistent.)
+- Do not make names or aliases automatic merge evidence.
+
+## Resolved Decisions
+
+1. **Tester Part 1 — non-admin merging own personal duplicates that also live in view-only spaces.** _Decided (2026-05-29):_ a user may merge their own personal people and space people in spaces where they are owner/editor. The blanket `allAttachedProfilesRepairable` gate is narrowed to a per-scope conflict-repairability gate (see Access and Permissions). The merge is refused only when completing it would require collapsing a row in a scope the actor can only view, and that refusal now carries an actionable, space-named message.

--- a/docs/plans/2026-05-29-same-scope-merge-collapse-plan.md
+++ b/docs/plans/2026-05-29-same-scope-merge-collapse-plan.md
@@ -1,0 +1,259 @@
+# Same-Scope Merge Collapse Implementation Plan
+
+**Goal:** Make `mergeScopedPeople` (`POST /people/same-person`) collapse same-physical-scope duplicates instead of refusing them, and narrow the permission gate so a user can merge their own personal people and editor-space people. Server-side fix; every UI entry point benefits without per-screen routing changes.
+
+**Spec:** `docs/plans/2026-05-29-same-scope-merge-collapse-design.md` (read it first — this plan implements it exactly; do not diverge without updating the spec).
+
+**Method:** Strict TDD, red-green-refactor. Every behaviour gets the smallest failing test, observed failing _for the expected reason_, before the minimal production code that passes it. Land the repository collapse before the service flips off the `hasScopedProfileConflict` throw, so the service never calls into an unimplemented collapse.
+
+**Tech stack:** NestJS services/repositories, Kysely (transaction-aware), Vitest unit + medium (testcontainers) tests, Playwright/Vitest e2e.
+
+---
+
+## Reference — exact code touchpoints
+
+- `server/src/repositories/face-identity.repository.ts`
+  - `mergeIdentities` (line ~2496) — add opt-in collapse; keep the existing body as "identity finalisation".
+  - `countMergeConflicts` (~2596) / `getMergeConflicts` (~2637) — unchanged; still used by automatic reconciliation.
+  - `linkPersonFaces` (~2007) — parameterise with an optional executor for reuse on `trx`.
+  - `resolveRepairRefs` (~1128) + `RepairRefsResolution` type (~122) — change the permission fields (Task 4).
+  - `areAttachedProfilesRepairable` (~1303) / `hasRepairProfileConflict` (~1333) — replace with a per-conflict-scope check (Task 4).
+- `server/src/services/person.service.ts`
+  - `mergeScopedPeople` (~169) — gate change + pass `collapseScopedConflicts: true`.
+- `server/src/repositories/shared-space.repository.ts`
+  - `reassignPersonFacesSafe` (~1539), `recountPersons` (~1798), `deletePerson` (~1486) — SQL to mirror on `trx` (do **not** call directly inside the transaction).
+- `server/src/repositories/person.repository.ts`
+  - `reassignFaces` (~115, `UpdateFacesData`) — SQL to mirror on `trx`.
+- Schema (cascade facts, already verified): `person_face_suggestion.personId`, `shared_space_person_face.personId`, `shared_space_person_alias.personId` are all `ON DELETE CASCADE`. Partial-unique indexes: `person_ownerId_identityId_key`, `shared_space_person_spaceId_identityId_key`. **No DB migration is required** — this change is behavioural (an opt-in flag plus new read queries), with no schema change.
+
+### Test commands
+
+```bash
+# server unit (focused)
+pnpm --dir server test src/services/person.service.spec.ts -- --run -t "<name>"
+# server medium (real DB via testcontainers)
+pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -- --run -t "<name>"
+# e2e api (needs the e2e stack: `make e2e` once, or run against a `make dev` stack via `make e2e-api-dev`)
+pnpm --dir e2e test server/api/person.e2e-spec.ts
+# gates
+pnpm --dir server lint && pnpm --dir server format && pnpm --dir server check
+```
+
+### Transaction discipline (applies to all repository tasks)
+
+The collapse runs inside `mergeIdentities`' existing `this.db.transaction()`. **Every collapse query runs on `trx`.** Never call `this.db`-based helpers (`reassignPersonFacesSafe`, `recountPersons`, `reassignFaces`, `resolveAssignedFace`, the un-parameterised `linkPersonFaces`) inside the transaction — that reserves a second pool connection and deadlocks the 10-connection pool (issue #595, `feedback_kysely_no_thisdb_in_transaction`). Reuse SQL either by (1) parameterising the helper with `db: Kysely<DB> | Transaction<DB> = this.db` and passing `trx`, or (2) inlining the equivalent SQL on `trx`.
+
+---
+
+## Coverage Matrix — every spec test maps to a task
+
+| Spec test (from `## TDD Requirements`)                                          | Task | Layer            |
+| ------------------------------------------------------------------------------- | ---- | ---------------- |
+| same-space collapse, conflict-safe both-rows face                               | 1    | medium repo      |
+| same-owner collapse, `linkPersonFaces` unlinked-face, name/birthDate fill       | 1    | medium repo      |
+| source `person_face_suggestion` rows gone after collapse (cascade)              | 1    | medium repo      |
+| survivor selection (target present → survives; absent → lowest-id source)       | 2    | medium repo      |
+| two source identities in one scope, target absent → single survivor, no UQ viol | 2    | medium repo      |
+| multi-source batch, some scopes conflict & some don't                           | 2    | medium repo      |
+| pet-type collapse                                                               | 2    | medium repo      |
+| hidden survivor/source preserved                                                | 2    | medium repo      |
+| cross-scope non-conflict: personal + space (diff scope) → both survive          | 2    | medium repo      |
+| cross-scope non-conflict: two spaces → both survive                             | 2    | medium repo      |
+| legacy `collapseScopedConflicts: false` no-op/`NOT EXISTS` preserved            | 1    | medium repo      |
+| `getMergeConflicts` still reports counts                                        | 1    | medium repo      |
+| idempotency of collapsing merge                                                 | 2    | medium repo      |
+| concurrency (overlapping merges) — if feasible                                  | 2    | medium repo      |
+| same-space refs (editor) → `mergeIdentities(collapse:true)`, no throw           | 4    | service unit     |
+| permission narrowing: own personals + view-only no-collision → success          | 3, 4 | service + medium |
+| both in view-only space → `Forbidden` w/ space-named message                    | 3, 4 | service + medium |
+| mixed: repairable conflict + unrelated view-only no-conflict → success          | 4    | service unit     |
+| preserve: non-repairable/inaccessible selected ref → `BadRequest`               | 4    | service unit     |
+| preserve: incompatible type → `BadRequest`                                      | 4    | service unit     |
+| preserve: success queues `SharedSpacePersonMetadataBackfill`                    | 4    | service unit     |
+| reconciliation still skips conflicts, never passes `collapse:true`              | 5    | service unit     |
+| `mergeSpacePeople` / `mergePerson` unchanged                                    | 5    | service/medium   |
+| route: same-space merge → success, combined counts                              | 6    | e2e              |
+| route: non-admin editor same-space → success                                    | 6    | e2e              |
+| route: non-admin own personals also in view-only (no collision) → success       | 6    | e2e              |
+| route: viewer both-in-view-only-space → `Forbidden` space-named                 | 6    | e2e              |
+| route: navigate to collapsed source id → not found                              | 6    | e2e              |
+
+---
+
+## Task 0 — Baseline regression audit
+
+Confirm the suites this plan touches are green before changing anything. Stop and fix any red before Task 1.
+
+- [ ] Run and confirm PASS:
+
+```bash
+pnpm --dir server test src/services/person.service.spec.ts -- --run -t "scoped people repair|mergePerson"
+pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -- --run
+pnpm --dir server test src/services/shared-space.service.spec.ts -- --run -t "mergeSpacePeople|reconcil|dedup"
+```
+
+---
+
+## Task 1 — Repository: opt-in collapse in `mergeIdentities` (same-space + same-owner)
+
+**Files:** `server/src/repositories/face-identity.repository.ts`, `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+- [ ] **Step 1 (RED): same-space collapse test.** In the medium spec, add a test under `describe(FaceIdentityRepository.name, …)`: create one space, two `shared_space_person` rows (target identity + source identity) each with `shared_space_person_face` links — include one `asset_face` linked to **both** rows. Call `sut.mergeIdentities({ targetIdentityId, sourceIdentityIds:[source], source:'manual', collapseScopedConflicts:true })`. Assert: one `shared_space_person` remains in the space on the target identity; its `shared_space_person_face` set is the **union** (no PK violation, no duplicate); the source `shared_space_person` row is gone; the source `face_identity` row is deleted. Run → **RED** (flag unknown / not collapsing).
+
+```bash
+pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -- --run -t "collapses two same-space"
+```
+
+- [ ] **Step 2 (RED): same-owner collapse test.** Two `person` rows owned by one user (target + source identities). Give the source person a face with **no** `face_identity_face` row yet, and leave the survivor `name` empty while the source has a name. Merge with `collapseScopedConflicts:true`. Assert: one `person` remains on the target identity; `asset_face.personId` reassigned; **every** survivor face (including the previously unlinked one) has a `face_identity_face` row on the target identity; source person deleted; survivor `name` filled from source. Run → **RED**.
+
+- [ ] **Step 3 (RED): suggestion cascade test.** Source person has a pending `person_face_suggestion`. After the same-owner collapse, assert no `person_face_suggestion` rows reference the deleted person. Run → **RED**.
+
+- [ ] **Step 4 (implement).**
+  - Add `collapseScopedConflicts?: boolean` to the `mergeIdentities` input type (default `false`).
+  - Parameterise `linkPersonFaces(input, db: Kysely<DB> | Transaction<DB> = this.db)` and use `db` throughout it.
+  - Inside the `mergeIdentities` transaction, **before** `countMergeConflicts`, when the flag is set:
+    1. `SELECT … FOR UPDATE` the `face_identity` rows for `I = [target, ...sources]`.
+    2. Load the `person` and `shared_space_person` rows whose `identityId IN I`, grouped by physical scope (`ownerId` / `spaceId`).
+    3. For each scope with ≥2 rows from `I`, pick the survivor (row on the target identity, else lowest `id`) and collapse the rest, all on `trx`:
+       - **personal:** fill survivor `name`/`birthDate` if empty; `UPDATE asset_face SET personId = survivor WHERE personId = nonsurvivor`; `this.linkPersonFaces({ personId: survivor, identityId: target, source:'manual' }, trx)`; `DELETE FROM person WHERE id = nonsurvivor` (suggestions cascade).
+       - **space:** conflict-safe reassign of `shared_space_person_face` (delete links already on survivor, then `UPDATE … SET personId = survivor`); recompute the survivor's `faceCount`/`assetCount` by mirroring `recountPersons`' self-contained `UPDATE shared_space_person` on `trx` — this is required, because `mergeSpacePeople` calls `recountPersons` explicitly and the queued `SharedSpacePersonMetadataBackfill` does **not** recompute per-space-person face/asset counts; `DELETE FROM shared_space_person WHERE id = nonsurvivor` (faces/aliases cascade).
+  - Leave the existing body unchanged; after collapse `countMergeConflicts` returns 0 so the early-return path is not taken and the `NOT EXISTS` reassignments are no-conflict.
+  - Run Steps 1–3 → **GREEN**.
+
+- [ ] **Step 5 (RED→GREEN): legacy behaviour preserved.** Add/confirm a test: with `collapseScopedConflicts` omitted/`false`, a same-space conflict still produces the early-return no-op (`spaceProfileConflictCount: 1`, no rows moved). Confirm `getMergeConflicts` still returns the same-owner/same-space counts. Run → **GREEN** (no code change needed; this guards the default path).
+
+- [ ] **Step 6 (refactor).** Factor the collapse into a private `collapseScopedConflicts(trx, { targetIdentityId, sourceIdentityIds })` helper for readability; no behaviour change. Re-run the whole medium repo spec:
+
+```bash
+pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -- --run
+```
+
+- [ ] **Step 7 (commit).** `feat(server): collapse same-scope conflicts in identity merge (opt-in)`
+
+---
+
+## Task 2 — Repository: survivor selection, multi-source, cross-scope non-conflict, type/hidden, idempotency
+
+**Files:** same medium spec + `face-identity.repository.ts` (only if a test exposes a gap).
+
+- [ ] **Step 1 (RED): survivor selection.** (a) target identity has a profile in the scope → it survives. (b) target identity absent, two source identities present → the lowest-`id` source profile survives and is reassigned to the target identity. Run → **RED** if selection isn't deterministic over the full `I`.
+- [ ] **Step 2 (RED): two source identities, one space, target absent** → single survivor, no `shared_space_person_spaceId_identityId_key` violation (the latent multi-source defect).
+- [ ] **Step 3 (RED): multi-source batch** (target + 2 sources) with a conflict in one scope and none in another → conflicted scope collapses to one; non-conflicted scope reassigns with no deletion.
+- [ ] **Step 4 (RED): pet type** — two pet `shared_space_person` rows in one space collapse identically (type carried through).
+- [ ] **Step 5 (RED): hidden preserved** — collapsing a hidden source into a visible survivor (and vice versa) keeps the survivor's `isHidden`; merge is not gated on hidden (manual path).
+- [ ] **Step 6 (RED): cross-scope non-conflict regressions** — (a) `person` (owner A) + `shared_space_person` (space X) → identity merge only, **both rows survive** on the target identity, nothing deleted. (b) two `shared_space_person` rows in **different** spaces → both survive.
+- [ ] **Step 7 (RED): idempotency** — re-run the collapsing merge over the merged set; assert no row/identity changes.
+- [ ] **Step 8 (RED, best-effort): concurrency** — if expressible in medium tests, two overlapping collapsing merges do not both delete the survivor / leave a duplicate; one wins, the other no-ops or errors without corrupting state (relies on the `FOR UPDATE` from Task 1).
+- [ ] **Step 9 (implement gaps → GREEN).** Most pass from Task 1; fix only what a red test exposes (likely survivor-selection ordering and the source–source case). Re-run full medium spec.
+- [ ] **Step 10 (commit).** `test(server): cover survivor selection, multi-source, cross-scope, idempotency for collapse`
+
+---
+
+> **Ordering note (compile safety).** `RepairRefsResolution` is shared by its producer (`resolveRepairRefs`) and consumer (`mergeScopedPeople`). Changing it is a breaking change for both. To keep every task `tsc`-green, this is done **additively** (Task 3 adds `blockingConflict` while keeping the old fields) then **switched** (Task 4 moves the service onto it and only then removes the dead fields). Do not remove `allAttachedProfilesRepairable`/`hasScopedProfileConflict` until Task 4 Step 6.
+
+## Task 3 — Resolver: per-conflict-scope repairability (additive)
+
+**Files:** `server/src/repositories/face-identity.repository.ts`, `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+Implements the real DB check and surfaces it as a **new, additive** field. The build stays green because nothing is removed yet.
+
+- [ ] **Step 1: additive type.** Add `blockingConflict?: { scope: 'space'; spaceId: string; spaceName: string } | { scope: 'personal' }` to the `accessible: true` branch of `RepairRefsResolution`. Keep `allAttachedProfilesRepairable` and `hasScopedProfileConflict` for now. (`blockingConflict === undefined` ⇒ every conflicted scope is repairable by the actor.)
+- [ ] **Step 2 (RED, medium): space conflict in a view-only space → blocking.** Two identities each with a `shared_space_person` in one space where the actor is **Viewer**. Assert `resolveRepairRefs(actor, dto)` returns `blockingConflict: { scope:'space', spaceId, spaceName }`. Run → **RED**.
+- [ ] **Step 3 (RED, medium): same conflict where actor is Editor → not blocking.** `blockingConflict: undefined`.
+- [ ] **Step 4 (RED, medium): personal conflict in another user's scope → blocking.** Two identities each with a `person` owned by user U ≠ actor, surfaced via space refs in **different** editor spaces (so the only conflict is the unrepairable personal one). Assert `blockingConflict: { scope:'personal' }`.
+- [ ] **Step 5 (RED, medium): own-personal + unrelated view-only space, no collision → not blocking** (tester Part 1). Two of the actor's `person` rows (a same-owner conflict, repairable) whose identities also each have a space-person in **different** view-only spaces (no same-space collision) → `blockingConflict: undefined`.
+- [ ] **Step 6 (implement → GREEN).** Add `findBlockingMergeConflictScope(actorUserId, identityIds)`:
+  - personal: `SELECT 1 FROM person WHERE identityId IN I AND ownerId <> actor GROUP BY ownerId HAVING count(DISTINCT identityId) >= 2 LIMIT 1` → `{ scope:'personal' }`.
+  - space: group `shared_space_person` by `spaceId` for `identityId IN I`, left-join `shared_space_member` for the actor, take a space `HAVING count(DISTINCT identityId) >= 2` whose actor role is not owner/editor; return `{ scope:'space', spaceId, spaceName }` (join the space name). Prefer a space result over a personal one for the more actionable message.
+    Populate `blockingConflict` in `resolveRepairRefs` from it; leave the old fields in place. Run → **GREEN**. Build still compiles (additive).
+- [ ] **Step 7 (commit).** `feat(server): resolve per-conflict-scope repairability for scoped merge`
+
+---
+
+## Task 4 — Service: enable collapse, switch to `blockingConflict`, remove dead gate
+
+**Files:** `server/src/services/person.service.ts`, `server/src/services/person.service.spec.ts`, `RepairRefsResolution` (cleanup) in `face-identity.repository.ts`.
+
+Unit tests here mock `resolveRepairRefs`; the real resolver landed in Task 3.
+
+- [ ] **Step 1 (RED): same-scope editor success.** Repurpose the existing test `rejects same-person repair when the scoped profiles conflict in the same owner or space` → `collapses same-scope conflicts the actor can repair`: mock `{ accessible:true, targetIdentityId, sourceIdentityIds, type, blockingConflict: undefined }`; assert `mergeIdentities` called with `{ …, source:'manual', collapseScopedConflicts:true }` and **no throw**. Run → **RED**.
+- [ ] **Step 2 (RED): blocking conflict → Forbidden.** Repurpose `rejects global merge when an involved identity has inaccessible attached profiles` → mock `blockingConflict: { scope:'space', spaceId, spaceName:'Holidays' }`; assert `ForbiddenException` whose message names the space; `mergeIdentities` not called. Run → **RED**.
+- [ ] **Step 3 (RED): mixed repairable conflict + unrelated view-only attachment** → `blockingConflict: undefined` → success with `collapseScopedConflicts:true`.
+- [ ] **Step 4 (update preserved tests).** `rejects same-person repair for inaccessible scoped profiles` (accessible:false → `BadRequest`) stays. `merges same-person repair only after access and repairability checks` → add `collapseScopedConflicts:true` to the expected `mergeIdentities` call; keep the `SharedSpacePersonMetadataBackfill` queue assertion. (Incompatible type still returns `accessible:false, reason:'incompatible-type'` → `BadRequest`; keep/observe that test.)
+- [ ] **Step 5 (implement → GREEN).** In `mergeScopedPeople`: after the `accessible` check, `if (resolved.blockingConflict) throw new ForbiddenException(<space-named message | generic personal message>)`; delete the `allAttachedProfilesRepairable` `ForbiddenException` and the `hasScopedProfileConflict` `BadRequestException`; call `mergeIdentities({ targetIdentityId, sourceIdentityIds, source:'manual', collapseScopedConflicts:true })`. Run service spec → **GREEN**.
+- [ ] **Step 6 (cleanup → still green).** Now that no caller reads them, remove `allAttachedProfilesRepairable` and `hasScopedProfileConflict` from `RepairRefsResolution` and from `resolveRepairRefs`, and delete the now-dead private `areAttachedProfilesRepairable` / `hasRepairProfileConflict` (grep to confirm no other caller — `getMergeConflicts`/`countMergeConflicts` are separate and stay). Run `pnpm --dir server check` + both specs → **GREEN**.
+
+```bash
+pnpm --dir server test src/services/person.service.spec.ts -- --run -t "scoped people repair"
+pnpm --dir server check
+```
+
+- [ ] **Step 7 (commit).** `feat(server): scoped merge collapses same-scope conflicts and narrows permission gate`
+
+---
+
+## Task 5 — Reconciliation & physical-endpoint regression
+
+**Files:** `server/src/services/shared-space.service.spec.ts` (+ run mergePerson/mergeSpacePeople suites).
+
+- [ ] **Step 1.** Confirm `applySharedSpaceIdentityReconciliationClaim` still preflights `getMergeConflicts`, skips on any conflict, and calls `mergeIdentities` **without** `collapseScopedConflicts` (default false). Add an assertion if missing.
+- [ ] **Step 2.** Run `mergeSpacePeople`, `mergePerson`, and the reconciliation/dedup suites; all green (the `linkPersonFaces` executor default keeps existing call sites identical).
+
+```bash
+pnpm --dir server test src/services/shared-space.service.spec.ts -- --run
+pnpm --dir server test src/services/person.service.spec.ts -- --run -t "mergePerson"
+```
+
+- [ ] **Step 3 (commit, if any test added).** `test(server): guard reconciliation does not collapse on conflict`
+
+---
+
+## Task 6 — Route / e2e coverage
+
+**Files:** `e2e/src/specs/server/api/person.e2e-spec.ts`, `e2e/src/specs/server/api/shared-space.e2e-spec.ts`
+
+- [ ] **Step 1 (RED→GREEN).** Add e2e covering, via `POST /people/same-person`:
+  - two same-space duplicates → 200; the surviving identity resolves to one accessible person with the **combined** asset and face counts.
+  - a **non-admin editor** merges two duplicates in their editor space → success (Test case B for a non-admin).
+  - a **non-admin** merges two of their own personal duplicates that also appear (no collision) in a view-only space → success (tester Part 1).
+  - a **viewer** merging two profiles that both appear in that view-only space → `403` with the space-named message.
+  - fetching the collapsed source profile id afterward → not-found.
+
+```bash
+# requires the e2e stack up (`make e2e`, or `make e2e-api-dev` against a `make dev` stack)
+pnpm --dir e2e test server/api/person.e2e-spec.ts
+```
+
+- [ ] **Step 2 (commit).** `test(e2e): cover same-scope merge collapse and viewer refusal`
+
+---
+
+## Task 7 — Final verification & generated artifacts
+
+- [ ] Regenerate the SQL snapshot for any new `@GenerateSql`-decorated query: `make sql` (updates `server/src/queries/face-identity.repository.sql`). No OpenAPI change is expected (no new endpoint/DTO); if a DTO did change, run `pnpm --dir server build && pnpm --dir server sync:open-api && make open-api`.
+- [ ] Gates:
+
+```bash
+pnpm --dir server lint && pnpm --dir server format && pnpm --dir server check
+pnpm --dir server test src/services/person.service.spec.ts -- --run
+pnpm --dir server test:medium test/medium/specs/repositories/face-identity.repository.spec.ts -- --run
+git diff --check
+```
+
+- [ ] Manual smoke (per spec): merge two same-space duplicates from the global `/people` page (was failing) and from the space grid; merge own personal duplicates as a non-admin; confirm a viewer is refused with the named message.
+- [ ] **Commit.** `chore(server): regenerate SQL snapshot for scoped merge collapse`
+
+---
+
+## Task 8 — Web routing simplification (optional, non-blocking)
+
+Per the spec's "Web Follow-up": with the server collapse in place, the per-screen merge routing can simplify to "personal-only batch ⇒ `mergePerson`; everything else ⇒ `mergeScopedPeople`," keeping the in-space `mergeSpacePeople` fast path. Out of scope for the core fix; do only after Tasks 1–7 are merged, and keep the existing web merge specs green (`web/src/.../person-detail-page.spec.ts`, `space-person-detail-page.spec.ts`, `person-merge-suggestion-modal.spec.ts`).
+
+---
+
+## Definition of Done
+
+- Every Coverage-Matrix row has a green test that was first observed red.
+- `mergeScopedPeople` collapses repairable same-scope conflicts and refuses unrepairable ones with a space-named `ForbiddenException`; tester Test case B and Part 1 both pass.
+- Automatic reconciliation, `mergeSpacePeople`, and `mergePerson` behaviour unchanged.
+- `pnpm --dir server lint && format && check` clean; SQL snapshot regenerated; `git diff --check` clean.

--- a/docs/plans/2026-05-29-same-scope-merge-collapse-plan.md
+++ b/docs/plans/2026-05-29-same-scope-merge-collapse-plan.md
@@ -216,7 +216,7 @@ pnpm --dir server test src/services/person.service.spec.ts -- --run -t "mergePer
   - two same-space duplicates → 200; the surviving identity resolves to one accessible person with the **combined** asset and face counts.
   - a **non-admin editor** merges two duplicates in their editor space → success (Test case B for a non-admin).
   - a **non-admin** merges two of their own personal duplicates that also appear (no collision) in a view-only space → success (tester Part 1).
-  - a **viewer** merging two profiles that both appear in that view-only space → `403` with the space-named message.
+  - a **viewer** who owns two personal people whose identities ALSO collide as separate space-people in a space they can only view → `403` with the space-named message. (Note: a viewer passing the view-only `space-person` refs _directly_ yields `400` — a viewer cannot resolve a space-person ref it can't repair, so the conflict check is never reached. The `403` path requires the actor to select refs it CAN repair, here its own personal people.)
   - fetching the collapsed source profile id afterward → not-found.
 
 ```bash

--- a/e2e/src/specs/server/api/person.e2e-spec.ts
+++ b/e2e/src/specs/server/api/person.e2e-spec.ts
@@ -1,5 +1,12 @@
-import { getPerson, LoginResponseDto, PersonResponseDto } from '@immich/sdk';
-import { uuidDto } from 'src/fixtures';
+import {
+  getPerson,
+  LoginResponseDto,
+  mergeScopedPeople,
+  PersonResponseDto,
+  Type2 as ScopedPersonRefType,
+  SharedSpaceRole,
+} from '@immich/sdk';
+import { createUserDto, uuidDto } from 'src/fixtures';
 import { errorDto } from 'src/responses';
 import { app, asBearerAuth, utils } from 'src/utils';
 import request from 'supertest';
@@ -342,5 +349,174 @@ describe('/people', () => {
       expect(status).toBe(400);
       expect(body).toEqual(errorDto.badRequest('Cannot merge a person into themselves'));
     });
+  });
+});
+
+// Gives an identity-LESS shared_space_person (from utils.createSpacePerson) its own
+// face_identity, so two such rows in the SAME space sit on DIFFERENT identities and
+// therefore form a same-space conflict that mergeScopedPeople must collapse.
+//
+// Mirrors the medium-test `createAccessibleSpaceIdentity` helper: insert a
+// face_identity (type 'person'), point both the backing global person row and the
+// space-person row at it, and link the backing face to it with source 'manual'.
+const giveSpacePersonAnIdentity = async (input: {
+  globalPersonId: string;
+  spacePersonId: string;
+  faceId: string;
+}): Promise<string> => {
+  const client = await utils.connectDatabase();
+
+  const identityResult = await client.query(
+    `INSERT INTO "face_identity" ("type", "representativeFaceId") VALUES ('person', $1) RETURNING id`,
+    [input.faceId],
+  );
+  const identityId = identityResult.rows[0].id as string;
+
+  await client.query(`UPDATE "person" SET "identityId" = $1 WHERE id = $2`, [identityId, input.globalPersonId]);
+  await client.query(`UPDATE "shared_space_person" SET "identityId" = $1 WHERE id = $2`, [
+    identityId,
+    input.spacePersonId,
+  ]);
+  await client.query(
+    `INSERT INTO "face_identity_face" ("assetFaceId", "identityId", "source") VALUES ($1, $2, 'manual')`,
+    [input.faceId, identityId],
+  );
+
+  return identityId;
+};
+
+describe('/people/same-person (scoped merge collapse)', () => {
+  let admin: LoginResponseDto;
+
+  beforeAll(async () => {
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+  });
+
+  it('collapses two same-owner personal duplicates into one surviving person', async () => {
+    // Test case A: two personal people owned by the same user, each on its own identity
+    // (utils.createFace mints an identity per person). The merge must collapse the source
+    // into the target and delete the source person row.
+    const [target, source] = await Promise.all([
+      utils.createPerson(admin.accessToken, { name: 'Same Owner Target' }),
+      utils.createPerson(admin.accessToken, { name: 'Same Owner Source' }),
+    ]);
+
+    const targetAsset = await utils.createAsset(admin.accessToken);
+    const sourceAsset = await utils.createAsset(admin.accessToken);
+    await utils.createFace({ assetId: targetAsset.id, personId: target.id });
+    await utils.createFace({ assetId: sourceAsset.id, personId: source.id });
+
+    await mergeScopedPeople(
+      {
+        mergeScopedPeopleDto: {
+          target: { type: ScopedPersonRefType.Person, id: target.id },
+          sources: [{ type: ScopedPersonRefType.Person, id: source.id }],
+        },
+      },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    // Target survives.
+    const survivor = await getPerson({ id: target.id }, { headers: asBearerAuth(admin.accessToken) });
+    expect(survivor).toMatchObject({ id: target.id });
+
+    // Source person row is gone (collapsed). Missing personal person → 400 (bulk-access pattern).
+    const { status: sourceStatus, body: sourceBody } = await request(app)
+      .get(`/people/${source.id}`)
+      .set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(sourceStatus).toBe(400);
+    expect(sourceBody).toEqual(errorDto.badRequest());
+  });
+
+  it('collapses two same-space duplicates into one surviving space person', async () => {
+    // Test case B: two space-people in ONE space, on two different identities. The merge
+    // collapses them to a single surviving shared_space_person row; the other id is gone.
+    const space = await utils.createSpace(admin.accessToken, { name: 'Same Space Collapse' });
+    const asset = await utils.createAsset(admin.accessToken);
+    await utils.addSpaceAssets(admin.accessToken, space.id, [asset.id]);
+
+    const targetSp = await utils.createSpacePerson(space.id, 'Space Target', admin.userId, asset.id);
+    const sourceSp = await utils.createSpacePerson(space.id, 'Space Source', admin.userId, asset.id);
+    await giveSpacePersonAnIdentity(targetSp);
+    await giveSpacePersonAnIdentity(sourceSp);
+
+    await mergeScopedPeople(
+      {
+        mergeScopedPeopleDto: {
+          target: { type: ScopedPersonRefType.SpacePerson, id: targetSp.spacePersonId, spaceId: space.id },
+          sources: [{ type: ScopedPersonRefType.SpacePerson, id: sourceSp.spacePersonId, spaceId: space.id }],
+        },
+      },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    // Exactly one of the two created space-people survives, and it is the target.
+    const { status: listStatus, body: listBody } = await request(app)
+      .get(`/shared-spaces/${space.id}/people?withHidden=true`)
+      .set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(listStatus).toBe(200);
+    const remainingIds = (listBody as { id: string }[]).map((p) => p.id);
+    expect(remainingIds).toContain(targetSp.spacePersonId);
+    expect(remainingIds).not.toContain(sourceSp.spacePersonId);
+
+    // The collapsed source space-person id is no longer addressable → 400 'Person not found'.
+    const { status: sourceStatus, body: sourceBody } = await request(app)
+      .get(`/shared-spaces/${space.id}/people/${sourceSp.spacePersonId}`)
+      .set('Authorization', `Bearer ${admin.accessToken}`);
+    expect(sourceStatus).toBe(400);
+    expect((sourceBody as { message: string }).message).toMatch(/Person not found/i);
+  });
+
+  it('refuses a same-space conflict in a view-only space with a space-named message', async () => {
+    // The actor owns two PERSONAL people on two different identities, and both identities
+    // also appear as separate space-people in a space the actor can only VIEW.
+    //
+    // Why personal refs (not space-person refs): a space-person ref only resolves when the
+    // actor is owner/editor of the space (resolveRepairProfile → isRepairRole gate at
+    // face-identity.repository.ts:1286). A viewer passing space-person refs would 400
+    // ('not found or not accessible'), never reaching the conflict check. To exercise the
+    // ForbiddenException path (the actual viewer-refusal behaviour), the actor selects refs
+    // it CAN repair (its own personal people) while the blocking same-space conflict is
+    // discovered by findBlockingMergeConflictScope — it groups shared_space_person by space,
+    // finds two of the merged identities there, and sees the actor is not owner/editor
+    // (face-identity.repository.ts:1311-1330), producing the 403 with the space name.
+    const owner = await utils.userSetup(admin.accessToken, createUserDto.create('scoped-merge-owner'));
+    const viewer = await utils.userSetup(admin.accessToken, createUserDto.create('scoped-merge-viewer'));
+
+    // The space, owned by `owner`; `viewer` is added as a Viewer.
+    const space = await utils.createSpace(owner.accessToken, { name: 'View Only Holidays' });
+    const ownerAsset = await utils.createAsset(owner.accessToken);
+    await utils.addSpaceAssets(owner.accessToken, space.id, [ownerAsset.id]);
+    await utils.addSpaceMember(owner.accessToken, space.id, {
+      userId: viewer.userId,
+      role: SharedSpaceRole.Viewer,
+    });
+
+    // Two space-people on two distinct identities in that view-only space.
+    const spA = await utils.createSpacePerson(space.id, 'Alice', owner.userId, ownerAsset.id);
+    const spB = await utils.createSpacePerson(space.id, 'Alice (2)', owner.userId, ownerAsset.id);
+    const identityA = await giveSpacePersonAnIdentity(spA);
+    const identityB = await giveSpacePersonAnIdentity(spB);
+
+    // The viewer's own two personal people, each pinned onto one of those identities so the
+    // refs the viewer selects are repairable (own personal rows) but the merge would have to
+    // collapse a row in the view-only space.
+    const viewerPersonA = await utils.createPerson(viewer.accessToken, { name: 'My Alice' });
+    const viewerPersonB = await utils.createPerson(viewer.accessToken, { name: 'My Alice (2)' });
+    const client = await utils.connectDatabase();
+    await client.query(`UPDATE "person" SET "identityId" = $1 WHERE id = $2`, [identityA, viewerPersonA.id]);
+    await client.query(`UPDATE "person" SET "identityId" = $1 WHERE id = $2`, [identityB, viewerPersonB.id]);
+
+    const { status, body } = await request(app)
+      .post('/people/same-person')
+      .set('Authorization', `Bearer ${viewer.accessToken}`)
+      .send({
+        target: { type: 'person', id: viewerPersonA.id },
+        sources: [{ type: 'person', id: viewerPersonB.id }],
+      });
+
+    expect(status).toBe(403);
+    expect((body as { message: string }).message).toContain('View Only Holidays');
   });
 });

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -129,8 +129,6 @@ export type RepairRefsResolution =
       targetIdentityId: string;
       sourceIdentityIds: string[];
       type: string;
-      allAttachedProfilesRepairable: boolean;
-      hasScopedProfileConflict: boolean;
       blockingConflict?: { scope: 'space'; spaceId: string; spaceName: string } | { scope: 'personal' };
     };
 
@@ -1152,19 +1150,13 @@ export class FaceIdentityRepository {
       ),
     ];
     const identityIds = [...new Set([target.identityId, ...sourceIdentityIds])];
-    const [allAttachedProfilesRepairable, hasScopedProfileConflict, blockingConflict] = await Promise.all([
-      this.areAttachedProfilesRepairable(actorUserId, identityIds),
-      this.hasRepairProfileConflict(target.identityId, sourceIdentityIds),
-      this.findBlockingMergeConflictScope(actorUserId, identityIds),
-    ]);
+    const blockingConflict = await this.findBlockingMergeConflictScope(actorUserId, identityIds);
 
     return {
       accessible: true,
       targetIdentityId: target.identityId,
       sourceIdentityIds,
       type: target.identityType,
-      allAttachedProfilesRepairable,
-      hasScopedProfileConflict,
       blockingConflict,
     };
   }
@@ -1301,71 +1293,6 @@ export class FaceIdentityRepository {
           representativeFaceId: row.representativeFaceId,
         }
       : null;
-  }
-
-  private async areAttachedProfilesRepairable(actorUserId: string, identityIds: string[]): Promise<boolean> {
-    if (identityIds.length === 0) {
-      return false;
-    }
-
-    const inaccessiblePersonal = await this.db
-      .selectFrom('person')
-      .select('id')
-      .where('identityId', 'in', identityIds)
-      .where('ownerId', '!=', actorUserId)
-      .limit(1)
-      .executeTakeFirst();
-    if (inaccessiblePersonal) {
-      return false;
-    }
-
-    const spaceRows = await this.db
-      .selectFrom('shared_space_person')
-      .leftJoin('shared_space_member', (join) =>
-        join
-          .onRef('shared_space_member.spaceId', '=', 'shared_space_person.spaceId')
-          .on('shared_space_member.userId', '=', actorUserId),
-      )
-      .select(['shared_space_person.id', 'shared_space_member.role'])
-      .where('shared_space_person.identityId', 'in', identityIds)
-      .execute();
-
-    return spaceRows.every((row) => this.isRepairRole(row.role));
-  }
-
-  private async hasRepairProfileConflict(targetIdentityId: string, sourceIdentityIds: string[]): Promise<boolean> {
-    if (sourceIdentityIds.length === 0) {
-      return false;
-    }
-
-    const personalConflict = await this.db
-      .selectFrom('person as source_person')
-      .innerJoin('person as target_person', (join) =>
-        join
-          .onRef('target_person.ownerId', '=', 'source_person.ownerId')
-          .on('target_person.identityId', '=', targetIdentityId),
-      )
-      .select('source_person.id')
-      .where('source_person.identityId', 'in', sourceIdentityIds)
-      .limit(1)
-      .executeTakeFirst();
-    if (personalConflict) {
-      return true;
-    }
-
-    const spaceConflict = await this.db
-      .selectFrom('shared_space_person as source_person')
-      .innerJoin('shared_space_person as target_person', (join) =>
-        join
-          .onRef('target_person.spaceId', '=', 'source_person.spaceId')
-          .on('target_person.identityId', '=', targetIdentityId),
-      )
-      .select('source_person.id')
-      .where('source_person.identityId', 'in', sourceIdentityIds)
-      .limit(1)
-      .executeTakeFirst();
-
-    return !!spaceConflict;
   }
 
   /**

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -131,6 +131,7 @@ export type RepairRefsResolution =
       type: string;
       allAttachedProfilesRepairable: boolean;
       hasScopedProfileConflict: boolean;
+      blockingConflict?: { scope: 'space'; spaceId: string; spaceName: string } | { scope: 'personal' };
     };
 
 export type DetachRefResolution =
@@ -1151,9 +1152,10 @@ export class FaceIdentityRepository {
       ),
     ];
     const identityIds = [...new Set([target.identityId, ...sourceIdentityIds])];
-    const [allAttachedProfilesRepairable, hasScopedProfileConflict] = await Promise.all([
+    const [allAttachedProfilesRepairable, hasScopedProfileConflict, blockingConflict] = await Promise.all([
       this.areAttachedProfilesRepairable(actorUserId, identityIds),
       this.hasRepairProfileConflict(target.identityId, sourceIdentityIds),
+      this.findBlockingMergeConflictScope(actorUserId, identityIds),
     ]);
 
     return {
@@ -1163,6 +1165,7 @@ export class FaceIdentityRepository {
       type: target.identityType,
       allAttachedProfilesRepairable,
       hasScopedProfileConflict,
+      blockingConflict,
     };
   }
 
@@ -1363,6 +1366,53 @@ export class FaceIdentityRepository {
       .executeTakeFirst();
 
     return !!spaceConflict;
+  }
+
+  /**
+   * Returns the physical scope whose same-scope conflict the actor cannot repair, or `undefined` when every
+   * conflicted scope is repairable. A scope is conflicted when two or more of the merged identities hold a separate
+   * profile there. A space result is preferred over a personal one because it yields a more actionable message.
+   */
+  private async findBlockingMergeConflictScope(
+    actorUserId: string,
+    identityIds: string[],
+  ): Promise<{ scope: 'space'; spaceId: string; spaceName: string } | { scope: 'personal' } | undefined> {
+    if (identityIds.length < 2) {
+      return undefined;
+    }
+
+    const blockingSpace = await this.db
+      .selectFrom('shared_space_person')
+      .innerJoin('shared_space', 'shared_space.id', 'shared_space_person.spaceId')
+      .leftJoin('shared_space_member', (join) =>
+        join
+          .onRef('shared_space_member.spaceId', '=', 'shared_space_person.spaceId')
+          .on('shared_space_member.userId', '=', actorUserId)
+          .on('shared_space_member.role', 'in', [SharedSpaceRole.Owner, SharedSpaceRole.Editor]),
+      )
+      .select(['shared_space_person.spaceId as spaceId', 'shared_space.name as spaceName'])
+      .where('shared_space_person.identityId', 'in', identityIds)
+      .groupBy(['shared_space_person.spaceId', 'shared_space.name'])
+      .having((eb) => eb.fn.count('shared_space_person.identityId').distinct(), '>=', 2)
+      .having((eb) => eb.fn.count('shared_space_member.userId'), '=', 0)
+      .limit(1)
+      .executeTakeFirst();
+
+    if (blockingSpace) {
+      return { scope: 'space', spaceId: blockingSpace.spaceId, spaceName: blockingSpace.spaceName };
+    }
+
+    const blockingPersonal = await this.db
+      .selectFrom('person')
+      .select('person.ownerId')
+      .where('person.identityId', 'in', identityIds)
+      .where('person.ownerId', '!=', actorUserId)
+      .groupBy('person.ownerId')
+      .having((eb) => eb.fn.count('person.identityId').distinct(), '>=', 2)
+      .limit(1)
+      .executeTakeFirst();
+
+    return blockingPersonal ? { scope: 'personal' } : undefined;
   }
 
   private async getProfileForDetach(

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -2004,8 +2004,8 @@ export class FaceIdentityRepository {
   }
 
   @GenerateSql({ params: [{ personId: DummyValue.UUID, identityId: DummyValue.UUID, source: 'manual' }] })
-  async linkPersonFaces(input: LinkPersonFacesInput): Promise<void> {
-    await this.db
+  async linkPersonFaces(input: LinkPersonFacesInput, db: Kysely<DB> | Transaction<DB> = this.db): Promise<void> {
+    await db
       .insertInto('face_identity_face')
       .columns(['assetFaceId', 'identityId', 'source', 'confidence'])
       .expression((eb) =>
@@ -2497,6 +2497,7 @@ export class FaceIdentityRepository {
     targetIdentityId: string;
     sourceIdentityIds: string[];
     source: FaceIdentityFaceSource;
+    collapseScopedConflicts?: boolean;
   }): Promise<MergeIdentitiesResult> {
     const sourceIdentityIds = [...new Set(input.sourceIdentityIds)].filter((id) => id !== input.targetIdentityId);
     if (sourceIdentityIds.length === 0) {
@@ -2518,6 +2519,13 @@ export class FaceIdentityRepository {
       );
       if (incompatible) {
         throw new Error('Cannot merge face identities with different types');
+      }
+
+      if (input.collapseScopedConflicts) {
+        await this.collapseScopedConflicts(trx, {
+          targetIdentityId: input.targetIdentityId,
+          sourceIdentityIds,
+        });
       }
 
       const { personalProfileConflictCount, spaceProfileConflictCount } = await this.countMergeConflicts(trx, {
@@ -2591,6 +2599,214 @@ export class FaceIdentityRepository {
         spaceProfileConflictCount,
       };
     });
+  }
+
+  /**
+   * Collapse same-physical-scope duplicate profiles before the identity-link reassignment runs.
+   *
+   * A "same-scope conflict" is two or more profiles whose identity is in `I = {target} ∪ sources`
+   * that share one physical scope (`person.ownerId` or `shared_space_person.spaceId`). The
+   * partial-unique indexes `person_ownerId_identityId_key` / `shared_space_person_spaceId_identityId_key`
+   * forbid two of them carrying the target identity, so we pick a deterministic survivor per scope,
+   * move the redundant profiles' faces onto it, link them to the target identity, and delete the rest.
+   *
+   * Transaction discipline (issue #595): every query runs on `trx`. We never call a `this.db`-based
+   * repository helper here — that would reserve a second pool connection while the transaction holds
+   * the first and deadlock the 10-connection pool. The SQL below mirrors `personRepository.reassignFaces`,
+   * `sharedSpaceRepository.reassignPersonFacesSafe`, and `recountPersons`, issued directly on `trx`.
+   */
+  private async collapseScopedConflicts(
+    trx: Transaction<DB>,
+    input: {
+      targetIdentityId: string;
+      sourceIdentityIds: string[];
+    },
+  ): Promise<void> {
+    const identityIds = [input.targetIdentityId, ...input.sourceIdentityIds];
+
+    // Lock the candidate identity rows so a concurrent overlapping merge serialises behind us
+    // and observes the collapsed state (or fails its own transaction) rather than racing.
+    await trx.selectFrom('face_identity').select('id').where('id', 'in', identityIds).forUpdate().execute();
+
+    await this.collapsePersonalConflicts(trx, input);
+    await this.collapseSpaceConflicts(trx, input);
+  }
+
+  private async collapsePersonalConflicts(
+    trx: Transaction<DB>,
+    input: {
+      targetIdentityId: string;
+      sourceIdentityIds: string[];
+    },
+  ): Promise<void> {
+    const identityIds = [input.targetIdentityId, ...input.sourceIdentityIds];
+    const rows = await trx
+      .selectFrom('person')
+      .select(['id', 'ownerId', 'identityId', 'name', 'birthDate'])
+      .where('identityId', 'in', identityIds)
+      .execute();
+
+    const byOwner = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const group = byOwner.get(row.ownerId);
+      if (group) {
+        group.push(row);
+      } else {
+        byOwner.set(row.ownerId, [row]);
+      }
+    }
+
+    for (const group of byOwner.values()) {
+      if (group.length < 2) {
+        continue;
+      }
+
+      const survivor = this.pickSurvivor(group, input.targetIdentityId);
+      for (const nonSurvivor of group) {
+        if (nonSurvivor.id === survivor.id) {
+          continue;
+        }
+
+        // Fill missing display metadata from the collapsed row (mirrors mergePerson's fill-if-empty).
+        const update: { name?: string; birthDate?: typeof nonSurvivor.birthDate } = {};
+        if (!survivor.name && nonSurvivor.name) {
+          update.name = nonSurvivor.name;
+          survivor.name = nonSurvivor.name;
+        }
+        if (!survivor.birthDate && nonSurvivor.birthDate) {
+          update.birthDate = nonSurvivor.birthDate;
+          survivor.birthDate = nonSurvivor.birthDate;
+        }
+        if (Object.keys(update).length > 0) {
+          await trx.updateTable('person').set(update).where('id', '=', survivor.id).execute();
+        }
+
+        // Mirror personRepository.reassignFaces (asset_face.personId source → survivor).
+        await trx
+          .updateTable('asset_face')
+          .set({ personId: survivor.id })
+          .where('personId', '=', nonSurvivor.id)
+          .execute();
+
+        // Link the survivor's faces (including freshly-moved ones with no prior identity link)
+        // to the target identity — mergeIdentities' own reassignment only moves existing links.
+        await this.linkPersonFaces(
+          { personId: survivor.id, identityId: input.targetIdentityId, source: 'manual' },
+          trx,
+        );
+
+        // Suggestions, aliases, etc. cascade-delete with the row.
+        await trx.deleteFrom('person').where('id', '=', nonSurvivor.id).execute();
+      }
+    }
+  }
+
+  private async collapseSpaceConflicts(
+    trx: Transaction<DB>,
+    input: {
+      targetIdentityId: string;
+      sourceIdentityIds: string[];
+    },
+  ): Promise<void> {
+    const identityIds = [input.targetIdentityId, ...input.sourceIdentityIds];
+    const rows = await trx
+      .selectFrom('shared_space_person')
+      .select(['id', 'spaceId', 'identityId'])
+      .where('identityId', 'in', identityIds)
+      .execute();
+
+    const bySpace = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const group = bySpace.get(row.spaceId);
+      if (group) {
+        group.push(row);
+      } else {
+        bySpace.set(row.spaceId, [row]);
+      }
+    }
+
+    for (const group of bySpace.values()) {
+      if (group.length < 2) {
+        continue;
+      }
+
+      const survivor = this.pickSurvivor(group, input.targetIdentityId);
+      for (const nonSurvivor of group) {
+        if (nonSurvivor.id === survivor.id) {
+          continue;
+        }
+
+        // Conflict-safe reassign of shared_space_person_face (mirrors reassignPersonFacesSafe):
+        // (personId, assetFaceId) is the PK, so drop links already on the survivor before moving.
+        await trx
+          .deleteFrom('shared_space_person_face')
+          .where('personId', '=', nonSurvivor.id)
+          .where(
+            'assetFaceId',
+            'in',
+            trx.selectFrom('shared_space_person_face').select('assetFaceId').where('personId', '=', survivor.id),
+          )
+          .execute();
+        await trx
+          .updateTable('shared_space_person_face')
+          .set({ personId: survivor.id })
+          .where('personId', '=', nonSurvivor.id)
+          .execute();
+
+        // Faces/aliases/suggestions of the redundant row cascade-delete with it.
+        await trx.deleteFrom('shared_space_person').where('id', '=', nonSurvivor.id).execute();
+      }
+
+      // Recompute the survivor's face/asset counts (mirrors recountPersons' self-contained UPDATE).
+      // The queued SharedSpacePersonMetadataBackfill does NOT recount per-space-person, so this is required.
+      await this.recountSpacePerson(trx, survivor.id);
+    }
+  }
+
+  private pickSurvivor<T extends { id: string; identityId: string | null }>(group: T[], targetIdentityId: string): T {
+    const onTarget = group.filter((row) => row.identityId === targetIdentityId);
+    const candidates = onTarget.length > 0 ? onTarget : group;
+    let best = candidates[0];
+    for (const row of candidates) {
+      if (row.id < best.id) {
+        best = row;
+      }
+    }
+    return best;
+  }
+
+  private async recountSpacePerson(trx: Transaction<DB>, personId: string): Promise<void> {
+    await trx
+      .updateTable('shared_space_person')
+      .set((eb) => ({
+        faceCount: eb
+          .selectFrom('shared_space_person_face')
+          .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+          .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+          .where('asset_face.deletedAt', 'is', null)
+          .where('asset_face.isVisible', 'is', true)
+          .where('asset.deletedAt', 'is', null)
+          .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+          .select((eb2) => eb2.fn.countAll().$castTo<number>().as('count'))
+          .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id'),
+        assetCount: eb
+          .selectFrom('shared_space_person_face')
+          .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+          .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+          .where('asset_face.deletedAt', 'is', null)
+          .where('asset_face.isVisible', 'is', true)
+          .where('asset.deletedAt', 'is', null)
+          .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+          .select((eb2) =>
+            eb2.fn
+              .count(eb2.fn('distinct', ['asset_face.assetId']))
+              .$castTo<number>()
+              .as('count'),
+          )
+          .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id'),
+      }))
+      .where('id', '=', personId)
+      .execute();
   }
 
   private async countMergeConflicts(

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -4809,7 +4809,6 @@ describe(PersonService.name, () => {
       const auth = AuthFactory.create();
       mocks.faceIdentity.resolveRepairRefs.mockResolvedValue({
         accessible: false,
-        allAttachedProfilesRepairable: false,
       } as any);
 
       await expect(
@@ -4829,7 +4828,7 @@ describe(PersonService.name, () => {
         targetIdentityId: 'identity-1',
         sourceIdentityIds: ['identity-2'],
         type: 'person',
-        allAttachedProfilesRepairable: true,
+        blockingConflict: undefined,
       } as any);
       mocks.faceIdentity.mergeIdentities.mockResolvedValue({
         personalProfileConflictCount: 0,
@@ -4845,6 +4844,7 @@ describe(PersonService.name, () => {
         targetIdentityId: 'identity-1',
         sourceIdentityIds: ['identity-2'],
         source: 'manual',
+        collapseScopedConflicts: true,
       });
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.SharedSpacePersonMetadataBackfill,
@@ -4852,14 +4852,14 @@ describe(PersonService.name, () => {
       });
     });
 
-    it('rejects global merge when an involved identity has inaccessible attached profiles', async () => {
+    it('rejects merge when a same-scope conflict lives in a space the actor can only view', async () => {
       const auth = AuthFactory.create();
       mocks.faceIdentity.resolveRepairRefs.mockResolvedValue({
         accessible: true,
         targetIdentityId: 'identity-1',
         sourceIdentityIds: ['identity-2'],
         type: 'person',
-        allAttachedProfilesRepairable: false,
+        blockingConflict: { scope: 'space', spaceId: 'space-1', spaceName: 'Holidays' },
       } as any);
 
       await expect(
@@ -4867,30 +4867,72 @@ describe(PersonService.name, () => {
           target: { type: 'person', id: newUuid() },
           sources: [{ type: 'space-person', id: newUuid(), spaceId: newUuid() }],
         }),
-      ).rejects.toBeInstanceOf(ForbiddenException);
+      ).rejects.toThrow(
+        expect.objectContaining({
+          constructor: ForbiddenException,
+          message: expect.stringContaining('Holidays'),
+        }),
+      );
 
       expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
     });
 
-    it('rejects same-person repair when the scoped profiles conflict in the same owner or space', async () => {
+    it('allows a repairable same-scope conflict alongside an unrelated view-only attachment', async () => {
       const auth = AuthFactory.create();
       mocks.faceIdentity.resolveRepairRefs.mockResolvedValue({
         accessible: true,
         targetIdentityId: 'identity-1',
         sourceIdentityIds: ['identity-2'],
         type: 'person',
-        allAttachedProfilesRepairable: true,
-        hasScopedProfileConflict: true,
+        blockingConflict: undefined,
       } as any);
+      mocks.faceIdentity.mergeIdentities.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 0,
+      });
 
       await expect(
         sut.mergeScopedPeople(auth, {
           target: { type: 'person', id: newUuid() },
           sources: [{ type: 'person', id: newUuid() }],
         }),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).resolves.not.toThrow();
 
-      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
+        targetIdentityId: 'identity-1',
+        sourceIdentityIds: ['identity-2'],
+        source: 'manual',
+        collapseScopedConflicts: true,
+      });
+    });
+
+    it('collapses same-scope conflicts the actor can repair', async () => {
+      const auth = AuthFactory.create();
+      mocks.faceIdentity.resolveRepairRefs.mockResolvedValue({
+        accessible: true,
+        targetIdentityId: 'identity-1',
+        sourceIdentityIds: ['identity-2'],
+        type: 'person',
+        blockingConflict: undefined,
+      } as any);
+      mocks.faceIdentity.mergeIdentities.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 0,
+      });
+
+      await expect(
+        sut.mergeScopedPeople(auth, {
+          target: { type: 'person', id: newUuid() },
+          sources: [{ type: 'person', id: newUuid() }],
+        }),
+      ).resolves.not.toThrow();
+
+      expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
+        targetIdentityId: 'identity-1',
+        sourceIdentityIds: ['identity-2'],
+        source: 'manual',
+        collapseScopedConflicts: true,
+      });
     });
 
     it('detaches a scoped profile after access and backing-face checks', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -171,17 +171,19 @@ export class PersonService extends BaseService {
     if (!resolved.accessible) {
       throw new BadRequestException('One or more people were not found or are not accessible');
     }
-    if (!resolved.allAttachedProfilesRepairable) {
-      throw new ForbiddenException('Cannot merge identities with inaccessible attached profiles');
-    }
-    if (resolved.hasScopedProfileConflict) {
-      throw new BadRequestException('Cannot merge people that already have separate profiles in the same scope');
+    if (resolved.blockingConflict) {
+      throw new ForbiddenException(
+        resolved.blockingConflict.scope === 'space'
+          ? `These people also share a separate profile in shared space "${resolved.blockingConflict.spaceName}", which you can only view. Ask an editor of "${resolved.blockingConflict.spaceName}" to merge them.`
+          : `These people are also linked in another user's library, so they can't be merged here.`,
+      );
     }
 
     await this.faceIdentityRepository.mergeIdentities({
       targetIdentityId: resolved.targetIdentityId,
       sourceIdentityIds: resolved.sourceIdentityIds,
       source: 'manual',
+      collapseScopedConflicts: true,
     });
     await this.queueSpacePersonMetadataBackfill();
   }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -3017,6 +3017,213 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  describe('mergeIdentities collapseScopedConflicts', () => {
+    it('collapses two same-space profiles into one survivor on the target identity', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const targetSpacePerson = await newSpacePerson(ctx, space.id);
+        const sourceSpacePerson = await newSpacePerson(ctx, space.id);
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: sharedFace } = await ctx.newAssetFace({ assetId: asset.id });
+        const { assetFace: sourceOnlyFace } = await ctx.newAssetFace({ assetId: asset.id });
+        const { assetFace: targetOnlyFace } = await ctx.newAssetFace({ assetId: asset.id });
+        // sharedFace is linked to BOTH space people (the conflict-safe case).
+        await linkSpaceFace(ctx, targetSpacePerson.id, sharedFace.id);
+        await linkSpaceFace(ctx, targetSpacePerson.id, targetOnlyFace.id);
+        await linkSpaceFace(ctx, sourceSpacePerson.id, sharedFace.id);
+        await linkSpaceFace(ctx, sourceSpacePerson.id, sourceOnlyFace.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+
+        const result = await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const survivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('spaceId', '=', space.id)
+          .execute();
+        const survivorFaces = await ctx.database
+          .selectFrom('shared_space_person_face')
+          .select('assetFaceId')
+          .where('personId', '=', targetSpacePerson.id)
+          .orderBy('assetFaceId')
+          .execute();
+        const sourceRow = await ctx.database
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('id', '=', sourceSpacePerson.id)
+          .executeTakeFirst();
+        const sourceIdentityRow = await ctx.database
+          .selectFrom('face_identity')
+          .select('id')
+          .where('id', '=', sourceIdentity.id)
+          .executeTakeFirst();
+
+        expect(result).toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 0 });
+        expect(survivors).toEqual([{ id: targetSpacePerson.id, identityId: targetIdentity.id }]);
+        expect(survivorFaces.map((row) => row.assetFaceId).toSorted()).toEqual(
+          [sharedFace.id, sourceOnlyFace.id, targetOnlyFace.id].toSorted(),
+        );
+        expect(sourceRow).toBeUndefined();
+        expect(sourceIdentityRow).toBeUndefined();
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('collapses two same-owner people, linking every survivor face and filling missing metadata', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id, name: '' });
+        const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id, name: 'Source Name' });
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        // Survivor face that already exists on the target person.
+        const { assetFace: targetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: targetPerson.id });
+        // Source face WITHOUT a face_identity_face row yet — only linkPersonFaces covers it.
+        const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+        const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+        const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+        await sut.linkFace({ assetFaceId: targetFace.id, identityId: targetIdentity.id, source: 'owner-person' });
+
+        const result = await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const survivors = await ctx.database
+          .selectFrom('person')
+          .select(['id', 'identityId', 'name'])
+          .where('ownerId', '=', user.id)
+          .execute();
+        const reassignedFace = await ctx.database
+          .selectFrom('asset_face')
+          .select('personId')
+          .where('id', '=', sourceFace.id)
+          .executeTakeFirstOrThrow();
+        const links = await ctx.database
+          .selectFrom('face_identity_face')
+          .select(['assetFaceId', 'identityId'])
+          .where('assetFaceId', 'in', [targetFace.id, sourceFace.id])
+          .orderBy('assetFaceId')
+          .execute();
+        const sourceRow = await ctx.database
+          .selectFrom('person')
+          .select('id')
+          .where('id', '=', sourcePerson.id)
+          .executeTakeFirst();
+
+        expect(result).toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 0 });
+        expect(survivors).toEqual([{ id: targetPerson.id, identityId: targetIdentity.id, name: 'Source Name' }]);
+        expect(reassignedFace.personId).toBe(targetPerson.id);
+        expect(links.every((link) => link.identityId === targetIdentity.id)).toBe(true);
+        expect(links.map((link) => link.assetFaceId).toSorted()).toEqual([sourceFace.id, targetFace.id].toSorted());
+        expect(sourceRow).toBeUndefined();
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('cascade-deletes pending suggestions of a collapsed same-owner source person', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
+        const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: targetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: targetPerson.id });
+        const { assetFace: suggestedFace } = await ctx.newAssetFace({ assetId: asset.id });
+        const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+        const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+        await sut.linkFace({ assetFaceId: targetFace.id, identityId: targetIdentity.id, source: 'owner-person' });
+        const suggestion = await ctx.database
+          .insertInto('person_face_suggestion')
+          .values({ personId: sourcePerson.id, assetFaceId: suggestedFace.id, distance: 0.1, status: 'pending' })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const remaining = await ctx.database
+          .selectFrom('person_face_suggestion')
+          .select('id')
+          .where('id', '=', suggestion.id)
+          .executeTakeFirst();
+        const danglingForDeletedPerson = await ctx.database
+          .selectFrom('person_face_suggestion')
+          .select('id')
+          .where('personId', '=', sourcePerson.id)
+          .execute();
+
+        expect(remaining).toBeUndefined();
+        expect(danglingForDeletedPerson).toEqual([]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('preserves the early-return no-op when collapseScopedConflicts is not set', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const targetSpacePerson = await newSpacePerson(ctx, space.id);
+        const sourceSpacePerson = await newSpacePerson(ctx, space.id);
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id });
+        await linkSpaceFace(ctx, sourceSpacePerson.id, sourceFace.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+
+        const result = await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+        });
+
+        const survivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('spaceId', '=', space.id)
+          .orderBy('id')
+          .execute();
+
+        expect(result).toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 1 });
+        expect(survivors).toEqual(
+          [
+            { id: targetSpacePerson.id, identityId: targetIdentity.id },
+            { id: sourceSpacePerson.id, identityId: sourceIdentity.id },
+          ].toSorted((a, b) => a.id.localeCompare(b.id)),
+        );
+
+        await expect(
+          sut.getMergeConflicts({
+            targetIdentityId: targetIdentity.id,
+            sourceIdentityIds: [sourceIdentity.id],
+          }),
+        ).resolves.toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 1 });
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+  });
+
   it('counts same-owner personal conflicts before identity merge', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -3872,6 +3872,135 @@ describe(FaceIdentityRepository.name, () => {
       expect(resolved).toEqual(expect.objectContaining({ accessible: true, hasScopedProfileConflict: true }));
     });
 
+    it('reports a same-space conflict in a view-only space as a blocking space conflict', async () => {
+      const { ctx, sut } = setup();
+      const { user: actor } = await ctx.newUser();
+      const { user: spaceOwner } = await ctx.newUser();
+      const { person: personAlpha } = await ctx.newPerson({ ownerId: actor.id });
+      const { person: personBeta } = await ctx.newPerson({ ownerId: actor.id });
+      const identityAlpha = await sut.ensurePersonIdentity(personAlpha.id);
+      const identityBeta = await sut.ensurePersonIdentity(personBeta.id);
+      const { space } = await ctx.newSharedSpace({ createdById: spaceOwner.id, name: 'Holidays' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: spaceOwner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: actor.id, role: SharedSpaceRole.Viewer });
+      await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identityAlpha.id, type: 'person' })
+        .execute();
+      await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identityBeta.id, type: 'person' })
+        .execute();
+
+      const resolved = await sut.resolveRepairRefs(actor.id, {
+        target: { type: 'person', id: personAlpha.id },
+        sources: [{ type: 'person', id: personBeta.id }],
+      });
+
+      expect(resolved).toEqual(
+        expect.objectContaining({
+          accessible: true,
+          blockingConflict: { scope: 'space', spaceId: space.id, spaceName: 'Holidays' },
+        }),
+      );
+    });
+
+    it('does not block a same-space conflict in a space the actor can edit', async () => {
+      const { ctx, sut } = setup();
+      const { user: actor } = await ctx.newUser();
+      const { user: spaceOwner } = await ctx.newUser();
+      const { person: personAlpha } = await ctx.newPerson({ ownerId: actor.id });
+      const { person: personBeta } = await ctx.newPerson({ ownerId: actor.id });
+      const identityAlpha = await sut.ensurePersonIdentity(personAlpha.id);
+      const identityBeta = await sut.ensurePersonIdentity(personBeta.id);
+      const { space } = await ctx.newSharedSpace({ createdById: spaceOwner.id, name: 'Holidays' });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: spaceOwner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: actor.id, role: SharedSpaceRole.Editor });
+      await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identityAlpha.id, type: 'person' })
+        .execute();
+      await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identityBeta.id, type: 'person' })
+        .execute();
+
+      const resolved = await sut.resolveRepairRefs(actor.id, {
+        target: { type: 'person', id: personAlpha.id },
+        sources: [{ type: 'person', id: personBeta.id }],
+      });
+
+      expect(resolved).toEqual(expect.objectContaining({ accessible: true, blockingConflict: undefined }));
+    });
+
+    it("reports a same-owner conflict in another user's personal scope as a blocking personal conflict", async () => {
+      const { ctx, sut } = setup();
+      const { user: actor } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const { space: spaceAlpha } = await ctx.newSharedSpace({ createdById: actor.id });
+      const { space: spaceBeta } = await ctx.newSharedSpace({ createdById: actor.id });
+      await ctx.newSharedSpaceMember({ spaceId: spaceAlpha.id, userId: actor.id, role: SharedSpaceRole.Editor });
+      await ctx.newSharedSpaceMember({ spaceId: spaceBeta.id, userId: actor.id, role: SharedSpaceRole.Editor });
+
+      // Identity alpha: stranger personal + editor space person (alpha space).
+      const { person: strangerAlpha } = await ctx.newPerson({ ownerId: stranger.id });
+      const identityAlpha = await sut.ensurePersonIdentity(strangerAlpha.id);
+      const spacePersonAlpha = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: spaceAlpha.id, identityId: identityAlpha.id, type: 'person' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+
+      // Identity beta: stranger personal + editor space person (beta space, different space).
+      const { person: strangerBeta } = await ctx.newPerson({ ownerId: stranger.id });
+      const identityBeta = await sut.ensurePersonIdentity(strangerBeta.id);
+      const spacePersonBeta = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: spaceBeta.id, identityId: identityBeta.id, type: 'person' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+
+      const resolved = await sut.resolveRepairRefs(actor.id, {
+        target: { type: 'space-person', id: spacePersonAlpha.id, spaceId: spaceAlpha.id },
+        sources: [{ type: 'space-person', id: spacePersonBeta.id, spaceId: spaceBeta.id }],
+      });
+
+      expect(resolved).toEqual(expect.objectContaining({ accessible: true, blockingConflict: { scope: 'personal' } }));
+    });
+
+    it('does not block own personal duplicates that also live in different view-only spaces without collision', async () => {
+      const { ctx, sut } = setup();
+      const { user: actor } = await ctx.newUser();
+      const { user: spaceOwner } = await ctx.newUser();
+      const { person: personAlpha } = await ctx.newPerson({ ownerId: actor.id });
+      const { person: personBeta } = await ctx.newPerson({ ownerId: actor.id });
+      const identityAlpha = await sut.ensurePersonIdentity(personAlpha.id);
+      const identityBeta = await sut.ensurePersonIdentity(personBeta.id);
+
+      const { space: spaceOne } = await ctx.newSharedSpace({ createdById: spaceOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: spaceOne.id, userId: spaceOwner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: spaceOne.id, userId: actor.id, role: SharedSpaceRole.Viewer });
+      await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: spaceOne.id, identityId: identityAlpha.id, type: 'person' })
+        .execute();
+
+      const { space: spaceTwo } = await ctx.newSharedSpace({ createdById: spaceOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: spaceTwo.id, userId: spaceOwner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: spaceTwo.id, userId: actor.id, role: SharedSpaceRole.Viewer });
+      await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: spaceTwo.id, identityId: identityBeta.id, type: 'person' })
+        .execute();
+
+      const resolved = await sut.resolveRepairRefs(actor.id, {
+        target: { type: 'person', id: personAlpha.id },
+        sources: [{ type: 'person', id: personBeta.id }],
+      });
+
+      expect(resolved).toEqual(expect.objectContaining({ accessible: true, blockingConflict: undefined }));
+    });
+
     it('rejects detach when selected space-person faces also back non-repairable personal profiles', async () => {
       const { ctx, sut } = setup();
       const { user: actor } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -3821,7 +3821,7 @@ describe(FaceIdentityRepository.name, () => {
       );
     });
 
-    it('reports identity repair as unsafe when an attached space profile is not repairable by the actor', async () => {
+    it('does not block a merge when an attached space profile in a view-only space has no same-space collision', async () => {
       const { ctx, sut } = setup();
       const { user: actor } = await ctx.newUser();
       const { user: stranger } = await ctx.newUser();
@@ -3853,10 +3853,10 @@ describe(FaceIdentityRepository.name, () => {
       });
 
       expect(actorIdentity.id).toBeTruthy();
-      expect(resolved).toEqual(expect.objectContaining({ accessible: true, allAttachedProfilesRepairable: false }));
+      expect(resolved).toEqual(expect.objectContaining({ accessible: true, blockingConflict: undefined }));
     });
 
-    it('reports same-owner personal repair as a scoped profile conflict', async () => {
+    it('does not block a same-owner personal repair the actor controls', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
@@ -3869,7 +3869,7 @@ describe(FaceIdentityRepository.name, () => {
         sources: [{ type: 'person', id: sourcePerson.id }],
       });
 
-      expect(resolved).toEqual(expect.objectContaining({ accessible: true, hasScopedProfileConflict: true }));
+      expect(resolved).toEqual(expect.objectContaining({ accessible: true, blockingConflict: undefined }));
     });
 
     it('reports a same-space conflict in a view-only space as a blocking space conflict', async () => {

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -3222,6 +3222,421 @@ describe(FaceIdentityRepository.name, () => {
         await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
       }
     });
+
+    it('keeps the survivor on the target identity when the target has a profile in the scope', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { person: targetPerson } = await ctx.newPerson({ ownerId: user.id });
+        const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: targetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: targetPerson.id });
+        const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
+        const targetIdentity = await sut.ensurePersonIdentity(targetPerson.id);
+        const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+        await sut.linkFace({ assetFaceId: targetFace.id, identityId: targetIdentity.id, source: 'owner-person' });
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const survivors = await ctx.database
+          .selectFrom('person')
+          .select(['id', 'identityId'])
+          .where('ownerId', '=', user.id)
+          .execute();
+        const reassignedFace = await ctx.database
+          .selectFrom('asset_face')
+          .select('personId')
+          .where('id', '=', sourceFace.id)
+          .executeTakeFirstOrThrow();
+
+        // The target row survives (its own id is kept); the source's faces move onto it.
+        expect(survivors).toEqual([{ id: targetPerson.id, identityId: targetIdentity.id }]);
+        expect(reassignedFace.personId).toBe(targetPerson.id);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('keeps the lowest-id source profile when the target identity is absent from the scope', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        // The target identity owns a personal profile, so it is never deleted.
+        const { person: targetAnchor } = await ctx.newPerson({ ownerId: user.id });
+        const targetIdentity = await sut.ensurePersonIdentity(targetAnchor.id);
+        // Two SOURCE identities both have a profile in this space; the target identity does not.
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const sourceSpacePersonA = await newSpacePerson(ctx, space.id);
+        const sourceSpacePersonB = await newSpacePerson(ctx, space.id);
+        const sourceIdentityA = await sut.ensureSpacePersonIdentity(sourceSpacePersonA.id);
+        const sourceIdentityB = await sut.ensureSpacePersonIdentity(sourceSpacePersonB.id);
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: faceA } = await ctx.newAssetFace({ assetId: asset.id });
+        const { assetFace: faceB } = await ctx.newAssetFace({ assetId: asset.id });
+        await linkSpaceFace(ctx, sourceSpacePersonA.id, faceA.id);
+        await linkSpaceFace(ctx, sourceSpacePersonB.id, faceB.id);
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentityA.id, sourceIdentityB.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const survivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('spaceId', '=', space.id)
+          .execute();
+        const survivorFaces = await ctx.database
+          .selectFrom('shared_space_person_face')
+          .select('assetFaceId')
+          .where('personId', '=', [sourceSpacePersonA.id, sourceSpacePersonB.id].toSorted()[0])
+          .orderBy('assetFaceId')
+          .execute();
+
+        // The lowest-id source profile survives and is reassigned to the target identity.
+        const expectedSurvivorId = [sourceSpacePersonA.id, sourceSpacePersonB.id].toSorted()[0];
+        expect(survivors).toEqual([{ id: expectedSurvivorId, identityId: targetIdentity.id }]);
+        expect(survivorFaces.map((row) => row.assetFaceId).toSorted()).toEqual([faceA.id, faceB.id].toSorted());
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('collapses two source identities in one space into a single survivor without a unique-index violation', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { person: targetAnchor } = await ctx.newPerson({ ownerId: user.id });
+        const targetIdentity = await sut.ensurePersonIdentity(targetAnchor.id);
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const sourceSpacePersonA = await newSpacePerson(ctx, space.id);
+        const sourceSpacePersonB = await newSpacePerson(ctx, space.id);
+        const sourceIdentityA = await sut.ensureSpacePersonIdentity(sourceSpacePersonA.id);
+        const sourceIdentityB = await sut.ensureSpacePersonIdentity(sourceSpacePersonB.id);
+
+        // A naive single UPDATE of both source rows to the target identity would violate
+        // shared_space_person_spaceId_identityId_key; survivor selection must collapse instead.
+        await expect(
+          sut.mergeIdentities({
+            targetIdentityId: targetIdentity.id,
+            sourceIdentityIds: [sourceIdentityA.id, sourceIdentityB.id],
+            source: 'manual',
+            collapseScopedConflicts: true,
+          }),
+        ).resolves.toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 0 });
+
+        const survivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('spaceId', '=', space.id)
+          .execute();
+
+        expect(survivors).toEqual([
+          { id: [sourceSpacePersonA.id, sourceSpacePersonB.id].toSorted()[0], identityId: targetIdentity.id },
+        ]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('collapses a conflicting scope while reassigning a non-conflicting scope in a multi-source batch', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        // Target identity anchored by a personal profile so it is never deleted.
+        const { person: targetAnchor } = await ctx.newPerson({ ownerId: user.id });
+        const targetIdentity = await sut.ensurePersonIdentity(targetAnchor.id);
+
+        // Conflicted space: both sources have a profile here, target identity absent → collapse to one.
+        const { space: conflictedSpace } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: conflictedSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const conflictPersonA = await newSpacePerson(ctx, conflictedSpace.id);
+        const conflictPersonB = await newSpacePerson(ctx, conflictedSpace.id);
+        const sourceIdentityA = await sut.ensureSpacePersonIdentity(conflictPersonA.id);
+        const sourceIdentityB = await sut.ensureSpacePersonIdentity(conflictPersonB.id);
+
+        // Non-conflicted space: only source B has a profile here → reassign, no deletion.
+        const { space: cleanSpace } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: cleanSpace.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const cleanPerson = await ctx.database
+          .insertInto('shared_space_person')
+          .values({ spaceId: cleanSpace.id, identityId: sourceIdentityB.id })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentityA.id, sourceIdentityB.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const conflictedSurvivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('spaceId', '=', conflictedSpace.id)
+          .execute();
+        const cleanSurvivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('spaceId', '=', cleanSpace.id)
+          .execute();
+
+        expect(conflictedSurvivors).toEqual([
+          { id: [conflictPersonA.id, conflictPersonB.id].toSorted()[0], identityId: targetIdentity.id },
+        ]);
+        // The non-conflicted profile is reassigned to the target identity, not deleted.
+        expect(cleanSurvivors).toEqual([{ id: cleanPerson.id, identityId: targetIdentity.id }]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('collapses two pet-type space people in one space carrying the type through', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const targetSpacePerson = await ctx.database
+          .insertInto('shared_space_person')
+          .values({ spaceId: space.id, type: 'pet' })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+        const sourceSpacePerson = await ctx.database
+          .insertInto('shared_space_person')
+          .values({ spaceId: space.id, type: 'pet' })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id });
+        await linkSpaceFace(ctx, sourceSpacePerson.id, sourceFace.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+
+        const result = await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const survivors = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId', 'type'])
+          .where('spaceId', '=', space.id)
+          .execute();
+        const survivorFaces = await ctx.database
+          .selectFrom('shared_space_person_face')
+          .select('assetFaceId')
+          .where('personId', '=', targetSpacePerson.id)
+          .execute();
+
+        expect(result).toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 0 });
+        expect(survivors).toEqual([{ id: targetSpacePerson.id, identityId: targetIdentity.id, type: 'pet' }]);
+        expect(survivorFaces.map((row) => row.assetFaceId)).toEqual([sourceFace.id]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('preserves the survivor isHidden flag regardless of source/survivor hidden state', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        // Case 1: hidden source collapses into a visible survivor → survivor stays visible.
+        const { person: visibleSurvivor } = await ctx.newPerson({ ownerId: user.id, isHidden: false });
+        const { person: hiddenSource } = await ctx.newPerson({ ownerId: user.id, isHidden: true });
+        const visibleIdentity = await sut.ensurePersonIdentity(visibleSurvivor.id);
+        const hiddenSourceIdentity = await sut.ensurePersonIdentity(hiddenSource.id);
+
+        // Case 2: visible source collapses into a hidden survivor → survivor stays hidden.
+        const { person: hiddenSurvivor } = await ctx.newPerson({ ownerId: user.id, isHidden: true });
+        const { person: visibleSource } = await ctx.newPerson({ ownerId: user.id, isHidden: false });
+        const hiddenIdentity = await sut.ensurePersonIdentity(hiddenSurvivor.id);
+        const visibleSourceIdentity = await sut.ensurePersonIdentity(visibleSource.id);
+
+        await sut.mergeIdentities({
+          targetIdentityId: visibleIdentity.id,
+          sourceIdentityIds: [hiddenSourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+        await sut.mergeIdentities({
+          targetIdentityId: hiddenIdentity.id,
+          sourceIdentityIds: [visibleSourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const visibleSurvivorRow = await ctx.database
+          .selectFrom('person')
+          .select(['id', 'isHidden'])
+          .where('id', '=', visibleSurvivor.id)
+          .executeTakeFirstOrThrow();
+        const hiddenSurvivorRow = await ctx.database
+          .selectFrom('person')
+          .select(['id', 'isHidden'])
+          .where('id', '=', hiddenSurvivor.id)
+          .executeTakeFirstOrThrow();
+
+        expect(visibleSurvivorRow.isHidden).toBe(false);
+        expect(hiddenSurvivorRow.isHidden).toBe(true);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('does not delete a personal and a space profile in different scopes (identity merge only)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        // Source identity has a personal profile (owner scope).
+        const { person: sourcePerson } = await ctx.newPerson({ ownerId: user.id });
+        const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
+        // Target identity has a space profile (space scope) — different physical scope, no conflict.
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const targetSpacePerson = await newSpacePerson(ctx, space.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const personRow = await ctx.database
+          .selectFrom('person')
+          .select(['id', 'identityId'])
+          .where('id', '=', sourcePerson.id)
+          .executeTakeFirst();
+        const spaceRow = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('id', '=', targetSpacePerson.id)
+          .executeTakeFirst();
+
+        // Both rows survive on the target identity; nothing deleted.
+        expect(personRow).toEqual({ id: sourcePerson.id, identityId: targetIdentity.id });
+        expect(spaceRow).toEqual({ id: targetSpacePerson.id, identityId: targetIdentity.id });
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('does not delete two space profiles in different spaces (identity merge only)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const targetSpacePerson = await newSpacePerson(ctx, spaceA.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+
+        const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const sourceSpacePerson = await newSpacePerson(ctx, spaceB.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const targetRow = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('id', '=', targetSpacePerson.id)
+          .executeTakeFirst();
+        const sourceRow = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('id', '=', sourceSpacePerson.id)
+          .executeTakeFirst();
+
+        // Different spaces ⇒ both rows survive on the target identity.
+        expect(targetRow).toEqual({ id: targetSpacePerson.id, identityId: targetIdentity.id });
+        expect(sourceRow).toEqual({ id: sourceSpacePerson.id, identityId: targetIdentity.id });
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('is idempotent: re-running the merged set changes nothing', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const targetSpacePerson = await newSpacePerson(ctx, space.id);
+        const sourceSpacePerson = await newSpacePerson(ctx, space.id);
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace: sourceFace } = await ctx.newAssetFace({ assetId: asset.id });
+        await linkSpaceFace(ctx, sourceSpacePerson.id, sourceFace.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+
+        await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const snapshot = async () => {
+          const survivors = await ctx.database
+            .selectFrom('shared_space_person')
+            .select(['id', 'identityId'])
+            .where('spaceId', '=', space.id)
+            .orderBy('id')
+            .execute();
+          const faces = await ctx.database
+            .selectFrom('shared_space_person_face')
+            .select('assetFaceId')
+            .where('personId', '=', targetSpacePerson.id)
+            .orderBy('assetFaceId')
+            .execute();
+          const identities = await ctx.database
+            .selectFrom('face_identity')
+            .select('id')
+            .where('id', 'in', [targetIdentity.id, sourceIdentity.id])
+            .orderBy('id')
+            .execute();
+          return { survivors, faces, identities };
+        };
+
+        const before = await snapshot();
+
+        // Re-run: the source identity is gone, so the effective source set is empty → genuine no-op.
+        const second = await sut.mergeIdentities({
+          targetIdentityId: targetIdentity.id,
+          sourceIdentityIds: [sourceIdentity.id],
+          source: 'manual',
+          collapseScopedConflicts: true,
+        });
+
+        const after = await snapshot();
+
+        expect(second).toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 0 });
+        expect(after).toEqual(before);
+        expect(before.identities).toEqual([{ id: targetIdentity.id }]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
   });
 
   it('counts same-owner personal conflicts before identity merge', async () => {


### PR DESCRIPTION
## What

When merging two people that live in the **same scope** (e.g. two duplicate profiles in one personal library or one shared space), `mergeScopedPeople` previously rejected the operation with "…separate profiles in the same scope". This makes the `/people` page merge action fail for the most common case — deduplicating two faces of the same person.

This PR makes scoped merge **collapse** same-scope conflicts: reassign the redundant person's faces onto the survivor, delete the redundant row, and recount — instead of refusing.

It also **narrows the permission gate** so a non-admin can merge their own personal people and editor-space people. The merge is refused only when completing it would delete a person row in a **view-only** space, returning a `403` that names the space (`…shared space "Holidays", which you can only view. Ask an editor…`).

## Scope of behavior change

- Collapse is **opt-in**: only `mergeScopedPeople` passes the new `collapseScopedConflicts` flag. Automatic reconciliation, `mergeSpacePeople`, and `mergePerson` are unchanged.
- Survivor selection, multi-source merges, cross-scope, pet/hidden people, and idempotency are all covered by new medium tests on a real testcontainers DB.

## Stacking

Based on `brainstorm/face-recognition-suggestions` (#592), which already carries the people-merge-propagation work this builds on. Diff is the 7 commits on top — retarget to `main` once #592 lands.

## Verification

- Full server unit suite: 4575 passed / 0 failed
- Medium suites on real DB: face-identity (101), person.service (279), shared-space.service (427), person.controller (43), people-identity-rbac (66), face-identity-repair (12), metadata-rbac (46)
- lint (zero-warnings), tsc clean, no SQL snapshot drift, `git diff --check` clean
- e2e: typecheck + lint clean (full e2e runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)