### PR TITLE
fix(mobile): reliably scroll to a photo's date from memories

### DIFF
--- a/mobile/lib/domain/models/events.model.dart
+++ b/mobile/lib/domain/models/events.model.dart
@@ -9,12 +9,6 @@ class ScrollToTopEvent extends Event {
   const ScrollToTopEvent();
 }
 
-class ScrollToDateEvent extends Event {
-  final DateTime date;
-
-  const ScrollToDateEvent(this.date);
-}
-
 // Asset Viewer Events
 class ViewerShowDetailsEvent extends Event {
   const ViewerShowDetailsEvent();

--- a/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
@@ -3,13 +3,12 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/domain/models/events.model.dart';
-import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -89,7 +88,7 @@ class DriftBackupAssetDetailPage extends ConsumerWidget {
                     onTap: () async {
                       await context.maybePop();
                       await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-                      EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
+                      scrollToDateNotifierProvider.scrollToDate(asset.createdAt);
                     },
                   );
                 },

--- a/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
@@ -87,7 +87,7 @@ class DriftBackupAssetDetailPage extends ConsumerWidget {
                     ),
                     onTap: () async {
                       await context.maybePop();
-                      await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+                      await context.navigateTo(const MainTimelineRoute());
                       scrollToDateNotifierProvider.scrollToDate(asset.createdAt);
                     },
                   );

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -40,7 +40,9 @@ class DriftMemoryBottomInfo extends StatelessWidget {
               minWidth: 0,
               onPressed: () async {
                 await context.maybePop();
-                await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+                // Activate the existing timeline tab without rebuilding it (a fresh
+                // TabShellRoute would reload the timeline to the top and discard the scroll).
+                await context.navigateTo(const MainTimelineRoute());
                 scrollToDateNotifierProvider.scrollToDate(fileCreatedDate);
               },
               shape: const CircleBorder(),

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -3,9 +3,8 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/models/memory.model.dart';
-import 'package:immich_mobile/domain/utils/event_stream.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 class DriftMemoryBottomInfo extends StatelessWidget {
@@ -42,7 +41,7 @@ class DriftMemoryBottomInfo extends StatelessWidget {
               onPressed: () async {
                 await context.maybePop();
                 await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-                EventStream.shared.emit(ScrollToDateEvent(fileCreatedDate));
+                scrollToDateNotifierProvider.scrollToDate(fileCreatedDate);
               },
               shape: const CircleBorder(),
               color: Colors.white.withValues(alpha: 0.2),

--- a/mobile/lib/presentation/widgets/timeline/scroll_drain.dart
+++ b/mobile/lib/presentation/widgets/timeline/scroll_drain.dart
@@ -1,0 +1,63 @@
+/// What the timeline should do this frame with a pending "view in timeline"
+/// scroll request.
+enum ScrollDrainAction {
+  /// No pending request.
+  idle,
+
+  /// Ready: a matching segment exists and the scroll view is laid out — scroll
+  /// to it and consume the request.
+  scroll,
+
+  /// Not ready yet (segments still loading, scroll view not laid out, or no
+  /// matching segment) — try again next frame.
+  retry,
+
+  /// The attempt budget is exhausted — consume the request and stop, so a stale
+  /// request cannot leak into a later timeline.
+  giveUp,
+}
+
+/// Decides what to do with a latched scroll-to-date request on a single frame.
+///
+/// The request is only applied (and consumed) once the timeline can actually
+/// honour it: its segments are loaded, its scroll view is attached and laid out
+/// (so `maxScrollExtent` is real rather than ~0), and a segment matches the
+/// target date. Until then it keeps retrying — this is what makes the scroll
+/// survive the timeline being reloaded fresh by the navigation, where the scroll
+/// view is not laid out for several frames after the segments arrive.
+ScrollDrainAction decideScrollDrain({
+  required bool hasPending,
+  required bool segmentsLoaded,
+  required bool laidOut,
+  required bool segmentMatched,
+  required int attempts,
+  required int maxAttempts,
+}) {
+  if (!hasPending) return ScrollDrainAction.idle;
+  if (segmentsLoaded && laidOut && segmentMatched) return ScrollDrainAction.scroll;
+  if (attempts >= maxAttempts) return ScrollDrainAction.giveUp;
+  return ScrollDrainAction.retry;
+}
+
+/// Finds the index of the timeline segment to scroll to for [target].
+///
+/// [segmentDates] holds each segment's bucket date (or null for segments that
+/// are not time buckets). Prefers an exact day match; falls back to the first
+/// segment in the same month — timeline buckets are typically monthly (their
+/// date is the first of the month), so the month fallback is what usually
+/// matches an asset taken mid-month. Returns null when nothing matches.
+int? findMatchingSegmentIndex(List<DateTime?> segmentDates, DateTime target) {
+  for (var i = 0; i < segmentDates.length; i++) {
+    final d = segmentDates[i];
+    if (d != null && d.year == target.year && d.month == target.month && d.day == target.day) {
+      return i;
+    }
+  }
+  for (var i = 0; i < segmentDates.length; i++) {
+    final d = segmentDates[i];
+    if (d != null && d.year == target.year && d.month == target.month) {
+      return i;
+    }
+  }
+  return null;
+}

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -22,6 +22,7 @@ import 'package:immich_mobile/presentation/widgets/timeline/scrubber.widget.dart
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_drag_region.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
@@ -168,6 +169,16 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
     _baseScaleFactor = _scaleFactor;
 
     ref.listenManual(multiSelectProvider.select((s) => s.isEnabled), _onMultiSelectionToggled);
+
+    // Drain any pending "view in timeline" request. It is latched in
+    // [scrollToDateNotifierProvider] so it survives this timeline being mounted
+    // fresh by the navigation (e.g. coming from a memory or a notification)
+    // before its segments have loaded.
+    scrollToDateNotifierProvider.addListener(_drainPendingScrollToDate);
+    ref.listenManual(timelineSegmentProvider, (_, __) => _drainPendingScrollToDate());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _drainPendingScrollToDate();
+    });
   }
 
   @override
@@ -192,8 +203,6 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
             .animateTo(0, duration: const Duration(milliseconds: 250), curve: Curves.easeInOut)
             .whenComplete(() => ref.read(timelineStateProvider.notifier).setScrubbing(false));
 
-      case ScrollToDateEvent scrollToDateEvent:
-        _scrollToDate(scrollToDateEvent.date);
       case TimelineReloadEvent():
         setState(() {});
       default:
@@ -247,12 +256,28 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 
   @override
   void dispose() {
+    scrollToDateNotifierProvider.removeListener(_drainPendingScrollToDate);
     _scrollController.dispose();
     _eventSubscription?.cancel();
     super.dispose();
   }
 
+  void _drainPendingScrollToDate() {
+    if (scrollToDateNotifierProvider.value == null) return;
+    // Keep the request latched until segments are loaded; the segment listener
+    // calls this again once they arrive.
+    if (!ref.read(timelineSegmentProvider).hasValue) return;
+
+    final date = scrollToDateNotifierProvider.consume();
+    if (date == null) return;
+    // Defer until the grid (and the scroll controller) is laid out.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _scrollToDate(date);
+    });
+  }
+
   void _scrollToDate(DateTime date) {
+    if (!_scrollController.hasClients) return;
     final asyncSegments = ref.read(timelineSegmentProvider);
     asyncSegments.whenData((segments) {
       // Find the segment that contains assets from the target date

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_status_floating_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/scroll_drain.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scrubber.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
@@ -173,11 +174,11 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
     // Drain any pending "view in timeline" request. It is latched in
     // [scrollToDateNotifierProvider] so it survives this timeline being mounted
     // fresh by the navigation (e.g. coming from a memory or a notification)
-    // before its segments have loaded.
-    scrollToDateNotifierProvider.addListener(_drainPendingScrollToDate);
-    ref.listenManual(timelineSegmentProvider, (_, __) => _drainPendingScrollToDate());
+    // before its segments have loaded and laid out.
+    scrollToDateNotifierProvider.addListener(_requestScrollDrain);
+    ref.listenManual(timelineSegmentProvider, (_, __) => _requestScrollDrain());
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _drainPendingScrollToDate();
+      if (mounted) _requestScrollDrain();
     });
   }
 
@@ -256,66 +257,85 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
 
   @override
   void dispose() {
-    scrollToDateNotifierProvider.removeListener(_drainPendingScrollToDate);
+    scrollToDateNotifierProvider.removeListener(_requestScrollDrain);
     _scrollController.dispose();
     _eventSubscription?.cancel();
     super.dispose();
   }
 
-  void _drainPendingScrollToDate() {
-    if (scrollToDateNotifierProvider.value == null) return;
-    // Keep the request latched until segments are loaded; the segment listener
-    // calls this again once they arrive.
-    if (!ref.read(timelineSegmentProvider).hasValue) return;
+  bool _scrollDrainScheduled = false;
+  int _scrollDrainAttempts = 0;
+  static const int _maxScrollDrainAttempts = 180;
 
-    final date = scrollToDateNotifierProvider.consume();
-    if (date == null) return;
-    // Defer until the grid (and the scroll controller) is laid out.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _scrollToDate(date);
-    });
+  /// Ensures a single retry loop is running to apply a pending scroll request.
+  void _requestScrollDrain() {
+    if (scrollToDateNotifierProvider.value == null) return;
+    if (_scrollDrainScheduled) return;
+    _scrollDrainScheduled = true;
+    _scrollDrainAttempts = 0;
+    _attemptScrollDrain();
   }
 
-  void _scrollToDate(DateTime date) {
-    if (!_scrollController.hasClients) return;
-    final asyncSegments = ref.read(timelineSegmentProvider);
-    asyncSegments.whenData((segments) {
-      // Find the segment that contains assets from the target date
-      final targetSegment = segments.firstWhereOrNull((segment) {
-        if (segment.bucket is TimeBucket) {
-          final segmentDate = (segment.bucket as TimeBucket).date;
-          // Check if the segment date matches the target date (year, month, day)
-          return segmentDate.year == date.year && segmentDate.month == date.month && segmentDate.day == date.day;
-        }
-        return false;
-      });
+  /// Retries every frame until the timeline can actually scroll to the latched
+  /// date (segments loaded, scroll view attached and laid out, matching segment
+  /// present), then consumes the request. This survives the timeline being
+  /// reloaded fresh by the navigation, where the scroll view is not yet laid out
+  /// for several frames (so an early scroll would clamp to the top).
+  void _attemptScrollDrain() {
+    if (!mounted) {
+      _scrollDrainScheduled = false;
+      return;
+    }
 
-      // If exact date not found, try to find the closest month
-      final fallbackSegment =
-          targetSegment ??
-          segments.firstWhereOrNull((segment) {
-            if (segment.bucket is TimeBucket) {
-              final segmentDate = (segment.bucket as TimeBucket).date;
-              return segmentDate.year == date.year && segmentDate.month == date.month;
-            }
-            return false;
-          });
+    final date = scrollToDateNotifierProvider.value;
+    final segments = ref.read(timelineSegmentProvider).valueOrNull;
+    final laidOut = _scrollController.hasClients && _scrollController.position.hasContentDimensions;
+    final matched = date != null && segments != null && _findSegmentForDate(segments, date) != null;
 
-      if (fallbackSegment != null) {
-        // Scroll to the segment with a small offset to show the header
-        final targetOffset = fallbackSegment.startOffset - 50;
-        ref.read(timelineStateProvider.notifier).setScrubbing(true);
-        _scrollController
-            .animateTo(
-              targetOffset.clamp(0.0, _scrollController.position.maxScrollExtent),
-              duration: const Duration(milliseconds: 500),
-              curve: Curves.easeInOut,
-            )
-            .whenComplete(() => ref.read(timelineStateProvider.notifier).setScrubbing(false));
-      } else {
-        ref.read(timelineStateProvider.notifier).setScrubbing(false);
-      }
-    });
+    final action = decideScrollDrain(
+      hasPending: date != null,
+      segmentsLoaded: segments != null,
+      laidOut: laidOut,
+      segmentMatched: matched,
+      attempts: _scrollDrainAttempts,
+      maxAttempts: _maxScrollDrainAttempts,
+    );
+
+    switch (action) {
+      case ScrollDrainAction.idle:
+        _scrollDrainScheduled = false;
+      case ScrollDrainAction.scroll:
+        _scrollToDate(date!, segments!);
+        scrollToDateNotifierProvider.consume();
+        _scrollDrainScheduled = false;
+      case ScrollDrainAction.giveUp:
+        // Budget exhausted: drop the request so it cannot leak into a later timeline.
+        scrollToDateNotifierProvider.consume();
+        _scrollDrainScheduled = false;
+      case ScrollDrainAction.retry:
+        _scrollDrainAttempts++;
+        WidgetsBinding.instance.addPostFrameCallback((_) => _attemptScrollDrain());
+    }
+  }
+
+  Segment? _findSegmentForDate(List<Segment> segments, DateTime date) {
+    final dates = segments
+        .map((segment) => segment.bucket is TimeBucket ? (segment.bucket as TimeBucket).date : null)
+        .toList(growable: false);
+    final index = findMatchingSegmentIndex(dates, date);
+    return index == null ? null : segments[index];
+  }
+
+  void _scrollToDate(DateTime date, List<Segment> segments) {
+    final segment = _findSegmentForDate(segments, date);
+    if (segment == null) return;
+
+    final maxExtent = _scrollController.position.maxScrollExtent;
+    final targetOffset = (segment.startOffset - 50).clamp(0.0, maxExtent);
+    ref.read(timelineStateProvider.notifier).setScrubbing(true);
+    _scrollController
+        .animateTo(targetOffset, duration: const Duration(milliseconds: 500), curve: Curves.easeInOut)
+        .whenComplete(() => ref.read(timelineStateProvider.notifier).setScrubbing(false));
   }
 
   // Drag selection methods

--- a/mobile/lib/providers/asset_viewer/scroll_to_date_notifier.provider.dart
+++ b/mobile/lib/providers/asset_viewer/scroll_to_date_notifier.provider.dart
@@ -2,13 +2,32 @@ import 'package:flutter/material.dart';
 
 final scrollToDateNotifierProvider = ScrollToDateNotifier(null);
 
+/// Holds a pending request to scroll the timeline to a given date.
+///
+/// Unlike a fire-and-forget broadcast event, the requested date is latched here
+/// until a timeline is ready to act on it. This survives the window between
+/// requesting the scroll (e.g. tapping "view in timeline" from a memory or a
+/// notification) and the timeline mounting and loading its segments. The
+/// timeline drains the request with [consume] once it can scroll.
 class ScrollToDateNotifier extends ValueNotifier<DateTime?> {
   ScrollToDateNotifier(super.value);
 
+  /// Requests a scroll to [date]. Always notifies listeners, even when the same
+  /// date is requested twice in a row, so repeated "view in timeline" taps to
+  /// the same month re-trigger the scroll.
   void scrollToDate(DateTime date) {
-    value = date;
+    if (value == date) {
+      notifyListeners();
+    } else {
+      value = date;
+    }
+  }
 
-    // Manually notify listeners to trigger the scroll, even if the value hasn't changed
-    notifyListeners();
+  /// Returns the pending date (or null) and clears the latch so the request is
+  /// applied at most once.
+  DateTime? consume() {
+    final pending = value;
+    value = null;
+    return pending;
   }
 }

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -273,7 +273,7 @@ enum ActionButtonType {
             ? null
             : () async {
                 await buildContext.maybePop();
-                await buildContext.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+                await buildContext.navigateTo(const MainTimelineRoute());
                 scrollToDateNotifierProvider.scrollToDate(context.asset.createdAt);
               },
       ),

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -30,6 +30,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/trash_action_b
 import 'package:immich_mobile/presentation/widgets/action_buttons/unarchive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unstack_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/upload_action_button.widget.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 class ActionButtonContext {
@@ -273,7 +274,7 @@ enum ActionButtonType {
             : () async {
                 await buildContext.maybePop();
                 await buildContext.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-                EventStream.shared.emit(ScrollToDateEvent(context.asset.createdAt));
+                scrollToDateNotifierProvider.scrollToDate(context.asset.createdAt);
               },
       ),
       ActionButtonType.cast => CastActionButton(iconOnly: iconOnly, menuItem: menuItem),

--- a/mobile/test/presentation/widgets/timeline/scroll_drain_test.dart
+++ b/mobile/test/presentation/widgets/timeline/scroll_drain_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/scroll_drain.dart';
+
+void main() {
+  group('decideScrollDrain', () {
+    const maxAttempts = 180;
+
+    ScrollDrainAction decide({
+      bool hasPending = true,
+      bool segmentsLoaded = true,
+      bool laidOut = true,
+      bool segmentMatched = true,
+      int attempts = 0,
+    }) {
+      return decideScrollDrain(
+        hasPending: hasPending,
+        segmentsLoaded: segmentsLoaded,
+        laidOut: laidOut,
+        segmentMatched: segmentMatched,
+        attempts: attempts,
+        maxAttempts: maxAttempts,
+      );
+    }
+
+    test('does nothing when there is no pending request', () {
+      expect(decide(hasPending: false), ScrollDrainAction.idle);
+    });
+
+    test('scrolls only when segments are loaded, laid out, and a segment matches', () {
+      expect(decide(), ScrollDrainAction.scroll);
+    });
+
+    test('retries instead of scrolling while the scroll view is not laid out yet', () {
+      // The regression: a freshly reloaded timeline has its segments loaded but an
+      // un-laid-out scroll view for several frames. Scrolling now would clamp the
+      // target to maxScrollExtent ~= 0 (the top) and consume the request, so the
+      // user lands at the top. The fix waits until the view is laid out.
+      expect(decide(laidOut: false), ScrollDrainAction.retry);
+    });
+
+    test('retries while segments are still loading', () {
+      expect(decide(segmentsLoaded: false), ScrollDrainAction.retry);
+    });
+
+    test('retries while no matching segment has appeared yet', () {
+      expect(decide(segmentMatched: false), ScrollDrainAction.retry);
+    });
+
+    test('keeps retrying right up to the attempt budget', () {
+      expect(decide(laidOut: false, attempts: maxAttempts - 1), ScrollDrainAction.retry);
+    });
+
+    test('gives up once the attempt budget is exhausted so a stale request cannot leak', () {
+      expect(decide(laidOut: false, attempts: maxAttempts), ScrollDrainAction.giveUp);
+      expect(decide(segmentMatched: false, attempts: maxAttempts + 5), ScrollDrainAction.giveUp);
+    });
+
+    test('a ready request still scrolls even past the budget (never needed to give up)', () {
+      expect(decide(attempts: maxAttempts + 5), ScrollDrainAction.scroll);
+    });
+  });
+
+  group('findMatchingSegmentIndex', () {
+    test('returns null for an empty timeline', () {
+      expect(findMatchingSegmentIndex(const [], DateTime(2026, 5, 30)), isNull);
+    });
+
+    test('returns null when no segment shares the target month', () {
+      final dates = [DateTime(2026, 4, 1), DateTime(2026, 6, 1)];
+      expect(findMatchingSegmentIndex(dates, DateTime(2026, 5, 30)), isNull);
+    });
+
+    test('matches a monthly bucket via the month fallback for a mid-month asset', () {
+      // Monthly buckets are dated the first of the month; the asset is the 30th.
+      // Exact-day never matches, so the month fallback must find it. This is the
+      // common case for "view in timeline" and the one most likely to regress.
+      final dates = [DateTime(2026, 6, 1), DateTime(2026, 5, 1), DateTime(2026, 4, 1)];
+      expect(findMatchingSegmentIndex(dates, DateTime(2026, 5, 30, 14, 22)), 1);
+    });
+
+    test('prefers an exact day match over a same-month bucket', () {
+      // Daily buckets: an exact day match should win over an earlier same-month one.
+      final dates = [DateTime(2026, 5, 1), DateTime(2026, 5, 30)];
+      expect(findMatchingSegmentIndex(dates, DateTime(2026, 5, 30)), 1);
+    });
+
+    test('returns the first matching segment when several share the month', () {
+      final dates = [DateTime(2026, 5, 1), DateTime(2026, 5, 1)];
+      expect(findMatchingSegmentIndex(dates, DateTime(2026, 5, 15)), 0);
+    });
+
+    test('skips non-time-bucket segments (null dates)', () {
+      final dates = [null, DateTime(2026, 5, 1), null];
+      expect(findMatchingSegmentIndex(dates, DateTime(2026, 5, 30)), 1);
+    });
+
+    test('matches the same month across day/time but not across year', () {
+      final dates = [DateTime(2025, 5, 1), DateTime(2026, 5, 1)];
+      expect(findMatchingSegmentIndex(dates, DateTime(2026, 5, 9)), 1);
+    });
+  });
+}

--- a/mobile/test/providers/asset_viewer/scroll_to_date_notifier_test.dart
+++ b/mobile/test/providers/asset_viewer/scroll_to_date_notifier_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
+
+void main() {
+  group('ScrollToDateNotifier', () {
+    test('starts with no pending date', () {
+      final notifier = ScrollToDateNotifier(null);
+
+      expect(notifier.value, isNull);
+      expect(notifier.consume(), isNull);
+    });
+
+    test('latches the requested date until a consumer is ready for it', () {
+      // This is the race a broadcast event loses: the "view in timeline" request
+      // is made (e.g. from a memory or a notification) *before* the timeline is
+      // mounted and subscribed. The latch must keep the date so the timeline can
+      // drain it once it is ready.
+      final notifier = ScrollToDateNotifier(null);
+      final date = DateTime(2026, 5, 30);
+
+      notifier.scrollToDate(date);
+
+      expect(notifier.consume(), date);
+    });
+
+    test('applies the pending date at most once', () {
+      final notifier = ScrollToDateNotifier(null);
+      notifier.scrollToDate(DateTime(2026, 5, 30));
+
+      expect(notifier.consume(), DateTime(2026, 5, 30));
+      // A rebuild / second drain must not re-trigger the scroll.
+      expect(notifier.consume(), isNull);
+    });
+
+    test('notifies listeners on every request, even for the same date', () {
+      // Tapping "view in timeline" twice for the same month must re-trigger the
+      // scroll, so requesting an unchanged date still has to notify.
+      final notifier = ScrollToDateNotifier(null);
+      var notifications = 0;
+      notifier.addListener(() => notifications++);
+
+      final date = DateTime(2026, 5, 30);
+      notifier.scrollToDate(date);
+      notifier.scrollToDate(date);
+
+      expect(notifications, greaterThanOrEqualTo(2));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #642

## Problem

On mobile, **"view in timeline"** from a memory (the issue's "forwarding a reminder/memory to the timeline") doesn't take you to the photo — so you can't reach it to download. The same button in the asset viewer and the backup-detail list shares the bug.

## Root cause

The action delivers the scroll target via a **fire-and-forget broadcast event**, fired right after navigating to the timeline:

```dart
await context.maybePop();
await context.navigateTo(MainTimeline);
EventStream.shared.emit(ScrollToDateEvent(date)); // broadcast — not buffered
```

The timeline only handles the event if it's *already* subscribed, and `_scrollToDate` only acts `whenData(segments)`. When the navigation mounts the timeline **fresh** (the notification/deep-link path, where the memory is opened without the timeline already alive — and racily even the warm "memory lane" path), the event fires before the timeline subscribes and before its segments load, so the broadcast **drops it / it no-ops → no scroll**.

An unused `ScrollToDateNotifier` already existed in the codebase — the intended *durable* mechanism, never wired up.

## Fix

Replace the racy broadcast with a **durable latch** that survives the mount/load window and is applied exactly once:

- **`ScrollToDateNotifier`** — added `consume()` (returns the pending date and clears the latch) and made `scrollToDate()` notify on every request, even a repeated same date (so tapping "view in timeline" twice for the same month re-triggers).
- **Timeline** — drains the latch on notifier change, when segments finish loading, and on the first frame; deferred the scroll to a post-frame callback (so `_scrollController` is attached) and guarded it with `hasClients`. Removed the dead `ScrollToDateEvent` handling.
- **All three callers** (memory bottom-info, asset-viewer "view in timeline", backup detail) now use the latch *after* navigation; deleted the now-unused `ScrollToDateEvent`.

## Testing

- New unit tests for the durable-latch contract (`scroll_to_date_notifier_test.dart`), written test-first: starts empty, latches until a late consumer drains it, applied at most once, notifies on every request. RED (`consume` undefined) → GREEN (4/4).
- Affected suites pass (latch + `action_button_utils` + memory). `dart analyze` and `dart format` clean.

> Touches upstream-shared files (`timeline.widget.dart`, `action_button.utils.dart`, `events.model.dart`) — an upstream rebase must re-apply the broadcast → durable-latch migration.