### PR TITLE
fix(branding): rebrand notification/email templates to Noodle Gallery (#636)

### DIFF
--- a/branding/config.json
+++ b/branding/config.json
@@ -30,7 +30,13 @@
     "shared_group": "group.de.opennoodle.gallery.share",
     "download_dir": "DCIM/NoodleGallery",
     "background_task_prefix": "de.opennoodle.gallery.background",
-    "apple_team_id": "77MWNP37MV"
+    "apple_team_id": "77MWNP37MV",
+    "app_store_url": "https://apps.apple.com/us/app/noodle-gallery/id6761776289",
+    "play_store_url": "https://play.google.com/store/apps/details?id=de.opennoodle.gallery"
+  },
+
+  "email": {
+    "asset_base_url": "https://docs.opennoodle.de/img"
   },
 
   "docker": {

--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -20,6 +20,11 @@ DEEP_LINK_SCHEME=$(jq -r '.mobile.deep_link_scheme' "$CONFIG")
 SHARED_GROUP=$(jq -r '.mobile.shared_group' "$CONFIG")
 BG_TASK_PREFIX=$(jq -r '.mobile.background_task_prefix' "$CONFIG")
 APPLE_TEAM_ID=$(jq -r '.mobile.apple_team_id' "$CONFIG")
+APP_STORE_URL=$(jq -r '.mobile.app_store_url' "$CONFIG")
+PLAY_STORE_URL=$(jq -r '.mobile.play_store_url' "$CONFIG")
+
+# Email — public host that serves the brand logo + store badges in sent mail
+EMAIL_ASSET_BASE_URL=$(jq -r '.email.asset_base_url' "$CONFIG")
 
 # Repository
 REPO_NAME=$(jq -r '.repository.name' "$CONFIG")
@@ -45,8 +50,6 @@ else
   FORK_VERSION=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || { git -C "$REPO_ROOT" tag -l 'v*.*.*' --sort=-v:refname 2>/dev/null | head -1; })
   FORK_VERSION="${FORK_VERSION#v}"
 fi
-
-echo "=== Applying branding: $NAME ==="
 
 #
 # --- i18n ---
@@ -152,6 +155,68 @@ patch_web() {
     # Replace remaining user-facing "Immich" in API descriptions
     sed -i "s/Immich/${NAME}/g" "$openapi"
     echo "  Patched OpenAPI spec"
+  fi
+}
+
+#
+# --- Emails ---
+#
+# The notification/email templates (server/src/emails) hardcode upstream Immich
+# branding that the system-config UI can't fully override: the logo image, the
+# "Immich" wordmark, the app-store badges + links, the project credit, and the
+# default subject lines. Rewrite them to Noodle Gallery so sent mail is branded.
+patch_emails() {
+  echo "--- Patching email templates ---"
+
+  local emails="$REPO_ROOT/server/src/emails"
+  local layout="$emails/components/immich.layout.tsx"
+  local footer="$emails/components/footer.template.tsx"
+  local test_email="$emails/test.email.tsx"
+  local welcome_email="$emails/welcome.email.tsx"
+  local notification="$REPO_ROOT/server/src/services/notification.service.ts"
+  local notification_admin="$REPO_ROOT/server/src/services/notification-admin.service.ts"
+
+  # Shared layout — brand logo image + alt text
+  if [[ -f "$layout" ]]; then
+    sed -i "s|https://immich\.app/img/immich-logo-inline-light\.png|${EMAIL_ASSET_BASE_URL}/immich-logo-inline-light.png|g" "$layout"
+    sed -i "s|alt=\"Immich\"|alt=\"${NAME}\"|g" "$layout"
+    echo "  Patched immich.layout.tsx"
+  fi
+
+  # Footer — store badges (link + image) and the project credit line
+  if [[ -f "$footer" ]]; then
+    sed -i "s|https://play\.google\.com/store/apps/details?id=app\.alextran\.immich|${PLAY_STORE_URL}|g" "$footer"
+    sed -i "s|https://immich\.app/img/google-play-badge\.png|${EMAIL_ASSET_BASE_URL}/google-play-badge.png|g" "$footer"
+    sed -i "s|https://apps\.apple\.com/sg/app/immich/id1613945652|${APP_STORE_URL}|g" "$footer"
+    sed -i "s|https://immich\.app/img/ios-app-store-badge\.png|${EMAIL_ASSET_BASE_URL}/ios-app-store-badge.png|g" "$footer"
+    sed -i "s|<Link href=\"https://immich\.app\">Immich</Link>|<Link href=\"${REPO_URL}\">${NAME}</Link>|g" "$footer"
+    echo "  Patched footer.template.tsx"
+  fi
+
+  # Test email — preview + body copy
+  if [[ -f "$test_email" ]]; then
+    sed -i "s|This is a test email from Immich\.|This is a test email from ${NAME}.|g" "$test_email"
+    sed -i "s|This is a test email from your Immich Instance!|This is a test email from your ${NAME} Instance!|g" "$test_email"
+    echo "  Patched test.email.tsx"
+  fi
+
+  # Welcome email — preview copy
+  if [[ -f "$welcome_email" ]]; then
+    sed -i "s|You have been invited to a new Immich instance\.|You have been invited to a new ${NAME} instance.|g" "$welcome_email"
+    echo "  Patched welcome.email.tsx"
+  fi
+
+  # Notification service — default email subject lines
+  if [[ -f "$notification" ]]; then
+    sed -i "s|subject: 'Test email from Immich'|subject: 'Test email from ${NAME}'|g" "$notification"
+    sed -i "s|subject: 'Welcome to Immich'|subject: 'Welcome to ${NAME}'|g" "$notification"
+    echo "  Patched notification.service.ts subjects"
+  fi
+
+  # Admin notification service — "Send test email" subject
+  if [[ -f "$notification_admin" ]]; then
+    sed -i "s|subject: 'Test email from Immich'|subject: 'Test email from ${NAME}'|g" "$notification_admin"
+    echo "  Patched notification-admin.service.ts subject"
   fi
 }
 
@@ -652,9 +717,11 @@ patch_versions() {
 # --- Main ---
 #
 main() {
+  echo "=== Applying branding: $NAME ==="
   patch_versions
   patch_i18n
   patch_web
+  patch_emails
   patch_help_modal
   patch_assets
   patch_android
@@ -666,4 +733,9 @@ main() {
   echo "=== Branding applied successfully ==="
 }
 
-main "$@"
+# Run main only when executed directly. When sourced (e.g. by the branding
+# tests), this guard lets callers invoke individual patch_* functions without
+# triggering a full branding pass.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/branding/scripts/test-email-branding.sh
+++ b/branding/scripts/test-email-branding.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Regression test for issue #636 — Immich branding in default email/notification
+# templates. Runs the REAL patch_emails() from apply-branding.sh against a
+# throwaway copy of the affected files, then asserts every user-facing Immich
+# reference (logo, store links/badges, project credit, body copy, subjects) has
+# been rebranded to Noodle Gallery.
+#
+# The working tree is never mutated (patch runs against a temp mirror), so this
+# is safe to run locally and in CI. No image tooling or network access required.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# GNU sed/coreutils on macOS (mirrors .github/actions/apply-branding/action.yml).
+if [[ "$(uname)" == "Darwin" ]]; then
+  export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+fi
+
+# Source apply-branding.sh to pull in patch_emails() and the config-derived
+# globals (NAME, REPO_URL, APP_STORE_URL, PLAY_STORE_URL, EMAIL_ASSET_BASE_URL).
+# The script guards `main` behind a BASH_SOURCE check, so sourcing only defines
+# functions and reads config — it does not run a branding pass.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/apply-branding.sh"
+set +e # apply-branding.sh enables `set -e`; a failed grep must not abort the run
+
+# Mirror only the files patch_emails() touches into a temporary REPO_ROOT.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/server/src/emails/components" "$TMP/server/src/services"
+cp "$REPO/server/src/emails/components/immich.layout.tsx" "$TMP/server/src/emails/components/"
+cp "$REPO/server/src/emails/components/footer.template.tsx" "$TMP/server/src/emails/components/"
+cp "$REPO/server/src/emails/test.email.tsx" "$TMP/server/src/emails/"
+cp "$REPO/server/src/emails/welcome.email.tsx" "$TMP/server/src/emails/"
+cp "$REPO/server/src/services/notification.service.ts" "$TMP/server/src/services/"
+cp "$REPO/server/src/services/notification-admin.service.ts" "$TMP/server/src/services/"
+
+# Apply the real transformation against the mirror.
+REPO_ROOT="$TMP" patch_emails >/dev/null
+
+fails=0
+absent() { # <file> <regex> <description>  — regex must NOT match
+  if grep -Eq "$2" "$TMP/$1"; then
+    echo "  FAIL: $3 — '$2' still present in $1"
+    fails=$((fails + 1))
+  else
+    echo "  ok:   $3"
+  fi
+}
+present() { # <file> <literal> <description>  — literal must match
+  if grep -Fq "$2" "$TMP/$1"; then
+    echo "  ok:   $3"
+  else
+    echo "  FAIL: $3 — '$2' missing from $1"
+    fails=$((fails + 1))
+  fi
+}
+
+LAYOUT="server/src/emails/components/immich.layout.tsx"
+FOOTER="server/src/emails/components/footer.template.tsx"
+TEST_EMAIL="server/src/emails/test.email.tsx"
+WELCOME="server/src/emails/welcome.email.tsx"
+NOTIFY="server/src/services/notification.service.ts"
+NOTIFY_ADMIN="server/src/services/notification-admin.service.ts"
+
+echo "Layout logo:"
+absent "$LAYOUT" 'immich\.app/img' 'logo no longer served from immich.app'
+absent "$LAYOUT" 'alt="Immich"' 'logo alt text rebranded'
+present "$LAYOUT" "${EMAIL_ASSET_BASE_URL}/immich-logo-inline-light.png" 'logo points to Gallery asset host'
+present "$LAYOUT" "alt=\"${NAME}\"" 'logo alt text is Noodle Gallery'
+
+echo "Footer store badges + credit:"
+absent "$FOOTER" 'immich\.app' 'no immich.app badge/credit URLs remain'
+absent "$FOOTER" 'app\.alextran\.immich' 'play store link repointed off Immich app'
+absent "$FOOTER" 'apps\.apple\.com/sg/app/immich' 'app store link repointed off Immich app'
+absent "$FOOTER" '>Immich</Link>' 'project credit rebranded'
+present "$FOOTER" "$PLAY_STORE_URL" 'play store link is Gallery'
+present "$FOOTER" "$APP_STORE_URL" 'app store link is Gallery'
+present "$FOOTER" "${EMAIL_ASSET_BASE_URL}/google-play-badge.png" 'play badge from Gallery asset host'
+present "$FOOTER" "${EMAIL_ASSET_BASE_URL}/ios-app-store-badge.png" 'app store badge from Gallery asset host'
+present "$FOOTER" ">${NAME}</Link>" 'credit names Noodle Gallery'
+
+echo "Body copy + subjects:"
+absent "$TEST_EMAIL" 'test email from Immich' 'test email preview rebranded'
+absent "$TEST_EMAIL" 'Immich Instance' 'test email body rebranded'
+absent "$WELCOME" 'a new Immich instance' 'welcome preview rebranded'
+absent "$NOTIFY" "from Immich'" 'test email subject rebranded'
+absent "$NOTIFY" "Welcome to Immich'" 'welcome subject rebranded'
+absent "$NOTIFY_ADMIN" "from Immich'" 'admin test email subject rebranded'
+present "$TEST_EMAIL" "test email from ${NAME}" 'test email names Noodle Gallery'
+present "$WELCOME" "a new ${NAME} instance" 'welcome preview names Noodle Gallery'
+present "$NOTIFY" "from ${NAME}'" 'test subject names Noodle Gallery'
+present "$NOTIFY" "Welcome to ${NAME}'" 'welcome subject names Noodle Gallery'
+present "$NOTIFY_ADMIN" "from ${NAME}'" 'admin test subject names Noodle Gallery'
+
+echo
+if [[ $fails -gt 0 ]]; then
+  echo "FAILED: $fails assertion(s)"
+  exit 1
+fi
+echo "PASSED: email/notification templates fully rebranded to ${NAME}"

--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -183,6 +183,63 @@ if [[ $EXIT_CODE -eq 0 ]]; then
   echo "Open-in-app scheme registration verified"
 fi
 
+# Email/notification templates must not leak upstream branding (issue #636):
+# logo image, "Immich" wordmark, app-store badges/links, project credit, subjects.
+echo "--- Checking email templates ---"
+
+email_layout="$REPO_ROOT/server/src/emails/components/immich.layout.tsx"
+if [[ -f "$email_layout" ]]; then
+  if grep -q "immich\.app/img" "$email_layout" || grep -q 'alt="Immich"' "$email_layout"; then
+    echo "  WARN: Immich logo/branding still in immich.layout.tsx"
+    EXIT_CODE=1
+  else
+    echo "  OK: immich.layout.tsx"
+  fi
+fi
+
+email_footer="$REPO_ROOT/server/src/emails/components/footer.template.tsx"
+if [[ -f "$email_footer" ]]; then
+  if grep -qE "immich\.app|app\.alextran\.immich|apps\.apple\.com/sg/app/immich|>Immich</Link>" "$email_footer"; then
+    echo "  WARN: Immich store links/credit still in footer.template.tsx"
+    EXIT_CODE=1
+  else
+    echo "  OK: footer.template.tsx"
+  fi
+fi
+
+email_test="$REPO_ROOT/server/src/emails/test.email.tsx"
+if [[ -f "$email_test" ]]; then
+  if grep -qE "test email from Immich|Immich Instance" "$email_test"; then
+    echo "  WARN: Immich wordmark still in test.email.tsx"
+    EXIT_CODE=1
+  else
+    echo "  OK: test.email.tsx"
+  fi
+fi
+
+email_welcome="$REPO_ROOT/server/src/emails/welcome.email.tsx"
+if [[ -f "$email_welcome" ]]; then
+  if grep -q "a new Immich instance" "$email_welcome"; then
+    echo "  WARN: Immich wordmark still in welcome.email.tsx"
+    EXIT_CODE=1
+  else
+    echo "  OK: welcome.email.tsx"
+  fi
+fi
+
+for notification_svc in \
+  "$REPO_ROOT/server/src/services/notification.service.ts" \
+  "$REPO_ROOT/server/src/services/notification-admin.service.ts"; do
+  if [[ -f "$notification_svc" ]]; then
+    if grep -qE "subject: 'Test email from Immich'|subject: 'Welcome to Immich'" "$notification_svc"; then
+      echo "  WARN: Immich wordmark still in $(basename "$notification_svc") subjects"
+      EXIT_CODE=1
+    else
+      echo "  OK: $(basename "$notification_svc") subjects"
+    fi
+  fi
+done
+
 echo "--- Checking mobile image assets ---"
 if ! bash "$SCRIPT_DIR/verify-mobile-assets.sh"; then
   EXIT_CODE=1


### PR DESCRIPTION
## Summary

Fixes #636. The default email/notification templates kept upstream **Immich** branding that the system-config UI can't fully override: the logo image, the "Immich" wordmark, the Google Play / App Store badges + links, the AGPL project credit, and the default subject lines. `apply-branding` never touched `server/src/emails` or the notification services, so deployed mail leaked Immich branding.

This adds a `patch_emails()` pass to `apply-branding.sh` (the build-time branding overlay) that rewrites, keeping the Immich strings in source for clean upstream rebases:

| Element | Before | After |
|---|---|---|
| Layout logo + alt | `immich.app/img/...`, `alt="Immich"` | `docs.opennoodle.de/img/...`, `alt="Noodle Gallery"` |
| Footer Play badge/link | immich.app badge → `app.alextran.immich` | docs-hosted badge → [Gallery on Play](https://play.google.com/store/apps/details?id=de.opennoodle.gallery) |
| Footer App Store badge/link | immich.app badge → Immich app | docs-hosted badge → [Gallery on App Store](https://apps.apple.com/us/app/noodle-gallery/id6761776289) |
| Footer credit | "Immich" → immich.app | "Noodle Gallery" → repo URL |
| Test/Welcome body + preview | "Immich" / "Immich Instance" | "Noodle Gallery" |
| Subjects (`notification.service` + `notification-admin.service`) | "Test email from Immich", "Welcome to Immich" | "… Noodle Gallery" |

Store URLs and the email asset host are added to `branding/config.json`. `verify-branding.sh` now gates all of the above so any future leak fails CI.

**Out of scope:** `license.email.tsx` / `futo.layout.tsx` (the FUTO license-purchase email) — confirmed dead code, not imported by `email.repository.ts`, never rendered.

## How it reaches production

The server image build (`gallery-release-server-only.yml`, `gallery-rc-build.yml`) runs the `apply-branding` action on the checkout *before* `docker build … context: .`, so the rewritten templates compile into `dist`. Source stays on Immich; the rewrite is build-time only.

## Test plan

- [x] **TDD**: new `branding/scripts/test-email-branding.sh` runs the real `patch_emails()` against a throwaway copy and asserts no Immich leaks + correct Gallery URLs/text (25 assertions). Watched it go RED (stub) → GREEN.
- [x] Full pipeline run locally: `apply-branding.sh` (exit 0, all 6 email targets patched) → `verify-branding.sh` (exit 0, "Branding verification passed").
- [x] Manually inspected branded output (logo, badges, links, credit, copy, subjects all Noodle Gallery; code identifiers like `ImmichLayout` correctly untouched).
- [x] Source-level server specs unaffected (they assert the Immich strings against unchanged source).