### PR TITLE
fix(server): scope Folder Explorer to shared-space access for non-admins (#637)

### DIFF
--- a/server/src/queries/view.repository.sql
+++ b/server/src/queries/view.repository.sql
@@ -6,8 +6,28 @@ select distinct
 from
   "asset"
 where
-  "ownerId" = $2::uuid
-  and "visibility" = $3
+  (
+    "asset"."ownerId" = $2::uuid
+    or exists (
+      select
+      from
+        "shared_space_asset"
+        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
+      where
+        "shared_space_asset"."assetId" = "asset"."id"
+        and "shared_space_member"."userId" = $3::uuid
+    )
+    or exists (
+      select
+      from
+        "shared_space_library"
+        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
+      where
+        "shared_space_library"."libraryId" = "asset"."libraryId"
+        and "shared_space_member"."userId" = $4::uuid
+    )
+  )
+  and "visibility" = $5
   and "deletedAt" is null
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
@@ -23,13 +43,33 @@ from
   "asset"
   left join "asset_exif" on "asset"."id" = "asset_exif"."assetId"
 where
-  "ownerId" = $1::uuid
-  and "visibility" = $2
+  (
+    "asset"."ownerId" = $1::uuid
+    or exists (
+      select
+      from
+        "shared_space_asset"
+        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
+      where
+        "shared_space_asset"."assetId" = "asset"."id"
+        and "shared_space_member"."userId" = $2::uuid
+    )
+    or exists (
+      select
+      from
+        "shared_space_library"
+        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
+      where
+        "shared_space_library"."libraryId" = "asset"."libraryId"
+        and "shared_space_member"."userId" = $3::uuid
+    )
+  )
+  and "visibility" = $4
   and "deletedAt" is null
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
   and "localDateTime" is not null
-  and "originalPath" like $3
-  and "originalPath" not like $4
+  and "originalPath" like $5
+  and "originalPath" not like $6
 order by
-  regexp_replace("asset"."originalPath", $5, $6) asc
+  regexp_replace("asset"."originalPath", $7, $8) asc

--- a/server/src/repositories/view-repository.ts
+++ b/server/src/repositories/view-repository.ts
@@ -1,4 +1,4 @@
-import { Kysely } from 'kysely';
+import { ExpressionBuilder, Kysely } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { AssetVisibility } from 'src/enum';
@@ -14,7 +14,7 @@ export class ViewRepository {
       .selectFrom('asset')
       .select((eb) => eb.fn<string>('substring', ['asset.originalPath', eb.val('^(.*/)[^/]*$')]).as('directoryPath'))
       .distinct()
-      .where('ownerId', '=', asUuid(userId))
+      .where((eb) => this.ownedOrSpaceAccessible(eb, userId))
       .where('visibility', '=', AssetVisibility.Timeline)
       .where('deletedAt', 'is', null)
       .where('fileCreatedAt', 'is not', null)
@@ -34,7 +34,7 @@ export class ViewRepository {
       .selectFrom('asset')
       .selectAll('asset')
       .$call(withExif)
-      .where('ownerId', '=', asUuid(userId))
+      .where((eb) => this.ownedOrSpaceAccessible(eb, userId))
       .where('visibility', '=', AssetVisibility.Timeline)
       .where('deletedAt', 'is', null)
       .where('fileCreatedAt', 'is not', null)
@@ -47,5 +47,30 @@ export class ViewRepository {
         'asc',
       )
       .execute();
+  }
+
+  // The folder explorer shows folders for assets a user can actually see: their own,
+  // plus any reachable through a shared space they are a member of — either added to
+  // the space directly or via a library linked to the space. Mirrors the access rules
+  // in AccessRepository.checkSpaceAccess so non-admin space members are not stuck with
+  // an empty tree (issue #637).
+  private ownedOrSpaceAccessible(eb: ExpressionBuilder<DB, 'asset'>, userId: string) {
+    return eb.or([
+      eb('asset.ownerId', '=', asUuid(userId)),
+      eb.exists(
+        eb
+          .selectFrom('shared_space_asset')
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+          .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+          .where('shared_space_member.userId', '=', asUuid(userId)),
+      ),
+      eb.exists(
+        eb
+          .selectFrom('shared_space_library')
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+          .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+          .where('shared_space_member.userId', '=', asUuid(userId)),
+      ),
+    ]);
   }
 }

--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -58,6 +58,7 @@ import { TagRepository } from 'src/repositories/tag.repository';
 import { TelemetryRepository } from 'src/repositories/telemetry.repository';
 import { UserRepository } from 'src/repositories/user.repository';
 import { VersionHistoryRepository } from 'src/repositories/version-history.repository';
+import { ViewRepository } from 'src/repositories/view-repository';
 import { WorkflowRepository } from 'src/repositories/workflow.repository';
 import { DB } from 'src/schema';
 import { AlbumTable } from 'src/schema/tables/album.table';
@@ -491,6 +492,7 @@ const newRealRepository = <T>(key: ClassConstructor<T>, db: Kysely<DB>): T => {
     case SystemMetadataRepository:
     case UserRepository:
     case VersionHistoryRepository:
+    case ViewRepository:
     case WorkflowRepository: {
       return new key(db);
     }

--- a/server/test/medium/specs/repositories/view-repository.spec.ts
+++ b/server/test/medium/specs/repositories/view-repository.spec.ts
@@ -1,0 +1,228 @@
+import { Kysely } from 'kysely';
+import { AssetVisibility, SharedSpaceRole } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { ViewRepository } from 'src/repositories/view-repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db || defaultDatabase,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(ViewRepository) };
+};
+
+type Ctx = ReturnType<typeof setup>['ctx'];
+
+// Seed an asset added directly to a space, with `member` joined at the given role.
+// The asset is owned by the space creator (a different user), so any visibility the
+// member gets comes purely from their space membership — never from ownership.
+const seedDirectSpaceAsset = async (
+  ctx: Ctx,
+  role: SharedSpaceRole,
+  originalPath: string,
+  visibility: AssetVisibility = AssetVisibility.Timeline,
+) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath, visibility });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role });
+  return { owner, member, space, asset };
+};
+
+// Seed an asset reachable through a library linked to a space, with `member` joined.
+const seedLinkedLibraryAsset = async (ctx: Ctx, role: SharedSpaceRole, originalPath: string) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  const { library } = await ctx.newLibrary({ ownerId: owner.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id, originalPath });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role });
+  return { owner, member, space, library, asset };
+};
+
+const ALL_ROLES = [SharedSpaceRole.Viewer, SharedSpaceRole.Editor, SharedSpaceRole.Owner];
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(ViewRepository.name, () => {
+  // ============================================================================
+  // Folder tree (getUniqueOriginalPaths) — permission matrix
+  // ============================================================================
+  describe('getUniqueOriginalPaths', () => {
+    it('GRANT — owner sees folders for assets they own', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      await ctx.newAsset({ ownerId: user.id, originalPath: '/lib/owner/family/p1.jpg' });
+
+      const result = await sut.getUniqueOriginalPaths(user.id);
+
+      expect(result).toContain('/lib/owner/family');
+    });
+
+    it.each(ALL_ROLES)('GRANT — space %s sees folders for assets shared directly into the space', async (role) => {
+      const { ctx, sut } = setup();
+      const { member } = await seedDirectSpaceAsset(ctx, role, `/archive/2025/${role}-direct/IMG.jpg`);
+
+      const result = await sut.getUniqueOriginalPaths(member.id);
+
+      expect(result).toContain(`/archive/2025/${role}-direct`);
+    });
+
+    it.each(ALL_ROLES)(
+      'GRANT — space %s sees folders for assets in a library linked to the space',
+      async (role) => {
+        const { ctx, sut } = setup();
+        const { member } = await seedLinkedLibraryAsset(ctx, role, `/external/cam/${role}-lib/clip.jpg`);
+
+        const result = await sut.getUniqueOriginalPaths(member.id);
+
+        expect(result).toContain(`/external/cam/${role}-lib`);
+      },
+    );
+
+    it('GRANT — member sees the folder even when showInTimeline is disabled', async () => {
+      const { ctx, sut } = setup();
+      const { member, space } = await seedDirectSpaceAsset(
+        ctx,
+        SharedSpaceRole.Viewer,
+        '/archive/no-timeline/IMG.jpg',
+      );
+      await ctx.database
+        .updateTable('shared_space_member')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', member.id)
+        .execute();
+
+      const result = await sut.getUniqueOriginalPaths(member.id);
+
+      expect(result).toContain('/archive/no-timeline');
+    });
+
+    it('DENY — non-member sees no folders for space assets', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: '/private/owner/secret/p1.jpg' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getUniqueOriginalPaths(stranger.id);
+
+      expect(result).toEqual([]);
+    });
+
+    it('DENY — member of a different space does not see the asset folder', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: outsider } = await ctx.newUser();
+      const { space: withAsset } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { space: other } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: '/private/owner/other-space/p1.jpg' });
+      await ctx.newSharedSpaceAsset({ spaceId: withAsset.id, assetId: asset.id, addedById: owner.id });
+      // outsider belongs to a different space that does NOT contain the asset
+      await ctx.newSharedSpaceMember({ spaceId: other.id, userId: outsider.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getUniqueOriginalPaths(outsider.id);
+
+      expect(result).not.toContain('/private/owner/other-space');
+    });
+
+    it('DENY — a removed member no longer sees the folder', async () => {
+      const { ctx, sut } = setup();
+      const { member, space } = await seedDirectSpaceAsset(ctx, SharedSpaceRole.Editor, '/archive/removed/IMG.jpg');
+
+      await expect(sut.getUniqueOriginalPaths(member.id)).resolves.toContain('/archive/removed');
+
+      await ctx.database
+        .deleteFrom('shared_space_member')
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', member.id)
+        .execute();
+
+      await expect(sut.getUniqueOriginalPaths(member.id)).resolves.not.toContain('/archive/removed');
+    });
+
+    it('DENY — member does not see folders for non-timeline (hidden) shared assets', async () => {
+      const { ctx, sut } = setup();
+      const { member } = await seedDirectSpaceAsset(
+        ctx,
+        SharedSpaceRole.Viewer,
+        '/archive/hidden/IMG.jpg',
+        AssetVisibility.Hidden,
+      );
+
+      const result = await sut.getUniqueOriginalPaths(member.id);
+
+      expect(result).not.toContain('/archive/hidden');
+    });
+  });
+
+  // ============================================================================
+  // Folder contents (getAssetsByOriginalPath) — permission matrix
+  // ============================================================================
+  describe('getAssetsByOriginalPath', () => {
+    it.each(ALL_ROLES)('GRANT — space %s gets folder contents shared directly into the space', async (role) => {
+      const { ctx, sut } = setup();
+      const path = `/archive/contents/${role}-direct`;
+      const { member, asset } = await seedDirectSpaceAsset(ctx, role, `${path}/IMG_8997.jpg`);
+
+      const result = await sut.getAssetsByOriginalPath(member.id, path);
+
+      expect(result.map((a) => a.id)).toEqual([asset.id]);
+    });
+
+    it.each(ALL_ROLES)('GRANT — space %s gets folder contents from a linked library', async (role) => {
+      const { ctx, sut } = setup();
+      const path = `/external/contents/${role}-lib`;
+      const { member, asset } = await seedLinkedLibraryAsset(ctx, role, `${path}/clip.jpg`);
+
+      const result = await sut.getAssetsByOriginalPath(member.id, path);
+
+      expect(result.map((a) => a.id)).toEqual([asset.id]);
+    });
+
+    it('DENY — non-member gets no folder contents', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: '/private/owner/contents/p1.jpg' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getAssetsByOriginalPath(stranger.id, '/private/owner/contents');
+
+      expect(result).toEqual([]);
+    });
+
+    it('DENY — a removed member no longer gets folder contents', async () => {
+      const { ctx, sut } = setup();
+      const path = '/archive/contents/removed';
+      const { member, space, asset } = await seedDirectSpaceAsset(ctx, SharedSpaceRole.Editor, `${path}/IMG.jpg`);
+
+      await expect(sut.getAssetsByOriginalPath(member.id, path)).resolves.toEqual([
+        expect.objectContaining({ id: asset.id }),
+      ]);
+
+      await ctx.database
+        .deleteFrom('shared_space_member')
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', member.id)
+        .execute();
+
+      await expect(sut.getAssetsByOriginalPath(member.id, path)).resolves.toEqual([]);
+    });
+  });
+});

--- a/server/test/medium/specs/repositories/view-repository.spec.ts
+++ b/server/test/medium/specs/repositories/view-repository.spec.ts
@@ -80,25 +80,18 @@ describe(ViewRepository.name, () => {
       expect(result).toContain(`/archive/2025/${role}-direct`);
     });
 
-    it.each(ALL_ROLES)(
-      'GRANT — space %s sees folders for assets in a library linked to the space',
-      async (role) => {
-        const { ctx, sut } = setup();
-        const { member } = await seedLinkedLibraryAsset(ctx, role, `/external/cam/${role}-lib/clip.jpg`);
+    it.each(ALL_ROLES)('GRANT — space %s sees folders for assets in a library linked to the space', async (role) => {
+      const { ctx, sut } = setup();
+      const { member } = await seedLinkedLibraryAsset(ctx, role, `/external/cam/${role}-lib/clip.jpg`);
 
-        const result = await sut.getUniqueOriginalPaths(member.id);
+      const result = await sut.getUniqueOriginalPaths(member.id);
 
-        expect(result).toContain(`/external/cam/${role}-lib`);
-      },
-    );
+      expect(result).toContain(`/external/cam/${role}-lib`);
+    });
 
     it('GRANT — member sees the folder even when showInTimeline is disabled', async () => {
       const { ctx, sut } = setup();
-      const { member, space } = await seedDirectSpaceAsset(
-        ctx,
-        SharedSpaceRole.Viewer,
-        '/archive/no-timeline/IMG.jpg',
-      );
+      const { member, space } = await seedDirectSpaceAsset(ctx, SharedSpaceRole.Viewer, '/archive/no-timeline/IMG.jpg');
       await ctx.database
         .updateTable('shared_space_member')
         .set({ showInTimeline: false })


### PR DESCRIPTION
Fixes #637.

## Problem

A non-admin Space member who opens a photo's info panel and clicks the file path lands on the Folder Explorer with an empty tree (only the home icon). Admins work because they own the assets.

Root cause: `ViewRepository.getUniqueOriginalPaths` and `getAssetsByOriginalPath` filtered strictly by `ownerId = userId`. A Space member owns none of the Space's assets, so both queries returned `[]`. This is purely the ownership filter — `FolderRead` permission and the page itself were fine (the API returned a 200 with `[]`).

## Fix

Replace the `ownerId = userId` filter in both queries with a shared `ownedOrSpaceAccessible` predicate: assets the user **owns**, **OR** assets reachable through a shared space they're a member of — added directly **or** via a library linked to the space. This mirrors the canonical access rules in `AccessRepository.checkSpaceAccess`, using correlated `EXISTS` subqueries (no row multiplication; `distinct` preserved).

Member folder access is independent of the per-member `showInTimeline` preference, since this is on-demand navigation to photos the user can already see, not a passive timeline feed.

Scope: server-only (unified personal Folder Explorer view). No new routes, no API signature change, no SDK/Dart/web regeneration. The existing `/folders` page and the photo-path link work as-is.

## Tests — full permission matrix

New medium spec `test/medium/specs/repositories/view-repository.spec.ts` (20 cases) covers, for both `getUniqueOriginalPaths` and `getAssetsByOriginalPath`:

- **GRANT** — owner sees own folders; viewer/editor/owner roles × {direct asset, linked library}; member with `showInTimeline` disabled.
- **DENY** — non-member; member of a *different* space; *removed* member (lifecycle); non-timeline (hidden) shared assets.

Also registered `ViewRepository` in the medium-test harness (`newRealRepository`), which was missing.

## Verification

- `view-repository.spec.ts`: 20/20 pass (written test-first; the 15 feature-gap cases were watched failing before the fix).
- Server unit suite: 4480 passed, 0 failed. `tsc --noEmit` clean, ESLint clean.
- `pnpm sync:sql` regenerated `view.repository.sql` (the only generated-file change; no schema/migration changes).

## Out of scope

The info-panel path-toggle button is owner-gated in `detail-panel.svelte`, but the path link itself is not and the reporter could already see the path — so the reported flow is fully fixed server-side.