### PR TITLE
fix(server): unstick shared-space face-recognition jobs

### DIFF
--- a/docs/plans/2026-05-30-hagen-stuck-jobs-debug.md
+++ b/docs/plans/2026-05-30-hagen-stuck-jobs-debug.md
@@ -1,0 +1,217 @@
+# Hagen stuck/cycling jobs — diagnosis & fix plan (2026-05-30)
+
+Production: fotos.meischner.info, v4.56.7, 563k assets, 3 spaces.
+Worktree branch: `worktree-debug+hagen-stuck-jobs` (based on origin/main @ 2e1299dcc0).
+bullmq@5.75.2 installed.
+
+> Session note: the interactive harness output transport degraded mid-session (multi-line
+> tool results truncate to ~1 line). All code anchors below were read cleanly _before_ that.
+> Resume in a fresh session to execute the TDD work with reliable reads/test output.
+
+---
+
+## STATUS — IMPLEMENTED (2026-05-30, fresh session)
+
+Both fixes implemented via TDD on this branch. Full server unit suite: **4495 passed**;
+tsc + eslint clean; medium (real-DB) tests pass.
+
+**Finding 1 (queue robustness)**
+
+- `handleSharedSpacePersonDedup` now runs exactly ONE pass per job and re-queues a follow-up
+  `SharedSpacePersonDedup` (`{ spaceId, pass: pass + 1 }`) while merges remain, capped at
+  `SHARED_SPACE_DEDUP_MAX_PASSES` (100). Each job stays short so the BullMQ lock never expires.
+- Follow-up passes use a **pass-scoped jobId** (`space-dedup-<spaceId>-pass-<n>`) in
+  `job.repository.getJobOptions` so they enqueue while the current job is still `active`; the bare
+  `space-dedup-<spaceId>` id is kept for the initial trigger (external-trigger dedupe preserved).
+- `buildWorkerOptions` gives the FacialRecognition queue a 5-min `lockDuration`/`stalledInterval`
+  (defense-in-depth for any remaining long handler); other queues stay on BullMQ defaults.
+- `JobRepository.removeOrphanedActiveJobs` / `reconcileOrphanedActiveJobs` LREM job ids stuck in
+  the `active` list with no backing hash (the orphan class). Wired into `QueueService.onBootstrap`
+  before `startWorkers` on the Microservices worker (best-effort; never blocks startup). Does NOT
+  use `clean(0,_,'active')` — only hashless ids are removed, so live jobs are never touched.
+
+**Finding 2 (reconciliation collapse)**
+
+- `applySharedSpaceIdentityReconciliationClaim`: personal-profile conflicts STILL skip; on a
+  space-profile conflict it now calls `collapseSameSpaceReconciliationConflicts`, which uses the
+  new `faceIdentityRepository.getSpaceMergeConflictPairs` (spans all spaces, since `mergeIdentities`
+  checks conflicts globally), picks a survivor by `nameSource` precedence manual>inherited>auto>none
+  (tie-break faceCount, then id), folds the loser in (reassign faces, migrate aliases, delete,
+  recount), then runs `mergeIdentities` collision-free.
+
+**Tests added:** unit collapse matrix + chunking/cap + worker-options + orphan self-heal + bootstrap
+ordering; medium `getSpaceMergeConflictPairs` + collapse-then-merge unique-index convergence.
+
+---
+
+## Finding 1 — Zombie `space-dedup` job permanently "active", starves facialRecognition queue
+
+### Symptom
+
+`space-dedup-f04f559e-...` sits in BullMQ `active` list with NO backing job hash; no PG query;
+no logs; `space-identity-reconcile-f04f559e-all-members-all-people` blocked behind it.
+Only server restart or shell `LREM` clears it. No user-accessible recovery.
+
+### Confirmed facts (file:line)
+
+- Worker: `job.repository.ts:108-118` — `new Worker(queueName, ..., { ...bull.config, concurrency: 1 })`.
+- `bull.config`: `config.repository.ts:297-308` — `prefix:'immich_bull'`, `defaultJobOptions:{attempts:1, removeOnComplete:true, removeOnFail:false}`. **No** lockDuration/stalledInterval/maxStalledCount/lockRenewTime set → BullMQ defaults: lockDuration 30s, stalledInterval 30s, maxStalledCount 1, lockRenewTime 15s.
+- FacialRecognition is NOT a concurrent queue (`queue.service.ts` isConcurrentQueue) → stays concurrency 1.
+- jobIds (deterministic): `job.repository.ts:401` `space-dedup-${spaceId}`; `:403-408` `space-identity-reconcile-${spaceId}-${userId ?? 'all-members'}-${spacePersonId ?? 'all-people'}`. Both `removeOnComplete:true`, no removeOnFail/attempts override, NO bullmq `deduplication` option (relies on legacy jobId).
+- Add path: `job.repository.ts:241-283` `queueAll` → for jobId items uses `queue.add()`. Dedup/reconcile fall through to plain `queue.add` (NOT in `isSharedSpaceFacePipelineJob` 448-455, so `removePausedStableJob` 436-446 does NOT apply to them).
+- Handler `handleSharedSpacePersonDedup`: `shared-space.service.ts:1704-1875`. Up to `MAX_PASSES=100` (`:1721`) passes; each pass re-runs `getSpacePersonsWithEmbeddings` + per-person vector `findClosestSpacePerson` + per-merge `reassignPersonFacesSafe`/`migrateAliases`/`mergeIdentitiesForSpacePersonEvidence`/`inheritSpacePersonMetadata`/`updatePerson`/`deletePerson` + `recountPersons`. Inner try/catch swallow per-merge errors. Returns `Skipped`(:1709)/`Success`(:1874). MAX_PASSES path `break`s then returns Success (does NOT throw). On a 563k-asset/large space this is many seconds→minutes — far exceeds the 30s lock.
+- No custom Redis active-list surgery anywhere (no moveToFailed/moveToCompleted/LREM/RPOPLPUSH/obliterate). `removePausedStableJob`/`removeFailedStableJob` are state-gated (paused/failed) and don't touch active dedup jobs. No boot-time clean/obliterate/pause (`queue.service.ts:78-84` onBootstrap only does setup + startWorkers on microservices worker).
+
+### #595 connection-pool deadlock — RULED OUT
+
+`mergeIdentitiesForSpacePersonEvidence` (`shared-space.service.ts:2284-2311`) opens NO transaction;
+it calls `assignIdentityToPerson` then `faceIdentityRepository.mergeIdentities` **sequentially**.
+`mergeIdentities` (`face-identity.repository.ts:~2460-2556`) is fully `trx`-threaded incl
+`countMergeConflicts(trx, ...)`. `getMergeConflicts` (`:2600-2605`) uses `this.db` but is only ever
+called standalone, outside any open transaction. So there is NO nested `this.db`-in-transaction.
+Finding 1 is NOT a deadlock — it is the long-handler/short-lock/no-recovery class.
+
+### Root cause (class)
+
+A long, unbounded handler runs on a shared concurrency-1 queue under a 30s lock with no
+user-reachable recovery. Any single wedge — process restart/OOM mid-pass, a Redis blip dropping
+the lock, or lock-expiry + stalled-recovery (maxStalledCount 1) racing with `removeOnComplete:true`
+— leaves an orphaned `active` entry with no hash that **blocks the entire FacialRecognition queue**
+(core face recognition + all space jobs). Restart/LREM is the only escape.
+
+### Fix plan (Finding 1)
+
+1. **Chunk the dedup handler (primary fix).** Replace the in-process up-to-100-pass `while` loop
+   with ONE pass per job; if `mergedAny`, re-queue a follow-up `SharedSpacePersonDedup` for the
+   same space (jobId frees after `removeOnComplete`). Each job stays short → lock never expires.
+   Keep MAX_PASSES as a guard via a pass counter carried in job data.
+2. **Per-queue worker settings.** Extend `startWorkers` (`job.repository.ts:108-118`) to pass
+   `lockDuration`/`stalledInterval` (bullmq v5 top-level WorkerOptions) for long-handler queues as
+   defense-in-depth (e.g. FacialRecognition 2-5 min). Confirm exact WorkerOptions field placement
+   for 5.75.2.
+3. **Self-heal orphaned active jobs (user-reachable, no shell).** On bootstrap and/or an admin/
+   maintenance action, detect `active` job ids whose `getJob(id)` returns null (orphan) and remove
+   them safely. Design the BullMQ-native removal carefully — do NOT blanket `clean(0,_,'active')`
+   (kills legit running jobs). Likely: enumerate active ids, null-hash → LREM via queue client.
+4. **Isolate dedup/reconcile off the core queue (optional, recommended).** New QueueName so a wedge
+   can't starve core face recognition. Trade-off: enum + wiring + worker.
+
+---
+
+## Finding 2 — Identity reconciliation skips same-space duplicates forever ("merge conflicts")
+
+### Symptom
+
+Every ~6h (library scan cron `0 */6 * * *`) logs
+`WARN SharedSpaceService: Skipping shared-space identity reconciliation for space person <id>: merge conflicts`
+for the SAME persons (245c078b, 5930ee66, ...). /people shows duplicates that never collapse.
+
+### Root cause — CONFIRMED
+
+`applySharedSpaceIdentityReconciliationClaim` (`shared-space.service.ts:1484-1504`):
+pre-checks `faceIdentityRepository.getMergeConflicts(...)`; if
+`personalProfileConflictCount>0 || spaceProfileConflictCount>0` → logs warning + `return` (no merge).
+`countMergeConflicts` (`face-identity.repository.ts:2559-2598`, esp. the space branch `2582-2591`)
+flags **two `shared_space_person` rows in the SAME space**, one holding the target identity and one
+the source identity. Merging would set source.identityId = target → collides with unique partial
+index `shared_space_person_spaceId_identityId_key (spaceId, identityId) WHERE identityId IS NOT NULL`.
+So it bails. `mergeIdentities` re-guards the same way (`2486-2495`) and its space UPDATE
+(`2519-2533`) skips colliding rows via `NOT EXISTS`.
+
+Why it never converges: dedup (`handleSharedSpacePersonDedup`) only collapses space-persons whose
+**embeddings** are within maxDistance (`findClosestSpacePerson`). Hagen's stuck pairs are the same
+real person but farther apart in embedding space, so dedup never touches them. Identity
+reconciliation is the ONLY path that knows they're the same (bridged via a member's matching local
+person) — and it's exactly the path that refuses to act. → infinite recurrence + /people dupes.
+
+### Decision (from user)
+
+On same-space conflict, **COLLAPSE** the two space-persons instead of skipping. Survivor by
+`nameSource` precedence **manual > inherited > auto > none**; tie-break by face count, then id.
+
+### Fix plan (Finding 2)
+
+1. In `applySharedSpaceIdentityReconciliationClaim`, when the conflict is a SPACE conflict, resolve
+   the two same-space `shared_space_person` rows (source-identity row vs target-identity row),
+   choose survivor by nameSource precedence (tie-break faceCount, then id), then COLLAPSE:
+   reassign loser faces (`reassignPersonFacesSafe` repo:1530), `migrateAliases` (repo:1871), carry
+   winning name+nameSource, complete identity merge, delete loser (`deletePerson` repo:1623),
+   `recountPersons` (repo:1789). Must run BEFORE `mergeIdentities`' colliding-row-skip UPDATE.
+2. Keep the collapse transactional in ONE repo method (respect unique index; avoid #595 pattern —
+   thread `trx`, never `this.db` inside the txn). Likely a new repo method
+   `collapseSameSpaceConflict(spaceId, survivorId, loserId, ...)` or extend mergeIdentities to
+   collapse instead of skip when given a space-collapse directive.
+3. **personalProfileConflict (same owner, two LOCAL persons): recommend STILL SKIP** — that's the
+   user's own local data across the bridge; auto-collapsing local persons could be wrong. Only
+   collapse the space-side conflict. CONFIRM with user before coding.
+4. Confirm exact `nameSource` enum strings + precedence helper: `chooseSpacePersonNameUpdate`
+   (`shared-space.service.ts:2344`), `chooseAutomaticTargetIdentity`, and the enum source. (Could
+   not re-read this session — verify in fresh session.)
+
+### Test seams (TDD)
+
+- Unit: `server/src/services/shared-space.service.spec.ts` (exists, large) — use `newTestService`.
+  First failing test: two same-space space-persons (one `nameSource:'manual'` named, one `'auto'`),
+  a reconciliation claim bridging their identities → EXPECT collapse to the manual-named survivor
+  (loser deleted, faces reassigned, name carried), NOT a skip-with-warning.
+- Medium (real DB): `server/test/medium/specs/repositories/face-identity.repository.spec.ts` and
+  `.../shared-space.repository.spec.ts` for the transactional collapse + unique-index behavior.
+
+---
+
+## Immediate mitigations for Hagen (no code change)
+
+- **Zombie job:** restart server (reliable). Or shell surgical:
+  `redis-cli LREM immich_bull:facialRecognition:active 0 "space-dedup-f04f559e-7fea-4838-bb41-ea8c8999632e"`
+  then let the worker pick up the waiting reconcile job. Avoid admin "Clear queue" (maps to
+  `queue.clean(...)`; semantics for an orphaned _active_ entry are uncertain — restart is safer).
+- **Duplicate people:** manually merge the duplicate persons in the space people view
+  (`mergeSpacePeople`) until the collapse fix ships.
+
+## Decisions locked (2026-05-30)
+
+- **Finding 2 collapse:** survivor by nameSource precedence **manual > inherited > auto > none**;
+  tie-break faceCount, then id. CONFIRMED.
+- **personalProfileConflict (same owner, two local persons): STILL SKIP.** Only the SPACE-side
+  conflict auto-collapses. Do not auto-merge a user's own local persons across the bridge. CONFIRMED.
+- **Execution:** resume the TDD work in a FRESH session (this session's interactive tool-output
+  transport degraded — multi-line results intermittently truncated to ~1 line).
+
+## Confirmed repo facts for the collapse (read 2026-05-30)
+
+- `nameSource` is a free `character varying` default `'none'` (NOT a DB enum); values seen in code:
+  `'none' | 'manual' | 'inherited' | 'auto'`. `shared-space-person.table.ts:74-75`.
+- Unique partial index `shared_space_person_spaceId_identityId_key (spaceId, identityId) WHERE identityId IS NOT NULL`
+  — table.ts:25-30. This is exactly what the collapse must respect.
+- Reusable repo primitives (all on shared-space.repository.ts, all use `this.db` — NOT trx-wrapped):
+  `reassignPersonFacesSafe(from,to)` :1530 (deletes dup faces then reassigns — PK-safe),
+  `migrateAliases(from,to)` :1871, `deletePerson(id)` :1486, `recountPersons(ids)` :1789,
+  `deleteOrphanedPersonsByIds(spaceId,ids)` :1757. A transactional `.transaction()` example exists at repo :1903.
+- `mergeIdentitiesForSpacePersonEvidence` (service :2284-2336) opens NO transaction; calls
+  `faceIdentityRepository.mergeIdentities` (trx-threaded) then `updatePerson`. The space collapse
+  must run BEFORE mergeIdentities so the source space-person row is gone and the NOT EXISTS
+  colliding-row skip (face-identity.repository.ts:2519-2533) doesn't strand it.
+- metadata/name precedence helper for inheritance lives near `inheritSpacePersonMetadata`
+  (service :2338+, nameSource handling at :2370-2373) — reuse its precedence notion for the
+  survivor name carry-over rather than inventing a new ordering.
+
+## Open items still to nail in fresh session (cheap, do first)
+
+- Exact bullmq 5.75.2 WorkerOptions field placement for `lockDuration`/`stalledInterval`
+  (top-level WorkerOptions; verify against node_modules type once deps installed in the worktree).
+- Safe BullMQ-native removal of an orphaned ACTIVE job for the self-heal (enumerate active ids,
+  `getJob(id) === null` ⇒ orphan ⇒ remove via queue client LREM on `<prefix>:<queue>:active`;
+  do NOT blanket `clean(0,_,'active')` — it kills legit running jobs).
+- Decide dedicated queue vs. reuse FacialRecognition for dedup/reconcile (recommend dedicated so a
+  wedge can't starve core face recognition — but it's enum+wiring+worker cost; confirm scope).
+
+## Resume prompt (paste into a fresh session in this worktree)
+
+> Resume the Hagen stuck-jobs fixes. Read `docs/plans/2026-05-30-hagen-stuck-jobs-debug.md` first.
+> Implement BOTH fixes via TDD (superpowers:test-driven-development), starting with Finding 2
+> (the collapse — lower risk, clear test seam in shared-space.service.spec.ts), then Finding 1
+> (chunk the dedup handler + per-queue lock/stalled settings + orphaned-active self-heal).
+> Decisions are locked in the plan: collapse survivor = nameSource precedence manual>inherited>auto>none
+> (tie-break faceCount then id); personalProfile conflicts STILL skip. Run `cd server && pnpm test`
+> for unit specs; use medium tests for the transactional repo collapse. Then prep PR(s) and the
+> Hagen reply.

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -64,6 +64,24 @@ export type MergeIdentitiesResult = {
   spaceProfileConflictCount: number;
 };
 
+/**
+ * A pair of `shared_space_person` rows in the SAME space that both hold one side of an identity
+ * merge — one row on the target identity, one on a source identity. Merging would collide with the
+ * `(spaceId, identityId)` unique partial index, so these pairs are collapsed (loser folded into the
+ * survivor) before the identity merge runs.
+ */
+export type SpaceMergeConflictPair = {
+  spaceId: string;
+  sourceId: string;
+  sourceName: string;
+  sourceNameSource: string;
+  sourceFaceCount: number;
+  targetId: string;
+  targetName: string;
+  targetNameSource: string;
+  targetFaceCount: number;
+};
+
 export type AccessibleIdentityFaceMatch = {
   identityId: string;
   type: string;
@@ -2602,5 +2620,43 @@ export class FaceIdentityRepository {
     sourceIdentityIds: string[];
   }): Promise<MergeIdentitiesResult> {
     return this.countMergeConflicts(this.db, input);
+  }
+
+  /**
+   * Returns the same-space `shared_space_person` conflict pairs that block this identity merge:
+   * for every space holding both a target-identity row and a source-identity row, the two rows with
+   * the fields needed to choose a collapse survivor (id, name, nameSource, faceCount). Spans all
+   * spaces because {@link mergeIdentities} checks conflicts globally — collapsing only the current
+   * space would still leave the merge blocked by another space's pair.
+   */
+  async getSpaceMergeConflictPairs(input: {
+    targetIdentityId: string;
+    sourceIdentityIds: string[];
+  }): Promise<SpaceMergeConflictPair[]> {
+    const sourceIdentityIds = [...new Set(input.sourceIdentityIds)].filter((id) => id !== input.targetIdentityId);
+    if (sourceIdentityIds.length === 0) {
+      return [];
+    }
+
+    return this.db
+      .selectFrom('shared_space_person as source_person')
+      .innerJoin('shared_space_person as target_person', (join) =>
+        join
+          .onRef('target_person.spaceId', '=', 'source_person.spaceId')
+          .on('target_person.identityId', '=', input.targetIdentityId),
+      )
+      .where('source_person.identityId', 'in', sourceIdentityIds)
+      .select([
+        'source_person.spaceId as spaceId',
+        'source_person.id as sourceId',
+        'source_person.name as sourceName',
+        'source_person.nameSource as sourceNameSource',
+        'source_person.faceCount as sourceFaceCount',
+        'target_person.id as targetId',
+        'target_person.name as targetName',
+        'target_person.nameSource as targetNameSource',
+        'target_person.faceCount as targetFaceCount',
+      ])
+      .execute();
   }
 }

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises';
 import { JobName, QueueName } from 'src/enum';
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { EventRepository } from 'src/repositories/event.repository';
-import { JobRepository } from 'src/repositories/job.repository';
+import { buildWorkerOptions, JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { JobCounts } from 'src/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -52,6 +52,16 @@ const setup = (counts: JobCounts[] = []) => {
   return { sut, queue, logger };
 };
 
+const stubActiveList = (queue: ReturnType<typeof setup>['queue'], activeIds: string[]) => {
+  const client = {
+    lrange: vi.fn().mockResolvedValue(activeIds),
+    lrem: vi.fn().mockResolvedValue(1),
+  };
+  (queue as any).client = Promise.resolve(client);
+  (queue as any).toKey = vi.fn((type: string) => `immich_bull:facialRecognition:${type}`);
+  return client;
+};
+
 const setHandlers = (sut: JobRepository, jobs: JobName[]) => {
   (sut as unknown as { handlers: Record<JobName, { queueName: QueueName }> }).handlers = Object.fromEntries(
     jobs.map((name) => [name, { queueName: QueueName.BackgroundTask }]),
@@ -65,6 +75,65 @@ describe(JobRepository.name, () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('buildWorkerOptions', () => {
+    it('gives the FacialRecognition queue a lock and stalled interval well above the 30s default', () => {
+      const options = buildWorkerOptions({ prefix: 'immich_bull' } as any, QueueName.FacialRecognition);
+
+      expect(options.concurrency).toBe(1);
+      expect(options.prefix).toBe('immich_bull');
+      // Long handlers (face-match-all, identity reconciliation, a dedup pass on a huge space) must
+      // not be declared stalled and orphaned while still healthy.
+      expect(options.lockDuration ?? 0).toBeGreaterThanOrEqual(120_000);
+      expect(options.stalledInterval ?? 0).toBeGreaterThanOrEqual(120_000);
+    });
+
+    it('leaves other queues on BullMQ lock defaults', () => {
+      const options = buildWorkerOptions({ prefix: 'immich_bull' } as any, QueueName.ThumbnailGeneration);
+
+      expect(options.concurrency).toBe(1);
+      expect(options.prefix).toBe('immich_bull');
+      expect(options.lockDuration).toBeUndefined();
+      expect(options.stalledInterval).toBeUndefined();
+    });
+  });
+
+  describe('removeOrphanedActiveJobs', () => {
+    it('removes active job ids whose hash is gone (orphans) and leaves real active jobs untouched', async () => {
+      const { sut, queue } = setup();
+      const client = stubActiveList(queue, ['orphan-1', 'real-1']);
+      // A real active job still has its hash; an orphan's hash was removed (e.g. removeOnComplete
+      // racing stalled-recovery) leaving a dangling id that wedges the concurrency-1 queue.
+      queue.getJob = vi.fn((id: string) => Promise.resolve(id === 'real-1' ? ({ id } as any) : undefined));
+
+      const removed = await sut.removeOrphanedActiveJobs(QueueName.FacialRecognition);
+
+      expect(removed).toEqual(['orphan-1']);
+      expect(client.lrem).toHaveBeenCalledWith('immich_bull:facialRecognition:active', 0, 'orphan-1');
+      expect(client.lrem).not.toHaveBeenCalledWith('immich_bull:facialRecognition:active', 0, 'real-1');
+    });
+
+    it('does nothing when the active list is empty', async () => {
+      const { sut, queue } = setup();
+      const client = stubActiveList(queue, []);
+
+      const removed = await sut.removeOrphanedActiveJobs(QueueName.FacialRecognition);
+
+      expect(removed).toEqual([]);
+      expect(client.lrem).not.toHaveBeenCalled();
+    });
+
+    it('does not remove anything when every active id still has a backing job', async () => {
+      const { sut, queue } = setup();
+      const client = stubActiveList(queue, ['real-1', 'real-2']);
+      queue.getJob = vi.fn((id: string) => Promise.resolve({ id }) as any);
+
+      const removed = await sut.removeOrphanedActiveJobs(QueueName.FacialRecognition);
+
+      expect(removed).toEqual([]);
+      expect(client.lrem).not.toHaveBeenCalled();
+    });
   });
 
   it('should return immediately when queues have no active waiting delayed or paused jobs', async () => {
@@ -672,6 +741,35 @@ describe(JobRepository.name, () => {
     for (const call of queue.add.mock.calls) {
       expect(call[2]).not.toHaveProperty('removeOnFail', true);
     }
+  });
+
+  it('uses a pass-scoped job id for follow-up dedup passes so they enqueue while the base job is active', async () => {
+    const { sut, queue } = setup();
+    setHandlers(sut, [JobName.SharedSpacePersonDedup]);
+
+    await sut.queueAll([
+      { name: JobName.SharedSpacePersonDedup, data: { spaceId: 'space-1', pass: 1 } },
+      { name: JobName.SharedSpacePersonDedup, data: { spaceId: 'space-1', pass: 2 } },
+      { name: JobName.SharedSpacePersonDedup, data: { spaceId: 'space-1', pass: 3 } },
+    ]);
+
+    // pass 1 (and the no-pass initial trigger) keep the bare jobId so external triggers dedupe.
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpacePersonDedup,
+      { spaceId: 'space-1', pass: 1 },
+      { jobId: 'space-dedup-space-1', removeOnComplete: true },
+    );
+    // Follow-up passes are pass-scoped so they don't collide with the still-active current job.
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpacePersonDedup,
+      { spaceId: 'space-1', pass: 2 },
+      { jobId: 'space-dedup-space-1-pass-2', removeOnComplete: true },
+    );
+    expect(queue.add).toHaveBeenCalledWith(
+      JobName.SharedSpacePersonDedup,
+      { spaceId: 'space-1', pass: 3 },
+      { jobId: 'space-dedup-space-1-pass-3', removeOnComplete: true },
+    );
   });
 
   it('does not remove failed from-backfill shared-space jobs while queueing duplicates', async () => {

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -1,7 +1,7 @@
 import { getQueueToken } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
 import { ModuleRef, Reflector } from '@nestjs/core';
-import { JobsOptions, Queue, Worker } from 'bullmq';
+import { JobsOptions, Queue, Worker, WorkerOptions } from 'bullmq';
 import { setTimeout } from 'node:timers/promises';
 import { JobConfig } from 'src/decorators';
 import { QueueJobResponseDto, QueueJobSearchDto } from 'src/dtos/queue.dto';
@@ -20,6 +20,25 @@ type JobMapItem = {
 };
 
 const FORCE_FACIAL_RECOGNITION_QUEUE_ALL_JOB_ID = `${JobName.FacialRecognitionQueueAll}/force`;
+
+/**
+ * Per-queue worker lock overrides. BullMQ defaults to a 30s lock + 30s stalled check + maxStalledCount
+ * 1, which is fine for short handlers but dangerous for queues whose handlers can legitimately run for
+ * minutes. The FacialRecognition queue (concurrency 1) runs space face-match-all, identity
+ * reconciliation, and per-pass dedup; on a large space a single healthy handler can exceed 30s, get
+ * declared stalled, and be orphaned in the "active" list — starving the whole queue, core face
+ * recognition included. A longer lock + stalled interval keeps slow-but-healthy jobs alive.
+ */
+const WORKER_OPTIONS_BY_QUEUE: Partial<Record<QueueName, Pick<WorkerOptions, 'lockDuration' | 'stalledInterval'>>> = {
+  [QueueName.FacialRecognition]: { lockDuration: 300_000, stalledInterval: 300_000 },
+};
+
+/** Builds the BullMQ worker options for a queue, layering any per-queue lock overrides on top. */
+export const buildWorkerOptions = (baseConfig: WorkerOptions, queueName: QueueName): WorkerOptions => ({
+  ...baseConfig,
+  concurrency: 1,
+  ...WORKER_OPTIONS_BY_QUEUE[queueName],
+});
 
 export type QueueTelemetryStatus = 'active' | 'completed' | 'failed' | 'delayed' | 'waiting' | 'paused';
 export type QueueTelemetryStalenessStatus = 'waiting' | 'delayed' | 'failed';
@@ -112,7 +131,7 @@ export class JobRepository {
       this.workers[queueName] = new Worker(
         queueName,
         (job) => this.eventRepository.emit('JobRun', queueName, job as JobItem),
-        { ...bull.config, concurrency: 1 },
+        buildWorkerOptions(bull.config, queueName),
       );
     }
   }
@@ -161,6 +180,41 @@ export class JobRepository {
 
   clear(name: QueueName, type: QueueCleanType) {
     return this.getQueue(name).clean(0, 1000, type);
+  }
+
+  /** Reconcile every queue's "active" list against its job hashes, dropping orphaned entries. */
+  async reconcileOrphanedActiveJobs(): Promise<void> {
+    for (const queueName of Object.values(QueueName)) {
+      const removed = await this.removeOrphanedActiveJobs(queueName);
+      if (removed.length > 0) {
+        this.logger.warn(`Removed ${removed.length} orphaned active job(s) from ${queueName}: ${removed.join(', ')}`);
+      }
+    }
+  }
+
+  /**
+   * Removes job ids stuck in a queue's BullMQ "active" list that no longer have a backing job hash.
+   * These orphans (e.g. removeOnComplete racing stalled-recovery) permanently wedge a concurrency-1
+   * queue with no user-reachable recovery. We deliberately do NOT use `clean(0, _, 'active')`, which
+   * targets jobs by age and would kill legitimately-running jobs; instead we LREM only ids whose
+   * `getJob` returns nothing. A genuine in-flight job always has its hash, so it is never touched.
+   * Intended to run at bootstrap, before workers start.
+   */
+  async removeOrphanedActiveJobs(name: QueueName): Promise<string[]> {
+    const queue = this.getQueue(name);
+    const activeKey = queue.toKey('active');
+    const client = await queue.client;
+    const activeIds = await client.lrange(activeKey, 0, -1);
+
+    const removed: string[] = [];
+    for (const jobId of activeIds) {
+      const job = await queue.getJob(jobId);
+      if (!job) {
+        await client.lrem(activeKey, 0, jobId);
+        removed.push(jobId);
+      }
+    }
+    return removed;
   }
 
   getJobCounts(name: QueueName): Promise<JobCounts> {
@@ -398,7 +452,14 @@ export class JobRepository {
         };
       }
       case JobName.SharedSpacePersonDedup: {
-        return { jobId: `space-dedup-${item.data.spaceId}`, removeOnComplete: true };
+        // Follow-up passes (pass >= 2) use a pass-scoped jobId so they enqueue even while the
+        // current dedup job is still "active" (the base jobId stays occupied until the handler
+        // returns). The initial trigger (no pass) keeps the bare jobId so concurrent external
+        // triggers still dedupe into one.
+        const pass = (item.data as { pass?: number }).pass;
+        const jobId =
+          pass && pass > 1 ? `space-dedup-${item.data.spaceId}-pass-${pass}` : `space-dedup-${item.data.spaceId}`;
+        return { jobId, removeOnComplete: true };
       }
       case JobName.SharedSpaceIdentityReconciliation: {
         const data = item.data as { spaceId: string; userId?: string; spacePersonId?: string };

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -124,39 +124,71 @@ describe(QueueService.name, () => {
   });
 
   describe('onBootstrap', () => {
-    it('should setup job repository', () => {
+    it('should setup job repository', async () => {
       sut.setServices([]);
-      sut.onBootstrap();
+      await sut.onBootstrap();
 
       expect(mocks.job.setup).toHaveBeenCalledWith([]);
     });
 
-    it('should start workers on microservices', () => {
+    it('should start workers on microservices', async () => {
       mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
 
       sut.setServices([]);
-      sut.onBootstrap();
+      await sut.onBootstrap();
 
       expect(mocks.job.setup).toHaveBeenCalled();
       expect(mocks.job.startWorkers).toHaveBeenCalled();
     });
 
-    it('should not start workers on non-microservices', () => {
+    it('should not start workers on non-microservices', async () => {
       mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
 
       sut.setServices([]);
-      sut.onBootstrap();
+      await sut.onBootstrap();
 
       expect(mocks.job.setup).toHaveBeenCalled();
       expect(mocks.job.startWorkers).not.toHaveBeenCalled();
     });
+
+    it('should reconcile orphaned active jobs before starting workers on microservices', async () => {
+      mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+      mocks.job.reconcileOrphanedActiveJobs.mockResolvedValue();
+
+      sut.setServices([]);
+      await sut.onBootstrap();
+
+      expect(mocks.job.reconcileOrphanedActiveJobs).toHaveBeenCalled();
+      const reconcileOrder = mocks.job.reconcileOrphanedActiveJobs.mock.invocationCallOrder[0];
+      const startOrder = mocks.job.startWorkers.mock.invocationCallOrder[0];
+      expect(reconcileOrder).toBeLessThan(startOrder);
+    });
+
+    it('should not reconcile orphaned active jobs on non-microservices', async () => {
+      mocks.config.getWorker.mockReturnValue(ImmichWorker.Api);
+
+      sut.setServices([]);
+      await sut.onBootstrap();
+
+      expect(mocks.job.reconcileOrphanedActiveJobs).not.toHaveBeenCalled();
+    });
+
+    it('still starts workers when orphan reconciliation fails', async () => {
+      mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+      mocks.job.reconcileOrphanedActiveJobs.mockRejectedValue(new Error('redis down'));
+
+      sut.setServices([]);
+      await sut.onBootstrap();
+
+      expect(mocks.job.startWorkers).toHaveBeenCalled();
+    });
   });
 
   describe('setServices', () => {
-    it('should store service constructors', () => {
+    it('should store service constructors', async () => {
       class TestService {}
       sut.setServices([TestService]);
-      sut.onBootstrap();
+      await sut.onBootstrap();
 
       expect(mocks.job.setup).toHaveBeenCalledWith([TestService]);
     });

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -76,9 +76,17 @@ export class QueueService extends BaseService {
   }
 
   @OnEvent({ name: 'AppBootstrap', priority: BootstrapEventPriority.JobService })
-  onBootstrap() {
+  async onBootstrap() {
     this.jobRepository.setup(this.services);
     if (this.worker === ImmichWorker.Microservices) {
+      // Best-effort: clear job ids orphaned in the BullMQ "active" list (no backing hash) before
+      // workers start. Such orphans permanently wedge a concurrency-1 queue with no user-reachable
+      // recovery. Never block worker startup on this maintenance step.
+      try {
+        await this.jobRepository.reconcileOrphanedActiveJobs();
+      } catch (error) {
+        this.logger.warn(`Failed to reconcile orphaned active jobs on bootstrap: ${error}`);
+      }
       this.jobRepository.startWorkers();
     }
   }

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -20,7 +20,7 @@ import {
   SharedSpaceRole,
   UserAvatarColor,
 } from 'src/enum';
-import { SharedSpaceService } from 'src/services/shared-space.service';
+import { SHARED_SPACE_DEDUP_MAX_PASSES, SharedSpaceService } from 'src/services/shared-space.service';
 import { StorageService } from 'src/services/storage.service';
 import { ImmichFileResponse, ImmichStreamResponse } from 'src/utils/file';
 import { factory, newDate, newUuid } from 'test/small.factory';
@@ -2841,6 +2841,109 @@ describe(SharedSpaceService.name, () => {
 
       await sut.handleSharedSpaceIdentityReconciliation({ spaceId: 'space-1', userId: 'member-1' });
 
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+    });
+
+    it('should collapse a same-space conflict into the higher-precedence survivor and proceed with the merge', async () => {
+      setupStrictReconciliationFixture(mocks);
+      mocks.sharedSpace.reassignPersonFacesSafe.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.migrateAliases.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 1,
+      });
+      // Two same-space space-persons hold the two sides of the merge. The source-identity row is
+      // manually named; the target-identity row is auto-named, so the manual row must survive.
+      mocks.faceIdentity.getSpaceMergeConflictPairs.mockResolvedValue([
+        {
+          spaceId: 'space-1',
+          sourceId: 'space-person-dup',
+          sourceName: 'Alice',
+          sourceNameSource: 'manual',
+          sourceFaceCount: 3,
+          targetId: 'space-person-1',
+          targetName: '',
+          targetNameSource: 'auto',
+          targetFaceCount: 1,
+        },
+      ]);
+
+      await sut.handleSharedSpaceIdentityReconciliation({ spaceId: 'space-1', userId: 'member-1' });
+
+      // The auto-named loser is folded into the manual-named survivor before the identity merge.
+      expect(mocks.sharedSpace.reassignPersonFacesSafe).toHaveBeenCalledWith('space-person-1', 'space-person-dup');
+      expect(mocks.sharedSpace.migrateAliases).toHaveBeenCalledWith('space-person-1', 'space-person-dup');
+      expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith('space-person-1');
+      expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith(['space-person-dup']);
+
+      // With the colliding row gone, the merge now proceeds instead of being skipped.
+      expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalledWith({
+        targetIdentityId: 'space-identity',
+        sourceIdentityIds: ['local-identity'],
+        source: 'shared-space-evidence',
+      });
+    });
+
+    it('should break a nameSource tie by face count, keeping the larger space-person', async () => {
+      setupStrictReconciliationFixture(mocks);
+      mocks.sharedSpace.reassignPersonFacesSafe.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.migrateAliases.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 0,
+        spaceProfileConflictCount: 1,
+      });
+      // Both rows are manually named, so the tie falls to face count: the target row (5 faces)
+      // outweighs the source row (2 faces) and survives.
+      mocks.faceIdentity.getSpaceMergeConflictPairs.mockResolvedValue([
+        {
+          spaceId: 'space-1',
+          sourceId: 'space-person-dup',
+          sourceName: 'Bob',
+          sourceNameSource: 'manual',
+          sourceFaceCount: 2,
+          targetId: 'space-person-1',
+          targetName: 'Robert',
+          targetNameSource: 'manual',
+          targetFaceCount: 5,
+        },
+      ]);
+
+      await sut.handleSharedSpaceIdentityReconciliation({ spaceId: 'space-1', userId: 'member-1' });
+
+      expect(mocks.sharedSpace.reassignPersonFacesSafe).toHaveBeenCalledWith('space-person-dup', 'space-person-1');
+      expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith('space-person-dup');
+      expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith(['space-person-1']);
+      expect(mocks.faceIdentity.mergeIdentities).toHaveBeenCalled();
+    });
+
+    it('should still skip without collapsing when the conflict is a personal-profile conflict', async () => {
+      setupStrictReconciliationFixture(mocks);
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 1,
+        spaceProfileConflictCount: 0,
+      });
+
+      await sut.handleSharedSpaceIdentityReconciliation({ spaceId: 'space-1', userId: 'member-1' });
+
+      expect(mocks.faceIdentity.getSpaceMergeConflictPairs).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.reassignPersonFacesSafe).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deletePerson).not.toHaveBeenCalled();
+      expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
+    });
+
+    it('should not collapse or merge when a personal-profile conflict accompanies a space conflict', async () => {
+      setupStrictReconciliationFixture(mocks);
+      mocks.faceIdentity.getMergeConflicts.mockResolvedValue({
+        personalProfileConflictCount: 1,
+        spaceProfileConflictCount: 1,
+      });
+
+      await sut.handleSharedSpaceIdentityReconciliation({ spaceId: 'space-1', userId: 'member-1' });
+
+      expect(mocks.faceIdentity.getSpaceMergeConflictPairs).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.reassignPersonFacesSafe).not.toHaveBeenCalled();
       expect(mocks.faceIdentity.mergeIdentities).not.toHaveBeenCalled();
     });
 
@@ -8064,6 +8167,104 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceId);
     });
 
+    it('runs a single pass and re-queues the next dedup pass after a merge (keeps each job short)', async () => {
+      const spaceId = newUuid();
+      const personA = newUuid();
+      const personB = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getSpacePersonsWithEmbeddings
+        .mockResolvedValueOnce([
+          {
+            id: personA,
+            name: 'Alice',
+            type: 'person',
+            isHidden: false,
+            faceCount: 5,
+            representativeFaceId: null,
+            embedding: '[0.1,0.2]',
+          },
+          {
+            id: personB,
+            name: '',
+            type: 'person',
+            isHidden: false,
+            faceCount: 2,
+            representativeFaceId: null,
+            embedding: '[0.11,0.21]',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: personA,
+            name: 'Alice',
+            type: 'person',
+            isHidden: false,
+            faceCount: 7,
+            representativeFaceId: null,
+            embedding: '[0.1,0.2]',
+          },
+        ]);
+      mocks.sharedSpace.findClosestSpacePerson.mockImplementation(
+        (_spaceId: string, _embedding: string, options: { excludePersonIds?: string[] }) => {
+          if (options.excludePersonIds?.includes(personA)) {
+            return Promise.resolve([{ personId: personB, name: '', distance: 0.1 }]);
+          }
+          return Promise.resolve([]);
+        },
+      );
+      mocks.sharedSpace.reassignPersonFacesSafe.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.migrateAliases.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(void 0 as any);
+      mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);
+
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+
+      expect(result).toBe(JobStatus.Success);
+      // Exactly one pass per job — the in-process up-to-100-pass loop is gone, so the BullMQ lock
+      // never expires under a long handler.
+      expect(mocks.sharedSpace.getSpacePersonsWithEmbeddings).toHaveBeenCalledTimes(1);
+      // A merge happened, so a fresh, short follow-up pass is queued to continue the work.
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId, pass: 2 },
+      });
+    });
+
+    it('does not re-queue another dedup pass when nothing merged', async () => {
+      const spaceId = newUuid();
+      const personA = newUuid();
+      const personB = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getSpacePersonsWithEmbeddings.mockResolvedValue([
+        {
+          id: personA,
+          name: 'Alice',
+          type: 'person',
+          isHidden: false,
+          faceCount: 5,
+          representativeFaceId: null,
+          embedding: '[0.1,0.2]',
+        },
+        {
+          id: personB,
+          name: 'Bob',
+          type: 'person',
+          isHidden: false,
+          faceCount: 2,
+          representativeFaceId: null,
+          embedding: '[9,9]',
+        },
+      ]);
+      mocks.sharedSpace.findClosestSpacePerson.mockResolvedValue([]);
+
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
+    });
+
     it('should physically merge strict identity-backed space people before merging supporting identities', async () => {
       const spaceId = 'space-1';
       mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
@@ -8297,7 +8498,16 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.updatePerson.mockResolvedValue(void 0 as any);
       mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);
 
-      const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+      // Each job now runs a single pass and re-queues the next, so a transitive chain spans multiple
+      // jobs: pass 1 merges B, pass 2 merges C, pass 3 converges. Drain the chain explicitly.
+      await sut.handleSharedSpacePersonDedup({ spaceId });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId, pass: 2 },
+      });
+      await sut.handleSharedSpacePersonDedup({ spaceId, pass: 2 });
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId, pass: 3 });
+
       expect(result).toBe(JobStatus.Success);
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith(personB);
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalledWith(personC);
@@ -8570,13 +8780,14 @@ describe(SharedSpaceService.name, () => {
       );
     });
 
-    it('should abort after MAX_PASSES to prevent infinite loop', async () => {
+    it('should stop re-queuing at the pass cap to prevent a runaway chain', async () => {
       const spaceId = newUuid();
       const personA = newUuid();
       const personB = newUuid();
 
       mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
-      // Always return same 2 persons — simulates bug where deleted person keeps reappearing
+      // Always return the same 2 persons — simulates the bug where a deleted person keeps reappearing
+      // and every pass keeps merging, so only the cap can stop the chain.
       mocks.sharedSpace.getSpacePersonsWithEmbeddings.mockResolvedValue([
         {
           id: personA,
@@ -8603,10 +8814,22 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.updatePerson.mockResolvedValue(void 0 as any);
       mocks.sharedSpace.deletePerson.mockResolvedValue(void 0 as any);
 
-      const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+      // Below the cap a merge re-queues the next pass.
+      await sut.handleSharedSpacePersonDedup({ spaceId, pass: SHARED_SPACE_DEDUP_MAX_PASSES - 1 });
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.SharedSpacePersonDedup,
+        data: { spaceId, pass: SHARED_SPACE_DEDUP_MAX_PASSES },
+      });
+
+      mocks.job.queue.mockClear();
+
+      // At the cap the merge still happens but no further pass is queued.
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId, pass: SHARED_SPACE_DEDUP_MAX_PASSES });
       expect(result).toBe(JobStatus.Success);
-      // Should have been called many times but eventually stopped
       expect(mocks.sharedSpace.deletePerson).toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
     });
 
     it('should clean up orphaned persons even with no merges', async () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -72,6 +72,22 @@ const ROLE_HIERARCHY: Record<SharedSpaceRole, number> = {
 const getSharedSpaceRoleScore = (role: string) => ROLE_HIERARCHY[role as SharedSpaceRole] ?? 0;
 const getMetadataSourceScore = (sourceProfileType?: string | null) => (sourceProfileType === 'user-person' ? 1 : 0);
 
+/** nameSource collapse precedence: a manually-set name wins over an inherited/auto/empty one. */
+const NAME_SOURCE_PRECEDENCE: Record<string, number> = {
+  manual: 3,
+  inherited: 2,
+  auto: 1,
+  none: 0,
+};
+const getNameSourcePrecedence = (nameSource: string) => NAME_SOURCE_PRECEDENCE[nameSource] ?? 0;
+
+/**
+ * Upper bound on chained {@link SharedSpaceService.handleSharedSpacePersonDedup} passes for one
+ * space. Each job runs a single pass and re-queues the next; this caps the chain so a pathological
+ * always-reappears bug can't queue passes forever.
+ */
+export const SHARED_SPACE_DEDUP_MAX_PASSES = 100;
+
 type SpacePersonMatchResult = {
   id: string;
   identityId?: string | null;
@@ -1488,11 +1504,23 @@ export class SharedSpaceService extends BaseService {
       targetIdentityId: claim.targetIdentityId,
       sourceIdentityIds: [claim.sourceIdentityId],
     });
-    if (conflicts.personalProfileConflictCount > 0 || conflicts.spaceProfileConflictCount > 0) {
+
+    // A personal-profile conflict means a single owner has two local people on the two identities.
+    // Auto-collapsing a user's own people could be wrong, so we still refuse to merge here.
+    if (conflicts.personalProfileConflictCount > 0) {
       this.logger.warn(
-        `Skipping shared-space identity reconciliation for space person ${claim.spacePersonId}: merge conflicts`,
+        `Skipping shared-space identity reconciliation for space person ${claim.spacePersonId}: personal-profile conflict`,
       );
       return;
+    }
+
+    // A space-profile conflict means the same space already has two space-people on the two
+    // identities — they are the same real person bridged by a member's local profile, but dedup
+    // can never close their embedding gap, so reconciliation is the only path. Collapse them
+    // (loser folded into the higher-precedence survivor) before merging, otherwise mergeIdentities
+    // would bail forever on the (spaceId, identityId) unique index.
+    if (conflicts.spaceProfileConflictCount > 0) {
+      await this.collapseSameSpaceReconciliationConflicts(claim);
     }
 
     await this.faceIdentityRepository.mergeIdentities({
@@ -1501,6 +1529,64 @@ export class SharedSpaceService extends BaseService {
       source: 'shared-space-evidence',
     });
     await this.queueSpacePersonMetadataBackfill(claim.targetIdentityId);
+  }
+
+  /**
+   * Collapses every same-space `shared_space_person` pair that would block the identity merge.
+   * For each pair the survivor is chosen by nameSource precedence (manual > inherited > auto >
+   * none), tie-broken by face count then id; the loser's faces and aliases move to the survivor and
+   * the loser row is deleted. The survivor's winning name is preserved by construction (it always
+   * has at least the loser's nameSource precedence). The subsequent mergeIdentities then sets the
+   * survivor onto the canonical target identity without colliding.
+   */
+  private async collapseSameSpaceReconciliationConflicts(claim: SharedSpaceIdentityReconciliationClaim): Promise<void> {
+    const pairs = await this.faceIdentityRepository.getSpaceMergeConflictPairs({
+      targetIdentityId: claim.targetIdentityId,
+      sourceIdentityIds: [claim.sourceIdentityId],
+    });
+
+    for (const pair of pairs) {
+      const target = {
+        id: pair.targetId,
+        name: pair.targetName,
+        nameSource: pair.targetNameSource,
+        faceCount: pair.targetFaceCount,
+      };
+      const source = {
+        id: pair.sourceId,
+        name: pair.sourceName,
+        nameSource: pair.sourceNameSource,
+        faceCount: pair.sourceFaceCount,
+      };
+      const [survivor, loser] = this.chooseSpaceConflictSurvivor(target, source);
+
+      this.logger.log(
+        `Collapsing same-space identity conflict in space ${pair.spaceId}: folding ${loser.id} (${loser.name || 'unnamed'}, ${loser.nameSource}) into ${survivor.id} (${survivor.name || 'unnamed'}, ${survivor.nameSource})`,
+      );
+
+      await this.sharedSpaceRepository.reassignPersonFacesSafe(loser.id, survivor.id);
+      await this.sharedSpaceRepository.migrateAliases(loser.id, survivor.id);
+      await this.sharedSpaceRepository.deletePerson(loser.id);
+      await this.sharedSpaceRepository.recountPersons([survivor.id]);
+    }
+  }
+
+  private chooseSpaceConflictSurvivor<T extends { id: string; nameSource: string; faceCount: number }>(
+    a: T,
+    b: T,
+  ): [survivor: T, loser: T] {
+    const [survivor, loser] = [a, b].toSorted((x, y) => {
+      const precedenceDelta = getNameSourcePrecedence(y.nameSource) - getNameSourcePrecedence(x.nameSource);
+      if (precedenceDelta !== 0) {
+        return precedenceDelta;
+      }
+      const faceDelta = Number(y.faceCount) - Number(x.faceCount);
+      if (faceDelta !== 0) {
+        return faceDelta;
+      }
+      return x.id.localeCompare(y.id);
+    });
+    return [survivor, loser];
   }
 
   @OnJob({ name: JobName.SharedSpaceFaceMatch, queue: QueueName.FacialRecognition })
@@ -1718,159 +1804,166 @@ export class SharedSpaceService extends BaseService {
     await this.sharedSpaceRepository.repairInvalidRepresentativeFaces(job.spaceId);
     await this.sharedSpaceRepository.repairOrphanedRepresentativeFaces(job.spaceId);
 
-    const MAX_PASSES = 100;
-    let totalMerges = 0;
-    let pass = 0;
-    let mergedAny = true;
+    // One pass per job. A single in-process up-to-100-pass loop on a large space (e.g. Hagen's
+    // 563k-asset space) easily ran for minutes — far longer than BullMQ's 30s lock. When the lock
+    // expired mid-pass the entry could be orphaned in the "active" list with no recovery, starving
+    // the whole concurrency-1 FacialRecognition queue (core face recognition included). Each
+    // invocation now does exactly ONE pass and re-queues a fresh, short follow-up when a merge
+    // happened, carrying a pass counter that is capped to prevent a runaway chain.
+    const pass = job.pass ?? 1;
     const affectedIdentityIds = new Set<string>();
+    let mergedAny = false;
 
-    while (mergedAny) {
-      mergedAny = false;
-      pass++;
+    const persons = await this.sharedSpaceRepository.getSpacePersonsWithEmbeddings(job.spaceId);
+    this.logger.log(`Dedup pass ${pass} for space ${job.spaceId}: ${persons.length} persons to check`);
 
-      if (pass > MAX_PASSES) {
-        this.logger.error(
-          `Dedup for space ${job.spaceId} exceeded ${MAX_PASSES} passes — aborting to prevent infinite loop`,
-        );
-        break;
-      }
-
-      const persons = await this.sharedSpaceRepository.getSpacePersonsWithEmbeddings(job.spaceId);
-      this.logger.log(`Dedup pass ${pass} for space ${job.spaceId}: ${persons.length} persons to check`);
-
-      if (persons.length <= 1) {
-        break;
-      }
-
-      const deletedIds = new Set<string>();
-      const targetIds = new Set<string>();
-      let passMerges = 0;
-
-      for (const person of persons) {
-        if (deletedIds.has(person.id)) {
-          continue;
-        }
-
-        if (person.isHidden) {
-          continue;
-        }
-
-        const matches = await this.sharedSpaceRepository.findClosestSpacePerson(job.spaceId, person.embedding, {
-          maxDistance,
-          numResults: 2,
-          excludePersonIds: [person.id, ...deletedIds],
-          type: person.type,
-        });
-
-        if (matches.length === 0) {
-          continue;
-        }
-
-        const compatibleMatches: Array<{ person: (typeof persons)[number]; distance: number }> = [];
-        for (const match of matches) {
-          const matchPerson = persons.find((p) => p.id === match.personId);
-          if (!matchPerson || deletedIds.has(match.personId)) {
-            this.logger.debug(
-              `Dedup: skipping stale match ${match.personId} for person ${person.id} (already merged in this pass)`,
-            );
-            continue;
-          }
-          if (matchPerson.isHidden || matchPerson.type !== person.type) {
-            continue;
-          }
-          compatibleMatches.push({ person: matchPerson, distance: match.distance });
-        }
-
-        if (compatibleMatches.length !== 1) {
-          continue;
-        }
-
-        const { person: matchPerson, distance } = compatibleMatches[0];
-
-        // Determine target (more faces) and source
-        const [target, source] =
-          person.faceCount >= matchPerson.faceCount ? [person, matchPerson] : [matchPerson, person];
-
-        this.logger.log(
-          `Dedup: merging person ${source.id} (${source.name || 'unnamed'}, ${source.faceCount} faces) into ${target.id} (${target.name || 'unnamed'}, ${target.faceCount} faces), distance=${distance.toFixed(4)}`,
-        );
-
-        // Reassign faces and migrate aliases
-        await this.sharedSpaceRepository.reassignPersonFacesSafe(source.id, target.id);
-        await this.sharedSpaceRepository.migrateAliases(source.id, target.id);
-
-        const candidateIdentityIds = [target.identityId, source.identityId].filter(
-          (identityId): identityId is string => !!identityId,
-        );
-        if (candidateIdentityIds.length > 0) {
-          const mergedIdentityId = await this.mergeIdentitiesForSpacePersonEvidence({
-            spaceId: job.spaceId,
-            targetSpacePersonId: target.id,
-            candidateIdentityIds,
-          });
-          await this.inheritSpacePersonMetadata(job.spaceId, target.id, mergedIdentityId);
-          affectedIdentityIds.add(mergedIdentityId);
-        }
-
-        // Refresh representativeFaceId to a face with a valid embedding from the merged pool
-        if (target.representativeFaceSource !== 'manual') {
-          const newRepFace = await this.sharedSpaceRepository.getFirstFaceIdForPerson(target.id);
-          if (newRepFace && newRepFace !== target.representativeFaceId) {
-            try {
-              await this.sharedSpaceRepository.updatePerson(target.id, { representativeFaceId: newRepFace });
-            } catch (error) {
-              this.logger.warn(`Dedup: failed to update representativeFaceId for target ${target.id}: ${error}`);
-            }
-          }
-        }
-
-        // Determine merged properties
-        const updates: Partial<{ name: string; isHidden: boolean }> = {};
-        if (!target.name && source.name) {
-          updates.name = source.name;
-        }
-
-        // Update and delete separately so deletePerson still runs if updatePerson fails
-        try {
-          if (Object.keys(updates).length > 0) {
-            await this.sharedSpaceRepository.updatePerson(target.id, updates);
-          }
-        } catch (error) {
-          // Target may have been concurrently deleted — faces were already reassigned, continue to delete source
-          this.logger.warn(`Dedup: updatePerson failed for target ${target.id}: ${error}`);
-        }
-
-        try {
-          await this.sharedSpaceRepository.deletePerson(source.id);
-        } catch (error) {
-          // Source may have been concurrently deleted — safe to ignore
-          this.logger.warn(`Dedup: deletePerson failed for source ${source.id}: ${error}`);
-        }
-
-        deletedIds.add(source.id);
-        targetIds.add(target.id);
-        passMerges++;
-        mergedAny = true;
-      }
-
-      if (targetIds.size > 0) {
-        await this.sharedSpaceRepository.recountPersons([...targetIds]);
-      }
-
-      totalMerges += passMerges;
-      this.logger.log(`Dedup pass ${pass} complete: ${passMerges} merges`);
+    if (persons.length <= 1) {
+      // Safety net: drop space-persons left with no faces.
+      await this.sharedSpaceRepository.deleteOrphanedPersons(job.spaceId);
+      return JobStatus.Success;
     }
 
-    // Clean up orphaned persons (no faces linked) as safety net
+    const deletedIds = new Set<string>();
+    const targetIds = new Set<string>();
+    let passMerges = 0;
+
+    for (const person of persons) {
+      if (deletedIds.has(person.id)) {
+        continue;
+      }
+
+      if (person.isHidden) {
+        continue;
+      }
+
+      const matches = await this.sharedSpaceRepository.findClosestSpacePerson(job.spaceId, person.embedding, {
+        maxDistance,
+        numResults: 2,
+        excludePersonIds: [person.id, ...deletedIds],
+        type: person.type,
+      });
+
+      if (matches.length === 0) {
+        continue;
+      }
+
+      const compatibleMatches: Array<{ person: (typeof persons)[number]; distance: number }> = [];
+      for (const match of matches) {
+        const matchPerson = persons.find((p) => p.id === match.personId);
+        if (!matchPerson || deletedIds.has(match.personId)) {
+          this.logger.debug(
+            `Dedup: skipping stale match ${match.personId} for person ${person.id} (already merged in this pass)`,
+          );
+          continue;
+        }
+        if (matchPerson.isHidden || matchPerson.type !== person.type) {
+          continue;
+        }
+        compatibleMatches.push({ person: matchPerson, distance: match.distance });
+      }
+
+      if (compatibleMatches.length !== 1) {
+        continue;
+      }
+
+      const { person: matchPerson, distance } = compatibleMatches[0];
+
+      // Determine target (more faces) and source
+      const [target, source] =
+        person.faceCount >= matchPerson.faceCount ? [person, matchPerson] : [matchPerson, person];
+
+      this.logger.log(
+        `Dedup: merging person ${source.id} (${source.name || 'unnamed'}, ${source.faceCount} faces) into ${target.id} (${target.name || 'unnamed'}, ${target.faceCount} faces), distance=${distance.toFixed(4)}`,
+      );
+
+      // Reassign faces and migrate aliases
+      await this.sharedSpaceRepository.reassignPersonFacesSafe(source.id, target.id);
+      await this.sharedSpaceRepository.migrateAliases(source.id, target.id);
+
+      const candidateIdentityIds = [target.identityId, source.identityId].filter(
+        (identityId): identityId is string => !!identityId,
+      );
+      if (candidateIdentityIds.length > 0) {
+        const mergedIdentityId = await this.mergeIdentitiesForSpacePersonEvidence({
+          spaceId: job.spaceId,
+          targetSpacePersonId: target.id,
+          candidateIdentityIds,
+        });
+        await this.inheritSpacePersonMetadata(job.spaceId, target.id, mergedIdentityId);
+        affectedIdentityIds.add(mergedIdentityId);
+      }
+
+      // Refresh representativeFaceId to a face with a valid embedding from the merged pool
+      if (target.representativeFaceSource !== 'manual') {
+        const newRepFace = await this.sharedSpaceRepository.getFirstFaceIdForPerson(target.id);
+        if (newRepFace && newRepFace !== target.representativeFaceId) {
+          try {
+            await this.sharedSpaceRepository.updatePerson(target.id, { representativeFaceId: newRepFace });
+          } catch (error) {
+            this.logger.warn(`Dedup: failed to update representativeFaceId for target ${target.id}: ${error}`);
+          }
+        }
+      }
+
+      // Determine merged properties
+      const updates: Partial<{ name: string; isHidden: boolean }> = {};
+      if (!target.name && source.name) {
+        updates.name = source.name;
+      }
+
+      // Update and delete separately so deletePerson still runs if updatePerson fails
+      try {
+        if (Object.keys(updates).length > 0) {
+          await this.sharedSpaceRepository.updatePerson(target.id, updates);
+        }
+      } catch (error) {
+        // Target may have been concurrently deleted — faces were already reassigned, continue to delete source
+        this.logger.warn(`Dedup: updatePerson failed for target ${target.id}: ${error}`);
+      }
+
+      try {
+        await this.sharedSpaceRepository.deletePerson(source.id);
+      } catch (error) {
+        // Source may have been concurrently deleted — safe to ignore
+        this.logger.warn(`Dedup: deletePerson failed for source ${source.id}: ${error}`);
+      }
+
+      deletedIds.add(source.id);
+      targetIds.add(target.id);
+      passMerges++;
+      mergedAny = true;
+    }
+
+    if (targetIds.size > 0) {
+      await this.sharedSpaceRepository.recountPersons([...targetIds]);
+    }
+
+    // Clean up orphaned persons (no faces linked) as a safety net. Cheap and idempotent, so it runs
+    // each pass rather than only on convergence.
     await this.sharedSpaceRepository.deleteOrphanedPersons(job.spaceId);
 
     for (const identityId of affectedIdentityIds) {
       await this.queueSpacePersonMetadataBackfill(identityId);
     }
 
-    this.logger.log(
-      `Dedup finished for space ${job.spaceId}: ${totalMerges} total merges across ${pass} pass${pass === 1 ? '' : 'es'}`,
-    );
+    this.logger.log(`Dedup pass ${pass} for space ${job.spaceId} complete: ${passMerges} merges`);
+
+    // Re-queue a fresh, short follow-up pass while merges are still happening, capped to avoid a
+    // runaway chain. The follow-up uses a pass-scoped jobId (see job.repository getJobOptions) so it
+    // enqueues even though this job is still "active".
+    if (mergedAny) {
+      if (pass < SHARED_SPACE_DEDUP_MAX_PASSES) {
+        await this.jobRepository.queue({
+          name: JobName.SharedSpacePersonDedup,
+          data: { spaceId: job.spaceId, pass: pass + 1 },
+        });
+      } else {
+        this.logger.error(
+          `Dedup for space ${job.spaceId} reached the ${SHARED_SPACE_DEDUP_MAX_PASSES}-pass cap — stopping to prevent a runaway chain`,
+        );
+      }
+    }
+
     return JobStatus.Success;
   }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -273,6 +273,8 @@ export interface ISharedSpaceIdentityReconciliationJob extends IBaseJob {
 
 export interface ISharedSpacePersonDedupJob extends IBaseJob {
   spaceId: string;
+  /** 1-based pass number. Each dedup job runs one pass and re-queues the next with pass + 1. */
+  pass?: number;
 }
 
 export interface ISharedSpacePersonMetadataBackfillJob extends IBaseJob {

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -3017,6 +3017,134 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  describe('getSpaceMergeConflictPairs', () => {
+    it('returns the conflicting same-space rows with the fields needed to pick a survivor', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+
+        const targetSpacePerson = await ctx.database
+          .insertInto('shared_space_person')
+          .values({ spaceId: space.id, name: '', nameSource: 'auto', faceCount: 1, type: 'person' })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+        const sourceSpacePerson = await ctx.database
+          .insertInto('shared_space_person')
+          .values({ spaceId: space.id, name: 'Alice', nameSource: 'manual', faceCount: 3, type: 'person' })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+
+        await expect(
+          sut.getSpaceMergeConflictPairs({
+            targetIdentityId: targetIdentity.id,
+            sourceIdentityIds: [sourceIdentity.id],
+          }),
+        ).resolves.toEqual([
+          {
+            spaceId: space.id,
+            sourceId: sourceSpacePerson.id,
+            sourceName: 'Alice',
+            sourceNameSource: 'manual',
+            sourceFaceCount: 3,
+            targetId: targetSpacePerson.id,
+            targetName: '',
+            targetNameSource: 'auto',
+            targetFaceCount: 1,
+          },
+        ]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('returns no pairs when only one side is present in a space', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        const sourceSpacePerson = await newSpacePerson(ctx, space.id);
+        const targetSpacePerson = await newSpacePerson(ctx, space.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(targetSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(sourceSpacePerson.id);
+        // Remove the target-identity row so the space holds only the source side.
+        await ctx.database.deleteFrom('shared_space_person').where('id', '=', targetSpacePerson.id).execute();
+
+        await expect(
+          sut.getSpaceMergeConflictPairs({
+            targetIdentityId: targetIdentity.id,
+            sourceIdentityIds: [sourceIdentity.id],
+          }),
+        ).resolves.toEqual([]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+  });
+
+  describe('same-space collapse convergence', () => {
+    it('migrates the surviving space-person onto the target identity once the colliding row is collapsed', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      try {
+        const { space } = await ctx.newSharedSpace({ createdById: user.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+        // The loser holds the target identity; the survivor holds the source identity and must end
+        // up on the canonical target identity after the collapse + merge.
+        const loserSpacePerson = await newSpacePerson(ctx, space.id);
+        const survivorSpacePerson = await newSpacePerson(ctx, space.id);
+        const targetIdentity = await sut.ensureSpacePersonIdentity(loserSpacePerson.id);
+        const sourceIdentity = await sut.ensureSpacePersonIdentity(survivorSpacePerson.id);
+
+        // While both rows exist the merge is blocked by the (spaceId, identityId) unique index.
+        await expect(
+          sut.mergeIdentities({
+            targetIdentityId: targetIdentity.id,
+            sourceIdentityIds: [sourceIdentity.id],
+            source: 'shared-space-evidence',
+          }),
+        ).resolves.toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 1 });
+        const blocked = await ctx.database
+          .selectFrom('shared_space_person')
+          .select('identityId')
+          .where('id', '=', survivorSpacePerson.id)
+          .executeTakeFirstOrThrow();
+        expect(blocked.identityId).toBe(sourceIdentity.id);
+
+        // Collapse the colliding row away (faces are reassigned to the survivor in the service path).
+        await ctx.database.deleteFrom('shared_space_person').where('id', '=', loserSpacePerson.id).execute();
+
+        await expect(
+          sut.mergeIdentities({
+            targetIdentityId: targetIdentity.id,
+            sourceIdentityIds: [sourceIdentity.id],
+            source: 'shared-space-evidence',
+          }),
+        ).resolves.toEqual({ personalProfileConflictCount: 0, spaceProfileConflictCount: 0 });
+
+        const survivor = await ctx.database
+          .selectFrom('shared_space_person')
+          .select(['id', 'identityId'])
+          .where('id', '=', survivorSpacePerson.id)
+          .executeTakeFirstOrThrow();
+        expect(survivor.identityId).toBe(targetIdentity.id);
+
+        const loserGone = await ctx.database
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('id', '=', loserSpacePerson.id)
+          .executeTakeFirst();
+        expect(loserGone).toBeUndefined();
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+  });
+
   describe('repair', () => {
     it('merges non-conflicting identities by moving face links without merging scoped metadata', async () => {
       const { ctx, sut } = setup();

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -20,6 +20,8 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     getJobTypes: vitest.fn().mockResolvedValue([]),
     getTelemetryMetrics: vitest.fn(),
     clear: vitest.fn(),
+    reconcileOrphanedActiveJobs: vitest.fn().mockImplementation(() => Promise.resolve()),
+    removeOrphanedActiveJobs: vitest.fn().mockImplementation(() => Promise.resolve([])),
     waitForQueueCompletion: vitest.fn(),
     removeJob: vitest.fn(),
   };


### PR DESCRIPTION
Fixes the Hagen report of **stuck / cycling shared-space face jobs** on a 563k-asset instance. Two independent root causes, one cohesive fix.

## Finding 1 — zombie `space-dedup` job starved the `FacialRecognition` queue

`handleSharedSpacePersonDedup` ran an in-process **up-to-100-pass loop**. On a large space a single invocation ran for minutes — far past BullMQ's 30s lock. When the lock expired mid-pass the entry could be orphaned in the `active` list (hash gone via `removeOnComplete` racing stalled-recovery), wedging the **concurrency-1** queue (core face recognition included) with no user-reachable recovery — only a restart or shell `LREM` cleared it.

- **Chunk the handler to one pass per job.** It now runs a single pass and re-queues a follow-up `SharedSpacePersonDedup` while merges remain, capped at `SHARED_SPACE_DEDUP_MAX_PASSES` (100) via a pass counter in job data. Each job stays short, so the lock never expires.
- **Pass-scoped follow-up jobId** (`space-dedup-<spaceId>-pass-<n>`) so the follow-up enqueues while the current job is still `active`; the bare `space-dedup-<spaceId>` id is kept for the initial trigger, preserving external-trigger dedupe.
- **Longer worker lock for `FacialRecognition`** (`buildWorkerOptions`: 5-min `lockDuration`/`stalledInterval`) as defense-in-depth for any remaining long handler. Other queues stay on BullMQ defaults.
- **Self-heal orphaned active jobs** on microservices bootstrap (`reconcileOrphanedActiveJobs`): `LREM` only ids in the `active` list with **no backing job hash**. Deliberately *not* `clean(0,_,'active')`, which targets by age and would kill live jobs — a genuine in-flight job always has its hash, so it's never touched.

## Finding 2 — identity reconciliation skipped same-space duplicates forever

Every 6h scan logged `Skipping ... merge conflicts` for the same people; `/people` duplicates never collapsed. `applySharedSpaceIdentityReconciliationClaim` bailed whenever two `shared_space_person` rows in one space held the source vs target identity (would collide with the `(spaceId, identityId)` unique partial index). Dedup can't close their embedding gap, so reconciliation was the only path — and it refused.

- On a **space-profile conflict**, collapse the two rows into the higher-precedence survivor (`nameSource` **manual > inherited > auto > none**, tie-break faceCount then id): reassign the loser's faces, migrate aliases, delete the loser, recount, then run `mergeIdentities` collision-free. The new `getSpaceMergeConflictPairs` spans all spaces (mergeIdentities checks conflicts globally).
- **Personal-profile conflicts still skip** — a user's own local people are never auto-collapsed.

## Test plan

- [x] Unit: collapse decision matrix (survivor precedence, faceCount tie-break, personal-conflict skip), dedup one-pass + re-queue + cap, `buildWorkerOptions`, orphan self-heal, bootstrap ordering
- [x] Medium (real DB): `getSpaceMergeConflictPairs` query + collapse-then-merge respects the unique partial index and migrates the survivor onto the target identity
- [x] Both dedup-draining medium specs converge with the self-re-queue
- [x] Full server unit suite: 4495 passed; `tsc --noEmit` + eslint (`--max-warnings 0`) clean

Diagnosis and design in `docs/plans/2026-05-30-hagen-stuck-jobs-debug.md`.