### PR TITLE
fix(server): scope tag view to shared-space access for non-admins (#647)

### DIFF
--- a/server/src/queries/tag.repository.sql
+++ b/server/src/queries/tag.repository.sql
@@ -56,7 +56,33 @@ select
 from
   "tag"
 where
-  "userId" = $1
+  (
+    "tag"."userId" = $1::uuid
+    or exists (
+      select
+      from
+        "tag_asset"
+        inner join "asset" on "asset"."id" = "tag_asset"."assetId"
+        inner join "shared_space_asset" on "shared_space_asset"."assetId" = "asset"."id"
+        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
+      where
+        "tag_asset"."tagId" = "tag"."id"
+        and "asset"."deletedAt" is null
+        and "shared_space_member"."userId" = $2::uuid
+    )
+    or exists (
+      select
+      from
+        "tag_asset"
+        inner join "asset" on "asset"."id" = "tag_asset"."assetId"
+        inner join "shared_space_library" on "shared_space_library"."libraryId" = "asset"."libraryId"
+        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
+      where
+        "tag_asset"."tagId" = "tag"."id"
+        and "asset"."deletedAt" is null
+        and "shared_space_member"."userId" = $3::uuid
+    )
+  )
 order by
   "value"
 

--- a/server/src/repositories/tag.repository.ts
+++ b/server/src/repositories/tag.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Insertable, Kysely, sql, Updateable } from 'kysely';
+import { ExpressionBuilder, Insertable, Kysely, sql, Updateable } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { Chunked, ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
@@ -7,6 +7,7 @@ import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
 import { TagAssetTable } from 'src/schema/tables/tag-asset.table';
 import { TagTable } from 'src/schema/tables/tag.table';
+import { asUuid } from 'src/utils/database';
 
 @Injectable()
 export class TagRepository {
@@ -70,7 +71,43 @@ export class TagRepository {
 
   @GenerateSql({ params: [DummyValue.UUID] })
   getAll(userId: string) {
-    return this.db.selectFrom('tag').select(columns.tag).where('userId', '=', userId).orderBy('value').execute();
+    return this.db
+      .selectFrom('tag')
+      .select(columns.tag)
+      .where((eb) => this.ownedOrSpaceAccessible(eb, userId))
+      .orderBy('value')
+      .execute();
+  }
+
+  // The tag explorer lists tags for assets a user can actually see: their own tags,
+  // plus tags on any asset reachable through a shared space they are a member of —
+  // either added to the space directly or via a library linked to the space. Mirrors
+  // the access rules in AccessRepository/ViewRepository so non-admin space members are
+  // not stuck with an empty tag tree (issue #647).
+  private ownedOrSpaceAccessible(eb: ExpressionBuilder<DB, 'tag'>, userId: string) {
+    return eb.or([
+      eb('tag.userId', '=', asUuid(userId)),
+      eb.exists(
+        eb
+          .selectFrom('tag_asset')
+          .innerJoin('asset', 'asset.id', 'tag_asset.assetId')
+          .innerJoin('shared_space_asset', 'shared_space_asset.assetId', 'asset.id')
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+          .whereRef('tag_asset.tagId', '=', 'tag.id')
+          .where('asset.deletedAt', 'is', null)
+          .where('shared_space_member.userId', '=', asUuid(userId)),
+      ),
+      eb.exists(
+        eb
+          .selectFrom('tag_asset')
+          .innerJoin('asset', 'asset.id', 'tag_asset.assetId')
+          .innerJoin('shared_space_library', 'shared_space_library.libraryId', 'asset.libraryId')
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+          .whereRef('tag_asset.tagId', '=', 'tag.id')
+          .where('asset.deletedAt', 'is', null)
+          .where('shared_space_member.userId', '=', asUuid(userId)),
+      ),
+    ]);
   }
 
   @GenerateSql({ params: [{ userId: DummyValue.UUID, color: DummyValue.STRING, value: DummyValue.STRING }] })

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -1,9 +1,10 @@
 import { Kysely } from 'kysely';
-import { AssetFileType, AssetOrder, AssetVisibility } from 'src/enum';
+import { AssetFileType, AssetOrder, AssetVisibility, SharedSpaceRole } from 'src/enum';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { TagRepository } from 'src/repositories/tag.repository';
 import { DB } from 'src/schema';
 import { BaseService } from 'src/services/base.service';
 import { newMediumService } from 'test/medium.factory';
@@ -767,6 +768,47 @@ describe(AssetRepository.name, () => {
           visibility: AssetVisibility.Timeline,
         }),
       ).resolves.toEqual([{ count: 1, timeBucket: '2026-03-01' }]);
+    });
+  });
+
+  describe('getTimeBucket — tag navigation with shared-space access (issue #647)', () => {
+    it('returns an owner-tagged asset to a member only when the shared-space scope is included', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const memberAuth = factory.auth({ user: { id: member.id } });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      // Owner tags their own asset and shares it into the space the member belongs to.
+      const asset = await createTimelineAssetWithPeople(ctx, owner.id, []);
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+      // upsertValue (not create) so tag_closure is populated — the tag-id timeline filter
+      // (withAnyTagId) joins through tag_closure, matching production's tag creation path.
+      const tag = await ctx.get(TagRepository).upsertValue({ userId: owner.id, value: 'family' });
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+
+      // Mirrors what the tags page now sends for a non-admin member (own + shared-space
+      // assets, tag-filtered): the owner's tagged asset must show up.
+      const withSpace = await sut.getTimeBucket(
+        '2026-03-01',
+        {
+          userIds: [member.id],
+          timelineSpaceIds: [space.id],
+          tagIds: [tag.id],
+          visibility: AssetVisibility.Timeline,
+        },
+        memberAuth,
+      );
+      expect((JSON.parse(withSpace.assets) as TimeBucketAssets).id).toEqual([asset.id]);
+
+      // Without the shared-space scope the member only sees their own assets — none here.
+      const ownOnly = await sut.getTimeBucket(
+        '2026-03-01',
+        { userIds: [member.id], tagIds: [tag.id], visibility: AssetVisibility.Timeline },
+        memberAuth,
+      );
+      expect((JSON.parse(ownOnly.assets) as TimeBucketAssets).id ?? []).not.toContain(asset.id);
     });
   });
 

--- a/server/test/medium/specs/repositories/tag.repository.spec.ts
+++ b/server/test/medium/specs/repositories/tag.repository.spec.ts
@@ -1,0 +1,183 @@
+import { Kysely } from 'kysely';
+import { SharedSpaceRole } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { TagRepository } from 'src/repositories/tag.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db || defaultDatabase,
+    real: [TagRepository],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(TagRepository) };
+};
+
+type Ctx = ReturnType<typeof setup>['ctx'];
+
+const createTag = (ctx: Ctx, userId: string, value: string) => ctx.get(TagRepository).create({ userId, value });
+
+// Seed a tag owned by the space creator, attached to an asset added directly to a
+// space, with `member` joined at the given role. The tag and asset are owned by a
+// different user, so any visibility the member gets comes purely from their space
+// membership — never from ownership.
+const seedDirectSpaceTag = async (ctx: Ctx, role: SharedSpaceRole, value: string) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id });
+  const tag = await createTag(ctx, owner.id, value);
+  await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role });
+  return { owner, member, space, asset, tag };
+};
+
+// Seed a tag attached to an asset reachable through a library linked to a space.
+const seedLinkedLibraryTag = async (ctx: Ctx, role: SharedSpaceRole, value: string) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  const { library } = await ctx.newLibrary({ ownerId: owner.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id, libraryId: library.id });
+  const tag = await createTag(ctx, owner.id, value);
+  await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role });
+  return { owner, member, space, library, asset, tag };
+};
+
+const ALL_ROLES = [SharedSpaceRole.Viewer, SharedSpaceRole.Editor, SharedSpaceRole.Owner];
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(TagRepository.name, () => {
+  // ============================================================================
+  // getAll — shared-space access permission matrix (issue #647)
+  // ============================================================================
+  describe('getAll', () => {
+    it('GRANT — owner sees their own tag (even with no assets attached)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const tag = await createTag(ctx, user.id, 'owner/solo');
+
+      const result = await sut.getAll(user.id);
+
+      expect(result.map((t) => t.id)).toContain(tag.id);
+    });
+
+    it.each(ALL_ROLES)('GRANT — space %s sees a tag on an asset shared directly into the space', async (role) => {
+      const { ctx, sut } = setup();
+      const { member, tag } = await seedDirectSpaceTag(ctx, role, `direct/${role}`);
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).toContain(tag.id);
+    });
+
+    it.each(ALL_ROLES)('GRANT — space %s sees a tag on an asset in a library linked to the space', async (role) => {
+      const { ctx, sut } = setup();
+      const { member, tag } = await seedLinkedLibraryTag(ctx, role, `library/${role}`);
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).toContain(tag.id);
+    });
+
+    it('GRANT — member sees the tag even when showInTimeline is disabled', async () => {
+      const { ctx, sut } = setup();
+      const { member, space, tag } = await seedDirectSpaceTag(ctx, SharedSpaceRole.Viewer, 'direct/no-timeline');
+      await ctx.database
+        .updateTable('shared_space_member')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', member.id)
+        .execute();
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).toContain(tag.id);
+    });
+
+    it('DENY — non-member does not see a tag on a space asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const tag = await createTag(ctx, owner.id, 'private/secret');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getAll(stranger.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — member of a different space does not see the tag', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: outsider } = await ctx.newUser();
+      const { space: withAsset } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { space: other } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const tag = await createTag(ctx, owner.id, 'private/other-space');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: withAsset.id, assetId: asset.id, addedById: owner.id });
+      // outsider belongs to a different space that does NOT contain the asset
+      await ctx.newSharedSpaceMember({ spaceId: other.id, userId: outsider.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getAll(outsider.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — member does not see a tag that is only on the owner’s non-shared asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+      // tag attached to an asset the owner never shared into the space
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const tag = await createTag(ctx, owner.id, 'private/unshared');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — member does not see a tag attached only to a soft-deleted shared asset', async () => {
+      const { ctx, sut } = setup();
+      const { member, asset, tag } = await seedDirectSpaceTag(ctx, SharedSpaceRole.Editor, 'direct/deleted');
+      await ctx.softDeleteAsset(asset.id);
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — a removed member no longer sees the tag', async () => {
+      const { ctx, sut } = setup();
+      const { member, space, tag } = await seedDirectSpaceTag(ctx, SharedSpaceRole.Editor, 'direct/removed');
+
+      await expect(sut.getAll(member.id).then((r) => r.map((t) => t.id))).resolves.toContain(tag.id);
+
+      await ctx.database
+        .deleteFrom('shared_space_member')
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', member.id)
+        .execute();
+
+      await expect(sut.getAll(member.id).then((r) => r.map((t) => t.id))).resolves.not.toContain(tag.id);
+    });
+  });
+});

--- a/server/test/medium/specs/repositories/tag.repository.spec.ts
+++ b/server/test/medium/specs/repositories/tag.repository.spec.ts
@@ -20,7 +20,9 @@ const setup = (db?: Kysely<DB>) => {
 
 type Ctx = ReturnType<typeof setup>['ctx'];
 
-const createTag = (ctx: Ctx, userId: string, value: string) => ctx.get(TagRepository).create({ userId, value });
+// Create a tag the way production does (upsertValue), which also populates tag_closure
+// — required for any tag-id timeline/search filter (withAnyTagId) to match the asset.
+const createTag = (ctx: Ctx, userId: string, value: string) => ctx.get(TagRepository).upsertValue({ userId, value });
 
 // Seed a tag owned by the space creator, attached to an asset added directly to a
 // space, with `member` joined at the given role. The tag and asset are owned by a
@@ -178,6 +180,32 @@ describe(TagRepository.name, () => {
         .execute();
 
       await expect(sut.getAll(member.id).then((r) => r.map((t) => t.id))).resolves.not.toContain(tag.id);
+    });
+
+    it('GRANT — member sees same-value tags from every owner who shared a tagged asset', async () => {
+      const { ctx, sut } = setup();
+      // Tags are per-user, so two owners tagging "family" produce two distinct tag rows
+      // with the same value. A member who can reach both owners' assets through the space
+      // should get BOTH rows (the web tree then collapses them onto one "family" node).
+      const { user: ownerA } = await ctx.newUser();
+      const { user: ownerB } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: ownerA.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const { asset: assetA } = await ctx.newAsset({ ownerId: ownerA.id });
+      const tagA = await createTag(ctx, ownerA.id, 'family');
+      await ctx.newTagAsset({ tagIds: [tagA.id], assetIds: [assetA.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: assetA.id, addedById: ownerA.id });
+
+      const { asset: assetB } = await ctx.newAsset({ ownerId: ownerB.id });
+      const tagB = await createTag(ctx, ownerB.id, 'family');
+      await ctx.newTagAsset({ tagIds: [tagB.id], assetIds: [assetB.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: assetB.id, addedById: ownerB.id });
+
+      const ids = await sut.getAll(member.id).then((r) => r.map((t) => t.id));
+
+      expect(ids).toEqual(expect.arrayContaining([tagA.id, tagB.id]));
     });
   });
 });

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -31,7 +31,7 @@
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { getTagActions } from '$lib/services/tag.service';
   import { joinPaths, TreeNode } from '$lib/utils/tree-utils';
-  import { getAllTags, type TagResponseDto } from '@immich/sdk';
+  import { AssetVisibility, getAllTags, type TagResponseDto } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider, Text } from '@immich/ui';
   import { mdiDotsVertical, mdiTag, mdiTagMultiple } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -48,7 +48,15 @@
   const tag = $derived(tree.traverse(data.path));
 
   let timelineManager = $state<TimelineManager>() as TimelineManager;
-  const options = $derived({ deferInit: !tag, tagId: tag?.id });
+  // Tags can belong to a space's owner while the tagged assets are only reachable
+  // through the shared space. Opt into shared-space assets (which requires an explicit
+  // timeline visibility) so non-admin members actually see photos under a tag (#647).
+  const options = $derived({
+    deferInit: !tag,
+    tagId: tag?.id,
+    visibility: AssetVisibility.Timeline,
+    withSharedSpaces: true,
+  });
 
   const handleNavigation = (tag: string) => navigateToView(joinPaths(data.path, tag));
 

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/tags-page.spec.ts
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/tags-page.spec.ts
@@ -1,7 +1,7 @@
 import TestWrapper from '$lib/components/TestWrapper.svelte';
-import type { TagResponseDto } from '@immich/sdk';
+import { AssetVisibility, type TagResponseDto } from '@immich/sdk';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import TagsPage from './+page.svelte';
 
@@ -198,5 +198,24 @@ describe('Tags page cmdk selection context', () => {
     expect(options.getOnDelete()).toEqual(expect.any(Function));
     expect(options.getOnUndoDelete()).toEqual(expect.any(Function));
     expect(options.getAddSelectedToCurrentSpace?.()).toBeUndefined();
+  });
+});
+
+describe('Tags page timeline scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Non-admin space members can see a tag owned by the space creator, but the assets
+  // under it belong to the creator and are only reachable through the shared space.
+  // The timeline must opt into shared-space assets (and pin timeline visibility, which
+  // withSharedSpaces requires) so the tag actually shows photos for them (issue #647).
+  it('requests shared-space assets so non-admin members see photos under a tag', () => {
+    renderPage();
+
+    const options = screen.getByTestId('timeline-options').textContent ?? '';
+    expect(options).toContain('"tagId":"tag-1"');
+    expect(options).toContain('"withSharedSpaces":true');
+    expect(options).toContain(`"visibility":"${AssetVisibility.Timeline}"`);
   });
 });


### PR DESCRIPTION
## Problem

Fixes #647. When a non-admin user clicked a tag in a photo's detail panel, the `/tags` page loaded with the correct URL but showed an empty tree and no photos. As admin the same link worked. Tags are core to discovery, and Noodle is explicitly a user-centric multi-user system — members with access to a Space should be able to browse the tag structure of photos they can see.

## Root cause (two halves)

1. **Empty tree** — `TagRepository.getAll(userId)` filtered strictly by `userId`. Tags on shared photos belong to the uploader, so a space member's `getAll` returned nothing.
2. **Empty timeline** — even with the tree populated, opening a tag ran the Timeline scoped to the member's *own* assets (the tagged photos belong to the owner), so no photos showed.

## Fix

Mirrors the merged Folder Explorer fix (#646):

- **Server** — `getAll` now uses an `ownedOrSpaceAccessible` predicate: the user's own tags **OR** tags on a non-deleted asset reachable through a shared space they belong to (asset added directly, or via a linked library). Mirrors `AccessRepository`/`ViewRepository`.
- **Web** — the tags page Timeline now passes `withSharedSpaces: true` + `visibility: Timeline` (the latter is required by the server to allow `withSharedSpaces`) so members actually see the photos under a tag.
- Regenerated `tag.repository.sql` (verified against a full-schema DB — only `getAll` changed).

## Tests (TDD — each watched fail first)

- **New medium permission matrix** `tag.repository.spec.ts` — 13 cases: owner; 3 roles × direct-asset; 3 roles × linked-library; showInTimeline-off; DENY for non-member, other-space, unshared asset, soft-deleted asset, removed member.
- **Web** `tags-page.spec.ts` — asserts the timeline opts into shared-space assets.

## Verification

- Tag medium matrix: 13/13 (8 failed before the fix)
- Full server unit suite: 4480 passed, 9 skipped, 0 failed
- Web tags-page: 2/2; timeline-manager: 50/50
- `tsc --noEmit` clean, eslint `--max-warnings 0` clean

## Note

Pinning `visibility: Timeline` on the tags page means archived-only tagged assets no longer appear in the tag view — consistent with the main photos timeline, and required to enable `withSharedSpaces`.