### PR TITLE
fix(branding): repoint App download links modal off Immich apps (#649)

### DIFF
--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -31,6 +31,7 @@ REPO_NAME=$(jq -r '.repository.name' "$CONFIG")
 REPO_URL=$(jq -r '.repository.url' "$CONFIG")
 REPO_DOCS_URL=$(jq -r '.repository.docs_url' "$CONFIG")
 REPO_ISSUES_URL=$(jq -r '.repository.issues_url' "$CONFIG")
+REPO_RELEASES_URL=$(jq -r '.repository.releases_url' "$CONFIG")
 
 # Docker
 DOCKER_REGISTRY=$(jq -r '.docker.registry' "$CONFIG")
@@ -156,6 +157,55 @@ patch_web() {
     sed -i "s/Immich/${NAME}/g" "$openapi"
     echo "  Patched OpenAPI spec"
   fi
+}
+
+#
+# --- App download modal ---
+#
+# The "App download links" modal (Tools menu + onboarding) hardcodes the upstream
+# Immich Play Store, App Store, and F-Droid badges (issue #649). Repoint the two
+# store badges to the Noodle Gallery apps. Noodle Gallery is not published on
+# F-Droid, so that badge is replaced with a link to the GitHub releases page.
+patch_app_download_modal() {
+  echo "--- Patching app download modal ---"
+  local modal="$REPO_ROOT/web/src/lib/modals/AppDownloadModal.svelte"
+  [[ -f "$modal" ]] || return 0
+
+  # Repoint the Play Store + App Store badges to the Noodle Gallery apps.
+  sed -i "s|https://play\.google\.com/store/apps/details?id=app\.alextran\.immich|${PLAY_STORE_URL}|g" "$modal"
+  sed -i "s|https://apps\.apple\.com/us/app/immich/id1613945652|${APP_STORE_URL}|g" "$modal"
+
+  # Replace the F-Droid badge (no Noodle F-Droid app) with a GitHub releases
+  # link. Mirrors patch_help_modal's awk block-rewrite: swap the <a id="fdroid-link">
+  # ...</a> anchor for a text link styled like the adjacent Obtainium link.
+  local tmp
+  tmp=$(mktemp)
+  awk -v url="$REPO_RELEASES_URL" '
+    /id="fdroid-link"/ { skip = 1 }
+    skip && /<\/a>/ {
+      skip = 0
+      print "    <a"
+      print "      href=\"" url "\""
+      print "      target=\"_blank\""
+      print "      rel=\"noreferrer\""
+      print "      id=\"github-release-link\""
+      print "      class=\"mt-2 text-center underline text-sm immich-form-label\""
+      print "    >"
+      print "      Get it on GitHub"
+      print "    </a>"
+      next
+    }
+    skip { next }
+    { print }
+  ' "$modal" > "$tmp"
+  chmod 644 "$tmp"
+  mv "$tmp" "$modal"
+
+  # fdroidBadge import is now unused — drop it to keep the build lint-clean
+  # regardless of where it sits in the destructured import list.
+  sed -i "s/, fdroidBadge//g; s/fdroidBadge, //g" "$modal"
+
+  echo "  Patched AppDownloadModal.svelte"
 }
 
 #
@@ -721,6 +771,7 @@ main() {
   patch_versions
   patch_i18n
   patch_web
+  patch_app_download_modal
   patch_emails
   patch_help_modal
   patch_assets

--- a/branding/scripts/test-app-download-branding.sh
+++ b/branding/scripts/test-app-download-branding.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Regression test for issue #649 — the "App download links" modal
+# (web/src/lib/modals/AppDownloadModal.svelte) ships upstream Immich store links.
+# Runs the REAL patch_app_download_modal() from apply-branding.sh against a
+# throwaway copy of the modal, then asserts the Play/App Store badges point at
+# the Noodle Gallery apps and the F-Droid badge (no Noodle F-Droid app exists)
+# has been replaced with a GitHub releases link.
+#
+# The working tree is never mutated (patch runs against a temp mirror), so this
+# is safe to run locally and in CI. No image tooling or network access required.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# GNU sed/coreutils on macOS (mirrors .github/actions/apply-branding/action.yml).
+if [[ "$(uname)" == "Darwin" ]]; then
+  export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+fi
+
+# Source apply-branding.sh to pull in patch_app_download_modal() and the
+# config-derived globals (PLAY_STORE_URL, APP_STORE_URL, REPO_RELEASES_URL).
+# The script guards `main` behind a BASH_SOURCE check, so sourcing only defines
+# functions and reads config — it does not run a branding pass.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/apply-branding.sh"
+set +e # apply-branding.sh enables `set -e`; a failed grep must not abort the run
+
+# Mirror only the file patch_app_download_modal() touches into a temp REPO_ROOT.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/web/src/lib/modals"
+cp "$REPO/web/src/lib/modals/AppDownloadModal.svelte" "$TMP/web/src/lib/modals/"
+
+# Apply the real transformation against the mirror.
+REPO_ROOT="$TMP" patch_app_download_modal >/dev/null
+
+fails=0
+absent() { # <file> <regex> <description>  — regex must NOT match
+  if grep -Eq "$2" "$TMP/$1"; then
+    echo "  FAIL: $3 — '$2' still present in $1"
+    fails=$((fails + 1))
+  else
+    echo "  ok:   $3"
+  fi
+}
+present() { # <file> <literal> <description>  — literal must match
+  if grep -Fq "$2" "$TMP/$1"; then
+    echo "  ok:   $3"
+  else
+    echo "  FAIL: $3 — '$2' missing from $1"
+    fails=$((fails + 1))
+  fi
+}
+
+MODAL="web/src/lib/modals/AppDownloadModal.svelte"
+
+echo "Store badges repointed off Immich:"
+absent "$MODAL" 'app\.alextran\.immich' 'play store link no longer targets the Immich app'
+absent "$MODAL" 'apps\.apple\.com/us/app/immich/id1613945652' 'app store link no longer targets the Immich app'
+absent "$MODAL" 'f-droid\.org' 'F-Droid link removed (no Noodle F-Droid app)'
+absent "$MODAL" 'fdroidBadge' 'unused fdroidBadge import dropped'
+
+echo "Badges + fallback point at Noodle Gallery:"
+present "$MODAL" "$PLAY_STORE_URL" 'play store link is the Noodle Gallery app'
+present "$MODAL" "$APP_STORE_URL" 'app store link is the Noodle Gallery app'
+present "$MODAL" "$REPO_RELEASES_URL" 'F-Droid badge replaced with GitHub releases link'
+present "$MODAL" 'id="github-release-link"' 'GitHub releases link rendered'
+
+echo
+if [[ $fails -gt 0 ]]; then
+  echo "FAILED: $fails assertion(s)"
+  exit 1
+fi
+echo "PASSED: app download modal fully rebranded to ${NAME}"

--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -105,6 +105,18 @@ if [[ -f "$help_modal" ]]; then
   fi
 fi
 
+# App download modal (issue #649) — store badges must not point at the Immich apps.
+# Noodle has no F-Droid listing, so that badge is replaced with a GitHub link.
+app_download_modal="$REPO_ROOT/web/src/lib/modals/AppDownloadModal.svelte"
+if [[ -f "$app_download_modal" ]]; then
+  if grep -qE "app\.alextran\.immich|app/immich/id1613945652|f-droid\.org|fdroidBadge" "$app_download_modal"; then
+    echo "  WARN: Immich store link/F-Droid badge still present in AppDownloadModal.svelte"
+    EXIT_CODE=1
+  else
+    echo "  OK: AppDownloadModal.svelte (store links patched)"
+  fi
+fi
+
 # Check Dockerfiles for upstream repo references
 echo "--- Checking Dockerfiles ---"
 for dockerfile in "server/Dockerfile" "machine-learning/Dockerfile"; do


### PR DESCRIPTION
Fixes #649.

## Problem

The **App download links** modal (Tools menu + onboarding) shows Google Play, App Store, and F-Droid badges that link to the **upstream Immich app**, not Noodle Gallery.

`web/src/lib/modals/AppDownloadModal.svelte` is a pristine upstream Immich file (every commit touching it is an upstream PR) that hardcodes:

- Play: `…?id=app.alextran.immich`
- App Store: `…/app/immich/id1613945652`
- F-Droid: `…/packages/app.alextran.immich/`

## Fix

Brand it at build time in `apply-branding.sh` — exactly how the email footer's *identical* store links are already handled (`patch_emails`, and `patch_help_modal` for element removal). This keeps the upstream source untouched so rebases stay clean.

- **Play Store + App Store** badges repointed to the Noodle Gallery apps (`config.json` → `mobile.play_store_url` / `mobile.app_store_url`).
- **F-Droid** badge replaced with a **GitHub releases** link (`repository.releases_url`) — Noodle Gallery has no F-Droid listing, matching the issue's "or be removed until a Noodle app is available".
- Unused `fdroidBadge` import dropped so the branded build stays lint-clean.

The store *badge images* come from `@immich/ui` (generic, not Immich-branded), so only the link `href`s change.

## Branded output

```svelte
<a href="https://play.google.com/store/apps/details?id=de.opennoodle.gallery" target="_blank" id="play-store-link">…</a>
<a href="https://apps.apple.com/us/app/noodle-gallery/id6761776289" target="_blank" id="app-store-link">…</a>
<a href="https://github.com/open-noodle/gallery/releases" … id="github-release-link">Get it on GitHub</a>
```

## Guardrails

- **`verify-branding.sh` gate** (CI-enforced via `.github/actions/apply-branding`): fails the branding step if a rebase reintroduces `app.alextran.immich` / `app/immich/id1613945652` / `f-droid.org` / `fdroidBadge` in the modal.
- **`test-app-download-branding.sh`**: sourceable regression test mirroring `test-email-branding.sh` — runs the real `patch_app_download_modal` against a temp mirror and asserts the rewrites.

## Testing

- `branding/scripts/test-app-download-branding.sh` → PASS (8/8 assertions).
- Verify gate validated both ways: WARNs on unbranded source, clean on branded output.
- `shellcheck` clean on all three scripts; `git diff` confirms the upstream modal source is untouched.

## Note (out of scope)

`ObtainiumConfigModal.svelte` also embeds `app.alextran.immich` and `"author"/"name":"Immich"` in its generated Obtainium link. That's a separate feature from the #649 dialog; happy to fix it in a follow-up if wanted.