### PR TITLE
fix(mobile): drain in-flight HTTP before iOS background-worker teardown

### DIFF
--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/logger_db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
 import 'package:immich_mobile/platform/background_worker_api.g.dart';
 import 'package:immich_mobile/platform/background_worker_lock_api.g.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
@@ -177,6 +178,14 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       final backgroundSyncManager = _ref?.read(backgroundSyncProvider);
       final nativeSyncApi = _ref?.read(nativeSyncApiProvider);
 
+      // Abort and drain in-flight HTTP requests first. On iOS the background
+      // isolate shares a native URLSession; if it is destroyed while a request
+      // is in flight, the cupertino_http delegate later calls back into the
+      // dead isolate and crashes (SIGABRT). Draining here makes their callbacks
+      // fire while the isolate is still alive, before the native side calls
+      // engine.destroyContext().
+      await NetworkRepository.shutdown();
+
       await _drift.close();
       await _driftLogger.close();
 
@@ -297,6 +306,11 @@ class BackgroundWorkerLockService {
 Future<void> backgroundSyncNativeEntrypoint() async {
   WidgetsFlutterBinding.ensureInitialized();
   DartPluginRegistrant.ensureInitialized();
+
+  // Track in-flight HTTP requests so they can be drained before this isolate is
+  // torn down. Must run before Bootstrap.initDomain (which calls
+  // NetworkRepository.init).
+  NetworkRepository.enableShutdownTracking();
 
   final (drift, logDB) = await Bootstrap.initDomain(shouldBufferLogs: false, listenStoreUpdates: false);
   await BackgroundWorkerBgService(drift: drift, driftLogger: logDB).init();

--- a/mobile/lib/infrastructure/repositories/draining_http_client.dart
+++ b/mobile/lib/infrastructure/repositories/draining_http_client.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+
+/// An [http.Client] wrapper that can gracefully drain in-flight requests.
+///
+/// This exists to fix an iOS background-worker crash: the background isolate
+/// shares a native [URLSession] with the foreground via `cupertino_http`. When
+/// the isolate is torn down (`engine.destroyContext()`) while a request is
+/// still in flight, the request's per-task delegate later fires
+/// `didCompleteWithError` on a background queue and invokes an FFI callback
+/// belonging to the now-dead isolate, tripping a Dart VM assertion (SIGABRT).
+///
+/// To make teardown safe, the background isolate wraps its client in a
+/// [DrainingHttpClient] and calls [shutdown] before signalling completion to
+/// the native side. [shutdown] aborts every in-flight request — so their
+/// delegate callbacks fire *while the isolate is still alive* — awaits their
+/// settlement, and only then closes the underlying client.
+class DrainingHttpClient extends http.BaseClient {
+  DrainingHttpClient(this._inner);
+
+  final http.Client _inner;
+
+  /// Abort triggers for requests this client made abortable. Completing one
+  /// cancels the corresponding in-flight request.
+  final Set<Completer<void>> _abortTriggers = {};
+
+  /// Futures that complete once an in-flight request has fully settled.
+  final Set<Future<void>> _inFlight = {};
+
+  bool _closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (_closed) {
+      throw http.ClientException('HTTP request failed. Client is already closed.', request.url);
+    }
+
+    final settled = Completer<void>();
+    _inFlight.add(settled.future);
+
+    // Make plain requests abortable so [shutdown] can cancel them. Requests
+    // that are already abortable manage their own trigger; request types we
+    // can't safely re-create (streamed/multipart) are tracked but not
+    // forcibly cancelled here.
+    Completer<void>? trigger;
+    final http.BaseRequest outgoing;
+    if (request is http.Request && request is! http.Abortable) {
+      trigger = Completer<void>();
+      _abortTriggers.add(trigger);
+      outgoing = _toAbortableRequest(request, trigger.future);
+    } else {
+      outgoing = request;
+    }
+
+    void settle() {
+      if (trigger != null) {
+        _abortTriggers.remove(trigger);
+      }
+      _inFlight.remove(settled.future);
+      if (!settled.isCompleted) {
+        settled.complete();
+      }
+    }
+
+    try {
+      final response = await _inner.send(outgoing);
+      // The request is not fully settled until its body has been delivered:
+      // `cupertino_http` fires its completion FFI callback when the response
+      // stream closes, so the request must stay tracked (and abortable) until
+      // then.
+      final tracked = response.stream.transform(
+        StreamTransformer<List<int>, List<int>>.fromHandlers(
+          handleData: (data, sink) => sink.add(data),
+          handleError: (error, stackTrace, sink) {
+            sink.addError(error, stackTrace);
+            settle();
+          },
+          handleDone: (sink) {
+            settle();
+            sink.close();
+          },
+        ),
+      );
+      return http.StreamedResponse(
+        tracked,
+        response.statusCode,
+        contentLength: response.contentLength,
+        request: response.request,
+        headers: response.headers,
+        isRedirect: response.isRedirect,
+        persistentConnection: response.persistentConnection,
+        reasonPhrase: response.reasonPhrase,
+      );
+    } catch (_) {
+      settle();
+      rethrow;
+    }
+  }
+
+  /// Aborts all in-flight requests, awaits their settlement (bounded by
+  /// [timeout]), then closes the underlying client.
+  ///
+  /// After this completes, [send] throws and no in-flight request can call back
+  /// into the isolate.
+  Future<void> shutdown({Duration timeout = const Duration(seconds: 3)}) async {
+    _closed = true;
+
+    for (final trigger in _abortTriggers.toList()) {
+      if (!trigger.isCompleted) {
+        trigger.complete();
+      }
+    }
+
+    if (_inFlight.isNotEmpty) {
+      await Future.wait(_inFlight.toList()).timeout(timeout, onTimeout: () => const []);
+    }
+
+    _inner.close();
+  }
+
+  @override
+  void close() => _inner.close();
+
+  http.AbortableRequest _toAbortableRequest(http.Request request, Future<void> abortTrigger) {
+    return http.AbortableRequest(request.method, request.url, abortTrigger: abortTrigger)
+      ..followRedirects = request.followRedirects
+      ..maxRedirects = request.maxRedirects
+      ..persistentConnection = request.persistentConnection
+      ..encoding = request.encoding
+      ..headers.addAll(request.headers)
+      ..bodyBytes = request.bodyBytes;
+  }
+}

--- a/mobile/lib/infrastructure/repositories/network.repository.dart
+++ b/mobile/lib/infrastructure/repositories/network.repository.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:cupertino_http/cupertino_http.dart';
 import 'package:http/http.dart' as http;
+import 'package:immich_mobile/infrastructure/repositories/draining_http_client.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:ok_http/ok_http.dart';
 import 'package:web_socket/web_socket.dart';
@@ -11,6 +12,24 @@ class NetworkRepository {
   static http.Client? _client;
   static Pointer<Void>? _clientPointer;
 
+  /// When set, the iOS client is wrapped in a [DrainingHttpClient] so in-flight
+  /// requests can be aborted and drained at teardown. Enabled only in the
+  /// background-worker isolate via [enableShutdownTracking].
+  static bool _trackInFlight = false;
+  static DrainingHttpClient? _draining;
+
+  /// Enables graceful shutdown tracking of in-flight requests for the current
+  /// isolate. Must be called before [init].
+  ///
+  /// The iOS background worker shares a native [URLSession] across isolates; if
+  /// the isolate is destroyed while a request is in flight, the request's
+  /// `cupertino_http` delegate later calls back into the dead isolate and
+  /// crashes the process. Tracking lets [shutdown] cancel and drain those
+  /// requests first. See [DrainingHttpClient].
+  static void enableShutdownTracking() {
+    _trackInFlight = true;
+  }
+
   static Future<void> init() async {
     final clientPointer = Pointer<Void>.fromAddress(await networkApi.getClientPointer());
     if (clientPointer == _clientPointer) {
@@ -18,11 +37,14 @@ class NetworkRepository {
     }
     _clientPointer = clientPointer;
     _client?.close();
+    _draining = null;
+
+    final http.Client base;
     if (Platform.isIOS) {
       final session = URLSession.fromRawPointer(clientPointer.cast());
-      _client = CupertinoClient.fromSharedSession(session);
+      base = CupertinoClient.fromSharedSession(session);
     } else {
-      _client = OkHttpClient.fromJniGlobalRef(
+      base = OkHttpClient.fromJniGlobalRef(
         clientPointer,
         configuration: const OkHttpClientConfiguration(
           connectTimeout: Duration(seconds: 30),
@@ -31,6 +53,25 @@ class NetworkRepository {
         ),
       );
     }
+
+    // Only iOS needs draining: the crash is specific to cupertino_http's
+    // shared-session FFI delegate. Android's background worker is unaffected.
+    if (_trackInFlight && Platform.isIOS) {
+      _client = _draining = DrainingHttpClient(base);
+    } else {
+      _client = base;
+    }
+  }
+
+  /// Aborts and drains any in-flight requests, then closes the client.
+  ///
+  /// No-op unless [enableShutdownTracking] was called before [init]. Must run
+  /// before the native side destroys the background isolate so that no
+  /// in-flight `cupertino_http` request can call back into a dead isolate.
+  static Future<void> shutdown({Duration timeout = const Duration(milliseconds: 1500)}) async {
+    final draining = _draining;
+    _draining = null;
+    await draining?.shutdown(timeout: timeout);
   }
 
   static Future<void> setHeaders(Map<String, String> headers, List<String> serverUrls, {String? token}) async {

--- a/mobile/test/domain/services/background_worker_http_teardown_test.dart
+++ b/mobile/test/domain/services/background_worker_http_teardown_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guard for the iOS background-worker teardown crash (EXC_CRASH /
+/// SIGABRT in `cupertino_http`'s `_StreamingTaskDelegate` after the headless
+/// engine is destroyed). The background isolate must drain in-flight HTTP
+/// requests before the native side calls `engine.destroyContext()`.
+///
+/// `BackgroundWorker.swift` is upstream Immich code that gets rebased; this
+/// fork-only Dart wiring is easy to drop on a rebase, so assert it stays put.
+void main() {
+  final source = File('lib/domain/services/background_worker.service.dart').readAsStringSync();
+
+  test('background isolate enables in-flight HTTP tracking before init', () {
+    expect(source, contains('NetworkRepository.enableShutdownTracking()'));
+
+    final enableAt = source.indexOf('NetworkRepository.enableShutdownTracking()');
+    final initDomainAt = source.indexOf('Bootstrap.initDomain(');
+    expect(enableAt, greaterThanOrEqualTo(0));
+    expect(initDomainAt, greaterThan(enableAt), reason: 'tracking must be enabled before Bootstrap.initDomain');
+  });
+
+  test('cleanup drains in-flight HTTP requests before tearing down the isolate', () {
+    expect(source, contains('await NetworkRepository.shutdown()'));
+
+    final shutdownAt = source.indexOf('await NetworkRepository.shutdown()');
+    final driftCloseAt = source.indexOf('await _drift.close()');
+    expect(shutdownAt, greaterThanOrEqualTo(0));
+    expect(driftCloseAt, greaterThan(shutdownAt), reason: 'HTTP must be drained before the rest of cleanup runs');
+  });
+}

--- a/mobile/test/infrastructure/repositories/draining_http_client_test.dart
+++ b/mobile/test/infrastructure/repositories/draining_http_client_test.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:immich_mobile/infrastructure/repositories/draining_http_client.dart';
+
+/// A fake [http.Client] that lets a test hold requests in flight and observe
+/// whether the client honored an [http.Abortable] trigger before being closed.
+class _FakeInnerClient extends http.BaseClient {
+  _FakeInnerClient({this.honorAbort = true});
+
+  /// When false, the client ignores the abort trigger (simulating a request
+  /// that refuses to cancel), so [DrainingHttpClient.shutdown] must fall back
+  /// to its timeout.
+  final bool honorAbort;
+  final List<http.BaseRequest> sent = [];
+  final List<Completer<http.StreamedResponse>> _pending = [];
+  bool closed = false;
+  bool hadPendingRequestsAtClose = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    sent.add(request);
+    final completer = Completer<http.StreamedResponse>();
+    _pending.add(completer);
+    // Mimic a real client (e.g. CupertinoClient) that fails an in-flight
+    // request when its abort trigger fires.
+    if (honorAbort) {
+      if (request case http.Abortable(:final abortTrigger?)) {
+        abortTrigger.whenComplete(() {
+          if (!completer.isCompleted) {
+            completer.completeError(http.RequestAbortedException(request.url));
+          }
+        });
+      }
+    }
+    return completer.future;
+  }
+
+  @override
+  void close() {
+    hadPendingRequestsAtClose = _pending.any((c) => !c.isCompleted);
+    closed = true;
+  }
+}
+
+/// A fake [http.Client] that returns a streamed response whose body stays open,
+/// mimicking `cupertino_http`: aborting the request injects an error into the
+/// response stream and closes it.
+class _StreamingFakeClient extends http.BaseClient {
+  late StreamController<List<int>> body;
+  bool closed = false;
+  bool hadOpenStreamAtClose = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    body = StreamController<List<int>>();
+    if (request case http.Abortable(:final abortTrigger?)) {
+      unawaited(
+        abortTrigger.whenComplete(() {
+          if (!body.isClosed) {
+            body.addError(http.RequestAbortedException(request.url));
+            unawaited(body.close());
+          }
+        }),
+      );
+    }
+    return http.StreamedResponse(body.stream, 200);
+  }
+
+  @override
+  void close() {
+    hadOpenStreamAtClose = !body.isClosed;
+    closed = true;
+  }
+}
+
+void main() {
+  test('keeps a request in flight until its response body stream completes', () async {
+    final inner = _StreamingFakeClient();
+    final client = DrainingHttpClient(inner);
+
+    // The response headers arrive, but the body is still streaming.
+    final response = await client.send(http.Request('GET', Uri.parse('https://example.com/api/sync')));
+    expect(inner.body.isClosed, isFalse);
+
+    // Consume the stream the way ApiClient does.
+    final drained = expectLater(response.stream.toBytes(), throwsA(isA<http.ClientException>()));
+
+    // Shutdown must abort the still-open stream and wait for it to close before
+    // closing the inner client — otherwise the isolate could be destroyed while
+    // the body is mid-flight.
+    await client.shutdown();
+
+    expect(inner.closed, isTrue);
+    expect(
+      inner.hadOpenStreamAtClose,
+      isFalse,
+      reason: 'response stream must be drained before the inner client is closed',
+    );
+
+    await drained;
+  });
+
+  test('rejects new requests after shutdown', () async {
+    final inner = _FakeInnerClient();
+    final client = DrainingHttpClient(inner);
+
+    await client.shutdown();
+
+    await expectLater(client.get(Uri.parse('https://example.com/api/sync')), throwsA(isA<http.ClientException>()));
+    expect(inner.sent, isEmpty);
+  });
+
+  test('rewrites a plain request into an abortable request preserving method, headers and body', () async {
+    final inner = _FakeInnerClient();
+    final client = DrainingHttpClient(inner);
+
+    final request = http.Request('POST', Uri.parse('https://example.com/api/things'))
+      ..headers['x-custom'] = 'value'
+      ..body = 'payload';
+    final pending = client.send(request);
+    await pumpEventQueue();
+
+    final outgoing = inner.sent.single;
+    expect(outgoing, isA<http.AbortableRequest>());
+    expect(outgoing.method, 'POST');
+    expect(outgoing.url, Uri.parse('https://example.com/api/things'));
+    expect(outgoing.headers['x-custom'], 'value');
+    expect((outgoing as http.Request).body, 'payload');
+
+    final done = expectLater(pending, throwsA(isA<http.ClientException>()));
+    await client.shutdown();
+    await done;
+  });
+
+  test('shutdown returns within the timeout even if a request never settles', () async {
+    final inner = _FakeInnerClient(honorAbort: false);
+    final client = DrainingHttpClient(inner);
+
+    unawaited(client.get(Uri.parse('https://example.com/api/sync')).catchError((_) => http.Response('', 499)));
+    await pumpEventQueue();
+
+    await client.shutdown(timeout: const Duration(milliseconds: 50));
+
+    expect(inner.closed, isTrue);
+  });
+
+  test('shutdown aborts in-flight requests and closes the inner client only after they settle', () async {
+    final inner = _FakeInnerClient();
+    final client = DrainingHttpClient(inner);
+
+    // Start a request the inner client will never complete on its own.
+    final pending = client.get(Uri.parse('https://example.com/api/sync'));
+    await pumpEventQueue();
+
+    // The request reached the inner client as an abortable request so it can
+    // be cancelled during teardown.
+    expect(inner.sent, hasLength(1));
+    expect(inner.sent.single, isA<http.Abortable>());
+    expect((inner.sent.single as http.Abortable).abortTrigger, isNotNull);
+    expect(inner.closed, isFalse);
+
+    // Attach the failure expectation before aborting so the in-flight request's
+    // error (raised during shutdown) is observed rather than reported as
+    // unhandled.
+    final aborted = expectLater(pending, throwsA(isA<http.ClientException>()));
+
+    // Graceful shutdown must abort the in-flight request, await its settlement,
+    // and only then close the underlying client.
+    await client.shutdown();
+
+    expect(inner.closed, isTrue);
+    expect(
+      inner.hadPendingRequestsAtClose,
+      isFalse,
+      reason: 'inner client must be closed only after in-flight requests settle',
+    );
+
+    await aborted;
+  });
+}


### PR DESCRIPTION
## The crash

EXC_CRASH (SIGABRT) on iOS, recurring across TestFlight builds **4.56.0 (270) → 4.56.8 (275)** (2026-05-12, 05-30 ×2, 05-31). The crashing thread is identical every time:

```
abort
dart::Assert::Fail(...)                          (assert.cc:54)
DLRT_GetFfiCallbackMetadata + 976                (runtime_entry.cc:5122)
cupertino_http _StreamingTaskDelegate.urlSession(_:task:didCompleteWithError:)
                                                 (CUPHTTPStreamingTask.swift:156)
CFNetwork __NSCFURLSessionDelegateWrapper task:didCompleteWithError:...
libdispatch (background queue)
```

Concurrent threads in the same reports confirm it is a **teardown/lifecycle race**, not a logic bug: one report has a thread in `-[FlutterEngine dealloc]` ← `BackgroundWorker.__deallocating_deinit`; another in `FlutterEngine.__allocating_init` ← `BackgroundWorker.swift:51` ← `handleBackgroundRefresh`.

## Root cause

1. iOS background refresh → `BackgroundWorkerApiImpl.handleBackgroundRefresh` runs a headless `FlutterEngine` (`BackgroundWorker.swift`).
2. The background isolate makes HTTP calls through `cupertino_http`'s `CupertinoClient.fromSharedSession(session)`, where `session` is the **process-wide, native-owned** `URLSessionManager.shared.session` (shared with the foreground isolate via an FFI pointer).
3. When the worker finishes — or the `maxSeconds` / 2 s fallback timer fires — `BackgroundWorker.complete()` calls `engine.destroyContext()` **without** waiting for in-flight requests.
4. Dart cleanup (`background_worker.service.dart`) closes Drift, disposes the ref, cancels hashing/sync — but **never closes the HTTP client**. `CupertinoClient.fromSharedSession(...).close()` is a no-op for shared sessions anyway (`_ownsSession == false`): it neither invalidates the session nor cancels tasks.
5. An in-flight request then completes (usually failing pre-headers as iOS suspends networking) → its per-task `NSURLSession` delegate fires `didCompleteWithError` on a background queue → invokes the Dart FFI callback (`NativeCallable`/`ObjCBlock`) belonging to the **destroyed isolate** → `DLRT_GetFfiCallbackMetadata` asserts → `abort()`.

`BackgroundWorker.swift` is byte-identical to upstream Immich and they pin the same `cupertino_http` commit, so this affects upstream too; there is no fix to cherry-pick.

## Fix — Dart-side ordered teardown

`DrainingHttpClient` wraps the background isolate's `http.Client`:
- rewrites plain `Request`s (the sync/API calls that crash) into `AbortableRequest`s so they can be cancelled;
- tracks each request **until its response body stream completes** (cupertino_http fires its completion FFI callback at stream close, so a mid-stream teardown is also a crash window);
- `shutdown()` completes every abort trigger → `task.cancel()` makes the delegate callbacks fire **while the isolate is still alive**, awaits settlement (bounded), then closes the inner client.

Wiring:
- `backgroundSyncNativeEntrypoint` calls `NetworkRepository.enableShutdownTracking()` before init (iOS only).
- `_handleCleanup()` calls `await NetworkRepository.shutdown()` as its **first** step. Cleanup runs before `destroyContext()` on every path — the backup loop always `await cleanup()`s in its `finally`, and the native cancel path routes through it. The 1.5 s drain bound keeps it under the native 2 s fallback, making the timeout a true last resort.

### Why no native `invalidateAndCancel()` belt-and-braces
The session is a **shared singleton** also used by the foreground isolate, and its native delegate handles **mTLS / basic-auth**. `URLSession.invalidateAndCancel()` would break foreground networking and mTLS and can't be undone — so the correct fix is Dart-side ordering, not a native session kill.

## Tests
- `draining_http_client_test.dart` — 5 tests covering the invariant: aborts in-flight requests and closes the inner client only after they settle; tracks until the response stream completes; rejects requests after shutdown; rewrites `Request`→`AbortableRequest` preserving method/headers/body; bounded by timeout.
- `background_worker_http_teardown_test.dart` — source guard (same style as the existing native-files guard) that the fork-only wiring survives upstream rebases.
- `dart analyze --fatal-infos lib test` clean, `dart format` clean, full `flutter test` green (1445 passed).

## Validation
On-device validation is best-effort only: the bug is a non-deterministic timing race that can't be triggered reliably on demand. The fix is proven by the unit-tested ordering invariant. Happy to do a device build + background-fetch smoke test as a follow-up if wanted.