### PR TITLE
fix(mobile): continue iOS background backup past the first 100-item batch

### DIFF
--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -511,7 +511,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     }
 
     _logger.info("Resuming upload ${tasks.length} assets");
-    return _backgroundUploadService.resume();
+    return _backgroundUploadService.resume(userId);
   }
 }
 

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -131,6 +131,25 @@ class BackgroundUploadService {
 
   bool shouldAbortQueuingTasks = false;
 
+  /// Maximum number of upload tasks enqueued per batch. iOS limits how many
+  /// tasks a background URLSession handles at once, so candidates are enqueued
+  /// in batches and the next batch is queued as the current one drains.
+  @visibleForTesting
+  int backupBatchSize = 100;
+
+  /// Asset IDs already enqueued during the current backup session.
+  ///
+  /// [DriftBackupRepository.getCandidates] only drops an asset once it appears
+  /// locally as a remote asset (populated by sync), so without this we would
+  /// re-enqueue the in-flight / just-finished batch before sync catches up.
+  final Set<String> _enqueuedAssetIds = {};
+
+  /// The user whose backup is currently draining; used to enqueue the next batch.
+  String? _activeBackupUserId;
+
+  /// Guards against overlapping next-batch enqueues from concurrent completions.
+  bool _isQueuingNextBatch = false;
+
   void _onTaskProgressCallback(TaskProgressUpdate update) {
     if (!_taskProgressController.isClosed) {
       _taskProgressController.add(update);
@@ -184,21 +203,36 @@ class BackgroundUploadService {
   Future<void> uploadBackupCandidates(String userId) async {
     await _storageRepository.clearCache();
     shouldAbortQueuingTasks = false;
+    _activeBackupUserId = userId;
 
     final candidates = await _backupRepository.getCandidates(userId);
-    await _backgroundBackupStatusService.recordCandidateCount(candidates.length);
+
+    // Report the total once per session; subsequent batches are continuations.
+    final isFirstBatch = _enqueuedAssetIds.isEmpty;
+    if (isFirstBatch) {
+      await _backgroundBackupStatusService.recordCandidateCount(candidates.length);
+    }
+
     if (candidates.isEmpty) {
       _logger.info("No new backup candidates found, finishing background upload");
+      _resetBackupSession();
       return;
     }
 
-    _logger.info("Found ${candidates.length} backup candidates for background tasks");
+    // Skip assets already enqueued this session (see [_enqueuedAssetIds]).
+    final pending = candidates.where((asset) => !_enqueuedAssetIds.contains(asset.id)).toList(growable: false);
+    if (pending.isEmpty) {
+      _logger.info("All ${candidates.length} candidates already enqueued this session, finishing");
+      _resetBackupSession();
+      return;
+    }
 
-    const batchSize = 100;
-    final batch = candidates.take(batchSize).toList();
-    List<UploadTask> tasks = [];
+    _logger.info("Found ${candidates.length} backup candidates (${pending.length} not yet enqueued this session)");
 
+    final batch = pending.take(backupBatchSize).toList();
+    final List<UploadTask> tasks = [];
     for (final asset in batch) {
+      _enqueuedAssetIds.add(asset.id);
       final task = await getUploadTask(asset);
       if (task != null) {
         tasks.add(task);
@@ -217,6 +251,7 @@ class BackgroundUploadService {
   /// Returns the number of tasks left in the queue
   Future<int> cancel() async {
     shouldAbortQueuingTasks = true;
+    _resetBackupSession();
 
     await _storageRepository.clearCache();
     await _uploadRepository.reset(kBackupGroup);
@@ -226,9 +261,18 @@ class BackgroundUploadService {
     return activeTasks.length;
   }
 
-  /// Resume background backup processing
-  Future<void> resume() {
-    return _uploadRepository.start();
+  /// Resume background backup processing and arm batch continuation so the rest
+  /// of the backlog is queued as the resumed tasks drain.
+  ///
+  /// Seeds the session with the assets already in flight (taskId == asset id) so
+  /// the next batch does not re-enqueue them.
+  Future<void> resume(String userId) async {
+    _activeBackupUserId = userId;
+    final active = await _uploadRepository.getActiveTasks(kBackupGroup);
+    for (final task in active) {
+      _enqueuedAssetIds.add(task.taskId);
+    }
+    await _uploadRepository.start();
   }
 
   bool _isLivePhotoMotionTask(Task task) {
@@ -271,6 +315,42 @@ class BackgroundUploadService {
       default:
         break;
     }
+
+    await _maybeQueueNextBackupBatch(update);
+  }
+
+  /// When a backup task reaches a terminal state and the queue has drained,
+  /// enqueue the next batch so a single trigger works through the whole backlog
+  /// instead of stalling after [backupBatchSize] items.
+  Future<void> _maybeQueueNextBackupBatch(TaskStatusUpdate update) async {
+    if (update.task.group != kBackupGroup || !update.status.isFinalState) {
+      return;
+    }
+    final userId = _activeBackupUserId;
+    if (userId == null || shouldAbortQueuingTasks || _isQueuingNextBatch) {
+      return;
+    }
+
+    _isQueuingNextBatch = true;
+    try {
+      final active = await _uploadRepository.getActiveTasks(kBackupGroup);
+      if (active.any((task) => task.taskId != update.task.taskId)) {
+        // Other tasks of this batch are still uploading; the next batch is
+        // queued when the last one completes. (The just-completed task may still
+        // be reported active depending on update ordering, so ignore it.)
+        return;
+      }
+      await uploadBackupCandidates(userId);
+    } catch (error, stackTrace) {
+      _logger.severe("Failed to enqueue next backup batch", error, stackTrace);
+    } finally {
+      _isQueuingNextBatch = false;
+    }
+  }
+
+  void _resetBackupSession() {
+    _enqueuedAssetIds.clear();
+    _activeBackupUserId = null;
   }
 
   Future<void> _handleLivePhoto(TaskStatusUpdate update) async {

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -150,6 +150,9 @@ class BackgroundUploadService {
   /// Guards against overlapping next-batch enqueues from concurrent completions.
   bool _isQueuingNextBatch = false;
 
+  /// Last final status update received while a drain check was already running.
+  TaskStatusUpdate? _pendingBackupDrainUpdate;
+
   void _onTaskProgressCallback(TaskProgressUpdate update) {
     if (!_taskProgressController.isClosed) {
       _taskProgressController.add(update);
@@ -194,6 +197,18 @@ class BackgroundUploadService {
   /// Get a list of tasks that are ENQUEUED or RUNNING
   Future<List<Task>> getActiveTasks(String group) {
     return _uploadRepository.getActiveTasks(group);
+  }
+
+  bool _isBackupUploadGroup(String group) {
+    return group == kBackupGroup || group == kBackupLivePhotoGroup;
+  }
+
+  Future<List<Task>> _getActiveBackupTasks() async {
+    final activeGroups = await Future.wait([
+      _uploadRepository.getActiveTasks(kBackupGroup),
+      _uploadRepository.getActiveTasks(kBackupLivePhotoGroup),
+    ]);
+    return activeGroups.expand((group) => group).toList(growable: false);
   }
 
   /// Start background upload using iOS URLSession
@@ -268,7 +283,7 @@ class BackgroundUploadService {
   /// the next batch does not re-enqueue them.
   Future<void> resume(String userId) async {
     _activeBackupUserId = userId;
-    final active = await _uploadRepository.getActiveTasks(kBackupGroup);
+    final active = await _getActiveBackupTasks();
     for (final task in active) {
       _enqueuedAssetIds.add(task.taskId);
     }
@@ -323,18 +338,22 @@ class BackgroundUploadService {
   /// enqueue the next batch so a single trigger works through the whole backlog
   /// instead of stalling after [backupBatchSize] items.
   Future<void> _maybeQueueNextBackupBatch(TaskStatusUpdate update) async {
-    if (update.task.group != kBackupGroup || !update.status.isFinalState) {
+    if (!_isBackupUploadGroup(update.task.group) || !update.status.isFinalState) {
       return;
     }
     final userId = _activeBackupUserId;
-    if (userId == null || shouldAbortQueuingTasks || _isQueuingNextBatch) {
+    if (userId == null || shouldAbortQueuingTasks) {
+      return;
+    }
+    if (_isQueuingNextBatch) {
+      _pendingBackupDrainUpdate = update;
       return;
     }
 
     _isQueuingNextBatch = true;
     try {
-      final active = await _uploadRepository.getActiveTasks(kBackupGroup);
-      if (active.any((task) => task.taskId != update.task.taskId)) {
+      final active = await _getActiveBackupTasks();
+      if (active.any((task) => task.group != update.task.group || task.taskId != update.task.taskId)) {
         // Other tasks of this batch are still uploading; the next batch is
         // queued when the last one completes. (The just-completed task may still
         // be reported active depending on update ordering, so ignore it.)
@@ -344,7 +363,12 @@ class BackgroundUploadService {
     } catch (error, stackTrace) {
       _logger.severe("Failed to enqueue next backup batch", error, stackTrace);
     } finally {
+      final pendingUpdate = _pendingBackupDrainUpdate;
+      _pendingBackupDrainUpdate = null;
       _isQueuingNextBatch = false;
+      if (pendingUpdate != null) {
+        await _maybeQueueNextBackupBatch(pendingUpdate);
+      }
     }
   }
 

--- a/mobile/test/providers/backup/drift_backup_provider_test.dart
+++ b/mobile/test/providers/backup/drift_backup_provider_test.dart
@@ -107,11 +107,11 @@ void main() {
     when(
       () => backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup),
     ).thenAnswer((_) async => [livePhotoStillTask]);
-    when(() => backgroundUploadService.resume()).thenAnswer((_) async {});
+    when(() => backgroundUploadService.resume('user-1')).thenAnswer((_) async {});
 
     await sut.startBackup('user-1');
 
-    verify(() => backgroundUploadService.resume()).called(1);
+    verify(() => backgroundUploadService.resume('user-1')).called(1);
     verifyNever(() => backgroundUploadService.uploadBackupCandidates('user-1'));
   });
 

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -691,12 +692,12 @@ void main() {
       when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
     }
 
-    UploadTask backupTask(String id) => UploadTask(
+    UploadTask backupTask(String id, {String group = kBackupGroup}) => UploadTask(
       taskId: id,
       url: 'http://test-server.com/assets',
       filename: '$id.jpg',
       baseDirectory: BaseDirectory.temporary,
-      group: kBackupGroup,
+      group: group,
     );
 
     setUp(() {
@@ -707,6 +708,7 @@ void main() {
         final tasks = invocation.positionalArguments.first as List;
         return List<bool>.filled(tasks.length, true);
       });
+      when(() => mockUploadRepository.getActiveTasks(kBackupLivePhotoGroup)).thenAnswer((_) async => <Task>[]);
     });
 
     tearDown(() => debugDefaultTargetPlatformOverride = null);
@@ -762,6 +764,63 @@ void main() {
 
       // a1 finishes and the queue drains -> next batch enqueues a2 only.
       capturedStatusCallback()(TaskStatusUpdate(backupTask(a1.id), TaskStatus.complete));
+      await pumpEventQueue();
+
+      final captured = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured;
+      expect(captured, hasLength(1));
+      expect((captured.single as List).cast<UploadTask>().map((t) => t.taskId), [a2.id]);
+    });
+
+    test('rechecks the drain when final callbacks overlap while a drain check is in progress', () async {
+      final a1 = LocalAssetStub.image1;
+      final a2 = LocalAssetStub.image2;
+      final a3 = LocalAssetStub.image1.copyWith(id: 'image3', name: 'image3.jpg');
+      stubUploadPath(a1);
+      stubUploadPath(a2);
+      stubUploadPath(a3);
+      sut.backupBatchSize = 2;
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => [a1, a2, a3]);
+
+      final firstDrainCheck = Completer<List<Task>>();
+      var activeCalls = 0;
+      when(() => mockUploadRepository.getActiveTasks(kBackupGroup)).thenAnswer((_) {
+        activeCalls++;
+        if (activeCalls == 1) {
+          return firstDrainCheck.future;
+        }
+        return Future.value(<Task>[]);
+      });
+
+      await sut.uploadBackupCandidates('user-1'); // enqueues a1 + a2
+
+      final onStatus = capturedStatusCallback();
+      onStatus(TaskStatusUpdate(backupTask(a1.id), TaskStatus.complete));
+      onStatus(TaskStatusUpdate(backupTask(a2.id), TaskStatus.complete));
+      firstDrainCheck.complete([backupTask(a2.id)]);
+      await pumpEventQueue();
+
+      expect(activeCalls, 2);
+      verify(() => mockUploadRepository.enqueueBackgroundAll(any())).called(2);
+    });
+
+    test('resume arms continuation from live photo still tasks and skips them after they finish', () async {
+      final a1 = LocalAssetStub.image1; // already uploading in kBackupLivePhotoGroup
+      final a2 = LocalAssetStub.image2; // the next asset to enqueue
+      stubUploadPath(a2);
+      sut.backupBatchSize = 1;
+      when(() => mockUploadRepository.start()).thenAnswer((_) async {});
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => [a1, a2]);
+
+      when(() => mockUploadRepository.getActiveTasks(kBackupGroup)).thenAnswer((_) async => <Task>[]);
+      var livePhotoActiveCalls = 0;
+      when(() => mockUploadRepository.getActiveTasks(kBackupLivePhotoGroup)).thenAnswer((_) async {
+        livePhotoActiveCalls++;
+        return livePhotoActiveCalls == 1 ? [backupTask(a1.id, group: kBackupLivePhotoGroup)] : <Task>[];
+      });
+
+      await sut.resume('user-1'); // seeds {a1}, arms continuation from the live-photo still group
+
+      capturedStatusCallback()(TaskStatusUpdate(backupTask(a1.id, group: kBackupLivePhotoGroup), TaskStatus.complete));
       await pumpEventQueue();
 
       final captured = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured;

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -681,4 +681,111 @@ void main() {
       expect(task.requiresWiFi, isFalse);
     });
   });
+
+  group('backup batch continuation', () {
+    void stubUploadPath(LocalAsset asset) {
+      final entity = MockAssetEntity();
+      when(() => entity.isLivePhoto).thenReturn(false);
+      when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => entity);
+      when(() => mockStorageRepository.getFileForAsset(asset.id)).thenAnswer((_) async => File('/tmp/${asset.id}.jpg'));
+      when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
+    }
+
+    UploadTask backupTask(String id) => UploadTask(
+      taskId: id,
+      url: 'http://test-server.com/assets',
+      filename: '$id.jpg',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+    );
+
+    setUp(() {
+      // Android keeps enqueueTasks to a single enqueueBackgroundAll call.
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((invocation) async {
+        final tasks = invocation.positionalArguments.first as List;
+        return List<bool>.filled(tasks.length, true);
+      });
+    });
+
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('does not re-enqueue assets already enqueued in the same session', () async {
+      final a1 = LocalAssetStub.image1;
+      final a2 = LocalAssetStub.image2;
+      stubUploadPath(a1);
+      stubUploadPath(a2);
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => [a1, a2]);
+
+      await sut.uploadBackupCandidates('user-1'); // enqueues a1 + a2
+      await sut.uploadBackupCandidates('user-1'); // same candidates, already enqueued -> no-op
+
+      verify(() => mockUploadRepository.enqueueBackgroundAll(any())).called(1);
+    });
+
+    test('enqueues the next batch once the upload queue drains', () async {
+      final a1 = LocalAssetStub.image1;
+      final a2 = LocalAssetStub.image2;
+      stubUploadPath(a1);
+      stubUploadPath(a2);
+      sut.backupBatchSize = 1;
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => [a1, a2]);
+      when(() => mockUploadRepository.getActiveTasks(kBackupGroup)).thenAnswer((_) async => <Task>[]);
+
+      await sut.uploadBackupCandidates('user-1'); // enqueues a1 only (batch size 1)
+
+      // a1 finishes and the queue is now empty -> the next batch (a2) is enqueued.
+      capturedStatusCallback()(TaskStatusUpdate(backupTask(a1.id), TaskStatus.complete));
+      await pumpEventQueue();
+
+      verify(() => mockBackupRepository.getCandidates('user-1')).called(2);
+      verify(() => mockUploadRepository.enqueueBackgroundAll(any())).called(2);
+    });
+
+    test('resume arms continuation and skips assets already in flight', () async {
+      final a1 = LocalAssetStub.image1; // already uploading (resumed)
+      final a2 = LocalAssetStub.image2; // the next asset to enqueue
+      stubUploadPath(a2);
+      sut.backupBatchSize = 1;
+      when(() => mockUploadRepository.start()).thenAnswer((_) async {});
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => [a1, a2]);
+
+      var activeCalls = 0;
+      when(() => mockUploadRepository.getActiveTasks(kBackupGroup)).thenAnswer((_) async {
+        activeCalls++;
+        // First call (resume seeding) sees a1 in flight; later (drain check) empty.
+        return activeCalls == 1 ? [backupTask(a1.id)] : <Task>[];
+      });
+
+      await sut.resume('user-1'); // seeds {a1}, arms continuation
+
+      // a1 finishes and the queue drains -> next batch enqueues a2 only.
+      capturedStatusCallback()(TaskStatusUpdate(backupTask(a1.id), TaskStatus.complete));
+      await pumpEventQueue();
+
+      final captured = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured;
+      expect(captured, hasLength(1));
+      expect((captured.single as List).cast<UploadTask>().map((t) => t.taskId), [a2.id]);
+    });
+
+    test('does not enqueue the next batch while tasks are still active', () async {
+      final a1 = LocalAssetStub.image1;
+      final a2 = LocalAssetStub.image2;
+      stubUploadPath(a1);
+      stubUploadPath(a2);
+      sut.backupBatchSize = 1;
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => [a1, a2]);
+      when(
+        () => mockUploadRepository.getActiveTasks(kBackupGroup),
+      ).thenAnswer((_) async => [backupTask('still-running')]);
+
+      await sut.uploadBackupCandidates('user-1'); // enqueues a1
+
+      capturedStatusCallback()(TaskStatusUpdate(backupTask(a1.id), TaskStatus.complete));
+      await pumpEventQueue();
+
+      verify(() => mockUploadRepository.enqueueBackgroundAll(any())).called(1);
+    });
+  });
 }


### PR DESCRIPTION
## Problem

On iOS, backup stalls ~100 items at a time. With a large backlog (reported: ~7800 queued) it looks stuck after each batch.

## Root cause

On iOS, **all** backup (foreground and background) routes through `startBackupWithURLSession` → `BackgroundUploadService.uploadBackupCandidates`, which:
- enqueues only `candidates.take(100)` per call (`background_upload.service.dart`), and
- has **no continuation** — the completion handler (`_handleTaskStatusUpdate`) never enqueues the next batch when the queue drains.

The next 100 is only enqueued the next time `startBackup` is invoked — app-resume/lifecycle events (`app_life_cycle.provider.dart`) and background-worker wakes (`background_worker.service.dart`). iOS schedules background wakes sparsely, so a backlog drains ~100 per wake and appears stalled. (Pre-existing; unrelated to the background-worker crash fix in #657.)

## Fix

**Chain batches on drain:** when a backup task reaches a terminal state and the upload queue (`kBackupGroup`) has drained, enqueue the next batch — repeating until candidates are exhausted. A single trigger now works through the entire backlog (continuously while foregrounded, and as far as each background wake's window allows) instead of stopping after one batch.

**Avoid duplicate uploads:** `getCandidates` only drops an asset once it appears locally as a *remote* asset (populated by **sync**, not at upload time), so naively re-querying would re-enqueue the just-finished batch. The service now tracks asset IDs enqueued during the session (`_enqueuedAssetIds`) and skips them in subsequent batches; the set is cleared when the backlog is exhausted or backup is cancelled. Server-side checksum dedup is the backstop.

**Conservative scoping:** chaining is armed only by `uploadBackupCandidates`, not the `resume()` path — so cold-start resume keeps its existing sync-first behavior and gains no new duplicate risk. Batch concurrency on iOS still respects the 100-at-a-time URLSession limit; we just queue the next 100 as the prior batch finishes.

## Tests

`background_upload.service_test.dart` — new `backup batch continuation` group:
- does not re-enqueue assets already enqueued in the same session,
- enqueues the next batch once the upload queue drains,
- does not enqueue the next batch while tasks are still active.

`dart analyze --fatal-infos lib test` clean · `dart format` clean · full `flutter test` green (1468 passed). All 23 pre-existing service tests still pass.

## Validation
Behavior is proven by the unit-tested chaining invariants. On-device: with the build installed, foreground backup should now drain the full backlog continuously rather than stopping at ~100.