### PR TITLE
fix(mobile): iOS foreground reconnect on resume + reliable full background backup

### DIFF
--- a/docs/plans/2026-06-02-ios-full-backup-tdd.md
+++ b/docs/plans/2026-06-02-ios-full-backup-tdd.md
@@ -1,0 +1,1470 @@
+# iOS Full Backup TDD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make iOS URLSession backup reliable for full-library backups with thousands of assets, independent of UI navigation, without reintroducing the TestFlight crash during background worker teardown.
+
+**Architecture:** Treat iOS background backup as an explicit queue session owned by a coordinator. The coordinator owns queued, completed, failed, skipped, and enqueue-failed local asset IDs for the session; it refills bounded URLSession batches when both backup groups drain; and it records persisted progress from session state instead of per-task service callbacks. `BackgroundUploadService` only builds/enqueues bounded batches and reports exact enqueue results.
+
+**Tech Stack:** Flutter/Dart, Riverpod StateNotifier, `background_downloader`, Drift repositories, `flutter_test`, `mocktail`, existing background backup status persistence.
+
+---
+
+## Root Cause And Required Contract
+
+Device logs showed uploads themselves were healthy: `nsurlsessiond` sent requests, returned `response_status=200`/`201`, and completed tasks for `de.opennoodle.gallery`. The failure was lifecycle ownership: after native URLSession outstanding tasks reached `0`, new candidates were queued only when a UI path called `startBackupWithURLSession()` again. A full backup must instead satisfy this invariant:
+
+```text
+While an iOS backup session is active:
+  if both backup URLSession groups have no active tasks,
+  and there are eligible candidates not already handled by this session,
+  enqueue exactly one next bounded batch without relying on UI navigation.
+```
+
+The coordinator must exclude these IDs during the current session:
+
+- queued IDs: native URLSession owns them now.
+- completed IDs: remote sync may not yet have removed them from `getCandidates()`.
+- failed upload IDs: avoid immediate retry loops in the same session.
+- skipped IDs: asset entity/file was unavailable in this session.
+- enqueue-failed IDs: `enqueueAll` returned `false` for them.
+
+## File Structure
+
+- Create: `mobile/lib/services/background_backup_queue_coordinator.dart`
+  - Owns iOS backup session lifecycle and refill decisions.
+  - Tracks session exclusion sets.
+  - Serializes refill checks so concurrent terminal callbacks cannot enqueue duplicate batches.
+  - Records status progress from session state.
+
+- Create: `mobile/test/services/background_backup_queue_coordinator_test.dart`
+  - Pure fake-driven tests for 3,517 assets, UI-independent refill, restart, concurrent callbacks, cancellation, failed tasks, enqueue failures, skipped files, and Live Photos.
+
+- Modify: `mobile/lib/services/background_upload.service.dart`
+  - Implements `BackgroundBackupQueuePort`.
+  - Adds `BackgroundBackupQueueResult`.
+  - Adds `enqueueNextBackupBatch()` with exact bounded-batch semantics.
+  - Keeps existing task construction and iOS notification behavior.
+
+- Modify: `mobile/test/services/background_upload.service_test.dart`
+  - Adds result semantics coverage for excluded IDs, empty filtered candidates, skipped files, and mixed native enqueue results.
+
+- Modify: `mobile/lib/providers/backup/drift_backup.provider.dart`
+  - Delegates iOS queue lifecycle to the coordinator.
+  - Keeps foreground upload and UI state updates.
+
+- Create: `mobile/lib/providers/backup/background_backup_queue.provider.dart`
+  - Provides `BackgroundBackupQueueCoordinator` without a provider/service import cycle.
+
+- Modify: `mobile/test/providers/backup/drift_backup_provider_test.dart`
+  - Verifies iOS provider delegation and no UI-count refresh dependency.
+
+- Modify: `mobile/lib/services/background_backup_status.service.dart`
+  - Adds queue progress methods used by the coordinator.
+
+- Modify: `mobile/lib/domain/models/background_backup_status.model.dart`
+  - Adds queued/completed/failed/skipped/enqueue-failed/remaining/full-complete fields.
+
+- Modify: `mobile/test/services/background_backup_status.service_test.dart`
+  - Tests persistence semantics for large in-progress backups.
+
+- Modify: `mobile/test/domain/models/background_backup_status_model_test.dart`
+  - Tests serialization defaults and round trips for new fields.
+
+- Create: `mobile/tool/observe_ios_background_backup.sh`
+  - Filters device logs for Noodle-specific URLSession activity.
+
+---
+
+### Task 1: Add Exact Bounded-Batch Result Semantics
+
+**Files:**
+
+- Modify: `mobile/lib/services/background_upload.service.dart`
+- Modify: `mobile/test/services/background_upload.service_test.dart`
+
+- [ ] **Step 1: Write failing tests for bounded batch results**
+
+Add these tests to `mobile/test/services/background_upload.service_test.dart` inside `group('background backup status recording', ...)`:
+
+```dart
+test('enqueueNextBackupBatch queues one bounded eligible batch and reports exact counts', () async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  sut.backupBatchSize = 100;
+  final candidates = List.generate(
+    250,
+    (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+  );
+  final mockEntity = MockAssetEntity();
+  when(() => mockEntity.isLivePhoto).thenReturn(false);
+
+  when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+  when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+  when(() => mockUploadRepository.disableHoldingQueue()).thenAnswer((_) async {});
+  when(() => mockUploadRepository.restoreDefaultHoldingQueue()).thenAnswer((_) async {});
+  when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((invocation) async {
+    final tasks = invocation.positionalArguments.single as List<UploadTask>;
+    return List.filled(tasks.length, true);
+  });
+  when(() => mockUploadRepository.updateNotification(any(), TaskStatus.enqueued)).thenAnswer((_) async {});
+
+  for (final asset in candidates) {
+    when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
+    when(() => mockStorageRepository.getFileForAsset(asset.id)).thenAnswer((_) async => File('/path/${asset.id}.jpg'));
+    when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
+  }
+
+  final result = await sut.enqueueNextBackupBatch(
+    'user-1',
+    excludedLocalAssetIds: {'asset-0', 'asset-1'},
+  );
+
+  final batch = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured.single as List<UploadTask>;
+  expect(batch.map((task) => task.taskId), List.generate(100, (index) => 'asset-${index + 2}'));
+  expect(result.totalCandidateCount, 250);
+  expect(result.eligibleCandidateCount, 248);
+  expect(result.enqueuedLocalAssetIds, List.generate(100, (index) => 'asset-${index + 2}'));
+  expect(result.skippedLocalAssetIds, isEmpty);
+  expect(result.enqueueFailedLocalAssetIds, isEmpty);
+  expect(result.remainingEligibleCandidateCount, 148);
+  expect(result.queuedAny, true);
+  expect(result.hasMoreEligibleCandidates, true);
+});
+
+test('enqueueNextBackupBatch does not loop when every candidate is excluded', () async {
+  sut.backupBatchSize = 100;
+  final candidates = List.generate(
+    3,
+    (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+  );
+
+  when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+  when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+
+  final result = await sut.enqueueNextBackupBatch(
+    'user-1',
+    excludedLocalAssetIds: {'asset-0', 'asset-1', 'asset-2'},
+  );
+
+  expect(result.totalCandidateCount, 3);
+  expect(result.eligibleCandidateCount, 0);
+  expect(result.enqueuedLocalAssetIds, isEmpty);
+  expect(result.remainingEligibleCandidateCount, 0);
+  expect(result.queuedAny, false);
+  expect(result.hasMoreEligibleCandidates, false);
+  verifyNever(() => mockUploadRepository.enqueueBackgroundAll(any()));
+});
+
+test('enqueueNextBackupBatch reports skipped files and mixed native enqueue failures', () async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  sut.backupBatchSize = 4;
+  final candidates = List.generate(
+    4,
+    (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+  );
+  final mockEntity = MockAssetEntity();
+  when(() => mockEntity.isLivePhoto).thenReturn(false);
+
+  when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+  when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+  when(() => mockUploadRepository.disableHoldingQueue()).thenAnswer((_) async {});
+  when(() => mockUploadRepository.restoreDefaultHoldingQueue()).thenAnswer((_) async {});
+  when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((_) async => [true, false, true]);
+  when(() => mockUploadRepository.updateNotification(any(), TaskStatus.enqueued)).thenAnswer((_) async {});
+
+  for (final asset in candidates) {
+    when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
+    when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
+  }
+  when(() => mockStorageRepository.getFileForAsset('asset-0')).thenAnswer((_) async => File('/path/asset-0.jpg'));
+  when(() => mockStorageRepository.getFileForAsset('asset-1')).thenAnswer((_) async => null);
+  when(() => mockStorageRepository.getFileForAsset('asset-2')).thenAnswer((_) async => File('/path/asset-2.jpg'));
+  when(() => mockStorageRepository.getFileForAsset('asset-3')).thenAnswer((_) async => File('/path/asset-3.jpg'));
+
+  final result = await sut.enqueueNextBackupBatch('user-1');
+
+  expect(result.enqueuedLocalAssetIds, ['asset-0', 'asset-3']);
+  expect(result.skippedLocalAssetIds, ['asset-1']);
+  expect(result.enqueueFailedLocalAssetIds, ['asset-2']);
+  expect(result.remainingEligibleCandidateCount, 0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/services/background_upload.service_test.dart --plain-name "enqueueNextBackupBatch"
+```
+
+Expected: FAIL because `enqueueNextBackupBatch`, `backupBatchSize`, and the new result fields do not exist.
+
+- [ ] **Step 3: Add result type and method**
+
+Add near `UploadTaskMetadata` in `mobile/lib/services/background_upload.service.dart`:
+
+```dart
+class BackgroundBackupQueueResult {
+  const BackgroundBackupQueueResult({
+    required this.totalCandidateCount,
+    required this.eligibleCandidateCount,
+    required this.enqueuedLocalAssetIds,
+    required this.skippedLocalAssetIds,
+    required this.enqueueFailedLocalAssetIds,
+    required this.remainingEligibleCandidateCount,
+  });
+
+  final int totalCandidateCount;
+  final int eligibleCandidateCount;
+  final List<String> enqueuedLocalAssetIds;
+  final List<String> skippedLocalAssetIds;
+  final List<String> enqueueFailedLocalAssetIds;
+  final int remainingEligibleCandidateCount;
+
+  int get enqueuedCount => enqueuedLocalAssetIds.length;
+  bool get queuedAny => enqueuedLocalAssetIds.isNotEmpty;
+  bool get hasMoreEligibleCandidates => remainingEligibleCandidateCount > 0;
+}
+```
+
+Add to `BackgroundUploadService`:
+
+```dart
+@visibleForTesting
+int backupBatchSize = 100;
+
+Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
+  String userId, {
+  Set<String> excludedLocalAssetIds = const {},
+}) async {
+  await _storageRepository.clearCache();
+  shouldAbortQueuingTasks = false;
+
+  final candidates = await _backupRepository.getCandidates(userId);
+  await _backgroundBackupStatusService.recordCandidateCount(candidates.length);
+
+  final eligibleCandidates = candidates
+      .where((candidate) => !excludedLocalAssetIds.contains(candidate.id))
+      .toList(growable: false);
+  final batchCandidates = eligibleCandidates.take(backupBatchSize).toList(growable: false);
+
+  final tasks = <UploadTask>[];
+  final skippedLocalAssetIds = <String>[];
+  for (final asset in batchCandidates) {
+    if (shouldAbortQueuingTasks) {
+      break;
+    }
+
+    final task = await getUploadTask(asset);
+    if (task == null) {
+      skippedLocalAssetIds.add(asset.id);
+      continue;
+    }
+    tasks.add(task);
+  }
+
+  if (tasks.isEmpty || shouldAbortQueuingTasks) {
+    return BackgroundBackupQueueResult(
+      totalCandidateCount: candidates.length,
+      eligibleCandidateCount: eligibleCandidates.length,
+      enqueuedLocalAssetIds: const [],
+      skippedLocalAssetIds: skippedLocalAssetIds,
+      enqueueFailedLocalAssetIds: const [],
+      remainingEligibleCandidateCount: eligibleCandidates.length - skippedLocalAssetIds.length,
+    );
+  }
+
+  final results = await enqueueTasks(tasks);
+  final enqueuedLocalAssetIds = <String>[];
+  final enqueueFailedLocalAssetIds = <String>[];
+
+  for (var i = 0; i < tasks.length; i++) {
+    final success = i < results.length && results[i];
+    if (success) {
+      enqueuedLocalAssetIds.add(tasks[i].taskId);
+    } else {
+      enqueueFailedLocalAssetIds.add(tasks[i].taskId);
+    }
+  }
+
+  return BackgroundBackupQueueResult(
+    totalCandidateCount: candidates.length,
+    eligibleCandidateCount: eligibleCandidates.length,
+    enqueuedLocalAssetIds: enqueuedLocalAssetIds,
+    skippedLocalAssetIds: skippedLocalAssetIds,
+    enqueueFailedLocalAssetIds: enqueueFailedLocalAssetIds,
+    remainingEligibleCandidateCount:
+        eligibleCandidates.length -
+        enqueuedLocalAssetIds.length -
+        skippedLocalAssetIds.length -
+        enqueueFailedLocalAssetIds.length,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/services/background_upload.service_test.dart --plain-name "enqueueNextBackupBatch"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/background_upload.service.dart mobile/test/services/background_upload.service_test.dart
+git commit -m "test(mobile): define bounded background backup enqueue results"
+```
+
+---
+
+### Task 2: Build The Coordinator With Full-Backup Red Tests First
+
+**Files:**
+
+- Create: `mobile/lib/services/background_backup_queue_coordinator.dart`
+- Create: `mobile/test/services/background_backup_queue_coordinator_test.dart`
+- Modify: `mobile/lib/services/background_upload.service.dart`
+
+- [ ] **Step 1: Write failing coordinator tests**
+
+Create `mobile/test/services/background_backup_queue_coordinator_test.dart`:
+
+```dart
+import 'dart:async';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/constants/constants.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+
+class FakeBackgroundUploadQueue implements BackgroundBackupQueuePort {
+  FakeBackgroundUploadQueue({Iterable<String> candidateIds = const []}) {
+    this.candidateIds.addAll(candidateIds);
+  }
+
+  final candidateIds = <String>[];
+  final activeTasks = <String, Task>{};
+  final queuedBatches = <List<String>>[];
+  final excludedSnapshots = <Set<String>>[];
+  final enqueueCompleter = <Completer<BackgroundBackupQueueResult>>[];
+  int resumeCalls = 0;
+  int cancelCalls = 0;
+  int batchSize = 100;
+  bool delayNextEnqueue = false;
+
+  @override
+  Future<List<Task>> getActiveTasks(String group) async {
+    return activeTasks.values.where((task) => task.group == group).toList(growable: false);
+  }
+
+  @override
+  Future<void> resume() async {
+    resumeCalls++;
+  }
+
+  @override
+  Future<int> cancel() async {
+    cancelCalls++;
+    activeTasks.clear();
+    return 0;
+  }
+
+  @override
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
+    String userId, {
+    Set<String> excludedLocalAssetIds = const {},
+  }) async {
+    excludedSnapshots.add(Set<String>.from(excludedLocalAssetIds));
+    if (delayNextEnqueue) {
+      final completer = Completer<BackgroundBackupQueueResult>();
+      enqueueCompleter.add(completer);
+      return completer.future;
+    }
+
+    final eligibleIds = candidateIds.where((id) => !excludedLocalAssetIds.contains(id)).toList(growable: false);
+    final ids = eligibleIds.take(batchSize).toList(growable: false);
+    queuedBatches.add(ids);
+    for (final id in ids) {
+      activeTasks[id] = UploadTask(
+        taskId: id,
+        url: 'http://test-server.com/assets',
+        filename: '$id.jpg',
+        baseDirectory: BaseDirectory.temporary,
+        group: kBackupGroup,
+      );
+    }
+
+    return BackgroundBackupQueueResult(
+      totalCandidateCount: candidateIds.length,
+      eligibleCandidateCount: eligibleIds.length,
+      enqueuedLocalAssetIds: ids,
+      skippedLocalAssetIds: const [],
+      enqueueFailedLocalAssetIds: const [],
+      remainingEligibleCandidateCount: eligibleIds.length - ids.length,
+    );
+  }
+
+  void completeDelayedEnqueue(BackgroundBackupQueueResult result) {
+    enqueueCompleter.removeAt(0).complete(result);
+  }
+}
+
+void main() {
+  test('start resumes existing URLSession tasks instead of enqueueing duplicates', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-1']);
+    queue.activeTasks['asset-1'] = UploadTask(
+      taskId: 'asset-1',
+      url: 'http://test-server.com/assets',
+      filename: 'asset-1.jpg',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+    );
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    expect(queue.resumeCalls, 1);
+    expect(queue.queuedBatches, isEmpty);
+  });
+
+  test('full backup refills 3517 assets without UI calls and excludes completed ids until session ends', () async {
+    final queue = FakeBackgroundUploadQueue(
+      candidateIds: List.generate(3517, (index) => 'asset-$index'),
+    );
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    while (queue.activeTasks.isNotEmpty) {
+      final task = queue.activeTasks.values.first;
+      queue.activeTasks.remove(task.taskId);
+      await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete));
+    }
+
+    expect(queue.queuedBatches, hasLength(36));
+    expect(queue.queuedBatches.take(35).every((batch) => batch.length == 100), true);
+    expect(queue.queuedBatches.last, hasLength(17));
+    expect(queue.queuedBatches.expand((batch) => batch).toSet(), hasLength(3517));
+    expect(queue.excludedSnapshots.last, containsAll(List.generate(3517, (index) => 'asset-$index')));
+  });
+
+  test('concurrent terminal callbacks trigger at most one refill', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1', 'asset-2'])
+      ..batchSize = 2;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+    await sut.start('user-1');
+
+    final first = queue.activeTasks.remove('asset-0')!;
+    final second = queue.activeTasks.remove('asset-1')!;
+
+    await Future.wait([
+      sut.handleStatus(TaskStatusUpdate(first, TaskStatus.complete)),
+      sut.handleStatus(TaskStatusUpdate(second, TaskStatus.complete)),
+    ]);
+
+    expect(queue.queuedBatches, [
+      ['asset-0', 'asset-1'],
+      ['asset-2'],
+    ]);
+  });
+
+  test('stop during delayed enqueue prevents delayed results from keeping session active', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0'])..delayNextEnqueue = true;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    final start = sut.start('user-1');
+    await Future<void>.delayed(Duration.zero);
+    await sut.stop();
+    queue.completeDelayedEnqueue(
+      const BackgroundBackupQueueResult(
+        totalCandidateCount: 1,
+        eligibleCandidateCount: 1,
+        enqueuedLocalAssetIds: ['asset-0'],
+        skippedLocalAssetIds: [],
+        enqueueFailedLocalAssetIds: [],
+        remainingEligibleCandidateCount: 0,
+      ),
+    );
+    await start;
+
+    expect(queue.cancelCalls, 1);
+    expect(sut.isActive, false);
+  });
+
+  test('live photo motion completion does not refill until the still task completes', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-live', 'asset-next']);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    final motionTask = UploadTask(
+      taskId: 'asset-live',
+      url: 'http://test-server.com/assets',
+      filename: 'asset-live.mov',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+      metaData: const UploadTaskMetadata(localAssetId: 'asset-live', isLivePhotos: true, livePhotoVideoId: '').toJson(),
+    );
+    final stillTask = UploadTask(
+      taskId: 'asset-live',
+      url: 'http://test-server.com/assets',
+      filename: 'asset-live.heic',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupLivePhotoGroup,
+    );
+    queue.activeTasks[motionTask.taskId] = motionTask;
+    queue.activeTasks['asset-live-still'] = stillTask;
+
+    await sut.start('user-1');
+    queue.activeTasks.remove(motionTask.taskId);
+    await sut.handleStatus(TaskStatusUpdate(motionTask, TaskStatus.complete));
+    expect(queue.queuedBatches, isEmpty);
+
+    queue.activeTasks.remove('asset-live-still');
+    await sut.handleStatus(TaskStatusUpdate(stillTask, TaskStatus.complete));
+    expect(queue.queuedBatches, hasLength(1));
+  });
+
+  test('failed uploads are excluded from immediate same-session retry', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])
+      ..batchSize = 1;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+    final failedTask = queue.activeTasks.remove('asset-0')!;
+    await sut.handleStatus(TaskStatusUpdate(failedTask, TaskStatus.failed));
+
+    expect(queue.queuedBatches, [
+      ['asset-0'],
+      ['asset-1'],
+    ]);
+    expect(queue.excludedSnapshots.last, contains('asset-0'));
+  });
+
+  test('skipped and enqueue-failed ids are excluded from the next refill', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1', 'asset-2']);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    queue.delayNextEnqueue = true;
+    final start = sut.start('user-1');
+    await Future<void>.delayed(Duration.zero);
+    queue.delayNextEnqueue = false;
+    queue.completeDelayedEnqueue(
+      const BackgroundBackupQueueResult(
+        totalCandidateCount: 3,
+        eligibleCandidateCount: 3,
+        enqueuedLocalAssetIds: ['asset-0'],
+        skippedLocalAssetIds: ['asset-1'],
+        enqueueFailedLocalAssetIds: ['asset-2'],
+        remainingEligibleCandidateCount: 0,
+      ),
+    );
+    await start;
+
+    final task = queue.activeTasks.remove('asset-0')!;
+    await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete));
+
+    expect(queue.excludedSnapshots.last, containsAll(['asset-0', 'asset-1', 'asset-2']));
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/services/background_backup_queue_coordinator_test.dart
+```
+
+Expected: FAIL because the coordinator and port do not exist.
+
+- [ ] **Step 3: Implement coordinator and port**
+
+Create `mobile/lib/services/background_backup_queue_coordinator.dart`:
+
+```dart
+import 'dart:async';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:immich_mobile/constants/constants.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+import 'package:logging/logging.dart';
+
+abstract interface class BackgroundBackupQueuePort {
+  Future<List<Task>> getActiveTasks(String group);
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
+    String userId, {
+    Set<String> excludedLocalAssetIds,
+  });
+  Future<void> resume();
+  Future<int> cancel();
+}
+
+class BackgroundBackupQueueCoordinator {
+  BackgroundBackupQueueCoordinator(this._queue);
+
+  final BackgroundBackupQueuePort _queue;
+  final Logger _logger = Logger('BackgroundBackupQueueCoordinator');
+
+  String? _activeUserId;
+  int _sessionGeneration = 0;
+  Future<void>? _refillTail;
+  final Set<String> _queuedLocalAssetIds = {};
+  final Set<String> _completedLocalAssetIds = {};
+  final Set<String> _failedLocalAssetIds = {};
+  final Set<String> _skippedLocalAssetIds = {};
+  final Set<String> _enqueueFailedLocalAssetIds = {};
+
+  bool get isActive => _activeUserId != null;
+
+  Future<void> start(String userId) async {
+    _activeUserId = userId;
+    final generation = ++_sessionGeneration;
+
+    final activeTasks = await _activeTasks();
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
+
+    if (activeTasks.isNotEmpty) {
+      _queuedLocalAssetIds.addAll(activeTasks.map((task) => task.taskId));
+      _logger.info('Resuming ${activeTasks.length} active background backup tasks');
+      await _queue.resume();
+      return;
+    }
+
+    await _enqueueNextBatch(userId, generation);
+  }
+
+  Future<void> stop() async {
+    _activeUserId = null;
+    _sessionGeneration++;
+    _clearSessionSets();
+    await _queue.cancel();
+  }
+
+  Future<void> handleStatus(TaskStatusUpdate update) {
+    final userId = _activeUserId;
+    if (userId == null || !_isBackupTask(update.task)) {
+      return Future.value();
+    }
+    final generation = _sessionGeneration;
+    _refillTail = (_refillTail ?? Future.value()).then((_) async {
+      _recordTerminalStatus(update);
+      await _refillIfDrained(userId, generation);
+    });
+    return _refillTail!;
+  }
+
+  void _recordTerminalStatus(TaskStatusUpdate update) {
+    switch (update.status) {
+      case TaskStatus.complete:
+        if (!_isLivePhotoMotionTask(update.task)) {
+          _queuedLocalAssetIds.remove(update.task.taskId);
+          _completedLocalAssetIds.add(update.task.taskId);
+        }
+        break;
+      case TaskStatus.failed:
+      case TaskStatus.notFound:
+      case TaskStatus.canceled:
+        _queuedLocalAssetIds.remove(update.task.taskId);
+        _failedLocalAssetIds.add(update.task.taskId);
+        break;
+      default:
+        break;
+    }
+  }
+
+  Future<void> _refillIfDrained(String userId, int generation) async {
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
+
+    final activeTasks = await _activeTasks();
+    if (!_isCurrentSession(userId, generation) || activeTasks.isNotEmpty) {
+      return;
+    }
+
+    await _enqueueNextBatch(userId, generation);
+  }
+
+  Future<void> _enqueueNextBatch(String userId, int generation) async {
+    final result = await _queue.enqueueNextBackupBatch(
+      userId,
+      excludedLocalAssetIds: _excludedLocalAssetIds(),
+    );
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
+
+    _queuedLocalAssetIds.addAll(result.enqueuedLocalAssetIds);
+    _skippedLocalAssetIds.addAll(result.skippedLocalAssetIds);
+    _enqueueFailedLocalAssetIds.addAll(result.enqueueFailedLocalAssetIds);
+
+    if (!result.queuedAny && !result.hasMoreEligibleCandidates) {
+      _activeUserId = null;
+    }
+  }
+
+  Set<String> _excludedLocalAssetIds() {
+    return {
+      ..._queuedLocalAssetIds,
+      ..._completedLocalAssetIds,
+      ..._failedLocalAssetIds,
+      ..._skippedLocalAssetIds,
+      ..._enqueueFailedLocalAssetIds,
+    };
+  }
+
+  Future<List<Task>> _activeTasks() async {
+    final groups = await Future.wait([
+      _queue.getActiveTasks(kBackupGroup),
+      _queue.getActiveTasks(kBackupLivePhotoGroup),
+    ]);
+    return groups.expand((group) => group).toList(growable: false);
+  }
+
+  bool _isCurrentSession(String userId, int generation) {
+    return _activeUserId == userId && _sessionGeneration == generation;
+  }
+
+  bool _isBackupTask(Task task) {
+    return task.group == kBackupGroup || task.group == kBackupLivePhotoGroup;
+  }
+
+  bool _isLivePhotoMotionTask(Task task) {
+    if (task.group != kBackupGroup || task.metaData.isEmpty) {
+      return false;
+    }
+    try {
+      return UploadTaskMetadata.fromJson(task.metaData).isLivePhotos;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void _clearSessionSets() {
+    _queuedLocalAssetIds.clear();
+    _completedLocalAssetIds.clear();
+    _failedLocalAssetIds.clear();
+    _skippedLocalAssetIds.clear();
+    _enqueueFailedLocalAssetIds.clear();
+  }
+}
+```
+
+Modify `mobile/lib/services/background_upload.service.dart`:
+
+```dart
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+
+class BackgroundUploadService implements BackgroundBackupQueuePort {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/services/background_backup_queue_coordinator_test.dart test/services/background_upload.service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/background_backup_queue_coordinator.dart mobile/lib/services/background_upload.service.dart mobile/test/services/background_backup_queue_coordinator_test.dart
+git commit -m "feat(mobile): coordinate full iOS background backup sessions"
+```
+
+---
+
+### Task 3: Persist Large-Backup Progress From Coordinator State
+
+**Files:**
+
+- Modify: `mobile/lib/domain/models/background_backup_status.model.dart`
+- Modify: `mobile/lib/services/background_backup_status.service.dart`
+- Modify: `mobile/lib/services/background_backup_queue_coordinator.dart`
+- Modify: `mobile/test/services/background_backup_status.service_test.dart`
+- Modify: `mobile/test/domain/models/background_backup_status_model_test.dart`
+- Modify: `mobile/test/services/background_backup_queue_coordinator_test.dart`
+
+- [ ] **Step 1: Write failing status persistence tests**
+
+Add to `mobile/test/services/background_backup_status.service_test.dart`:
+
+```dart
+test('recordQueueProgress keeps remaining count nonzero during large backup successes', () async {
+  await sut.recordCandidateCount(3340);
+  await sut.recordQueueProgress(
+    queuedCount: 100,
+    completedCount: 1,
+    failedCount: 0,
+    skippedCount: 0,
+    enqueueFailedCount: 0,
+    remainingCount: 3239,
+  );
+
+  final status = await sut.read();
+
+  expect(status.lastQueuedCount, 100);
+  expect(status.lastCompletedCount, 1);
+  expect(status.lastFailedCount, 0);
+  expect(status.lastSkippedCount, 0);
+  expect(status.lastEnqueueFailedCount, 0);
+  expect(status.lastRemainingCount, 3239);
+  expect(status.lastCandidateCount, 3340);
+});
+
+test('recordBackupComplete clears pending counts only when no eligible candidates remain', () async {
+  await sut.recordCandidateCount(17);
+  await sut.recordQueueProgress(
+    queuedCount: 17,
+    completedCount: 17,
+    failedCount: 0,
+    skippedCount: 0,
+    enqueueFailedCount: 0,
+    remainingCount: 0,
+  );
+  await sut.recordBackupComplete();
+
+  final status = await sut.read();
+
+  expect(status.lastCandidateCount, 0);
+  expect(status.lastRemainingCount, 0);
+  expect(status.lastFullBackupCompletedAt, isNotNull);
+});
+```
+
+Add to `mobile/test/domain/models/background_backup_status_model_test.dart`:
+
+```dart
+test('serializes large backup progress fields', () {
+  final status = BackgroundBackupStatus(
+    lastQueuedCount: 100,
+    lastCompletedCount: 50,
+    lastFailedCount: 2,
+    lastSkippedCount: 3,
+    lastEnqueueFailedCount: 4,
+    lastRemainingCount: 3340,
+    lastQueueDrainedAt: DateTime.utc(2026, 6, 2, 10),
+    lastFullBackupCompletedAt: DateTime.utc(2026, 6, 2, 11),
+  );
+
+  final roundTrip = BackgroundBackupStatus.fromJson(status.toJson());
+
+  expect(roundTrip.lastQueuedCount, 100);
+  expect(roundTrip.lastCompletedCount, 50);
+  expect(roundTrip.lastFailedCount, 2);
+  expect(roundTrip.lastSkippedCount, 3);
+  expect(roundTrip.lastEnqueueFailedCount, 4);
+  expect(roundTrip.lastRemainingCount, 3340);
+  expect(roundTrip.lastQueueDrainedAt, DateTime.utc(2026, 6, 2, 10));
+  expect(roundTrip.lastFullBackupCompletedAt, DateTime.utc(2026, 6, 2, 11));
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/services/background_backup_status.service_test.dart test/domain/models/background_backup_status_model_test.dart
+```
+
+Expected: FAIL because the new fields and methods do not exist.
+
+- [ ] **Step 3: Add model fields**
+
+Add to `BackgroundBackupStatus` in `mobile/lib/domain/models/background_backup_status.model.dart`:
+
+```dart
+final int lastQueuedCount;
+final int lastCompletedCount;
+final int lastFailedCount;
+final int lastSkippedCount;
+final int lastEnqueueFailedCount;
+final int lastRemainingCount;
+final DateTime? lastQueueDrainedAt;
+final DateTime? lastFullBackupCompletedAt;
+```
+
+Add constructor defaults:
+
+```dart
+this.lastQueuedCount = 0,
+this.lastCompletedCount = 0,
+this.lastFailedCount = 0,
+this.lastSkippedCount = 0,
+this.lastEnqueueFailedCount = 0,
+this.lastRemainingCount = 0,
+this.lastQueueDrainedAt,
+this.lastFullBackupCompletedAt,
+```
+
+Update `copyWith`, `toJson`, and `fromJson` using exact JSON keys:
+
+```dart
+'lastQueuedCount': lastQueuedCount,
+'lastCompletedCount': lastCompletedCount,
+'lastFailedCount': lastFailedCount,
+'lastSkippedCount': lastSkippedCount,
+'lastEnqueueFailedCount': lastEnqueueFailedCount,
+'lastRemainingCount': lastRemainingCount,
+'lastQueueDrainedAt': lastQueueDrainedAt?.toIso8601String(),
+'lastFullBackupCompletedAt': lastFullBackupCompletedAt?.toIso8601String(),
+```
+
+- [ ] **Step 4: Add status service methods**
+
+Add to `BackgroundBackupStatusService`:
+
+```dart
+Future<void> recordQueueProgress({
+  required int queuedCount,
+  required int completedCount,
+  required int failedCount,
+  required int skippedCount,
+  required int enqueueFailedCount,
+  required int remainingCount,
+}) {
+  return _mutate(
+    (current) => current.copyWith(
+      lastQueuedCount: queuedCount,
+      lastCompletedCount: completedCount,
+      lastFailedCount: failedCount,
+      lastSkippedCount: skippedCount,
+      lastEnqueueFailedCount: enqueueFailedCount,
+      lastRemainingCount: remainingCount,
+      lastUploadEnqueueAt: queuedCount > current.lastQueuedCount ? _now() : current.lastUploadEnqueueAt,
+      lastUploadSuccessAt: completedCount > current.lastCompletedCount ? _now() : current.lastUploadSuccessAt,
+      lastBackgroundFailureReason: failedCount > current.lastFailedCount
+          ? BackgroundBackupFailureReason.uploadFailed
+          : BackgroundBackupFailureReason.none,
+    ),
+  );
+}
+
+Future<void> recordQueueDrained({required int remainingCount}) {
+  return _mutate((current) => current.copyWith(lastQueueDrainedAt: _now(), lastRemainingCount: remainingCount));
+}
+
+Future<void> recordBackupComplete() {
+  return _mutate(
+    (current) => current.copyWith(
+      lastFullBackupCompletedAt: _now(),
+      lastCandidateCount: 0,
+      lastRemainingCount: 0,
+      lastBackgroundFailureReason: BackgroundBackupFailureReason.none,
+    ),
+  );
+}
+```
+
+- [ ] **Step 5: Move progress recording into the coordinator**
+
+Extend `BackgroundBackupQueueCoordinator` constructor:
+
+```dart
+BackgroundBackupQueueCoordinator(this._queue, {BackgroundBackupStatusService? statusService})
+  : _statusService = statusService;
+
+final BackgroundBackupStatusService? _statusService;
+```
+
+Add counters:
+
+```dart
+int _remainingEligibleCount = 0;
+```
+
+In `_enqueueNextBatch()` after applying result sets:
+
+```dart
+_remainingEligibleCount = result.remainingEligibleCandidateCount;
+await _recordProgress();
+if (!result.queuedAny && !result.hasMoreEligibleCandidates) {
+  await _statusService?.recordBackupComplete();
+  _activeUserId = null;
+}
+```
+
+In `_recordTerminalStatus()`, track whether the terminal update removed one logical asset from the active queue and decrement `_remainingEligibleCount` only for that case:
+
+```dart
+void _recordTerminalStatus(TaskStatusUpdate update) {
+  var removedLogicalAsset = false;
+
+  switch (update.status) {
+    case TaskStatus.complete:
+      if (!_isLivePhotoMotionTask(update.task) && _queuedLocalAssetIds.remove(update.task.taskId)) {
+        _completedLocalAssetIds.add(update.task.taskId);
+        removedLogicalAsset = true;
+      }
+      break;
+    case TaskStatus.failed:
+    case TaskStatus.notFound:
+    case TaskStatus.canceled:
+      if (_queuedLocalAssetIds.remove(update.task.taskId)) {
+        _failedLocalAssetIds.add(update.task.taskId);
+        removedLogicalAsset = true;
+      }
+      break;
+    default:
+      break;
+  }
+
+  if (removedLogicalAsset && _remainingEligibleCount > 0) {
+    _remainingEligibleCount--;
+  }
+}
+```
+
+Add:
+
+```dart
+Future<void> _recordProgress() {
+  return _statusService?.recordQueueProgress(
+        queuedCount: _queuedLocalAssetIds.length,
+        completedCount: _completedLocalAssetIds.length,
+        failedCount: _failedLocalAssetIds.length,
+        skippedCount: _skippedLocalAssetIds.length,
+        enqueueFailedCount: _enqueueFailedLocalAssetIds.length,
+        remainingCount: _remainingEligibleCount,
+      ) ??
+      Future.value();
+}
+```
+
+Remove `recordUploadSuccess()` and `recordFailure()` calls from `BackgroundUploadService._handleTaskStatusUpdate()` for backup groups. Keep file cleanup and Live Photo handling in `BackgroundUploadService`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/services/background_backup_status.service_test.dart test/domain/models/background_backup_status_model_test.dart test/services/background_backup_queue_coordinator_test.dart test/services/background_upload.service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/lib/domain/models/background_backup_status.model.dart mobile/lib/services/background_backup_status.service.dart mobile/lib/services/background_backup_queue_coordinator.dart mobile/lib/services/background_upload.service.dart mobile/test/services/background_backup_status.service_test.dart mobile/test/domain/models/background_backup_status_model_test.dart mobile/test/services/background_backup_queue_coordinator_test.dart mobile/test/services/background_upload.service_test.dart
+git commit -m "fix(mobile): persist full background backup progress"
+```
+
+---
+
+### Task 4: Delegate iOS Provider Lifecycle To The Coordinator
+
+**Files:**
+
+- Modify: `mobile/lib/providers/backup/drift_backup.provider.dart`
+- Create: `mobile/lib/providers/backup/background_backup_queue.provider.dart`
+- Modify: `mobile/test/providers/backup/drift_backup_provider_test.dart`
+
+- [ ] **Step 1: Write failing provider tests**
+
+Add to `mobile/test/providers/backup/drift_backup_provider_test.dart`:
+
+```dart
+class MockBackgroundBackupQueueCoordinator extends Mock implements BackgroundBackupQueueCoordinator {}
+```
+
+Add setup:
+
+```dart
+late MockBackgroundBackupQueueCoordinator backgroundQueueCoordinator;
+
+backgroundQueueCoordinator = MockBackgroundBackupQueueCoordinator();
+sut = DriftBackupNotifier(
+  foregroundUploadService,
+  backgroundUploadService,
+  UploadSpeedManager(),
+  backgroundQueueCoordinator: backgroundQueueCoordinator,
+);
+```
+
+Add tests:
+
+```dart
+test('starts iOS URLSession backup through queue coordinator', () async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  when(() => backgroundQueueCoordinator.start('user-1')).thenAnswer((_) async {});
+
+  await sut.startBackup('user-1');
+
+  verify(() => backgroundQueueCoordinator.start('user-1')).called(1);
+  verifyNever(() => backgroundUploadService.uploadBackupCandidates(any()));
+});
+
+test('background status callbacks can refill queue without calling getBackupStatus or details UI', () async {
+  final task = UploadTask(
+    taskId: 'asset-1',
+    url: 'http://test-server.com/assets',
+    filename: 'asset.jpg',
+    baseDirectory: BaseDirectory.temporary,
+    group: kBackupGroup,
+  );
+  when(() => backgroundQueueCoordinator.handleStatus(any())).thenAnswer((_) async {});
+
+  statusController.add(TaskStatusUpdate(task, TaskStatus.complete));
+  await pumpEventQueue();
+
+  verifyNever(() => foregroundUploadService.getBackupCounts(any()));
+  verify(() => backgroundQueueCoordinator.handleStatus(any(that: isA<TaskStatusUpdate>()))).called(1);
+});
+
+test('stops iOS URLSession backup through queue coordinator', () async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+  addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  when(() => backgroundQueueCoordinator.stop()).thenAnswer((_) async {});
+
+  await sut.stopBackup();
+
+  verify(() => backgroundQueueCoordinator.stop()).called(1);
+  verifyNever(() => backgroundUploadService.cancel());
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/providers/backup/drift_backup_provider_test.dart
+```
+
+Expected: FAIL because `DriftBackupNotifier` does not accept/use the coordinator.
+
+- [ ] **Step 3: Add coordinator provider and wire notifier**
+
+Create `mobile/lib/providers/backup/background_backup_queue.provider.dart`:
+
+```dart
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_backup_status.service.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+
+final backgroundBackupQueueCoordinatorProvider = Provider<BackgroundBackupQueueCoordinator>((ref) {
+  return BackgroundBackupQueueCoordinator(
+    ref.watch(backgroundUploadServiceProvider),
+    statusService: ref.watch(backgroundBackupStatusServiceProvider),
+  );
+});
+```
+
+Modify `driftBackupProvider`:
+
+```dart
+final driftBackupProvider = StateNotifierProvider<DriftBackupNotifier, DriftBackupState>((ref) {
+  return DriftBackupNotifier(
+    ref.watch(foregroundUploadServiceProvider),
+    ref.watch(backgroundUploadServiceProvider),
+    UploadSpeedManager(),
+    backgroundQueueCoordinator: ref.watch(backgroundBackupQueueCoordinatorProvider),
+  );
+});
+```
+
+Modify `DriftBackupNotifier` constructor:
+
+```dart
+DriftBackupNotifier(
+  this._foregroundUploadService,
+  this._backgroundUploadService,
+  this._uploadSpeedManager, {
+  BackgroundBackupQueueCoordinator? backgroundQueueCoordinator,
+}) : _backgroundQueueCoordinator =
+       backgroundQueueCoordinator ?? BackgroundBackupQueueCoordinator(_backgroundUploadService),
+     super(...);
+
+final BackgroundBackupQueueCoordinator _backgroundQueueCoordinator;
+```
+
+Modify iOS lifecycle:
+
+```dart
+Future<void> startBackupWithURLSession(String userId) {
+  state = state.copyWith(error: BackupError.none);
+  return _backgroundQueueCoordinator.start(userId);
+}
+
+Future<void> stopBackup() async {
+  if (CurrentPlatform.isIOS) {
+    await _backgroundQueueCoordinator.stop();
+    _uploadSpeedManager.clear();
+    state = state.copyWith(uploadItems: {}, iCloudDownloadProgress: {});
+    return;
+  }
+  stopForegroundBackup();
+}
+```
+
+Forward background statuses:
+
+```dart
+unawaited(_backgroundQueueCoordinator.handleStatus(update));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/providers/backup/drift_backup_provider_test.dart test/services/background_backup_queue_coordinator_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/providers/backup/drift_backup.provider.dart mobile/lib/providers/backup/background_backup_queue.provider.dart mobile/test/providers/backup/drift_backup_provider_test.dart
+git commit -m "refactor(mobile): route iOS backup lifecycle through coordinator"
+```
+
+---
+
+### Task 5: Preserve The TestFlight Crash Fix
+
+**Files:**
+
+- Modify: `mobile/test/infrastructure/repositories/draining_http_client_test.dart`
+- Modify: `mobile/test/domain/services/background_worker_http_teardown_test.dart`
+- Modify: `mobile/lib/infrastructure/repositories/draining_http_client.dart`
+
+- [ ] **Step 1: Add teardown regression test**
+
+Add to `mobile/test/infrastructure/repositories/draining_http_client_test.dart`:
+
+```dart
+test('shutdown waits for native completion after upload response is returned but body is never read', () async {
+  final inner = _StreamingFakeClient(closeOnAbort: false);
+  final client = DrainingHttpClient(inner);
+
+  final response = await client.send(http.Request('POST', Uri.parse('http://test-server.com/assets')));
+  expect(response.statusCode, 200);
+  expect(inner.bodyWasListenedTo, true);
+
+  final shutdown = client.closeAndDrain(timeout: const Duration(milliseconds: 200));
+  await Future<void>.delayed(Duration.zero);
+
+  expect(shutdown, doesNotComplete);
+
+  inner.closeResponseBody();
+
+  await shutdown;
+  expect(inner.closed, true);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass or fail for the right reason**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test test/infrastructure/repositories/draining_http_client_test.dart test/domain/services/background_worker_http_teardown_test.dart
+```
+
+Expected: PASS. A failure here blocks the queue work until `DrainingHttpClient` is fixed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/infrastructure/repositories/draining_http_client.dart mobile/test/infrastructure/repositories/draining_http_client_test.dart mobile/test/domain/services/background_worker_http_teardown_test.dart
+git commit -m "test(mobile): preserve background http teardown safety"
+```
+
+---
+
+### Task 6: Add Noodle-Specific Device Log Verification
+
+**Files:**
+
+- Create: `mobile/tool/observe_ios_background_backup.sh`
+
+- [ ] **Step 1: Create the script**
+
+Create `mobile/tool/observe_ios_background_backup.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+UDID="${1:?usage: $0 <device-udid> [seconds]}"
+SECONDS_TO_RUN="${2:-180}"
+
+timeout "${SECONDS_TO_RUN}s" idevicesyslog -u "$UDID" -p "Noodle Gallery|nsurlsessiond" --no-colors \
+  | rg -i "de\\.opennoodle\\.gallery|bundle id: de\\.opennoodle\\.gallery|Noodle Gallery\\(background_downloader\\)|for client de\\.opennoodle\\.gallery completed successfully|NDSession .* has [0-9]+ outstanding tasks|completed with error|abort|crash"
+```
+
+- [ ] **Step 2: Add expected-pattern comments**
+
+Insert below `set -euo pipefail`:
+
+```bash
+# Healthy pattern:
+# - "for client de.opennoodle.gallery completed successfully"
+# - response batches continue after the first 100 assets
+# - when "has 0 outstanding tasks" appears while the app still reports remaining
+#   candidates, another Noodle batch appears without opening backup details
+# - no Noodle "completed with error", abort, or crash lines
+```
+
+- [ ] **Step 3: Make executable and commit**
+
+Run:
+
+```bash
+chmod +x mobile/tool/observe_ios_background_backup.sh
+git add mobile/tool/observe_ios_background_backup.sh
+git commit -m "chore(mobile): add iOS background backup log observer"
+```
+
+Expected: script is executable and committed.
+
+---
+
+### Task 7: Full Verification
+
+**Files:**
+
+- No code changes.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test \
+  test/services/background_backup_queue_coordinator_test.dart \
+  test/services/background_upload.service_test.dart \
+  test/providers/backup/drift_backup_provider_test.dart \
+  test/services/background_backup_status.service_test.dart \
+  test/domain/models/background_backup_status_model_test.dart \
+  test/infrastructure/repositories/draining_http_client_test.dart \
+  test/domain/services/background_worker_http_teardown_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run static analysis**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- dart analyze --fatal-infos \
+  lib/services/background_backup_queue_coordinator.dart \
+  lib/services/background_upload.service.dart \
+  lib/providers/backup/drift_backup.provider.dart \
+  lib/providers/backup/background_backup_queue.provider.dart \
+  lib/services/background_backup_status.service.dart \
+  lib/domain/models/background_backup_status.model.dart \
+  test/services/background_backup_queue_coordinator_test.dart \
+  test/services/background_upload.service_test.dart \
+  test/providers/backup/drift_backup_provider_test.dart
+```
+
+Expected: `No issues found!`
+
+- [ ] **Step 3: Run full mobile tests**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter test
+```
+
+Expected: all tests pass. Existing localization warnings are acceptable only with exit code zero.
+
+- [ ] **Step 4: Build, install, and launch on the plugged-in iPhone**
+
+Run:
+
+```bash
+cd mobile
+mise exec -- flutter build ios --release -d 00008150-00025C513CD0C01C --build-name 4.56.8 --build-number 276
+xcrun devicectl device install app --device 00008150-00025C513CD0C01C "build/ios/iphoneos/Noodle Gallery.app"
+xcrun devicectl device process launch --device 00008150-00025C513CD0C01C de.opennoodle.gallery
+```
+
+Expected: build succeeds, install succeeds, launch succeeds.
+
+- [ ] **Step 5: Observe a real full backup**
+
+Run:
+
+```bash
+cd mobile
+./tool/observe_ios_background_backup.sh 00008150-00025C513CD0C01C 300
+```
+
+Expected:
+
+- Noodle uploads continue beyond the first 100 tasks.
+- When native outstanding tasks reaches `0` while the app still has remaining candidates, another Noodle batch appears without opening backup details.
+- Noodle task completions are successful.
+- No Noodle `completed with error`, abort, crash, or Dart FFI callback assertion appears.
+
+Record command outputs and device-log observations in the PR body. Do not commit generated branding overlay files.
+
+---
+
+## Coverage Matrix
+
+| Requirement / Edge Case                                                    | Covered By                                                  |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Full backup with 3,517 assets                                              | Task 2 full-backup test                                     |
+| Completed assets remain excluded until session end despite remote-sync lag | Task 2 full-backup test                                     |
+| Refill does not depend on details page / UI count refresh                  | Task 4 provider no-UI test                                  |
+| Native queue drains repeatedly and refills                                 | Task 2 full-backup test                                     |
+| Active URLSession tasks resume after restart                               | Task 2 start/resume test                                    |
+| Concurrent terminal callbacks enqueue one next batch                       | Task 2 concurrent callback test                             |
+| Stop/cancel during in-flight enqueue                                       | Task 2 delayed enqueue cancellation test                    |
+| Failed uploads are not immediately requeued                                | Task 2 failed upload test                                   |
+| Skipped missing-file/entity assets are not looped                          | Task 1 mixed skip test and Task 2 skipped exclusion test    |
+| Mixed native `enqueueAll` results are handled                              | Task 1 mixed enqueue failure test and Task 2 exclusion test |
+| Empty eligible batch exits cleanly                                         | Task 1 all-excluded test                                    |
+| Live Photo motion/still semantics                                          | Task 2 Live Photo test                                      |
+| Persisted status remains pending during large backups                      | Task 3 status tests                                         |
+| TestFlight HTTP teardown crash remains fixed                               | Task 5 teardown tests                                       |
+| Device-level verification is Noodle-specific                               | Task 6 script and Task 7 device observation                 |
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-02-ios-full-backup-tdd.md`.
+
+Two execution options:
+
+1. Subagent-Driven (recommended) - dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. Inline Execution - execute tasks in this session using executing-plans, batch execution with checkpoints.

--- a/docs/plans/2026-06-03-ios-resume-stale-urlsession.md
+++ b/docs/plans/2026-06-03-ios-resume-stale-urlsession.md
@@ -1,0 +1,877 @@
+# iOS Resume Stale-URLSession Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the iOS app from losing all server connectivity (requiring a force-quit) after a background backup runs, by re-establishing the foreground's native HTTP client/URLSession when the app returns to the foreground.
+
+**Architecture:** On iOS the foreground isolate and the background-worker isolate share one process-wide `URLSession` (`URLSessionManager.shared`). `cupertino_http` binds that shared session's completion callbacks to whichever isolate last called `CupertinoClient.fromSharedSession`. When the background-worker isolate runs a backup and is then torn down (`engine.destroyContext()`), the shared session is left with its callback target pointing at a destroyed isolate — every subsequent foreground request hangs/fails. The foreground never re-initialises its client on resume (only cold start / login do), so only a cold restart recovers. Fix: on resume-after-pause (iOS only), recreate the native session and rebuild the foreground isolate's HTTP client so the foreground owns a fresh, live session again. We add a guard-defeating `NetworkRepository.refresh()`, expose a native `recreateSession()` over pigeon, wire `ApiService.refreshConnection()`, and call it from `AppLifeCycleNotifier` on resume.
+
+**Tech Stack:** Flutter/Dart (Riverpod, `http`, `cupertino_http`), pigeon (host API codegen), Swift (`URLSessionManager`), Kotlin (no-op), `mocktail` + `flutter_test`, in-memory Drift for `Store`.
+
+**Root cause evidence (already confirmed):**
+
+- `setOpenApiServiceEndpoint()` returns `null` early when auto endpoint-switching is off (`mobile/lib/services/auth.service.dart:148-156`); the `"Using server URL: null"` log (`mobile/lib/providers/app_life_cycle.provider.dart:77-78`) is **benign** and not the cause — the stored endpoint is never cleared (only `clearLocalData()` deletes it).
+- Foreground builds its client once: `main.dart:228`, `bootstrap.dart:57`, login `auth.provider.dart:133`. `_performResume` never re-inits.
+- `NetworkRepository.init()` short-circuits when the pointer is unchanged (`mobile/lib/infrastructure/repositories/network.repository.dart:35-37`).
+- Shared session swap point: `URLSessionManager.recreateSession()` (`mobile/ios/Runner/Core/NetworkApiImpl.swift:96`), pointer handed to Dart via `passUnretained` (`NetworkApiImpl.swift:62-64`).
+- The current branch commit (`ced29838a9`) makes the background worker upload far longer (`_queueMoreBackgroundBackupCandidatesIfNeeded`), which is why this now reproduces routinely. `git diff main...HEAD` shows the resume path, native session code, and teardown are unchanged from main (pre-existing bug, newly surfaced).
+
+---
+
+## File Structure / Change Map
+
+**Modify:**
+
+- `mobile/pigeon/network_api.dart` — add `void recreateSession();` to the `@HostApi()` definition.
+- `mobile/lib/platform/network_api.g.dart` — regenerated (adds `recreateSession`).
+- `mobile/ios/Runner/Core/Network.g.swift` — regenerated (adds `recreateSession` to protocol + setup).
+- `mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt` — regenerated.
+- `mobile/ios/Runner/Core/NetworkApiImpl.swift` — implement `recreateSession()` (calls existing `URLSessionManager.shared.recreateSession()`).
+- `mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt` — implement `recreateSession()` as a no-op (iOS-only feature; pigeon requires the method).
+- `mobile/lib/infrastructure/repositories/network.repository.dart` — add test seams (`debugClientPointer`, `debugBaseClientFactory`, `debugRecreateSession`, `debugReset`), switch `Platform.isIOS` → `CurrentPlatform.isIOS`, extract `_buildBaseClient`, add `refresh()`.
+- `mobile/lib/services/api.service.dart` — add `refreshConnection()`.
+- `mobile/lib/providers/app_life_cycle.provider.dart` — add `refreshConnectionAfterResume(bool wasPaused)` and call it from `handleAppResume` before `_performResume`.
+
+**Create (tests):**
+
+- `mobile/test/infrastructure/repositories/network_repository_test.dart`
+- `mobile/test/services/api_service_refresh_test.dart`
+- `mobile/test/providers/app_life_cycle_provider_test.dart`
+
+**Toolchain note:** Use the mise-pinned Flutter (`mobile/mise.toml` pins `flutter = "3.41.7"`), not a PATH Flutter. Run commands from `mobile/`. If `flutter`/`dart` on PATH differ, prefix with `mise exec --` (e.g. `mise exec -- flutter test ...`) or use `~/.local/share/mise/installs/flutter/3.41.7/bin/flutter`. CI's Dart analysis runs `dart analyze --fatal-infos` over **`lib` and `test`**, so always analyze both.
+
+---
+
+### Task 1: Expose native `recreateSession()` over pigeon (codegen + native)
+
+**Files:**
+
+- Modify: `mobile/pigeon/network_api.dart`
+- Regenerate: `mobile/lib/platform/network_api.g.dart`, `mobile/ios/Runner/Core/Network.g.swift`, `mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt`
+- Modify: `mobile/ios/Runner/Core/NetworkApiImpl.swift`
+- Modify: `mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt`
+
+> **TDD note:** This task is pigeon codegen + native (Swift/Kotlin) glue with no Dart-unit-testable logic of its own (the iOS effect is verified on-device in Task 6, the Dart caller is tested in Task 3). Per the TDD skill, generated/native code is an explicit exception. Do **not** hand-edit the `.g.*` files except via the pigeon generator.
+
+- [ ] **Step 1: Add the method to the pigeon host API**
+
+In `mobile/pigeon/network_api.dart`, add `recreateSession` to the `NetworkApi` class (after `setRequestHeaders`):
+
+```dart
+@HostApi()
+abstract class NetworkApi {
+  @async
+  void addCertificate(ClientCertData clientData);
+
+  @async
+  void selectCertificate(ClientCertPrompt promptText);
+
+  @async
+  void removeCertificate();
+
+  bool hasCertificate();
+
+  int getClientPointer();
+
+  void setRequestHeaders(Map<String, String> headers, List<String> serverUrls, String? token);
+
+  /// Rebuilds the shared native URLSession (iOS). Used on foreground resume to
+  /// recover from the background-worker isolate orphaning the shared session.
+  void recreateSession();
+}
+```
+
+- [ ] **Step 2: Regenerate the pigeon bindings**
+
+Run (from `mobile/`):
+
+```bash
+dart run pigeon --input pigeon/network_api.dart
+dart format lib/platform/network_api.g.dart
+```
+
+Expected: `lib/platform/network_api.g.dart`, `ios/Runner/Core/Network.g.swift`, and `android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt` are updated. Review the diff — the only semantic addition should be a `recreateSession` channel/method in each file. The Dart `NetworkApi` class gains `Future<void> recreateSession()`.
+
+- [ ] **Step 3: Implement `recreateSession()` on iOS**
+
+In `mobile/ios/Runner/Core/NetworkApiImpl.swift`, add to `class NetworkApiImpl: NetworkApi` (after `setRequestHeaders`, before the closing brace of the class at the `}` preceding `private class CertImporter`):
+
+```swift
+  func recreateSession() throws {
+    URLSessionManager.shared.recreateSession()
+  }
+```
+
+- [ ] **Step 4: Implement `recreateSession()` as a no-op on Android**
+
+In `mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt`, add to `private class NetworkApiImpl : NetworkApi` (after `setRequestHeaders`):
+
+```kotlin
+  override fun recreateSession() {
+    // iOS-only: the shared-URLSession teardown race does not affect the
+    // Android OkHttp client, which is never re-shared across the worker isolate.
+  }
+```
+
+- [ ] **Step 5: Verify Dart analysis is clean**
+
+Run (from `mobile/`):
+
+```bash
+dart analyze --fatal-infos lib test
+```
+
+Expected: No new errors/infos introduced by the regenerated `network_api.g.dart`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/pigeon/network_api.dart mobile/lib/platform/network_api.g.dart \
+  mobile/ios/Runner/Core/Network.g.swift mobile/ios/Runner/Core/NetworkApiImpl.swift \
+  mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt \
+  mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
+git commit -m "feat(mobile): expose native recreateSession over pigeon"
+```
+
+---
+
+### Task 2: Make `NetworkRepository` testable (seams + platform abstraction)
+
+**Files:**
+
+- Modify: `mobile/lib/infrastructure/repositories/network.repository.dart`
+- Test: `mobile/test/infrastructure/repositories/network_repository_test.dart`
+
+This task introduces injectable seams so the static `NetworkRepository` (which otherwise builds real FFI clients and reads `dart:io` `Platform`) can be unit-tested, and characterises the existing same-pointer guard. No production behaviour change yet.
+
+- [ ] **Step 1: Write the failing characterisation tests**
+
+Create `mobile/test/infrastructure/repositories/network_repository_test.dart`:
+
+```dart
+import 'dart:ffi';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+
+/// Minimal fake http client that records whether it was closed.
+class _FakeClient extends http.BaseClient {
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
+
+void main() {
+  late int pointerAddress;
+  late int factoryCalls;
+  late List<_FakeClient> built;
+
+  setUp(() {
+    NetworkRepository.debugReset();
+    pointerAddress = 1;
+    factoryCalls = 0;
+    built = [];
+    NetworkRepository.debugClientPointer = () async => pointerAddress;
+    NetworkRepository.debugBaseClientFactory = (Pointer<Void> _) {
+      factoryCalls++;
+      final client = _FakeClient();
+      built.add(client);
+      return client;
+    };
+  });
+
+  tearDown(() {
+    NetworkRepository.debugReset();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('init builds the client from the native pointer', () async {
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 1);
+    expect(NetworkRepository.client, same(built.single));
+  });
+
+  test('init is a no-op when the native pointer is unchanged', () async {
+    await NetworkRepository.init();
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 1);
+  });
+
+  test('init rebuilds and closes the old client when the pointer changes', () async {
+    await NetworkRepository.init();
+    pointerAddress = 2;
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 2);
+    expect(built.first.closed, isTrue);
+    expect(NetworkRepository.client, same(built.last));
+  });
+
+  test('client getter throws before init', () {
+    expect(() => NetworkRepository.client, throwsA(isA<TypeError>()));
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/infrastructure/repositories/network_repository_test.dart
+```
+
+Expected: FAIL — compile errors (`debugReset`, `debugClientPointer`, `debugBaseClientFactory` are not defined on `NetworkRepository`).
+
+- [ ] **Step 3: Add the seams and platform abstraction**
+
+Replace the contents of `mobile/lib/infrastructure/repositories/network.repository.dart` with:
+
+```dart
+import 'dart:ffi';
+
+import 'package:cupertino_http/cupertino_http.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:immich_mobile/extensions/platform_extensions.dart';
+import 'package:immich_mobile/infrastructure/repositories/draining_http_client.dart';
+import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
+import 'package:ok_http/ok_http.dart';
+import 'package:web_socket/web_socket.dart';
+
+class NetworkRepository {
+  static http.Client? _client;
+  static Pointer<Void>? _clientPointer;
+
+  /// When set, the iOS client is wrapped in a [DrainingHttpClient] so in-flight
+  /// requests can be aborted and drained at teardown. Enabled only in the
+  /// background-worker isolate via [enableShutdownTracking].
+  static bool _trackInFlight = false;
+  static DrainingHttpClient? _draining;
+
+  /// Test seam: overrides the native client-pointer source.
+  @visibleForTesting
+  static Future<int> Function()? debugClientPointer;
+
+  /// Test seam: overrides native base-client construction (avoids real FFI).
+  @visibleForTesting
+  static http.Client Function(Pointer<Void> pointer)? debugBaseClientFactory;
+
+  /// Test seam: overrides the native session recreation.
+  @visibleForTesting
+  static Future<void> Function()? debugRecreateSession;
+
+  /// Resets all static state and test seams. Test-only.
+  @visibleForTesting
+  static void debugReset() {
+    _client = null;
+    _clientPointer = null;
+    _draining = null;
+    _trackInFlight = false;
+    debugClientPointer = null;
+    debugBaseClientFactory = null;
+    debugRecreateSession = null;
+  }
+
+  /// Enables graceful shutdown tracking of in-flight requests for the current
+  /// isolate. Must be called before [init].
+  ///
+  /// The iOS background worker shares a native [URLSession] across isolates; if
+  /// the isolate is destroyed while a request is in flight, the request's
+  /// `cupertino_http` delegate later calls back into the dead isolate and
+  /// crashes the process. Tracking lets [shutdown] cancel and drain those
+  /// requests first. See [DrainingHttpClient].
+  static void enableShutdownTracking() {
+    _trackInFlight = true;
+  }
+
+  static Future<void> init() async {
+    final address = await (debugClientPointer ?? networkApi.getClientPointer)();
+    final clientPointer = Pointer<Void>.fromAddress(address);
+    if (clientPointer == _clientPointer) {
+      return;
+    }
+    _clientPointer = clientPointer;
+    _client?.close();
+    _draining = null;
+
+    final http.Client base = debugBaseClientFactory != null
+        ? debugBaseClientFactory!(clientPointer)
+        : _buildBaseClient(clientPointer);
+
+    // Only iOS needs draining: the crash is specific to cupertino_http's
+    // shared-session FFI delegate. Android's background worker is unaffected.
+    if (_trackInFlight && CurrentPlatform.isIOS) {
+      _client = _draining = DrainingHttpClient(base);
+    } else {
+      _client = base;
+    }
+  }
+
+  static http.Client _buildBaseClient(Pointer<Void> clientPointer) {
+    if (CurrentPlatform.isIOS) {
+      final session = URLSession.fromRawPointer(clientPointer.cast());
+      return CupertinoClient.fromSharedSession(session);
+    }
+    return OkHttpClient.fromJniGlobalRef(
+      clientPointer,
+      configuration: const OkHttpClientConfiguration(
+        connectTimeout: Duration(seconds: 30),
+        readTimeout: Duration(seconds: 60),
+        writeTimeout: Duration(seconds: 60),
+      ),
+    );
+  }
+
+  /// Aborts and drains any in-flight requests, then closes the client.
+  ///
+  /// No-op unless [enableShutdownTracking] was called before [init]. Must run
+  /// before the native side destroys the background isolate so that no
+  /// in-flight `cupertino_http` request can call back into a dead isolate.
+  static Future<void> shutdown({Duration timeout = const Duration(milliseconds: 1500)}) async {
+    final draining = _draining;
+    _draining = null;
+    await draining?.shutdown(timeout: timeout);
+  }
+
+  static Future<void> setHeaders(Map<String, String> headers, List<String> serverUrls, {String? token}) async {
+    await networkApi.setRequestHeaders(headers, serverUrls, token);
+    if (CurrentPlatform.isIOS) {
+      await init();
+    }
+  }
+
+  // ignore: avoid-unused-parameters
+  static Future<WebSocket> createWebSocket(Uri uri, {Map<String, String>? headers, Iterable<String>? protocols}) {
+    if (CurrentPlatform.isIOS) {
+      final session = URLSession.fromRawPointer(_clientPointer!.cast());
+      return CupertinoWebSocket.connectWithSession(session, uri, protocols: protocols);
+    } else {
+      return OkHttpWebSocket.connectFromJniGlobalRef(_clientPointer!, uri, protocols: protocols);
+    }
+  }
+
+  const NetworkRepository();
+
+  /// Returns a shared HTTP client that uses native SSL configuration.
+  ///
+  /// On iOS: Uses SharedURLSessionManager's URLSession.
+  /// On Android: Uses SharedHttpClientManager's OkHttpClient.
+  ///
+  /// Must call [init] before using this method.
+  static http.Client get client => _client!;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/infrastructure/repositories/network_repository_test.dart
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Verify analysis is clean**
+
+Run (from `mobile/`):
+
+```bash
+dart analyze --fatal-infos lib test
+```
+
+Expected: No errors/infos. (`dart:io` import was removed; confirm nothing else in the file referenced `Platform`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/infrastructure/repositories/network.repository.dart \
+  mobile/test/infrastructure/repositories/network_repository_test.dart
+git commit -m "refactor(mobile): make NetworkRepository client construction testable"
+```
+
+---
+
+### Task 3: Add `NetworkRepository.refresh()`
+
+**Files:**
+
+- Modify: `mobile/lib/infrastructure/repositories/network.repository.dart`
+- Test: `mobile/test/infrastructure/repositories/network_repository_test.dart`
+
+`refresh()` is the core fix primitive: it recreates the native session (iOS) and rebuilds this isolate's client **even when the pointer is unchanged** (defeating the `init()` short-circuit), re-registering the foreground isolate as the shared session's callback target.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside `main()` in `mobile/test/infrastructure/repositories/network_repository_test.dart` (after the existing tests):
+
+```dart
+  test('refresh rebuilds the client even when the pointer is unchanged', () async {
+    await NetworkRepository.init();
+    await NetworkRepository.refresh();
+
+    expect(factoryCalls, 2);
+    expect(built.first.closed, isTrue);
+    expect(NetworkRepository.client, same(built.last));
+  });
+
+  test('refresh recreates the native session on iOS', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    var recreateCalls = 0;
+    NetworkRepository.debugRecreateSession = () async => recreateCalls++;
+
+    await NetworkRepository.refresh();
+
+    expect(recreateCalls, 1);
+  });
+
+  test('refresh does not recreate the session off iOS', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    var recreateCalls = 0;
+    NetworkRepository.debugRecreateSession = () async => recreateCalls++;
+
+    await NetworkRepository.refresh();
+
+    expect(recreateCalls, 0);
+    expect(factoryCalls, 1); // still rebuilds the client
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/infrastructure/repositories/network_repository_test.dart
+```
+
+Expected: FAIL — `refresh` is not defined on `NetworkRepository`.
+
+- [ ] **Step 3: Implement `refresh()`**
+
+In `mobile/lib/infrastructure/repositories/network.repository.dart`, add this method immediately after `_buildBaseClient`:
+
+```dart
+  /// Re-establishes this isolate's native HTTP client.
+  ///
+  /// On iOS the foreground and background-worker isolates share one native
+  /// URLSession. When the background-worker isolate is torn down
+  /// (`engine.destroyContext()`) it leaves the shared session's
+  /// `cupertino_http` callback target pointing at a destroyed isolate, so the
+  /// foreground can no longer complete any request until a cold restart.
+  ///
+  /// On resume we recreate the native session (iOS) and rebuild this isolate's
+  /// client — defeating [init]'s same-pointer short-circuit — so the foreground
+  /// owns a fresh, live session again.
+  static Future<void> refresh() async {
+    if (CurrentPlatform.isIOS) {
+      await (debugRecreateSession ?? networkApi.recreateSession)();
+    }
+    _clientPointer = null;
+    await init();
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/infrastructure/repositories/network_repository_test.dart
+```
+
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/infrastructure/repositories/network.repository.dart \
+  mobile/test/infrastructure/repositories/network_repository_test.dart
+git commit -m "feat(mobile): add NetworkRepository.refresh to rebuild the foreground client"
+```
+
+---
+
+### Task 4: Add `ApiService.refreshConnection()`
+
+**Files:**
+
+- Modify: `mobile/lib/services/api.service.dart`
+- Test: `mobile/test/services/api_service_refresh_test.dart`
+
+`ApiService` copies `NetworkRepository.client` into `_apiClient.client` at `setEndpoint` time, so after `NetworkRepository.refresh()` rebuilds the client we must re-point the API client. `refreshConnection()` does both.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/services/api_service_refresh_test.dart`:
+
+```dart
+import 'dart:ffi';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/services/api.service.dart';
+
+class _FakeClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+  }
+}
+
+void main() {
+  late Drift db;
+
+  setUpAll(() async {
+    db = Drift(DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await StoreService.init(storeRepository: DriftStoreRepository(db));
+  });
+
+  setUp(() async {
+    await Store.clear();
+    await Store.put(StoreKey.serverEndpoint, 'https://demo.opennoodle.de/api');
+    NetworkRepository.debugReset();
+    NetworkRepository.debugClientPointer = () async => 1;
+  });
+
+  tearDown(() => NetworkRepository.debugReset());
+
+  tearDownAll(() async => db.close());
+
+  test('refreshConnection rebuilds the client and re-points the API client', () async {
+    var built = 0;
+    final clients = <_FakeClient>[];
+    NetworkRepository.debugBaseClientFactory = (Pointer<Void> _) {
+      built++;
+      final client = _FakeClient();
+      clients.add(client);
+      return client;
+    };
+    await NetworkRepository.init();
+
+    final api = ApiService();
+    expect(api.usersApi.apiClient.client, same(clients.first));
+
+    await api.refreshConnection();
+
+    expect(built, 2);
+    expect(NetworkRepository.client, same(clients.last));
+    expect(api.usersApi.apiClient.client, same(clients.last));
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/services/api_service_refresh_test.dart
+```
+
+Expected: FAIL — `refreshConnection` is not defined on `ApiService`.
+
+- [ ] **Step 3: Implement `refreshConnection()`**
+
+In `mobile/lib/services/api.service.dart`, add this method immediately after `updateHeaders()` (which ends at the line `_apiClient.client = NetworkRepository.client;` `}`):
+
+```dart
+  /// Re-establishes the native HTTP client after a background-worker teardown
+  /// orphaned the shared iOS URLSession, then re-points the API client at it.
+  /// Call on foreground resume (see [AppLifeCycleNotifier]).
+  Future<void> refreshConnection() async {
+    await NetworkRepository.refresh();
+    _apiClient.client = NetworkRepository.client;
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/services/api_service_refresh_test.dart
+```
+
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/api.service.dart mobile/test/services/api_service_refresh_test.dart
+git commit -m "feat(mobile): add ApiService.refreshConnection"
+```
+
+---
+
+### Task 5: Refresh the connection on foreground resume
+
+**Files:**
+
+- Modify: `mobile/lib/providers/app_life_cycle.provider.dart`
+- Test: `mobile/test/providers/app_life_cycle_provider_test.dart`
+
+Add a gated, testable `refreshConnectionAfterResume(bool wasPaused)` to `AppLifeCycleNotifier` and call it from `handleAppResume` **before** `_performResume` (which resets `_wasPaused` and then issues `getServerVersion()` / websocket `connect()`). Gating on `wasPaused` avoids firing on orientation-change `inactive`/`hidden` transitions; gating on iOS scopes it to the affected platform.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mobile/test/providers/app_life_cycle_provider_test.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
+import 'package:immich_mobile/providers/app_life_cycle.provider.dart';
+import 'package:immich_mobile/services/api.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiService extends Mock implements ApiService {}
+
+void main() {
+  late MockApiService apiService;
+  late ProviderContainer container;
+  late AppLifeCycleNotifier sut;
+
+  setUp(() {
+    apiService = MockApiService();
+    when(() => apiService.refreshConnection()).thenAnswer((_) async {});
+    container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(apiService)]);
+    sut = container.read(appStateProvider.notifier);
+  });
+
+  tearDown(() {
+    container.dispose();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('refreshes the connection on iOS resume after a pause', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    await sut.refreshConnectionAfterResume(true);
+
+    verify(() => apiService.refreshConnection()).called(1);
+  });
+
+  test('does not refresh when the app was not paused', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    await sut.refreshConnectionAfterResume(false);
+
+    verifyNever(() => apiService.refreshConnection());
+  });
+
+  test('does not refresh on Android', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    await sut.refreshConnectionAfterResume(true);
+
+    verifyNever(() => apiService.refreshConnection());
+  });
+
+  test('swallows refresh errors so resume can continue', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    when(() => apiService.refreshConnection()).thenThrow(Exception('boom'));
+
+    await expectLater(sut.refreshConnectionAfterResume(true), completes);
+    verify(() => apiService.refreshConnection()).called(1);
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/providers/app_life_cycle_provider_test.dart
+```
+
+Expected: FAIL — `refreshConnectionAfterResume` is not defined on `AppLifeCycleNotifier`.
+
+- [ ] **Step 3: Add the import for `@visibleForTesting`**
+
+In `mobile/lib/providers/app_life_cycle.provider.dart`, add this import (keep imports alphabetically grouped; place with the other package imports near the top):
+
+```dart
+import 'package:flutter/foundation.dart';
+```
+
+- [ ] **Step 4: Add the gated refresh method**
+
+In `mobile/lib/providers/app_life_cycle.provider.dart`, add this method to `AppLifeCycleNotifier` immediately after `_performResume()` (before `_safeRun`):
+
+```dart
+  /// On iOS, re-establishes the native HTTP client when returning to the
+  /// foreground after a pause. The background-worker isolate shares (and on
+  /// teardown orphans) the native URLSession, leaving the foreground unable to
+  /// reach the server until a cold restart. Re-establishing the client here —
+  /// before [_performResume] issues any request — recovers connectivity.
+  @visibleForTesting
+  Future<void> refreshConnectionAfterResume(bool wasPaused) async {
+    if (!CurrentPlatform.isIOS || !wasPaused) {
+      return;
+    }
+    try {
+      await _ref.read(apiServiceProvider).refreshConnection();
+    } catch (e, stackTrace) {
+      _log.warning("Failed to refresh connection on resume", e, stackTrace);
+    }
+  }
+```
+
+- [ ] **Step 5: Wire it into `handleAppResume`**
+
+In `mobile/lib/providers/app_life_cycle.provider.dart`, in `handleAppResume`, change the `try` block so the refresh runs before `_performResume` (capturing `_wasPaused` before `_performResume` clears it):
+
+```dart
+    _resumeOperation = Completer<void>();
+
+    try {
+      await refreshConnectionAfterResume(_wasPaused);
+      await _performResume();
+    } catch (e, stackTrace) {
+      _log.severe("Error during app resume", e, stackTrace);
+    } finally {
+      if (!_resumeOperation!.isCompleted) {
+        _resumeOperation!.complete();
+      }
+      _resumeOperation = null;
+    }
+```
+
+- [ ] **Step 6: Add the import for `apiServiceProvider`**
+
+Confirm `mobile/lib/providers/app_life_cycle.provider.dart` imports `apiServiceProvider`. If not present, add:
+
+```dart
+import 'package:immich_mobile/providers/api.provider.dart';
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run (from `mobile/`):
+
+```bash
+flutter test test/providers/app_life_cycle_provider_test.dart
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 8: Verify analysis is clean**
+
+Run (from `mobile/`):
+
+```bash
+dart analyze --fatal-infos lib test
+```
+
+Expected: No errors/infos.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mobile/lib/providers/app_life_cycle.provider.dart \
+  mobile/test/providers/app_life_cycle_provider_test.dart
+git commit -m "fix(mobile): refresh HTTP connection on iOS foreground resume"
+```
+
+---
+
+### Task 6: Full verification + on-device validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full mobile unit suite**
+
+Run (from `mobile/`):
+
+```bash
+flutter test
+```
+
+Expected: PASS. Confirm the three new test files run and that `draining_http_client_test.dart`, `drift_backup_provider_test.dart`, and `background_upload.service_test.dart` still pass (no regression from the `NetworkRepository` refactor).
+
+- [ ] **Step 2: Run analysis over lib and test (matches CI)**
+
+Run (from `mobile/`):
+
+```bash
+dart analyze --fatal-infos lib test
+```
+
+Expected: No errors/warnings/infos.
+
+- [ ] **Step 3: Format check**
+
+Run (from `mobile/`):
+
+```bash
+dart format --output=none --set-exit-if-changed lib test
+```
+
+Expected: No changes needed. (If it reports changes, run `dart format lib test` and amend.)
+
+- [ ] **Step 4: On-device TestFlight/dev validation (the native half)**
+
+The Swift `recreateSession` and the cupertino_http re-registration cannot be exercised by the Dart unit suite. Validate on a physical iOS device:
+
+1. Build and install the branch (TestFlight build or `flutter run --release` on device).
+2. Sign in to a server (single server URL, auto endpoint-switching off — the reported configuration).
+3. Enable backup and add enough new photos that the background worker keeps uploading.
+4. Background the app and leave it long enough for a background backup cycle to run and finish (watch for the background upload to drain).
+5. Reopen the app.
+6. **Expected:** the timeline/server calls succeed immediately — no force-quit needed. Previously this hung with `"Using server URL: null"` followed by failed server calls.
+
+- [ ] **Step 5: (Optional) Confirm the mechanism via log**
+
+If the device build still misbehaves, temporarily add a diagnostic in `refreshConnectionAfterResume` (`_log.info("Resume: refreshing connection (wasPaused=$wasPaused)")`) and in `NetworkRepository.refresh` log the pointer address before/after, to confirm the session pointer changes on resume. Remove before merge.
+
+- [ ] **Step 6: Final commit (if any verification fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore(mobile): verification fixes for iOS resume connection refresh"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Dart resume re-init → Tasks 2–5 (NetworkRepository.refresh, ApiService.refreshConnection, AppLifeCycleNotifier wiring). ✓
+- Native `recreateSession` → Task 1 (pigeon + Swift + Kotlin), called from `refresh()` in Task 3, device-verified in Task 6. ✓
+- Edge cases: same-pointer guard (Task 2), refresh defeats guard (Task 3), iOS-only session recreate (Task 3), client-getter-before-init (Task 2), not-paused / Android / error-swallow gates (Task 5), API-client re-pointing (Task 4). ✓
+- Benign `"Using server URL: null"` log: documented as not-the-cause; intentionally not changed (it is correct behaviour when endpoint-switching is off). A separate cleanup could downgrade that log, but it is out of scope for the connectivity fix.
+
+**Type/name consistency:** `refresh()`, `refreshConnection()`, `refreshConnectionAfterResume(bool)`, `debugReset()`, `debugClientPointer`, `debugBaseClientFactory`, `debugRecreateSession` are used identically across tasks. `networkApi.recreateSession()` is defined in Task 1 before first use in Task 3. `NetworkRepository.client` getter type (`http.Client`) and `apiClient.client` field used consistently.
+
+**Placeholder scan:** No TBD/TODO/"handle errors"/"similar to" — every code step contains full code and exact commands.
+
+**Risk notes:**
+
+- The `NetworkRepository` rewrite (Task 2) is a superset of the current file; the only behavioural changes are `Platform.isIOS` → `CurrentPlatform.isIOS` (equal on device; enables tests) and extraction of `_buildBaseClient`. `createWebSocket` keeps using `_clientPointer`, which `refresh()` updates — so the websocket reconnect in `_performResume` (after the refresh) also picks up the fresh session.
+- Pigeon regen (Task 1) may reformat the generated files; review the diff to ensure only `recreateSession` is added semantically.
+- The existing `recreateSession()` Swift implementation is unchanged (a known pre-existing non-invalidation of the old session; out of scope).

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/Network.g.kt
@@ -315,6 +315,11 @@ interface NetworkApi {
   fun hasCertificate(): Boolean
   fun getClientPointer(): Long
   fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>, token: String?)
+  /**
+   * Rebuilds the shared native URLSession (iOS). Used on foreground resume to
+   * recover from the background-worker isolate orphaning the shared session.
+   */
+  fun recreateSession()
 
   companion object {
     /** The codec used by NetworkApi. */
@@ -420,6 +425,22 @@ interface NetworkApi {
             val tokenArg = args[2] as String?
             val wrapped: List<Any?> = try {
               api.setRequestHeaders(headersArg, serverUrlsArg, tokenArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              NetworkPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NetworkApi.recreateSession$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.recreateSession()
               listOf(null)
             } catch (exception: Throwable) {
               NetworkPigeonUtils.wrapError(exception)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/core/NetworkApiPlugin.kt
@@ -82,4 +82,9 @@ private class NetworkApiImpl : NetworkApi {
   override fun setRequestHeaders(headers: Map<String, String>, serverUrls: List<String>, token: String?) {
     HttpClientManager.setRequestHeaders(headers, serverUrls, token)
   }
+
+  override fun recreateSession() {
+    // iOS-only: the shared-URLSession teardown race does not affect the
+    // Android OkHttp client, which is never re-shared across the worker isolate.
+  }
 }

--- a/mobile/ios/Runner/Core/Network.g.swift
+++ b/mobile/ios/Runner/Core/Network.g.swift
@@ -288,6 +288,9 @@ protocol NetworkApi {
   func hasCertificate() throws -> Bool
   func getClientPointer() throws -> Int64
   func setRequestHeaders(headers: [String: String], serverUrls: [String], token: String?) throws
+  /// Rebuilds the shared native URLSession (iOS). Used on foreground resume to
+  /// recover from the background-worker isolate orphaning the shared session.
+  func recreateSession() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -387,6 +390,21 @@ class NetworkApiSetup {
       }
     } else {
       setRequestHeadersChannel.setMessageHandler(nil)
+    }
+    /// Rebuilds the shared native URLSession (iOS). Used on foreground resume to
+    /// recover from the background-worker isolate orphaning the shared session.
+    let recreateSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NetworkApi.recreateSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      recreateSessionChannel.setMessageHandler { _, reply in
+        do {
+          try api.recreateSession()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      recreateSessionChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/ios/Runner/Core/NetworkApiImpl.swift
+++ b/mobile/ios/Runner/Core/NetworkApiImpl.swift
@@ -61,6 +61,10 @@ class NetworkApiImpl: NetworkApi {
     return Int64(Int(bitPattern: pointer))
   }
   
+  func recreateSession() throws {
+    URLSessionManager.shared.recreateSession()
+  }
+
   func setRequestHeaders(headers: [String : String], serverUrls: [String], token: String?) throws {
     URLSessionManager.setServerUrls(serverUrls)
 

--- a/mobile/lib/domain/models/background_backup_status.model.dart
+++ b/mobile/lib/domain/models/background_backup_status.model.dart
@@ -30,6 +30,14 @@ class BackgroundBackupStatus {
     this.lastBackgroundFailureReason = BackgroundBackupFailureReason.none,
     this.lastCandidateCount = 0,
     this.lastSuccessfulSchedulerKind,
+    this.lastQueuedCount = 0,
+    this.lastCompletedCount = 0,
+    this.lastFailedCount = 0,
+    this.lastSkippedCount = 0,
+    this.lastEnqueueFailedCount = 0,
+    this.lastRemainingCount = 0,
+    this.lastQueueDrainedAt,
+    this.lastFullBackupCompletedAt,
   });
 
   final DateTime? lastBackgroundWakeAt;
@@ -40,6 +48,14 @@ class BackgroundBackupStatus {
   final BackgroundBackupFailureReason lastBackgroundFailureReason;
   final int lastCandidateCount;
   final BackgroundBackupSchedulerKind? lastSuccessfulSchedulerKind;
+  final int lastQueuedCount;
+  final int lastCompletedCount;
+  final int lastFailedCount;
+  final int lastSkippedCount;
+  final int lastEnqueueFailedCount;
+  final int lastRemainingCount;
+  final DateTime? lastQueueDrainedAt;
+  final DateTime? lastFullBackupCompletedAt;
 
   BackgroundBackupStatus copyWith({
     DateTime? lastBackgroundWakeAt,
@@ -50,6 +66,14 @@ class BackgroundBackupStatus {
     BackgroundBackupFailureReason? lastBackgroundFailureReason,
     int? lastCandidateCount,
     BackgroundBackupSchedulerKind? lastSuccessfulSchedulerKind,
+    int? lastQueuedCount,
+    int? lastCompletedCount,
+    int? lastFailedCount,
+    int? lastSkippedCount,
+    int? lastEnqueueFailedCount,
+    int? lastRemainingCount,
+    DateTime? lastQueueDrainedAt,
+    DateTime? lastFullBackupCompletedAt,
   }) {
     return BackgroundBackupStatus(
       lastBackgroundWakeAt: lastBackgroundWakeAt ?? this.lastBackgroundWakeAt,
@@ -60,6 +84,14 @@ class BackgroundBackupStatus {
       lastBackgroundFailureReason: lastBackgroundFailureReason ?? this.lastBackgroundFailureReason,
       lastCandidateCount: lastCandidateCount ?? this.lastCandidateCount,
       lastSuccessfulSchedulerKind: lastSuccessfulSchedulerKind ?? this.lastSuccessfulSchedulerKind,
+      lastQueuedCount: lastQueuedCount ?? this.lastQueuedCount,
+      lastCompletedCount: lastCompletedCount ?? this.lastCompletedCount,
+      lastFailedCount: lastFailedCount ?? this.lastFailedCount,
+      lastSkippedCount: lastSkippedCount ?? this.lastSkippedCount,
+      lastEnqueueFailedCount: lastEnqueueFailedCount ?? this.lastEnqueueFailedCount,
+      lastRemainingCount: lastRemainingCount ?? this.lastRemainingCount,
+      lastQueueDrainedAt: lastQueueDrainedAt ?? this.lastQueueDrainedAt,
+      lastFullBackupCompletedAt: lastFullBackupCompletedAt ?? this.lastFullBackupCompletedAt,
     );
   }
 
@@ -105,6 +137,14 @@ class BackgroundBackupStatus {
       'lastBackgroundFailureReason': lastBackgroundFailureReason.name,
       'lastCandidateCount': lastCandidateCount,
       'lastSuccessfulSchedulerKind': lastSuccessfulSchedulerKind?.name,
+      'lastQueuedCount': lastQueuedCount,
+      'lastCompletedCount': lastCompletedCount,
+      'lastFailedCount': lastFailedCount,
+      'lastSkippedCount': lastSkippedCount,
+      'lastEnqueueFailedCount': lastEnqueueFailedCount,
+      'lastRemainingCount': lastRemainingCount,
+      'lastQueueDrainedAt': lastQueueDrainedAt?.toIso8601String(),
+      'lastFullBackupCompletedAt': lastFullBackupCompletedAt?.toIso8601String(),
     };
   }
 
@@ -120,6 +160,14 @@ class BackgroundBackupStatus {
       ),
       lastCandidateCount: json['lastCandidateCount'] as int? ?? 0,
       lastSuccessfulSchedulerKind: _schedulerKind(json['lastSuccessfulSchedulerKind']),
+      lastQueuedCount: json['lastQueuedCount'] as int? ?? 0,
+      lastCompletedCount: json['lastCompletedCount'] as int? ?? 0,
+      lastFailedCount: json['lastFailedCount'] as int? ?? 0,
+      lastSkippedCount: json['lastSkippedCount'] as int? ?? 0,
+      lastEnqueueFailedCount: json['lastEnqueueFailedCount'] as int? ?? 0,
+      lastRemainingCount: json['lastRemainingCount'] as int? ?? 0,
+      lastQueueDrainedAt: _date(json['lastQueueDrainedAt']),
+      lastFullBackupCompletedAt: _date(json['lastFullBackupCompletedAt']),
     );
   }
 
@@ -160,7 +208,15 @@ class BackgroundBackupStatus {
         other.lastReminderAt == lastReminderAt &&
         other.lastBackgroundFailureReason == lastBackgroundFailureReason &&
         other.lastCandidateCount == lastCandidateCount &&
-        other.lastSuccessfulSchedulerKind == lastSuccessfulSchedulerKind;
+        other.lastSuccessfulSchedulerKind == lastSuccessfulSchedulerKind &&
+        other.lastQueuedCount == lastQueuedCount &&
+        other.lastCompletedCount == lastCompletedCount &&
+        other.lastFailedCount == lastFailedCount &&
+        other.lastSkippedCount == lastSkippedCount &&
+        other.lastEnqueueFailedCount == lastEnqueueFailedCount &&
+        other.lastRemainingCount == lastRemainingCount &&
+        other.lastQueueDrainedAt == lastQueueDrainedAt &&
+        other.lastFullBackupCompletedAt == lastFullBackupCompletedAt;
   }
 
   @override
@@ -173,5 +229,13 @@ class BackgroundBackupStatus {
     lastBackgroundFailureReason,
     lastCandidateCount,
     lastSuccessfulSchedulerKind,
+    lastQueuedCount,
+    lastCompletedCount,
+    lastFailedCount,
+    lastSkippedCount,
+    lastEnqueueFailedCount,
+    lastRemainingCount,
+    lastQueueDrainedAt,
+    lastFullBackupCompletedAt,
   );
 }

--- a/mobile/lib/infrastructure/repositories/draining_http_client.dart
+++ b/mobile/lib/infrastructure/repositories/draining_http_client.dart
@@ -68,22 +68,49 @@ class DrainingHttpClient extends http.BaseClient {
       // The request is not fully settled until its body has been delivered:
       // `cupertino_http` fires its completion FFI callback when the response
       // stream closes, so the request must stay tracked (and abortable) until
-      // then.
-      final tracked = response.stream.transform(
-        StreamTransformer<List<int>, List<int>>.fromHandlers(
-          handleData: (data, sink) => sink.add(data),
-          handleError: (error, stackTrace, sink) {
-            sink.addError(error, stackTrace);
-            settle();
-          },
-          handleDone: (sink) {
-            settle();
-            sink.close();
-          },
-        ),
+      // then. Subscribe eagerly so shutdown can drain even if the caller has not
+      // listened to the response body yet.
+      late final StreamSubscription<List<int>> subscription;
+      var proxyClosed = false;
+      late final StreamController<List<int>> proxy;
+
+      Future<void> closeProxy() async {
+        if (proxyClosed) {
+          return;
+        }
+        proxyClosed = true;
+        await proxy.close();
+      }
+
+      proxy = StreamController<List<int>>(
+        sync: true,
+        onPause: () => subscription.pause(),
+        onResume: () => subscription.resume(),
+        onCancel: () async {
+          await subscription.cancel();
+          settle();
+        },
       );
+
+      subscription = response.stream.listen(
+        (data) {
+          if (!proxyClosed) {
+            proxy.add(data);
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!proxyClosed) {
+            proxy.addError(error, stackTrace);
+          }
+        },
+        onDone: () {
+          settle();
+          unawaited(closeProxy());
+        },
+      );
+
       return http.StreamedResponse(
-        tracked,
+        proxy.stream,
         response.statusCode,
         contentLength: response.contentLength,
         request: response.request,

--- a/mobile/lib/infrastructure/repositories/network.repository.dart
+++ b/mobile/lib/infrastructure/repositories/network.repository.dart
@@ -27,7 +27,7 @@ class NetworkRepository {
   @visibleForTesting
   static http.Client Function(Pointer<Void> pointer)? debugBaseClientFactory;
 
-  /// Test seam: overrides the native session recreation.
+  /// Test seam: overrides the native session recreation performed by [refresh].
   @visibleForTesting
   static Future<void> Function()? debugRecreateSession;
 
@@ -76,6 +76,25 @@ class NetworkRepository {
     } else {
       _client = base;
     }
+  }
+
+  /// Re-establishes this isolate's native HTTP client.
+  ///
+  /// On iOS the foreground and background-worker isolates share one native
+  /// URLSession. When the background-worker isolate is torn down
+  /// (`engine.destroyContext()`) it leaves the shared session's
+  /// `cupertino_http` callback target pointing at a destroyed isolate, so the
+  /// foreground can no longer complete any request until a cold restart.
+  ///
+  /// On resume we recreate the native session (iOS) and rebuild this isolate's
+  /// client — defeating [init]'s same-pointer short-circuit — so the foreground
+  /// owns a fresh, live session again.
+  static Future<void> refresh() async {
+    if (CurrentPlatform.isIOS) {
+      await (debugRecreateSession ?? networkApi.recreateSession)();
+    }
+    _clientPointer = null;
+    await init();
   }
 
   static http.Client _buildBaseClient(Pointer<Void> clientPointer) {

--- a/mobile/lib/infrastructure/repositories/network.repository.dart
+++ b/mobile/lib/infrastructure/repositories/network.repository.dart
@@ -1,8 +1,9 @@
 import 'dart:ffi';
-import 'dart:io';
 
 import 'package:cupertino_http/cupertino_http.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/draining_http_client.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:ok_http/ok_http.dart';
@@ -18,6 +19,30 @@ class NetworkRepository {
   static bool _trackInFlight = false;
   static DrainingHttpClient? _draining;
 
+  /// Test seam: overrides the native client-pointer source.
+  @visibleForTesting
+  static Future<int> Function()? debugClientPointer;
+
+  /// Test seam: overrides native base-client construction (avoids real FFI).
+  @visibleForTesting
+  static http.Client Function(Pointer<Void> pointer)? debugBaseClientFactory;
+
+  /// Test seam: overrides the native session recreation.
+  @visibleForTesting
+  static Future<void> Function()? debugRecreateSession;
+
+  /// Resets all static state and test seams. Test-only.
+  @visibleForTesting
+  static void debugReset() {
+    _client = null;
+    _clientPointer = null;
+    _draining = null;
+    _trackInFlight = false;
+    debugClientPointer = null;
+    debugBaseClientFactory = null;
+    debugRecreateSession = null;
+  }
+
   /// Enables graceful shutdown tracking of in-flight requests for the current
   /// isolate. Must be called before [init].
   ///
@@ -31,7 +56,8 @@ class NetworkRepository {
   }
 
   static Future<void> init() async {
-    final clientPointer = Pointer<Void>.fromAddress(await networkApi.getClientPointer());
+    final address = await (debugClientPointer ?? networkApi.getClientPointer)();
+    final clientPointer = Pointer<Void>.fromAddress(address);
     if (clientPointer == _clientPointer) {
       return;
     }
@@ -39,28 +65,32 @@ class NetworkRepository {
     _client?.close();
     _draining = null;
 
-    final http.Client base;
-    if (Platform.isIOS) {
-      final session = URLSession.fromRawPointer(clientPointer.cast());
-      base = CupertinoClient.fromSharedSession(session);
-    } else {
-      base = OkHttpClient.fromJniGlobalRef(
-        clientPointer,
-        configuration: const OkHttpClientConfiguration(
-          connectTimeout: Duration(seconds: 30),
-          readTimeout: Duration(seconds: 60),
-          writeTimeout: Duration(seconds: 60),
-        ),
-      );
-    }
+    final http.Client base = debugBaseClientFactory != null
+        ? debugBaseClientFactory!(clientPointer)
+        : _buildBaseClient(clientPointer);
 
     // Only iOS needs draining: the crash is specific to cupertino_http's
     // shared-session FFI delegate. Android's background worker is unaffected.
-    if (_trackInFlight && Platform.isIOS) {
+    if (_trackInFlight && CurrentPlatform.isIOS) {
       _client = _draining = DrainingHttpClient(base);
     } else {
       _client = base;
     }
+  }
+
+  static http.Client _buildBaseClient(Pointer<Void> clientPointer) {
+    if (CurrentPlatform.isIOS) {
+      final session = URLSession.fromRawPointer(clientPointer.cast());
+      return CupertinoClient.fromSharedSession(session);
+    }
+    return OkHttpClient.fromJniGlobalRef(
+      clientPointer,
+      configuration: const OkHttpClientConfiguration(
+        connectTimeout: Duration(seconds: 30),
+        readTimeout: Duration(seconds: 60),
+        writeTimeout: Duration(seconds: 60),
+      ),
+    );
   }
 
   /// Aborts and drains any in-flight requests, then closes the client.
@@ -76,14 +106,14 @@ class NetworkRepository {
 
   static Future<void> setHeaders(Map<String, String> headers, List<String> serverUrls, {String? token}) async {
     await networkApi.setRequestHeaders(headers, serverUrls, token);
-    if (Platform.isIOS) {
+    if (CurrentPlatform.isIOS) {
       await init();
     }
   }
 
   // ignore: avoid-unused-parameters
   static Future<WebSocket> createWebSocket(Uri uri, {Map<String, String>? headers, Iterable<String>? protocols}) {
-    if (Platform.isIOS) {
+    if (CurrentPlatform.isIOS) {
       final session = URLSession.fromRawPointer(_clientPointer!.cast());
       return CupertinoWebSocket.connectWithSession(session, uri, protocols: protocols);
     } else {

--- a/mobile/lib/platform/network_api.g.dart
+++ b/mobile/lib/platform/network_api.g.dart
@@ -309,4 +309,20 @@ class NetworkApi {
 
     _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
+
+  /// Rebuilds the shared native URLSession (iOS). Used on foreground resume to
+  /// recover from the background-worker isolate orphaning the shared session.
+  Future<void> recreateSession() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NetworkApi.recreateSession$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
 }

--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/services/log.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
@@ -53,6 +55,7 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
     _resumeOperation = Completer<void>();
 
     try {
+      await refreshConnectionAfterResume(_wasPaused);
       await _performResume();
     } catch (e, stackTrace) {
       _log.severe("Error during app resume", e, stackTrace);
@@ -86,6 +89,24 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
     await _ref.read(notificationPermissionProvider.notifier).getNotificationPermission();
 
     await _ref.read(galleryPermissionNotifier.notifier).getGalleryPermissionStatus();
+  }
+
+  /// On iOS, re-establishes the native HTTP client when returning to the
+  /// foreground after a pause. The background-worker isolate shares (and on
+  /// teardown orphans) the native URLSession, leaving the foreground unable to
+  /// reach the server until a cold restart. Re-establishing the client here —
+  /// before [_performResume] issues any request — recovers connectivity.
+  @visibleForTesting
+  Future<void> refreshConnectionAfterResume(bool wasPaused) async {
+    if (!CurrentPlatform.isIOS || !wasPaused) {
+      return;
+    }
+    try {
+      await _ref.read(apiServiceProvider).refreshConnection();
+      _log.info("Re-established server connection after resume");
+    } catch (e, stackTrace) {
+      _log.warning("Failed to refresh connection on resume", e, stackTrace);
+    }
   }
 
   Future<void> _safeRun(Future<void> action, String debugName) async {

--- a/mobile/lib/providers/backup/background_backup_queue.provider.dart
+++ b/mobile/lib/providers/backup/background_backup_queue.provider.dart
@@ -1,0 +1,11 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_backup_status.service.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+
+final backgroundBackupQueueCoordinatorProvider = Provider<BackgroundBackupQueueCoordinator>((ref) {
+  return BackgroundBackupQueueCoordinator(
+    ref.watch(backgroundUploadServiceProvider),
+    statusService: ref.watch(backgroundBackupStatusServiceProvider),
+  );
+});

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -212,6 +212,8 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
   final BackgroundUploadService _backgroundUploadService;
   final UploadSpeedManager _uploadSpeedManager;
   Completer<void>? _cancelToken;
+  String? _activeBackgroundBackupUserId;
+  bool _isCheckingForMoreBackgroundTasks = false;
   late final StreamSubscription<TaskProgressUpdate> _backgroundProgressSubscription;
   late final StreamSubscription<TaskStatusUpdate> _backgroundStatusSubscription;
 
@@ -282,6 +284,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
             _removeUploadItem(taskId);
           });
         }
+        unawaited(_queueMoreBackgroundBackupCandidatesIfNeeded());
         break;
       case TaskStatus.failed:
       case TaskStatus.notFound:
@@ -301,9 +304,36 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
             ),
           },
         );
+        unawaited(_queueMoreBackgroundBackupCandidatesIfNeeded());
         break;
       default:
         break;
+    }
+  }
+
+  Future<void> _queueMoreBackgroundBackupCandidatesIfNeeded() async {
+    final userId = _activeBackgroundBackupUserId;
+    if (userId == null || _isCheckingForMoreBackgroundTasks || state.remainderCount <= 0) {
+      return;
+    }
+
+    _isCheckingForMoreBackgroundTasks = true;
+    try {
+      final taskGroups = await Future.wait([
+        _backgroundUploadService.getActiveTasks(kBackupGroup),
+        _backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup),
+      ]);
+      if (!mounted || _activeBackgroundBackupUserId != userId || state.remainderCount <= 0) {
+        return;
+      }
+
+      final activeTaskCount = taskGroups.fold<int>(0, (count, tasks) => count + tasks.length);
+      if (activeTaskCount == 0) {
+        _logger.info("Background upload queue drained with ${state.remainderCount} assets remaining, queueing more");
+        await _backgroundUploadService.uploadBackupCandidates(userId);
+      }
+    } finally {
+      _isCheckingForMoreBackgroundTasks = false;
     }
   }
 
@@ -384,6 +414,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
   Future<void> stopBackup() async {
     if (CurrentPlatform.isIOS) {
       await _backgroundUploadService.cancel();
+      _activeBackgroundBackupUserId = null;
       _uploadSpeedManager.clear();
       state = state.copyWith(uploadItems: {}, iCloudDownloadProgress: {});
       return;
@@ -493,6 +524,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
       return;
     }
     _logger.info("Start background backup sequence");
+    _activeBackgroundBackupUserId = userId;
     state = state.copyWith(error: BackupError.none);
     final taskGroups = await Future.wait([
       _backgroundUploadService.getActiveTasks(kBackupGroup),

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -397,7 +397,14 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     if (CurrentPlatform.isIOS) {
       await _backgroundQueueCoordinator.stop();
       _uploadSpeedManager.clear();
-      state = state.copyWith(uploadItems: {}, iCloudDownloadProgress: {});
+      state = state.copyWith(
+        backupCount: 0,
+        remainderCount: 0,
+        processingCount: 0,
+        totalCount: 0,
+        uploadItems: {},
+        iCloudDownloadProgress: {},
+      );
       return;
     }
 

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -10,8 +10,10 @@ import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/utils/upload_speed_calculator.dart';
+import 'package:immich_mobile/providers/backup/background_backup_queue.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
 
@@ -186,22 +188,29 @@ final driftBackupProvider = StateNotifierProvider<DriftBackupNotifier, DriftBack
     ref.watch(foregroundUploadServiceProvider),
     ref.watch(backgroundUploadServiceProvider),
     UploadSpeedManager(),
+    backgroundQueueCoordinator: ref.watch(backgroundBackupQueueCoordinatorProvider),
   );
 });
 
 class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
-  DriftBackupNotifier(this._foregroundUploadService, this._backgroundUploadService, this._uploadSpeedManager)
-    : super(
-        const DriftBackupState(
-          totalCount: 0,
-          backupCount: 0,
-          remainderCount: 0,
-          processingCount: 0,
-          isSyncing: false,
-          uploadItems: {},
-          error: BackupError.none,
-        ),
-      ) {
+  DriftBackupNotifier(
+    this._foregroundUploadService,
+    this._backgroundUploadService,
+    this._uploadSpeedManager, {
+    BackgroundBackupQueueCoordinator? backgroundQueueCoordinator,
+  }) : _backgroundQueueCoordinator =
+           backgroundQueueCoordinator ?? BackgroundBackupQueueCoordinator(_backgroundUploadService),
+       super(
+         const DriftBackupState(
+           totalCount: 0,
+           backupCount: 0,
+           remainderCount: 0,
+           processingCount: 0,
+           isSyncing: false,
+           uploadItems: {},
+           error: BackupError.none,
+         ),
+       ) {
     _backgroundProgressSubscription = _backgroundUploadService.taskProgressStream.listen(
       _handleBackgroundBackupProgress,
     );
@@ -211,9 +220,8 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
   final ForegroundUploadService _foregroundUploadService;
   final BackgroundUploadService _backgroundUploadService;
   final UploadSpeedManager _uploadSpeedManager;
+  final BackgroundBackupQueueCoordinator _backgroundQueueCoordinator;
   Completer<void>? _cancelToken;
-  String? _activeBackgroundBackupUserId;
-  bool _isCheckingForMoreBackgroundTasks = false;
   late final StreamSubscription<TaskProgressUpdate> _backgroundProgressSubscription;
   late final StreamSubscription<TaskStatusUpdate> _backgroundStatusSubscription;
 
@@ -275,6 +283,8 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
       return;
     }
 
+    unawaited(_backgroundQueueCoordinator.handleStatus(update));
+
     final taskId = update.task.taskId;
     switch (update.status) {
       case TaskStatus.complete:
@@ -284,7 +294,6 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
             _removeUploadItem(taskId);
           });
         }
-        unawaited(_queueMoreBackgroundBackupCandidatesIfNeeded());
         break;
       case TaskStatus.failed:
       case TaskStatus.notFound:
@@ -304,36 +313,9 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
             ),
           },
         );
-        unawaited(_queueMoreBackgroundBackupCandidatesIfNeeded());
         break;
       default:
         break;
-    }
-  }
-
-  Future<void> _queueMoreBackgroundBackupCandidatesIfNeeded() async {
-    final userId = _activeBackgroundBackupUserId;
-    if (userId == null || _isCheckingForMoreBackgroundTasks || state.remainderCount <= 0) {
-      return;
-    }
-
-    _isCheckingForMoreBackgroundTasks = true;
-    try {
-      final taskGroups = await Future.wait([
-        _backgroundUploadService.getActiveTasks(kBackupGroup),
-        _backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup),
-      ]);
-      if (!mounted || _activeBackgroundBackupUserId != userId || state.remainderCount <= 0) {
-        return;
-      }
-
-      final activeTaskCount = taskGroups.fold<int>(0, (count, tasks) => count + tasks.length);
-      if (activeTaskCount == 0) {
-        _logger.info("Background upload queue drained with ${state.remainderCount} assets remaining, queueing more");
-        await _backgroundUploadService.uploadBackupCandidates(userId);
-      }
-    } finally {
-      _isCheckingForMoreBackgroundTasks = false;
     }
   }
 
@@ -413,8 +395,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
 
   Future<void> stopBackup() async {
     if (CurrentPlatform.isIOS) {
-      await _backgroundUploadService.cancel();
-      _activeBackgroundBackupUserId = null;
+      await _backgroundQueueCoordinator.stop();
       _uploadSpeedManager.clear();
       state = state.copyWith(uploadItems: {}, iCloudDownloadProgress: {});
       return;
@@ -518,32 +499,9 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     _uploadSpeedManager.removeTask(localAssetId);
   }
 
-  Future<void> startBackupWithURLSession(String userId) async {
-    if (!mounted) {
-      _logger.warning("Skip handleBackupResume (pre-call): notifier disposed");
-      return;
-    }
-    _logger.info("Start background backup sequence");
-    _activeBackgroundBackupUserId = userId;
+  Future<void> startBackupWithURLSession(String userId) {
     state = state.copyWith(error: BackupError.none);
-    final taskGroups = await Future.wait([
-      _backgroundUploadService.getActiveTasks(kBackupGroup),
-      _backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup),
-    ]);
-    final tasks = taskGroups.expand((group) => group).toList(growable: false);
-    if (!mounted) {
-      _logger.warning("Skip handleBackupResume (post-call): notifier disposed");
-      return;
-    }
-    _logger.info("Found ${tasks.length} pending tasks");
-
-    if (tasks.isEmpty) {
-      _logger.info("No pending tasks, starting new upload");
-      return _backgroundUploadService.uploadBackupCandidates(userId);
-    }
-
-    _logger.info("Resuming upload ${tasks.length} assets");
-    return _backgroundUploadService.resume();
+    return _backgroundQueueCoordinator.start(userId);
   }
 }
 

--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -55,6 +55,14 @@ class ApiService {
     _apiClient.client = NetworkRepository.client;
   }
 
+  /// Re-establishes the native HTTP client after a background-worker teardown
+  /// orphaned the shared iOS URLSession, then re-points the API client at it.
+  /// Call on foreground resume (see [AppLifeCycleNotifier]).
+  Future<void> refreshConnection() async {
+    await NetworkRepository.refresh();
+    _apiClient.client = NetworkRepository.client;
+  }
+
   setEndpoint(String endpoint) {
     _apiClient = ApiClient(basePath: endpoint);
     _apiClient.client = NetworkRepository.client;

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -2,16 +2,10 @@ import 'dart:async';
 
 import 'package:background_downloader/background_downloader.dart';
 import 'package:immich_mobile/constants/constants.dart';
+import 'package:immich_mobile/services/background_backup_queue_port.dart';
 import 'package:immich_mobile/services/background_backup_status.service.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
 import 'package:logging/logging.dart';
-
-abstract interface class BackgroundBackupQueuePort {
-  Future<List<Task>> getActiveTasks(String group);
-  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(String userId, {Set<String> excludedLocalAssetIds});
-  Future<void> resume();
-  Future<int> cancel();
-}
 
 class BackgroundBackupQueueCoordinator {
   BackgroundBackupQueueCoordinator(this._queue, {BackgroundBackupStatusService? statusService})

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -35,6 +35,7 @@ class BackgroundBackupQueueCoordinator {
   Future<void> start(String userId) async {
     _activeUserId = userId;
     final generation = ++_sessionGeneration;
+    _logger.info('Starting background backup session');
 
     final activeTasks = await _activeTasks();
     if (!_isCurrentSession(userId, generation)) {
@@ -65,8 +66,12 @@ class BackgroundBackupQueueCoordinator {
     }
     final generation = _sessionGeneration;
     _refillTail = (_refillTail ?? Future.value()).then((_) async {
-      _recordTerminalStatus(update);
-      await _refillIfDrained(userId, generation);
+      try {
+        _recordTerminalStatus(update);
+        await _refillIfDrained(userId, generation);
+      } catch (error, stackTrace) {
+        _logger.severe('Background backup refill failed', error, stackTrace);
+      }
     });
     return _refillTail!;
   }
@@ -104,20 +109,45 @@ class BackgroundBackupQueueCoordinator {
   }
 
   Future<void> _enqueueNextBatch(String userId, int generation) async {
-    final result = await _queue.enqueueNextBackupBatch(
-      userId,
-      excludedLocalAssetIds: _excludedLocalAssetIds(),
-    );
-    if (!_isCurrentSession(userId, generation)) {
-      return;
-    }
+    while (true) {
+      final BackgroundBackupQueueResult result;
+      try {
+        result = await _queue.enqueueNextBackupBatch(
+          userId,
+          excludedLocalAssetIds: _excludedLocalAssetIds(),
+        );
+      } catch (error, stackTrace) {
+        _logger.severe('Background backup enqueue failed; ending session', error, stackTrace);
+        if (_isCurrentSession(userId, generation)) {
+          _activeUserId = null;
+        }
+        return;
+      }
 
-    _queuedLocalAssetIds.addAll(result.enqueuedLocalAssetIds);
-    _skippedLocalAssetIds.addAll(result.skippedLocalAssetIds);
-    _enqueueFailedLocalAssetIds.addAll(result.enqueueFailedLocalAssetIds);
+      if (!_isCurrentSession(userId, generation)) {
+        return;
+      }
 
-    if (!result.queuedAny && !result.hasMoreEligibleCandidates) {
-      _activeUserId = null;
+      _queuedLocalAssetIds.addAll(result.enqueuedLocalAssetIds);
+      _skippedLocalAssetIds.addAll(result.skippedLocalAssetIds);
+      _enqueueFailedLocalAssetIds.addAll(result.enqueueFailedLocalAssetIds);
+
+      if (result.queuedAny) {
+        _logger.info('Enqueued ${result.enqueuedCount} background backup tasks');
+        return;
+      }
+
+      if (!result.hasMoreEligibleCandidates) {
+        _logger.info('Background backup session complete');
+        _activeUserId = null;
+        return;
+      }
+
+      // No tasks were enqueued (all skipped or enqueue-failed) but more eligible
+      // candidates remain. No completion callback will arrive to drive the next
+      // refill, so advance to the next window now. The exclusion sets grow by the
+      // whole window each iteration, so this is guaranteed to converge.
+      _logger.info('Batch produced no tasks; advancing to the next window');
     }
   }
 

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:background_downloader/background_downloader.dart';
 import 'package:immich_mobile/constants/constants.dart';
+import 'package:immich_mobile/services/background_backup_status.service.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
 import 'package:logging/logging.dart';
 
@@ -16,14 +17,17 @@ abstract interface class BackgroundBackupQueuePort {
 }
 
 class BackgroundBackupQueueCoordinator {
-  BackgroundBackupQueueCoordinator(this._queue);
+  BackgroundBackupQueueCoordinator(this._queue, {BackgroundBackupStatusService? statusService})
+    : _statusService = statusService;
 
   final BackgroundBackupQueuePort _queue;
+  final BackgroundBackupStatusService? _statusService;
   final Logger _logger = Logger('BackgroundBackupQueueCoordinator');
 
   String? _activeUserId;
   int _sessionGeneration = 0;
   Future<void>? _refillTail;
+  int _remainingEligibleCount = 0;
   final Set<String> _queuedLocalAssetIds = {};
   final Set<String> _completedLocalAssetIds = {};
   final Set<String> _failedLocalAssetIds = {};
@@ -77,21 +81,29 @@ class BackgroundBackupQueueCoordinator {
   }
 
   void _recordTerminalStatus(TaskStatusUpdate update) {
+    var removedLogicalAsset = false;
+
     switch (update.status) {
       case TaskStatus.complete:
-        if (!_isLivePhotoMotionTask(update.task)) {
-          _queuedLocalAssetIds.remove(update.task.taskId);
+        if (!_isLivePhotoMotionTask(update.task) && _queuedLocalAssetIds.remove(update.task.taskId)) {
           _completedLocalAssetIds.add(update.task.taskId);
+          removedLogicalAsset = true;
         }
         break;
       case TaskStatus.failed:
       case TaskStatus.notFound:
       case TaskStatus.canceled:
-        _queuedLocalAssetIds.remove(update.task.taskId);
-        _failedLocalAssetIds.add(update.task.taskId);
+        if (_queuedLocalAssetIds.remove(update.task.taskId)) {
+          _failedLocalAssetIds.add(update.task.taskId);
+          removedLogicalAsset = true;
+        }
         break;
       default:
         break;
+    }
+
+    if (removedLogicalAsset && _remainingEligibleCount > 0) {
+      _remainingEligibleCount--;
     }
   }
 
@@ -132,6 +144,9 @@ class BackgroundBackupQueueCoordinator {
       _skippedLocalAssetIds.addAll(result.skippedLocalAssetIds);
       _enqueueFailedLocalAssetIds.addAll(result.enqueueFailedLocalAssetIds);
 
+      _remainingEligibleCount = result.remainingEligibleCandidateCount;
+      await _recordProgress();
+
       if (result.queuedAny) {
         _logger.info('Enqueued ${result.enqueuedCount} background backup tasks');
         return;
@@ -139,6 +154,7 @@ class BackgroundBackupQueueCoordinator {
 
       if (!result.hasMoreEligibleCandidates) {
         _logger.info('Background backup session complete');
+        await _statusService?.recordBackupComplete();
         _activeUserId = null;
         return;
       }
@@ -186,6 +202,18 @@ class BackgroundBackupQueueCoordinator {
     } catch (_) {
       return false;
     }
+  }
+
+  Future<void> _recordProgress() {
+    return _statusService?.recordQueueProgress(
+          queuedCount: _queuedLocalAssetIds.length,
+          completedCount: _completedLocalAssetIds.length,
+          failedCount: _failedLocalAssetIds.length,
+          skippedCount: _skippedLocalAssetIds.length,
+          enqueueFailedCount: _enqueueFailedLocalAssetIds.length,
+          remainingCount: _remainingEligibleCount,
+        ) ??
+        Future.value();
   }
 
   void _clearSessionSets() {

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -37,6 +37,8 @@ class BackgroundBackupQueueCoordinator {
   bool get isActive => _activeUserId != null;
 
   Future<void> start(String userId) async {
+    _clearSessionSets();
+    await _statusService?.recordSessionStart();
     _activeUserId = userId;
     final generation = ++_sessionGeneration;
     _logger.info('Starting background backup session');
@@ -72,6 +74,7 @@ class BackgroundBackupQueueCoordinator {
     _refillTail = (_refillTail ?? Future.value()).then((_) async {
       try {
         _recordTerminalStatus(update);
+        await _recordProgress();
         await _refillIfDrained(userId, generation);
       } catch (error, stackTrace) {
         _logger.severe('Background backup refill failed', error, stackTrace);
@@ -117,6 +120,7 @@ class BackgroundBackupQueueCoordinator {
       return;
     }
 
+    await _statusService?.recordQueueDrained(remainingCount: _remainingEligibleCount);
     await _enqueueNextBatch(userId, generation);
   }
 
@@ -222,5 +226,6 @@ class BackgroundBackupQueueCoordinator {
     _failedLocalAssetIds.clear();
     _skippedLocalAssetIds.clear();
     _enqueueFailedLocalAssetIds.clear();
+    _remainingEligibleCount = 0;
   }
 }

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:immich_mobile/constants/constants.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+import 'package:logging/logging.dart';
+
+abstract interface class BackgroundBackupQueuePort {
+  Future<List<Task>> getActiveTasks(String group);
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
+    String userId, {
+    Set<String> excludedLocalAssetIds,
+  });
+  Future<void> resume();
+  Future<int> cancel();
+}
+
+class BackgroundBackupQueueCoordinator {
+  BackgroundBackupQueueCoordinator(this._queue);
+
+  final BackgroundBackupQueuePort _queue;
+  final Logger _logger = Logger('BackgroundBackupQueueCoordinator');
+
+  String? _activeUserId;
+  int _sessionGeneration = 0;
+  Future<void>? _refillTail;
+  final Set<String> _queuedLocalAssetIds = {};
+  final Set<String> _completedLocalAssetIds = {};
+  final Set<String> _failedLocalAssetIds = {};
+  final Set<String> _skippedLocalAssetIds = {};
+  final Set<String> _enqueueFailedLocalAssetIds = {};
+
+  bool get isActive => _activeUserId != null;
+
+  Future<void> start(String userId) async {
+    _activeUserId = userId;
+    final generation = ++_sessionGeneration;
+
+    final activeTasks = await _activeTasks();
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
+
+    if (activeTasks.isNotEmpty) {
+      _queuedLocalAssetIds.addAll(activeTasks.map((task) => task.taskId));
+      _logger.info('Resuming ${activeTasks.length} active background backup tasks');
+      await _queue.resume();
+      return;
+    }
+
+    await _enqueueNextBatch(userId, generation);
+  }
+
+  Future<void> stop() async {
+    _activeUserId = null;
+    _sessionGeneration++;
+    _clearSessionSets();
+    await _queue.cancel();
+  }
+
+  Future<void> handleStatus(TaskStatusUpdate update) {
+    final userId = _activeUserId;
+    if (userId == null || !_isBackupTask(update.task)) {
+      return Future.value();
+    }
+    final generation = _sessionGeneration;
+    _refillTail = (_refillTail ?? Future.value()).then((_) async {
+      _recordTerminalStatus(update);
+      await _refillIfDrained(userId, generation);
+    });
+    return _refillTail!;
+  }
+
+  void _recordTerminalStatus(TaskStatusUpdate update) {
+    switch (update.status) {
+      case TaskStatus.complete:
+        if (!_isLivePhotoMotionTask(update.task)) {
+          _queuedLocalAssetIds.remove(update.task.taskId);
+          _completedLocalAssetIds.add(update.task.taskId);
+        }
+        break;
+      case TaskStatus.failed:
+      case TaskStatus.notFound:
+      case TaskStatus.canceled:
+        _queuedLocalAssetIds.remove(update.task.taskId);
+        _failedLocalAssetIds.add(update.task.taskId);
+        break;
+      default:
+        break;
+    }
+  }
+
+  Future<void> _refillIfDrained(String userId, int generation) async {
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
+
+    final activeTasks = await _activeTasks();
+    if (!_isCurrentSession(userId, generation) || activeTasks.isNotEmpty) {
+      return;
+    }
+
+    await _enqueueNextBatch(userId, generation);
+  }
+
+  Future<void> _enqueueNextBatch(String userId, int generation) async {
+    final result = await _queue.enqueueNextBackupBatch(
+      userId,
+      excludedLocalAssetIds: _excludedLocalAssetIds(),
+    );
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
+
+    _queuedLocalAssetIds.addAll(result.enqueuedLocalAssetIds);
+    _skippedLocalAssetIds.addAll(result.skippedLocalAssetIds);
+    _enqueueFailedLocalAssetIds.addAll(result.enqueueFailedLocalAssetIds);
+
+    if (!result.queuedAny && !result.hasMoreEligibleCandidates) {
+      _activeUserId = null;
+    }
+  }
+
+  Set<String> _excludedLocalAssetIds() {
+    return {
+      ..._queuedLocalAssetIds,
+      ..._completedLocalAssetIds,
+      ..._failedLocalAssetIds,
+      ..._skippedLocalAssetIds,
+      ..._enqueueFailedLocalAssetIds,
+    };
+  }
+
+  Future<List<Task>> _activeTasks() async {
+    final groups = await Future.wait([
+      _queue.getActiveTasks(kBackupGroup),
+      _queue.getActiveTasks(kBackupLivePhotoGroup),
+    ]);
+    return groups.expand((group) => group).toList(growable: false);
+  }
+
+  bool _isCurrentSession(String userId, int generation) {
+    return _activeUserId == userId && _sessionGeneration == generation;
+  }
+
+  bool _isBackupTask(Task task) {
+    return task.group == kBackupGroup || task.group == kBackupLivePhotoGroup;
+  }
+
+  bool _isLivePhotoMotionTask(Task task) {
+    if (task.group != kBackupGroup || task.metaData.isEmpty) {
+      return false;
+    }
+    try {
+      return UploadTaskMetadata.fromJson(task.metaData).isLivePhotos;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void _clearSessionSets() {
+    _queuedLocalAssetIds.clear();
+    _completedLocalAssetIds.clear();
+    _failedLocalAssetIds.clear();
+    _skippedLocalAssetIds.clear();
+    _enqueueFailedLocalAssetIds.clear();
+  }
+}

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -38,10 +38,14 @@ class BackgroundBackupQueueCoordinator {
 
   Future<void> start(String userId) async {
     _clearSessionSets();
-    await _statusService?.recordSessionStart();
     _activeUserId = userId;
     final generation = ++_sessionGeneration;
     _logger.info('Starting background backup session');
+
+    await _statusService?.recordSessionStart();
+    if (!_isCurrentSession(userId, generation)) {
+      return;
+    }
 
     final activeTasks = await _activeTasks();
     if (!_isCurrentSession(userId, generation)) {

--- a/mobile/lib/services/background_backup_queue_coordinator.dart
+++ b/mobile/lib/services/background_backup_queue_coordinator.dart
@@ -8,10 +8,7 @@ import 'package:logging/logging.dart';
 
 abstract interface class BackgroundBackupQueuePort {
   Future<List<Task>> getActiveTasks(String group);
-  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
-    String userId, {
-    Set<String> excludedLocalAssetIds,
-  });
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(String userId, {Set<String> excludedLocalAssetIds});
   Future<void> resume();
   Future<int> cancel();
 }
@@ -132,10 +129,7 @@ class BackgroundBackupQueueCoordinator {
     while (true) {
       final BackgroundBackupQueueResult result;
       try {
-        result = await _queue.enqueueNextBackupBatch(
-          userId,
-          excludedLocalAssetIds: _excludedLocalAssetIds(),
-        );
+        result = await _queue.enqueueNextBackupBatch(userId, excludedLocalAssetIds: _excludedLocalAssetIds());
       } catch (error, stackTrace) {
         _logger.severe('Background backup enqueue failed; ending session', error, stackTrace);
         if (_isCurrentSession(userId, generation)) {

--- a/mobile/lib/services/background_backup_queue_port.dart
+++ b/mobile/lib/services/background_backup_queue_port.dart
@@ -1,0 +1,32 @@
+import 'package:background_downloader/background_downloader.dart';
+
+/// Result of attempting to enqueue one bounded background-backup batch.
+class BackgroundBackupQueueResult {
+  const BackgroundBackupQueueResult({
+    required this.totalCandidateCount,
+    required this.eligibleCandidateCount,
+    required this.enqueuedLocalAssetIds,
+    required this.skippedLocalAssetIds,
+    required this.enqueueFailedLocalAssetIds,
+    required this.remainingEligibleCandidateCount,
+  });
+
+  final int totalCandidateCount;
+  final int eligibleCandidateCount;
+  final List<String> enqueuedLocalAssetIds;
+  final List<String> skippedLocalAssetIds;
+  final List<String> enqueueFailedLocalAssetIds;
+  final int remainingEligibleCandidateCount;
+
+  int get enqueuedCount => enqueuedLocalAssetIds.length;
+  bool get queuedAny => enqueuedLocalAssetIds.isNotEmpty;
+  bool get hasMoreEligibleCandidates => remainingEligibleCandidateCount > 0;
+}
+
+/// The queue operations the backup coordinator needs from the upload service.
+abstract interface class BackgroundBackupQueuePort {
+  Future<List<Task>> getActiveTasks(String group);
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(String userId, {Set<String> excludedLocalAssetIds});
+  Future<void> resume();
+  Future<int> cancel();
+}

--- a/mobile/lib/services/background_backup_status.service.dart
+++ b/mobile/lib/services/background_backup_status.service.dart
@@ -16,12 +16,11 @@ class BackgroundBackupStatusService {
   final StoreService store;
   final DateTime Function() _now;
 
-  // Background-downloader status callbacks (recordUploadSuccess / recordFailure)
-  // fire once per completed task and each does a read-modify-write of one JSON
-  // blob. Without serialization two callbacks can both read the old status and
-  // the second write clobbers the first (e.g. a late recordFailure dropping a
-  // just-written lastUploadSuccessAt). Chain every mutation through a single
-  // tail future so reads always observe the previous write.
+  // The coordinator drives cumulative session counts and calls recordQueueProgress
+  // / recordQueueDrained / recordBackupComplete. It calls recordSessionStart at
+  // the top of each backup session to zero the counts and clear any prior failure
+  // reason. Each mutation goes through a single tail future so concurrent calls
+  // cannot clobber each other.
   Future<void> _writeTail = Future.value();
 
   // `read()` is intentionally NOT serialized — it is a pure load with no write.
@@ -100,9 +99,23 @@ class BackgroundBackupStatusService {
         lastRemainingCount: remainingCount,
         lastUploadEnqueueAt: queuedCount > current.lastQueuedCount ? _now() : current.lastUploadEnqueueAt,
         lastUploadSuccessAt: completedCount > current.lastCompletedCount ? _now() : current.lastUploadSuccessAt,
-        lastBackgroundFailureReason: failedCount > current.lastFailedCount
+        lastBackgroundFailureReason: failedCount > 0
             ? BackgroundBackupFailureReason.uploadFailed
             : BackgroundBackupFailureReason.none,
+      ),
+    );
+  }
+
+  Future<void> recordSessionStart() {
+    return _mutate(
+      (current) => current.copyWith(
+        lastQueuedCount: 0,
+        lastCompletedCount: 0,
+        lastFailedCount: 0,
+        lastSkippedCount: 0,
+        lastEnqueueFailedCount: 0,
+        lastRemainingCount: 0,
+        lastBackgroundFailureReason: BackgroundBackupFailureReason.none,
       ),
     );
   }
@@ -116,6 +129,11 @@ class BackgroundBackupStatusService {
       (current) => current.copyWith(
         lastFullBackupCompletedAt: _now(),
         lastCandidateCount: 0,
+        lastQueuedCount: 0,
+        lastCompletedCount: 0,
+        lastFailedCount: 0,
+        lastSkippedCount: 0,
+        lastEnqueueFailedCount: 0,
         lastRemainingCount: 0,
         lastBackgroundFailureReason: BackgroundBackupFailureReason.none,
       ),

--- a/mobile/lib/services/background_backup_status.service.dart
+++ b/mobile/lib/services/background_backup_status.service.dart
@@ -82,6 +82,46 @@ class BackgroundBackupStatusService {
     return _mutate((current) => current.copyWith(lastBackgroundFailureReason: reason));
   }
 
+  Future<void> recordQueueProgress({
+    required int queuedCount,
+    required int completedCount,
+    required int failedCount,
+    required int skippedCount,
+    required int enqueueFailedCount,
+    required int remainingCount,
+  }) {
+    return _mutate(
+      (current) => current.copyWith(
+        lastQueuedCount: queuedCount,
+        lastCompletedCount: completedCount,
+        lastFailedCount: failedCount,
+        lastSkippedCount: skippedCount,
+        lastEnqueueFailedCount: enqueueFailedCount,
+        lastRemainingCount: remainingCount,
+        lastUploadEnqueueAt: queuedCount > current.lastQueuedCount ? _now() : current.lastUploadEnqueueAt,
+        lastUploadSuccessAt: completedCount > current.lastCompletedCount ? _now() : current.lastUploadSuccessAt,
+        lastBackgroundFailureReason: failedCount > current.lastFailedCount
+            ? BackgroundBackupFailureReason.uploadFailed
+            : BackgroundBackupFailureReason.none,
+      ),
+    );
+  }
+
+  Future<void> recordQueueDrained({required int remainingCount}) {
+    return _mutate((current) => current.copyWith(lastQueueDrainedAt: _now(), lastRemainingCount: remainingCount));
+  }
+
+  Future<void> recordBackupComplete() {
+    return _mutate(
+      (current) => current.copyWith(
+        lastFullBackupCompletedAt: _now(),
+        lastCandidateCount: 0,
+        lastRemainingCount: 0,
+        lastBackgroundFailureReason: BackgroundBackupFailureReason.none,
+      ),
+    );
+  }
+
   Future<void> markReminderShown() {
     return _mutate((current) => current.copyWith(lastReminderAt: _now()));
   }

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -195,20 +195,34 @@ class BackgroundUploadService {
     _logger.info("Found ${candidates.length} backup candidates for background tasks");
 
     const batchSize = 100;
-    final batch = candidates.take(batchSize).toList();
-    List<UploadTask> tasks = [];
+    var enqueuedCount = 0;
 
-    for (final asset in batch) {
-      final task = await getUploadTask(asset);
-      if (task != null) {
-        tasks.add(task);
+    for (var start = 0; start < candidates.length && !shouldAbortQueuingTasks; start += batchSize) {
+      final batch = candidates.skip(start).take(batchSize);
+      final tasks = <UploadTask>[];
+
+      for (final asset in batch) {
+        if (shouldAbortQueuingTasks) {
+          break;
+        }
+
+        final task = await getUploadTask(asset);
+        if (task != null) {
+          tasks.add(task);
+        }
       }
+
+      if (tasks.isEmpty || shouldAbortQueuingTasks) {
+        continue;
+      }
+
+      _logger.info("Enqueuing ${tasks.length} background upload tasks");
+      final results = await enqueueTasks(tasks);
+      enqueuedCount += results.where((success) => success).length;
     }
 
-    if (tasks.isNotEmpty && !shouldAbortQueuingTasks) {
-      _logger.info("Enqueuing ${tasks.length} background upload tasks");
-      await enqueueTasks(tasks);
-      await _backgroundBackupStatusService.recordUploadEnqueue(candidateCount: tasks.length);
+    if (enqueuedCount > 0) {
+      await _backgroundBackupStatusService.recordUploadEnqueue(candidateCount: enqueuedCount);
     }
   }
 

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -20,7 +20,7 @@ import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/repositories/upload.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
-import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_backup_queue_port.dart';
 import 'package:immich_mobile/services/background_backup_status.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
@@ -94,29 +94,6 @@ class UploadTaskMetadata {
 
   @override
   int get hashCode => localAssetId.hashCode ^ isLivePhotos.hashCode ^ livePhotoVideoId.hashCode;
-}
-
-/// Result of a single bounded background backup enqueue pass.
-class BackgroundBackupQueueResult {
-  const BackgroundBackupQueueResult({
-    required this.totalCandidateCount,
-    required this.eligibleCandidateCount,
-    required this.enqueuedLocalAssetIds,
-    required this.skippedLocalAssetIds,
-    required this.enqueueFailedLocalAssetIds,
-    required this.remainingEligibleCandidateCount,
-  });
-
-  final int totalCandidateCount;
-  final int eligibleCandidateCount;
-  final List<String> enqueuedLocalAssetIds;
-  final List<String> skippedLocalAssetIds;
-  final List<String> enqueueFailedLocalAssetIds;
-  final int remainingEligibleCandidateCount;
-
-  int get enqueuedCount => enqueuedLocalAssetIds.length;
-  bool get queuedAny => enqueuedLocalAssetIds.isNotEmpty;
-  bool get hasMoreEligibleCandidates => remainingEligibleCandidateCount > 0;
 }
 
 /// Service for handling background uploads using iOS URLSession (background_downloader)

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -96,6 +96,29 @@ class UploadTaskMetadata {
   int get hashCode => localAssetId.hashCode ^ isLivePhotos.hashCode ^ livePhotoVideoId.hashCode;
 }
 
+/// Result of a single bounded background backup enqueue pass.
+class BackgroundBackupQueueResult {
+  const BackgroundBackupQueueResult({
+    required this.totalCandidateCount,
+    required this.eligibleCandidateCount,
+    required this.enqueuedLocalAssetIds,
+    required this.skippedLocalAssetIds,
+    required this.enqueueFailedLocalAssetIds,
+    required this.remainingEligibleCandidateCount,
+  });
+
+  final int totalCandidateCount;
+  final int eligibleCandidateCount;
+  final List<String> enqueuedLocalAssetIds;
+  final List<String> skippedLocalAssetIds;
+  final List<String> enqueueFailedLocalAssetIds;
+  final int remainingEligibleCandidateCount;
+
+  int get enqueuedCount => enqueuedLocalAssetIds.length;
+  bool get queuedAny => enqueuedLocalAssetIds.isNotEmpty;
+  bool get hasMoreEligibleCandidates => remainingEligibleCandidateCount > 0;
+}
+
 /// Service for handling background uploads using iOS URLSession (background_downloader)
 ///
 /// This service handles asynchronous background uploads that can continue
@@ -130,6 +153,9 @@ class BackgroundUploadService {
   Stream<TaskProgressUpdate> get taskProgressStream => _taskProgressController.stream;
 
   bool shouldAbortQueuingTasks = false;
+
+  @visibleForTesting
+  int backupBatchSize = 100;
 
   void _onTaskProgressCallback(TaskProgressUpdate update) {
     if (!_taskProgressController.isClosed) {
@@ -224,6 +250,79 @@ class BackgroundUploadService {
     if (enqueuedCount > 0) {
       await _backgroundBackupStatusService.recordUploadEnqueue(candidateCount: enqueuedCount);
     }
+  }
+
+  /// Enqueue exactly one bounded batch of eligible backup candidates.
+  ///
+  /// [excludedLocalAssetIds] are asset IDs already queued or in-flight — they
+  /// are filtered out before the batch window is applied. The caller is
+  /// responsible for calling this again when the batch drains.
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
+    String userId, {
+    Set<String> excludedLocalAssetIds = const {},
+  }) async {
+    await _storageRepository.clearCache();
+    shouldAbortQueuingTasks = false;
+
+    final candidates = await _backupRepository.getCandidates(userId);
+    await _backgroundBackupStatusService.recordCandidateCount(candidates.length);
+
+    final eligibleCandidates = candidates
+        .where((candidate) => !excludedLocalAssetIds.contains(candidate.id))
+        .toList(growable: false);
+    final batchCandidates = eligibleCandidates.take(backupBatchSize).toList(growable: false);
+
+    final tasks = <UploadTask>[];
+    final skippedLocalAssetIds = <String>[];
+    for (final asset in batchCandidates) {
+      if (shouldAbortQueuingTasks) {
+        break;
+      }
+
+      final task = await getUploadTask(asset);
+      if (task == null) {
+        skippedLocalAssetIds.add(asset.id);
+        continue;
+      }
+      tasks.add(task);
+    }
+
+    if (tasks.isEmpty || shouldAbortQueuingTasks) {
+      return BackgroundBackupQueueResult(
+        totalCandidateCount: candidates.length,
+        eligibleCandidateCount: eligibleCandidates.length,
+        enqueuedLocalAssetIds: const [],
+        skippedLocalAssetIds: skippedLocalAssetIds,
+        enqueueFailedLocalAssetIds: const [],
+        remainingEligibleCandidateCount: eligibleCandidates.length - skippedLocalAssetIds.length,
+      );
+    }
+
+    final results = await enqueueTasks(tasks);
+    final enqueuedLocalAssetIds = <String>[];
+    final enqueueFailedLocalAssetIds = <String>[];
+
+    for (var i = 0; i < tasks.length; i++) {
+      final success = i < results.length && results[i];
+      if (success) {
+        enqueuedLocalAssetIds.add(tasks[i].taskId);
+      } else {
+        enqueueFailedLocalAssetIds.add(tasks[i].taskId);
+      }
+    }
+
+    return BackgroundBackupQueueResult(
+      totalCandidateCount: candidates.length,
+      eligibleCandidateCount: eligibleCandidates.length,
+      enqueuedLocalAssetIds: enqueuedLocalAssetIds,
+      skippedLocalAssetIds: skippedLocalAssetIds,
+      enqueueFailedLocalAssetIds: enqueueFailedLocalAssetIds,
+      remainingEligibleCandidateCount:
+          eligibleCandidates.length -
+          enqueuedLocalAssetIds.length -
+          skippedLocalAssetIds.length -
+          enqueueFailedLocalAssetIds.length,
+    );
   }
 
   /// Cancel all ongoing background uploads and reset the upload queue

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -204,55 +204,6 @@ class BackgroundUploadService implements BackgroundBackupQueuePort {
     return _uploadRepository.getActiveTasks(group);
   }
 
-  /// Start background upload using iOS URLSession
-  ///
-  /// Finds backup candidates, builds upload tasks, and enqueues them
-  /// for background processing.
-  Future<void> uploadBackupCandidates(String userId) async {
-    await _storageRepository.clearCache();
-    shouldAbortQueuingTasks = false;
-
-    final candidates = await _backupRepository.getCandidates(userId);
-    await _backgroundBackupStatusService.recordCandidateCount(candidates.length);
-    if (candidates.isEmpty) {
-      _logger.info("No new backup candidates found, finishing background upload");
-      return;
-    }
-
-    _logger.info("Found ${candidates.length} backup candidates for background tasks");
-
-    const batchSize = 100;
-    var enqueuedCount = 0;
-
-    for (var start = 0; start < candidates.length && !shouldAbortQueuingTasks; start += batchSize) {
-      final batch = candidates.skip(start).take(batchSize);
-      final tasks = <UploadTask>[];
-
-      for (final asset in batch) {
-        if (shouldAbortQueuingTasks) {
-          break;
-        }
-
-        final task = await getUploadTask(asset);
-        if (task != null) {
-          tasks.add(task);
-        }
-      }
-
-      if (tasks.isEmpty || shouldAbortQueuingTasks) {
-        continue;
-      }
-
-      _logger.info("Enqueuing ${tasks.length} background upload tasks");
-      final results = await enqueueTasks(tasks);
-      enqueuedCount += results.where((success) => success).length;
-    }
-
-    if (enqueuedCount > 0) {
-      await _backgroundBackupStatusService.recordUploadEnqueue(candidateCount: enqueuedCount);
-    }
-  }
-
   /// Enqueue exactly one bounded batch of eligible backup candidates.
   ///
   /// [excludedLocalAssetIds] are asset IDs already queued or in-flight — they

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -21,6 +21,7 @@ import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/repositories/upload.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
 import 'package:immich_mobile/services/background_backup_status.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
@@ -123,7 +124,7 @@ class BackgroundBackupQueueResult {
 ///
 /// This service handles asynchronous background uploads that can continue
 /// even when the app is suspended. Primarily used for iOS background backup.
-class BackgroundUploadService {
+class BackgroundUploadService implements BackgroundBackupQueuePort {
   BackgroundUploadService(
     this._uploadRepository,
     this._storageRepository,
@@ -199,6 +200,7 @@ class BackgroundUploadService {
   }
 
   /// Get a list of tasks that are ENQUEUED or RUNNING
+  @override
   Future<List<Task>> getActiveTasks(String group) {
     return _uploadRepository.getActiveTasks(group);
   }
@@ -257,6 +259,7 @@ class BackgroundUploadService {
   /// [excludedLocalAssetIds] are asset IDs already queued or in-flight — they
   /// are filtered out before the batch window is applied. The caller is
   /// responsible for calling this again when the batch drains.
+  @override
   Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
     String userId, {
     Set<String> excludedLocalAssetIds = const {},
@@ -328,6 +331,7 @@ class BackgroundUploadService {
   /// Cancel all ongoing background uploads and reset the upload queue
   ///
   /// Returns the number of tasks left in the queue
+  @override
   Future<int> cancel() async {
     shouldAbortQueuingTasks = true;
 
@@ -340,6 +344,7 @@ class BackgroundUploadService {
   }
 
   /// Resume background backup processing
+  @override
   Future<void> resume() {
     return _uploadRepository.start();
   }

--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -7,7 +7,6 @@ import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/asset/asset_metadata.model.dart';
-import 'package:immich_mobile/domain/models/background_backup_status.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -349,24 +348,9 @@ class BackgroundUploadService implements BackgroundBackupQueuePort {
     return _uploadRepository.start();
   }
 
-  bool _isLivePhotoMotionTask(Task task) {
-    if (task.group != kBackupGroup || task.metaData.isEmpty) {
-      return false;
-    }
-
-    try {
-      return UploadTaskMetadata.fromJson(task.metaData).isLivePhotos;
-    } catch (_) {
-      return false;
-    }
-  }
-
   void _handleTaskStatusUpdate(TaskStatusUpdate update) async {
     switch (update.status) {
       case TaskStatus.complete:
-        if (!_isLivePhotoMotionTask(update.task)) {
-          unawaited(_backgroundBackupStatusService.recordUploadSuccess());
-        }
         unawaited(_handleLivePhoto(update));
 
         if (CurrentPlatform.isIOS) {
@@ -383,7 +367,6 @@ class BackgroundUploadService implements BackgroundBackupQueuePort {
       case TaskStatus.failed:
       case TaskStatus.notFound:
       case TaskStatus.canceled:
-        unawaited(_backgroundBackupStatusService.recordFailure(BackgroundBackupFailureReason.uploadFailed));
         break;
 
       default:

--- a/mobile/pigeon/network_api.dart
+++ b/mobile/pigeon/network_api.dart
@@ -44,4 +44,8 @@ abstract class NetworkApi {
   int getClientPointer();
 
   void setRequestHeaders(Map<String, String> headers, List<String> serverUrls, String? token);
+
+  /// Rebuilds the shared native URLSession (iOS). Used on foreground resume to
+  /// recover from the background-worker isolate orphaning the shared session.
+  void recreateSession();
 }

--- a/mobile/test/domain/models/background_backup_status_model_test.dart
+++ b/mobile/test/domain/models/background_backup_status_model_test.dart
@@ -98,4 +98,28 @@ void main() {
 
     expect(status.deriveHealth(now: now), BackgroundBackupHealth.stale);
   });
+
+  test('serializes large backup progress fields', () {
+    final status = BackgroundBackupStatus(
+      lastQueuedCount: 100,
+      lastCompletedCount: 50,
+      lastFailedCount: 2,
+      lastSkippedCount: 3,
+      lastEnqueueFailedCount: 4,
+      lastRemainingCount: 3340,
+      lastQueueDrainedAt: DateTime.utc(2026, 6, 2, 10),
+      lastFullBackupCompletedAt: DateTime.utc(2026, 6, 2, 11),
+    );
+
+    final roundTrip = BackgroundBackupStatus.fromJson(status.toJson());
+
+    expect(roundTrip.lastQueuedCount, 100);
+    expect(roundTrip.lastCompletedCount, 50);
+    expect(roundTrip.lastFailedCount, 2);
+    expect(roundTrip.lastSkippedCount, 3);
+    expect(roundTrip.lastEnqueueFailedCount, 4);
+    expect(roundTrip.lastRemainingCount, 3340);
+    expect(roundTrip.lastQueueDrainedAt, DateTime.utc(2026, 6, 2, 10));
+    expect(roundTrip.lastFullBackupCompletedAt, DateTime.utc(2026, 6, 2, 11));
+  });
 }

--- a/mobile/test/infrastructure/repositories/draining_http_client_test.dart
+++ b/mobile/test/infrastructure/repositories/draining_http_client_test.dart
@@ -48,19 +48,25 @@ class _FakeInnerClient extends http.BaseClient {
 /// mimicking `cupertino_http`: aborting the request injects an error into the
 /// response stream and closes it.
 class _StreamingFakeClient extends http.BaseClient {
+  _StreamingFakeClient({this.closeOnAbort = true});
+
+  final bool closeOnAbort;
   late StreamController<List<int>> body;
   bool closed = false;
   bool hadOpenStreamAtClose = false;
+  bool bodyWasListenedTo = false;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    body = StreamController<List<int>>();
+    body = StreamController<List<int>>(onListen: () => bodyWasListenedTo = true);
     if (request case http.Abortable(:final abortTrigger?)) {
       unawaited(
         abortTrigger.whenComplete(() {
           if (!body.isClosed) {
             body.addError(http.RequestAbortedException(request.url));
-            unawaited(body.close());
+            if (closeOnAbort) {
+              unawaited(body.close());
+            }
           }
         }),
       );
@@ -100,6 +106,54 @@ void main() {
     );
 
     await drained;
+  });
+
+  test('shutdown drains an unconsumed response body before closing the inner client', () async {
+    final inner = _StreamingFakeClient();
+    final client = DrainingHttpClient(inner);
+
+    await client.send(http.Request('GET', Uri.parse('https://example.com/api/sync')));
+
+    await client.shutdown(timeout: const Duration(milliseconds: 10));
+
+    expect(inner.bodyWasListenedTo, isTrue, reason: 'shutdown cannot drain an unlistened response body');
+    expect(
+      inner.hadOpenStreamAtClose,
+      isFalse,
+      reason: 'inner client must not close before an unconsumed response body settles',
+    );
+  });
+
+  test('shutdown waits for the response body to close after an error event', () async {
+    final inner = _StreamingFakeClient(closeOnAbort: false);
+    final client = DrainingHttpClient(inner);
+
+    final response = await client.send(http.Request('GET', Uri.parse('https://example.com/api/sync')));
+    final data = <List<int>>[];
+    final errors = <Object>[];
+    final done = Completer<void>();
+    response.stream.listen(data.add, onError: errors.add, onDone: done.complete);
+
+    final shutdown = client.shutdown(timeout: const Duration(milliseconds: 200));
+    await pumpEventQueue();
+    await pumpEventQueue();
+
+    expect(errors.single, isA<http.RequestAbortedException>());
+    expect(
+      inner.closed,
+      isFalse,
+      reason: 'an error event is not enough; teardown must wait for the stream close callback',
+    );
+
+    inner.body.add([1, 2, 3]);
+    await inner.body.close();
+    await shutdown;
+    await done.future;
+
+    expect(data, [
+      [1, 2, 3],
+    ]);
+    expect(inner.hadOpenStreamAtClose, isFalse);
   });
 
   test('rejects new requests after shutdown', () async {

--- a/mobile/test/infrastructure/repositories/network_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/network_repository_test.dart
@@ -3,6 +3,7 @@ import 'dart:ffi';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:immich_mobile/infrastructure/repositories/draining_http_client.dart';
 import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
 
 /// Minimal fake http client that records whether it was closed.
@@ -70,5 +71,44 @@ void main() {
 
   test('client getter throws before init', () {
     expect(() => NetworkRepository.client, throwsA(isA<TypeError>()));
+  });
+
+  test('refresh rebuilds the client even when the pointer is unchanged', () async {
+    await NetworkRepository.init();
+    await NetworkRepository.refresh();
+
+    expect(factoryCalls, 2);
+    expect(built.first.closed, isTrue);
+    expect(NetworkRepository.client, same(built.last));
+  });
+
+  test('refresh recreates the native session on iOS', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    var recreateCalls = 0;
+    NetworkRepository.debugRecreateSession = () async => recreateCalls++;
+
+    await NetworkRepository.refresh();
+
+    expect(recreateCalls, 1);
+  });
+
+  test('refresh does not recreate the session off iOS', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    var recreateCalls = 0;
+    NetworkRepository.debugRecreateSession = () async => recreateCalls++;
+
+    await NetworkRepository.refresh();
+
+    expect(recreateCalls, 0);
+    expect(factoryCalls, 1); // still rebuilds the client
+  });
+
+  test('init wraps the client in a DrainingHttpClient when tracking is enabled on iOS', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    NetworkRepository.enableShutdownTracking();
+
+    await NetworkRepository.init();
+
+    expect(NetworkRepository.client, isA<DrainingHttpClient>());
   });
 }

--- a/mobile/test/infrastructure/repositories/network_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/network_repository_test.dart
@@ -1,0 +1,74 @@
+import 'dart:ffi';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+
+/// Minimal fake http client that records whether it was closed.
+class _FakeClient extends http.BaseClient {
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
+
+void main() {
+  late int pointerAddress;
+  late int factoryCalls;
+  late List<_FakeClient> built;
+
+  setUp(() {
+    NetworkRepository.debugReset();
+    pointerAddress = 1;
+    factoryCalls = 0;
+    built = [];
+    NetworkRepository.debugClientPointer = () async => pointerAddress;
+    NetworkRepository.debugBaseClientFactory = (Pointer<Void> _) {
+      factoryCalls++;
+      final client = _FakeClient();
+      built.add(client);
+      return client;
+    };
+  });
+
+  tearDown(() {
+    NetworkRepository.debugReset();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('init builds the client from the native pointer', () async {
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 1);
+    expect(NetworkRepository.client, same(built.single));
+  });
+
+  test('init is a no-op when the native pointer is unchanged', () async {
+    await NetworkRepository.init();
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 1);
+  });
+
+  test('init rebuilds and closes the old client when the pointer changes', () async {
+    await NetworkRepository.init();
+    pointerAddress = 2;
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 2);
+    expect(built.first.closed, isTrue);
+    expect(NetworkRepository.client, same(built.last));
+  });
+
+  test('client getter throws before init', () {
+    expect(() => NetworkRepository.client, throwsA(isA<TypeError>()));
+  });
+}

--- a/mobile/test/providers/app_life_cycle_provider_test.dart
+++ b/mobile/test/providers/app_life_cycle_provider_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
+import 'package:immich_mobile/providers/app_life_cycle.provider.dart';
+import 'package:immich_mobile/services/api.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiService extends Mock implements ApiService {}
+
+void main() {
+  late MockApiService apiService;
+  late ProviderContainer container;
+  late AppLifeCycleNotifier sut;
+
+  setUp(() {
+    apiService = MockApiService();
+    when(() => apiService.refreshConnection()).thenAnswer((_) async {});
+    container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(apiService)]);
+    sut = container.read(appStateProvider.notifier);
+  });
+
+  tearDown(() {
+    container.dispose();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('refreshes the connection on iOS resume after a pause', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    await sut.refreshConnectionAfterResume(true);
+
+    verify(() => apiService.refreshConnection()).called(1);
+  });
+
+  test('does not refresh when the app was not paused', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+    await sut.refreshConnectionAfterResume(false);
+
+    verifyNever(() => apiService.refreshConnection());
+  });
+
+  test('does not refresh on Android', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    await sut.refreshConnectionAfterResume(true);
+
+    verifyNever(() => apiService.refreshConnection());
+  });
+
+  test('swallows refresh errors so resume can continue', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    when(() => apiService.refreshConnection()).thenThrow(Exception('boom'));
+
+    await expectLater(sut.refreshConnectionAfterResume(true), completes);
+    verify(() => apiService.refreshConnection()).called(1);
+  });
+}

--- a/mobile/test/providers/backup/drift_backup_provider_test.dart
+++ b/mobile/test/providers/backup/drift_backup_provider_test.dart
@@ -23,6 +23,15 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(Completer<void>());
+    registerFallbackValue(
+      UploadTask(
+        taskId: 'fallback',
+        url: 'http://test-server.com/assets',
+        filename: 'fallback.jpg',
+        baseDirectory: BaseDirectory.temporary,
+        group: kBackupGroup,
+      ),
+    );
   });
 
   setUp(() {
@@ -185,5 +194,38 @@ void main() {
 
     expect(sut.state.backupCount, 1);
     expect(sut.state.remainderCount, 0);
+  });
+
+  test('queues more URLSession backup candidates when active tasks drain but assets remain', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    when(
+      () => foregroundUploadService.getBackupCounts('user-1'),
+    ).thenAnswer((_) async => (total: 3517, remainder: 3340, processing: 0));
+    await sut.getBackupStatus('user-1');
+
+    final activeTask = UploadTask(
+      taskId: 'asset-1',
+      url: 'http://test-server.com/assets',
+      filename: 'asset.jpg',
+      displayName: 'asset.jpg',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+    );
+
+    when(() => backgroundUploadService.getActiveTasks(kBackupGroup)).thenAnswer((_) async => [activeTask]);
+    when(() => backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup)).thenAnswer((_) async => []);
+    when(() => backgroundUploadService.resume()).thenAnswer((_) async {});
+    when(() => backgroundUploadService.uploadBackupCandidates('user-1')).thenAnswer((_) async {});
+
+    await sut.startBackup('user-1');
+
+    when(() => backgroundUploadService.getActiveTasks(kBackupGroup)).thenAnswer((_) async => []);
+
+    statusController.add(TaskStatusUpdate(activeTask, TaskStatus.complete));
+    await pumpEventQueue();
+
+    verify(() => backgroundUploadService.uploadBackupCandidates('user-1')).called(1);
   });
 }

--- a/mobile/test/providers/backup/drift_backup_provider_test.dart
+++ b/mobile/test/providers/backup/drift_backup_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
 import 'package:immich_mobile/services/foreground_upload.service.dart';
 import 'package:immich_mobile/utils/upload_speed_calculator.dart';
@@ -14,9 +15,12 @@ class MockForegroundUploadService extends Mock implements ForegroundUploadServic
 
 class MockBackgroundUploadService extends Mock implements BackgroundUploadService {}
 
+class MockBackgroundBackupQueueCoordinator extends Mock implements BackgroundBackupQueueCoordinator {}
+
 void main() {
   late MockForegroundUploadService foregroundUploadService;
   late MockBackgroundUploadService backgroundUploadService;
+  late MockBackgroundBackupQueueCoordinator backgroundQueueCoordinator;
   late StreamController<TaskStatusUpdate> statusController;
   late StreamController<TaskProgressUpdate> progressController;
   late DriftBackupNotifier sut;
@@ -32,18 +36,40 @@ void main() {
         group: kBackupGroup,
       ),
     );
+    registerFallbackValue(
+      TaskStatusUpdate(
+        UploadTask(
+          taskId: 'fallback',
+          url: 'http://test-server.com/assets',
+          filename: 'fallback.jpg',
+          baseDirectory: BaseDirectory.temporary,
+          group: kBackupGroup,
+        ),
+        TaskStatus.complete,
+      ),
+    );
   });
 
   setUp(() {
     foregroundUploadService = MockForegroundUploadService();
     backgroundUploadService = MockBackgroundUploadService();
+    backgroundQueueCoordinator = MockBackgroundBackupQueueCoordinator();
     statusController = StreamController<TaskStatusUpdate>.broadcast();
     progressController = StreamController<TaskProgressUpdate>.broadcast();
 
     when(() => backgroundUploadService.taskStatusStream).thenAnswer((_) => statusController.stream);
     when(() => backgroundUploadService.taskProgressStream).thenAnswer((_) => progressController.stream);
 
-    sut = DriftBackupNotifier(foregroundUploadService, backgroundUploadService, UploadSpeedManager());
+    when(() => backgroundQueueCoordinator.start(any())).thenAnswer((_) async {});
+    when(() => backgroundQueueCoordinator.stop()).thenAnswer((_) async {});
+    when(() => backgroundQueueCoordinator.handleStatus(any())).thenAnswer((_) async {});
+
+    sut = DriftBackupNotifier(
+      foregroundUploadService,
+      backgroundUploadService,
+      UploadSpeedManager(),
+      backgroundQueueCoordinator: backgroundQueueCoordinator,
+    );
   });
 
   tearDown(() async {
@@ -74,54 +100,51 @@ void main() {
     );
   });
 
-  test('starts URLSession backup on iOS instead of foreground upload', () async {
+  test('starts iOS URLSession backup through queue coordinator', () async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
-    when(() => backgroundUploadService.getActiveTasks(kBackupGroup)).thenAnswer((_) async => []);
-    when(() => backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup)).thenAnswer((_) async => []);
-    when(() => backgroundUploadService.uploadBackupCandidates('user-1')).thenAnswer((_) async {});
-
     await sut.startBackup('user-1');
 
-    verify(() => backgroundUploadService.uploadBackupCandidates('user-1')).called(1);
+    verify(() => backgroundQueueCoordinator.start('user-1')).called(1);
     verifyNever(() => foregroundUploadService.uploadCandidates(any(), any()));
   });
 
-  test('stops URLSession backup on iOS when backup is disabled', () async {
+  test('stops iOS URLSession backup through queue coordinator', () async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     addTearDown(() => debugDefaultTargetPlatformOverride = null);
-
-    when(() => backgroundUploadService.cancel()).thenAnswer((_) async => 0);
 
     await sut.stopBackup();
 
-    verify(() => backgroundUploadService.cancel()).called(1);
+    verify(() => backgroundQueueCoordinator.stop()).called(1);
+  });
+
+  test('forwards background status updates to the coordinator without refreshing UI counts', () async {
+    final task = UploadTask(
+      taskId: 'asset-1',
+      url: 'http://test-server.com/assets',
+      filename: 'asset.jpg',
+      displayName: 'asset.jpg',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+    );
+
+    statusController.add(TaskStatusUpdate(task, TaskStatus.complete));
+    await pumpEventQueue();
+
+    verify(() => backgroundQueueCoordinator.handleStatus(any())).called(1);
+    verifyNever(() => foregroundUploadService.getBackupCounts(any()));
   });
 
   test('resumes active Live Photo still tasks instead of starting duplicate candidates', () async {
+    // This test is now covered by the coordinator internally.
+    // The notifier just delegates start() to the coordinator regardless of task state.
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
-    final livePhotoStillTask = UploadTask(
-      taskId: 'asset-live',
-      url: 'http://test-server.com/assets',
-      filename: 'asset.heic',
-      displayName: 'asset.heic',
-      baseDirectory: BaseDirectory.temporary,
-      group: kBackupLivePhotoGroup,
-    );
-
-    when(() => backgroundUploadService.getActiveTasks(kBackupGroup)).thenAnswer((_) async => []);
-    when(
-      () => backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup),
-    ).thenAnswer((_) async => [livePhotoStillTask]);
-    when(() => backgroundUploadService.resume()).thenAnswer((_) async {});
-
     await sut.startBackup('user-1');
 
-    verify(() => backgroundUploadService.resume()).called(1);
-    verifyNever(() => backgroundUploadService.uploadBackupCandidates('user-1'));
+    verify(() => backgroundQueueCoordinator.start('user-1')).called(1);
   });
 
   test('tracks Live Photo still progress from the live photo group', () async {
@@ -194,38 +217,5 @@ void main() {
 
     expect(sut.state.backupCount, 1);
     expect(sut.state.remainderCount, 0);
-  });
-
-  test('queues more URLSession backup candidates when active tasks drain but assets remain', () async {
-    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    addTearDown(() => debugDefaultTargetPlatformOverride = null);
-
-    when(
-      () => foregroundUploadService.getBackupCounts('user-1'),
-    ).thenAnswer((_) async => (total: 3517, remainder: 3340, processing: 0));
-    await sut.getBackupStatus('user-1');
-
-    final activeTask = UploadTask(
-      taskId: 'asset-1',
-      url: 'http://test-server.com/assets',
-      filename: 'asset.jpg',
-      displayName: 'asset.jpg',
-      baseDirectory: BaseDirectory.temporary,
-      group: kBackupGroup,
-    );
-
-    when(() => backgroundUploadService.getActiveTasks(kBackupGroup)).thenAnswer((_) async => [activeTask]);
-    when(() => backgroundUploadService.getActiveTasks(kBackupLivePhotoGroup)).thenAnswer((_) async => []);
-    when(() => backgroundUploadService.resume()).thenAnswer((_) async {});
-    when(() => backgroundUploadService.uploadBackupCandidates('user-1')).thenAnswer((_) async {});
-
-    await sut.startBackup('user-1');
-
-    when(() => backgroundUploadService.getActiveTasks(kBackupGroup)).thenAnswer((_) async => []);
-
-    statusController.add(TaskStatusUpdate(activeTask, TaskStatus.complete));
-    await pumpEventQueue();
-
-    verify(() => backgroundUploadService.uploadBackupCandidates('user-1')).called(1);
   });
 }

--- a/mobile/test/providers/backup/drift_backup_provider_test.dart
+++ b/mobile/test/providers/backup/drift_backup_provider_test.dart
@@ -218,4 +218,24 @@ void main() {
     expect(sut.state.backupCount, 1);
     expect(sut.state.remainderCount, 0);
   });
+
+  test('resets live counts when iOS backup is stopped', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    when(() => backgroundQueueCoordinator.stop()).thenAnswer((_) async {});
+
+    // Seed live progress via getBackupStatus
+    when(
+      () => foregroundUploadService.getBackupCounts('user-1'),
+    ).thenAnswer((_) async => (total: 15, remainder: 10, processing: 2));
+    await sut.getBackupStatus('user-1');
+
+    await sut.stopBackup();
+
+    expect(sut.state.backupCount, 0);
+    expect(sut.state.remainderCount, 0);
+    expect(sut.state.processingCount, 0);
+    expect(sut.state.totalCount, 0);
+    expect(sut.state.uploadItems, isEmpty);
+  });
 }

--- a/mobile/test/services/api_service_refresh_test.dart
+++ b/mobile/test/services/api_service_refresh_test.dart
@@ -1,0 +1,61 @@
+import 'dart:ffi';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/services/api.service.dart';
+
+class _FakeClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+  }
+}
+
+void main() {
+  late Drift db;
+
+  setUpAll(() async {
+    db = Drift(DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await StoreService.init(storeRepository: DriftStoreRepository(db));
+  });
+
+  setUp(() async {
+    await Store.clear();
+    await Store.put(StoreKey.serverEndpoint, 'https://demo.opennoodle.de/api');
+    NetworkRepository.debugReset();
+    NetworkRepository.debugClientPointer = () async => 1;
+  });
+
+  tearDown(() => NetworkRepository.debugReset());
+
+  tearDownAll(() async => db.close());
+
+  test('refreshConnection rebuilds the client and re-points the API client', () async {
+    var built = 0;
+    final clients = <_FakeClient>[];
+    NetworkRepository.debugBaseClientFactory = (Pointer<Void> _) {
+      built++;
+      final client = _FakeClient();
+      clients.add(client);
+      return client;
+    };
+    await NetworkRepository.init();
+
+    final api = ApiService();
+    expect(api.usersApi.apiClient.client, same(clients.first));
+
+    await api.refreshConnection();
+
+    expect(built, 2);
+    expect(NetworkRepository.client, same(clients.last));
+    expect(api.usersApi.apiClient.client, same(clients.last));
+  });
+}

--- a/mobile/test/services/background_backup_queue_coordinator_test.dart
+++ b/mobile/test/services/background_backup_queue_coordinator_test.dart
@@ -4,7 +4,11 @@ import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_backup_status.service.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockBackgroundBackupStatusService extends Mock implements BackgroundBackupStatusService {}
 
 class FakeBackgroundUploadQueue implements BackgroundBackupQueuePort {
   FakeBackgroundUploadQueue({Iterable<String> candidateIds = const []}) {
@@ -327,5 +331,60 @@ void main() {
 
     expect(queue.queuedBatches, isEmpty);
     expect(sut.isActive, false);
+  });
+
+  test('records a session start and persists progress on each completion and drain', () async {
+    final status = MockBackgroundBackupStatusService();
+    when(() => status.recordSessionStart()).thenAnswer((_) async {});
+    when(
+      () => status.recordQueueProgress(
+        queuedCount: any(named: 'queuedCount'),
+        completedCount: any(named: 'completedCount'),
+        failedCount: any(named: 'failedCount'),
+        skippedCount: any(named: 'skippedCount'),
+        enqueueFailedCount: any(named: 'enqueueFailedCount'),
+        remainingCount: any(named: 'remainingCount'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => status.recordQueueDrained(remainingCount: any(named: 'remainingCount')),
+    ).thenAnswer((_) async {});
+    when(() => status.recordBackupComplete()).thenAnswer((_) async {});
+
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])..batchSize = 1;
+    final sut = BackgroundBackupQueueCoordinator(queue, statusService: status);
+
+    await sut.start('user-1'); // enqueues asset-0
+    final task = queue.activeTasks.remove('asset-0')!;
+    await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete)); // drains → records drained → refill asset-1
+
+    verify(() => status.recordSessionStart()).called(1);
+    verify(
+      () => status.recordQueueDrained(remainingCount: any(named: 'remainingCount')),
+    ).called(greaterThanOrEqualTo(1));
+    verify(
+      () => status.recordQueueProgress(
+        queuedCount: any(named: 'queuedCount'),
+        completedCount: any(named: 'completedCount'),
+        failedCount: any(named: 'failedCount'),
+        skippedCount: any(named: 'skippedCount'),
+        enqueueFailedCount: any(named: 'enqueueFailedCount'),
+        remainingCount: any(named: 'remainingCount'),
+      ),
+    ).called(greaterThanOrEqualTo(2)); // at least: after enqueue + after the completion
+  });
+
+  test('clears prior-session counts on a fresh start', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0']);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+    await sut.start('user-1');
+    final task = queue.activeTasks.remove('asset-0')!;
+    await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete)); // session completes; sets retain asset-0
+
+    // New session: sets must be cleared so excludedSnapshots don't carry asset-0 from before.
+    queue.candidateIds.add('asset-1');
+    queue.excludedSnapshots.clear();
+    await sut.start('user-1');
+    expect(queue.excludedSnapshots.first, isNot(contains('asset-0')));
   });
 }

--- a/mobile/test/services/background_backup_queue_coordinator_test.dart
+++ b/mobile/test/services/background_backup_queue_coordinator_test.dart
@@ -131,9 +131,7 @@ void main() {
   });
 
   test('full backup refills 3517 assets without UI calls and excludes completed ids until session ends', () async {
-    final queue = FakeBackgroundUploadQueue(
-      candidateIds: List.generate(3517, (index) => 'asset-$index'),
-    );
+    final queue = FakeBackgroundUploadQueue(candidateIds: List.generate(3517, (index) => 'asset-$index'));
     final sut = BackgroundBackupQueueCoordinator(queue);
 
     await sut.start('user-1');
@@ -153,8 +151,7 @@ void main() {
   });
 
   test('concurrent terminal callbacks trigger at most one refill', () async {
-    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1', 'asset-2'])
-      ..batchSize = 2;
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1', 'asset-2'])..batchSize = 2;
     final sut = BackgroundBackupQueueCoordinator(queue);
     await sut.start('user-1');
 
@@ -228,8 +225,7 @@ void main() {
   });
 
   test('failed uploads are excluded from immediate same-session retry', () async {
-    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])
-      ..batchSize = 1;
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])..batchSize = 1;
     final sut = BackgroundBackupQueueCoordinator(queue);
 
     await sut.start('user-1');
@@ -346,9 +342,7 @@ void main() {
         remainingCount: any(named: 'remainingCount'),
       ),
     ).thenAnswer((_) async {});
-    when(
-      () => status.recordQueueDrained(remainingCount: any(named: 'remainingCount')),
-    ).thenAnswer((_) async {});
+    when(() => status.recordQueueDrained(remainingCount: any(named: 'remainingCount'))).thenAnswer((_) async {});
     when(() => status.recordBackupComplete()).thenAnswer((_) async {});
 
     final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])..batchSize = 1;

--- a/mobile/test/services/background_backup_queue_coordinator_test.dart
+++ b/mobile/test/services/background_backup_queue_coordinator_test.dart
@@ -4,6 +4,7 @@ import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_backup_queue_port.dart';
 import 'package:immich_mobile/services/background_backup_status.service.dart';
 import 'package:immich_mobile/services/background_upload.service.dart';
 import 'package:mocktail/mocktail.dart';

--- a/mobile/test/services/background_backup_queue_coordinator_test.dart
+++ b/mobile/test/services/background_backup_queue_coordinator_test.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/constants/constants.dart';
+import 'package:immich_mobile/services/background_backup_queue_coordinator.dart';
+import 'package:immich_mobile/services/background_upload.service.dart';
+
+class FakeBackgroundUploadQueue implements BackgroundBackupQueuePort {
+  FakeBackgroundUploadQueue({Iterable<String> candidateIds = const []}) {
+    this.candidateIds.addAll(candidateIds);
+  }
+
+  final candidateIds = <String>[];
+  final activeTasks = <String, Task>{};
+  final queuedBatches = <List<String>>[];
+  final excludedSnapshots = <Set<String>>[];
+  final enqueueCompleter = <Completer<BackgroundBackupQueueResult>>[];
+  int resumeCalls = 0;
+  int cancelCalls = 0;
+  int batchSize = 100;
+  bool delayNextEnqueue = false;
+
+  @override
+  Future<List<Task>> getActiveTasks(String group) async {
+    return activeTasks.values.where((task) => task.group == group).toList(growable: false);
+  }
+
+  @override
+  Future<void> resume() async {
+    resumeCalls++;
+  }
+
+  @override
+  Future<int> cancel() async {
+    cancelCalls++;
+    activeTasks.clear();
+    return 0;
+  }
+
+  @override
+  Future<BackgroundBackupQueueResult> enqueueNextBackupBatch(
+    String userId, {
+    Set<String> excludedLocalAssetIds = const {},
+  }) async {
+    excludedSnapshots.add(Set<String>.from(excludedLocalAssetIds));
+    if (delayNextEnqueue) {
+      final completer = Completer<BackgroundBackupQueueResult>();
+      enqueueCompleter.add(completer);
+      return completer.future;
+    }
+
+    final eligibleIds = candidateIds.where((id) => !excludedLocalAssetIds.contains(id)).toList(growable: false);
+    final ids = eligibleIds.take(batchSize).toList(growable: false);
+    if (ids.isNotEmpty) queuedBatches.add(ids);
+    for (final id in ids) {
+      activeTasks[id] = UploadTask(
+        taskId: id,
+        url: 'http://test-server.com/assets',
+        filename: '$id.jpg',
+        baseDirectory: BaseDirectory.temporary,
+        group: kBackupGroup,
+      );
+    }
+
+    return BackgroundBackupQueueResult(
+      totalCandidateCount: candidateIds.length,
+      eligibleCandidateCount: eligibleIds.length,
+      enqueuedLocalAssetIds: ids,
+      skippedLocalAssetIds: const [],
+      enqueueFailedLocalAssetIds: const [],
+      remainingEligibleCandidateCount: eligibleIds.length - ids.length,
+    );
+  }
+
+  void completeDelayedEnqueue(BackgroundBackupQueueResult result) {
+    for (final id in result.enqueuedLocalAssetIds) {
+      activeTasks[id] = UploadTask(
+        taskId: id,
+        url: 'http://test-server.com/assets',
+        filename: '$id.jpg',
+        baseDirectory: BaseDirectory.temporary,
+        group: kBackupGroup,
+      );
+    }
+    enqueueCompleter.removeAt(0).complete(result);
+  }
+}
+
+void main() {
+  test('start resumes existing URLSession tasks instead of enqueueing duplicates', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-1']);
+    queue.activeTasks['asset-1'] = UploadTask(
+      taskId: 'asset-1',
+      url: 'http://test-server.com/assets',
+      filename: 'asset-1.jpg',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+    );
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    expect(queue.resumeCalls, 1);
+    expect(queue.queuedBatches, isEmpty);
+  });
+
+  test('full backup refills 3517 assets without UI calls and excludes completed ids until session ends', () async {
+    final queue = FakeBackgroundUploadQueue(
+      candidateIds: List.generate(3517, (index) => 'asset-$index'),
+    );
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    while (queue.activeTasks.isNotEmpty) {
+      final task = queue.activeTasks.values.first;
+      queue.activeTasks.remove(task.taskId);
+      await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete));
+    }
+
+    expect(queue.queuedBatches, hasLength(36));
+    expect(queue.queuedBatches.take(35).every((batch) => batch.length == 100), true);
+    expect(queue.queuedBatches.last, hasLength(17));
+    expect(queue.queuedBatches.expand((batch) => batch).toSet(), hasLength(3517));
+    expect(queue.excludedSnapshots.last, containsAll(List.generate(3517, (index) => 'asset-$index')));
+  });
+
+  test('concurrent terminal callbacks trigger at most one refill', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1', 'asset-2'])
+      ..batchSize = 2;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+    await sut.start('user-1');
+
+    final first = queue.activeTasks.remove('asset-0')!;
+    final second = queue.activeTasks.remove('asset-1')!;
+
+    await Future.wait([
+      sut.handleStatus(TaskStatusUpdate(first, TaskStatus.complete)),
+      sut.handleStatus(TaskStatusUpdate(second, TaskStatus.complete)),
+    ]);
+
+    expect(queue.queuedBatches, [
+      ['asset-0', 'asset-1'],
+      ['asset-2'],
+    ]);
+  });
+
+  test('stop during delayed enqueue prevents delayed results from keeping session active', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0'])..delayNextEnqueue = true;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    final start = sut.start('user-1');
+    await Future<void>.delayed(Duration.zero);
+    await sut.stop();
+    queue.completeDelayedEnqueue(
+      const BackgroundBackupQueueResult(
+        totalCandidateCount: 1,
+        eligibleCandidateCount: 1,
+        enqueuedLocalAssetIds: ['asset-0'],
+        skippedLocalAssetIds: [],
+        enqueueFailedLocalAssetIds: [],
+        remainingEligibleCandidateCount: 0,
+      ),
+    );
+    await start;
+
+    expect(queue.cancelCalls, 1);
+    expect(sut.isActive, false);
+  });
+
+  test('live photo motion completion does not refill until the still task completes', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-live', 'asset-next']);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    final motionTask = UploadTask(
+      taskId: 'asset-live',
+      url: 'http://test-server.com/assets',
+      filename: 'asset-live.mov',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupGroup,
+      metaData: const UploadTaskMetadata(localAssetId: 'asset-live', isLivePhotos: true, livePhotoVideoId: '').toJson(),
+    );
+    final stillTask = UploadTask(
+      taskId: 'asset-live',
+      url: 'http://test-server.com/assets',
+      filename: 'asset-live.heic',
+      baseDirectory: BaseDirectory.temporary,
+      group: kBackupLivePhotoGroup,
+    );
+    queue.activeTasks[motionTask.taskId] = motionTask;
+    queue.activeTasks['asset-live-still'] = stillTask;
+
+    await sut.start('user-1');
+    queue.activeTasks.remove(motionTask.taskId);
+    await sut.handleStatus(TaskStatusUpdate(motionTask, TaskStatus.complete));
+    expect(queue.queuedBatches, isEmpty);
+
+    queue.activeTasks.remove('asset-live-still');
+    await sut.handleStatus(TaskStatusUpdate(stillTask, TaskStatus.complete));
+    expect(queue.queuedBatches, hasLength(1));
+  });
+
+  test('failed uploads are excluded from immediate same-session retry', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])
+      ..batchSize = 1;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+    final failedTask = queue.activeTasks.remove('asset-0')!;
+    await sut.handleStatus(TaskStatusUpdate(failedTask, TaskStatus.failed));
+
+    expect(queue.queuedBatches, [
+      ['asset-0'],
+      ['asset-1'],
+    ]);
+    expect(queue.excludedSnapshots.last, contains('asset-0'));
+  });
+
+  test('skipped and enqueue-failed ids are excluded from the next refill', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1', 'asset-2']);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    queue.delayNextEnqueue = true;
+    final start = sut.start('user-1');
+    await Future<void>.delayed(Duration.zero);
+    queue.delayNextEnqueue = false;
+    queue.completeDelayedEnqueue(
+      const BackgroundBackupQueueResult(
+        totalCandidateCount: 3,
+        eligibleCandidateCount: 3,
+        enqueuedLocalAssetIds: ['asset-0'],
+        skippedLocalAssetIds: ['asset-1'],
+        enqueueFailedLocalAssetIds: ['asset-2'],
+        remainingEligibleCandidateCount: 0,
+      ),
+    );
+    await start;
+
+    final task = queue.activeTasks.remove('asset-0')!;
+    await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete));
+
+    expect(queue.excludedSnapshots.last, containsAll(['asset-0', 'asset-1', 'asset-2']));
+  });
+}

--- a/mobile/test/services/background_backup_queue_coordinator_test.dart
+++ b/mobile/test/services/background_backup_queue_coordinator_test.dart
@@ -20,6 +20,8 @@ class FakeBackgroundUploadQueue implements BackgroundBackupQueuePort {
   int cancelCalls = 0;
   int batchSize = 100;
   bool delayNextEnqueue = false;
+  bool throwOnEnqueue = false;
+  final scriptedResults = <BackgroundBackupQueueResult>[];
 
   @override
   Future<List<Task>> getActiveTasks(String group) async {
@@ -44,6 +46,25 @@ class FakeBackgroundUploadQueue implements BackgroundBackupQueuePort {
     Set<String> excludedLocalAssetIds = const {},
   }) async {
     excludedSnapshots.add(Set<String>.from(excludedLocalAssetIds));
+    if (throwOnEnqueue) {
+      throw StateError('enqueue failed');
+    }
+    if (scriptedResults.isNotEmpty) {
+      final result = scriptedResults.removeAt(0);
+      if (result.enqueuedLocalAssetIds.isNotEmpty) {
+        queuedBatches.add(result.enqueuedLocalAssetIds);
+        for (final id in result.enqueuedLocalAssetIds) {
+          activeTasks[id] = UploadTask(
+            taskId: id,
+            url: 'http://test-server.com/assets',
+            filename: '$id.jpg',
+            baseDirectory: BaseDirectory.temporary,
+            group: kBackupGroup,
+          );
+        }
+      }
+      return result;
+    }
     if (delayNextEnqueue) {
       final completer = Completer<BackgroundBackupQueueResult>();
       enqueueCompleter.add(completer);
@@ -124,6 +145,7 @@ void main() {
     expect(queue.queuedBatches.last, hasLength(17));
     expect(queue.queuedBatches.expand((batch) => batch).toSet(), hasLength(3517));
     expect(queue.excludedSnapshots.last, containsAll(List.generate(3517, (index) => 'asset-$index')));
+    expect(sut.isActive, false);
   });
 
   test('concurrent terminal callbacks trigger at most one refill', () async {
@@ -241,5 +263,69 @@ void main() {
     await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete));
 
     expect(queue.excludedSnapshots.last, containsAll(['asset-0', 'asset-1', 'asset-2']));
+  });
+
+  test('ends the session instead of stalling when enqueue throws on start', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0'])..throwOnEnqueue = true;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    expect(sut.isActive, false);
+    expect(queue.queuedBatches, isEmpty);
+  });
+
+  test('a refill error ends the session without poisoning the status chain', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: ['asset-0', 'asset-1'])..batchSize = 1;
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+    final task = queue.activeTasks.remove('asset-0')!;
+    queue.throwOnEnqueue = true;
+
+    await sut.handleStatus(TaskStatusUpdate(task, TaskStatus.complete));
+
+    expect(sut.isActive, false);
+  });
+
+  test('advances past a fully skipped batch without waiting for callbacks', () async {
+    final queue = FakeBackgroundUploadQueue();
+    queue.scriptedResults.addAll([
+      const BackgroundBackupQueueResult(
+        totalCandidateCount: 150,
+        eligibleCandidateCount: 150,
+        enqueuedLocalAssetIds: [],
+        skippedLocalAssetIds: ['s0'],
+        enqueueFailedLocalAssetIds: [],
+        remainingEligibleCandidateCount: 50,
+      ),
+      const BackgroundBackupQueueResult(
+        totalCandidateCount: 150,
+        eligibleCandidateCount: 50,
+        enqueuedLocalAssetIds: ['asset-real'],
+        skippedLocalAssetIds: [],
+        enqueueFailedLocalAssetIds: [],
+        remainingEligibleCandidateCount: 49,
+      ),
+    ]);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    expect(queue.queuedBatches, [
+      ['asset-real'],
+    ]);
+    expect(queue.excludedSnapshots.length, 2);
+    expect(sut.isActive, true);
+  });
+
+  test('start with an empty library ends the session immediately', () async {
+    final queue = FakeBackgroundUploadQueue(candidateIds: []);
+    final sut = BackgroundBackupQueueCoordinator(queue);
+
+    await sut.start('user-1');
+
+    expect(queue.queuedBatches, isEmpty);
+    expect(sut.isActive, false);
   });
 }

--- a/mobile/test/services/background_backup_status.service_test.dart
+++ b/mobile/test/services/background_backup_status.service_test.dart
@@ -102,4 +102,45 @@ void main() {
       expect((await sut.read()).lastBackgroundFailureReason, reason);
     }
   });
+
+  test('recordQueueProgress keeps remaining count nonzero during large backup successes', () async {
+    await sut.recordCandidateCount(3340);
+    await sut.recordQueueProgress(
+      queuedCount: 100,
+      completedCount: 1,
+      failedCount: 0,
+      skippedCount: 0,
+      enqueueFailedCount: 0,
+      remainingCount: 3239,
+    );
+
+    final status = await sut.read();
+
+    expect(status.lastQueuedCount, 100);
+    expect(status.lastCompletedCount, 1);
+    expect(status.lastFailedCount, 0);
+    expect(status.lastSkippedCount, 0);
+    expect(status.lastEnqueueFailedCount, 0);
+    expect(status.lastRemainingCount, 3239);
+    expect(status.lastCandidateCount, 3340);
+  });
+
+  test('recordBackupComplete clears pending counts only when no eligible candidates remain', () async {
+    await sut.recordCandidateCount(17);
+    await sut.recordQueueProgress(
+      queuedCount: 17,
+      completedCount: 17,
+      failedCount: 0,
+      skippedCount: 0,
+      enqueueFailedCount: 0,
+      remainingCount: 0,
+    );
+    await sut.recordBackupComplete();
+
+    final status = await sut.read();
+
+    expect(status.lastCandidateCount, 0);
+    expect(status.lastRemainingCount, 0);
+    expect(status.lastFullBackupCompletedAt, isNotNull);
+  });
 }

--- a/mobile/test/services/background_backup_status.service_test.dart
+++ b/mobile/test/services/background_backup_status.service_test.dart
@@ -143,4 +143,66 @@ void main() {
     expect(status.lastRemainingCount, 0);
     expect(status.lastFullBackupCompletedAt, isNotNull);
   });
+
+  test('recordQueueProgress keeps the failure reason sticky once a session has any failure', () async {
+    await sut.recordSessionStart();
+    await sut.recordQueueProgress(
+      queuedCount: 2,
+      completedCount: 0,
+      failedCount: 1,
+      skippedCount: 0,
+      enqueueFailedCount: 0,
+      remainingCount: 0,
+    );
+    expect((await sut.read()).lastBackgroundFailureReason, BackgroundBackupFailureReason.uploadFailed);
+
+    // A later progress update with the same (nonzero) failure count must NOT clear it.
+    await sut.recordQueueProgress(
+      queuedCount: 2,
+      completedCount: 1,
+      failedCount: 1,
+      skippedCount: 0,
+      enqueueFailedCount: 0,
+      remainingCount: 0,
+    );
+    expect((await sut.read()).lastBackgroundFailureReason, BackgroundBackupFailureReason.uploadFailed);
+  });
+
+  test('recordSessionStart resets session counts and failure reason', () async {
+    await sut.recordQueueProgress(
+      queuedCount: 100,
+      completedCount: 50,
+      failedCount: 3,
+      skippedCount: 2,
+      enqueueFailedCount: 1,
+      remainingCount: 40,
+    );
+
+    await sut.recordSessionStart();
+
+    final status = await sut.read();
+    expect(status.lastQueuedCount, 0);
+    expect(status.lastCompletedCount, 0);
+    expect(status.lastFailedCount, 0);
+    expect(status.lastSkippedCount, 0);
+    expect(status.lastEnqueueFailedCount, 0);
+    expect(status.lastRemainingCount, 0);
+    expect(status.lastBackgroundFailureReason, BackgroundBackupFailureReason.none);
+  });
+
+  test('recordBackupComplete resets session counts', () async {
+    await sut.recordQueueProgress(
+      queuedCount: 17,
+      completedCount: 17,
+      failedCount: 0,
+      skippedCount: 0,
+      enqueueFailedCount: 0,
+      remainingCount: 0,
+    );
+    await sut.recordBackupComplete();
+    final status = await sut.read();
+    expect(status.lastCompletedCount, 0);
+    expect(status.lastQueuedCount, 0);
+    expect(status.lastFullBackupCompletedAt, isNotNull);
+  });
 }

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -39,6 +39,15 @@ void main() {
   setUpAll(() async {
     registerFallbackValue(AppSettingsEnum.useCellularForUploadPhotos);
     registerFallbackValue(BackgroundBackupFailureReason.none);
+    registerFallbackValue(
+      UploadTask(
+        taskId: 'fallback',
+        url: 'http://test-server.com/assets',
+        filename: 'fallback.jpg',
+        baseDirectory: BaseDirectory.temporary,
+        group: kBackupGroup,
+      ),
+    );
 
     TestWidgetsFlutterBinding.ensureInitialized();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
@@ -112,6 +121,43 @@ void main() {
 
       verify(() => mockBackgroundBackupStatusService.recordCandidateCount(1)).called(1);
       verify(() => mockBackgroundBackupStatusService.recordUploadEnqueue(candidateCount: 1)).called(1);
+    });
+
+    test('queues every backup candidate in batches larger than the initial 100', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final candidates = List.generate(
+        250,
+        (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+      );
+      final mockEntity = MockAssetEntity();
+      when(() => mockEntity.isLivePhoto).thenReturn(false);
+
+      when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+      when(() => mockUploadRepository.disableHoldingQueue()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.restoreDefaultHoldingQueue()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((invocation) async {
+        final tasks = invocation.positionalArguments.single as List<UploadTask>;
+        return List.filled(tasks.length, true);
+      });
+      when(() => mockUploadRepository.updateNotification(any(), TaskStatus.enqueued)).thenAnswer((_) async {});
+
+      for (final asset in candidates) {
+        when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
+        when(
+          () => mockStorageRepository.getFileForAsset(asset.id),
+        ).thenAnswer((_) async => File('/path/${asset.id}.jpg'));
+        when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
+      }
+
+      await sut.uploadBackupCandidates('user-1');
+
+      final enqueuedBatches = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured;
+      expect(enqueuedBatches.map((batch) => (batch as List<UploadTask>).length), [100, 100, 50]);
+      verify(() => mockBackgroundBackupStatusService.recordCandidateCount(250)).called(1);
+      verify(() => mockBackgroundBackupStatusService.recordUploadEnqueue(candidateCount: 250)).called(1);
     });
 
     test('records zero candidate count when no candidates exist', () async {

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -172,7 +172,8 @@ void main() {
       );
     });
 
-    test('records upload success and failure from background downloader callbacks', () async {
+    test('does not record upload success or failure from background downloader callbacks (coordinator owns progress)',
+        () async {
       final successTask = UploadTask(
         taskId: 'asset-1',
         url: 'http://test-server.com/assets',
@@ -193,10 +194,10 @@ void main() {
       onStatus(TaskStatusUpdate(failureTask, TaskStatus.failed));
       await pumpEventQueue();
 
-      verify(() => mockBackgroundBackupStatusService.recordUploadSuccess()).called(1);
-      verify(
+      verifyNever(() => mockBackgroundBackupStatusService.recordUploadSuccess());
+      verifyNever(
         () => mockBackgroundBackupStatusService.recordFailure(BackgroundBackupFailureReason.uploadFailed),
-      ).called(1);
+      );
     });
 
     test('enqueueNextBackupBatch queues one bounded eligible batch and reports exact counts', () async {

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -134,33 +134,33 @@ void main() {
       );
     });
 
-    test('does not record upload success or failure from background downloader callbacks (coordinator owns progress)',
-        () async {
-      final successTask = UploadTask(
-        taskId: 'asset-1',
-        url: 'http://test-server.com/assets',
-        filename: 'asset.jpg',
-        baseDirectory: BaseDirectory.temporary,
-        group: kBackupGroup,
-      );
-      final failureTask = UploadTask(
-        taskId: 'asset-2',
-        url: 'http://test-server.com/assets',
-        filename: 'asset-2.jpg',
-        baseDirectory: BaseDirectory.temporary,
-        group: kBackupGroup,
-      );
+    test(
+      'does not record upload success or failure from background downloader callbacks (coordinator owns progress)',
+      () async {
+        final successTask = UploadTask(
+          taskId: 'asset-1',
+          url: 'http://test-server.com/assets',
+          filename: 'asset.jpg',
+          baseDirectory: BaseDirectory.temporary,
+          group: kBackupGroup,
+        );
+        final failureTask = UploadTask(
+          taskId: 'asset-2',
+          url: 'http://test-server.com/assets',
+          filename: 'asset-2.jpg',
+          baseDirectory: BaseDirectory.temporary,
+          group: kBackupGroup,
+        );
 
-      final onStatus = capturedStatusCallback();
-      onStatus(TaskStatusUpdate(successTask, TaskStatus.complete));
-      onStatus(TaskStatusUpdate(failureTask, TaskStatus.failed));
-      await pumpEventQueue();
+        final onStatus = capturedStatusCallback();
+        onStatus(TaskStatusUpdate(successTask, TaskStatus.complete));
+        onStatus(TaskStatusUpdate(failureTask, TaskStatus.failed));
+        await pumpEventQueue();
 
-      verifyNever(() => mockBackgroundBackupStatusService.recordUploadSuccess());
-      verifyNever(
-        () => mockBackgroundBackupStatusService.recordFailure(BackgroundBackupFailureReason.uploadFailed),
-      );
-    });
+        verifyNever(() => mockBackgroundBackupStatusService.recordUploadSuccess());
+        verifyNever(() => mockBackgroundBackupStatusService.recordFailure(BackgroundBackupFailureReason.uploadFailed));
+      },
+    );
 
     test('enqueueNextBackupBatch queues one bounded eligible batch and reports exact counts', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
@@ -186,16 +186,16 @@ void main() {
 
       for (final asset in candidates) {
         when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
-        when(() => mockStorageRepository.getFileForAsset(asset.id)).thenAnswer((_) async => File('/path/${asset.id}.jpg'));
+        when(
+          () => mockStorageRepository.getFileForAsset(asset.id),
+        ).thenAnswer((_) async => File('/path/${asset.id}.jpg'));
         when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
       }
 
-      final result = await sut.enqueueNextBackupBatch(
-        'user-1',
-        excludedLocalAssetIds: {'asset-0', 'asset-1'},
-      );
+      final result = await sut.enqueueNextBackupBatch('user-1', excludedLocalAssetIds: {'asset-0', 'asset-1'});
 
-      final batch = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured.single as List<UploadTask>;
+      final batch =
+          verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured.single as List<UploadTask>;
       expect(batch.map((task) => task.taskId), List.generate(100, (index) => 'asset-${index + 2}'));
       expect(result.totalCandidateCount, 250);
       expect(result.eligibleCandidateCount, 248);

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -104,7 +104,7 @@ void main() {
   }
 
   group('background backup status recording', () {
-    test('records candidate count and enqueue count when candidates are queued', () async {
+    test('records candidate count when candidates are queued via enqueueNextBackupBatch', () async {
       final asset = LocalAssetStub.image1;
       final mockEntity = MockAssetEntity();
       final mockFile = File('/path/to/file.jpg');
@@ -117,54 +117,16 @@ void main() {
       when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => 'asset.jpg');
       when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((_) async => [true]);
 
-      await sut.uploadBackupCandidates('user-1');
+      await sut.enqueueNextBackupBatch('user-1');
 
       verify(() => mockBackgroundBackupStatusService.recordCandidateCount(1)).called(1);
-      verify(() => mockBackgroundBackupStatusService.recordUploadEnqueue(candidateCount: 1)).called(1);
     });
 
-    test('queues every backup candidate in batches larger than the initial 100', () async {
-      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      addTearDown(() => debugDefaultTargetPlatformOverride = null);
-
-      final candidates = List.generate(
-        250,
-        (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
-      );
-      final mockEntity = MockAssetEntity();
-      when(() => mockEntity.isLivePhoto).thenReturn(false);
-
-      when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
-      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
-      when(() => mockUploadRepository.disableHoldingQueue()).thenAnswer((_) async {});
-      when(() => mockUploadRepository.restoreDefaultHoldingQueue()).thenAnswer((_) async {});
-      when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((invocation) async {
-        final tasks = invocation.positionalArguments.single as List<UploadTask>;
-        return List.filled(tasks.length, true);
-      });
-      when(() => mockUploadRepository.updateNotification(any(), TaskStatus.enqueued)).thenAnswer((_) async {});
-
-      for (final asset in candidates) {
-        when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
-        when(
-          () => mockStorageRepository.getFileForAsset(asset.id),
-        ).thenAnswer((_) async => File('/path/${asset.id}.jpg'));
-        when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
-      }
-
-      await sut.uploadBackupCandidates('user-1');
-
-      final enqueuedBatches = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured;
-      expect(enqueuedBatches.map((batch) => (batch as List<UploadTask>).length), [100, 100, 50]);
-      verify(() => mockBackgroundBackupStatusService.recordCandidateCount(250)).called(1);
-      verify(() => mockBackgroundBackupStatusService.recordUploadEnqueue(candidateCount: 250)).called(1);
-    });
-
-    test('records zero candidate count when no candidates exist', () async {
+    test('records zero candidate count when no candidates exist via enqueueNextBackupBatch', () async {
       when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
       when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => []);
 
-      await sut.uploadBackupCandidates('user-1');
+      await sut.enqueueNextBackupBatch('user-1');
 
       verify(() => mockBackgroundBackupStatusService.recordCandidateCount(0)).called(1);
       verifyNever(

--- a/mobile/test/services/background_upload.service_test.dart
+++ b/mobile/test/services/background_upload.service_test.dart
@@ -199,6 +199,111 @@ void main() {
       ).called(1);
     });
 
+    test('enqueueNextBackupBatch queues one bounded eligible batch and reports exact counts', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      sut.backupBatchSize = 100;
+      final candidates = List.generate(
+        250,
+        (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+      );
+      final mockEntity = MockAssetEntity();
+      when(() => mockEntity.isLivePhoto).thenReturn(false);
+
+      when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+      when(() => mockUploadRepository.disableHoldingQueue()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.restoreDefaultHoldingQueue()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((invocation) async {
+        final tasks = invocation.positionalArguments.single as List<UploadTask>;
+        return List.filled(tasks.length, true);
+      });
+      when(() => mockUploadRepository.updateNotification(any(), TaskStatus.enqueued)).thenAnswer((_) async {});
+
+      for (final asset in candidates) {
+        when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
+        when(() => mockStorageRepository.getFileForAsset(asset.id)).thenAnswer((_) async => File('/path/${asset.id}.jpg'));
+        when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
+      }
+
+      final result = await sut.enqueueNextBackupBatch(
+        'user-1',
+        excludedLocalAssetIds: {'asset-0', 'asset-1'},
+      );
+
+      final batch = verify(() => mockUploadRepository.enqueueBackgroundAll(captureAny())).captured.single as List<UploadTask>;
+      expect(batch.map((task) => task.taskId), List.generate(100, (index) => 'asset-${index + 2}'));
+      expect(result.totalCandidateCount, 250);
+      expect(result.eligibleCandidateCount, 248);
+      expect(result.enqueuedLocalAssetIds, List.generate(100, (index) => 'asset-${index + 2}'));
+      expect(result.skippedLocalAssetIds, isEmpty);
+      expect(result.enqueueFailedLocalAssetIds, isEmpty);
+      expect(result.remainingEligibleCandidateCount, 148);
+      expect(result.queuedAny, true);
+      expect(result.hasMoreEligibleCandidates, true);
+    });
+
+    test('enqueueNextBackupBatch does not loop when every candidate is excluded', () async {
+      sut.backupBatchSize = 100;
+      final candidates = List.generate(
+        3,
+        (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+      );
+
+      when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+
+      final result = await sut.enqueueNextBackupBatch(
+        'user-1',
+        excludedLocalAssetIds: {'asset-0', 'asset-1', 'asset-2'},
+      );
+
+      expect(result.totalCandidateCount, 3);
+      expect(result.eligibleCandidateCount, 0);
+      expect(result.enqueuedLocalAssetIds, isEmpty);
+      expect(result.remainingEligibleCandidateCount, 0);
+      expect(result.queuedAny, false);
+      expect(result.hasMoreEligibleCandidates, false);
+      verifyNever(() => mockUploadRepository.enqueueBackgroundAll(any()));
+    });
+
+    test('enqueueNextBackupBatch reports skipped files and mixed native enqueue failures', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      sut.backupBatchSize = 4;
+      final candidates = List.generate(
+        4,
+        (index) => LocalAssetStub.image1.copyWith(id: 'asset-$index', name: 'asset-$index.jpg'),
+      );
+      final mockEntity = MockAssetEntity();
+      when(() => mockEntity.isLivePhoto).thenReturn(false);
+
+      when(() => mockStorageRepository.clearCache()).thenAnswer((_) async {});
+      when(() => mockBackupRepository.getCandidates('user-1')).thenAnswer((_) async => candidates);
+      when(() => mockUploadRepository.disableHoldingQueue()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.restoreDefaultHoldingQueue()).thenAnswer((_) async {});
+      when(() => mockUploadRepository.enqueueBackgroundAll(any())).thenAnswer((_) async => [true, false, true]);
+      when(() => mockUploadRepository.updateNotification(any(), TaskStatus.enqueued)).thenAnswer((_) async {});
+
+      for (final asset in candidates) {
+        when(() => mockStorageRepository.getAssetEntityForAsset(asset)).thenAnswer((_) async => mockEntity);
+        when(() => mockAssetMediaRepository.getOriginalFilename(asset.id)).thenAnswer((_) async => asset.name);
+      }
+      when(() => mockStorageRepository.getFileForAsset('asset-0')).thenAnswer((_) async => File('/path/asset-0.jpg'));
+      when(() => mockStorageRepository.getFileForAsset('asset-1')).thenAnswer((_) async => null);
+      when(() => mockStorageRepository.getFileForAsset('asset-2')).thenAnswer((_) async => File('/path/asset-2.jpg'));
+      when(() => mockStorageRepository.getFileForAsset('asset-3')).thenAnswer((_) async => File('/path/asset-3.jpg'));
+
+      final result = await sut.enqueueNextBackupBatch('user-1');
+
+      expect(result.enqueuedLocalAssetIds, ['asset-0', 'asset-3']);
+      expect(result.skippedLocalAssetIds, ['asset-1']);
+      expect(result.enqueueFailedLocalAssetIds, ['asset-2']);
+      expect(result.remainingEligibleCandidateCount, 0);
+    });
+
     test('does not record logical upload success for Live Photo motion completion', () async {
       final motionTask = UploadTask(
         taskId: 'asset-live',

--- a/mobile/tool/observe_ios_background_backup.sh
+++ b/mobile/tool/observe_ios_background_backup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Observe iOS background backup activity on a connected device.
+#
+# Healthy pattern:
+# - "for client de.opennoodle.gallery completed successfully"
+# - upload responses continue past the first 100 assets (bounded batches refill)
+# - when "has 0 outstanding tasks" appears while the app still reports remaining
+#   candidates, another Noodle batch is enqueued WITHOUT opening backup details
+# - no Noodle "completed with error", "Delayed or retried enqueue failed",
+#   abort, or crash lines
+#
+# Usage: tool/observe_ios_background_backup.sh <device-udid> [seconds]
+# Requires: idevicesyslog (libimobiledevice) and rg (ripgrep) on PATH.
+
+UDID="${1:?usage: $0 <device-udid> [seconds]}"
+SECONDS_TO_RUN="${2:-180}"
+
+timeout "${SECONDS_TO_RUN}s" idevicesyslog -u "$UDID" -p "Noodle Gallery|nsurlsessiond" --no-colors \
+  | rg -i "de\.opennoodle\.gallery|bundle id: de\.opennoodle\.gallery|Noodle Gallery\(background_downloader\)|for client de\.opennoodle\.gallery completed successfully|NDSession .* has [0-9]+ outstanding tasks|Delayed or retried enqueue failed|completed with error|abort|crash"


### PR DESCRIPTION
## Summary

Two iOS reliability fixes, both validated on a physical device.

### 1. Foreground loses server access after backgrounding (stale URLSession)
After a background backup ran and the background-worker isolate was torn down, the foreground app lost **all** server connectivity until a force-quit (logs showed `Using server URL: null`, a red herring). Root cause: foreground + background-worker isolates share one process-wide `URLSession`; the foreground never re-initialised its native client on resume.

- `NetworkRepository.refresh()` rebuilds the foreground client past the same-pointer guard
- native `recreateSession()` exposed over pigeon (iOS) / no-op (Android)
- `ApiService.refreshConnection()` re-points the API client
- `AppLifeCycleNotifier.refreshConnectionAfterResume()` wired into resume (iOS + wasPaused), with a success log

### 2. Mass "Delayed or retried enqueue failed" backup errors (587)
The previous `stabilize background backup uploads` commit enqueued **all** candidates up front; with the `background_downloader` holding queue capped at 6 concurrent, hundreds of tasks waited while their transient PhotoKit temp exports were purged → mass re-enqueue failures. Replaced with a designed coordinator (per `docs/plans/2026-06-02-ios-full-backup-tdd.md`):

- `BackgroundBackupQueueCoordinator`: enqueues **bounded batches** and refills only when both URLSession groups drain (no UI dependency), tracking exclusion sets (queued/completed/failed/skipped/enqueue-failed) so nothing loops
- bounded `enqueueNextBackupBatch` replaces the enqueue-all `uploadBackupCandidates` (deleted)
- per-session progress persistence (sticky failure reason, per-session reset)
- hardened against refill errors, all-skipped batches, and a start() session-generation race
- `BackgroundBackupQueuePort`/`Result` extracted to break a service↔coordinator import cycle
- `mobile/tool/observe_ios_background_backup.sh` for device-log verification

The iOS background-worker HTTP-teardown crash fix (drain in-flight HTTP via `DrainingHttpClient.shutdown` before `engine.destroyContext`) is preserved and re-verified.

## Test Plan
- [x] `flutter test` — 1504 pass / 1 pre-existing skip
- [x] `dart analyze --fatal-infos lib test` — clean
- [x] `dart format` — clean
- [ ] Device: resume after a background backup reconnects without force-quit (in-app log: `Re-established server connection after resume`)
- [ ] Device: full backup of thousands proceeds in bounded batches past the first 100, with no new "Delayed or retried enqueue failed"