### PR TITLE
fix(server): keep shared-space person dedup to one chain per space

### DIFF
--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -99,6 +99,29 @@ describe(JobRepository.name, () => {
     });
   });
 
+  describe('hasInFlightDedupChain', () => {
+    it('returns true when a pass-scoped follow-up exists for the space', async () => {
+      const { sut, queue } = setup();
+      queue.getJobs.mockResolvedValue([{ id: 'space-dedup-space-1-pass-5' }] as any);
+
+      await expect(sut.hasInFlightDedupChain('space-1')).resolves.toBe(true);
+    });
+
+    it('returns false when only the bare initial job exists (no follow-up yet)', async () => {
+      const { sut, queue } = setup();
+      queue.getJobs.mockResolvedValue([{ id: 'space-dedup-space-1' }] as any);
+
+      await expect(sut.hasInFlightDedupChain('space-1')).resolves.toBe(false);
+    });
+
+    it("does not match a different space's chain", async () => {
+      const { sut, queue } = setup();
+      queue.getJobs.mockResolvedValue([{ id: 'space-dedup-space-2-pass-3' }] as any);
+
+      await expect(sut.hasInFlightDedupChain('space-1')).resolves.toBe(false);
+    });
+  });
+
   describe('removeOrphanedActiveJobs', () => {
     it('removes active job ids whose hash is gone (orphans) and leaves real active jobs untouched', async () => {
       const { sut, queue } = setup();

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -228,6 +228,29 @@ export class JobRepository {
     ) as unknown as Promise<JobCounts>;
   }
 
+  /**
+   * True when a dedup chain is already running for the space — a pass-scoped follow-up
+   * (`space-dedup-<spaceId>-pass-<n>`, n >= 2) is queued, active, delayed, or paused on the
+   * FacialRecognition queue. The initial dedup trigger uses the bare `space-dedup-<spaceId>` id,
+   * which only de-duplicates concurrent triggers while pass 1 is still in flight; once a chain
+   * advances to pass-scoped follow-ups the bare id frees, so the next trigger would otherwise start a
+   * parallel chain (doubling work + reviving the removeOnComplete/stalled-recovery orphan race on the
+   * shared pass-scoped jobIds). {@link SharedSpaceService.handleSharedSpacePersonDedup} uses this to
+   * keep one chain per space. Relies on the FacialRecognition queue being concurrency 1: the gating
+   * pass-1 job is the only active dedup job and carries the bare id, never the `-pass-` prefix, so it
+   * never matches itself.
+   */
+  async hasInFlightDedupChain(spaceId: string): Promise<boolean> {
+    const prefix = `space-dedup-${spaceId}-pass-`;
+    const jobs = await this.getQueue(QueueName.FacialRecognition).getJobs(
+      ['active', 'waiting', 'delayed', 'paused'],
+      0,
+      1000,
+      true,
+    );
+    return jobs.some((job) => job?.id?.startsWith(prefix));
+  }
+
   async getJobTypes(name: QueueName): Promise<JobTypeCounts[]> {
     // Process 'paused' before 'waiting': BullMQ may include the same job in both lists
     // when a queue is paused. ID-based dedup then correctly attributes it to 'paused'.

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -8196,6 +8196,35 @@ describe(SharedSpaceService.name, () => {
       );
     });
 
+    it('skips the initial pass when a dedup chain is already running for the space (prevents a 2nd chain)', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getSpacePersonsWithEmbeddings.mockResolvedValue([]);
+      mocks.job.hasInFlightDedupChain.mockResolvedValue(true);
+
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId });
+
+      expect(result).toBe(JobStatus.Skipped);
+      // Bails out before scanning persons and never starts a parallel chain.
+      expect(mocks.sharedSpace.getSpacePersonsWithEmbeddings).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: JobName.SharedSpacePersonDedup }),
+      );
+    });
+
+    it('does not gate follow-up passes (pass >= 2) even when a chain is reported in flight', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));
+      mocks.sharedSpace.getSpacePersonsWithEmbeddings.mockResolvedValue([]);
+      // A follow-up IS the running chain; gating it would stall dedup forever.
+      mocks.job.hasInFlightDedupChain.mockResolvedValue(true);
+
+      const result = await sut.handleSharedSpacePersonDedup({ spaceId, pass: 2 });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.sharedSpace.getSpacePersonsWithEmbeddings).toHaveBeenCalled();
+    });
+
     it('should physically merge strict identity-backed space people before merging supporting identities', async () => {
       const spaceId = 'space-1';
       mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true }));

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1768,6 +1768,18 @@ export class SharedSpaceService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    // Single-flight: at most one dedup chain per space. Only the initial trigger (pass 1) is gated —
+    // a follow-up (pass >= 2) IS the running chain and must continue. The bare initial jobId only
+    // de-duplicates triggers while pass 1 is in flight; once a chain advances to pass-scoped
+    // follow-ups the bare id frees, so without this guard the next external trigger (e.g. a bulk
+    // face-assign run) starts a parallel chain — doubling the work and reviving the
+    // removeOnComplete/stalled-recovery orphan race on the shared pass-scoped jobIds.
+    const pass = job.pass ?? 1;
+    if (pass === 1 && (await this.jobRepository.hasInFlightDedupChain(job.spaceId))) {
+      this.logger.debug(`Dedup skipped for space ${job.spaceId}: a dedup chain is already running`);
+      return JobStatus.Skipped;
+    }
+
     const { machineLearning } = await this.getConfig({ withCache: true });
     const maxDistance = machineLearning.facialRecognition.maxDistance;
 
@@ -1783,7 +1795,6 @@ export class SharedSpaceService extends BaseService {
     // the whole concurrency-1 FacialRecognition queue (core face recognition included). Each
     // invocation now does exactly ONE pass and re-queues a fresh, short follow-up when a merge
     // happened, carrying a pass counter that is capped to prevent a runaway chain.
-    const pass = job.pass ?? 1;
     const affectedIdentityIds = new Set<string>();
     let mergedAny = false;
 

--- a/server/test/medium/specs/services/metadata.service.spec.ts
+++ b/server/test/medium/specs/services/metadata.service.spec.ts
@@ -145,6 +145,7 @@ const setupSharedSpaceService = (db?: Kysely<DB>) => {
   });
 
   ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).queue.mockResolvedValue();
+  ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository).hasInFlightDedupChain.mockResolvedValue(false);
   ctx
     .getMock<SystemMetadataRepository, Mocked<SystemMetadataRepository>>(SystemMetadataRepository)
     .get.mockResolvedValue({

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -55,6 +55,7 @@ const setup = (db?: Kysely<DB>) => {
   const jobs = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
   jobs.queue.mockResolvedValue();
   jobs.queueAll.mockResolvedValue();
+  jobs.hasInFlightDedupChain.mockResolvedValue(false);
   return { ctx, sut, faceIdentityRepository: ctx.get(FaceIdentityRepository) };
 };
 
@@ -76,6 +77,7 @@ const setupSharedSpace = (db?: Kysely<DB>) => {
   const jobs = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
   jobs.queue.mockResolvedValue();
   jobs.queueAll.mockResolvedValue();
+  jobs.hasInFlightDedupChain.mockResolvedValue(false);
   return { ctx, sut, faceIdentityRepository: ctx.get(FaceIdentityRepository), jobs };
 };
 

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -35,6 +35,7 @@ const setup = (db?: Kysely<DB>) => {
   const jobs = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
   jobs.queue.mockResolvedValue();
   jobs.queueAll.mockResolvedValue();
+  jobs.hasInFlightDedupChain.mockResolvedValue(false);
   return {
     ctx,
     sut,

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -17,6 +17,7 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     isActive: vitest.fn(),
     isPaused: vitest.fn(),
     getJobCounts: vitest.fn(),
+    hasInFlightDedupChain: vitest.fn().mockResolvedValue(false),
     getJobTypes: vitest.fn().mockResolvedValue([]),
     getTelemetryMetrics: vitest.fn(),
     clear: vitest.fn(),


### PR DESCRIPTION
## Problem

Shared-space person dedup runs as a chain of one-pass-per-job BullMQ jobs on the concurrency-1 `FacialRecognition` queue. The initial trigger enqueues a bare `space-dedup-<spaceId>` job; follow-up passes use a pass-scoped id `space-dedup-<spaceId>-pass-<n>` so they can enqueue while the current job is still active.

The bare id only de-duplicates concurrent triggers **while pass 1 is in flight**. As soon as a chain advances to its pass-scoped follow-up, the bare id frees, so the next external trigger (e.g. a large face-assignment run that fires many shared-space face-match jobs over time) starts a **second, parallel chain** for the same space.

Two chains for one space then:
- roughly **double** the dedup work, so the per-space pass cap is reached about twice as fast; and
- churn the **same** pass-scoped jobIds at a high rate, reviving the `removeOnComplete`/stalled-recovery race that briefly orphans jobs in the queue's `active` list (lock gone, no DB activity, later recovered by the BullMQ stalled check).

## Fix

Gate the initial pass to enforce a single chain per space:

- New `JobRepository.hasInFlightDedupChain(spaceId)` — true when a pass-scoped follow-up (`space-dedup-<spaceId>-pass-<n>`, n >= 2) is already queued / active / delayed / paused on the `FacialRecognition` queue.
- `handleSharedSpacePersonDedup` skips the initial pass (pass 1) when a chain is already in flight. Follow-up passes (pass >= 2) are never gated — they *are* the running chain, which re-scans all persons each pass, so skipping the duplicate trigger loses no work.

Correctness relies on the `FacialRecognition` queue being concurrency 1: the gating pass-1 job carries the bare id (never the `-pass-` prefix), so it never matches itself.

## Tests

- `JobRepository.hasInFlightDedupChain`: true for a pass-scoped follow-up, false for the bare initial job, and does not match another space's chain.
- `handleSharedSpacePersonDedup`: skips the initial pass when a chain is running (no second chain, no re-queue); does not gate follow-up passes.

Full server unit suite green; tsc, eslint, prettier clean.