### PR TITLE
fix(web): send shared-link expiresAt as UTC datetime (#667)

### DIFF
--- a/web/src/lib/components/SharedLinkExpiration.spec.ts
+++ b/web/src/lib/components/SharedLinkExpiration.spec.ts
@@ -1,0 +1,64 @@
+import { renderWithTooltips } from '$tests/helpers';
+import SharedLinkExpirationHost from '@test-data/mocks/shared-link-expiration-host.stub.svelte';
+import { screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { Settings } from 'luxon';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// The server validates `expiresAt` with Zod's `z.iso.datetime()`, which only accepts
+// UTC ("Z") timestamps and rejects any string carrying a numeric timezone offset.
+const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+describe('SharedLinkExpiration component', () => {
+  let originalZone: typeof Settings.defaultZone;
+
+  beforeEach(() => {
+    originalZone = Settings.defaultZone;
+    // Reproduce a user behind a non-UTC timezone. Luxon's `DateTime.toISO()` emits the
+    // local offset (e.g. `-04:00`) here — which the server rejects. A UTC test env would
+    // mask the bug because the offset would collapse to `Z`.
+    Settings.defaultZone = 'America/New_York';
+  });
+
+  afterEach(() => {
+    Settings.defaultZone = originalZone;
+  });
+
+  // Preset buttons carry visible text; the date-picker trigger is icon-only.
+  const getPresetButtons = () => screen.getAllByRole('button').filter((button) => button.textContent?.trim());
+
+  it('emits a UTC (Z) ISO 8601 string when an expiry preset is selected', async () => {
+    renderWithTooltips(SharedLinkExpirationHost, {});
+    const user = userEvent.setup();
+
+    const presetButtons = getPresetButtons();
+    expect(presetButtons.length).toBeGreaterThan(1);
+
+    // The last preset is a positive duration ("in 1 year"); the first is "never".
+    await user.click(presetButtons.at(-1)!);
+    await tick();
+
+    const value = screen.getByTestId('expires-at-value').textContent ?? '';
+    expect(value).toMatch(ISO_UTC);
+    expect(value).not.toContain('+');
+    // Sanity: the emitted instant is a real, future date.
+    expect(Number.isNaN(Date.parse(value))).toBe(false);
+    expect(Date.parse(value)).toBeGreaterThan(Date.now());
+  });
+
+  it('clears the expiry when the "never" preset is selected', async () => {
+    renderWithTooltips(SharedLinkExpirationHost, {});
+    const user = userEvent.setup();
+
+    const presetButtons = getPresetButtons();
+    // Set a real expiry first, then "never" (the first preset) should clear it.
+    await user.click(presetButtons.at(-1)!);
+    await tick();
+    expect(screen.getByTestId('expires-at-value').textContent).not.toBe('');
+
+    await user.click(presetButtons[0]);
+    await tick();
+    expect(screen.getByTestId('expires-at-value').textContent).toBe('');
+  });
+});

--- a/web/src/lib/components/SharedLinkExpiration.svelte
+++ b/web/src/lib/components/SharedLinkExpiration.svelte
@@ -35,7 +35,8 @@
 
   const setSelectedDate = (value: DateTime | undefined) => {
     selectedPresetValue = null; // Clear preset when manually setting date
-    expiresAt = value ? value.toISO() : null;
+    // Serialize as UTC ("Z"); the server's ISO 8601 validator rejects offset forms (e.g. +02:00).
+    expiresAt = value ? value.toUTC().toISO() : null;
   };
 
   const selectPreset = (value: number) => {
@@ -45,7 +46,8 @@
       return;
     }
     const newDate = DateTime.now().plus(value);
-    expiresAt = newDate.toISO();
+    // Serialize as UTC ("Z"); the server's ISO 8601 validator rejects offset forms (e.g. +02:00).
+    expiresAt = newDate.toUTC().toISO();
   };
 
   const isSelected = (value: number) => {

--- a/web/src/test-data/mocks/shared-link-expiration-host.stub.svelte
+++ b/web/src/test-data/mocks/shared-link-expiration-host.stub.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import SharedLinkExpiration from '$lib/components/SharedLinkExpiration.svelte';
+
+  let expiresAt = $state<string | null>(null);
+</script>
+
+<!-- Surfaces the value SharedLinkExpiration binds out, so tests can assert the exact
+     string that would be sent to the API as `expiresAt`. -->
+<div data-testid="expires-at-value">{expiresAt ?? ''}</div>
+<SharedLinkExpiration bind:expiresAt />


### PR DESCRIPTION
Closes #667

## Problem

Creating a shared link (album or asset) with **any** expiry — a preset (_in 1 day_, _in 7 days_, …) or a manually picked date — failed immediately with HTTP 400:

```
[expiresAt] Invalid input: expected ISO 8601 datetime string, received string
```

Only the **No expiry** option worked, making the expiry feature unusable. Reported against a `de-DE` instance, but it affects every user outside UTC.

## Root cause

`SharedLinkExpiration.svelte` serialized the expiry with luxon's `DateTime.toISO()`, which emits the **local timezone offset**, e.g. `2026-06-13T00:00:00.000-04:00`.

The server validates `expiresAt` with Zod's `z.iso.datetime()` (`server/src/validation.ts` → `isoDatetimeToDate`). By default that schema only accepts **UTC (`Z`)** timestamps and rejects any string carrying a numeric offset — so the offset form was rejected. Its error message (`received ${typeof iss.input}` → `received string`) is exactly what users saw; the localized `13.06.2026` in the report was just the date-picker's display format, not the wire value.

For users in UTC the offset collapses to `Z`, which is why it slipped through.

## Fix

Serialize as UTC via `.toUTC().toISO()` on both the preset and manual-date paths. This produces `…Z`, matching how the rest of the web app sends datetimes to the API (`Date.prototype.toISOString()` everywhere else). The selected instant is unchanged.

## Tests

Added `SharedLinkExpiration.spec.ts` (with a small bindable host fixture) that selects a preset under a **non-UTC** default zone (`America/New_York`) and asserts the emitted `expiresAt` is a UTC `Z` ISO string. Forcing the zone is required because the test env pins `TZ=UTC`, which would otherwise mask the bug. The test is RED before the fix and GREEN after.

Verified locally: `eslint` (changed files), `tsc --noEmit`, and the new + existing shared-link specs all pass.