### PR TITLE
fix(mobile): pin multi_json so fastlane release bundle resolves

### DIFF
--- a/mobile/android/gallery-release/Gemfile
+++ b/mobile/android/gallery-release/Gemfile
@@ -1,3 +1,9 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+# fastlane loads every default action on startup, including ones backed by
+# google-apis-* -> representable/json, which requires multi_json without
+# declaring it. Newer googleauth/signet dropped multi_json too, so nothing
+# pulls it into the bundle. Pin it directly or `bundle exec fastlane` dies
+# with "multi_json is not part of the bundle".
+gem "multi_json"

--- a/mobile/ios/Gemfile
+++ b/mobile/ios/Gemfile
@@ -3,3 +3,9 @@ source "https://rubygems.org"
 gem "fastlane"
 gem "cocoapods"
 gem "abbrev" # Required for Ruby 3.4+
+# representable/json (pulled in by fastlane -> google-apis-*) requires
+# multi_json but no longer declares it as a dependency, and newer
+# googleauth/signet dropped it too, so nothing else pulls it into the
+# bundle. Pin it directly or `bundle exec fastlane` dies with
+# "multi_json is not part of the bundle".
+gem "multi_json"


### PR DESCRIPTION
## Problem

The mobile release (`Release Mobile` → `gallery-build-mobile.yml`) fails in the iOS job at `bundle exec fastlane gha_release_prod`:

```
multi_json is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
  from representable-3.2.0/lib/representable/json.rb:1
  ...
  from fastlane-2.235.0/.../create_app_on_managed_play_store.rb:1
```

## Root cause

Upstream commit `f8afef0f9d` ("gha ios release") deleted `mobile/ios/Gemfile.lock` and gitignored it, so CI now resolves Ruby gems **fresh** from RubyGems on every run.

fastlane loads every default action on startup, pulling in the `google-apis-* → representable/json` chain. `representable 3.2.0` does `require "multi_json"` but no longer declares it as a gemspec dependency. `multi_json` used to ride in transitively via `googleauth`/`signet`, but the now-latest **`googleauth 1.17.0`** and **`signet 0.22.0`** dropped their `multi_json` dependency. So nothing pulls `multi_json` into the bundle and the require fails.

(Local builds still work because an older, gitignored lock pins `googleauth 1.16.2`/`signet 0.21.0`, which still carry `multi_json`.)

## Fix

Pin `gem "multi_json"` directly in the two fastlane Gemfiles the release flow uses:
- `mobile/ios/Gemfile` (iOS `gha_release_prod`)
- `mobile/android/gallery-release/Gemfile` (Android `fastlane android internal` — same crash on fastlane startup)

## Verification

Reproduced the exact failing require chain in isolation and confirmed the fix:

```
# without multi_json:
printf 'source "https://rubygems.org"\ngem "google-apis-playcustomapp_v1"\n' > Gemfile
bundle install && bundle exec ruby -e "require 'google/apis/playcustomapp_v1'"
# => Gem::LoadError: multi_json is not part of the bundle (matches CI)

# with `gem "multi_json"` added => loads OK
```

Both release Gemfiles now resolve with `multi_json 1.21.1`.