### PR TITLE
fix(mobile): timeline grouping labels match web (Years/Months/All) + bounce returns to Years

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2745,7 +2745,7 @@
   "time_based_memories": "Time-based memories",
   "time_based_memories_duration": "Number of seconds to display each image.",
   "timeline": "Timeline",
-  "timeline_grouping_days": "Days",
+  "timeline_grouping_all": "All",
   "timeline_grouping_months": "Months",
   "timeline_grouping_selector": "Timeline grouping",
   "timeline_grouping_years": "Years",

--- a/mobile/lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart
@@ -33,7 +33,9 @@ class TimelineGroupingSelector extends ConsumerWidget {
 
   static const double _maxWidth = 218;
   static const double _height = 48;
-  static const double _compactWidth = 84;
+  // Wide enough for the longest label ("Months") at the default text scale; larger text scales
+  // down via FittedBox rather than truncating.
+  static const double _compactWidth = 112;
   static const double _compactHeight = 40;
 
   final bool enabled;
@@ -102,66 +104,42 @@ class TimelineGroupingSelector extends ConsumerWidget {
   }
 }
 
-class _TimelineGroupingCompactSelector extends StatefulWidget {
+/// Bounce direction of the compact timeline-grouping chip: `true` means the next tap zooms in
+/// toward "All", `false` means it zooms out toward "Years". Kept in a provider rather than widget
+/// State because the timeline tears down and rebuilds the app-bar subtree on every segment reload
+/// (a grouping change flashes the loading state). Storing the direction in ephemeral State reset
+/// it on each reload, trapping the chip between "Months" and "All" so it never bounced back to
+/// "Years". The extremes are self-correcting (a tap on Years/All forces the direction), so only
+/// the ambiguous middle ("Months") relies on this surviving recreation.
+final timelineGroupingZoomingInProvider = StateProvider<bool>((ref) => true);
+
+class _TimelineGroupingCompactSelector extends ConsumerWidget {
   const _TimelineGroupingCompactSelector({required this.selected, required this.enabled, required this.onSelected});
 
   final GroupAssetsBy selected;
   final bool enabled;
   final Future<void> Function(GroupAssetsBy groupBy) onSelected;
 
-  @override
-  State<_TimelineGroupingCompactSelector> createState() => _TimelineGroupingCompactSelectorState();
-}
-
-class _TimelineGroupingCompactSelectorState extends State<_TimelineGroupingCompactSelector> {
-  // Direction the next tap moves: true = toward Day (zoom in), false = toward Year (zoom out).
-  bool _zoomingIn = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _syncDirectionAtExtreme(widget.selected);
-  }
-
-  @override
-  void didUpdateWidget(_TimelineGroupingCompactSelector oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.selected != widget.selected) {
-      _syncDirectionAtExtreme(widget.selected);
-    }
-  }
-
-  // At the extremes the direction is forced; in the middle (Month) keep whatever it was.
-  void _syncDirectionAtExtreme(GroupAssetsBy selected) {
+  Future<void> _selectNext(WidgetRef ref) async {
+    final direction = ref.read(timelineGroupingZoomingInProvider.notifier);
+    final GroupAssetsBy next;
     switch (selected) {
       case GroupAssetsBy.year:
-        _zoomingIn = true;
-      case GroupAssetsBy.month:
-        break;
-      case GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none:
-        _zoomingIn = false;
-    }
-  }
-
-  Future<void> _selectNext() async {
-    final GroupAssetsBy next;
-    switch (widget.selected) {
-      case GroupAssetsBy.year:
         next = GroupAssetsBy.month;
-        _zoomingIn = true;
+        direction.state = true; // continue zooming in toward All
       case GroupAssetsBy.month:
-        if (_zoomingIn) {
+        if (direction.state) {
           next = GroupAssetsBy.day;
-          _zoomingIn = false; // just arrived at the zoom-in extreme (Day)
+          direction.state = false; // reached the zoom-in extreme (All); bounce back up next
         } else {
           next = GroupAssetsBy.year;
-          _zoomingIn = true; // just arrived at the zoom-out extreme (Year)
+          direction.state = true; // reached the zoom-out extreme (Years); bounce back down next
         }
       case GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none:
         next = GroupAssetsBy.month;
-        _zoomingIn = false;
+        direction.state = false; // continue zooming out toward Years
     }
-    await widget.onSelected(next);
+    await onSelected(next);
   }
 
   Future<void> _showMenu(BuildContext context) async {
@@ -183,55 +161,57 @@ class _TimelineGroupingCompactSelectorState extends State<_TimelineGroupingCompa
     );
 
     if (selectedGroupBy != null && context.mounted) {
-      await widget.onSelected(selectedGroupBy);
+      await onSelected(selectedGroupBy);
     }
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final label = _compactLabel(context, widget.selected);
-    final foreground = widget.enabled ? colors.onPrimary : colors.onSurface.withValues(alpha: 0.5);
+    final label = _label(context, selected);
+    final foreground = enabled ? colors.onPrimary : colors.onSurface.withValues(alpha: 0.5);
 
     return Semantics(
       key: const Key('timeline-grouping-compact-selector'),
       container: true,
       button: true,
-      enabled: widget.enabled,
+      enabled: enabled,
       label: _translated('timeline_grouping_selector', 'Timeline grouping'),
       value: label,
-      onTap: widget.enabled ? () => unawaited(_selectNext()) : null,
-      onLongPress: widget.enabled ? () => unawaited(_showMenu(context)) : null,
+      onTap: enabled ? () => unawaited(_selectNext(ref)) : null,
+      onLongPress: enabled ? () => unawaited(_showMenu(context)) : null,
       child: ExcludeSemantics(
         child: Opacity(
-          opacity: widget.enabled ? 1 : 0.45,
+          opacity: enabled ? 1 : 0.45,
           child: SizedBox(
             width: TimelineGroupingSelector._compactWidth,
             height: TimelineGroupingSelector._compactHeight,
             child: Material(
-              color: widget.enabled ? colors.primary : colors.surfaceContainerHighest,
+              color: enabled ? colors.primary : colors.surfaceContainerHighest,
               shape: StadiumBorder(
                 side: BorderSide(
-                  color: widget.enabled
+                  color: enabled
                       ? colors.primary.withValues(alpha: 0.42)
                       : colors.outlineVariant.withValues(alpha: 0.7),
                 ),
               ),
               clipBehavior: Clip.antiAlias,
               child: InkWell(
-                onTap: widget.enabled ? () => unawaited(_selectNext()) : null,
-                onLongPress: widget.enabled ? () => unawaited(_showMenu(context)) : null,
+                onTap: enabled ? () => unawaited(_selectNext(ref)) : null,
+                onLongPress: enabled ? () => unawaited(_showMenu(context)) : null,
                 borderRadius: BorderRadius.circular(999),
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 10),
                   child: Center(
-                    child: Text(
-                      label,
-                      maxLines: 1,
-                      overflow: TextOverflow.clip,
-                      softWrap: false,
-                      style: theme.textTheme.labelLarge?.copyWith(color: foreground, fontWeight: FontWeight.w700),
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        label,
+                        maxLines: 1,
+                        softWrap: false,
+                        style: theme.textTheme.labelLarge?.copyWith(color: foreground, fontWeight: FontWeight.w700),
+                      ),
                     ),
                   ),
                 ),
@@ -304,21 +284,15 @@ class _TimelineGroupingSegment extends StatelessWidget {
   }
 }
 
+// Labels mirror the web timeline grouping control (Years / Months / All) so the two
+// platforms read identically. Both the inline segments and the compact app-bar chip use
+// these; the chip is sized to fit the widest label ("Months") to avoid truncation.
 String _label(BuildContext context, GroupAssetsBy groupBy) {
   return switch (groupBy) {
     GroupAssetsBy.year => _translated('timeline_grouping_years', 'Years'),
     GroupAssetsBy.month => _translated('timeline_grouping_months', 'Months'),
-    GroupAssetsBy.day => _translated('timeline_grouping_days', 'Days'),
-    GroupAssetsBy.auto || GroupAssetsBy.none => _translated('timeline_grouping_days', 'Days'),
-  };
-}
-
-String _compactLabel(BuildContext context, GroupAssetsBy groupBy) {
-  return switch (groupBy) {
-    GroupAssetsBy.year => _translated('timeline_grouping_year', 'Year'),
-    GroupAssetsBy.month => _translated('timeline_grouping_month', 'Month'),
-    GroupAssetsBy.day => _translated('timeline_grouping_day', 'Day'),
-    GroupAssetsBy.auto || GroupAssetsBy.none => _translated('timeline_grouping_day', 'Day'),
+    GroupAssetsBy.day => _translated('timeline_grouping_all', 'All'),
+    GroupAssetsBy.auto || GroupAssetsBy.none => _translated('timeline_grouping_all', 'All'),
   };
 }
 

--- a/mobile/test/presentation/pages/dev/main_timeline_page_test.dart
+++ b/mobile/test/presentation/pages/dev/main_timeline_page_test.dart
@@ -57,7 +57,9 @@ void main() {
 
       expect(find.byType(TimelineGroupingSelector), findsOneWidget);
       expect(find.byKey(const Key('timeline-grouping-compact-selector')), findsOneWidget);
-      expect(tester.getSize(find.byKey(const Key('timeline-grouping-compact-selector'))).width, lessThanOrEqualTo(92));
+      // The chip is sized to fit its widest label ("Months") without truncating, yet stays a
+      // compact app-bar action rather than sprawling across the bar.
+      expect(tester.getSize(find.byKey(const Key('timeline-grouping-compact-selector'))).width, lessThanOrEqualTo(120));
       expect(find.byType(SortIconButton), findsOneWidget);
       expect(find.byType(FilterIconButton), findsOneWidget);
     });

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_selector_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_selector_test.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart' as drift;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
@@ -83,7 +83,7 @@ void main() {
         expect(tester.getSemantics(find.byKey(const Key('timeline-grouping-selector'))).label, 'Timeline grouping');
         expect(find.bySemanticsLabel('Years'), findsOneWidget);
         expect(find.bySemanticsLabel('Months'), findsOneWidget);
-        expect(find.bySemanticsLabel('Days'), findsOneWidget);
+        expect(find.bySemanticsLabel('All'), findsOneWidget);
 
         final years = tester.getSemantics(find.byKey(const Key('timeline-grouping-year')));
         final months = tester.getSemantics(find.byKey(const Key('timeline-grouping-month')));
@@ -105,7 +105,7 @@ void main() {
       }
     });
 
-    testWidgets('normalizes unsupported auto and none values to Days visually', (tester) async {
+    testWidgets('normalizes unsupported auto and none values to the All segment visually', (tester) async {
       await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.auto.index);
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
@@ -174,8 +174,8 @@ void main() {
           final label = switch (groupBy) {
             GroupAssetsBy.year => 'Years',
             GroupAssetsBy.month => 'Months',
-            GroupAssetsBy.day => 'Days',
-            GroupAssetsBy.auto || GroupAssetsBy.none => 'Days',
+            GroupAssetsBy.day => 'All',
+            GroupAssetsBy.auto || GroupAssetsBy.none => 'All',
           };
           final node = tester.getSemantics(find.byKey(Key('timeline-grouping-${groupBy.name}')));
           expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isFalse, reason: label);
@@ -293,10 +293,11 @@ void main() {
       expect(find.byKey(const Key('timeline-grouping-year')), findsNothing);
       expect(find.byKey(const Key('timeline-grouping-month')), findsNothing);
       expect(find.byKey(const Key('timeline-grouping-day')), findsNothing);
-      expect(find.text('Day'), findsOneWidget);
+      expect(find.text('All'), findsOneWidget);
+      expect(find.text('Day'), findsNothing);
       expect(find.text('Days'), findsNothing);
       expect(find.byIcon(Icons.expand_more_rounded), findsNothing);
-      expect(tester.getSize(find.byKey(const Key('timeline-grouping-compact-selector'))).width, lessThanOrEqualTo(92));
+      expect(tester.getSize(find.byKey(const Key('timeline-grouping-compact-selector'))).width, lessThanOrEqualTo(120));
     });
 
     testWidgets('compact mode tapping Day zooms out to Month', (tester) async {
@@ -309,7 +310,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.month.index);
-      expect(find.text('Month'), findsOneWidget);
+      expect(find.text('Months'), findsOneWidget);
     });
 
     testWidgets('compact mode bounces between extremes', (tester) async {
@@ -336,6 +337,46 @@ void main() {
       expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.year.index);
     });
 
+    testWidgets('compact mode keeps bouncing back to Years when the chip is recreated between taps', (tester) async {
+      // The timeline destroys and recreates the app-bar subtree whenever its segments reload
+      // (every grouping change flashes the timelineSegmentProvider loading state). The bounce
+      // direction must survive that recreation, otherwise the chip gets stuck oscillating
+      // Months <-> All and never returns to Years.
+      await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.year.index);
+
+      var generation = 0;
+      late StateSetter setOuter;
+      await tester.pumpConsumerWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            setOuter = setState;
+            // A fresh key on every generation forces the selector's State to be disposed and
+            // rebuilt, exactly like the timeline swapping its loading/data slivers.
+            return TimelineGroupingSelector.compact(key: ValueKey(generation));
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final selector = find.byKey(const Key('timeline-grouping-compact-selector'));
+
+      Future<void> tapAndRecreate() async {
+        await tester.tap(selector);
+        await tester.pumpAndSettle();
+        setOuter(() => generation++);
+        await tester.pumpAndSettle();
+      }
+
+      await tapAndRecreate();
+      expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.month.index); // Years -> Months
+      await tapAndRecreate();
+      expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.day.index); // Months -> All
+      await tapAndRecreate();
+      expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.month.index); // All -> Months
+      await tapAndRecreate();
+      expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.year.index); // Months -> Years (the bug)
+    });
+
     testWidgets('compact mode opens a direct selection menu on long press', (tester) async {
       await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.day.index);
 
@@ -348,8 +389,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.month.index);
-      expect(find.text('Month'), findsOneWidget);
-      expect(find.text('Months'), findsNothing);
+      expect(find.text('Months'), findsOneWidget);
+      expect(find.text('Month'), findsNothing);
     });
 
     testWidgets('compact mode resumes bouncing after a long-press menu selection', (tester) async {
@@ -375,24 +416,42 @@ void main() {
       expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.day.index);
     });
 
-    testWidgets('compact mode fits Month without ellipsizing at large mobile text scale', (tester) async {
+    testWidgets('compact mode shows the full "Months" label at normal size and never clips when enlarged', (
+      tester,
+    ) async {
+      // "Months" is the widest grouping label. At the default text scale it must render at full
+      // size inside the compact chip; when the OS enlarges text it may scale down to fit but must
+      // never clip (the old "Mo..." truncation).
       await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.month.index);
 
-      await tester.pumpConsumerWidget(
-        const MediaQuery(
-          data: MediaQueryData(textScaler: TextScaler.linear(1.25)),
-          child: CustomScrollView(
-            slivers: [
-              SliverAppBar(actions: [TimelineGroupingSelector.compact()]),
-            ],
+      Future<void> pumpAt(double scale) async {
+        await tester.pumpConsumerWidget(
+          MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+            child: const CustomScrollView(
+              slivers: [
+                SliverAppBar(actions: [TimelineGroupingSelector.compact()]),
+              ],
+            ),
           ),
-        ),
-      );
-      await tester.pumpAndSettle();
+        );
+        await tester.pumpAndSettle();
+      }
 
-      expect(find.text('Month'), findsOneWidget);
-      expect(find.textContaining('...'), findsNothing);
-      expect(tester.getSize(find.byKey(const Key('timeline-grouping-compact-selector'))).width, lessThanOrEqualTo(112));
+      // Default scale: the glyphs are painted at their full intrinsic width (not shrunk, not clipped).
+      await pumpAt(1.0);
+      expect(find.text('Months'), findsOneWidget);
+      expect(find.text('Month'), findsNothing);
+      final paragraph = tester.renderObject<RenderParagraph>(find.text('Months'));
+      final intrinsic = paragraph.getMaxIntrinsicWidth(double.infinity);
+      expect(tester.getRect(find.text('Months')).width, greaterThanOrEqualTo(intrinsic - 0.5));
+      expect(tester.takeException(), isNull);
+
+      // Enlarged text: the label still renders in full (scaled down to fit), bounded by the chip.
+      await pumpAt(2.0);
+      expect(find.text('Months'), findsOneWidget);
+      final chipWidth = tester.getSize(find.byKey(const Key('timeline-grouping-compact-selector'))).width;
+      expect(tester.getRect(find.text('Months')).width, lessThanOrEqualTo(chipWidth));
       expect(tester.takeException(), isNull);
     });
   });


### PR DESCRIPTION
Follow-up to #670. Two related fixes to the mobile timeline grouping selector.

## 1. Wording matches the web UI
The mobile chip showed `Year / Month / Day`; the web control shows `Years / Months / All`. Unified both the compact app-bar chip and the inline segments on `Years / Months / All` (the `day` grouping reads "All", same as web). The compact chip is widened to fit "Months" at the default text scale and wraps the label in `FittedBox(scaleDown)` so enlarged accessibility text shrinks gracefully instead of truncating to "Mo…" (the reason it was previously shortened to singular).

## 2. Bounce no longer gets stuck at All
The chip ping-pongs `Years ↔ Months ↔ All`. The bounce direction was stored in ephemeral widget `State`, but the timeline destroys and recreates the app-bar subtree on **every** grouping change (`timelineSegmentProvider` is a `StreamProvider.autoDispose` → each change flashes `AsyncLoading`, and `asyncSegments.widgetWhen` swaps between two structurally different `CustomScrollView`s). That recreation reset the direction to its default, trapping the chip oscillating `Months ↔ All`, never returning to `Years`.

Fix: move the direction into a kept-alive `StateProvider<bool>` (same pattern as the sibling `timelineZoomAnchorProvider`), which survives the loading-flash recreation. The compact selector becomes a `ConsumerWidget`, dropping the now-unnecessary lifecycle sync (the extremes are self-correcting; only the ambiguous middle needed to persist).

## Tests
- New regression test reproduces the bounce bug by recreating the chip's `State` between taps while the `ProviderScope` stays mounted — fails on the old code at `Months → Years`, passes now.
- New test asserts "Months" renders full-size at normal scale and never clips when enlarged.
- Existing label/semantics tests updated for `All`.
- `test/presentation/widgets/timeline/` — 99/99 pass. `dart analyze --fatal-infos` and `dart format` clean. i18n prettier (sort-json) clean.