### PR TITLE
fix(mobile): timeline grouping works with active filters (Months/Years no longer empty)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-mobile-filter-grouping-fix-design.md
+++ b/docs/superpowers/specs/2026-06-09-mobile-filter-grouping-fix-design.md
@@ -1,0 +1,258 @@
+# Timeline Grouping × Filters — Empty Month/Year on iOS (Bug 3)
+
+**Date:** 2026-06-09
+**Status:** Design — awaiting review
+**Related:** [2026-05-19-timeline-grouping-design.md](./2026-05-19-timeline-grouping-design.md), [2026-05-22-mobile-timeline-overview-design.md](./2026-05-22-mobile-timeline-overview-design.md), [2026-06-08-timeline-grouping-fixes-design.md](./2026-06-08-timeline-grouping-fixes-design.md) (PR #625, #670, #674); [2026-05-31-mobile-search-infinite-scroll-and-sort-design.md](../../plans/2026-05-31-mobile-search-infinite-scroll-and-sort-design.md) (#654 live search + sort)
+
+## Context
+
+Hagen's third report against timeline grouping. With **any filter active** (person, text/smart search, etc.), the Years/Months/Days grouping breaks on the iOS app:
+
+- **Day view (filter active):** works — filtered photos render grouped by day.
+- **Month view (filter active):** completely empty — no month tiles.
+- **Year:** reported as "missing from the switcher entirely".
+- Reproduces with multiple filter types, so it is a general filter × grouping problem, not person-specific.
+
+**Environment:** server `v4.57.0-rc1`, iOS TestFlight `v4.57.0`.
+
+This is the inverse of what the overview design promised. [2026-05-22-mobile-timeline-overview-design.md](./2026-05-22-mobile-timeline-overview-design.md) explicitly required filters to compose with grouping — _"Keep active filters/search/person/album/space constraints in effect so overview cards only represent matching assets"_ (Goals), _"a filtered Photos timeline only shows years matching the active filters"_ (§Years), and a repository test that _"Year and month overview counts match the assets returned by day mode under the same filters."_ The plumbing to drill down from a filtered overview already exists. The mobile **search/filter data path was just never wired to produce dated buckets**, so the overview renders nothing.
+
+## Root cause
+
+When a filter is active, the timeline switches its data source:
+
+- **Empty filter** → `factory.main(...)`, whose Drift bucket query `GROUP BY`s on a date expression keyed by the current `GroupAssetsBy`, emitting proper **`TimeBucket(date, assetCount)`** rows (`timeline.repository.dart` `_watchMainBucket` + `effectiveCreatedAt(groupBy)` + `truncateDate(groupBy)`).
+- **Active filter** → `buildPhotosTimelineQuery` (`mobile/lib/providers/photos_filter/timeline_query.provider.dart:38-53`) builds the timeline from `factory.fromAssetStream(notifier.getAssets, notifier.count, TimelineOrigin.search)`.
+
+`fromAssetStream` (`mobile/lib/infrastructure/repositories/timeline.repository.dart:585-596`) emits **plain, date-less `Bucket(assetCount)` segments** via `_generateBuckets` (`timeline.repository.dart:1162-1171`) and **takes no `GroupAssetsBy` at all**:
+
+```dart
+TimelineQuery fromAssetStream(List<BaseAsset> Function() getAssets, Stream<int> assetCount, TimelineOrigin origin) => (
+  bucketSource: () async* {
+    yield _generateBuckets(getAssets().length);          // List<Bucket>, no dates
+    yield* assetCount.map(_generateBuckets);
+  },
+  assetSource: (offset, count) => Future.value(getAssets().skip(offset).take(count).toList(growable: false)),
+  origin: origin,
+);
+```
+
+The renderer then breaks on these date-less buckets:
+
+- `timelineSegmentProvider` (`mobile/lib/presentation/widgets/timeline/timeline.state.dart:97-112`) picks the builder by the current `GroupAssetsBy`: month/year → `TimelineOverviewSegmentBuilder`; day → `FixedSegmentBuilder`.
+- `TimelineOverviewSegment` (`mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart:52-53`) bails when the bucket is not a `TimeBucket`:
+
+  ```dart
+  if (bucket is! TimeBucket) {
+    return const SizedBox.shrink();   // ← every month/year tile renders empty
+  }
+  ```
+
+- `FixedSegmentBuilder` (day) guards `bucket is TimeBucket` before reading `.date` (`fixed/segment_builder.dart:40,66`) and `header.widget.dart:46` returns `SizedBox.shrink()` for a non-`TimeBucket` bucket — so a date-less day timeline renders a header-less grid fine, which is why **Day works** and **Month/Year are blank**.
+
+**"Year missing from the switcher" is a side effect, not a separate defect.** The selector unconditionally offers all three levels — `timelineGroupingSelectorGroups = [year, month, day]` (`timeline_grouping_selector.widget.dart:12`); there is no origin/filter restriction. The compact chip cycles by tapping (the ping-pong from PR #674), and with Month/Year rendering empty the user perceives Year as unreachable. Once buckets render, the level becomes reachable and populated; no selector change is required.
+
+### Why the existing pieces make this a small, well-scoped fix
+
+- `fromAssetsWithBuckets` (`timeline.repository.dart:598-615`) **already** proves the client-side pattern: sort a fixed asset list by date desc and group into day `TimeBucket`s. We generalise it to month/year, to honor the sort direction, and to the streaming case.
+- The overview card needs only a **count + one representative asset** per bucket, fetched **by global index** `firstAssetIndex` (cumulative bucket counts) from the service (`overview_segment.model.dart:61-63`, `overview_segment_builder.dart:36`). So the asset source must be laid out in the **same order** as the buckets. Because buckets are derived from the loaded assets, every bucket's `firstAssetIndex` is already in the loaded set — representatives never grey out waiting on a fetch.
+- This mirrors **web**, which already derives search/album/space overview representatives **client-side from already-loaded assets** (`gallery-viewer-grouping.ts`, called out as the untouched "scope boundary (b)" in the 2026-06-08 spec). This change brings the mobile search timeline to parity with that web behaviour.
+
+## Decisions (confirmed)
+
+1. **Build real date buckets for the filtered/search timeline** from the assets loaded so far, grouped by the active `GroupAssetsBy`. (Completes the overview design's intent.)
+2. **Relevance-sorted smart search is exempt from grouping.** When the active sort is _relevance_ (offered only for smart/`context` search — `sort_icon_button.widget.dart:28`), the filtered timeline stays a flat, relevance-ordered list and grouping does not apply. Confirmed acceptable by the product owner; preserves relevance ranking, which date grouping would destroy. **Smart search with a newest/oldest sort still groups** (it is date-ordered) — only relevance is flat.
+3. **Grouped views honor the newest/oldest sort direction.** `_order` maps newest → `AssetOrder.desc` and oldest → `AssetOrder.asc` (`search_api.repository.dart:18-22`). Date buckets and their assets are ordered to match the active sort (oldest → ascending / oldest-first; otherwise newest-first), so a chosen "oldest" sort is never silently flipped to newest-first.
+
+## Design
+
+Three coordinated changes, all **mobile-only**. No server/SDK/web changes.
+
+### 1. `fromAssetStream` builds grouped, direction-aware `TimeBucket`s (data layer)
+
+**`mobile/lib/infrastructure/repositories/timeline.repository.dart`** — give `fromAssetStream` a `groupBy` and a `descending` flag, and build dated buckets (reusing the `fromAssetsWithBuckets` pattern generalised to month/year and to either order). `GroupAssetsBy.none` preserves today's date-less segments (the flat/relevance path).
+
+```dart
+TimelineQuery fromAssetStream(
+  List<BaseAsset> Function() getAssets,
+  Stream<int> assetCount,
+  TimelineOrigin origin, {
+  GroupAssetsBy groupBy = GroupAssetsBy.none,
+  bool descending = true,
+}) => (
+  bucketSource: () async* {
+    yield _streamBuckets(getAssets(), groupBy, descending);
+    // assetCount fires whenever a page loads; re-bucket from the grown getAssets() (the emitted value is just a change signal).
+    yield* assetCount.map((_) => _streamBuckets(getAssets(), groupBy, descending));
+  },
+  assetSource: (offset, count) =>
+      Future.value(_orderedForGrouping(getAssets(), groupBy, descending).skip(offset).take(count).toList(growable: false)),
+  origin: origin,
+);
+
+// Date-less segments (flat) for `none`; dated TimeBuckets in `descending` order otherwise.
+List<Bucket> _streamBuckets(List<BaseAsset> assets, GroupAssetsBy groupBy, bool descending) {
+  if (groupBy == GroupAssetsBy.none) return _generateBuckets(assets.length);
+  final counts = <DateTime, int>{}; // LinkedHashMap: insertion order follows the pre-ordered asset list
+  for (final asset in _orderedForGrouping(assets, groupBy, descending)) {
+    final key = _localBucketDate(asset.createdAt, groupBy);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return [for (final e in counts.entries) TimeBucket(date: e.key, assetCount: e.value)];
+}
+
+List<BaseAsset> _orderedForGrouping(List<BaseAsset> assets, GroupAssetsBy groupBy, bool descending) {
+  if (groupBy == GroupAssetsBy.none) return assets; // keep the search order (relevance, as returned)
+  final sorted = [...assets]..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+  return descending ? sorted.reversed.toList(growable: false) : sorted;
+}
+
+// Mirrors `fromAssetsWithBuckets`' `.toLocal()` truncation. `BaseAsset.createdAt` is the capture time
+// (mapped from `fileCreatedAt`, `asset_extensions.dart:13`); `BaseAsset` carries no `localDateTime`.
+DateTime _localBucketDate(DateTime createdAt, GroupAssetsBy groupBy) {
+  final t = createdAt.toLocal();
+  return switch (groupBy) {
+    GroupAssetsBy.day || GroupAssetsBy.auto => DateTime(t.year, t.month, t.day),
+    GroupAssetsBy.month => DateTime(t.year, t.month),
+    GroupAssetsBy.year => DateTime(t.year),
+    GroupAssetsBy.none => DateTime(t.year, t.month, t.day),
+  };
+}
+```
+
+Both `bucketSource` and `assetSource` call `_orderedForGrouping` with the same args, so the representative-by-`firstAssetIndex` lookup always lands inside its bucket. (`_orderedForGrouping` re-sorts per `assetSource` call; negligible at filtered-result sizes — revisit only if a profile says otherwise.)
+
+**`mobile/lib/domain/services/timeline.service.dart:146-147`** — thread both params through the factory:
+
+```dart
+TimelineService fromAssetStream(
+  List<BaseAsset> Function() getAssets,
+  Stream<int> assetCount,
+  TimelineOrigin type, {
+  GroupAssetsBy groupBy = GroupAssetsBy.none,
+  bool descending = true,
+}) => TimelineService(_timelineRepository.fromAssetStream(getAssets, assetCount, type, groupBy: groupBy, descending: descending));
+```
+
+### 2. Query provider decides grouping + direction for the search timeline
+
+**`mobile/lib/providers/photos_filter/timeline_query.provider.dart`** — pass the active grouping and sort direction, except for relevance-sorted smart search which stays flat:
+
+```dart
+final notifier = ref.watch(photosFilterSearchProvider.notifier);
+final isSmart = filter.context != null && filter.context!.isNotEmpty;        // matches sort_icon_button.widget.dart:28
+final isRelevance = isSmart && filter.sort == SearchSortOrder.relevance;
+final groupBy = isRelevance ? GroupAssetsBy.none : factory.groupBy;          // factory.groupBy reads Setting.groupAssetsBy (auto→day)
+final descending = filter.sort != SearchSortOrder.oldest;                    // oldest → ascending, else newest-first
+final svc = factory.fromAssetStream(
+  notifier.getAssets, notifier.count, TimelineOrigin.search, groupBy: groupBy, descending: descending,
+);
+```
+
+Reactivity is already correct: `timeline_route_scope.dart` overrides `timelineServiceProvider` and **watches `Setting.groupAssetsBy`**, so switching Years/Months/Days rebuilds the service through `buildPhotosTimelineRouteService` → `buildPhotosTimelineQuery`, which re-reads `factory.groupBy`. (`buildPhotosTimelineQuery` already `ref.watch`es the effective filter, so a sort change rebuilds too.)
+
+### 3. Segment provider follows the bucket type
+
+**`mobile/lib/presentation/widgets/timeline/timeline.state.dart:97-112`** — render the flat grid whenever the service emitted date-less buckets, regardless of the setting, so a relevance/flat search never hits the empty-overview path:
+
+```dart
+yield* timelineService.watchBuckets().map((buckets) {
+  final hasDatedBuckets = buckets.isEmpty || buckets.first is TimeBucket;
+  final effectiveGroupBy = hasDatedBuckets ? groupBy : GroupAssetsBy.day; // date-less ⇒ flat grid
+  if (effectiveGroupBy == GroupAssetsBy.year || effectiveGroupBy == GroupAssetsBy.month) {
+    return TimelineOverviewSegmentBuilder(buckets: buckets, groupBy: effectiveGroupBy).generate();
+  }
+  return FixedSegmentBuilder(
+    buckets: buckets,
+    tileHeight: tileExtent,
+    columnCount: columnCount,
+    spacing: spacing,
+    groupBy: effectiveGroupBy,
+  ).generate();
+});
+```
+
+This is a no-op for every dated source (main/person/place/album/space/video/map and the new grouped search path). It changes only the **date-less** sources — `fromAssetStream` with `none` (relevance) and the three `fromAssets` callers (folder explorer `folder.page.dart:180`, activity `activity.service.dart:62`, deep-link `deep_link.service.dart:155`): for these, a Month/Year setting now renders the flat grid **instead of an empty overview** — strictly an improvement (those surfaces already showed nothing under Month/Year grouping today).
+
+## Behaviour after the fix
+
+| Filter + sort                                                              | Day / "All"                                           | Months / Years                                                                                |
+| -------------------------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Person / place / tag / favourite / rating / type / date (default → newest) | day-grouped grid, newest-first (now with day headers) | **month/year cover tiles render**, newest-first; tap drills down via the existing zoom anchor |
+| Any filter, **oldest** sort                                                | day-grouped grid, oldest-first                        | month/year cover tiles, oldest-first                                                          |
+| Smart/text search, **newest/oldest** sort                                  | day-grouped grid (date-ordered)                       | month/year cover tiles                                                                        |
+| Smart/text search, **relevance** sort                                      | flat, relevance-ordered grid (unchanged)              | flat grid (no empty overview — segment provider falls back)                                   |
+
+Hagen's main repro (person filter, default newest sort) is fully fixed: Month and Year populate, and Year is reachable.
+
+## Known limitations (documented, by design)
+
+- **Loaded-so-far coverage.** Overview covers reflect the results loaded so far, filling in as the user scrolls (the search notifier pages on scroll — `photos_filter_search.provider.dart`). In overview modes the compact tiles reach the bottom quickly, so `loadMore` (the page's `ScrollUpdateNotification` + `_SearchLoadMoreFooter`) eagerly pages through a filtered set until the viewport fills or results exhaust — coverage converges fast for realistic filtered sets. Matches the web `gallery-viewer-grouping` approach and the `time_buckets.provider` "When" accordion's existing not-the-whole-corpus note. A server-side filtered time-bucket endpoint for complete, upfront coverage of very large filtered sets is **out of scope**.
+- **Capture-date bucketing uses `fileCreatedAt.toLocal()`.** `BaseAsset` carries no `localDateTime`, so client-side grouping buckets by the capture instant converted to the device timezone — identical to the existing `fromAssetsWithBuckets`. For a photo captured in a timezone different from the device, this can place it in a different day/month than the **unfiltered** main timeline (which buckets by the asset's stored `localDateTime`). Pre-existing mobile date semantics; not introduced here.
+
+## Testing (TDD)
+
+**RED first, at the data layer where the bug lives**, then wire the upper layers. Watch each test fail before implementing.
+
+### Slice 1 — repository grouped buckets (`mobile/test/infrastructure/repositories/timeline_repository_test.dart`)
+
+`fromAssetStream` needs no DB; construct `DriftTimelineRepository(db)` (in-memory, as the file already does) and drive it with in-memory `RemoteAsset`s at chosen `createdAt`s.
+
+- **RED (compile):** write the bug test — `fromAssetStream(..., groupBy: GroupAssetsBy.month)` over assets in 2024-03 (×2), 2024-01 (×1), 2023-12 (×1), asserting `bucketSource().first` yields **`TimeBucket`s** `[(2024-03, 2), (2024-01, 1), (2023-12, 1)]`. Run it: it **fails to compile** — `fromAssetStream` has no `groupBy`/`descending` parameter (feature missing). This is the first RED.
+- **RED (assertion):** add the `groupBy`/`descending` parameters to the factory + repository signatures, defaulting to `GroupAssetsBy.none` / `true`, but **still returning `_generateBuckets` segments**. Re-run: now it compiles and **fails the assertion** (buckets are date-less `Bucket`s, not `TimeBucket`s). This proves the test catches the bug.
+- **GREEN:** implement `_streamBuckets` / `_orderedForGrouping` / `_localBucketDate`. Re-run → pass.
+- Then add (RED→GREEN each):
+  - `groupBy: year` → year `TimeBucket`s `[(2024, 3), (2023, 1)]`, newest-first.
+  - `groupBy: day` → day `TimeBucket`s, newest-first.
+  - **Direction:** `groupBy: month, descending: false` (oldest) → buckets ascending `[(2023-12, 1), (2024-01, 1), (2024-03, 2)]`, and `assetSource(0, n)` returns assets oldest-first.
+  - **Consistency:** for `month` descending, `assetSource(0, n)` is date-desc and bucket `firstAssetIndex` lands on that bucket's first asset.
+  - **Regression guard:** `groupBy: none` (default) → date-less `Bucket` segments unchanged, and `assetSource` preserves input order.
+  - **Empty:** `groupBy: month` over `[]` → `bucketSource().first` is empty; no throw.
+  - **Single bucket:** all assets in one month → one `TimeBucket`.
+  - **Year boundary:** 2023-12-31 and 2024-01-01 → for `month`, two buckets `2023-12` / `2024-01`; for `year`, `2023` / `2024`.
+  - **Re-emission:** push a new count on a `StreamController<int>` after appending an asset → second emission re-buckets from the grown `getAssets()`.
+
+### Slice 2 — query provider grouping/direction decision (`mobile/test/providers/photos_filter/timeline_query_provider_test.dart`)
+
+Existing tests mock `factory.fromAssetStream(any(), any(), TimelineOrigin.search)` — update the matchers for the new named `groupBy`/`descending`. **Adjust those mocks first (RED — the real call now passes named args the stub doesn't match), then add:**
+
+- Non-empty **non-smart** filter (e.g. person), grouping setting = month → called with `groupBy: GroupAssetsBy.month, descending: true`.
+- Same filter with `sort == oldest` → `descending: false`.
+- Smart filter (`context` set) + `sort == relevance` → `groupBy: GroupAssetsBy.none`.
+- Smart filter + `sort == newest` → grouping setting (not `none`).
+
+### Slice 3 — segment provider bucket-type fallback (`mobile/test/presentation/widgets/timeline/timeline_state_test.dart` or sibling)
+
+- Service emits **date-less `Bucket`s** + setting = month → `timelineSegmentProvider` yields `FixedSegment`s (flat grid), **not** empty `TimelineOverviewSegment`s. (RED today: it would build an empty overview.)
+- Service emits **`TimeBucket`s** + setting = month → yields `TimelineOverviewSegment`s (unchanged).
+- Empty bucket list + setting = month → no segments / no throw.
+
+### Slice 4 — integration acceptance (widget/provider)
+
+Where the existing overview/filter widget tests live: with an active person filter and grouping = Months, the timeline renders month overview cards, and **the sum of the month buckets' counts equals the loaded asset count** (no assets dropped vs the flat/day view under the same filter — the "counts match day mode under the same filters" guard from the 2026-05-22 design, applied to the client path). Add a **drill-down** test: tapping a month card switches grouping to Days and resolves the zoom anchor to that month on the client-bucketed search timeline. Add a **reactivity** test: changing `Setting.groupAssetsBy` while a filter is active rebuilds the service and re-emits buckets at the new grouping.
+
+### Manual verification
+
+On the iOS build / a personal-clone RC: person filter → Months shows tiles → tap a month drills to its days → Year shows tiles. Set sort to oldest → confirm grouped views are oldest-first. Confirm a relevance-sorted smart text search still shows the flat relevance-ordered list and does not blank out when Month/Year is selected.
+
+## Scope
+
+Mobile only. Files touched:
+
+- `mobile/lib/infrastructure/repositories/timeline.repository.dart` — `fromAssetStream` + `_streamBuckets`/`_orderedForGrouping`/`_localBucketDate`.
+- `mobile/lib/domain/services/timeline.service.dart` — `TimelineFactory.fromAssetStream` signature.
+- `mobile/lib/providers/photos_filter/timeline_query.provider.dart` — grouping/direction decision (the **only** production caller of `factory.fromAssetStream`, line 50).
+- `mobile/lib/presentation/widgets/timeline/timeline.state.dart` — `timelineSegmentProvider` bucket-type fallback.
+- Tests: `timeline_repository_test.dart`, `timeline_query_provider_test.dart` (mock-matcher update for the new named args), and a `timelineSegmentProvider` test.
+
+**No** server, SDK, OpenAPI, or web changes. No `GroupAssetsBy` enum/index changes. No grouping-selector UI change (the level set is already correct).
+
+## Out of scope
+
+- **Server-side filtered time buckets.** A search/filter-aware bucket endpoint giving complete, upfront month/year coverage for very large filtered sets (and per-bucket drill-down loading) is a larger server+mobile effort; client-side-from-loaded-assets matches web and resolves the reported bug.
+- **Grouping for relevance-sorted smart search** (intentionally flat, per Decision 2).
+- Mobile `mergedBucket` count-query optimisation and the chip "Day"→"All" label alignment (already out of scope in the 2026-06-08 spec).
+
+## Rollout / validation
+
+No flag — pure bug fix. Validate on the personal instance / a Hagen-scale personal-clone via the RC tooling (the build that surfaced this was `v4.57.0-rc1`); confirm Month/Year populate under a person filter and a metadata text filter, oldest sort renders oldest-first, and relevance smart search stays flat.

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -143,8 +143,15 @@ class TimelineFactory {
   TimelineService fromAssets(List<BaseAsset> assets, TimelineOrigin type) =>
       TimelineService(_timelineRepository.fromAssets(assets, type));
 
-  TimelineService fromAssetStream(List<BaseAsset> Function() getAssets, Stream<int> assetCount, TimelineOrigin type) =>
-      TimelineService(_timelineRepository.fromAssetStream(getAssets, assetCount, type));
+  TimelineService fromAssetStream(
+    List<BaseAsset> Function() getAssets,
+    Stream<int> assetCount,
+    TimelineOrigin type, {
+    GroupAssetsBy groupBy = GroupAssetsBy.none,
+    bool descending = true,
+  }) => TimelineService(
+    _timelineRepository.fromAssetStream(getAssets, assetCount, type, groupBy: groupBy, descending: descending),
+  );
 
   TimelineService fromAssetsWithBuckets(List<BaseAsset> assets, TimelineOrigin type) =>
       TimelineService(_timelineRepository.fromAssetsWithBuckets(assets, type));

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -1187,7 +1187,13 @@ List<Bucket> _buildBuckets(List<BaseAsset> assets, GroupAssetsBy groupBy, bool d
 
 List<BaseAsset> _orderedForGrouping(List<BaseAsset> assets, GroupAssetsBy groupBy, bool descending) {
   if (groupBy == GroupAssetsBy.none) return assets;
-  final sorted = [...assets]..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+  // Tie-break on heroTag so assets sharing an identical createdAt keep a stable order,
+  // keeping the overview representative (first asset per bucket) deterministic across rebuilds.
+  final sorted = [...assets]
+    ..sort((a, b) {
+      final byDate = a.createdAt.compareTo(b.createdAt);
+      return byDate != 0 ? byDate : a.heroTag.compareTo(b.heroTag);
+    });
   return descending ? sorted.reversed.toList(growable: false) : sorted.toList(growable: false);
 }
 

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -582,18 +582,22 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
     origin: origin,
   );
 
-  TimelineQuery fromAssetStream(List<BaseAsset> Function() getAssets, Stream<int> assetCount, TimelineOrigin origin) =>
-      (
-        bucketSource: () async* {
-          yield _generateBuckets(getAssets().length);
-          yield* assetCount.map(_generateBuckets);
-        },
-        assetSource: (offset, count) {
-          final assets = getAssets();
-          return Future.value(assets.skip(offset).take(count).toList(growable: false));
-        },
-        origin: origin,
-      );
+  TimelineQuery fromAssetStream(
+    List<BaseAsset> Function() getAssets,
+    Stream<int> assetCount,
+    TimelineOrigin origin, {
+    GroupAssetsBy groupBy = GroupAssetsBy.none,
+    bool descending = true,
+  }) => (
+    bucketSource: () async* {
+      yield _buildBuckets(getAssets(), groupBy, descending);
+      yield* assetCount.map((_) => _buildBuckets(getAssets(), groupBy, descending));
+    },
+    assetSource: (offset, count) => Future.value(
+      _orderedForGrouping(getAssets(), groupBy, descending).skip(offset).take(count).toList(growable: false),
+    ),
+    origin: origin,
+  );
 
   TimelineQuery fromAssetsWithBuckets(List<BaseAsset> assets, TimelineOrigin origin) {
     // Sort assets by date descending and group by day
@@ -1168,6 +1172,34 @@ List<Bucket> _generateBuckets(int count) {
     buckets[buckets.length - 1] = Bucket(assetCount: count % kTimelineNoneSegmentSize);
   }
   return buckets;
+}
+
+// Date-less segments (flat) for `none`; dated TimeBuckets in `descending` order otherwise.
+List<Bucket> _buildBuckets(List<BaseAsset> assets, GroupAssetsBy groupBy, bool descending) {
+  if (groupBy == GroupAssetsBy.none) return _generateBuckets(assets.length);
+  final counts = <DateTime, int>{}; // LinkedHashMap: insertion order follows the pre-ordered list
+  for (final asset in _orderedForGrouping(assets, groupBy, descending)) {
+    final key = _localBucketDate(asset.createdAt, groupBy);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return [for (final e in counts.entries) TimeBucket(date: e.key, assetCount: e.value)];
+}
+
+List<BaseAsset> _orderedForGrouping(List<BaseAsset> assets, GroupAssetsBy groupBy, bool descending) {
+  if (groupBy == GroupAssetsBy.none) return assets;
+  final sorted = [...assets]..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+  return descending ? sorted.reversed.toList(growable: false) : sorted.toList(growable: false);
+}
+
+DateTime _localBucketDate(DateTime createdAt, GroupAssetsBy groupBy) {
+  final t = createdAt.toLocal();
+  return switch (groupBy) {
+    GroupAssetsBy.day || GroupAssetsBy.auto => DateTime(t.year, t.month, t.day),
+    GroupAssetsBy.month => DateTime(t.year, t.month),
+    GroupAssetsBy.year => DateTime(t.year),
+    // Unreachable: _buildBuckets guards `none` before calling here. Present only to keep the switch exhaustive.
+    GroupAssetsBy.none => DateTime(t.year, t.month, t.day),
+  };
 }
 
 final _scopeDateFormat = DateFormat('yyyy-MM-dd', 'en');

--- a/mobile/lib/presentation/widgets/timeline/timeline.state.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.state.dart
@@ -98,8 +98,12 @@ final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>((ref) 
 
   final timelineService = ref.watch(timelineServiceProvider);
   yield* timelineService.watchBuckets().map((buckets) {
-    if (groupBy == GroupAssetsBy.year || groupBy == GroupAssetsBy.month) {
-      return TimelineOverviewSegmentBuilder(buckets: buckets, groupBy: groupBy).generate();
+    // A date-less bucket source (e.g. relevance-sorted search, or a `fromAssets` timeline) cannot
+    // render the year/month overview — fall back to the flat grid regardless of the grouping setting.
+    final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
+    final effectiveGroupBy = isDateless ? GroupAssetsBy.day : groupBy;
+    if (effectiveGroupBy == GroupAssetsBy.year || effectiveGroupBy == GroupAssetsBy.month) {
+      return TimelineOverviewSegmentBuilder(buckets: buckets, groupBy: effectiveGroupBy).generate();
     }
 
     return FixedSegmentBuilder(
@@ -107,7 +111,7 @@ final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>((ref) 
       tileHeight: tileExtent,
       columnCount: columnCount,
       spacing: spacing,
-      groupBy: groupBy,
+      groupBy: effectiveGroupBy,
     ).generate();
   });
 }, dependencies: [timelineServiceProvider, timelineArgsProvider]);

--- a/mobile/lib/providers/photos_filter/timeline_query.provider.dart
+++ b/mobile/lib/providers/photos_filter/timeline_query.provider.dart
@@ -1,11 +1,13 @@
 // photosTimelineQueryProvider — overrides `timelineServiceProvider` inside
 // `MainTimelinePage`. Empty filter / pre-login → main library service.
 // Non-empty + logged-in → search-backed service driven by the paginating
-// `photosFilterSearchProvider` notifier. The effective provider composes
-// temporal scope through the 500 ms debounced Photos filter before consumers
-// watch the result here.
+// `photosFilterSearchProvider` notifier, with `groupBy`/`descending` derived from the
+// active filter's sort + smart-search state (relevance smart search stays flat). The
+// effective provider composes temporal scope through the 800 ms debounced Photos filter
+// before consumers watch the result here.
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/models/search/search_filter.model.dart';
@@ -47,7 +49,17 @@ TimelineService buildPhotosTimelineQuery(Ref ref, SearchFilter filter) {
   }
 
   final notifier = ref.watch(photosFilterSearchProvider.notifier);
-  final svc = factory.fromAssetStream(notifier.getAssets, notifier.count, TimelineOrigin.search);
+  final isSmart = filter.context != null && filter.context!.isNotEmpty;
+  final isRelevance = isSmart && filter.sort == SearchSortOrder.relevance;
+  final groupBy = isRelevance ? GroupAssetsBy.none : factory.groupBy;
+  final descending = filter.sort != SearchSortOrder.oldest;
+  final svc = factory.fromAssetStream(
+    notifier.getAssets,
+    notifier.count,
+    TimelineOrigin.search,
+    groupBy: groupBy,
+    descending: descending,
+  );
   ref.onDispose(svc.dispose);
   return svc;
 }

--- a/mobile/test/infrastructure/repositories/timeline_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/timeline_repository_test.dart
@@ -10,11 +10,14 @@
 // but we want a test that proves it, so a future refactor can't silently
 // break reactivity.
 
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:immich_mobile/infrastructure/entities/exif.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/entities/remote_asset.entity.drift.dart';
@@ -830,5 +833,247 @@ void main() {
     expect(emissions.last, isEmpty);
 
     await sub.cancel();
+  });
+
+  // ---------------------------------------------------------------------------
+  // fromAssetStream grouped buckets (Slice 1 — data layer)
+  // ---------------------------------------------------------------------------
+
+  /// Builds a [RemoteAsset] with a specific [createdAt]; all other fields are
+  /// fixed to valid defaults so the constructor is satisfied.
+  RemoteAsset makeTestAsset(String id, DateTime createdAt) => RemoteAsset(
+    id: id,
+    checksum: 'cs-$id',
+    ownerId: 'owner',
+    name: '$id.jpg',
+    type: AssetType.image,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+    durationInSeconds: 0,
+    isFavorite: false,
+    isEdited: false,
+  );
+
+  group('DriftTimelineRepository.fromAssetStream() grouped buckets', () {
+    // Four test assets spanning three months / two years (all in local time).
+    late List<BaseAsset> assets;
+
+    setUp(() {
+      assets = [
+        makeTestAsset('a1', DateTime(2024, 3, 20)),
+        makeTestAsset('a2', DateTime(2024, 3, 5)),
+        makeTestAsset('a3', DateTime(2024, 1, 15)),
+        makeTestAsset('a4', DateTime(2023, 12, 31)),
+      ];
+    });
+
+    test('groupBy month → TimeBuckets newest-first', () async {
+      final query = sut.fromAssetStream(
+        () => assets,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+      );
+      final buckets = await query.bucketSource().first;
+      expect(buckets, [
+        TimeBucket(date: DateTime(2024, 3), assetCount: 2),
+        TimeBucket(date: DateTime(2024, 1), assetCount: 1),
+        TimeBucket(date: DateTime(2023, 12), assetCount: 1),
+      ]);
+    });
+
+    test('groupBy year → TimeBuckets newest-first', () async {
+      final query = sut.fromAssetStream(
+        () => assets,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.year,
+      );
+      final buckets = await query.bucketSource().first;
+      expect(buckets, [
+        TimeBucket(date: DateTime(2024), assetCount: 3),
+        TimeBucket(date: DateTime(2023), assetCount: 1),
+      ]);
+    });
+
+    test('groupBy day → day TimeBuckets newest-first', () async {
+      final query = sut.fromAssetStream(
+        () => assets,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.day,
+      );
+      final buckets = await query.bucketSource().first;
+      expect(buckets, [
+        TimeBucket(date: DateTime(2024, 3, 20), assetCount: 1),
+        TimeBucket(date: DateTime(2024, 3, 5), assetCount: 1),
+        TimeBucket(date: DateTime(2024, 1, 15), assetCount: 1),
+        TimeBucket(date: DateTime(2023, 12, 31), assetCount: 1),
+      ]);
+    });
+
+    test('groupBy month, descending false → buckets ascending and assets oldest-first', () async {
+      final query = sut.fromAssetStream(
+        () => assets,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+        descending: false,
+      );
+      final buckets = await query.bucketSource().first;
+      expect(buckets, [
+        TimeBucket(date: DateTime(2023, 12), assetCount: 1),
+        TimeBucket(date: DateTime(2024, 1), assetCount: 1),
+        TimeBucket(date: DateTime(2024, 3), assetCount: 2),
+      ]);
+      final fetchedAssets = await query.assetSource(0, assets.length);
+      // Oldest-first: 2023-12-31, 2024-01-15, 2024-03-05, 2024-03-20
+      expect(fetchedAssets.map((a) => a.createdAt), [
+        DateTime(2023, 12, 31),
+        DateTime(2024, 1, 15),
+        DateTime(2024, 3, 5),
+        DateTime(2024, 3, 20),
+      ]);
+    });
+
+    test('groupBy month, descending → assetSource is date-desc and bucket firstAssetIndex is consistent', () async {
+      final query = sut.fromAssetStream(
+        () => assets,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+      );
+      final buckets = await query.bucketSource().first;
+      final fetchedAssets = await query.assetSource(0, assets.length);
+      // Assets should be date-desc: 2024-03-20, 2024-03-05, 2024-01-15, 2023-12-31
+      expect(fetchedAssets.map((a) => a.createdAt), [
+        DateTime(2024, 3, 20),
+        DateTime(2024, 3, 5),
+        DateTime(2024, 1, 15),
+        DateTime(2023, 12, 31),
+      ]);
+      // Verify each bucket's firstAssetIndex (cumulative) lands in the right bucket.
+      int offset = 0;
+      for (final bucket in buckets) {
+        final tb = bucket as TimeBucket;
+        final rep = fetchedAssets[offset];
+        final repDate = rep.createdAt.toLocal();
+        expect(repDate.year, tb.date.year, reason: 'Year mismatch at offset $offset');
+        expect(repDate.month, tb.date.month, reason: 'Month mismatch at offset $offset');
+        offset += bucket.assetCount;
+      }
+    });
+
+    test(
+      'groupBy none (default) → date-less Bucket segments unchanged and assetSource preserves input order',
+      () async {
+        final query = sut.fromAssetStream(() => assets, const Stream<int>.empty(), TimelineOrigin.search);
+        final buckets = await query.bucketSource().first;
+        // none uses _generateBuckets: date-less Bucket(assetCount: ≤200 per segment)
+        for (final bucket in buckets) {
+          expect(bucket, isA<Bucket>());
+          expect(bucket, isNot(isA<TimeBucket>()));
+        }
+        expect(buckets.fold<int>(0, (sum, b) => sum + b.assetCount), assets.length);
+        // assetSource preserves the original input order (no sorting for none)
+        final fetched = await query.assetSource(0, assets.length);
+        expect(fetched.map((a) => a.name), assets.map((a) => a.name));
+      },
+    );
+
+    test('empty asset list → bucketSource emits empty list; no throw', () async {
+      final query = sut.fromAssetStream(
+        () => [],
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+      );
+      final buckets = await query.bucketSource().first;
+      expect(buckets, isEmpty);
+    });
+
+    test('single bucket: all assets in one month → one TimeBucket', () async {
+      final singleMonth = [
+        makeTestAsset('s1', DateTime(2024, 5, 1)),
+        makeTestAsset('s2', DateTime(2024, 5, 15)),
+        makeTestAsset('s3', DateTime(2024, 5, 31)),
+      ];
+      final query = sut.fromAssetStream(
+        () => singleMonth,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+      );
+      final buckets = await query.bucketSource().first;
+      expect(buckets, [TimeBucket(date: DateTime(2024, 5), assetCount: 3)]);
+    });
+
+    test('year boundary: 2023-12-31 and 2024-01-01 → correct month and year buckets', () async {
+      final boundary = [makeTestAsset('b1', DateTime(2023, 12, 31)), makeTestAsset('b2', DateTime(2024, 1, 1))];
+      // month grouping: two separate months (newest-first)
+      final monthQuery = sut.fromAssetStream(
+        () => boundary,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+      );
+      final monthBuckets = await monthQuery.bucketSource().first;
+      expect(monthBuckets, [
+        TimeBucket(date: DateTime(2024, 1), assetCount: 1),
+        TimeBucket(date: DateTime(2023, 12), assetCount: 1),
+      ]);
+      // year grouping: two separate years (newest-first)
+      final yearQuery = sut.fromAssetStream(
+        () => boundary,
+        const Stream<int>.empty(),
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.year,
+      );
+      final yearBuckets = await yearQuery.bucketSource().first;
+      expect(yearBuckets, [
+        TimeBucket(date: DateTime(2024), assetCount: 1),
+        TimeBucket(date: DateTime(2023), assetCount: 1),
+      ]);
+    });
+
+    test('re-emission: appending an asset triggers re-bucketing', () async {
+      final mutableAssets = <BaseAsset>[
+        makeTestAsset('r1', DateTime(2024, 3, 20)),
+        makeTestAsset('r2', DateTime(2024, 3, 5)),
+        makeTestAsset('r3', DateTime(2024, 1, 15)),
+        makeTestAsset('r4', DateTime(2023, 12, 31)),
+      ];
+      final controller = StreamController<int>();
+      final query = sut.fromAssetStream(
+        () => mutableAssets,
+        controller.stream,
+        TimelineOrigin.search,
+        groupBy: GroupAssetsBy.month,
+      );
+
+      final emissions = <List<Bucket>>[];
+      final sub = query.bucketSource().listen(emissions.add);
+
+      // First emission: 3 buckets
+      await Future<void>.delayed(Duration.zero);
+      expect(emissions, hasLength(1));
+      expect(emissions.first, hasLength(3));
+
+      // Add a new asset in a new month and signal via the stream
+      mutableAssets.add(makeTestAsset('r5', DateTime(2024, 6, 1)));
+      controller.add(mutableAssets.length);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(emissions, hasLength(2));
+      expect(emissions.last, hasLength(4)); // new 2024-06 bucket added
+      expect(
+        emissions.last.first,
+        TimeBucket(date: DateTime(2024, 6), assetCount: 1),
+        reason: 'Newest bucket should be 2024-06',
+      );
+
+      await sub.cancel();
+      await controller.close();
+    });
   });
 }

--- a/mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart
+++ b/mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart
@@ -1,0 +1,311 @@
+// Integration / acceptance tests for the filter × grouping fix.
+//
+// These wire the REAL provider chain:
+//   SearchService (mocked) → photosFilterSearchProvider (real) →
+//   TimelineFactory (real) → DriftTimelineRepository (real, in-memory Drift) →
+//   fromAssetStream (real, with GroupAssetsBy) → TimelineService →
+//   timelineSegmentProvider (real)
+//
+// Before the fix, `fromAssetStream` emitted date-less `Bucket`s regardless of
+// the grouping setting, causing `TimelineOverviewSegment` to render an empty
+// `SizedBox.shrink()` for every month/year tile.  These tests catch that
+// regression (they would have produced FixedSegments or an empty segment list
+// before the fix, not `TimelineOverviewSegment`s with correct counts).
+
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/search_result.model.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/search.service.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment.model.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
+import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
+import 'package:immich_mobile/providers/photos_filter/filter_count.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter_search.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/timeline_query.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockSearch extends Mock implements SearchService {}
+
+class _MockUserService extends Mock implements UserService {}
+
+class _FakeFilter extends Fake implements SearchFilter {}
+
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service, UserDto? initial) {
+    state = initial;
+  }
+}
+
+final _testUser = UserDto(id: 'user-1', email: 'test@example.com', name: 'Test User', profileChangedAt: DateTime(2024));
+
+/// Build a `RemoteAsset` with a specific `createdAt`.
+RemoteAsset _asset(String id, DateTime createdAt) => RemoteAsset(
+  id: id,
+  checksum: 'cs-$id',
+  ownerId: 'user-1',
+  name: '$id.jpg',
+  type: AssetType.image,
+  createdAt: createdAt,
+  updatedAt: createdAt,
+  durationInSeconds: 0,
+  isFavorite: false,
+  isEdited: false,
+);
+
+/// Assets spanning 2024-03 (×2) and 2024-01 (×1), newest-first.
+///
+/// Local `DateTime`s so `createdAt.toLocal()` is identity and the day/month/year
+/// bucket assertions are stable on any test-machine timezone (mirrors the repo unit tests).
+List<BaseAsset> _assets() => [
+  _asset('a1', DateTime(2024, 3, 15, 12)),
+  _asset('a2', DateTime(2024, 3, 15, 10)),
+  _asset('a3', DateTime(2024, 1, 10, 8)),
+];
+
+ProviderContainer _makeContainer({required SearchService search, required Drift db}) {
+  final mockUserSvc = _MockUserService();
+  when(() => mockUserSvc.tryGetMyUser()).thenReturn(_testUser);
+  when(() => mockUserSvc.watchMyUser()).thenAnswer((_) => const Stream.empty());
+
+  return ProviderContainer(
+    overrides: [
+      driftProvider.overrideWithValue(db),
+      searchServiceProvider.overrideWithValue(search),
+      infra.userServiceProvider.overrideWithValue(mockUserSvc),
+      currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(mockUserSvc, _testUser)),
+      timelineUsersProvider.overrideWith((_) => Stream.value([_testUser.id])),
+      photosFilterCountProvider.overrideWith((ref) => 0),
+      // Override timelineArgsProvider so timelineSegmentProvider (autoDispose)
+      // can be read without a widget tree.
+      timelineArgsProvider.overrideWith((_) => const TimelineArgs(maxWidth: 375, maxHeight: 812, columnCount: 3)),
+    ],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Drift db;
+
+  setUpAll(() async {
+    registerFallbackValue(_FakeFilter());
+    db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await StoreService.init(storeRepository: DriftStoreRepository(db), listenUpdates: false);
+    await Store.put(StoreKey.serverEndpoint, 'http://localhost:0');
+  });
+
+  setUp(() async {
+    await Store.clear();
+    await Store.put(StoreKey.serverEndpoint, 'http://localhost:0');
+  });
+
+  tearDownAll(() async {
+    await Store.clear();
+    await db.close();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1 — Filtered + Months → month overview segments, counts sum correctly.
+  //
+  // Real guard: before the fix `fromAssetStream` emitted date-less Bucket(n)
+  // segments; `timelineSegmentProvider` would have fallen back to FixedSegments
+  // (the isDateless guard) — or, in an older build, would have emitted empty
+  // TimelineOverviewSegments. After the fix it emits TimeBuckets → the segment
+  // provider produces TimelineOverviewSegments with correct counts.
+  // ---------------------------------------------------------------------------
+  test('Filtered + Months → month TimelineOverviewSegments, asset counts sum to total', () async {
+    final search = _MockSearch();
+    final assets = _assets();
+    when(() => search.search(any(), 1)).thenAnswer((_) async => SearchResult(assets: assets, nextPage: null));
+
+    await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.month.index);
+
+    final container = _makeContainer(search: search, db: db);
+    addTearDown(container.dispose);
+
+    // Set a non-smart, non-empty filter (notInAlbum=true → no context → non-smart).
+    container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+
+    // Keep `photosFilterSearchProvider` (autoDispose) alive for the duration of
+    // this test by subscribing a listener.  Without a listener the autoDispose
+    // machinery would collect it between the `await` and the bucket read,
+    // causing PhotosFilterSearchNotifier.getAssets to throw "after dispose".
+    final sub = container.listen(photosFilterSearchProvider, (_, __) {});
+    addTearDown(sub.close);
+
+    // Read the photos timeline query provider — this builds the search-backed
+    // TimelineService backed by the REAL TimelineFactory / DriftTimelineRepository.
+    final svc = container.read(photosTimelineQueryProvider);
+    expect(svc.origin, TimelineOrigin.search);
+
+    // Wait for the page-1 search load to settle deterministically.
+    await container.read(photosFilterSearchProvider.notifier).firstLoad;
+
+    // Read buckets from the REAL service (no mock factory — genuine end-to-end).
+    final buckets = await svc.watchBuckets().first;
+
+    // All buckets must be TimeBuckets (dated), not plain Buckets.
+    // REGRESSION: before the fix this would be [Bucket(assetCount: 3)] — one
+    // plain date-less bucket — and every month tile would render SizedBox.shrink().
+    expect(buckets, everyElement(isA<TimeBucket>()));
+
+    // Two distinct months.
+    expect(buckets.length, 2);
+    expect(buckets[0], isA<TimeBucket>());
+    expect((buckets[0] as TimeBucket).date.month, 3); // 2024-03, newest-first
+    expect((buckets[0] as TimeBucket).date.year, 2024);
+    expect(buckets[1], isA<TimeBucket>());
+    expect((buckets[1] as TimeBucket).date.month, 1); // 2024-01
+    expect((buckets[1] as TimeBucket).date.year, 2024);
+
+    // The sum of bucket counts must equal the loaded asset total — no assets dropped.
+    final countSum = buckets.fold<int>(0, (acc, b) => acc + b.assetCount);
+    expect(countSum, assets.length, reason: 'No assets should be dropped during month-grouping');
+
+    // Verify the segment provider too: TimelineOverviewSegments, not FixedSegments.
+    // Override timelineServiceProvider in a child scope to point at the real svc
+    // (timelineSegmentProvider depends on timelineServiceProvider).
+    final routeScope = ProviderContainer(
+      parent: container,
+      overrides: [timelineServiceProvider.overrideWithValue(svc)],
+    );
+    addTearDown(routeScope.dispose);
+
+    final segStream = routeScope.read(timelineSegmentProvider.future);
+    final segments = await segStream;
+
+    expect(segments, everyElement(isA<TimelineOverviewSegment>()));
+    expect(segments.length, 2, reason: 'One overview card per month');
+
+    final segCountSum = segments.fold<int>(0, (acc, s) => acc + s.bucket.assetCount);
+    expect(segCountSum, assets.length, reason: 'Segment counts must match loaded asset count');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2 — Reactivity: changing GroupAssetsBy while a filter is active
+  // rebuilds the service and re-emits buckets at the new granularity.
+  //
+  // month → day:  TimeBuckets (still dated) grouped at day granularity.
+  // month → year: TimeBuckets grouped at year granularity (1 bucket).
+  // ---------------------------------------------------------------------------
+  test('Changing groupAssetsBy while filter is active rebuilds service buckets at new granularity', () async {
+    final search = _MockSearch();
+    final assets = _assets();
+    when(() => search.search(any(), 1)).thenAnswer((_) async => SearchResult(assets: assets, nextPage: null));
+
+    await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.month.index);
+
+    final container = _makeContainer(search: search, db: db);
+    addTearDown(container.dispose);
+
+    container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+
+    // Keep `photosFilterSearchProvider` alive across the awaits.
+    final sub = container.listen(photosFilterSearchProvider, (_, __) {});
+    addTearDown(sub.close);
+
+    // Read the month-grouped service.
+    final svcMonth = container.read(photosTimelineQueryProvider);
+    await container.read(photosFilterSearchProvider.notifier).firstLoad;
+
+    final monthBuckets = await svcMonth.watchBuckets().first;
+    expect(monthBuckets, everyElement(isA<TimeBucket>()));
+    expect(monthBuckets.length, 2, reason: 'Month grouping: 2024-03 + 2024-01');
+
+    // Switch to day grouping via the settings provider (same mechanism as the UI selector).
+    await container.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.day.index);
+
+    // The provider re-evaluates: photosTimelineQueryProvider watches
+    // timelineFactoryProvider → timelineFactoryProvider reads settingsProvider.
+    // After invalidation the container rebuilds and returns a NEW service.
+    final svcDay = container.read(photosTimelineQueryProvider);
+
+    // A grouping change rebuilds only the service (not the notifier); firstLoad is already resolved.
+    await container.read(photosFilterSearchProvider.notifier).firstLoad;
+
+    final dayBuckets = await svcDay.watchBuckets().first;
+    // Day grouping: the 2 March assets share the same date (2024-03-15), so
+    // there are 2 distinct day buckets: 2024-03-15 and 2024-01-10.
+    expect(dayBuckets, everyElement(isA<TimeBucket>()));
+    expect(dayBuckets.length, 2, reason: 'Day grouping: 2024-03-15 (×2) + 2024-01-10 (×1)');
+    // Bucket dates are `DateTime(year, month, day)` in local time (no UTC offset).
+    // Compare year/month/day fields to avoid timezone-conversion mismatches.
+    expect((dayBuckets[0] as TimeBucket).date.year, 2024);
+    expect((dayBuckets[0] as TimeBucket).date.month, 3);
+    expect((dayBuckets[0] as TimeBucket).date.day, 15);
+    expect((dayBuckets[1] as TimeBucket).date.year, 2024);
+    expect((dayBuckets[1] as TimeBucket).date.month, 1);
+    expect((dayBuckets[1] as TimeBucket).date.day, 10);
+
+    final dayCountSum = dayBuckets.fold<int>(0, (acc, b) => acc + b.assetCount);
+    expect(dayCountSum, assets.length, reason: 'No assets dropped after regrouping to day');
+
+    // Switch to year grouping.
+    await container.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.year.index);
+    final svcYear = container.read(photosTimelineQueryProvider);
+    await container.read(photosFilterSearchProvider.notifier).firstLoad;
+
+    final yearBuckets = await svcYear.watchBuckets().first;
+    expect(yearBuckets, everyElement(isA<TimeBucket>()));
+    expect(yearBuckets.length, 1, reason: 'Year grouping: all 3 assets are in 2024');
+    expect((yearBuckets[0] as TimeBucket).date.year, 2024);
+    expect(yearBuckets[0].assetCount, assets.length);
+
+    // Segment provider emits FixedSegments for the day service in its route scope.
+    final dayRouteScope = ProviderContainer(
+      parent: container,
+      overrides: [timelineServiceProvider.overrideWithValue(svcDay)],
+    );
+    addTearDown(dayRouteScope.dispose);
+
+    // Restore day grouping (same mechanism as the UI selector) so the segment provider reads day.
+    await container.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.day.index);
+
+    final daySegments = await dayRouteScope.read(timelineSegmentProvider.future);
+    // With day grouping + TimeBuckets the segment provider uses FixedSegmentBuilder.
+    for (final seg in daySegments) {
+      expect(
+        seg,
+        isNot(isA<TimelineOverviewSegment>()),
+        reason: 'Day grouping produces FixedSegments, not overview cards',
+      );
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3 — Drill-down: DESCOPED.
+  //
+  // The drill-down handler lives in `sharedTimelineOverviewDrilldownProvider`
+  // and is fully tested by `overview_drilldown_provider_test.dart`.  The handler
+  // calls `settingsProvider.notifier.set(Setting.groupAssetsBy, ...)` and sets a
+  // zoom anchor — it does NOT inspect the timeline service at all, so the
+  // filtered vs unfiltered distinction makes no difference to the handler logic.
+  //
+  // Wiring a filtered widget test faithful enough to find and tap a rendered
+  // `TimelineOverviewCard` would require a full `EasyLocalization` + Flutter
+  // widget tree (the card uses `Semantics` labels via localized month names), and
+  // the value added would be duplicating what the zoom test already covers (it
+  // exercises the exact same tap → GroupAssetsBy.day + anchor path on the same
+  // handler).  The load-bearing acceptance is fully covered by tests 1 and 2.
+  // ---------------------------------------------------------------------------
+}

--- a/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
@@ -8,13 +8,15 @@ import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart'
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 
 void main() {
-  ProviderContainer containerFor(GroupAssetsBy groupBy) {
+  ProviderContainer containerFor(GroupAssetsBy groupBy, {bool dateless = false}) {
     final service = TimelineService((
       assetSource: (offset, count) async => const [],
-      bucketSource: () => Stream.value([
-        TimeBucket(date: DateTime(2025), assetCount: 2),
-        TimeBucket(date: DateTime(2024), assetCount: 1),
-      ]),
+      bucketSource: dateless
+          ? () => Stream.value([const Bucket(assetCount: 3), const Bucket(assetCount: 2)])
+          : () => Stream.value([
+              TimeBucket(date: DateTime(2025), assetCount: 2),
+              TimeBucket(date: DateTime(2024), assetCount: 1),
+            ]),
       origin: TimelineOrigin.main,
     ));
 
@@ -57,5 +59,56 @@ void main() {
     final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, everyElement(isA<FixedSegment>()));
+  });
+
+  // Slice 3: date-less bucket fallback tests
+
+  test('date-less buckets with month setting fall back to fixed grid segments', () async {
+    final container = containerFor(GroupAssetsBy.month, dateless: true);
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, everyElement(isA<FixedSegment>()));
+  });
+
+  test('date-less buckets with year setting fall back to fixed grid segments', () async {
+    final container = containerFor(GroupAssetsBy.year, dateless: true);
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, everyElement(isA<FixedSegment>()));
+  });
+
+  test('TimeBuckets with month setting still use overview segments', () async {
+    final container = containerFor(GroupAssetsBy.month);
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, everyElement(isA<TimelineOverviewSegment>()));
+  });
+
+  test('empty bucket list with month setting produces no segments and no throw', () async {
+    final service = TimelineService((
+      assetSource: (offset, count) async => const [],
+      bucketSource: () => Stream.value(const <Bucket>[]),
+      origin: TimelineOrigin.main,
+    ));
+
+    final container = ProviderContainer(
+      overrides: [
+        timelineServiceProvider.overrideWithValue(service),
+        timelineArgsProvider.overrideWithValue(
+          const TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3, groupBy: GroupAssetsBy.month),
+        ),
+      ],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await service.dispose();
+    });
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, isEmpty);
   });
 }

--- a/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
+++ b/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/search_result.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/search.service.dart';
@@ -79,6 +80,7 @@ void main() {
     registerFallbackValue(const TimelineTemporalScope.none());
     registerFallbackValue(() => const <BaseAsset>[]);
     registerFallbackValue(const Stream<int>.empty());
+    registerFallbackValue(GroupAssetsBy.day);
     db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
     await StoreService.init(storeRepository: DriftStoreRepository(db), listenUpdates: false);
   });
@@ -128,7 +130,15 @@ void main() {
       final search = _MockSearch();
       final fake = _FakeService();
       when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
-      when(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).thenReturn(fake);
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenReturn(fake);
 
       final container = _container(factory: factory, search: search, user: _user('u1'));
       container.read(photosFilterProvider.notifier).setText('paris');
@@ -138,7 +148,15 @@ void main() {
       expect(svc, same(fake));
       await Future<void>.delayed(const Duration(milliseconds: 5));
       verify(() => search.search(any(), 1)).called(1);
-      verify(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).called(1);
+      verify(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).called(1);
     });
 
     test('remote content change does NOT re-fire the search-backed timeline', () async {
@@ -146,7 +164,16 @@ void main() {
       final search = _MockSearch();
       final fake = _FakeService();
       when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
-      when(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).thenReturn(fake);
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenReturn(fake);
 
       final container = _container(factory: factory, search: search, user: _user('u1'));
       await container.read(timelineUsersProvider.future);
@@ -176,7 +203,16 @@ void main() {
         captured = invocation.positionalArguments.first as SearchFilter;
         return const SearchResult(assets: []);
       });
-      when(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).thenReturn(fake);
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenReturn(fake);
 
       final container = _container(factory: factory, search: search, user: _user('u1'));
       container.read(timelineTemporalScopeProvider.notifier).setYear(2025);
@@ -189,7 +225,15 @@ void main() {
       expect(captured, isNotNull);
       expect(captured!.date.takenAfter, DateTime(2025));
       expect(captured!.date.takenBefore, DateTime(2025, 12, 31, 23, 59, 59));
-      verify(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).called(1);
+      verify(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).called(1);
     });
 
     test('temporal scope composes with active text filter for search-backed timeline', () async {
@@ -201,7 +245,15 @@ void main() {
         captured = invocation.positionalArguments.first as SearchFilter;
         return const SearchResult(assets: []);
       });
-      when(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).thenReturn(fake);
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenReturn(fake);
 
       final container = _container(factory: factory, search: search, user: _user('u1'));
       container.read(photosFilterProvider.notifier).setText('paris');
@@ -272,7 +324,15 @@ void main() {
         captured = invocation.positionalArguments.first as SearchFilter;
         return const SearchResult(assets: []);
       });
-      when(() => factory.fromAssetStream(any(), any(), TimelineOrigin.search)).thenReturn(fake);
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenReturn(fake);
 
       final parent = _container(factory: factory, search: search, user: _user('u1'));
       parent.read(photosFilterProvider.notifier).setText('paris');
@@ -345,6 +405,146 @@ void main() {
       // Dispose is async; allow microtask drain.
       await Future<void>.delayed(const Duration(milliseconds: 5));
       expect(fake.disposed, isTrue);
+    });
+
+    // Grouping/direction decision tests (Slice 2)
+
+    test('non-smart filter uses active grouping setting and defaults to descending', () async {
+      final factory = _MockFactory();
+      final search = _MockSearch();
+      final fake = _FakeService();
+      when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      GroupAssetsBy? capturedGroupBy;
+      bool? capturedDescending;
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenAnswer((inv) {
+        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
+        capturedDescending = inv.namedArguments[const Symbol('descending')] as bool;
+        return fake;
+      });
+
+      final container = _container(factory: factory, search: search, user: _user('u1'));
+      // People-only filter: context is null → non-smart
+      container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+      addTearDown(container.dispose);
+
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(capturedGroupBy, GroupAssetsBy.month);
+      expect(capturedDescending, isTrue);
+    });
+
+    test('non-smart filter with oldest sort uses descending=false', () async {
+      final factory = _MockFactory();
+      final search = _MockSearch();
+      final fake = _FakeService();
+      when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      GroupAssetsBy? capturedGroupBy;
+      bool? capturedDescending;
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenAnswer((inv) {
+        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
+        capturedDescending = inv.namedArguments[const Symbol('descending')] as bool;
+        return fake;
+      });
+
+      final container = _container(factory: factory, search: search, user: _user('u1'));
+      container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+      container.read(photosFilterProvider.notifier).setSort(SearchSortOrder.oldest);
+      addTearDown(container.dispose);
+
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(capturedGroupBy, GroupAssetsBy.month);
+      expect(capturedDescending, isFalse);
+    });
+
+    test('smart filter with relevance sort uses groupBy=none (flat)', () async {
+      final factory = _MockFactory();
+      final search = _MockSearch();
+      final fake = _FakeService();
+      when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
+      // factory.groupBy must NOT be evaluated on the relevance path (groupBy short-circuits to none);
+      // stub it so an accidental access wouldn't throw, and assert below that it stays untouched.
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      GroupAssetsBy? capturedGroupBy;
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenAnswer((inv) {
+        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
+        return fake;
+      });
+
+      final container = _container(factory: factory, search: search, user: _user('u1'));
+      // setText sets context=non-empty + keeps sort=relevance (smart search default)
+      container.read(photosFilterProvider.notifier).setText('paris');
+      addTearDown(container.dispose);
+
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(capturedGroupBy, GroupAssetsBy.none);
+      verifyNever(() => factory.groupBy);
+    });
+
+    test('smart filter with newest sort uses active grouping setting (not none)', () async {
+      final factory = _MockFactory();
+      final search = _MockSearch();
+      final fake = _FakeService();
+      when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      GroupAssetsBy? capturedGroupBy;
+      bool? capturedDescending;
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenAnswer((inv) {
+        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
+        capturedDescending = inv.namedArguments[const Symbol('descending')] as bool;
+        return fake;
+      });
+
+      final container = _container(factory: factory, search: search, user: _user('u1'));
+      // setText keeps context='paris'; then switch to newest sort
+      container.read(photosFilterProvider.notifier).setText('paris');
+      container.read(photosFilterProvider.notifier).setSort(SearchSortOrder.newest);
+      addTearDown(container.dispose);
+
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      // Smart + newest → not relevance, so groupBy = factory.groupBy (month)
+      expect(capturedGroupBy, GroupAssetsBy.month);
+      expect(capturedDescending, isTrue);
     });
   });
 }


### PR DESCRIPTION
Fixes Hagen's third report against timeline grouping (#625/#670/#674): on iOS, with **any filter active**, the Years/Months grouping rendered **empty** (and Year felt unreachable). Day worked.

## Root cause

With a filter active, the timeline is built from `repository.fromAssetStream`, which emitted **date-less `Bucket` segments** and ignored the grouping setting. The overview renderer (`TimelineOverviewSegment`) needs `TimeBucket`s, so it drew `SizedBox.shrink()` for every month/year tile. "Year missing from the switcher" was a side-effect of the empty overview + the #674 tap-cycle, not a separate defect. This completes the search/filter path the 2026-05-22 overview design always intended (filters compose with grouping) — mirroring web's client-side `gallery-viewer-grouping`.

Design/spec: `docs/superpowers/specs/2026-06-09-mobile-filter-grouping-fix-design.md`.

## What changed (mobile-only, 3 coordinated layers)

1. **`fromAssetStream` builds real `TimeBucket`s** grouped by a new `groupBy` and ordered by a `descending` flag (newest/oldest), date-sorted so each overview card's representative-by-index stays consistent; date-less segments preserved for the `none` (flat) case.
2. **`buildPhotosTimelineQuery`** passes `groupBy`/`descending`: relevance-sorted **smart** search → `none` (stays flat, preserves relevance ranking); otherwise the active grouping setting; `descending = sort != oldest`.
3. **`timelineSegmentProvider`** falls back to the flat grid whenever buckets are date-less, so a relevance/flat search never renders an empty overview.

## Behaviour after

- Person/place/tag/favourite/etc. filter (default newest) → Month/Year cover tiles render; tap drills down via the existing zoom anchor. **Hagen's main repro fixed.**
- Oldest sort → oldest-first grouped views. Relevance smart search → flat (no grouping), unchanged ranking.

## Known limitations (documented in the spec)

Overview covers reflect results loaded-so-far (fill in on scroll, matching web). Client bucketing uses `fileCreatedAt.toLocal()` (no `localDateTime` on the in-memory model) — pre-existing, matches `fromAssetsWithBuckets`. Server-side filtered buckets are out of scope.

## Test plan

- New repository tests (month/year/day, asc+desc, firstAssetIndex consistency, none-regression, empty, single bucket, year boundary, stream re-emission).
- Query-provider tests (non-smart→setting, oldest→ascending, smart+relevance→none, smart+newest→setting).
- Segment-provider tests (date-less→flat grid for month & year; TimeBuckets→overview).
- End-to-end integration test wiring the **real** factory/repo + mocked search: filtered+Months → overview cards, counts sum to loaded total; grouping-switch reactivity.
- Drill-down acceptance deliberately not duplicated here — the handler is filter-agnostic and covered by `overview_drilldown_provider_test.dart`.
- ✅ Full mobile suite (1682 passed), `dart analyze --fatal-infos lib test` clean, format clean.

Built across 4 TDD slices, each spec- and code-quality-reviewed, plus a final holistic review.
