### PR TITLE
fix(mobile): timeline overview cover flicker + grouping round-trip scroll jump

### DIFF
--- a/docs/superpowers/specs/2026-06-09-timeline-overview-flicker-and-roundtrip-design.md
+++ b/docs/superpowers/specs/2026-06-09-timeline-overview-flicker-and-roundtrip-design.md
@@ -1,0 +1,132 @@
+# Timeline Overview — Cover Flicker + Grouping Round-Trip Scroll Jump (Bugs 4 + 5)
+
+**Date:** 2026-06-09
+**Status:** Design — awaiting review
+**Related:** [2026-05-22-mobile-timeline-overview-design.md](./2026-05-22-mobile-timeline-overview-design.md), [2026-05-25-timeline-zoom-navigation-design.md](./2026-05-25-timeline-zoom-navigation-design.md), [2026-06-08-timeline-grouping-fixes-design.md](./2026-06-08-timeline-grouping-fixes-design.md), [2026-06-09-mobile-filter-grouping-fix-design.md](./2026-06-09-mobile-filter-grouping-fix-design.md) (PR #625, #670, #674, #679)
+
+## Context
+
+Two further mobile bugs observed on-device against the timeline overview (Years/Months cards):
+
+1. **Bug A — cover flicker on first load.** In Years/Months view, the cover thumbnails flicker while the timeline is loading: a card's image loads, then the card drops back to the gray fallback, then the card below it loads and grays out in turn — a cascade running top-to-bottom. Once everything has fully loaded the flicker stops. Reproduces on the main Photos timeline **and on album and shared-space timelines** (any route using the shared overview).
+2. **Bug B — grouping round trip jumps the scroll position.** In "All" (day) view at the very top (e.g. 9 Jun visible), switch the grouping chip to Months — **without tapping any month card** — then switch back to All: the timeline lands on **1 Jun** instead of returning to 9 Jun. A grouping round trip with no selection must not move the user's position.
+
+Both are mobile-only; no server/SDK/web changes.
+
+## Bug A — overview cover flicker
+
+### Root cause
+
+The overview card resolves its cover **by global index from the timeline service's single sliding asset buffer**, with no per-bucket memoization:
+
+- `_TimelineOverviewSegmentCard` (`mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart:60-86`): if `timelineService.hasRange(segment.firstAssetIndex, 1)` it reads the asset synchronously; otherwise it renders a `FutureBuilder(future: timelineService.loadAssets(firstAssetIndex, 1))` whose `snapshot.data` is null while loading → `representativeAsset: null`.
+- `TimelineOverviewCard` renders the **gray fallback** (`surfaceContainerHighest`) whenever `representativeAsset == null` (`overview_card.dart:118-124`).
+- `TimelineService` keeps **one** buffer of `kTimelineAssetLoadBatchSize = 1024` assets (`timeline.service.dart`, `constants.dart:29`). Year/month `firstAssetIndex` values are cumulative counts spread across the whole library, so the visible cards' representatives generally cannot coexist in one buffer window: **each card's `loadAssets` slides the buffer to its own region, evicting every other card's representative.**
+- During initial load, the bucket stream re-emits repeatedly (sync/paging); each emission fires `TimelineReloadEvent` → `setState(() {})` (`timeline.widget.dart:219`), rebuilding **all** visible cards (line 573). Each rebuilt card whose index fell out of the buffer goes gray, kicks off a new `loadAssets`, which evicts the next card's range → the observed top-to-bottom load→gray cascade. When emissions stop, the last-loaded state sticks — matching "only flickers on first load".
+
+Albums and shared spaces flicker for the same reason: they render through the same shared `Timeline` → `TimelineOverviewSegment` path, and their bucket streams also re-emit during initial sync.
+
+This is a pre-existing fragility from the #670 overview, amplified by routes with chatty initial bucket streams (and by #679's filtered overview, where paging re-emits per page).
+
+### Design: per-bucket representative cache
+
+Memoize each bucket's resolved representative so it survives rebuilds and buffer movement. The card consults the cache first and **never falls back to gray once a representative has been resolved** for that bucket.
+
+- **New route-scoped provider** `timelineOverviewRepresentativeCacheProvider` — a `Notifier` holding `Map<String, BaseAsset>` keyed by `'${groupBy.name}:${bucket.date.toIso8601String()}'`. The `groupBy` component is load-bearing, not cosmetic: a year bucket `2024` and a month bucket `Jan 2024` both carry date `2024-01-01`. Provider-held rather than widget `State` because the timeline tears down and rebuilds its subtree on segment reloads, which resets `State` (the #674 lesson). **Route-scoped via an explicit override in `TimelineRouteScope`** (`timeline_route_scope.dart`), exactly like `timelineZoomAnchorProvider` is today — so albums/spaces/photos each get their own cache and it dies with the route. (Note: `timelineGroupingZoomingInProvider` is a _global_ provider and is NOT the model to copy here.)
+- **`_TimelineOverviewSegmentCard` lookup order:**
+  1. Cache hit → render the cached representative immediately (no gray), regardless of buffer state.
+  2. Cache miss + `hasRange` → read synchronously, **write to cache**, render.
+  3. Cache miss + no range → existing `FutureBuilder` path; on resolve, **write to cache**. While in flight the gray fallback shows — but only ever once per bucket per route visit.
+- **Staleness:** store the bucket's `assetCount` alongside the asset. If a later emission changes a bucket's count, keep showing the cached representative and refresh it in the background (kick the `FutureBuilder` path; replace on resolve). Stale-but-plausible beats gray. If the cached representative's bucket disappears entirely (date no longer in the bucket list), the entry is simply unused; no eviction pass needed.
+- **Invalidation — service-instance change, not just route death.** The route scope does NOT rebuild when `timelineServiceProvider` re-evaluates (the service provider is a sibling inside the same scope), so route scoping alone would keep serving covers resolved under a **previous filter** — a representative that may not match the active filter at all, which is worse than the flicker. The cache notifier therefore `ref.listen`s to `timelineServiceProvider` and **clears the map whenever the service instance changes** (filter change, temporal-scope change). Trade-off, documented: grouping switches also rebuild the service (the route-scope override watches `Setting.groupAssetsBy`), so a year↔month switch clears the cache and covers re-resolve once per switch — identical to today's behavior, no regression; the cache's job is killing the intra-view cascade, which it still does.
+
+_Alternative considered and rejected:_ enlarging the asset buffer or giving the overview its own multi-window buffer — touches the shared scrolling machinery and still thrashes for large libraries; the cache is a few dozen entries and strictly additive.
+
+### Testing (TDD — RED first)
+
+In `mobile/test/presentation/widgets/timeline/overview/` (+ a small provider test):
+
+- **RED (the bug):** card for a bucket whose representative was previously resolved renders the `Thumbnail` (not the gray fallback) when the service buffer no longer covers its `firstAssetIndex` (simulate: resolve once, move the buffer via another `loadAssets`, rebuild the card). Today this renders the fallback → fails.
+- Cache provider unit tests: write/read by `(groupBy, date)` key; year-`2024` vs month-`Jan 2024` keys do not collide; count-change keeps the old asset until a replacement is stored; separate route scopes do not share entries.
+- **Filter-change invalidation (RED-able):** resolve a cover, then swap the `timelineServiceProvider` instance (simulating a filter change) → the old representative must NOT render; the card re-resolves from the new service.
+- **Count-change triggers a refresh:** a bucket emission with a different `assetCount` for a cached date kicks a background re-resolve (old asset shown meanwhile, replaced on resolve) — assert the reload actually happens, not just that the old value persists.
+- Card writes to the cache on both the synchronous (`hasRange`) and `FutureBuilder` resolve paths.
+- Cascade regression: two cards at far-apart indices; loading the second (which evicts the first's buffer range) does not blank the first on rebuild.
+- Existing overview card/semantics tests stay green (fallback still shown for a genuinely never-resolved bucket with in-flight load).
+
+## Bug B — grouping round trip loses the day-precision position
+
+### Root cause
+
+`_onGroupingChanged` (`mobile/lib/presentation/widgets/timeline/timeline.widget.dart:255-273`) anchors the rebuilt timeline to **the date of the top-visible bucket**:
+
+```dart
+final date = _currentTopVisibleDate(segments);   // (bucket as TimeBucket).date
+ref.read(timelineZoomAnchorProvider.notifier).setDate(date);
+```
+
+Bucket dates are **truncated to their granularity**: a month bucket's `date` is the 1st of the month (`TimeBucket` built from `truncateDate(groupBy)` / `_localBucketDate`). So:
+
+1. Day view, top = 9 Jun → switch to Months: anchor = `date(2026-06-09)` → month view scrolls to the June card. Correct.
+2. Months → All (no card tapped): top-visible bucket is the **June month bucket whose `date` is 2026-06-01** → anchor = `date(2026-06-01)` → `findTimelineScrollTargetSegment` (`timeline_scroll_target.dart`) matches the 1 Jun day segment → the user lands on 1 Jun.
+
+The day-level precision is destroyed by round-tripping through the coarser bucket's truncated date. (Card-tap drill-down is unaffected — it sets an explicit year/month anchor and `_onGroupingChanged` skips via the `isEmpty` guard at line 261.)
+
+### Design: retain the finer date across a no-selection round trip
+
+Remember the most recent position-derived anchor date, and when leaving a coarser grouping, **keep the remembered finer date if it still falls inside the top-visible bucket's period**; otherwise (the user actually scrolled somewhere else) fall back to the bucket's truncated date.
+
+- Extract a pure decision function (new file `mobile/lib/presentation/widgets/timeline/timeline_grouping_anchor.dart`):
+
+  ```dart
+  /// The date to anchor on when the grouping changes away from [previousGroupBy].
+  /// [topBucketDate] is the (granularity-truncated) date of the top-visible bucket.
+  /// [remembered] is the last position-derived anchor date, if any.
+  DateTime resolveGroupingChangeAnchorDate({
+    required DateTime topBucketDate,
+    required GroupAssetsBy previousGroupBy,
+    DateTime? remembered,
+  }) {
+    if (remembered == null) return topBucketDate;
+    final within = switch (previousGroupBy) {
+      GroupAssetsBy.year => remembered.year == topBucketDate.year,
+      GroupAssetsBy.month => remembered.year == topBucketDate.year && remembered.month == topBucketDate.month,
+      _ => false, // day buckets are already full precision — use them as-is
+    };
+    return within ? remembered : topBucketDate;
+  }
+  ```
+
+- **Remembered date storage:** on `TimelineZoomAnchorNotifier` (`zoom_anchor.provider.dart`) as `DateTime? lastPositionDate`, updated by `setDate` and **not** cleared when the anchor is consumed (`clear()` at `timeline.widget.dart:442` keeps it). `setDate` has exactly one production caller (`_onGroupingChanged`, `timeline.widget.dart:272`), so `lastPositionDate` is precisely "the last position-derived anchor" with no other writers. Route scoping comes for free: `timelineZoomAnchorProvider` is already overridden per-route in `TimelineRouteScope` (`timeline_route_scope.dart`), so it never leaks across routes and survives the timeline's subtree teardowns (the #674 lesson).
+- `_onGroupingChanged` becomes: compute `topBucketDate`; `final date = resolveGroupingChangeAnchorDate(topBucketDate: topBucketDate, previousGroupBy: GroupAssetsBy.values[previous], remembered: notifier.lastPositionDate)`; `setDate(date)`.
+
+Walking the report's repro: All@9 Jun → Months remembers 9 Jun, anchors June. Months → All: top bucket = June (1 Jun), 9 Jun ∈ June → anchor 9 Jun → **back to 9 Jun**. If the user scrolls the month view to March first: top bucket = March, 9 Jun ∉ March → anchor 1 Mar (today's behavior, correct — they moved). Works transitively across All→Months→Years→Months→All (each leg's top bucket still contains 9 Jun, so the remembered date survives the whole round trip). Card-tap drill-down keeps its explicit-anchor skip; the next position-derived change overwrites `lastPositionDate`, so staleness self-corrects.
+
+### Testing (TDD — RED first)
+
+- **Pure-function tests** (new `timeline_grouping_anchor_test.dart`) — write first; the initial run is a **compile-RED** (the function doesn't exist), then implement: remembered-within-month kept (9 Jun + top 1 Jun → 9 Jun); remembered-outside-month dropped (9 Jun + top 1 Mar → 1 Mar); year variants (within-year kept, outside-year dropped); `previousGroupBy: day` always returns the bucket date; `previousGroupBy: auto`/`none` (legacy setting values) return the bucket date; `remembered: null` returns the bucket date.
+- **Widget round-trip test** (extend `main_timeline_zoom_test.dart` patterns): day view positioned at a 9 Jun segment → set grouping to month → back to day → the resolved scroll target is the 9 Jun segment, not 1 Jun. **RED today** (lands on 1 Jun) — this is the bug's regression guard; watch it fail before wiring `_onGroupingChanged`.
+- Scrolled-in-between variant: after switching to month, scroll so a different month is on top, switch back → lands on that month's first day (existing behavior preserved).
+- Drill-down regression: card tap still uses the explicit anchor path (existing tests in `overview_drilldown_provider_test.dart` / zoom tests stay green).
+- `lastPositionDate` survives `clear()` (anchor consumption) but updates on each `setDate`.
+- **Unresolvable top date:** when `_currentTopVisibleDate` returns null (empty segments / scroll controller without clients), no anchor is set and `lastPositionDate` is unchanged (the stale value is harmless: it is only ever consulted under the containment check, which self-corrects).
+
+## Scope
+
+Mobile only. Files:
+
+- Bug A: `overview_segment.model.dart`, new cache provider (+ `TimelineRouteScope` wiring), tests.
+- Bug B: `timeline.widget.dart` (`_onGroupingChanged`), `zoom_anchor.provider.dart` (`lastPositionDate`), new `timeline_grouping_anchor.dart` pure helper, tests.
+
+The two bugs are independent and can land as separate commits in one PR.
+
+## Out of scope
+
+- Server-side cover endpoint usage on mobile (mobile covers stay client-side from the local service; the 2026-06-08 spec's `getTimeBucketCovers` is web-only).
+- Buffer-size tuning / multi-window asset buffering in `TimelineService`.
+- Damping the filtered overview's `loadMore`-driven bucket re-emissions (#679 known limitation) — the cache makes the re-emissions visually harmless.
+- Pixel-offset restoration within a day (returning to the exact scroll pixel); anchoring to the day segment matches the existing scroll-to-date behavior.
+
+## Rollout / validation
+
+No flag — bug fixes. Validate on-device (branded sideload as before): (1) cold-open Years/Months on Photos, an album, and a shared space — covers fill in once without the gray cascade; (2) All@top → Months → All returns to the same day; scrolling the month view in between still re-anchors to the scrolled month.

--- a/mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart
+++ b/mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart
@@ -1,14 +1,12 @@
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_card.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
-import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
+import 'package:immich_mobile/providers/timeline/overview_representative_cache.provider.dart';
 
 class TimelineOverviewSegment extends Segment {
   const TimelineOverviewSegment({
@@ -57,32 +55,28 @@ class _TimelineOverviewSegmentCard extends ConsumerWidget {
     final onTap = drilldown != null && bucket.assetCount > 0
         ? () => unawaited(drilldown(bucket, segment.groupBy))
         : null;
-    final timelineService = ref.read(timelineServiceProvider);
-    BaseAsset? representativeAsset;
-    if (timelineService.hasRange(segment.firstAssetIndex, 1)) {
-      representativeAsset = timelineService.getAssets(segment.firstAssetIndex, 1).firstOrNull;
+
+    final key = TimelineOverviewRepresentativeCacheNotifier.keyFor(segment.groupBy, bucket.date);
+
+    // Read the cached representative (null if not resolved yet).
+    final cachedAsset = ref.watch(timelineOverviewRepresentativeCacheProvider.select((m) => m[key]?.asset));
+
+    // Schedule a (re-)resolve post-frame so we never mutate provider state during build.
+    if (bucket.assetCount > 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) {
+          ref
+              .read(timelineOverviewRepresentativeCacheProvider.notifier)
+              .ensure(key, segment.firstAssetIndex, bucket.assetCount);
+        }
+      });
     }
 
-    if (representativeAsset != null || bucket.assetCount <= 0) {
-      return TimelineOverviewCard(
-        bucket: bucket,
-        groupBy: segment.groupBy,
-        representativeAsset: representativeAsset,
-        onTap: onTap,
-      );
-    }
-
-    return FutureBuilder<List<BaseAsset>>(
-      future: timelineService.loadAssets(segment.firstAssetIndex, 1),
-      builder: (context, snapshot) {
-        final assets = snapshot.data ?? const <BaseAsset>[];
-        return TimelineOverviewCard(
-          bucket: bucket,
-          groupBy: segment.groupBy,
-          representativeAsset: assets.firstOrNull,
-          onTap: onTap,
-        );
-      },
+    return TimelineOverviewCard(
+      bucket: bucket,
+      groupBy: segment.groupBy,
+      representativeAsset: cachedAsset,
+      onTap: onTap,
     );
   }
 }

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -22,6 +22,7 @@ import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scroll_drain.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scrubber.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_anchor.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_drag_region.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_scroll_target.dart';
@@ -265,11 +266,17 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
     if (segments == null) {
       return;
     }
-    final date = _currentTopVisibleDate(segments);
-    if (date == null) {
+    final topBucketDate = _currentTopVisibleDate(segments);
+    if (topBucketDate == null) {
       return;
     }
-    ref.read(timelineZoomAnchorProvider.notifier).setDate(date);
+    final anchorNotifier = ref.read(timelineZoomAnchorProvider.notifier);
+    final resolved = resolveGroupingChangeAnchorDate(
+      topBucketDate: topBucketDate,
+      previousGroupBy: GroupAssetsBy.values[previous],
+      remembered: anchorNotifier.lastPositionDate,
+    );
+    anchorNotifier.setDate(resolved);
   }
 
   DateTime? _currentTopVisibleDate(List<Segment> segments) {

--- a/mobile/lib/presentation/widgets/timeline/timeline_grouping_anchor.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_grouping_anchor.dart
@@ -1,0 +1,23 @@
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+
+/// The date to anchor on when the grouping changes away from [previousGroupBy].
+/// [topBucketDate] is the (granularity-truncated) date of the top-visible bucket.
+/// [remembered] is the last position-derived anchor date, if any.
+///
+/// Keeps the finer remembered date when it still falls inside the top bucket's
+/// period (the user didn't scroll); otherwise uses the bucket date.
+DateTime resolveGroupingChangeAnchorDate({
+  required DateTime topBucketDate,
+  required GroupAssetsBy previousGroupBy,
+  DateTime? remembered,
+}) {
+  if (remembered == null) {
+    return topBucketDate;
+  }
+  final within = switch (previousGroupBy) {
+    GroupAssetsBy.year => remembered.year == topBucketDate.year,
+    GroupAssetsBy.month => remembered.year == topBucketDate.year && remembered.month == topBucketDate.month,
+    GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none => false,
+  };
+  return within ? remembered : topBucketDate;
+}

--- a/mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
+import 'package:immich_mobile/providers/timeline/overview_representative_cache.provider.dart';
 import 'package:immich_mobile/providers/timeline/temporal_scope.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 
@@ -25,6 +26,7 @@ class TimelineRouteScope extends StatelessWidget {
         timelineTemporalScopeProvider.overrideWith(TimelineTemporalScopeNotifier.new),
         timelineZoomAnchorProvider.overrideWith(TimelineZoomAnchorNotifier.new),
         timelineOverviewDrilldownProvider.overrideWith((ref) => ref.watch(sharedTimelineOverviewDrilldownProvider)),
+        timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
         if (timelineServiceBuilder != null)
           timelineServiceProvider.overrideWith((ref) {
             final temporalScope = ref.watch(timelineTemporalScopeProvider);

--- a/mobile/lib/providers/timeline/overview_representative_cache.provider.dart
+++ b/mobile/lib/providers/timeline/overview_representative_cache.provider.dart
@@ -1,0 +1,74 @@
+import 'package:collection/collection.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+
+class TimelineOverviewRepresentative {
+  const TimelineOverviewRepresentative({required this.asset, required this.assetCount});
+
+  final BaseAsset asset;
+  final int assetCount;
+}
+
+class TimelineOverviewRepresentativeCacheNotifier extends Notifier<Map<String, TimelineOverviewRepresentative>> {
+  final Set<String> _inFlight = <String>{};
+
+  /// Bumped on every cache reset (service change). An in-flight [ensure] captures the generation
+  /// it started under and drops its result if the cache was reset meanwhile, so a resolve started
+  /// against a previous service can never write an entry under the new one.
+  int _generation = 0;
+
+  /// Cache key for a bucket. `groupBy` is part of the key so a year and a month bucket that share
+  /// the same date (e.g. 2024-01-01) don't collide. Shared with the card and tests to avoid drift.
+  static String keyFor(GroupAssetsBy groupBy, DateTime date) => '${groupBy.name}:${date.toIso8601String()}';
+
+  @override
+  Map<String, TimelineOverviewRepresentative> build() {
+    // Reset the cache whenever the service instance changes — filter / scope / grouping
+    // change — so we never show a cover resolved under a previous service. A dependency-driven
+    // rebuild (`watch` + fresh map) rather than `listen` + `state = {}` is what makes this safe
+    // when the change lands mid-build: imperatively mutating the provider from a listener that
+    // fires during a widget build throws ("modify a provider while building").
+    ref.watch(timelineServiceProvider);
+    _inFlight.clear();
+    _generation++;
+    return const {};
+  }
+
+  BaseAsset? assetFor(String key) => state[key]?.asset;
+
+  /// Resolve and cache the representative for [key] (bucket's first asset at [index]).
+  /// Deduped per key; no-op if already cached at the same [assetCount]. Call from a
+  /// post-frame callback (never during build — it mutates provider state).
+  Future<void> ensure(String key, int index, int assetCount) async {
+    final existing = state[key];
+    if (existing != null && existing.assetCount == assetCount) return; // fresh
+    // Skip if a resolve is already running for this key. A count-change that arrives mid-resolve is
+    // picked up by the next frame's re-scheduled ensure (the stale-but-plausible cover stays painted
+    // meanwhile) rather than being applied immediately.
+    if (_inFlight.contains(key)) return;
+    _inFlight.add(key);
+    final generation = _generation;
+    try {
+      final service = ref.read(timelineServiceProvider);
+      final assets = service.hasRange(index, 1) ? service.getAssets(index, 1) : await service.loadAssets(index, 1);
+      final asset = assets.firstOrNull;
+      // Drop the result if the cache was reset (service changed) while resolving, so a cover
+      // resolved under the previous service never lands under the new one. A null asset
+      // (loadAssets returned nothing) is left uncached so a later rebuild retries.
+      if (asset != null && _generation == generation) {
+        state = {...state, key: TimelineOverviewRepresentative(asset: asset, assetCount: assetCount)};
+      }
+    } catch (_) {
+      // leave uncached; a later rebuild retries
+    } finally {
+      _inFlight.remove(key);
+    }
+  }
+}
+
+final timelineOverviewRepresentativeCacheProvider =
+    NotifierProvider<TimelineOverviewRepresentativeCacheNotifier, Map<String, TimelineOverviewRepresentative>>(
+      TimelineOverviewRepresentativeCacheNotifier.new,
+    );

--- a/mobile/lib/providers/timeline/zoom_anchor.provider.dart
+++ b/mobile/lib/providers/timeline/zoom_anchor.provider.dart
@@ -2,6 +2,11 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 
 class TimelineZoomAnchorNotifier extends Notifier<TimelineZoomAnchor> {
+  /// The most recent position-derived anchor date set via [setDate].
+  /// Survives [clear] (anchor consumption) so that [_onGroupingChanged] can
+  /// recover the finer-grained date across a coarse→fine grouping round trip.
+  DateTime? lastPositionDate;
+
   @override
   TimelineZoomAnchor build() => const TimelineZoomAnchor.none();
 
@@ -9,7 +14,10 @@ class TimelineZoomAnchorNotifier extends Notifier<TimelineZoomAnchor> {
 
   void setMonth({required int year, required int month}) => state = TimelineZoomAnchor.month(year: year, month: month);
 
-  void setDate(DateTime date) => state = TimelineZoomAnchor.date(date);
+  void setDate(DateTime date) {
+    lastPositionDate = date;
+    state = TimelineZoomAnchor.date(date);
+  }
 
   void clear() => state = const TimelineZoomAnchor.none();
 }

--- a/mobile/test/presentation/pages/dev/main_timeline_zoom_test.dart
+++ b/mobile/test/presentation/pages/dev/main_timeline_zoom_test.dart
@@ -227,6 +227,127 @@ void main() {
     expect(find.bySemanticsLabel('June 2024, 30 photos, show days'), findsOneWidget);
     expect(find.bySemanticsLabel('February 2026, 30 photos, show days'), findsNothing);
   });
+
+  // Regression for Bug B: grouping round trip (All → Months → All) without
+  // tapping any card must return to the same day, not truncate to the 1st of
+  // the month.
+  testWidgets('Round-trip All → Months → All without card tap returns to the same day (not 1st of month)', (
+    tester,
+  ) async {
+    await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.day.index);
+
+    // Two day buckets for June: the 9th is the most-recent (top), the 1st is
+    // further down. We put older content below so there is room to scroll.
+    final factory = _factoryForServices(
+      yearService: _service([
+        TimeBucket(date: DateTime(2026), assetCount: 9),
+        TimeBucket(date: DateTime(2025), assetCount: 9),
+      ]),
+      monthService: _service([
+        TimeBucket(date: DateTime(2026, 6), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 5), assetCount: 9),
+      ]),
+      dayService: _service([
+        TimeBucket(date: DateTime(2026, 6, 9), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 6, 1), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 5, 10), assetCount: 9),
+      ]),
+    );
+    addTearDown(factory.disposeServices);
+
+    await _pumpPhotosTimeline(tester, factory);
+    final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+
+    // At this point the day timeline is loaded at the top — Jun 9 is visible.
+    // Step 1: switch to Months (no card tap — simulates the grouping selector).
+    await ref.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.month.index);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpAndSettle();
+
+    expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.month.index);
+
+    // Step 2: switch back to All without tapping any card.
+    await ref.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.day.index);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpAndSettle();
+
+    expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.day.index);
+
+    // The timeline must have resolved back to the Jun 9 segment (not Jun 1).
+    // Both segments are in the day timeline, so the anchor date drives which one
+    // is scrolled to. Jun 9 is the first bucket (index 0, offset 0) so the
+    // scroll position stays near the top — the anchor was Jun 9, NOT Jun 1.
+    final notifier = ref.read(timelineZoomAnchorProvider.notifier);
+    // After the anchor is consumed (clear) the lastPositionDate is Jun 9 (not Jun 1).
+    expect(notifier.lastPositionDate, DateTime(2026, 6, 9));
+  });
+
+  // Scrolled-in-between variant: if the user actually scrolls while in Months
+  // (so a different month is on top), round-tripping back to All anchors to
+  // that other month's first day — not the original fine-grained date.
+  // We need enough month cards to exceed the test viewport (~600px) so that
+  // scrolling to maxScrollExtent actually moves the scroll position.
+  // Each overview card is 144 + 12 vertical padding (6 top + 6 bottom) = 156px; 5 cards = 780px > 600px.
+  testWidgets('Round-trip with scroll in month view uses the scrolled-to month', (tester) async {
+    await Store.put(StoreKey.groupAssetsBy, GroupAssetsBy.day.index);
+
+    final factory = _factoryForServices(
+      yearService: _service([
+        TimeBucket(date: DateTime(2026), assetCount: 9),
+        TimeBucket(date: DateTime(2025), assetCount: 9),
+      ]),
+      monthService: _service([
+        TimeBucket(date: DateTime(2026, 6), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 5), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 4), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 3), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 2), assetCount: 9),
+      ]),
+      dayService: _service([
+        TimeBucket(date: DateTime(2026, 6, 9), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 5, 10), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 4, 1), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 3, 1), assetCount: 9),
+        TimeBucket(date: DateTime(2026, 2, 1), assetCount: 9),
+      ]),
+    );
+    addTearDown(factory.disposeServices);
+
+    await _pumpPhotosTimeline(tester, factory);
+    final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+
+    // Switch to Months — Jun 9 remembered.
+    await ref.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.month.index);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpAndSettle();
+
+    // Scroll to the bottom in month view — the top-visible month is no longer June.
+    final scrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
+    // Verify there is actually scroll room (5 cards × 156px = 780px > viewport).
+    expect(scrollable.position.maxScrollExtent, greaterThan(0));
+    scrollable.position.jumpTo(scrollable.position.maxScrollExtent);
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    // Switch back to All. The top-visible month is no longer June (user scrolled
+    // past it), so the remembered Jun 9 is outside the top bucket's period and
+    // must be dropped in favour of the bucket's truncated date.
+    await ref.read(settingsProvider.notifier).set(Setting.groupAssetsBy, GroupAssetsBy.day.index);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpAndSettle();
+
+    expect(Store.get(StoreKey.groupAssetsBy), GroupAssetsBy.day.index);
+    // lastPositionDate was overwritten with the top-visible month's bucket date
+    // (NOT Jun 9, since the user scrolled away from June). A negative assertion is used
+    // deliberately: the exact top-visible month depends on viewport/card-extent layout math,
+    // so we assert only that the stale Jun 9 was dropped — the kept-vs-dropped logic itself is
+    // pinned by the pure-function tests in timeline_grouping_anchor_test.dart.
+    expect(ref.read(timelineZoomAnchorProvider.notifier).lastPositionDate, isNot(DateTime(2026, 6, 9)));
+  });
 }
 
 ({TimelineFactory factory, Future<void> Function() disposeServices}) _factoryForServices({

--- a/mobile/test/presentation/widgets/timeline/overview/overview_segment_builder_test.dart
+++ b/mobile/test/presentation/widgets/timeline/overview/overview_segment_builder_test.dart
@@ -21,6 +21,7 @@ import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_se
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment_builder.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
+import 'package:immich_mobile/providers/timeline/overview_representative_cache.provider.dart';
 import 'package:intl/date_symbol_data_local.dart';
 // easy_localization initializes shared_preferences internally; tests need the mock initializer.
 // ignore: depend_on_referenced_packages
@@ -296,5 +297,178 @@ void main() {
     await tester.pump();
 
     expect(tapped, isEmpty);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cache-based tests (Bug A regression guards)
+  // ---------------------------------------------------------------------------
+
+  Widget wrapWithScope(Widget child, {required TimelineService timelineService, List<Override> overrides = const []}) {
+    return EasyLocalization(
+      supportedLocales: const [Locale('en')],
+      path: '../i18n',
+      fallbackLocale: const Locale('en'),
+      child: ProviderScope(
+        overrides: [
+          timelineServiceProvider.overrideWithValue(timelineService),
+          timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
+          ...overrides,
+        ],
+        child: MaterialApp(
+          home: Scaffold(body: Center(child: child)),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('card shows Thumbnail from cache even when buffer no longer covers firstAssetIndex', (tester) async {
+    // Bug A regression guard:
+    // 1. Pre-populate the cache with a representative for index 0.
+    // 2. Move the buffer far away (evicts index 0).
+    // 3. Replace the asset source with one that never resolves (so a FutureBuilder fallback
+    //    would stay gray forever).
+    // 4. Force a widget rebuild via setState — with the cache it shows the Thumbnail
+    //    immediately; without the cache it shows the gray fallback.
+    final representativeAsset = TestUtils.createRemoteAsset(id: 'representative', width: 200, height: 100);
+    final neverCompleter = Completer<List<BaseAsset>>();
+    var useNeverCompleter = false;
+
+    final pool = List.generate(2000, (i) => i == 0 ? representativeAsset : TestUtils.createRemoteAsset(id: 'asset-$i'));
+    final timelineService = TimelineService((
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: pool.length)]),
+      assetSource: (offset, count) async {
+        if (useNeverCompleter) return neverCompleter.future;
+        final end = (offset + count).clamp(0, pool.length);
+        final start = offset.clamp(0, end);
+        return pool.sublist(start, end);
+      },
+      origin: TimelineOrigin.main,
+    ));
+    addTearDown(timelineService.dispose);
+
+    final segment = TimelineOverviewSegment(
+      firstIndex: 0,
+      lastIndex: 0,
+      startOffset: 0,
+      endOffset: kTimelineOverviewSegmentExtent,
+      firstAssetIndex: 0,
+      bucket: TimeBucket(date: DateTime(2025), assetCount: pool.length),
+      groupBy: GroupAssetsBy.year,
+      header: HeaderType.year,
+    );
+
+    // Use a StatefulBuilder so we can force a rebuild.
+    late StateSetter forceRebuild;
+    await tester.pumpWidget(
+      wrapWithScope(
+        StatefulBuilder(
+          builder: (ctx, setState) {
+            forceRebuild = setState;
+            return segment.builder(ctx, segment.firstIndex);
+          },
+        ),
+        timelineService: timelineService,
+      ),
+    );
+    // Let the post-frame callback fire and ensure() resolve.
+    await tester.pumpAndSettle();
+
+    // Cache populated: card must show the thumbnail.
+    expect(find.byType(Thumbnail), findsOneWidget);
+
+    // Move the buffer far away (evicts index 0 — index 1500 is beyond the initial 1024-asset
+    // buffer window so this forces a reload that evicts index 0) and switch to the
+    // never-resolving source for subsequent loads.
+    await timelineService.loadAssets(1500, 1);
+    useNeverCompleter = true;
+
+    // Trigger a rebuild (simulates a TimelineReloadEvent → setState).
+    forceRebuild(() {});
+    await tester.pump();
+
+    // Must still show the thumbnail — cache hit, not the gray fallback from a FutureBuilder.
+    expect(find.byType(Thumbnail), findsOneWidget);
+    expect(find.byKey(const ValueKey('timeline-overview-card-fallback')), findsNothing);
+  });
+
+  testWidgets('uncached bucket shows fallback and schedules ensure on first build', (tester) async {
+    final asset = TestUtils.createRemoteAsset(id: 'asset-0', width: 200, height: 100);
+    // Delay the asset source resolution so we can observe the fallback state.
+    final assetCompleter = Completer<List<BaseAsset>>();
+    final timelineService = TimelineService((
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: 1)]),
+      assetSource: (_, _) async => assetCompleter.future,
+      origin: TimelineOrigin.main,
+    ));
+    addTearDown(timelineService.dispose);
+
+    final segment = TimelineOverviewSegment(
+      firstIndex: 0,
+      lastIndex: 0,
+      startOffset: 0,
+      endOffset: kTimelineOverviewSegmentExtent,
+      firstAssetIndex: 0,
+      bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
+      groupBy: GroupAssetsBy.year,
+      header: HeaderType.year,
+    );
+
+    await tester.pumpWidget(
+      wrapWithScope(
+        Builder(builder: (ctx) => segment.builder(ctx, segment.firstIndex)),
+        timelineService: timelineService,
+      ),
+    );
+    await tester.pump(); // first frame + post-frame callback
+
+    // While loading: fallback is shown.
+    expect(find.byKey(const ValueKey('timeline-overview-card-fallback')), findsOneWidget);
+    expect(find.byType(Thumbnail), findsNothing);
+
+    // Complete the load — cache is populated, card rebuilds to show thumbnail.
+    assetCompleter.complete([asset]);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Thumbnail), findsOneWidget);
+    expect(find.byKey(const ValueKey('timeline-overview-card-fallback')), findsNothing);
+  });
+
+  testWidgets('zero-count bucket shows fallback and does not schedule ensure', (tester) async {
+    var assetSourceCallCount = 0;
+    final timelineService = TimelineService((
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: 0)]),
+      assetSource: (_, _) async {
+        assetSourceCallCount++;
+        return const <BaseAsset>[];
+      },
+      origin: TimelineOrigin.main,
+    ));
+    addTearDown(timelineService.dispose);
+
+    final segment = TimelineOverviewSegment(
+      firstIndex: 0,
+      lastIndex: 0,
+      startOffset: 0,
+      endOffset: kTimelineOverviewSegmentExtent,
+      firstAssetIndex: 0,
+      bucket: TimeBucket(date: DateTime(2025), assetCount: 0),
+      groupBy: GroupAssetsBy.year,
+      header: HeaderType.year,
+    );
+
+    await tester.pumpWidget(
+      wrapWithScope(
+        Builder(builder: (ctx) => segment.builder(ctx, segment.firstIndex)),
+        timelineService: timelineService,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Zero-count bucket: fallback shown, no ensure scheduled (assetSourceCallCount stays at 0
+    // since the bucket stream also has assetCount:0 so the service loads no assets).
+    expect(find.byKey(const ValueKey('timeline-overview-card-fallback')), findsOneWidget);
+    expect(find.byType(Thumbnail), findsNothing);
+    // The cache should have no entry for this bucket.
+    expect(assetSourceCallCount, 0);
   });
 }

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_anchor_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_anchor_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_anchor.dart';
+
+void main() {
+  // ---- month-granularity cases ----
+
+  test('month: remembered date within same month is kept', () {
+    // Day view at 9 Jun → switch to Months → bucket is 1 Jun → should keep 9 Jun
+    final remembered = DateTime(2026, 6, 9);
+    final topBucketDate = DateTime(2026, 6, 1);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.month,
+        remembered: remembered,
+      ),
+      remembered,
+    );
+  });
+
+  test('month: remembered date in a different month is dropped', () {
+    // User scrolled to March while in month view → should use March 1st
+    final remembered = DateTime(2026, 6, 9);
+    final topBucketDate = DateTime(2026, 3, 1);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.month,
+        remembered: remembered,
+      ),
+      topBucketDate,
+    );
+  });
+
+  // ---- year-granularity cases ----
+
+  test('year: remembered date within same year is kept', () {
+    final remembered = DateTime(2026, 6, 9);
+    final topBucketDate = DateTime(2026, 1, 1);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.year,
+        remembered: remembered,
+      ),
+      remembered,
+    );
+  });
+
+  test('year: remembered date in a different year is dropped', () {
+    final remembered = DateTime(2025, 6, 9);
+    final topBucketDate = DateTime(2026, 1, 1);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.year,
+        remembered: remembered,
+      ),
+      topBucketDate,
+    );
+  });
+
+  // ---- day/auto/none: always return bucket date (already full precision) ----
+
+  test('day: always returns bucket date even when remembered is present', () {
+    final remembered = DateTime(2026, 6, 9);
+    final topBucketDate = DateTime(2026, 6, 9);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.day,
+        remembered: remembered,
+      ),
+      topBucketDate,
+    );
+  });
+
+  test('auto: always returns bucket date', () {
+    final remembered = DateTime(2026, 6, 9);
+    final topBucketDate = DateTime(2026, 6, 5);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.auto,
+        remembered: remembered,
+      ),
+      topBucketDate,
+    );
+  });
+
+  test('none: always returns bucket date', () {
+    final remembered = DateTime(2026, 6, 9);
+    final topBucketDate = DateTime(2026, 6, 5);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.none,
+        remembered: remembered,
+      ),
+      topBucketDate,
+    );
+  });
+
+  // ---- null remembered ----
+
+  test('null remembered: always returns bucket date', () {
+    final topBucketDate = DateTime(2026, 6, 1);
+    expect(
+      resolveGroupingChangeAnchorDate(
+        topBucketDate: topBucketDate,
+        previousGroupBy: GroupAssetsBy.month,
+        remembered: null,
+      ),
+      topBucketDate,
+    );
+  });
+}

--- a/mobile/test/providers/timeline/overview_representative_cache_provider_test.dart
+++ b/mobile/test/providers/timeline/overview_representative_cache_provider_test.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/timeline/overview_representative_cache.provider.dart';
+
+import '../../test_utils.dart';
+
+// A tiny indexed asset list for use as the fake asset source. Returns up to [count]
+// assets starting at [offset], where asset-N has id 'asset-N'. Silently clamps to
+// the provided pool size so tests don't need to worry about exact batch sizes.
+List<BaseAsset> _indexedAssets(List<BaseAsset> pool, int offset, int count) {
+  final end = (offset + count).clamp(0, pool.length);
+  final start = offset.clamp(0, end);
+  return pool.sublist(start, end);
+}
+
+/// Lets the Dart event loop process pending microtasks and timer callbacks so that the
+/// TimelineService's bucket-stream subscription (which fires as a microtask from
+/// Stream.value.listen) and its initial assetSource load complete before the caller
+/// interacts with the cache notifier. In production this is never an issue because
+/// addPostFrameCallback fires after the first frame, by which time the subscription
+/// has already settled.
+Future<void> _pumpBucketStream() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+/// Builds a ProviderContainer with a fake TimelineService backed by [pool].
+/// The pool is indexed: asset at position N can be fetched at index N.
+ProviderContainer _containerFor(List<BaseAsset> pool, {List<TimeBucket>? buckets}) {
+  final service = TimelineService((
+    assetSource: (offset, count) async => _indexedAssets(pool, offset, count),
+    bucketSource: () => Stream.value(buckets ?? [TimeBucket(date: DateTime(2025), assetCount: pool.length)]),
+    origin: TimelineOrigin.main,
+  ));
+  final container = ProviderContainer(
+    overrides: [
+      timelineServiceProvider.overrideWithValue(service),
+      timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
+    ],
+  );
+  addTearDown(() async {
+    container.dispose();
+    await service.dispose();
+  });
+  return container;
+}
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // 1. ensure() stores the representative and assetFor() returns it
+  // ---------------------------------------------------------------------------
+  test('ensure stores the representative and assetFor returns it', () async {
+    final asset0 = TestUtils.createRemoteAsset(id: 'asset-0');
+    final pool = [asset0, TestUtils.createRemoteAsset(id: 'asset-1'), TestUtils.createRemoteAsset(id: 'asset-2')];
+    final container = _containerFor(pool);
+    await _pumpBucketStream(); // let bucket subscription settle
+
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    await notifier.ensure('year:2025-01-01T00:00:00.000', 0, pool.length);
+
+    expect(notifier.assetFor('year:2025-01-01T00:00:00.000'), same(asset0));
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Bug guard: cached asset survives buffer movement
+  //    After caching index 0, load far-away index 1000 (slides the buffer away).
+  //    assetFor() must still return the cached asset — it does not re-fetch from
+  //    the current buffer state.
+  // ---------------------------------------------------------------------------
+  test('cached representative survives buffer movement', () async {
+    // Create a large enough pool so both index 0 and index 1000 are valid.
+    final pool = List.generate(1500, (i) => TestUtils.createRemoteAsset(id: 'asset-$i'));
+    final container = _containerFor(pool);
+    await _pumpBucketStream();
+
+    final service = container.read(timelineServiceProvider);
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    final asset0 = pool[0];
+
+    // Resolve representative for index 0.
+    await notifier.ensure('year:2025-01-01T00:00:00.000', 0, pool.length);
+    expect(notifier.assetFor('year:2025-01-01T00:00:00.000'), same(asset0));
+
+    // Move the buffer far away (slides the window off index 0).
+    await service.loadAssets(1000, 1);
+
+    // Cache must still hold the previously resolved asset — independent of buffer state.
+    expect(notifier.assetFor('year:2025-01-01T00:00:00.000'), same(asset0));
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Dedupe: two concurrent ensure() calls issue only one resolve
+  // ---------------------------------------------------------------------------
+  test('concurrent ensure calls deduplicate the resolve', () async {
+    var callCount = 0;
+    final asset = TestUtils.createRemoteAsset(id: 'asset-0');
+    final pool = [asset];
+    final service = TimelineService((
+      assetSource: (offset, count) async {
+        callCount++;
+        return _indexedAssets(pool, offset, count);
+      },
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: pool.length)]),
+      origin: TimelineOrigin.main,
+    ));
+    final container = ProviderContainer(
+      overrides: [
+        timelineServiceProvider.overrideWithValue(service),
+        timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
+      ],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await service.dispose();
+    });
+    await _pumpBucketStream(); // let the initial bucket load complete (callCount=1)
+
+    final countAfterBucketLoad = callCount; // 1 from the initial bucket subscription load
+
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    // First call: key is not in-flight yet → starts resolving.
+    final f1 = notifier.ensure('year:2025-01-01T00:00:00.000', 0, pool.length);
+    // Second call: key is already in-flight → no-op (deduped).
+    final f2 = notifier.ensure('year:2025-01-01T00:00:00.000', 0, pool.length);
+
+    await f1;
+    await f2;
+
+    // Only the original bucket-load callCount plus ONE ensure resolve (not two).
+    // hasRange is true (bucket already loaded), so no extra assetSource call.
+    expect(callCount, countAfterBucketLoad);
+    expect(notifier.assetFor('year:2025-01-01T00:00:00.000'), same(asset));
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Count-change: re-resolves and updates stored assetCount
+  //    (The representative may be the same if the buffer hasn't moved, but the
+  //    assetCount in the stored entry must be updated and the call must not be a no-op.)
+  // ---------------------------------------------------------------------------
+  test('count change triggers re-resolve and updates stored assetCount', () async {
+    var resolveCount = 0;
+    final asset = TestUtils.createRemoteAsset(id: 'the-asset');
+    final pool = [asset];
+    final service = TimelineService((
+      assetSource: (offset, count) async {
+        resolveCount++;
+        return _indexedAssets(pool, offset, count);
+      },
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: pool.length)]),
+      origin: TimelineOrigin.main,
+    ));
+    final container = ProviderContainer(
+      overrides: [
+        timelineServiceProvider.overrideWithValue(service),
+        timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
+      ],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await service.dispose();
+    });
+    await _pumpBucketStream(); // initial bucket load fires (resolveCount=1)
+
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    const key = 'year:2025-01-01T00:00:00.000';
+
+    // Initial resolve with count 9. Buffer is hot so no extra assetSource call.
+    await notifier.ensure(key, 0, 9);
+    final entry9 = container.read(timelineOverviewRepresentativeCacheProvider)[key];
+    expect(entry9?.assetCount, 9);
+    expect(entry9?.asset, same(asset));
+
+    // Same count → no-op.
+    final countBeforeNoOp = resolveCount;
+    await notifier.ensure(key, 0, 9);
+    expect(resolveCount, countBeforeNoOp);
+
+    // Different count → re-resolve; assetCount must be updated.
+    await notifier.ensure(key, 0, 12);
+    final entry12 = container.read(timelineOverviewRepresentativeCacheProvider)[key];
+    expect(entry12?.assetCount, 12);
+    expect(entry12?.asset, same(asset)); // same asset (buffer still has it)
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Key isolation: year:2024 vs month:2024 don't collide
+  // ---------------------------------------------------------------------------
+  test('year and month keys for the same date do not collide', () async {
+    final yearAsset = TestUtils.createRemoteAsset(id: 'year-asset');
+    final monthAsset = TestUtils.createRemoteAsset(id: 'month-asset');
+
+    // Two buckets: year bucket has 1 asset (index 0), month bucket has 1 asset (index 1).
+    final pool = [yearAsset, monthAsset];
+    final container = _containerFor(
+      pool,
+      buckets: [
+        TimeBucket(date: DateTime(2024), assetCount: 1),
+        TimeBucket(date: DateTime(2024, 1), assetCount: 1),
+      ],
+    );
+    await _pumpBucketStream();
+
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    await notifier.ensure('year:2024-01-01T00:00:00.000', 0, 1);
+    await notifier.ensure('month:2024-01-01T00:00:00.000', 1, 1);
+
+    expect(notifier.assetFor('year:2024-01-01T00:00:00.000'), same(yearAsset));
+    expect(notifier.assetFor('month:2024-01-01T00:00:00.000'), same(monthAsset));
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. Invalidation: swapping timelineServiceProvider clears the cache
+  // ---------------------------------------------------------------------------
+  test('cache clears when the service instance changes', () async {
+    final asset = TestUtils.createRemoteAsset(id: 'cached-asset');
+
+    // Use a StateProvider to make the "current service" swappable at runtime.
+    final serviceSwitch = StateProvider<TimelineService?>((ref) => null);
+
+    final service1 = TimelineService((
+      assetSource: (_, _) async => [asset],
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: 1)]),
+      origin: TimelineOrigin.main,
+    ));
+    final service2 = TimelineService((
+      assetSource: (_, _) async => [],
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: 0)]),
+      origin: TimelineOrigin.main,
+    ));
+    addTearDown(() async {
+      await service1.dispose();
+      await service2.dispose();
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        timelineServiceProvider.overrideWith((ref) {
+          final s = ref.watch(serviceSwitch);
+          if (s == null) throw StateError('no service');
+          return s;
+        }),
+        timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // Initialise with service1 and force the provider graph to evaluate.
+    container.read(serviceSwitch.notifier).state = service1;
+    await _pumpBucketStream();
+    container.read(timelineServiceProvider);
+
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    await notifier.ensure('year:2025-01-01T00:00:00.000', 0, 1);
+    expect(notifier.assetFor('year:2025-01-01T00:00:00.000'), same(asset));
+
+    // Swap to a different service instance (simulates a filter change).
+    container.read(serviceSwitch.notifier).state = service2;
+    // Pump microtasks so the Riverpod scheduler re-runs build() (it watches timelineServiceProvider)
+    // and returns the cleared map.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(notifier.assetFor('year:2025-01-01T00:00:00.000'), isNull);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. same count does NOT re-resolve (no-op)
+  // ---------------------------------------------------------------------------
+  test('ensure with unchanged assetCount does not re-resolve', () async {
+    var callCount = 0;
+    final pool = [TestUtils.createRemoteAsset(id: 'once')];
+    final service = TimelineService((
+      assetSource: (offset, count) async {
+        callCount++;
+        return _indexedAssets(pool, offset, count);
+      },
+      bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: pool.length)]),
+      origin: TimelineOrigin.main,
+    ));
+    final container = ProviderContainer(
+      overrides: [
+        timelineServiceProvider.overrideWithValue(service),
+        timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
+      ],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await service.dispose();
+    });
+    await _pumpBucketStream(); // callCount=1 from bucket subscription
+
+    final notifier = container.read(timelineOverviewRepresentativeCacheProvider.notifier);
+    // First ensure: buffer is hot (hasRange=true), no extra assetSource call.
+    await notifier.ensure('year:2025-01-01T00:00:00.000', 0, pool.length);
+    final countAfterFirst = callCount;
+    // Second ensure with same count → no-op.
+    await notifier.ensure('year:2025-01-01T00:00:00.000', 0, pool.length);
+
+    expect(callCount, countAfterFirst); // no extra call
+  });
+}

--- a/mobile/test/providers/timeline/zoom_anchor_provider_test.dart
+++ b/mobile/test/providers/timeline/zoom_anchor_provider_test.dart
@@ -36,4 +36,50 @@ void main() {
     container.read(timelineZoomAnchorProvider.notifier).clear();
     expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
   });
+
+  // lastPositionDate — the remembered position-derived date used by
+  // _onGroupingChanged to survive a coarse→fine round-trip.
+
+  test('lastPositionDate is null before any setDate call', () {
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, isNull);
+  });
+
+  test('setDate updates lastPositionDate', () {
+    final date = DateTime(2026, 6, 9);
+    container.read(timelineZoomAnchorProvider.notifier).setDate(date);
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, date);
+  });
+
+  test('setDate updates both state and lastPositionDate', () {
+    final date = DateTime(2026, 6, 9);
+    container.read(timelineZoomAnchorProvider.notifier).setDate(date);
+    expect(container.read(timelineZoomAnchorProvider), TimelineZoomAnchor.date(date));
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, date);
+  });
+
+  test('clear() resets state to none but does NOT clear lastPositionDate', () {
+    final date = DateTime(2026, 6, 9);
+    container.read(timelineZoomAnchorProvider.notifier).setDate(date);
+    container.read(timelineZoomAnchorProvider.notifier).clear();
+    expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, date);
+  });
+
+  test('second setDate overwrites lastPositionDate', () {
+    final date1 = DateTime(2026, 6, 9);
+    final date2 = DateTime(2026, 3, 1);
+    container.read(timelineZoomAnchorProvider.notifier).setDate(date1);
+    container.read(timelineZoomAnchorProvider.notifier).setDate(date2);
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, date2);
+  });
+
+  test('setYear does not update lastPositionDate', () {
+    container.read(timelineZoomAnchorProvider.notifier).setYear(2025);
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, isNull);
+  });
+
+  test('setMonth does not update lastPositionDate', () {
+    container.read(timelineZoomAnchorProvider.notifier).setMonth(year: 2025, month: 3);
+    expect(container.read(timelineZoomAnchorProvider.notifier).lastPositionDate, isNull);
+  });
 }


### PR DESCRIPTION
Two independent mobile timeline overview bugs (observed on-device), implemented as two TDD slices, each spec- and code-quality-reviewed plus a final holistic review. Mobile-only; orthogonal to #679.

Spec: `docs/superpowers/specs/2026-06-09-timeline-overview-flicker-and-roundtrip-design.md`.

## Bug A — Years/Months cover thumbnails flicker on first load

In the Years/Months overview, cover thumbnails flickered while loading: a card's image loaded, dropped back to the gray fallback, then the next loaded and grayed in turn — a top-to-bottom cascade. Reproduced on Photos, albums, and shared spaces.

**Root cause:** each card pulled its cover by global index (`firstAssetIndex`) from the `TimelineService`'s single 1024-asset sliding buffer, recreating a `FutureBuilder` every build with no memoization. Year/month representatives sit at widely-spread indices, so each card's load evicted the others from the one buffer window; every `TimelineReloadEvent → setState` rebuild re-pulled → the evicted cards rendered the gray fallback.

**Fix:** a route-scoped `timelineOverviewRepresentativeCacheProvider` memoizes each bucket's resolved representative (keyed by grouping + bucket date). The card renders exclusively from the cache (`ref.watch(select(...))`) and schedules a post-frame `ensure()` that resolves once (sync via `hasRange`, else `loadAssets`), dedupes in-flight, and is dropped if the service changed mid-resolve (generation guard). The cache resets via a `ref.watch(timelineServiceProvider)`-driven rebuild on filter/scope/grouping change — never an imperative mutation during build. Covers now survive rebuilds and buffer movement → no cascade.

## Bug B — All→Months→All jumps to the 1st of the month

At the top of "All" showing 9 Jun, switching to Months and back (without tapping a month) landed on **1 Jun** instead of 9 Jun.

**Root cause:** `_onGroupingChanged` anchored to the top bucket's date, and a month bucket's date is truncated to the 1st — so the day precision was lost on the round trip.

**Fix:** a pure `resolveGroupingChangeAnchorDate` helper keeps the finer remembered date (`lastPositionDate`, set by `setDate`, surviving anchor consumption) when it still falls inside the top bucket's period; otherwise it uses the bucket date (the user scrolled). Preserves 9 Jun across All→Months→Years→Months→All; scrolling to another month in between still re-anchors there; card-tap drill-down is untouched (explicit-anchor guard).

## Test plan

- Bug A: cache-provider unit tests (store/read, **buffer-eviction survival** guard, dedupe, count-change, key isolation, **service-instance invalidation**) + overview card widget tests (cached → image even when buffer moved; uncached → fallback then resolves; zero-count schedules nothing).
- Bug B: pure-function tests (within/outside month + year, day/auto/none, null) + a **round-trip widget regression guard** (day→month→day returns to 9 Jun, RED before the fix).
- ✅ Full mobile suite (1689 passed), `dart analyze --fatal-infos lib test` clean, format clean.

On-device validation: cold-open Years/Months on Photos/album/space (covers fill in once, no gray cascade); All@top → Months → All returns to the same day.
