### PR TITLE
fix(web): route person menu writes for shared-space people to the space endpoint

### DIFF
--- a/e2e/src/specs/web/shared-space-person-profile.e2e-spec.ts
+++ b/e2e/src/specs/web/shared-space-person-profile.e2e-spec.ts
@@ -1,0 +1,99 @@
+import type { LoginResponseDto } from '@immich/sdk';
+import { SharedSpaceRole } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import { asBearerAuth, utils } from 'src/utils';
+
+// A space member's main People view shows shared_space_person profiles; person edits
+// from there must hit the shared-space endpoints (PUT /shared-spaces/:id/people/:personId),
+// not person.update, which only knows the person table.
+test.describe('Shared space person in the main People view', () => {
+  let editorLogin: LoginResponseDto;
+  let viewerLogin: LoginResponseDto;
+  let spaceId: string;
+  let spacePersonId: string;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    const admin = await utils.adminSetup();
+    const db = await utils.connectDatabase();
+
+    editorLogin = await utils.userSetup(admin.accessToken, {
+      email: 'space-editor@test.com',
+      name: 'Space Editor',
+      password: 'password',
+    });
+    viewerLogin = await utils.userSetup(admin.accessToken, {
+      email: 'space-viewer@test.com',
+      name: 'Space Viewer',
+      password: 'password',
+    });
+
+    const space = await utils.createSpace(admin.accessToken, { name: 'Family Space' });
+    spaceId = space.id;
+    await utils.addSpaceMember(admin.accessToken, space.id, {
+      userId: editorLogin.userId,
+      role: SharedSpaceRole.Editor,
+    });
+    await utils.addSpaceMember(admin.accessToken, space.id, {
+      userId: viewerLogin.userId,
+      role: SharedSpaceRole.Viewer,
+    });
+
+    const asset = await utils.createAsset(admin.accessToken);
+    await utils.addSpaceAssets(admin.accessToken, space.id, [asset.id]);
+
+    // createFace wires the face identity (face_identity + face_identity_face + person.identityId);
+    // the shared_space_person must join the same identity for members to see it under /people.
+    const person = await utils.createPerson(admin.accessToken, { name: 'Grandma' });
+    const faceId = await utils.createFace({ assetId: asset.id, personId: person.id });
+    const identityResult = await db.query(`SELECT "identityId" FROM "person" WHERE id = $1`, [person.id]);
+    const identityId = identityResult.rows[0].identityId as string;
+
+    const spacePersonResult = await db.query(
+      `INSERT INTO "shared_space_person"
+         ("spaceId", name, "isHidden", "faceCount", "assetCount", "representativeFaceId", "identityId", "type")
+       VALUES ($1, 'Grandma', false, 1, 1, $2, $3, 'person')
+       RETURNING id`,
+      [space.id, faceId, identityId],
+    );
+    spacePersonId = spacePersonResult.rows[0].id as string;
+    await db.query(`INSERT INTO "shared_space_person_face" ("personId", "assetFaceId") VALUES ($1, $2)`, [
+      spacePersonId,
+      faceId,
+    ]);
+  });
+
+  test('a space editor sets a birthday from the global person profile', async ({ context, page }) => {
+    await utils.setAuthCookies(context, editorLogin.accessToken);
+    await page.goto(`/people/${spacePersonId}`);
+    await expect(page.getByText('Grandma')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open', exact: true }).click();
+    await page.getByText('Set date of birth').click();
+    await page.locator('input[name="birthDate"]').fill('1953-04-12');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // The modal only closes when the save succeeds.
+    await expect(page.locator('input[name="birthDate"]')).toHaveCount(0);
+    await expect(page.getByText(/Born on/)).toBeVisible();
+
+    // The write landed on the shared space person, not the person table.
+    const response = await page.request.get(`/api/shared-spaces/${spaceId}/people/${spacePersonId}`, {
+      headers: asBearerAuth(editorLogin.accessToken),
+    });
+    expect(response.ok()).toBe(true);
+    expect(await response.json()).toMatchObject({ id: spacePersonId, birthDate: '1953-04-12' });
+  });
+
+  test('a space viewer is not offered person write actions', async ({ context, page }) => {
+    await utils.setAuthCookies(context, viewerLogin.accessToken);
+    await page.goto(`/people/${spacePersonId}`);
+    await expect(page.getByText('Grandma')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open', exact: true }).click();
+    await expect(page.getByText('Merge people')).toBeVisible();
+    await expect(page.getByText('Set date of birth')).toHaveCount(0);
+    await expect(page.getByText('Hide person')).toHaveCount(0);
+  });
+});

--- a/web/src/lib/services/person.service.spec.ts
+++ b/web/src/lib/services/person.service.spec.ts
@@ -1,0 +1,127 @@
+import { eventManager } from '$lib/managers/event-manager.svelte';
+import * as handleErrorModule from '$lib/utils/handle-error';
+import {
+  RepresentativeFaceSource,
+  Type,
+  updatePerson,
+  updateSpacePerson,
+  type SharedSpacePersonResponseDto,
+} from '@immich/sdk';
+import { toastManager } from '@immich/ui';
+import { personFactory } from '@test-data/factories/person-factory';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleUpdatePersonBirthDate } from './person.service';
+
+vi.mock('@immich/ui', async (orig) => {
+  const actual = await orig<typeof import('@immich/ui')>();
+  return {
+    ...actual,
+    toastManager: { primary: vi.fn(), danger: vi.fn(), warning: vi.fn(), success: vi.fn(), info: vi.fn() },
+  };
+});
+
+vi.mock('@immich/sdk', async (orig) => ({
+  ...(await orig<typeof import('@immich/sdk')>()),
+  updatePerson: vi.fn(),
+  updateSpacePerson: vi.fn(),
+}));
+
+const spacePersonResponse = (overrides: Partial<SharedSpacePersonResponseDto>): SharedSpacePersonResponseDto => ({
+  id: 'space-person-1',
+  spaceId: 'space-1',
+  name: 'Grandma',
+  thumbnailPath: '',
+  isHidden: false,
+  birthDate: null,
+  representativeFaceSource: RepresentativeFaceSource.Auto,
+  faceCount: 3,
+  assetCount: 10,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+  ...overrides,
+});
+
+let handleErrorSpy: ReturnType<typeof vi.spyOn>;
+let emitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  handleErrorSpy = vi.spyOn(handleErrorModule, 'handleError').mockImplementation(() => {});
+  emitSpy = vi.spyOn(eventManager, 'emit');
+});
+
+afterEach(() => {
+  handleErrorSpy.mockRestore();
+  emitSpy.mockRestore();
+});
+
+describe('handleUpdatePersonBirthDate', () => {
+  it('routes the birthday write to the shared space endpoint for a space-scoped person', async () => {
+    const person = personFactory.build({
+      id: 'space-person-1',
+      birthDate: null,
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    vi.mocked(updateSpacePerson).mockResolvedValue(spacePersonResponse({ birthDate: '1990-06-15' }));
+
+    await expect(handleUpdatePersonBirthDate(person, '1990-06-15')).resolves.toBe(true);
+
+    expect(updateSpacePerson).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'space-person-1',
+      sharedSpacePersonUpdateDto: { birthDate: '1990-06-15' },
+    });
+    expect(updatePerson).not.toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith(
+      'PersonUpdate',
+      expect.objectContaining({ id: person.id, name: person.name, birthDate: '1990-06-15' }),
+    );
+    expect(toastManager.primary).toHaveBeenCalledOnce();
+  });
+
+  it('clears the birthday of a space-scoped person', async () => {
+    const person = personFactory.build({
+      id: 'space-person-1',
+      birthDate: '1990-06-15',
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    vi.mocked(updateSpacePerson).mockResolvedValue(spacePersonResponse({ birthDate: null }));
+
+    await expect(handleUpdatePersonBirthDate(person, '')).resolves.toBe(true);
+
+    expect(updateSpacePerson).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'space-person-1',
+      sharedSpacePersonUpdateDto: { birthDate: '' },
+    });
+    expect(emitSpy).toHaveBeenCalledWith('PersonUpdate', expect.objectContaining({ id: person.id, birthDate: null }));
+  });
+
+  it('keeps using the person endpoint for an owned person', async () => {
+    const person = personFactory.build({
+      primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+    });
+    const updated = { ...person, birthDate: '1990-06-15' };
+    vi.mocked(updatePerson).mockResolvedValue(updated);
+
+    await expect(handleUpdatePersonBirthDate(person, '1990-06-15')).resolves.toBe(true);
+
+    expect(updatePerson).toHaveBeenCalledWith({ id: person.id, personUpdateDto: { birthDate: '1990-06-15' } });
+    expect(updateSpacePerson).not.toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith('PersonUpdate', updated);
+  });
+
+  it('handles failures from the shared space endpoint without emitting updates', async () => {
+    const person = personFactory.build({
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    const error = new Error('no access');
+    vi.mocked(updateSpacePerson).mockRejectedValue(error);
+
+    await expect(handleUpdatePersonBirthDate(person, '1990-06-15')).resolves.toBeUndefined();
+
+    expect(handleErrorSpy).toHaveBeenCalledWith(error, expect.any(String));
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(toastManager.primary).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/services/person.service.spec.ts
+++ b/web/src/lib/services/person.service.spec.ts
@@ -1,17 +1,34 @@
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import * as handleErrorModule from '$lib/utils/handle-error';
 import {
+  getMembers,
+  getPersonFaces,
+  getSpacePersonFaces,
   RepresentativeFaceSource,
+  SharedSpaceRole,
   Type,
   updatePerson,
+  updateRepresentativeFace,
   updateSpacePerson,
+  updateSpacePersonRepresentativeFace,
+  type PersonFacePageResponseDto,
+  type SharedSpaceMemberResponseDto,
   type SharedSpacePersonResponseDto,
 } from '@immich/sdk';
 import { toastManager } from '@immich/ui';
 import { personFactory } from '@test-data/factories/person-factory';
 import type { MessageFormatter } from 'svelte-i18n';
+import { getPersonFaceThumbnailUrl, getSpacePersonFaceThumbnailUrl } from '$lib/utils/people-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getPersonActions, handleUpdatePersonBirthDate } from './person.service';
+import {
+  getPersonActions,
+  getPersonFacesPage,
+  getPersonFaceThumbnail,
+  handleUpdatePersonBirthDate,
+  isSpaceEditor,
+  updatePersonName,
+  updatePersonRepresentativeFace,
+} from './person.service';
 
 vi.mock('@immich/ui', async (orig) => {
   const actual = await orig<typeof import('@immich/ui')>();
@@ -23,8 +40,13 @@ vi.mock('@immich/ui', async (orig) => {
 
 vi.mock('@immich/sdk', async (orig) => ({
   ...(await orig<typeof import('@immich/sdk')>()),
+  getMembers: vi.fn(),
+  getPersonFaces: vi.fn(),
+  getSpacePersonFaces: vi.fn(),
   updatePerson: vi.fn(),
+  updateRepresentativeFace: vi.fn(),
   updateSpacePerson: vi.fn(),
+  updateSpacePersonRepresentativeFace: vi.fn(),
 }));
 
 const spacePersonResponse = (overrides: Partial<SharedSpacePersonResponseDto>): SharedSpacePersonResponseDto => ({
@@ -186,6 +208,22 @@ describe('getPersonActions', () => {
     expect(emitSpy).toHaveBeenCalledWith('PersonUpdate', updated);
   });
 
+  it('handles failures when hiding a space-scoped person without emitting updates', async () => {
+    const person = personFactory.build({
+      isHidden: false,
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    const error = new Error('no access');
+    vi.mocked(updateSpacePerson).mockRejectedValue(error);
+
+    const { HidePerson } = getPersonActions($t, person);
+    await HidePerson.onAction(HidePerson);
+
+    expect(handleErrorSpy).toHaveBeenCalledWith(error, expect.any(String));
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(toastManager.primary).not.toHaveBeenCalled();
+  });
+
   it('does not offer favorite actions for a space-scoped person', () => {
     const person = personFactory.build({
       isFavorite: undefined,
@@ -207,5 +245,203 @@ describe('getPersonActions', () => {
     const { Favorite } = getPersonActions($t, person);
 
     expect(Favorite.$if?.()).toBe(true);
+  });
+});
+
+describe('isSpaceEditor', () => {
+  const member = (userId: string, role: SharedSpaceRole): SharedSpaceMemberResponseDto => ({
+    userId,
+    role,
+    email: `${userId}@test.dev`,
+    name: userId,
+    joinedAt: '2026-01-01T00:00:00Z',
+    sharePersonMetadata: true,
+    showInTimeline: true,
+  });
+
+  it('returns true for editors and owners', async () => {
+    vi.mocked(getMembers).mockResolvedValue([member('user-1', SharedSpaceRole.Editor)]);
+    await expect(isSpaceEditor('editor-space', 'user-1')).resolves.toBe(true);
+
+    vi.mocked(getMembers).mockResolvedValue([member('user-1', SharedSpaceRole.Owner)]);
+    await expect(isSpaceEditor('owner-space', 'user-1')).resolves.toBe(true);
+  });
+
+  it('returns false for viewers', async () => {
+    vi.mocked(getMembers).mockResolvedValue([
+      member('someone-else', SharedSpaceRole.Owner),
+      member('user-1', SharedSpaceRole.Viewer),
+    ]);
+
+    await expect(isSpaceEditor('viewer-space', 'user-1')).resolves.toBe(false);
+
+    expect(getMembers).toHaveBeenCalledWith({ id: 'viewer-space' });
+  });
+
+  it('fails open when the membership cannot be loaded', async () => {
+    vi.mocked(getMembers).mockRejectedValue(new Error('network'));
+
+    await expect(isSpaceEditor('unreachable-space', 'user-1')).resolves.toBe(true);
+  });
+
+  it('caches the result per space', async () => {
+    vi.mocked(getMembers).mockResolvedValue([member('user-1', SharedSpaceRole.Viewer)]);
+
+    await expect(isSpaceEditor('cached-space', 'user-1')).resolves.toBe(false);
+    await expect(isSpaceEditor('cached-space', 'user-1')).resolves.toBe(false);
+
+    expect(getMembers).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getPersonActions viewer gating', () => {
+  const $t = ((key: string) => key) as unknown as MessageFormatter;
+  const spaceProfile = { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' };
+
+  it('hides write actions for a space-scoped person when the user cannot edit', () => {
+    const visible = personFactory.build({ isHidden: false, primaryProfile: spaceProfile });
+    const hidden = personFactory.build({ isHidden: true, primaryProfile: spaceProfile });
+
+    const { SetDateOfBirth, HidePerson } = getPersonActions($t, visible, { canEditSpacePerson: false });
+    const { ShowPerson } = getPersonActions($t, hidden, { canEditSpacePerson: false });
+
+    expect(SetDateOfBirth.$if?.()).toBe(false);
+    expect(HidePerson.$if?.()).toBe(false);
+    expect(ShowPerson.$if?.()).toBe(false);
+  });
+
+  it('offers write actions for a space-scoped person by default', () => {
+    const person = personFactory.build({ isHidden: false, primaryProfile: spaceProfile });
+
+    const { SetDateOfBirth, HidePerson } = getPersonActions($t, person);
+
+    expect(SetDateOfBirth.$if?.()).not.toBe(false);
+    expect(HidePerson.$if?.()).toBe(true);
+  });
+
+  it('keeps write actions for an owned person regardless of the flag', () => {
+    const person = personFactory.build({
+      isHidden: false,
+      primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+    });
+
+    const { SetDateOfBirth, HidePerson } = getPersonActions($t, person, { canEditSpacePerson: false });
+
+    expect(SetDateOfBirth.$if?.()).not.toBe(false);
+    expect(HidePerson.$if?.()).toBe(true);
+  });
+});
+
+describe('representative face routing', () => {
+  const spaceScopedPerson = (overrides: Parameters<typeof personFactory.build>[0] = {}) =>
+    personFactory.build({
+      id: 'space-person-1',
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+      ...overrides,
+    });
+  const facesPage: PersonFacePageResponseDto = { faces: [], hasNextPage: false };
+
+  it('loads faces of a space-scoped person from the shared space endpoint', async () => {
+    vi.mocked(getSpacePersonFaces).mockResolvedValue(facesPage);
+
+    await expect(getPersonFacesPage(spaceScopedPerson(), { page: 2, size: 50 })).resolves.toEqual(facesPage);
+
+    expect(getSpacePersonFaces).toHaveBeenCalledWith({ id: 'space-1', personId: 'space-person-1', page: 2, size: 50 });
+    expect(getPersonFaces).not.toHaveBeenCalled();
+  });
+
+  it('loads faces of an owned person from the person endpoint', async () => {
+    const person = personFactory.build({ primaryProfile: { type: Type.UserPerson, id: 'person-1' } });
+    vi.mocked(getPersonFaces).mockResolvedValue(facesPage);
+
+    await expect(getPersonFacesPage(person, { page: 1, size: 20 })).resolves.toEqual(facesPage);
+
+    expect(getPersonFaces).toHaveBeenCalledWith({ id: person.id, page: 1, size: 20 });
+    expect(getSpacePersonFaces).not.toHaveBeenCalled();
+  });
+
+  it('updates the representative face of a space-scoped person via the shared space endpoint', async () => {
+    const person = spaceScopedPerson();
+    vi.mocked(updateSpacePersonRepresentativeFace).mockResolvedValue(
+      spacePersonResponse({ updatedAt: '2026-02-01T00:00:00Z' }),
+    );
+
+    const result = await updatePersonRepresentativeFace(person, 'face-1');
+
+    expect(updateSpacePersonRepresentativeFace).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'space-person-1',
+      spaceRepresentativeFaceUpdateDto: { assetFaceId: 'face-1' },
+    });
+    expect(updateRepresentativeFace).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ id: person.id, updatedAt: '2026-02-01T00:00:00Z' }));
+  });
+
+  it('updates the representative face of an owned person via the person endpoint', async () => {
+    const person = personFactory.build({ primaryProfile: { type: Type.UserPerson, id: 'person-1' } });
+    const updated = { ...person, updatedAt: '2026-02-01T00:00:00Z' };
+    vi.mocked(updateRepresentativeFace).mockResolvedValue(updated);
+
+    await expect(updatePersonRepresentativeFace(person, 'face-1')).resolves.toEqual(updated);
+
+    expect(updateRepresentativeFace).toHaveBeenCalledWith({
+      id: person.id,
+      representativeFaceUpdateDto: { assetFaceId: 'face-1' },
+    });
+    expect(updateSpacePersonRepresentativeFace).not.toHaveBeenCalled();
+  });
+
+  it('builds face thumbnail URLs for space-scoped and owned people', () => {
+    const spacePerson = spaceScopedPerson();
+    const ownedPerson = personFactory.build({ primaryProfile: { type: Type.UserPerson, id: 'person-1' } });
+
+    expect(getPersonFaceThumbnail(spacePerson, 'face-1')).toBe(
+      getSpacePersonFaceThumbnailUrl('space-1', 'space-person-1', 'face-1', spacePerson.updatedAt),
+    );
+    expect(getPersonFaceThumbnail(ownedPerson, 'face-2')).toBe(
+      getPersonFaceThumbnailUrl(ownedPerson.id, 'face-2', ownedPerson.updatedAt),
+    );
+  });
+});
+
+describe('updatePersonName', () => {
+  it('routes renames of a space-scoped person to the shared space endpoint', async () => {
+    const person = personFactory.build({
+      id: 'space-person-1',
+      name: 'Old Name',
+      numberOfAssets: 5,
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    vi.mocked(updateSpacePerson).mockResolvedValue(spacePersonResponse({ name: 'New Name', assetCount: 12 }));
+
+    const updated = await updatePersonName(person, 'New Name');
+
+    expect(updateSpacePerson).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'space-person-1',
+      sharedSpacePersonUpdateDto: { name: 'New Name' },
+    });
+    expect(updatePerson).not.toHaveBeenCalled();
+    expect(updated).toEqual(
+      expect.objectContaining({
+        id: person.id,
+        name: 'New Name',
+        numberOfAssets: 12,
+        updatedAt: '2026-01-02T00:00:00Z',
+      }),
+    );
+  });
+
+  it('keeps renames of an owned person on the person endpoint', async () => {
+    const person = personFactory.build({
+      primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+    });
+    const response = { ...person, name: 'New Name' };
+    vi.mocked(updatePerson).mockResolvedValue(response);
+
+    await expect(updatePersonName(person, 'New Name')).resolves.toEqual(response);
+
+    expect(updatePerson).toHaveBeenCalledWith({ id: person.id, personUpdateDto: { name: 'New Name' } });
+    expect(updateSpacePerson).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/services/person.service.spec.ts
+++ b/web/src/lib/services/person.service.spec.ts
@@ -9,8 +9,9 @@ import {
 } from '@immich/sdk';
 import { toastManager } from '@immich/ui';
 import { personFactory } from '@test-data/factories/person-factory';
+import type { MessageFormatter } from 'svelte-i18n';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { handleUpdatePersonBirthDate } from './person.service';
+import { getPersonActions, handleUpdatePersonBirthDate } from './person.service';
 
 vi.mock('@immich/ui', async (orig) => {
   const actual = await orig<typeof import('@immich/ui')>();
@@ -123,5 +124,88 @@ describe('handleUpdatePersonBirthDate', () => {
     expect(handleErrorSpy).toHaveBeenCalledWith(error, expect.any(String));
     expect(emitSpy).not.toHaveBeenCalled();
     expect(toastManager.primary).not.toHaveBeenCalled();
+  });
+});
+
+describe('getPersonActions', () => {
+  const $t = ((key: string) => key) as unknown as MessageFormatter;
+
+  it('routes hiding a space-scoped person to the shared space endpoint', async () => {
+    const person = personFactory.build({
+      id: 'space-person-1',
+      isHidden: false,
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    vi.mocked(updateSpacePerson).mockResolvedValue(spacePersonResponse({ isHidden: true }));
+
+    const { HidePerson } = getPersonActions($t, person);
+    await HidePerson.onAction(HidePerson);
+
+    expect(updateSpacePerson).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'space-person-1',
+      sharedSpacePersonUpdateDto: { isHidden: true },
+    });
+    expect(updatePerson).not.toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith('PersonUpdate', expect.objectContaining({ id: person.id, isHidden: true }));
+    expect(toastManager.primary).toHaveBeenCalledOnce();
+  });
+
+  it('routes unhiding a space-scoped person to the shared space endpoint', async () => {
+    const person = personFactory.build({
+      id: 'space-person-1',
+      isHidden: true,
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+    vi.mocked(updateSpacePerson).mockResolvedValue(spacePersonResponse({ isHidden: false }));
+
+    const { ShowPerson } = getPersonActions($t, person);
+    await ShowPerson.onAction(ShowPerson);
+
+    expect(updateSpacePerson).toHaveBeenCalledWith({
+      id: 'space-1',
+      personId: 'space-person-1',
+      sharedSpacePersonUpdateDto: { isHidden: false },
+    });
+    expect(emitSpy).toHaveBeenCalledWith('PersonUpdate', expect.objectContaining({ id: person.id, isHidden: false }));
+  });
+
+  it('keeps hiding an owned person on the person endpoint', async () => {
+    const person = personFactory.build({
+      isHidden: false,
+      primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+    });
+    const updated = { ...person, isHidden: true };
+    vi.mocked(updatePerson).mockResolvedValue(updated);
+
+    const { HidePerson } = getPersonActions($t, person);
+    await HidePerson.onAction(HidePerson);
+
+    expect(updatePerson).toHaveBeenCalledWith({ id: person.id, personUpdateDto: { isHidden: true } });
+    expect(updateSpacePerson).not.toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith('PersonUpdate', updated);
+  });
+
+  it('does not offer favorite actions for a space-scoped person', () => {
+    const person = personFactory.build({
+      isFavorite: undefined,
+      primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+    });
+
+    const { Favorite, Unfavorite } = getPersonActions($t, person);
+
+    expect(Favorite.$if?.()).toBe(false);
+    expect(Unfavorite.$if?.()).toBe(false);
+  });
+
+  it('offers favorite actions for an owned person', () => {
+    const person = personFactory.build({
+      isFavorite: false,
+      primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+    });
+
+    const { Favorite } = getPersonActions($t, person);
+
+    expect(Favorite.$if?.()).toBe(true);
   });
 });

--- a/web/src/lib/services/person.service.spec.ts
+++ b/web/src/lib/services/person.service.spec.ts
@@ -1,5 +1,6 @@
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import * as handleErrorModule from '$lib/utils/handle-error';
+import { getPersonFaceThumbnailUrl, getSpacePersonFaceThumbnailUrl } from '$lib/utils/people-utils';
 import {
   getMembers,
   getPersonFaces,
@@ -18,7 +19,6 @@ import {
 import { toastManager } from '@immich/ui';
 import { personFactory } from '@test-data/factories/person-factory';
 import type { MessageFormatter } from 'svelte-i18n';
-import { getPersonFaceThumbnailUrl, getSpacePersonFaceThumbnailUrl } from '$lib/utils/people-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getPersonActions,

--- a/web/src/lib/services/person.service.ts
+++ b/web/src/lib/services/person.service.ts
@@ -2,7 +2,7 @@ import { eventManager } from '$lib/managers/event-manager.svelte';
 import PersonEditBirthDateModal from '$lib/modals/PersonEditBirthDateModal.svelte';
 import { handleError } from '$lib/utils/handle-error';
 import { getFormatter } from '$lib/utils/i18n';
-import { updatePerson, type PersonResponseDto } from '@immich/sdk';
+import { Type, updatePerson, updateSpacePerson, type PersonResponseDto } from '@immich/sdk';
 import { modalManager, toastManager, type ActionItem } from '@immich/ui';
 import {
   mdiCalendarEditOutline,
@@ -103,7 +103,18 @@ export const handleUpdatePersonBirthDate = async (person: PersonResponseDto, bir
   const $t = await getFormatter();
 
   try {
-    const response = await updatePerson({ id: person.id, personUpdateDto: { birthDate } });
+    const profile = person.primaryProfile;
+    let response: PersonResponseDto;
+    if (profile?.type === Type.SpacePerson && profile.spaceId) {
+      const updated = await updateSpacePerson({
+        id: profile.spaceId,
+        personId: profile.id,
+        sharedSpacePersonUpdateDto: { birthDate },
+      });
+      response = { ...person, birthDate: updated.birthDate ?? null };
+    } else {
+      response = await updatePerson({ id: person.id, personUpdateDto: { birthDate } });
+    }
     toastManager.primary($t('date_of_birth_saved'));
     eventManager.emit('PersonUpdate', response);
     return true;

--- a/web/src/lib/services/person.service.ts
+++ b/web/src/lib/services/person.service.ts
@@ -13,6 +13,15 @@ import {
 } from '@mdi/js';
 import type { MessageFormatter } from 'svelte-i18n';
 
+// Members of a shared space see space-scoped people whose IDs do not exist in the person table;
+// writes for those must go to the shared space endpoint instead of person.update.
+const getSpaceProfile = (person: PersonResponseDto) => {
+  const profile = person.primaryProfile;
+  return profile?.type === Type.SpacePerson && profile.spaceId
+    ? { id: profile.id, spaceId: profile.spaceId }
+    : undefined;
+};
+
 export const getPersonActions = ($t: MessageFormatter, person: PersonResponseDto) => {
   const SetDateOfBirth: ActionItem = {
     title: $t('set_date_of_birth'),
@@ -20,17 +29,18 @@ export const getPersonActions = ($t: MessageFormatter, person: PersonResponseDto
     onAction: () => modalManager.show(PersonEditBirthDateModal, { person }),
   };
 
+  // Shared space people have no favorite state, so don't offer it for them.
   const Favorite: ActionItem = {
     title: $t('to_favorite'),
     icon: mdiHeartOutline,
-    $if: () => !person.isFavorite,
+    $if: () => !getSpaceProfile(person) && !person.isFavorite,
     onAction: () => handleFavoritePerson(person),
   };
 
   const Unfavorite: ActionItem = {
     title: $t('unfavorite'),
     icon: mdiHeartMinusOutline,
-    $if: () => !!person.isFavorite,
+    $if: () => !getSpaceProfile(person) && !!person.isFavorite,
     onAction: () => handleUnfavoritePerson(person),
   };
 
@@ -75,11 +85,24 @@ const handleUnfavoritePerson = async (person: { id: string }) => {
   }
 };
 
-const handleHidePerson = async (person: { id: string }) => {
+const updatePersonVisibility = async (person: PersonResponseDto, isHidden: boolean): Promise<PersonResponseDto> => {
+  const profile = getSpaceProfile(person);
+  if (profile) {
+    const updated = await updateSpacePerson({
+      id: profile.spaceId,
+      personId: profile.id,
+      sharedSpacePersonUpdateDto: { isHidden },
+    });
+    return { ...person, isHidden: updated.isHidden };
+  }
+  return updatePerson({ id: person.id, personUpdateDto: { isHidden } });
+};
+
+const handleHidePerson = async (person: PersonResponseDto) => {
   const $t = await getFormatter();
 
   try {
-    const response = await updatePerson({ id: person.id, personUpdateDto: { isHidden: true } });
+    const response = await updatePersonVisibility(person, true);
     toastManager.primary($t('changed_visibility_successfully'));
     eventManager.emit('PersonUpdate', response);
   } catch (error) {
@@ -87,11 +110,11 @@ const handleHidePerson = async (person: { id: string }) => {
   }
 };
 
-const handleShowPerson = async (person: { id: string }) => {
+const handleShowPerson = async (person: PersonResponseDto) => {
   const $t = await getFormatter();
 
   try {
-    const response = await updatePerson({ id: person.id, personUpdateDto: { isHidden: false } });
+    const response = await updatePersonVisibility(person, false);
     toastManager.primary($t('changed_visibility_successfully'));
     eventManager.emit('PersonUpdate', response);
   } catch (error) {
@@ -103,9 +126,9 @@ export const handleUpdatePersonBirthDate = async (person: PersonResponseDto, bir
   const $t = await getFormatter();
 
   try {
-    const profile = person.primaryProfile;
+    const profile = getSpaceProfile(person);
     let response: PersonResponseDto;
-    if (profile?.type === Type.SpacePerson && profile.spaceId) {
+    if (profile) {
       const updated = await updateSpacePerson({
         id: profile.spaceId,
         personId: profile.id,

--- a/web/src/lib/services/person.service.ts
+++ b/web/src/lib/services/person.service.ts
@@ -2,7 +2,20 @@ import { eventManager } from '$lib/managers/event-manager.svelte';
 import PersonEditBirthDateModal from '$lib/modals/PersonEditBirthDateModal.svelte';
 import { handleError } from '$lib/utils/handle-error';
 import { getFormatter } from '$lib/utils/i18n';
-import { Type, updatePerson, updateSpacePerson, type PersonResponseDto } from '@immich/sdk';
+import { getPersonFaceThumbnailUrl, getSpacePersonFaceThumbnailUrl } from '$lib/utils/people-utils';
+import {
+  getMembers,
+  getPersonFaces,
+  getSpacePersonFaces,
+  SharedSpaceRole,
+  Type,
+  updatePerson,
+  updateRepresentativeFace,
+  updateSpacePerson,
+  updateSpacePersonRepresentativeFace,
+  type PersonFacePageResponseDto,
+  type PersonResponseDto,
+} from '@immich/sdk';
 import { modalManager, toastManager, type ActionItem } from '@immich/ui';
 import {
   mdiCalendarEditOutline,
@@ -22,10 +35,41 @@ const getSpaceProfile = (person: PersonResponseDto) => {
     : undefined;
 };
 
-export const getPersonActions = ($t: MessageFormatter, person: PersonResponseDto) => {
+// Resolved per space and cached for the session; the server enforces the role on every
+// write, so membership lookup failures fail open instead of hiding working actions.
+const spaceEditableCache = new Map<string, Promise<boolean>>();
+
+const resolveSpaceEditable = async (spaceId: string, userId: string): Promise<boolean> => {
+  try {
+    const members = await getMembers({ id: spaceId });
+    const role = members.find((member) => member.userId === userId)?.role;
+    return role === SharedSpaceRole.Owner || role === SharedSpaceRole.Editor;
+  } catch {
+    return true;
+  }
+};
+
+export const isSpaceEditor = (spaceId: string, userId: string): Promise<boolean> => {
+  const key = `${spaceId}:${userId}`;
+  let cached = spaceEditableCache.get(key);
+  if (!cached) {
+    cached = resolveSpaceEditable(spaceId, userId);
+    spaceEditableCache.set(key, cached);
+  }
+  return cached;
+};
+
+export const getPersonActions = (
+  $t: MessageFormatter,
+  person: PersonResponseDto,
+  { canEditSpacePerson = true }: { canEditSpacePerson?: boolean } = {},
+) => {
+  const canWrite = () => !getSpaceProfile(person) || canEditSpacePerson;
+
   const SetDateOfBirth: ActionItem = {
     title: $t('set_date_of_birth'),
     icon: mdiCalendarEditOutline,
+    $if: canWrite,
     onAction: () => modalManager.show(PersonEditBirthDateModal, { person }),
   };
 
@@ -47,14 +91,14 @@ export const getPersonActions = ($t: MessageFormatter, person: PersonResponseDto
   const HidePerson: ActionItem = {
     title: $t('hide_person'),
     icon: mdiEyeOffOutline,
-    $if: () => !person.isHidden,
+    $if: () => !person.isHidden && canWrite(),
     onAction: () => handleHidePerson(person),
   };
 
   const ShowPerson: ActionItem = {
     title: $t('unhide_person'),
     icon: mdiEyeOutline,
-    $if: () => !!person.isHidden,
+    $if: () => !!person.isHidden && canWrite(),
     onAction: () => handleShowPerson(person),
   };
 
@@ -120,6 +164,60 @@ const handleShowPerson = async (person: PersonResponseDto) => {
   } catch (error) {
     handleError(error, $t('errors.something_went_wrong'));
   }
+};
+
+export const getPersonFacesPage = (
+  person: PersonResponseDto,
+  { page, size }: { page: number; size: number },
+): Promise<PersonFacePageResponseDto> => {
+  const profile = getSpaceProfile(person);
+  return profile
+    ? getSpacePersonFaces({ id: profile.spaceId, personId: profile.id, page, size })
+    : getPersonFaces({ id: person.id, page, size });
+};
+
+export const updatePersonRepresentativeFace = async (
+  person: PersonResponseDto,
+  assetFaceId: string,
+): Promise<PersonResponseDto> => {
+  const profile = getSpaceProfile(person);
+  if (profile) {
+    const updated = await updateSpacePersonRepresentativeFace({
+      id: profile.spaceId,
+      personId: profile.id,
+      spaceRepresentativeFaceUpdateDto: { assetFaceId },
+    });
+    return { ...person, updatedAt: updated.updatedAt };
+  }
+  return updateRepresentativeFace({ id: person.id, representativeFaceUpdateDto: { assetFaceId } });
+};
+
+export const getPersonFaceThumbnail = (person: PersonResponseDto, faceId: string): string => {
+  const profile = getSpaceProfile(person);
+  return profile
+    ? getSpacePersonFaceThumbnailUrl(profile.spaceId, profile.id, faceId, person.updatedAt)
+    : getPersonFaceThumbnailUrl(person.id, faceId, person.updatedAt);
+};
+
+export const updatePersonName = async (person: PersonResponseDto, name: string): Promise<PersonResponseDto> => {
+  const profile = getSpaceProfile(person);
+  if (profile) {
+    const updated = await updateSpacePerson({
+      id: profile.spaceId,
+      personId: profile.id,
+      sharedSpacePersonUpdateDto: { name },
+    });
+    return {
+      ...person,
+      name: updated.name,
+      birthDate: updated.birthDate ?? person.birthDate,
+      isHidden: updated.isHidden,
+      updatedAt: updated.updatedAt,
+      type: updated.type ?? person.type,
+      numberOfAssets: updated.assetCount,
+    };
+  }
+  return updatePerson({ id: person.id, personUpdateDto: { name } });
 };
 
 export const handleUpdatePersonBirthDate = async (person: PersonResponseDto, birthDate: string) => {

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -17,7 +17,7 @@
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import PersonMergeSuggestionModal from '$lib/modals/PersonMergeSuggestionModal.svelte';
   import { Route } from '$lib/route';
-  import { getPersonActions } from '$lib/services/person.service';
+  import { getPersonActions, isSpaceEditor, updatePersonName } from '$lib/services/person.service';
   import Dropdown from '$lib/elements/Dropdown.svelte';
   import { locale, PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
   import { websocketEvents } from '$lib/stores/websocket';
@@ -33,7 +33,6 @@
     getPerson,
     searchPerson,
     updatePerson,
-    updateSpacePerson,
     type PersonResponseDto,
   } from '@immich/sdk';
   import { Button, Icon, modalManager, toastManager } from '@immich/ui';
@@ -50,6 +49,7 @@
   } from '@mdi/js';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { quintOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
   import type { PageData } from './$types';
@@ -297,7 +297,28 @@
     !person.primaryProfile || person.primaryProfile.type === 'user-person';
   const isSpacePrimary = (person: PersonResponseDto) =>
     person.primaryProfile?.type === 'space-person' && !!person.primaryProfile.spaceId;
-  const canEditName = (person: PersonResponseDto) => isPersonalPrimary(person) || isSpacePrimary(person);
+
+  // Space-person renames need the editor role; resolve it once per space as people load
+  // and default to allowing edits until known (the server enforces the role regardless).
+  const requestedSpaceRoles = new SvelteSet<string>();
+  const editableSpaces = new SvelteMap<string, boolean>();
+  $effect(() => {
+    for (const person of people) {
+      const spaceId = person.primaryProfile?.type === 'space-person' ? person.primaryProfile.spaceId : undefined;
+      if (spaceId && !requestedSpaceRoles.has(spaceId)) {
+        requestedSpaceRoles.add(spaceId);
+        void isSpaceEditor(spaceId, authManager.user.id).then((editable) => {
+          editableSpaces.set(spaceId, editable);
+        });
+      }
+    }
+  });
+  const canEditSpacePerson = (person: PersonResponseDto) => {
+    const spaceId = person.primaryProfile?.type === 'space-person' ? person.primaryProfile.spaceId : undefined;
+    return !spaceId || (editableSpaces.get(spaceId) ?? true);
+  };
+  const canEditName = (person: PersonResponseDto) =>
+    isPersonalPrimary(person) || (isSpacePrimary(person) && canEditSpacePerson(person));
 
   const toManagedPerson = (person: PersonResponseDto): ManagedPerson => ({
     id: person.id,
@@ -354,40 +375,8 @@
   };
 
   const updateName = async (targetPerson: PersonResponseDto, name: string) => {
-    const spaceId =
-      targetPerson.primaryProfile?.type === 'space-person' ? targetPerson.primaryProfile.spaceId : undefined;
-
-    if (spaceId) {
-      const updatedPerson = await updateSpacePerson({
-        id: spaceId,
-        personId: targetPerson.primaryProfile?.id ?? targetPerson.id,
-        sharedSpacePersonUpdateDto: { name },
-      });
-
-      people = people.map((person: PersonResponseDto) =>
-        person.id === targetPerson.id
-          ? {
-              ...person,
-              name: updatedPerson.name,
-              birthDate: updatedPerson.birthDate ?? person.birthDate,
-              isHidden: updatedPerson.isHidden,
-              updatedAt: updatedPerson.updatedAt,
-              type: updatedPerson.type ?? person.type,
-              numberOfAssets: updatedPerson.assetCount,
-            }
-          : person,
-      );
-      newName = '';
-      return;
-    }
-
-    const id = targetPerson.primaryProfile?.id ?? targetPerson.id;
-    const updatedPerson = await updatePerson({
-      id,
-      personUpdateDto: { name },
-    });
-
-    people = people.map((person: PersonResponseDto) => (person.id === id ? updatedPerson : person));
+    const updatedPerson = await updatePersonName(targetPerson, name);
+    people = people.map((person: PersonResponseDto) => (person.id === targetPerson.id ? updatedPerson : person));
     newName = '';
   };
 

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -36,13 +36,19 @@
   import RepresentativeFacePickerModal from '$lib/modals/RepresentativeFacePickerModal.svelte';
   import { Route } from '$lib/route';
   import { getAssetBulkActions } from '$lib/services/asset.service';
-  import { getPersonActions } from '$lib/services/person.service';
+  import {
+    getPersonActions,
+    getPersonFacesPage,
+    getPersonFaceThumbnail,
+    isSpaceEditor,
+    updatePersonName,
+    updatePersonRepresentativeFace,
+  } from '$lib/services/person.service';
   import { locale } from '$lib/stores/preferences.store';
   import { websocketEvents } from '$lib/stores/websocket';
   import { createUrl, getPeopleThumbnailUrl } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
   import { isExternalUrl } from '$lib/utils/navigation';
-  import { getPersonFaceThumbnailUrl } from '$lib/utils/people-utils';
   import { isSpaceScopedPerson, toScopedPersonRef } from '$lib/utils/scoped-person-ref';
   import { getTimelineBucketZoomTarget, type ActivatableTimelineBucket } from '$lib/utils/timeline-zoom-navigation';
   import { getTimelineTopVisibleAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
@@ -50,14 +56,11 @@
     AssetVisibility,
     detachScopedPerson,
     getAllPeople,
-    getPersonFaces,
     getPerson,
     mergePerson,
     mergeScopedPeople,
     searchPerson,
     Type2 as ScopedPersonProfileType,
-    updateRepresentativeFace,
-    updatePerson,
     type PersonFaceResponseDto,
     type PersonResponseDto,
   } from '@immich/sdk';
@@ -282,7 +285,7 @@
     }
 
     try {
-      person = await updatePerson({ id: person.id, personUpdateDto: { name: personName } });
+      person = await updatePersonName(person, personName);
       toastManager.primary($t('change_name_successfully'));
     } catch (error) {
       handleError(error, $t('errors.unable_to_save_name'));
@@ -354,6 +357,22 @@
 
   let thumbnailData = $derived(getScopedThumbnailUrl(person));
 
+  // Space-person writes need the editor role; default to offering the actions until the
+  // membership resolves (the server enforces the role on every write regardless).
+  let canEditSpacePerson = $state(true);
+  $effect(() => {
+    const profile = person.primaryProfile;
+    canEditSpacePerson = true;
+    if (profile?.type === 'space-person' && profile.spaceId) {
+      const spaceId = profile.spaceId;
+      void isSpaceEditor(spaceId, authManager.user.id).then((editable) => {
+        if (person.primaryProfile?.spaceId === spaceId) {
+          canEditSpacePerson = editable;
+        }
+      });
+    }
+  });
+
   const handleSetVisibility = (assetIds: string[]) => {
     timelineManager.removeAssets(assetIds);
     assetMultiSelectManager.clear();
@@ -400,22 +419,21 @@
     await updateAssetCount();
   };
 
-  const { SetDateOfBirth, Favorite, Unfavorite, HidePerson, ShowPerson } = $derived(getPersonActions($t, person));
+  const { SetDateOfBirth, Favorite, Unfavorite, HidePerson, ShowPerson } = $derived(
+    getPersonActions($t, person, { canEditSpacePerson }),
+  );
   const SelectRepresentativeFace: ActionItem = {
     title: $t('select_representative_face'),
     icon: mdiAccountBoxOutline,
+    $if: () => canEditSpacePerson,
     onAction: async () => {
       const updated = await modalManager.show(RepresentativeFacePickerModal, {
         title: $t('select_representative_face'),
-        loadFaces: ({ page, size }: { page: number; size: number }) => getPersonFaces({ id: person.id, page, size }),
+        loadFaces: ({ page, size }: { page: number; size: number }) => getPersonFacesPage(person, { page, size }),
         updateFace: async (faceId: string) => {
-          person = await updateRepresentativeFace({
-            id: person.id,
-            representativeFaceUpdateDto: { assetFaceId: faceId },
-          });
+          person = await updatePersonRepresentativeFace(person, faceId);
         },
-        getThumbnailUrl: (face: PersonFaceResponseDto) =>
-          getPersonFaceThumbnailUrl(person.id, face.id, person.updatedAt),
+        getThumbnailUrl: (face: PersonFaceResponseDto) => getPersonFaceThumbnail(person, face.id),
         canUpdate: true,
       });
 
@@ -520,8 +538,8 @@
                     <button
                       type="button"
                       class="flex items-center justify-center"
-                      title={$t('edit_name')}
-                      onclick={() => (isEditingName = true)}
+                      title={canEditSpacePerson ? $t('edit_name') : undefined}
+                      onclick={() => (isEditingName = canEditSpacePerson)}
                     >
                       <ImageThumbnail
                         circle

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/person-detail-page.spec.ts
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/person-detail-page.spec.ts
@@ -1,7 +1,13 @@
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { authManager } from '$lib/managers/auth-manager.svelte';
-import { Type, type PersonResponseDto, type PersonStatisticsResponseDto } from '@immich/sdk';
+import {
+  SharedSpaceRole,
+  Type,
+  type PersonResponseDto,
+  type PersonStatisticsResponseDto,
+  type SharedSpaceMemberResponseDto,
+} from '@immich/sdk';
 import { modalManager } from '@immich/ui';
 import { preferencesFactory } from '@test-data/factories/preferences-factory';
 import { userAdminFactory } from '@test-data/factories/user-factory';
@@ -147,6 +153,18 @@ function makePerson(overrides: Partial<PersonResponseDto> = {}): PersonResponseD
     type: 'person',
     species: null,
     ...overrides,
+  };
+}
+
+function makeMember(userId: string, role: SharedSpaceRole): SharedSpaceMemberResponseDto {
+  return {
+    userId,
+    role,
+    email: `${userId}@test.dev`,
+    name: userId,
+    joinedAt: '2026-01-01T00:00:00.000Z',
+    sharePersonMetadata: true,
+    showInTimeline: true,
   };
 }
 
@@ -399,6 +417,36 @@ describe('Person detail page', () => {
     expect(screen.getByRole('img', { name: 'Alice' }).getAttribute('src')).toContain(
       '/shared-spaces/space-1/people/space-person-1/thumbnail?updatedAt=2026-01-02T00%3A00%3A00.000Z',
     );
+  });
+
+  it('hides space-person write actions when the current user is a space viewer', async () => {
+    sdkMock.getMembers.mockResolvedValue([makeMember('current-user-id', SharedSpaceRole.Viewer)]);
+    renderPage({
+      person: makePerson({
+        id: 'space-person-1',
+        primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'viewer-space-detail' },
+      }),
+    });
+
+    await waitFor(() => expect(sdkMock.getMembers).toHaveBeenCalledWith({ id: 'viewer-space-detail' }));
+    await waitFor(() => expect(screen.queryByText('set_date_of_birth')).not.toBeInTheDocument());
+    expect(screen.queryByText('hide_person')).not.toBeInTheDocument();
+    expect(screen.queryByText('select_representative_face')).not.toBeInTheDocument();
+  });
+
+  it('keeps space-person write actions for space editors', async () => {
+    sdkMock.getMembers.mockResolvedValue([makeMember('current-user-id', SharedSpaceRole.Editor)]);
+    renderPage({
+      person: makePerson({
+        id: 'space-person-1',
+        primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'editor-space-detail' },
+      }),
+    });
+
+    await waitFor(() => expect(sdkMock.getMembers).toHaveBeenCalledWith({ id: 'editor-space-detail' }));
+    expect(screen.getByText('set_date_of_birth')).toBeInTheDocument();
+    expect(screen.getByText('hide_person')).toBeInTheDocument();
+    expect(screen.getByText('select_representative_face')).toBeInTheDocument();
   });
 
   it('opens the representative face picker from the person menu', async () => {

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -6,6 +6,7 @@ import { authManager } from '$lib/managers/auth-manager.svelte';
 import { PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
 import {
   RepresentativeFaceSource,
+  SharedSpaceRole,
   Type,
   type PeopleFaceStatisticsResponseDto,
   type PeopleStatisticsResponseDto,
@@ -551,6 +552,32 @@ describe('Global people page', () => {
       });
     });
     expect(sdkMock.updatePerson).not.toHaveBeenCalled();
+  });
+
+  it('blocks inline renames for space-primary rows when the user is a viewer', async () => {
+    sdkMock.getMembers.mockResolvedValue([
+      {
+        userId: 'current-user-id',
+        role: SharedSpaceRole.Viewer,
+        email: 'me@test.dev',
+        name: 'Me',
+        joinedAt: '2026-01-01T00:00:00.000Z',
+        sharePersonMetadata: true,
+        showInTimeline: true,
+      },
+    ]);
+    renderPage([
+      makePerson({
+        id: 'space-person-2',
+        name: 'Shared Alice',
+        isFavorite: undefined,
+        primaryProfile: { type: Type.SpacePerson, id: 'space-person-2', spaceId: 'viewer-space-grid' },
+      }),
+    ]);
+
+    await waitFor(() => expect(sdkMock.getMembers).toHaveBeenCalledWith({ id: 'viewer-space-grid' }));
+    await waitFor(() => expect(screen.queryByDisplayValue('Shared Alice')).toBeNull());
+    expect(screen.getByText('Shared Alice')).toBeInTheDocument();
   });
 
   it('keeps personal actions off shared-space-only rows', async () => {

--- a/web/src/test-data/mocks/action-context-menu.stub.svelte
+++ b/web/src/test-data/mocks/action-context-menu.stub.svelte
@@ -2,6 +2,7 @@
   type ActionItem = {
     title: string;
     onAction?: () => void;
+    $if?: () => boolean;
   };
 
   interface Props {
@@ -11,12 +12,14 @@
 
   let { items = [], ...rest }: Props = $props();
   const ariaLabel = $derived(String(rest['aria-label'] ?? 'menu'));
+  // Mirror @immich/ui's isEnabled: items without $if are always shown.
+  const visibleItems = $derived(items.filter((item) => item.$if?.() ?? true));
 </script>
 
-{#if items.length > 0}
+{#if visibleItems.length > 0}
   <div>
     <button type="button" aria-label={ariaLabel}>menu</button>
-    {#each items as item (item.title)}
+    {#each visibleItems as item (item.title)}
       <button type="button" onclick={() => item.onAction?.()}>{item.title}</button>
     {/each}
   </div>


### PR DESCRIPTION
## Summary

Fixes person edits failing with `Not found or no person.update access` for a non-owner space member in the main People view, and stops offering write actions the server would reject.

**Root cause.** For a space member, the main People grid links space-primary people to `/people/<shared_space_person_id>`. The profile loads fine (the server's `getById` falls back to `getAccessiblePersonByProfileId`), but every menu write called `updatePerson`, whose `requireAccess(PersonUpdate)` only checks the `person` table → guaranteed failure for space-person UUIDs.

**Fixes** (all client-side; the shared-space endpoints already existed with Editor-role enforcement, `birthDateSource: 'manual'` tracking, and metadata backfill):

- **Birthday** (`handleUpdatePersonBirthDate`), **hide/unhide**, **name edits** (`updatePersonName`, also reused by the People grid's inline rename), and the **representative-face picker** (`getPersonFacesPage` / `updatePersonRepresentativeFace` / `getPersonFaceThumbnail`) now route to the shared-space endpoints when `person.primaryProfile` is a space person — the same pattern the grid already used for names.
- **Favorite/Unfavorite** cannot be routed (`shared_space_person` has no favorite column), so they are no longer offered for space-scoped people.
- **Viewer-role gating**: the member's role is resolved once per space (`isSpaceEditor`, cached, fails open — the server enforces the role regardless) and viewers are no longer offered birthday/hide/name/representative-face edits on the detail page or the grid.
- The context-menu test stub now honors `$if` like the real `@immich/ui` component.

## Test Plan

- [x] `web/src/lib/services/person.service.spec.ts` (TDD, watched fail first, 24 tests): routing for birthday/name/hide/representative-face, clear-birthday, error paths, favorite gating, `isSpaceEditor` role resolution/caching/fail-open, action `$if` gating
- [x] Page-level tests: viewer sees no write actions on the detail page, editor keeps them, grid blocks inline renames for viewers (`person-detail-page.spec.ts`, `people-page.spec.ts`)
- [x] **New web e2e** (`e2e/src/specs/web/shared-space-person-profile.e2e-spec.ts`): editor sets a birthday from `/people/<shared_space_person_id>` (verified in UI + via shared-space API readback); viewer is not offered write actions. Both tests fail against a pre-fix build; pass locally against the freshly built stack.
- [x] Full web unit suite green (3122 tests); web+e2e tsc, eslint, prettier clean