### PR TITLE
fix(face-identity): resolve shared-space person birthday from any identity profile

### DIFF
--- a/docs/superpowers/plans/2026-06-10-space-birthday-identity-display-resolution.md
+++ b/docs/superpowers/plans/2026-06-10-space-birthday-identity-display-resolution.md
@@ -14,11 +14,11 @@
 
 ## File structure
 
-| File | Responsibility | Change |
-| --- | --- | --- |
-| `server/src/repositories/face-identity.repository.ts` | The `hydrateAccessiblePeople` raw SQL (the only birthday-display resolver; search/other paths do not return birthDate — verified in spec) | Modify — 3 edits inside one SQL string |
-| `server/src/queries/face.identity.repository.sql` | Auto-generated SQL mirror (CI-enforced fresh) | Regenerate via `pnpm sync:sql` |
-| `server/test/medium/specs/repositories/face-identity.repository.spec.ts` | Real-DB coverage for `getAccessiblePeople` / `getAccessiblePersonByProfileId` | Modify — add tests |
+| File                                                                     | Responsibility                                                                                                                            | Change                                 |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `server/src/repositories/face-identity.repository.ts`                    | The `hydrateAccessiblePeople` raw SQL (the only birthday-display resolver; search/other paths do not return birthDate — verified in spec) | Modify — 3 edits inside one SQL string |
+| `server/src/queries/face.identity.repository.sql`                        | Auto-generated SQL mirror (CI-enforced fresh)                                                                                             | Regenerate via `pnpm sync:sql`         |
+| `server/test/medium/specs/repositories/face-identity.repository.spec.ts` | Real-DB coverage for `getAccessiblePeople` / `getAccessiblePersonByProfileId`                                                             | Modify — add tests                     |
 
 All edits to the SQL live inside the single template literal in `hydrateAccessiblePeople` (currently ~lines 1777–1927). Line numbers below are approximate — anchor on the quoted strings.
 
@@ -33,25 +33,31 @@ This is a fresh worktree with no `node_modules`. Medium tests need Docker (testc
 - [ ] **Step 1: Install workspace dependencies**
 
 Run from repo root:
+
 ```bash
 pnpm install
 ```
+
 Expected: completes; `server/node_modules` exists.
 
 - [ ] **Step 2: Confirm Docker is available (medium tests need it)**
 
 Run:
+
 ```bash
 docker info >/dev/null 2>&1 && echo "docker ok" || echo "docker MISSING"
 ```
+
 Expected: `docker ok`. If `docker MISSING`, start Docker Desktop before running any medium test.
 
 - [ ] **Step 3: Sanity-run the target medium spec (baseline, all green)**
 
 Run from `server/`:
+
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts
 ```
+
 Expected: the existing suite passes (this confirms the harness/DB works before we touch anything). Do not proceed until green.
 
 ---
@@ -61,6 +67,7 @@ Expected: the existing suite passes (this confirms the harness/DB works before w
 This is the genuine red test. Owner's `person` row supplies the **name** but has **no birthday**; a space-person of the same identity holds a `manual` birthday. The birthday must resolve onto the owner's view. It does not today (returns `null`), because birthday is read from `display_profiles` (the owner row, NULL) / `primary_profiles` (the owner row, NULL).
 
 **Files:**
+
 - Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 
 - [ ] **Step 1: Add the failing test**
@@ -68,66 +75,68 @@ This is the genuine red test. Owner's `person` row supplies the **name** but has
 Add this `it(...)` block immediately after the existing test that ends at the line containing `'uses a named accessible space profile for display while keeping a viewer-owned primary profile'` (the block closing near line 1570). Insert after its closing `});`:
 
 ```ts
-  it('resolves a space-set birthday for the owner when only a sibling space profile carries it', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { space } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-    // Owner's library person: has the NAME, but no birthday.
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-    // Space profile (set by an editor): carries the manual birthday, no name.
-    const spacePerson = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: space.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+it('resolves a space-set birthday for the owner when only a sibling space profile carries it', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  // Owner's library person: has the NAME, but no birthday.
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  // Space profile (set by an editor): carries the manual birthday, no name.
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+    .execute();
+
+  try {
+    const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        id: person.id,
+        name: 'Ina', // name still resolves from the owner profile
+        birthDate: '2014-02-14', // birthday resolves from the sibling space profile
+        primaryProfile: { type: 'user-person', id: person.id },
+      }),
+    ]);
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
     await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .deleteFrom('shared_space_asset')
+      .where('spaceId', '=', space.id)
+      .where('assetId', '=', asset.id)
       .execute();
-
-    try {
-      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-
-      expect(result.people).toEqual([
-        expect.objectContaining({
-          id: person.id,
-          name: 'Ina', // name still resolves from the owner profile
-          birthDate: '2014-02-14', // birthday resolves from the sibling space profile
-          primaryProfile: { type: 'user-person', id: person.id },
-        }),
-      ]);
-    } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
-    }
-  });
+  }
+});
 ```
 
 - [ ] **Step 2: Run the test and confirm it FAILS**
 
 Run from `server/`:
+
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "resolves a space-set birthday for the owner"
 ```
+
 Expected: FAIL. The received person has `birthDate: null` (name `'Ina'` is correct; birthday is the gap). This proves the bug.
 
 - [ ] **Step 3: Commit the failing test**
@@ -144,19 +153,23 @@ git commit -m "test(face-identity): failing repro — space-set birthday invisib
 Three edits inside the `hydrateAccessiblePeople` template literal, then regenerate the SQL mirror.
 
 **Files:**
+
 - Modify: `server/src/repositories/face-identity.repository.ts` (the `hydrateAccessiblePeople` SQL, ~lines 1824–1927)
 - Regenerate: `server/src/queries/face.identity.repository.sql`
 
 - [ ] **Step 1: Carry birthday provenance on the `person` branch of the `profiles` CTE**
 
 Find (the `person` UNION branch):
+
 ```ts
           person."identityId",
           person.name,
           person."birthDate",
           person."thumbnailPath",
 ```
+
 Replace with:
+
 ```ts
           person."identityId",
           person.name,
@@ -165,17 +178,21 @@ Replace with:
           person."updatedAt" AS "birthDateSourceUpdatedAt",
           person."thumbnailPath",
 ```
+
 (The `person` table has no source columns; the owner's value wins by position regardless, so a synthesized `'manual'`/`'none'` and `updatedAt` proxy are sufficient and never decision-critical.)
 
 - [ ] **Step 2: Carry birthday provenance on the `shared_space_person` branch**
 
 Find (the space-person UNION branch):
+
 ```ts
           COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name,
           shared_space_person."birthDate",
           ''::text AS "thumbnailPath",
 ```
+
 Replace with:
+
 ```ts
           COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name,
           shared_space_person."birthDate",
@@ -183,16 +200,20 @@ Replace with:
           shared_space_person."birthDateSourceUpdatedAt",
           ''::text AS "thumbnailPath",
 ```
+
 (Both branches now project the two new columns in the same position, so the UNION stays aligned. Column names come from the first branch: `"birthDateSource"`, `"birthDateSourceUpdatedAt"`.)
 
 - [ ] **Step 3: Add the `birthdate_rn` window to `ranked_profiles`**
 
 Find:
+
 ```ts
           ) AS primary_rn
         FROM profiles
 ```
+
 Replace with:
+
 ```ts
           ) AS primary_rn,
           row_number() OVER (
@@ -211,15 +232,19 @@ Replace with:
           ) AS birthdate_rn
         FROM profiles
 ```
+
 (`profiles."birthDate" IS NULL` sorts birthday-bearing rows first — `false` before `true` in Postgres — so the owner only reaches rank 1 when they actually have a birthday; otherwise the most-recent `manual` space value wins.)
 
 - [ ] **Step 4: Resolve `birthDate` from the new window in the final SELECT**
 
 Find:
+
 ```ts
         COALESCE(display_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
 ```
+
 Replace with:
+
 ```ts
         COALESCE(birthdate_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
 ```
@@ -227,12 +252,15 @@ Replace with:
 - [ ] **Step 5: Join the new ranked alias**
 
 Find:
+
 ```ts
       INNER JOIN ranked_profiles AS display_profiles
         ON display_profiles."identityId" = requested_identities."identityId"
         AND display_profiles.display_rn = 1
 ```
+
 Replace with:
+
 ```ts
       INNER JOIN ranked_profiles AS display_profiles
         ON display_profiles."identityId" = requested_identities."identityId"
@@ -241,47 +269,60 @@ Replace with:
         ON birthdate_profiles."identityId" = requested_identities."identityId"
         AND birthdate_profiles.birthdate_rn = 1
 ```
+
 (Every identity that has any profile has a `birthdate_rn = 1` row drawn from the same `profiles` population as `display_rn`/`primary_rn`, so this INNER JOIN never drops an identity the query already returned. Guarded by Task 6.)
 
 - [ ] **Step 6: Type-check**
 
 Run from `server/`:
+
 ```bash
 pnpm exec tsc --noEmit
 ```
+
 Expected: no errors. (The output row type `HydratedAccessiblePersonRow` is unchanged — we added no projected output columns, only internal CTE columns.)
 
 - [ ] **Step 7: Run the repro test and confirm it now PASSES**
 
 Run from `server/`:
+
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "resolves a space-set birthday for the owner"
 ```
+
 Expected: PASS.
 
 - [ ] **Step 8: Run the whole face-identity medium spec (no regression)**
 
 Run from `server/`:
+
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts
 ```
+
 Expected: all pass — including the existing `'uses a named accessible space profile for display while keeping a viewer-owned primary profile'` test (owner-birthday-only still resolves; name projection untouched).
 
 - [ ] **Step 9: Regenerate the SQL mirror**
 
 The `@GenerateSql` decorator means CI re-runs generation and fails if `src/queries/face.identity.repository.sql` is stale. Build, then regenerate. From repo root:
+
 ```bash
 make sql
 ```
+
 If `make sql` is unavailable in this environment, run from `server/`:
+
 ```bash
 pnpm build && pnpm sync:sql
 ```
+
 Then confirm the mirror picked up the change:
+
 ```bash
 git --no-pager diff --stat server/src/queries/face.identity.repository.sql
 git --no-pager diff server/src/queries/face.identity.repository.sql | grep -E "birthdate_rn|birthDateSource" | head
 ```
+
 Expected: the file is modified and contains `birthdate_rn` and `birthDateSource`.
 
 - [ ] **Step 10: Commit the fix + regenerated SQL together**
@@ -298,56 +339,55 @@ git commit -m "fix(face-identity): resolve birthday from any identity profile, n
 Same SQL backs `getAccessiblePersonByProfileId`. Lock that the single-person endpoint resolves the space birthday too.
 
 **Files:**
+
 - Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 
 - [ ] **Step 1: Add the test (place after the Task 1 test block)**
 
 ```ts
-  it('resolves a space-set birthday via the single-person view', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { space } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-    const spacePerson = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: space.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+it('resolves a space-set birthday via the single-person view', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+    .execute();
+
+  try {
+    const result = await sut.getAccessiblePersonByProfileId(user.id, person.id);
+
+    expect(result).toEqual(expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }));
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
     await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .deleteFrom('shared_space_asset')
+      .where('spaceId', '=', space.id)
+      .where('assetId', '=', asset.id)
       .execute();
-
-    try {
-      const result = await sut.getAccessiblePersonByProfileId(user.id, person.id);
-
-      expect(result).toEqual(
-        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }),
-      );
-    } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
-    }
-  });
+  }
+});
 ```
 
 - [ ] **Step 2: Run and confirm PASS**
@@ -355,6 +395,7 @@ Same SQL backs `getAccessiblePersonByProfileId`. Lock that the single-person end
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "resolves a space-set birthday via the single-person view"
 ```
+
 Expected: PASS (shared SQL).
 
 - [ ] **Step 3: Commit**
@@ -368,63 +409,62 @@ git commit -m "test(face-identity): single-person view resolves space-set birthd
 
 ## Task 4: Owner precedence over a space value
 
-Guards the `user-person`-first ORDER BY term. Owner has a birthday; a space has a *different* `manual` birthday with a *newer* source timestamp. The owner's value must still win (a recency-only ranking would wrongly pick the space value).
+Guards the `user-person`-first ORDER BY term. Owner has a birthday; a space has a _different_ `manual` birthday with a _newer_ source timestamp. The owner's value must still win (a recency-only ranking would wrongly pick the space value).
 
 **Files:**
+
 - Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 
 - [ ] **Step 1: Add the test**
 
 ```ts
-  it('prefers the owner birthday over a more-recent space birthday', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { space } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-    const { person } = await ctx.newPerson({
-      ownerId: user.id,
-      name: 'Ina',
-      birthDate: new Date('1990-01-01T00:00:00.000Z'),
-    });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-    const spacePerson = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: space.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer than the owner
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
-    await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
-      .execute();
-
-    try {
-      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '1990-01-01' }),
-      ]);
-    } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
-    }
+it('prefers the owner birthday over a more-recent space birthday', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { person } = await ctx.newPerson({
+    ownerId: user.id,
+    name: 'Ina',
+    birthDate: new Date('1990-01-01T00:00:00.000Z'),
   });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer than the owner
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+    .execute();
+
+  try {
+    const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+
+    expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '1990-01-01' })]);
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+    await ctx.database
+      .deleteFrom('shared_space_asset')
+      .where('spaceId', '=', space.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+  }
+});
 ```
 
 - [ ] **Step 2: Run and confirm PASS**
@@ -432,6 +472,7 @@ Guards the `user-person`-first ORDER BY term. Owner has a birthday; a space has 
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "prefers the owner birthday"
 ```
+
 Expected: PASS.
 
 - [ ] **Step 3: Commit**
@@ -448,6 +489,7 @@ git commit -m "test(face-identity): owner birthday wins over a newer space birth
 Two guards for the two cross-space ORDER BY terms. (a) Recency: two `manual` spaces, owner has none — the winner is given the **older** `updatedAt`/`profileId` but the **newer** `birthDateSourceUpdatedAt`, so only the `birthDateSourceUpdatedAt DESC` term selects it. (b) Source tier: a `manual` value must beat an `inherited` value even when the inherited one is more recent.
 
 **Files:**
+
 - Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 
 - [ ] **Step 1: Add a helper to build a second accessible space-person on the same identity, then the test**
@@ -455,140 +497,133 @@ Two guards for the two cross-space ORDER BY terms. (a) Recency: two `manual` spa
 Add this test (it creates two spaces the user owns, both linked to the same identity via the same asset face):
 
 ```ts
-  it('picks the most-recently edited manual birthday across spaces', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+it('picks the most-recently edited manual birthday across spaces', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
 
-    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
-    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
-    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
-    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
+  const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
+  const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
 
-    // Older edit, but inserted LAST (so a profileId/updatedAt-only ordering would pick it).
-    const newerWinner = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: spaceA.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // most recent
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+  // Older edit, but inserted LAST (so a profileId/updatedAt-only ordering would pick it).
+  const newerWinner = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: spaceA.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // most recent
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: newerWinner.id, assetFaceId: assetFace.id })
+    .execute();
+
+  const olderLoser = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: spaceB.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2013-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: olderLoser.id, assetFaceId: assetFace.id })
+    .execute();
+
+  try {
+    const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+    expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '2014-02-14' })]);
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', 'in', [newerWinner.id, olderLoser.id]).execute();
+  }
+});
+
+it('prefers a manual birthday over a more-recent inherited one', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+  const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
+  const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
+
+  const manualWinner = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: spaceA.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: manualWinner.id, assetFaceId: assetFace.id })
+    .execute();
+
+  const inheritedLoser = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: spaceB.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2013-02-14',
+      birthDateSource: 'inherited',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer, but inherited
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: inheritedLoser.id, assetFaceId: assetFace.id })
+    .execute();
+
+  try {
+    const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+    expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '2014-02-14' })]);
+  } finally {
     await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: newerWinner.id, assetFaceId: assetFace.id })
+      .deleteFrom('shared_space_person')
+      .where('id', 'in', [manualWinner.id, inheritedLoser.id])
       .execute();
-
-    const olderLoser = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: spaceB.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2013-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
-    await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: olderLoser.id, assetFaceId: assetFace.id })
-      .execute();
-
-    try {
-      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
-      ]);
-    } finally {
-      await ctx.database
-        .deleteFrom('shared_space_person')
-        .where('id', 'in', [newerWinner.id, olderLoser.id])
-        .execute();
-    }
-  });
-
-  it('prefers a manual birthday over a more-recent inherited one', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-
-    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
-    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
-    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
-    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
-
-    const manualWinner = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: spaceA.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
-    await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: manualWinner.id, assetFaceId: assetFace.id })
-      .execute();
-
-    const inheritedLoser = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: spaceB.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2013-02-14',
-        birthDateSource: 'inherited',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer, but inherited
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
-    await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: inheritedLoser.id, assetFaceId: assetFace.id })
-      .execute();
-
-    try {
-      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
-      ]);
-    } finally {
-      await ctx.database
-        .deleteFrom('shared_space_person')
-        .where('id', 'in', [manualWinner.id, inheritedLoser.id])
-        .execute();
-    }
-  });
+  }
+});
 ```
 
 - [ ] **Step 2: Run both and confirm PASS**
@@ -597,6 +632,7 @@ Add this test (it creates two spaces the user owns, both linked to the same iden
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "most-recently edited manual birthday"
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "manual birthday over a more-recent inherited"
 ```
+
 Expected: both PASS (resolve `2014-02-14`).
 
 - [ ] **Step 3: Commit**
@@ -613,144 +649,143 @@ git commit -m "test(face-identity): most-recent manual + manual-over-inherited b
 Three guards in one task (each its own `it`): they assert behavior the new INNER JOIN and visibility scoping must preserve.
 
 **Files:**
+
 - Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
 
 - [ ] **Step 1: Add the three guard tests**
 
 ```ts
-  it('returns the person with a null birthday when no profile has one', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { space } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-    const spacePerson = await ctx.database
-      .insertInto('shared_space_person')
-      .values({ spaceId: space.id, identityId: identity.id, name: '', representativeFaceId: assetFace.id, type: 'person' })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+it('returns the person with a null birthday when no profile has one', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+    .execute();
+
+  try {
+    const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+    expect(result.people).toEqual([expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null })]);
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
     await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .deleteFrom('shared_space_asset')
+      .where('spaceId', '=', space.id)
+      .where('assetId', '=', asset.id)
       .execute();
+  }
+});
 
-    try {
-      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null }),
-      ]);
-    } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
-    }
-  });
+it('does not surface a birthday from a hidden space profile unless withHidden is set', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      isHidden: true,
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+    .execute();
 
-  it('does not surface a birthday from a hidden space profile unless withHidden is set', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { space } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-    const spacePerson = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: space.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        isHidden: true,
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+  try {
+    const hiddenExcluded = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+    expect(hiddenExcluded.people).toEqual([expect.objectContaining({ id: person.id, birthDate: null })]);
+
+    const hiddenIncluded = await sut.getAccessiblePeople(user.id, { withHidden: true, page: 1, size: 50 });
+    expect(hiddenIncluded.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '2014-02-14' })]);
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
     await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .deleteFrom('shared_space_asset')
+      .where('spaceId', '=', space.id)
+      .where('assetId', '=', asset.id)
       .execute();
+  }
+});
 
-    try {
-      const hiddenExcluded = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(hiddenExcluded.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: null }),
-      ]);
+it('does not leak a birthday from a space hidden from the viewer timeline', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+  const { asset } = await ctx.newAsset({ ownerId: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: assetFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+    .execute();
+  // Hide the space from the viewer's timeline -> excluded from timeline_spaces.
+  await setMemberTimeline(ctx, { spaceId: space.id, userId: user.id, showInTimeline: false });
 
-      const hiddenIncluded = await sut.getAccessiblePeople(user.id, { withHidden: true, page: 1, size: 50 });
-      expect(hiddenIncluded.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
-      ]);
-    } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
-    }
-  });
-
-  it('does not leak a birthday from a space hidden from the viewer timeline', async () => {
-    const { ctx, sut } = setup();
-    const { user } = await ctx.newUser();
-    const { space } = await ctx.newSharedSpace({ createdById: user.id });
-    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
-    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
-    const { asset } = await ctx.newAsset({ ownerId: user.id });
-    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
-    const identity = await sut.ensurePersonIdentity(person.id);
-    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
-    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
-    const spacePerson = await ctx.database
-      .insertInto('shared_space_person')
-      .values({
-        spaceId: space.id,
-        identityId: identity.id,
-        name: '',
-        representativeFaceId: assetFace.id,
-        type: 'person',
-        birthDate: '2014-02-14',
-        birthDateSource: 'manual',
-        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
+  try {
+    const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+    expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: null })]);
+  } finally {
+    await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
     await ctx.database
-      .insertInto('shared_space_person_face')
-      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .deleteFrom('shared_space_asset')
+      .where('spaceId', '=', space.id)
+      .where('assetId', '=', asset.id)
       .execute();
-    // Hide the space from the viewer's timeline -> excluded from timeline_spaces.
-    await setMemberTimeline(ctx, { spaceId: space.id, userId: user.id, showInTimeline: false });
-
-    try {
-      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: null }),
-      ]);
-    } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
-    }
-  });
+  }
+});
 ```
 
 - [ ] **Step 2: Run the three guards and confirm PASS**
@@ -760,9 +795,10 @@ pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repositor
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "hidden space profile"
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "hidden from the viewer timeline"
 ```
+
 Expected: all PASS.
 
-> Note: if the no-birthday guard fails because the person row is *missing entirely* (not just `birthDate: null`), the new `INNER JOIN ranked_profiles AS birthdate_profiles` is dropping the identity — revisit Task 2 Step 5 (it must not filter out identities that have profiles).
+> Note: if the no-birthday guard fails because the person row is _missing entirely_ (not just `birthDate: null`), the new `INNER JOIN ranked_profiles AS birthdate_profiles` is dropping the identity — revisit Task 2 Step 5 (it must not filter out identities that have profiles).
 
 - [ ] **Step 3: Commit**
 
@@ -782,6 +818,7 @@ git commit -m "test(face-identity): birthday resolution boundary guards (none/hi
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts
 ```
+
 Expected: all tests pass (existing + 8 new).
 
 - [ ] **Step 2: Run the related shared-space medium specs (no regression)**
@@ -789,6 +826,7 @@ Expected: all tests pass (existing + 8 new).
 ```bash
 pnpm test:medium -- --run test/medium/specs/repositories/shared-space.repository.spec.ts test/medium/specs/services/shared-space-person-metadata-rbac.spec.ts
 ```
+
 Expected: pass.
 
 - [ ] **Step 3: Confirm generated SQL is committed and not stale**
@@ -797,6 +835,7 @@ Expected: pass.
 make sql
 git --no-pager status --porcelain server/src/queries/face.identity.repository.sql
 ```
+
 Expected: empty output (no diff — the mirror was already regenerated and committed in Task 2).
 
 - [ ] **Step 4: Type-check the server**
@@ -804,6 +843,7 @@ Expected: empty output (no diff — the mirror was already regenerated and commi
 ```bash
 pnpm exec tsc --noEmit
 ```
+
 Expected: no errors.
 
 - [ ] **Step 5: (Optional) Manual smoke against a running stack**

--- a/docs/superpowers/plans/2026-06-10-space-birthday-identity-display-resolution.md
+++ b/docs/superpowers/plans/2026-06-10-space-birthday-identity-display-resolution.md
@@ -1,0 +1,820 @@
+# Space-person birthday display resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a person's birthday display correctly for any viewer when it was set on any profile of the shared face identity (e.g. by a space editor), not only when it sits on the name-winner or the owner's own `person` row.
+
+**Architecture:** Pure read-time fix. `FaceIdentityRepository.hydrateAccessiblePeople` already resolves person metadata across the `person` + `shared_space_person` profiles of an identity via two ranking windows (`display_rn` for name, `primary_rn` for the canonical profile). Birthday currently piggybacks on those, so it is invisible unless it lives on the name-winner or the owner. We add a third window, `birthdate_rn` (the birthday analog of `display_rn`), and resolve `birthDate` from it. No writes to `person`, no schema change, no backfill change. Precedence: owner first, else most-recent `manual` (then `inherited`).
+
+**Tech Stack:** NestJS, Kysely (raw `sql` template), PostgreSQL, Vitest medium tests against a real DB (testcontainers). The method carries `@GenerateSql`, so its SQL is mirrored into `src/queries/face.identity.repository.sql` and must be regenerated.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `server/src/repositories/face-identity.repository.ts` | The `hydrateAccessiblePeople` raw SQL (the only birthday-display resolver; search/other paths do not return birthDate — verified in spec) | Modify — 3 edits inside one SQL string |
+| `server/src/queries/face.identity.repository.sql` | Auto-generated SQL mirror (CI-enforced fresh) | Regenerate via `pnpm sync:sql` |
+| `server/test/medium/specs/repositories/face-identity.repository.spec.ts` | Real-DB coverage for `getAccessiblePeople` / `getAccessiblePersonByProfileId` | Modify — add tests |
+
+All edits to the SQL live inside the single template literal in `hydrateAccessiblePeople` (currently ~lines 1777–1927). Line numbers below are approximate — anchor on the quoted strings.
+
+---
+
+## Task 0: Environment setup (one-time)
+
+This is a fresh worktree with no `node_modules`. Medium tests need Docker (testcontainers), and `sync:sql` needs the server built.
+
+**Files:** none (setup only)
+
+- [ ] **Step 1: Install workspace dependencies**
+
+Run from repo root:
+```bash
+pnpm install
+```
+Expected: completes; `server/node_modules` exists.
+
+- [ ] **Step 2: Confirm Docker is available (medium tests need it)**
+
+Run:
+```bash
+docker info >/dev/null 2>&1 && echo "docker ok" || echo "docker MISSING"
+```
+Expected: `docker ok`. If `docker MISSING`, start Docker Desktop before running any medium test.
+
+- [ ] **Step 3: Sanity-run the target medium spec (baseline, all green)**
+
+Run from `server/`:
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts
+```
+Expected: the existing suite passes (this confirms the harness/DB works before we touch anything). Do not proceed until green.
+
+---
+
+## Task 1: Failing repro test — space-set birthday is invisible to the owner
+
+This is the genuine red test. Owner's `person` row supplies the **name** but has **no birthday**; a space-person of the same identity holds a `manual` birthday. The birthday must resolve onto the owner's view. It does not today (returns `null`), because birthday is read from `display_profiles` (the owner row, NULL) / `primary_profiles` (the owner row, NULL).
+
+**Files:**
+- Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+Add this `it(...)` block immediately after the existing test that ends at the line containing `'uses a named accessible space profile for display while keeping a viewer-owned primary profile'` (the block closing near line 1570). Insert after its closing `});`:
+
+```ts
+  it('resolves a space-set birthday for the owner when only a sibling space profile carries it', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    // Owner's library person: has the NAME, but no birthday.
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    // Space profile (set by an editor): carries the manual birthday, no name.
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+
+      expect(result.people).toEqual([
+        expect.objectContaining({
+          id: person.id,
+          name: 'Ina', // name still resolves from the owner profile
+          birthDate: '2014-02-14', // birthday resolves from the sibling space profile
+          primaryProfile: { type: 'user-person', id: person.id },
+        }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+```
+
+- [ ] **Step 2: Run the test and confirm it FAILS**
+
+Run from `server/`:
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "resolves a space-set birthday for the owner"
+```
+Expected: FAIL. The received person has `birthDate: null` (name `'Ina'` is correct; birthday is the gap). This proves the bug.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts
+git commit -m "test(face-identity): failing repro — space-set birthday invisible to owner"
+```
+
+---
+
+## Task 2: Implement the SQL fix (the `birthdate_rn` window)
+
+Three edits inside the `hydrateAccessiblePeople` template literal, then regenerate the SQL mirror.
+
+**Files:**
+- Modify: `server/src/repositories/face-identity.repository.ts` (the `hydrateAccessiblePeople` SQL, ~lines 1824–1927)
+- Regenerate: `server/src/queries/face.identity.repository.sql`
+
+- [ ] **Step 1: Carry birthday provenance on the `person` branch of the `profiles` CTE**
+
+Find (the `person` UNION branch):
+```ts
+          person."identityId",
+          person.name,
+          person."birthDate",
+          person."thumbnailPath",
+```
+Replace with:
+```ts
+          person."identityId",
+          person.name,
+          person."birthDate",
+          CASE WHEN person."birthDate" IS NOT NULL THEN 'manual' ELSE 'none' END AS "birthDateSource",
+          person."updatedAt" AS "birthDateSourceUpdatedAt",
+          person."thumbnailPath",
+```
+(The `person` table has no source columns; the owner's value wins by position regardless, so a synthesized `'manual'`/`'none'` and `updatedAt` proxy are sufficient and never decision-critical.)
+
+- [ ] **Step 2: Carry birthday provenance on the `shared_space_person` branch**
+
+Find (the space-person UNION branch):
+```ts
+          COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name,
+          shared_space_person."birthDate",
+          ''::text AS "thumbnailPath",
+```
+Replace with:
+```ts
+          COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name,
+          shared_space_person."birthDate",
+          shared_space_person."birthDateSource",
+          shared_space_person."birthDateSourceUpdatedAt",
+          ''::text AS "thumbnailPath",
+```
+(Both branches now project the two new columns in the same position, so the UNION stays aligned. Column names come from the first branch: `"birthDateSource"`, `"birthDateSourceUpdatedAt"`.)
+
+- [ ] **Step 3: Add the `birthdate_rn` window to `ranked_profiles`**
+
+Find:
+```ts
+          ) AS primary_rn
+        FROM profiles
+```
+Replace with:
+```ts
+          ) AS primary_rn,
+          row_number() OVER (
+            PARTITION BY profiles."identityId"
+            ORDER BY
+              profiles."birthDate" IS NULL,
+              CASE WHEN profiles."profileType" = 'user-person' THEN 0 ELSE 1 END,
+              CASE profiles."birthDateSource"
+                WHEN 'manual' THEN 0
+                WHEN 'inherited' THEN 1
+                ELSE 2
+              END,
+              profiles."birthDateSourceUpdatedAt" DESC NULLS LAST,
+              profiles."updatedAt" DESC,
+              profiles."profileId"
+          ) AS birthdate_rn
+        FROM profiles
+```
+(`profiles."birthDate" IS NULL` sorts birthday-bearing rows first — `false` before `true` in Postgres — so the owner only reaches rank 1 when they actually have a birthday; otherwise the most-recent `manual` space value wins.)
+
+- [ ] **Step 4: Resolve `birthDate` from the new window in the final SELECT**
+
+Find:
+```ts
+        COALESCE(display_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
+```
+Replace with:
+```ts
+        COALESCE(birthdate_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
+```
+
+- [ ] **Step 5: Join the new ranked alias**
+
+Find:
+```ts
+      INNER JOIN ranked_profiles AS display_profiles
+        ON display_profiles."identityId" = requested_identities."identityId"
+        AND display_profiles.display_rn = 1
+```
+Replace with:
+```ts
+      INNER JOIN ranked_profiles AS display_profiles
+        ON display_profiles."identityId" = requested_identities."identityId"
+        AND display_profiles.display_rn = 1
+      INNER JOIN ranked_profiles AS birthdate_profiles
+        ON birthdate_profiles."identityId" = requested_identities."identityId"
+        AND birthdate_profiles.birthdate_rn = 1
+```
+(Every identity that has any profile has a `birthdate_rn = 1` row drawn from the same `profiles` population as `display_rn`/`primary_rn`, so this INNER JOIN never drops an identity the query already returned. Guarded by Task 6.)
+
+- [ ] **Step 6: Type-check**
+
+Run from `server/`:
+```bash
+pnpm exec tsc --noEmit
+```
+Expected: no errors. (The output row type `HydratedAccessiblePersonRow` is unchanged — we added no projected output columns, only internal CTE columns.)
+
+- [ ] **Step 7: Run the repro test and confirm it now PASSES**
+
+Run from `server/`:
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "resolves a space-set birthday for the owner"
+```
+Expected: PASS.
+
+- [ ] **Step 8: Run the whole face-identity medium spec (no regression)**
+
+Run from `server/`:
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts
+```
+Expected: all pass — including the existing `'uses a named accessible space profile for display while keeping a viewer-owned primary profile'` test (owner-birthday-only still resolves; name projection untouched).
+
+- [ ] **Step 9: Regenerate the SQL mirror**
+
+The `@GenerateSql` decorator means CI re-runs generation and fails if `src/queries/face.identity.repository.sql` is stale. Build, then regenerate. From repo root:
+```bash
+make sql
+```
+If `make sql` is unavailable in this environment, run from `server/`:
+```bash
+pnpm build && pnpm sync:sql
+```
+Then confirm the mirror picked up the change:
+```bash
+git --no-pager diff --stat server/src/queries/face.identity.repository.sql
+git --no-pager diff server/src/queries/face.identity.repository.sql | grep -E "birthdate_rn|birthDateSource" | head
+```
+Expected: the file is modified and contains `birthdate_rn` and `birthDateSource`.
+
+- [ ] **Step 10: Commit the fix + regenerated SQL together**
+
+```bash
+git add server/src/repositories/face-identity.repository.ts server/src/queries/face.identity.repository.sql
+git commit -m "fix(face-identity): resolve birthday from any identity profile, not just the name-winner"
+```
+
+---
+
+## Task 3: Single-person view parity
+
+Same SQL backs `getAccessiblePersonByProfileId`. Lock that the single-person endpoint resolves the space birthday too.
+
+**Files:**
+- Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+- [ ] **Step 1: Add the test (place after the Task 1 test block)**
+
+```ts
+  it('resolves a space-set birthday via the single-person view', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePersonByProfileId(user.id, person.id);
+
+      expect(result).toEqual(
+        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }),
+      );
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+```
+
+- [ ] **Step 2: Run and confirm PASS**
+
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "resolves a space-set birthday via the single-person view"
+```
+Expected: PASS (shared SQL).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts
+git commit -m "test(face-identity): single-person view resolves space-set birthday"
+```
+
+---
+
+## Task 4: Owner precedence over a space value
+
+Guards the `user-person`-first ORDER BY term. Owner has a birthday; a space has a *different* `manual` birthday with a *newer* source timestamp. The owner's value must still win (a recency-only ranking would wrongly pick the space value).
+
+**Files:**
+- Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+- [ ] **Step 1: Add the test**
+
+```ts
+  it('prefers the owner birthday over a more-recent space birthday', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({
+      ownerId: user.id,
+      name: 'Ina',
+      birthDate: new Date('1990-01-01T00:00:00.000Z'),
+    });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer than the owner
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '1990-01-01' }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+```
+
+- [ ] **Step 2: Run and confirm PASS**
+
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "prefers the owner birthday"
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts
+git commit -m "test(face-identity): owner birthday wins over a newer space birthday"
+```
+
+---
+
+## Task 5: Cross-space ordering — recency tiebreak + manual-over-inherited
+
+Two guards for the two cross-space ORDER BY terms. (a) Recency: two `manual` spaces, owner has none — the winner is given the **older** `updatedAt`/`profileId` but the **newer** `birthDateSourceUpdatedAt`, so only the `birthDateSourceUpdatedAt DESC` term selects it. (b) Source tier: a `manual` value must beat an `inherited` value even when the inherited one is more recent.
+
+**Files:**
+- Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+- [ ] **Step 1: Add a helper to build a second accessible space-person on the same identity, then the test**
+
+Add this test (it creates two spaces the user owns, both linked to the same identity via the same asset face):
+
+```ts
+  it('picks the most-recently edited manual birthday across spaces', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
+    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
+
+    // Older edit, but inserted LAST (so a profileId/updatedAt-only ordering would pick it).
+    const newerWinner = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceA.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // most recent
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: newerWinner.id, assetFaceId: assetFace.id })
+      .execute();
+
+    const olderLoser = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceB.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2013-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: olderLoser.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
+      ]);
+    } finally {
+      await ctx.database
+        .deleteFrom('shared_space_person')
+        .where('id', 'in', [newerWinner.id, olderLoser.id])
+        .execute();
+    }
+  });
+
+  it('prefers a manual birthday over a more-recent inherited one', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
+    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
+
+    const manualWinner = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceA.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: manualWinner.id, assetFaceId: assetFace.id })
+      .execute();
+
+    const inheritedLoser = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceB.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2013-02-14',
+        birthDateSource: 'inherited',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer, but inherited
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: inheritedLoser.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
+      ]);
+    } finally {
+      await ctx.database
+        .deleteFrom('shared_space_person')
+        .where('id', 'in', [manualWinner.id, inheritedLoser.id])
+        .execute();
+    }
+  });
+```
+
+- [ ] **Step 2: Run both and confirm PASS**
+
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "most-recently edited manual birthday"
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "manual birthday over a more-recent inherited"
+```
+Expected: both PASS (resolve `2014-02-14`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts
+git commit -m "test(face-identity): most-recent manual + manual-over-inherited birthday selection"
+```
+
+---
+
+## Task 6: Boundary guards — no-birthday, hidden exclusion, no cross-space leak
+
+Three guards in one task (each its own `it`): they assert behavior the new INNER JOIN and visibility scoping must preserve.
+
+**Files:**
+- Test: `server/test/medium/specs/repositories/face-identity.repository.spec.ts`
+
+- [ ] **Step 1: Add the three guard tests**
+
+```ts
+  it('returns the person with a null birthday when no profile has one', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({ spaceId: space.id, identityId: identity.id, name: '', representativeFaceId: assetFace.id, type: 'person' })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+
+  it('does not surface a birthday from a hidden space profile unless withHidden is set', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        isHidden: true,
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const hiddenExcluded = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(hiddenExcluded.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: null }),
+      ]);
+
+      const hiddenIncluded = await sut.getAccessiblePeople(user.id, { withHidden: true, page: 1, size: 50 });
+      expect(hiddenIncluded.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+
+  it('does not leak a birthday from a space hidden from the viewer timeline', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+    // Hide the space from the viewer's timeline -> excluded from timeline_spaces.
+    await setMemberTimeline(ctx, { spaceId: space.id, userId: user.id, showInTimeline: false });
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: null }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+```
+
+- [ ] **Step 2: Run the three guards and confirm PASS**
+
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "null birthday"
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "hidden space profile"
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts -t "hidden from the viewer timeline"
+```
+Expected: all PASS.
+
+> Note: if the no-birthday guard fails because the person row is *missing entirely* (not just `birthDate: null`), the new `INNER JOIN ranked_profiles AS birthdate_profiles` is dropping the identity — revisit Task 2 Step 5 (it must not filter out identities that have profiles).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/face-identity.repository.spec.ts
+git commit -m "test(face-identity): birthday resolution boundary guards (none/hidden/visibility)"
+```
+
+---
+
+## Task 7: Full-suite verification + manual smoke
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the complete face-identity medium spec**
+
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/face-identity.repository.spec.ts
+```
+Expected: all tests pass (existing + 8 new).
+
+- [ ] **Step 2: Run the related shared-space medium specs (no regression)**
+
+```bash
+pnpm test:medium -- --run test/medium/specs/repositories/shared-space.repository.spec.ts test/medium/specs/services/shared-space-person-metadata-rbac.spec.ts
+```
+Expected: pass.
+
+- [ ] **Step 3: Confirm generated SQL is committed and not stale**
+
+```bash
+make sql
+git --no-pager status --porcelain server/src/queries/face.identity.repository.sql
+```
+Expected: empty output (no diff — the mirror was already regenerated and committed in Task 2).
+
+- [ ] **Step 4: Type-check the server**
+
+```bash
+pnpm exec tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 5: (Optional) Manual smoke against a running stack**
+
+If a `make dev` stack is available: as a space editor, set a birthday on a named person; log in as the library owner; open the same person in `/people` — the birthday now shows. (This mirrors the spec's reproduction, expecting the field to be populated rather than empty.)
+
+---
+
+## Notes for the implementer
+
+- **Do not** add a write to the `person` table or change `inheritSpacePersonMetadata` / the backfill — this is a read-time-only fix by design (see spec "Scope / non-goals"). Stored per-space rows may still diverge; that is intentional and out of scope.
+- **Lint gate is deferred:** run `pnpm exec tsc --noEmit` in the loop; the full `pnpm lint` (eslint, slow) is a single final gate, not per-task.
+- The eight new tests are all in one file; keep them grouped near the existing `getAccessiblePeople` display tests (after the `'uses a named accessible space profile…'` test).
+- If `pnpm test:medium` cannot pull/start the Postgres testcontainer, ensure Docker is running (Task 0 Step 2) — the failure is environmental, not a code regression.

--- a/docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md
@@ -21,18 +21,18 @@ the same identity.
 
 ### Observed data (one identity, 4 spaces)
 
-| Profile                       | birthDate    | birthDateSource | note                          |
-| ----------------------------- | ------------ | --------------- | ----------------------------- |
-| `shared_space_person` (Karolin) | `2014-02-14` | `manual`        | set today by an editor        |
-| `shared_space_person`          | `NULL`       | `none`          |                               |
-| `shared_space_person`          | `NULL`       | `none`          |                               |
-| `shared_space_person`          | `2013-02-14` | `manual`        | set earlier by a different user (wrong year) |
-| `person` (owner library)      | `NULL`       | n/a             | never touched by space edits  |
+| Profile                         | birthDate    | birthDateSource | note                                         |
+| ------------------------------- | ------------ | --------------- | -------------------------------------------- |
+| `shared_space_person` (Karolin) | `2014-02-14` | `manual`        | set today by an editor                       |
+| `shared_space_person`           | `NULL`       | `none`          |                                              |
+| `shared_space_person`           | `NULL`       | `none`          |                                              |
+| `shared_space_person`           | `2013-02-14` | `manual`        | set earlier by a different user (wrong year) |
+| `person` (owner library)        | `NULL`       | n/a             | never touched by space edits                 |
 
 ## Root cause
 
 Person metadata is **resolved at read time**, not written back to `person`. The owner
-seeing a space-set *name* is not a write — it is a query-time `COALESCE` in
+seeing a space-set _name_ is not a write — it is a query-time `COALESCE` in
 `FaceIdentityRepository.hydrateAccessiblePeople` (`face-identity.repository.ts`, the
 `profiles` → `ranked_profiles` → final `SELECT` CTE chain). This same path serves both
 the people list (`getAccessiblePeople`) and the single-person view
@@ -138,15 +138,15 @@ unchanged. `name` continues to resolve via `display_profiles` exactly as today.
 ## Scope / non-goals
 
 - **No write-back to `person`.** The owner's library `person.birthDate` stays editor-immutable;
-  the owner simply *sees* the resolved identity birthday, identically to how they see a
+  the owner simply _sees_ the resolved identity birthday, identically to how they see a
   space-set name today.
 - **No change to the write-time backfill** (`inheritSpacePersonMetadata`) or to the
   diverging stored `shared_space_person` rows. Space D's stale `2013-02-14` remains in the
-  DB; it would only surface if it were the most-recent manual value *and* no owner value
+  DB; it would only surface if it were the most-recent manual value _and_ no owner value
   existed — consistent and acceptable.
 - **Search path is unaffected (verified).** `SearchRepository.searchFaces` /
   `getFilteredIdentityPeople` return only `id/name/profileType/profileId/spaceId` — no
-  `birthDate`. (`minBirthDate` there is an age *filter*, not a displayed value.) No change.
+  `birthDate`. (`minBirthDate` there is an age _filter_, not a displayed value.) No change.
 - **`getMetadataInheritanceCandidates` is unchanged.** It feeds the write-time backfill,
   which is out of scope (above).
 - **No schema migration.** All columns used already exist (`person.birthDate`;
@@ -185,7 +185,7 @@ is caught.
 ### TDD cadence (one test at a time; red → green → next)
 
 **Behavior-driving tests** — each must be written and confirmed to fail before the
-implementation step that makes it pass. They are constructed so a *partial* implementation
+implementation step that makes it pass. They are constructed so a _partial_ implementation
 cannot pass by accident:
 
 1. **Repro — space-only birthday (the bug).** Owner `person`: named, NULL birthday. One
@@ -196,7 +196,7 @@ cannot pass by accident:
 2. **Single-person view parity.** Same fixture via `getAccessiblePersonByProfileId` → same
    `2014-02-14`. **Red today.** Confirms the shared SQL covers both entry points.
 3. **Owner precedence over a space value.** Owner `person`: manual `1990-01-01`. A space:
-   manual `2014-02-14` (with a *newer* `birthDateSourceUpdatedAt`). → owner's `1990-01-01`
+   manual `2014-02-14` (with a _newer_ `birthDateSourceUpdatedAt`). → owner's `1990-01-01`
    wins. Drives the `user-person`-first ORDER BY term (a recency-only ranking would pick the
    space value and fail this test).
 4. **Most-recent-manual tiebreak (recency is the deciding factor).** Owner: no birthday. Two
@@ -205,7 +205,7 @@ cannot pass by accident:
    selects it — a naive `profileId`/`updatedAt` ordering would pick the wrong one. Asserts
    the newer-manual date.
 5. **Manual beats inherited.** Owner: no birthday. One space `manual` = date A, another space
-   `inherited` = date B with a *newer* `birthDateSourceUpdatedAt`. → date A (manual) wins,
+   `inherited` = date B with a _newer_ `birthDateSourceUpdatedAt`. → date A (manual) wins,
    proving the `manual < inherited` source tier outranks pure recency.
 
 **Boundary / regression guards** — assert behavior that must be preserved:

--- a/docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md
@@ -1,0 +1,175 @@
+# Space-person birthday display resolution
+
+**Date:** 2026-06-10
+**Status:** Approved (design)
+**Area:** server — `face-identity.repository.ts` read-time person resolution
+
+## Problem
+
+After the rc4 fix ("persist space people birthdays globally"), an editor in a shared
+space can set a birthday and it is correctly stored on that space's
+`shared_space_person` row. But the library owner (and other viewers) see an **empty**
+birthday field for that person, even though a birthday exists on a sibling profile of
+the same identity.
+
+### Reproduction
+
+1. Log in as a user with editor role in a shared space.
+2. Open a named person in `/people`, set a birthday.
+3. Log out; log in as the library owner (admin).
+4. Open the same person in `/people` — the birthday field is empty.
+
+### Observed data (one identity, 4 spaces)
+
+| Profile                       | birthDate    | birthDateSource | note                          |
+| ----------------------------- | ------------ | --------------- | ----------------------------- |
+| `shared_space_person` (Karolin) | `2014-02-14` | `manual`        | set today by an editor        |
+| `shared_space_person`          | `NULL`       | `none`          |                               |
+| `shared_space_person`          | `NULL`       | `none`          |                               |
+| `shared_space_person`          | `2013-02-14` | `manual`        | set earlier by a different user (wrong year) |
+| `person` (owner library)      | `NULL`       | n/a             | never touched by space edits  |
+
+## Root cause
+
+Person metadata is **resolved at read time**, not written back to `person`. The owner
+seeing a space-set *name* is not a write — it is a query-time `COALESCE` in
+`FaceIdentityRepository.hydrateAccessiblePeople` (`face-identity.repository.ts`, the
+`profiles` → `ranked_profiles` → final `SELECT` CTE chain). This same path serves both
+the people list (`getAccessiblePeople`) and the single-person view
+(`getAccessiblePersonByProfileId`).
+
+The resolver builds a `profiles` CTE union of the owner's `person` row plus every
+visible `shared_space_person` row for the identity, then ranks them:
+
+- `display_rn` — "best **named** profile" (ordered by has-name, then `profileRank`
+  where the owner's `person` = 0, then name alpha, then recency).
+- `primary_rn` — "canonical profile" (ordered user-person-first → the owner's `person`).
+
+The final projection resolves:
+
+```sql
+COALESCE(NULLIF(display_profiles.name, ''), primary_profiles.name, '') AS name,
+COALESCE(display_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
+```
+
+**Name** has a dedicated "best name" ranking (`display_rn`), so it finds a name wherever
+it lives. **Birthday has no ranking of its own** — it piggybacks on the name-winner and
+the owner. In the reproduction, the owner's `person` row is named (so it wins both
+`display_rn` and `primary_rn`) but has a NULL birthday, so `birthDate` resolves to
+`COALESCE(NULL, NULL) = NULL`. The `2014-02-14` on Karolin's space-person — which is
+neither the best-named profile nor the owner — is never consulted.
+
+This is purely a **read/display** defect. Both the write path and the stored rows are
+working as designed.
+
+## Decision
+
+Give `birthDate` its own selection across all profiles of the identity, symmetric to how
+`name` has `display_rn`. **Read-time only — no write-back to `person`, no change to the
+write-time backfill or stored rows.** This matches the existing name design exactly
+(names are never persisted to `person`; they are resolved on read).
+
+### Birthday precedence (when multiple profiles carry a birthday)
+
+**Owner first, then most-recent manual.** If the owner's own `person` row has a birthday,
+show it. Otherwise show the most recently edited manual birthday among the visible
+profiles. Implemented as an ordering where NULL birthdays sort last, so the owner only
+"wins" when they actually have a value.
+
+## Implementation
+
+A single SQL change in `FaceIdentityRepository.hydrateAccessiblePeople`. Three edits:
+
+### 1. `profiles` CTE — carry birthday provenance on both branches
+
+The `person` table has only `birthDate` (no `birthDateSource` / `birthDateSourceUpdatedAt`
+columns — confirmed in `person.table.ts`). The owner's value is authoritative by position,
+so synthesize a source for it:
+
+- **person branch:**
+  ```sql
+  CASE WHEN person."birthDate" IS NOT NULL THEN 'manual' ELSE 'none' END AS "birthDateSource",
+  person."updatedAt" AS "birthDateSourceUpdatedAt",
+  ```
+- **space-person branch:**
+  ```sql
+  shared_space_person."birthDateSource",
+  shared_space_person."birthDateSourceUpdatedAt",
+  ```
+
+### 2. `ranked_profiles` — add a `birthdate_rn` window (birthday analog of `display_rn`)
+
+```sql
+row_number() OVER (
+  PARTITION BY profiles."identityId"
+  ORDER BY
+    profiles."birthDate" IS NULL,                                          -- birthday-bearing first
+    CASE WHEN profiles."profileType" = 'user-person' THEN 0 ELSE 1 END,    -- owner/self first → owner wins IF present
+    CASE profiles."birthDateSource"
+      WHEN 'manual' THEN 0 WHEN 'inherited' THEN 1 ELSE 2 END,             -- manual over inherited
+    profiles."birthDateSourceUpdatedAt" DESC NULLS LAST,                   -- most-recent manual
+    profiles."updatedAt" DESC,
+    profiles."profileId"                                                   -- stable tiebreak
+) AS birthdate_rn
+```
+
+Because NULL birthdays sort last (line 1), the owner row only reaches `birthdate_rn = 1`
+when it actually has a birthday. When the owner has none, the most-recent manual space
+value wins — exactly "owner first, then most-recent manual."
+
+### 3. Final SELECT — resolve from the new alias
+
+```sql
+COALESCE(birthdate_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
+```
+
+and add the join:
+
+```sql
+INNER JOIN ranked_profiles AS birthdate_profiles
+  ON birthdate_profiles."identityId" = requested_identities."identityId"
+  AND birthdate_profiles.birthdate_rn = 1
+```
+
+All other projected columns (`name`, thumbnail, hidden, favorite, counts, etc.) are
+unchanged. `name` continues to resolve via `display_profiles` exactly as today.
+
+## Scope / non-goals
+
+- **No write-back to `person`.** The owner's library `person.birthDate` stays editor-immutable;
+  the owner simply *sees* the resolved identity birthday, identically to how they see a
+  space-set name today.
+- **No change to the write-time backfill** (`inheritSpacePersonMetadata`) or to the
+  diverging stored `shared_space_person` rows. Space D's stale `2013-02-14` remains in the
+  DB; it would only surface if it were the most-recent manual value *and* no owner value
+  existed — consistent and acceptable.
+- **No schema migration.** All columns used already exist.
+- **No new endpoint or DTO change.** `PersonResponseDto.birthDate` is already populated by
+  this resolver.
+
+## Testing (TDD)
+
+`hydrateAccessiblePeople` is raw SQL, so the failing-test-first must be a **medium test
+against a real Postgres** (testcontainers), in the `FaceIdentityRepository` medium suite.
+The exact harness/fixtures (identity, person, space, member, shared_space_person,
+shared_space_person_face, asset_face) will be confirmed when writing the plan.
+
+Tests (write first, watch fail, then implement):
+
+1. **Repro / primary fix (list view):** owner `person` named with NULL birthday + one
+   space-person with a manual birthday + NULL siblings → `getAccessiblePeople` returns the
+   owner's resolved person with the space birthday. (Red today.)
+2. **Single-person view:** same fixture via `getAccessiblePersonByProfileId` → resolves the
+   same birthday. (Red today; same SQL, explicit coverage.)
+3. **Owner precedence:** owner has a birthday AND a space has a different manual birthday →
+   owner's value wins.
+4. **Most-recent-manual tiebreak:** two spaces with manual birthdays, different
+   `birthDateSourceUpdatedAt`, owner has none → the most-recent manual value wins.
+5. **No-birthday-anywhere:** all profiles NULL → resolves NULL (no regression / no crash).
+6. **Name unaffected:** existing name-resolution assertions still pass (regression guard).
+
+## Affected files
+
+- `server/src/repositories/face-identity.repository.ts` — the `hydrateAccessiblePeople` SQL.
+- `server/src/repositories/face-identity.repository.spec.ts` (or the corresponding medium
+  test file) — new fixtures + assertions.

--- a/docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md
@@ -72,9 +72,10 @@ write-time backfill or stored rows.** This matches the existing name design exac
 ### Birthday precedence (when multiple profiles carry a birthday)
 
 **Owner first, then most-recent manual.** If the owner's own `person` row has a birthday,
-show it. Otherwise show the most recently edited manual birthday among the visible
-profiles. Implemented as an ordering where NULL birthdays sort last, so the owner only
-"wins" when they actually have a value.
+show it. Otherwise, among the visible profiles, prefer a `manual` birthday over an
+`inherited` one, and within a tier pick the most recently edited
+(`birthDateSourceUpdatedAt`). Implemented as an ordering where NULL birthdays sort last, so
+the owner only "wins" when they actually have a value.
 
 ## Implementation
 
@@ -143,33 +144,93 @@ unchanged. `name` continues to resolve via `display_profiles` exactly as today.
   diverging stored `shared_space_person` rows. Space D's stale `2013-02-14` remains in the
   DB; it would only surface if it were the most-recent manual value *and* no owner value
   existed — consistent and acceptable.
-- **No schema migration.** All columns used already exist.
+- **Search path is unaffected (verified).** `SearchRepository.searchFaces` /
+  `getFilteredIdentityPeople` return only `id/name/profileType/profileId/spaceId` — no
+  `birthDate`. (`minBirthDate` there is an age *filter*, not a displayed value.) No change.
+- **`getMetadataInheritanceCandidates` is unchanged.** It feeds the write-time backfill,
+  which is out of scope (above).
+- **No schema migration.** All columns used already exist (`person.birthDate`;
+  `shared_space_person.birthDate` / `birthDateSource` / `birthDateSourceUpdatedAt`). The
+  `person` table has no source columns — hence the synthesized source in step 1.
 - **No new endpoint or DTO change.** `PersonResponseDto.birthDate` is already populated by
-  this resolver.
+  this resolver via `mapAccessiblePerson` (`birthDate: asBirthDateString(row.birthDate)`).
+- **Visibility is not broadened.** `birthdate_rn` ranks only within the existing `profiles`
+  CTE, which is already scoped to the viewer's own `person` rows and the spaces visible to
+  them (`timeline_spaces`). A birthday in a space the viewer cannot see is never consulted.
+
+## Build & regeneration (required)
+
+- `hydrateAccessiblePeople` is decorated with `@GenerateSql` (`face-identity.repository.ts`
+  ~line 1764). Any change to its SQL **requires running `make sql`** to regenerate
+  `src/queries/face.identity.repository.sql`. **CI fails if this file is stale** — it must
+  be committed alongside the code change.
+- `face-identity-query-shape.spec.ts` asserts only keyword presence/absence
+  (`face_identity_face`, `<=>`, `face_search.embedding`) — adding the `birthdate_rn` window
+  and alias does **not** affect it. No change needed there.
 
 ## Testing (TDD)
 
-`hydrateAccessiblePeople` is raw SQL, so the failing-test-first must be a **medium test
-against a real Postgres** (testcontainers), in the `FaceIdentityRepository` medium suite.
-The exact harness/fixtures (identity, person, space, member, shared_space_person,
-shared_space_person_face, asset_face) will be confirmed when writing the plan.
+`hydrateAccessiblePeople` is raw SQL whose behavior only exists against a real database, so
+unit/mocked coverage cannot exercise it — all tests are **medium tests against a real
+Postgres** (testcontainers) in
+`test/medium/specs/repositories/face-identity.repository.spec.ts`. Fixture helpers already
+used by that suite: `ctx.newUser`, `ctx.newPerson({ ownerId, name, birthDate, isHidden })`,
+`ctx.newAsset`, `ctx.newAssetFace`, `ctx.newSharedSpace`, `ctx.newSharedSpaceMember`,
+`ctx.newSharedSpaceAsset`, `sut.ensurePersonIdentity(personId)`,
+`sut.linkFace({ assetFaceId, identityId, source })`, and a raw insert into
+`shared_space_person` (+ `shared_space_person_face`). Assertions compare against the
+formatted date string (e.g. `birthDate: '2014-02-14'`) so a timezone/off-by-one regression
+is caught.
 
-Tests (write first, watch fail, then implement):
+### TDD cadence (one test at a time; red → green → next)
 
-1. **Repro / primary fix (list view):** owner `person` named with NULL birthday + one
-   space-person with a manual birthday + NULL siblings → `getAccessiblePeople` returns the
-   owner's resolved person with the space birthday. (Red today.)
-2. **Single-person view:** same fixture via `getAccessiblePersonByProfileId` → resolves the
-   same birthday. (Red today; same SQL, explicit coverage.)
-3. **Owner precedence:** owner has a birthday AND a space has a different manual birthday →
-   owner's value wins.
-4. **Most-recent-manual tiebreak:** two spaces with manual birthdays, different
-   `birthDateSourceUpdatedAt`, owner has none → the most-recent manual value wins.
-5. **No-birthday-anywhere:** all profiles NULL → resolves NULL (no regression / no crash).
-6. **Name unaffected:** existing name-resolution assertions still pass (regression guard).
+**Behavior-driving tests** — each must be written and confirmed to fail before the
+implementation step that makes it pass. They are constructed so a *partial* implementation
+cannot pass by accident:
+
+1. **Repro — space-only birthday (the bug).** Owner `person`: named, NULL birthday. One
+   space-person: manual `2014-02-14`. Siblings: NULL. → `getAccessiblePeople(owner)` returns
+   the person with `birthDate: '2014-02-14'` **and** the correct name (name and birthday
+   resolve from different profiles simultaneously). **Red today** (returns `null`). Drives
+   adding `birthdate_rn` + the new alias/COALESCE.
+2. **Single-person view parity.** Same fixture via `getAccessiblePersonByProfileId` → same
+   `2014-02-14`. **Red today.** Confirms the shared SQL covers both entry points.
+3. **Owner precedence over a space value.** Owner `person`: manual `1990-01-01`. A space:
+   manual `2014-02-14` (with a *newer* `birthDateSourceUpdatedAt`). → owner's `1990-01-01`
+   wins. Drives the `user-person`-first ORDER BY term (a recency-only ranking would pick the
+   space value and fail this test).
+4. **Most-recent-manual tiebreak (recency is the deciding factor).** Owner: no birthday. Two
+   spaces, both `manual`. The winning row is given the **older** `profileId`/`updatedAt` but
+   the **newer** `birthDateSourceUpdatedAt`, so only the `birthDateSourceUpdatedAt DESC` term
+   selects it — a naive `profileId`/`updatedAt` ordering would pick the wrong one. Asserts
+   the newer-manual date.
+5. **Manual beats inherited.** Owner: no birthday. One space `manual` = date A, another space
+   `inherited` = date B with a *newer* `birthDateSourceUpdatedAt`. → date A (manual) wins,
+   proving the `manual < inherited` source tier outranks pure recency.
+
+**Boundary / regression guards** — assert behavior that must be preserved:
+
+6. **No birthday anywhere.** All profiles NULL → person is **still returned** with
+   `birthDate: null` (verifies the new `INNER JOIN ranked_profiles AS birthdate_profiles`
+   does not drop the identity).
+7. **Hidden profile excluded.** A hidden space-person holds the only birthday;
+   `withHidden: false` → `birthDate: null` (hidden rows are excluded from `profiles`, same as
+   for name). With `withHidden: true` → the birthday resolves.
+8. **Cross-space visibility — no leak.** The only birthday lives in a space the viewer is
+   **not** a member of (absent from `timeline_spaces`) → `birthDate: null`. Confirms the fix
+   does not broaden visibility.
+9. **Owner-birthday-only (existing guard).** The existing test
+   "uses a named accessible space profile for display while keeping a viewer-owned primary
+   profile" (`face-identity.repository.spec.ts:1519` — owner has birthday, space supplies the
+   name) must continue to pass. Verifies the fix preserves owner-only resolution.
+10. **Name resolution unchanged.** Existing name-resolution assertions still pass (the `name`
+    projection via `display_profiles` is untouched).
 
 ## Affected files
 
-- `server/src/repositories/face-identity.repository.ts` — the `hydrateAccessiblePeople` SQL.
-- `server/src/repositories/face-identity.repository.spec.ts` (or the corresponding medium
-  test file) — new fixtures + assertions.
+- `server/src/repositories/face-identity.repository.ts` — the `hydrateAccessiblePeople` SQL
+  (3 edits: `profiles` CTE columns, `birthdate_rn` window, final SELECT + join).
+- `server/src/queries/face.identity.repository.sql` — **regenerated via `make sql`** and
+  committed (CI-enforced).
+- `server/test/medium/specs/repositories/face-identity.repository.spec.ts` — new fixtures +
+  assertions (tests 1–8 above; 9–10 are existing guards).

--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -1196,6 +1196,11 @@ WITH
       person."identityId",
       person.name,
       person."birthDate",
+      CASE
+        WHEN person."birthDate" IS NOT NULL THEN 'manual'
+        ELSE 'none'
+      END AS "birthDateSource",
+      person."updatedAt" AS "birthDateSourceUpdatedAt",
       person."thumbnailPath",
       person."isHidden",
       person."isFavorite",
@@ -1225,6 +1230,8 @@ WITH
         ''
       ) AS name,
       shared_space_person."birthDate",
+      shared_space_person."birthDateSource",
+      shared_space_person."birthDateSourceUpdatedAt",
       ''::text AS "thumbnailPath",
       shared_space_person."isHidden",
       NULL::boolean AS "isFavorite",
@@ -1284,7 +1291,25 @@ WITH
           lower(profiles.name),
           profiles."updatedAt" DESC,
           profiles."profileId"
-      ) AS primary_rn
+      ) AS primary_rn,
+      row_number() OVER (
+        PARTITION BY
+          profiles."identityId"
+        ORDER BY
+          profiles."birthDate" IS NULL,
+          CASE
+            WHEN profiles."profileType" = 'user-person' THEN 0
+            ELSE 1
+          END,
+          CASE profiles."birthDateSource"
+            WHEN 'manual' THEN 0
+            WHEN 'inherited' THEN 1
+            ELSE 2
+          END,
+          profiles."birthDateSourceUpdatedAt" DESC NULLS LAST,
+          profiles."updatedAt" DESC,
+          profiles."profileId"
+      ) AS birthdate_rn
     FROM
       profiles
     WHERE
@@ -1307,7 +1332,7 @@ SELECT
     ''
   ) AS name,
   COALESCE(
-    display_profiles."birthDate",
+    birthdate_profiles."birthDate",
     primary_profiles."birthDate"
   ) AS "birthDate",
   primary_profiles."thumbnailPath",
@@ -1324,6 +1349,8 @@ FROM
   AND primary_profiles.primary_rn = 1
   INNER JOIN ranked_profiles AS display_profiles ON display_profiles."identityId" = requested_identities."identityId"
   AND display_profiles.display_rn = 1
+  INNER JOIN ranked_profiles AS birthdate_profiles ON birthdate_profiles."identityId" = requested_identities."identityId"
+  AND birthdate_profiles.birthdate_rn = 1
   LEFT JOIN asset_counts ON asset_counts."identityId" = requested_identities."identityId"
 ORDER BY
   requested_identities.ord

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -1829,6 +1829,8 @@ export class FaceIdentityRepository {
           person."identityId",
           person.name,
           person."birthDate",
+          CASE WHEN person."birthDate" IS NOT NULL THEN 'manual' ELSE 'none' END AS "birthDateSource",
+          person."updatedAt" AS "birthDateSourceUpdatedAt",
           person."thumbnailPath",
           person."isHidden",
           person."isFavorite",
@@ -1849,6 +1851,8 @@ export class FaceIdentityRepository {
           shared_space_person."identityId",
           COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name,
           shared_space_person."birthDate",
+          shared_space_person."birthDateSource",
+          shared_space_person."birthDateSourceUpdatedAt",
           ''::text AS "thumbnailPath",
           shared_space_person."isHidden",
           NULL::boolean AS "isFavorite",
@@ -1897,7 +1901,21 @@ export class FaceIdentityRepository {
               lower(profiles.name),
               profiles."updatedAt" DESC,
               profiles."profileId"
-          ) AS primary_rn
+          ) AS primary_rn,
+          row_number() OVER (
+            PARTITION BY profiles."identityId"
+            ORDER BY
+              profiles."birthDate" IS NULL,
+              CASE WHEN profiles."profileType" = 'user-person' THEN 0 ELSE 1 END,
+              CASE profiles."birthDateSource"
+                WHEN 'manual' THEN 0
+                WHEN 'inherited' THEN 1
+                ELSE 2
+              END,
+              profiles."birthDateSourceUpdatedAt" DESC NULLS LAST,
+              profiles."updatedAt" DESC,
+              profiles."profileId"
+          ) AS birthdate_rn
         FROM profiles
         WHERE EXISTS (SELECT 1 FROM accessible_faces WHERE accessible_faces."identityId" = profiles."identityId")
       )
@@ -1906,7 +1924,7 @@ export class FaceIdentityRepository {
         primary_profiles."profileId",
         primary_profiles."spaceId",
         COALESCE(NULLIF(display_profiles.name, ''), primary_profiles.name, '') AS name,
-        COALESCE(display_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
+        COALESCE(birthdate_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
         primary_profiles."thumbnailPath",
         primary_profiles."isHidden",
         primary_profiles."isFavorite",
@@ -1922,6 +1940,9 @@ export class FaceIdentityRepository {
       INNER JOIN ranked_profiles AS display_profiles
         ON display_profiles."identityId" = requested_identities."identityId"
         AND display_profiles.display_rn = 1
+      INNER JOIN ranked_profiles AS birthdate_profiles
+        ON birthdate_profiles."identityId" = requested_identities."identityId"
+        AND birthdate_profiles.birthdate_rn = 1
       LEFT JOIN asset_counts ON asset_counts."identityId" = requested_identities."identityId"
       ORDER BY requested_identities.ord
     `.execute(this.db);

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1717,6 +1717,141 @@ describe(FaceIdentityRepository.name, () => {
         .execute();
     }
   });
+
+  it('picks the most-recently edited manual birthday across spaces', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
+    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
+
+    // Newer edit (the winner), inserted FIRST so a profileId/updatedAt-only ordering would NOT pick it.
+    const newerWinner = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceA.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // most recent
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: newerWinner.id, assetFaceId: assetFace.id })
+      .execute();
+
+    const olderLoser = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceB.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2013-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: olderLoser.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
+      ]);
+    } finally {
+      await ctx.database
+        .deleteFrom('shared_space_person')
+        .where('id', 'in', [newerWinner.id, olderLoser.id])
+        .execute();
+    }
+  });
+
+  it('prefers a manual birthday over a more-recent inherited one', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' }); // owner: no birthday
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: asset.id, addedById: user.id });
+    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: user.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: asset.id, addedById: user.id });
+
+    const manualWinner = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceA.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2025-01-01T00:00:00.000Z'), // older
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: manualWinner.id, assetFaceId: assetFace.id })
+      .execute();
+
+    const inheritedLoser = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: spaceB.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2013-02-14',
+        birthDateSource: 'inherited',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'), // newer, but inherited
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: inheritedLoser.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
+      ]);
+    } finally {
+      await ctx.database
+        .deleteFrom('shared_space_person')
+        .where('id', 'in', [manualWinner.id, inheritedLoser.id])
+        .execute();
+    }
+  });
   it('filters unnamed identity-grouped people below the configured minimum face count', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1667,6 +1667,56 @@ describe(FaceIdentityRepository.name, () => {
         .execute();
     }
   });
+
+  it('prefers the owner birthday over a more-recent space birthday', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({
+      ownerId: user.id,
+      name: 'Ina',
+      birthDate: new Date('1990-01-01T00:00:00.000Z'),
+    });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '1990-01-01' }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
   it('filters unnamed identity-grouped people below the configured minimum face count', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1613,12 +1613,7 @@ describe(FaceIdentityRepository.name, () => {
         }),
       ]);
     } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1659,12 +1654,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }),
       );
     } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1709,12 +1699,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, birthDate: '1990-01-01' }),
       ]);
     } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1779,10 +1764,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
       ]);
     } finally {
-      await ctx.database
-        .deleteFrom('shared_space_person')
-        .where('id', 'in', [newerWinner.id, olderLoser.id])
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1846,10 +1828,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
       ]);
     } finally {
-      await ctx.database
-        .deleteFrom('shared_space_person')
-        .where('id', 'in', [manualWinner.id, inheritedLoser.id])
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1880,12 +1859,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null }),
       ]);
     } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1931,12 +1905,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
       ]);
     } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 
@@ -1978,12 +1947,7 @@ describe(FaceIdentityRepository.name, () => {
         expect.objectContaining({ id: person.id, birthDate: null }),
       ]);
     } finally {
-      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
-      await ctx.database
-        .deleteFrom('shared_space_asset')
-        .where('spaceId', '=', space.id)
-        .where('assetId', '=', asset.id)
-        .execute();
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
   });
 

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1569,6 +1569,59 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('resolves a space-set birthday for the owner when only a sibling space profile carries it', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    // Owner's library person: has the NAME, but no birthday.
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    // Space profile (set by an editor): carries the manual birthday, no name.
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+
+      expect(result.people).toEqual([
+        expect.objectContaining({
+          id: person.id,
+          name: 'Ina', // name still resolves from the owner profile
+          birthDate: '2014-02-14', // birthday resolves from the sibling space profile
+          primaryProfile: { type: 'user-person', id: person.id },
+        }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+
   it('filters unnamed identity-grouped people below the configured minimum face count', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1650,9 +1650,7 @@ describe(FaceIdentityRepository.name, () => {
     try {
       const result = await sut.getAccessiblePersonByProfileId(user.id, spacePerson.id);
 
-      expect(result).toEqual(
-        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }),
-      );
+      expect(result).toEqual(expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }));
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -1695,9 +1693,7 @@ describe(FaceIdentityRepository.name, () => {
     try {
       const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
 
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '1990-01-01' }),
-      ]);
+      expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '1990-01-01' })]);
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -1760,9 +1756,7 @@ describe(FaceIdentityRepository.name, () => {
 
     try {
       const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
-      ]);
+      expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '2014-02-14' })]);
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -1824,9 +1818,7 @@ describe(FaceIdentityRepository.name, () => {
 
     try {
       const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
-      ]);
+      expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '2014-02-14' })]);
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -1845,7 +1837,13 @@ describe(FaceIdentityRepository.name, () => {
     await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
     const spacePerson = await ctx.database
       .insertInto('shared_space_person')
-      .values({ spaceId: space.id, identityId: identity.id, name: '', representativeFaceId: assetFace.id, type: 'person' })
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+      })
       .returningAll()
       .executeTakeFirstOrThrow();
     await ctx.database
@@ -1855,9 +1853,7 @@ describe(FaceIdentityRepository.name, () => {
 
     try {
       const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null }),
-      ]);
+      expect(result.people).toEqual([expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null })]);
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -1896,14 +1892,10 @@ describe(FaceIdentityRepository.name, () => {
 
     try {
       const hiddenExcluded = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(hiddenExcluded.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: null }),
-      ]);
+      expect(hiddenExcluded.people).toEqual([expect.objectContaining({ id: person.id, birthDate: null })]);
 
       const hiddenIncluded = await sut.getAccessiblePeople(user.id, { withHidden: true, page: 1, size: 50 });
-      expect(hiddenIncluded.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
-      ]);
+      expect(hiddenIncluded.people).toEqual([expect.objectContaining({ id: person.id, birthDate: '2014-02-14' })]);
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
@@ -1943,9 +1935,7 @@ describe(FaceIdentityRepository.name, () => {
 
     try {
       const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
-      expect(result.people).toEqual([
-        expect.objectContaining({ id: person.id, birthDate: null }),
-      ]);
+      expect(result.people).toEqual([expect.objectContaining({ id: person.id, birthDate: null })]);
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1622,6 +1622,51 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('resolves a space-set birthday via the single-person view', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePersonByProfileId(user.id, spacePerson.id);
+
+      expect(result).toEqual(
+        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }),
+      );
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
   it('filters unnamed identity-grouped people below the configured minimum face count', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1852,6 +1852,141 @@ describe(FaceIdentityRepository.name, () => {
         .execute();
     }
   });
+
+  it('returns the person with a null birthday when no profile has one', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({ spaceId: space.id, identityId: identity.id, name: '', representativeFaceId: assetFace.id, type: 'person' })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, name: 'Ina', birthDate: null }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+
+  it('does not surface a birthday from a hidden space profile unless withHidden is set', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        isHidden: true,
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const hiddenExcluded = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(hiddenExcluded.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: null }),
+      ]);
+
+      const hiddenIncluded = await sut.getAccessiblePeople(user.id, { withHidden: true, page: 1, size: 50 });
+      expect(hiddenIncluded.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: '2014-02-14' }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+
+  it('does not leak a birthday from a space hidden from the viewer timeline', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+    // Hide the space from the viewer's timeline -> excluded from timeline_spaces.
+    await setMemberTimeline(ctx, { spaceId: space.id, userId: user.id, showInTimeline: false });
+
+    try {
+      const result = await sut.getAccessiblePeople(user.id, { withHidden: false, page: 1, size: 50 });
+      expect(result.people).toEqual([
+        expect.objectContaining({ id: person.id, birthDate: null }),
+      ]);
+    } finally {
+      await ctx.database.deleteFrom('shared_space_person').where('id', '=', spacePerson.id).execute();
+      await ctx.database
+        .deleteFrom('shared_space_asset')
+        .where('spaceId', '=', space.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+    }
+  });
+
   it('filters unnamed identity-grouped people below the configured minimum face count', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();


### PR DESCRIPTION
## Problem

After the rc4 "persist space people birthdays globally" fix, a birthday set by a shared-space editor was correctly stored on that space's `shared_space_person` row, but the **library owner (and other viewers) saw an empty birthday field** — even though a birthday existed on a sibling profile of the same face identity. Two editors in different spaces could also hold divergent values with no reconciliation in what was displayed.

## Root cause (read-time, not write-time)

Person metadata is resolved at **read time** in `FaceIdentityRepository.hydrateAccessiblePeople` — the owner seeing a space-set *name* is a query-time `COALESCE` across the `person` + `shared_space_person` profiles of an identity, not a write-back. That resolver already touched `birthDate`, but it read it only from two profiles:

```sql
COALESCE(NULLIF(display_profiles.name, ''), primary_profiles.name, '') AS name,
COALESCE(display_profiles."birthDate", primary_profiles."birthDate") AS "birthDate",
```

- `display_profiles` = the profile that wins `display_rn`, ranked **by name** ("best-named" profile).
- `primary_profiles` = the canonical profile, ranked user-person-first (the owner's `person` row).

`name` has a dedicated "best name" ranking; **`birthDate` had none** — it piggybacked on the name-winner. So when the owner's `person` row supplies the name (winning both windows) but has a NULL birthday, the birthday resolves to `COALESCE(NULL, NULL) = NULL`, ignoring the space-person that actually carries it.

## Fix

Give `birthDate` its own selection across all profiles of the identity — a `birthdate_rn` window, symmetric to `display_rn` — then resolve from it:

```sql
COALESCE(birthdate_profiles."birthDate", primary_profiles."birthDate") AS "birthDate"
```

Precedence (**owner first, then most-recent manual**): NULL birthdays sort last, so the owner's value wins only when present; otherwise the most-recently-edited `manual` birthday wins, preferring `manual` over `inherited`.

**Read-time only — no write-back to `person`, no schema change, no backfill change.** This matches the existing name design exactly (names are never persisted to the owner's library; they're resolved on read). Covers both the people list (`getAccessiblePeople`) and the single-person view (`getAccessiblePersonByProfileId`) via the same SQL. The `@GenerateSql` mirror (`face.identity.repository.sql`) is regenerated.

## Tests (TDD)

Medium tests (real Postgres) in `face-identity.repository.spec.ts`:

- **Repro** (red→green): owner named + NULL birthday, space-person manual birthday → resolves the space birthday + owner's name.
- Single-person view parity.
- Owner precedence over a newer space value; most-recent-manual tiebreak (fixture isolates the `birthDateSourceUpdatedAt` term); manual-over-inherited.
- Boundary guards: no-birthday-anywhere, hidden-profile exclusion (both `withHidden` modes), no cross-space-timeline leak.

New tests clean up via user-cascade to avoid `getBackfillWork` projection-work pollution. Verified: face-identity spec 106/106, related shared-space specs 173/173, `tsc` clean, SQL mirror fresh.

## Scope / non-goals

- No write to `person`; `inheritSpacePersonMetadata` / backfill unchanged. Diverging *stored* per-space rows remain as-is — what each viewer *sees* is now resolved correctly.
- Search path unaffected (it never returns `birthDate`).

Design + plan: `docs/superpowers/specs/2026-06-10-space-birthday-identity-display-resolution-design.md`, `docs/superpowers/plans/2026-06-10-space-birthday-identity-display-resolution.md`.
