### PR TITLE
fix(server): stop endless FaceIdentityBackfill loop and shared_space_person updatedAt churn

### DIFF
--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Insertable, Kysely, RawBuilder, Selectable, sql, Transaction } from 'kysely';
+import { ExpressionBuilder, Insertable, Kysely, RawBuilder, Selectable, sql, Transaction } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import {
@@ -2307,6 +2307,12 @@ export class FaceIdentityRepository {
     for (const group of groups) {
       const targetPerson = await this.getPersonByIdentity(person.ownerId, group.identityId, person.id);
       if (!targetPerson) {
+        // No person of this owner references the linked identity, so there is nowhere to move the
+        // faces. Trust the person they are already on and realign the link — otherwise
+        // person.identityId stays DISTINCT FROM face_identity_face.identityId, getBackfillWork()
+        // reports work forever, and handleFaceIdentityBackfill re-queues in a loop.
+        const strandedAssetFaceIds = await this.getPersonalBackfillAssetFaceIdsForIdentity(person.id, group.identityId);
+        await this.realignFacesToPersonIdentity(person.id, strandedAssetFaceIds);
         continue;
       }
 
@@ -2636,6 +2642,37 @@ export class FaceIdentityRepository {
       .execute();
   }
 
+  private spacePersonFaceCount(eb: ExpressionBuilder<DB, 'shared_space_person'>) {
+    return eb
+      .selectFrom('shared_space_person_face')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', 'is', true)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+      .select((eb2) => eb2.fn.countAll().$castTo<number>().as('count'))
+      .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id');
+  }
+
+  private spacePersonAssetCount(eb: ExpressionBuilder<DB, 'shared_space_person'>) {
+    return eb
+      .selectFrom('shared_space_person_face')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .where('asset_face.deletedAt', 'is', null)
+      .where('asset_face.isVisible', 'is', true)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
+      .select((eb2) =>
+        eb2.fn
+          .count(eb2.fn('distinct', ['asset_face.assetId']))
+          .$castTo<number>()
+          .as('count'),
+      )
+      .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id');
+  }
+
   private async recountSpacePersons(personIds: string[]): Promise<void> {
     if (personIds.length === 0) {
       return;
@@ -2644,33 +2681,19 @@ export class FaceIdentityRepository {
     await this.db
       .updateTable('shared_space_person')
       .set((eb) => ({
-        faceCount: eb
-          .selectFrom('shared_space_person_face')
-          .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
-          .innerJoin('asset', 'asset.id', 'asset_face.assetId')
-          .where('asset_face.deletedAt', 'is', null)
-          .where('asset_face.isVisible', 'is', true)
-          .where('asset.deletedAt', 'is', null)
-          .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
-          .select((eb2) => eb2.fn.countAll().$castTo<number>().as('count'))
-          .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id'),
-        assetCount: eb
-          .selectFrom('shared_space_person_face')
-          .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
-          .innerJoin('asset', 'asset.id', 'asset_face.assetId')
-          .where('asset_face.deletedAt', 'is', null)
-          .where('asset_face.isVisible', 'is', true)
-          .where('asset.deletedAt', 'is', null)
-          .where('asset.visibility', '=', sql.lit(AssetVisibility.Timeline))
-          .select((eb2) =>
-            eb2.fn
-              .count(eb2.fn('distinct', ['asset_face.assetId']))
-              .$castTo<number>()
-              .as('count'),
-          )
-          .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id'),
+        faceCount: this.spacePersonFaceCount(eb),
+        assetCount: this.spacePersonAssetCount(eb),
       }))
       .where('id', 'in', personIds)
+      // Recount runs for every person an identity backfill pass scans. Skip rows whose counts are
+      // already correct — an unconditional UPDATE fires the updatedAt trigger for the whole table
+      // once per pass, generating constant write load and updatedAt churn for sync watchers.
+      .where((eb) =>
+        eb.or([
+          eb('shared_space_person.faceCount', 'is distinct from', this.spacePersonFaceCount(eb)),
+          eb('shared_space_person.assetCount', 'is distinct from', this.spacePersonAssetCount(eb)),
+        ]),
+      )
       .execute();
   }
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -18,7 +18,7 @@ import {
   SystemMetadataKey,
 } from 'src/enum';
 import { FaceSearchResult } from 'src/repositories/search.repository';
-import { PersonService } from 'src/services/person.service';
+import { FACE_IDENTITY_BACKFILL_MAX_CONTINUATIONS, PersonService } from 'src/services/person.service';
 import { StorageService } from 'src/services/storage.service';
 import { ImmichFileResponse, ImmichStreamResponse } from 'src/utils/file';
 import { AssetFaceFactory } from 'test/factories/asset-face.factory';
@@ -2745,7 +2745,7 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FaceIdentityBackfill,
-        data: { continuationId: expect.any(String) },
+        data: expect.objectContaining({ continuationId: expect.any(String) }),
       });
       expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
@@ -2773,7 +2773,7 @@ describe(PersonService.name, () => {
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FaceIdentityBackfill,
-        data: { continuationId: expect.any(String) },
+        data: expect.objectContaining({ continuationId: expect.any(String) }),
       });
       expect((mocks.faceIdentity as any).getSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
       expect((mocks.faceIdentity as any).getPendingSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
@@ -2799,7 +2799,7 @@ describe(PersonService.name, () => {
       await expect(sut.handleFaceIdentityBackfill({ stage: 'person' })).resolves.toBe(JobStatus.Success);
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FaceIdentityBackfill,
-        data: { continuationId: 'a' },
+        data: expect.objectContaining({ continuationId: 'a' }),
       });
 
       mocks.job.queue.mockClear();
@@ -2809,8 +2809,67 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FaceIdentityBackfill,
-        data: { continuationId: 'b' },
+        data: expect.objectContaining({ continuationId: 'b' }),
       });
+    });
+
+    it('increments the continuation pass count on each re-queue', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+
+      await expect(
+        sut.handleFaceIdentityBackfill({ stage: 'person', continuationId: 'a', continuationCount: 2 }),
+      ).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { continuationId: 'b', continuationCount: 3 },
+      });
+    });
+
+    it('threads the continuation pass count through stage pagination requeues', async () => {
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({
+        processed: 1000,
+        nextCursor: 'person-cursor',
+      });
+
+      await expect(
+        sut.handleFaceIdentityBackfill({ stage: 'person', continuationId: 'a', continuationCount: 2 }),
+      ).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FaceIdentityBackfill,
+        data: { stage: 'person', cursor: 'person-cursor', continuationCount: 2 },
+      });
+    });
+
+    it('stops re-queueing when identity work persists at the continuation pass cap', async () => {
+      // A repair pass that cannot clear getBackfillWork() would otherwise re-queue itself forever —
+      // full table scans rewriting shared_space_person rows every ~30 minutes, indefinitely.
+      mocks.faceIdentity.backfillPersonalIdentities.mockResolvedValue({ processed: 0 });
+      mocks.faceIdentity.backfillSpacePersonIdentities.mockResolvedValue({ processed: 0, conflictCount: 0 });
+      (mocks.faceIdentity as any).getBackfillWork.mockResolvedValue({
+        hasPersonalIdentityWork: true,
+        hasSpacePersonIdentityWork: false,
+        hasSharedSpaceProjectionWork: false,
+      });
+
+      await expect(
+        sut.handleFaceIdentityBackfill({
+          stage: 'person',
+          continuationId: 'a',
+          continuationCount: FACE_IDENTITY_BACKFILL_MAX_CONTINUATIONS,
+        }),
+      ).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.job.queue).not.toHaveBeenCalledWith(expect.objectContaining({ name: JobName.FaceIdentityBackfill }));
+      expect((mocks.faceIdentity as any).getPendingSharedSpaceFaceMatchBackfillTargets).not.toHaveBeenCalled();
+      expect(mocks.logger.error).toHaveBeenCalledWith(expect.stringContaining('continuation'));
     });
 
     it('does not discover projection targets until paginated personal backfill is complete', async () => {
@@ -3193,7 +3252,7 @@ describe(PersonService.name, () => {
 
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.FaceIdentityBackfill,
-        data: { continuationId: expect.any(String) },
+        data: expect.objectContaining({ continuationId: expect.any(String) }),
       });
       expect(mocks.job.queueAll).not.toHaveBeenCalledWith(
         expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll })]),

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -65,6 +65,15 @@ import { Point, transformPoints } from 'src/utils/transform';
 
 const FACE_IDENTITY_BACKFILL_CHUNK_SIZE = 1000;
 
+/**
+ * Upper bound on full re-scan passes one backfill chain may take when getBackfillWork() keeps
+ * reporting identity work. Repair passes are designed to converge in one or two passes; work that
+ * is still outstanding at the cap indicates a convergence bug, and re-queueing would otherwise
+ * loop full-table scans forever. The next external trigger (bootstrap, post-recognition
+ * maintenance, or a manual run) starts a fresh chain.
+ */
+export const FACE_IDENTITY_BACKFILL_MAX_CONTINUATIONS = 5;
+
 @Injectable()
 export class PersonService extends BaseService {
   @OnEvent({ name: 'AppBootstrap', workers: [ImmichWorker.Microservices] })
@@ -510,6 +519,7 @@ export class PersonService extends BaseService {
     stage = 'person',
     cursor,
     continuationId,
+    continuationCount,
   }: JobOf<JobName.FaceIdentityBackfill>): Promise<JobStatus> {
     const affectedSpaceAssets: SharedSpaceFaceMatchBackfillTarget[] = [];
 
@@ -523,7 +533,7 @@ export class PersonService extends BaseService {
       if (result.nextCursor) {
         await this.jobRepository.queue({
           name: JobName.FaceIdentityBackfill,
-          data: { stage: 'person', cursor: result.nextCursor },
+          data: { stage: 'person', cursor: result.nextCursor, continuationCount },
         });
         return JobStatus.Success;
       }
@@ -542,7 +552,7 @@ export class PersonService extends BaseService {
     if (result.nextCursor) {
       await this.jobRepository.queue({
         name: JobName.FaceIdentityBackfill,
-        data: { stage: 'space-person', cursor: result.nextCursor },
+        data: { stage: 'space-person', cursor: result.nextCursor, continuationCount },
       });
       return JobStatus.Success;
     }
@@ -550,9 +560,19 @@ export class PersonService extends BaseService {
     const work = await this.faceIdentityRepository.getBackfillWork();
 
     if (work.hasPersonalIdentityWork || work.hasSpacePersonIdentityWork) {
+      const passCount = continuationCount ?? 0;
+      if (passCount >= FACE_IDENTITY_BACKFILL_MAX_CONTINUATIONS) {
+        this.logger.error(
+          `Face identity backfill still reports work after ${passCount} continuation passes — stopping to prevent an endless re-queue loop`,
+        );
+        return JobStatus.Success;
+      }
       await this.jobRepository.queue({
         name: JobName.FaceIdentityBackfill,
-        data: { continuationId: this.getNextFaceIdentityBackfillContinuationId(continuationId) },
+        data: {
+          continuationId: this.getNextFaceIdentityBackfillContinuationId(continuationId),
+          continuationCount: passCount + 1,
+        },
       });
       return JobStatus.Success;
     }

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -6673,6 +6673,98 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
     });
 
+    it('should not rewrite a person whose inherited metadata already matches the top candidate', async () => {
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const identityId = newUuid();
+      const sourcePersonId = newUuid();
+      const person = factory.sharedSpacePerson({
+        id: personId,
+        spaceId,
+        identityId,
+        name: 'Inherited Alice',
+        nameSource: 'inherited',
+        nameSourceProfileType: 'user-person',
+        nameSourceProfileId: sourcePersonId,
+        nameSourceUpdatedAt: newDate(),
+        birthDate: '1990-01-01',
+        birthDateSource: 'inherited',
+        birthDateSourceProfileType: 'user-person',
+        birthDateSourceProfileId: sourcePersonId,
+        birthDateSourceUpdatedAt: newDate(),
+      });
+
+      mocks.sharedSpace.getSpacePersonMetadataBackfillPage.mockResolvedValue([person]);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(person);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: sourcePersonId,
+          sourceProfileType: 'user-person',
+          sourceProfileId: sourcePersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Inherited Alice',
+          birthDate: new Date('1990-01-01'),
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 3,
+          isAssetAdder: false,
+        },
+      ]);
+
+      const result = await sut.backfillSpacePersonMetadata({ limit: 50 });
+
+      expect(result).toEqual({ processed: 1, inherited: 0, skipped: 1 });
+      expect(mocks.sharedSpace.updatePerson).not.toHaveBeenCalled();
+    });
+
+    it('should rewrite inherited metadata when the same value now comes from a different source profile', async () => {
+      const spaceId = newUuid();
+      const personId = newUuid();
+      const identityId = newUuid();
+      const oldSourcePersonId = newUuid();
+      const newSourcePersonId = newUuid();
+      const person = factory.sharedSpacePerson({
+        id: personId,
+        spaceId,
+        identityId,
+        name: 'Inherited Alice',
+        nameSource: 'inherited',
+        nameSourceProfileType: 'user-person',
+        nameSourceProfileId: oldSourcePersonId,
+        nameSourceUpdatedAt: newDate(),
+      });
+
+      mocks.sharedSpace.getSpacePersonMetadataBackfillPage.mockResolvedValue([person]);
+      mocks.sharedSpace.getPersonById.mockResolvedValue(person);
+      mocks.sharedSpace.getMetadataInheritanceCandidates.mockResolvedValue([
+        {
+          personId: newSourcePersonId,
+          sourceProfileType: 'user-person',
+          sourceProfileId: newSourcePersonId,
+          userId: newUuid(),
+          role: SharedSpaceRole.Owner,
+          name: 'Inherited Alice',
+          birthDate: null,
+          type: 'person',
+          species: null,
+          updatedAt: newDate(),
+          supportingFaceCount: 3,
+          isAssetAdder: false,
+        },
+      ]);
+      mocks.sharedSpace.updatePerson.mockResolvedValue(person);
+
+      const result = await sut.backfillSpacePersonMetadata({ limit: 50 });
+
+      expect(result).toEqual({ processed: 1, inherited: 1, skipped: 0 });
+      expect(mocks.sharedSpace.updatePerson).toHaveBeenCalledWith(
+        personId,
+        expect.objectContaining({ nameSourceProfileId: newSourcePersonId }),
+      );
+    });
+
     it('should inherit only from type-compatible candidates during metadata backfill', async () => {
       const spaceId = newUuid();
       const personId = newUuid();

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -2445,11 +2445,23 @@ export class SharedSpaceService extends BaseService {
     );
 
     if ((person.nameSource === 'none' || person.nameSource === 'inherited') && nameCandidate) {
-      updates.name = nameCandidate.value;
-      updates.nameSource = 'inherited';
-      updates.nameSourceProfileType = nameCandidate.candidate.sourceProfileType ?? 'user-person';
-      updates.nameSourceProfileId = nameCandidate.candidate.sourceProfileId ?? nameCandidate.candidate.personId;
-      updates.nameSourceUpdatedAt = now;
+      const nameSourceProfileType = nameCandidate.candidate.sourceProfileType ?? 'user-person';
+      const nameSourceProfileId = nameCandidate.candidate.sourceProfileId ?? nameCandidate.candidate.personId;
+      // Skip when the inherited value and its provenance are unchanged — the metadata backfill scans
+      // every space person, and re-stamping nameSourceUpdatedAt rewrites the row (updatedAt trigger)
+      // on every pass even though nothing changed.
+      const nameUnchanged =
+        person.nameSource === 'inherited' &&
+        person.name === nameCandidate.value &&
+        person.nameSourceProfileType === nameSourceProfileType &&
+        person.nameSourceProfileId === nameSourceProfileId;
+      if (!nameUnchanged) {
+        updates.name = nameCandidate.value;
+        updates.nameSource = 'inherited';
+        updates.nameSourceProfileType = nameSourceProfileType;
+        updates.nameSourceProfileId = nameSourceProfileId;
+        updates.nameSourceUpdatedAt = now;
+      }
     } else if (person.nameSource === 'inherited' && nameCandidates.length === 0) {
       updates.name = '';
       updates.nameSource = 'none';
@@ -2459,12 +2471,21 @@ export class SharedSpaceService extends BaseService {
     }
 
     if ((person.birthDateSource === 'none' || person.birthDateSource === 'inherited') && birthDateCandidate) {
-      updates.birthDate = birthDateCandidate.value;
-      updates.birthDateSource = 'inherited';
-      updates.birthDateSourceProfileType = birthDateCandidate.candidate.sourceProfileType ?? 'user-person';
-      updates.birthDateSourceProfileId =
+      const birthDateSourceProfileType = birthDateCandidate.candidate.sourceProfileType ?? 'user-person';
+      const birthDateSourceProfileId =
         birthDateCandidate.candidate.sourceProfileId ?? birthDateCandidate.candidate.personId;
-      updates.birthDateSourceUpdatedAt = now;
+      const birthDateUnchanged =
+        person.birthDateSource === 'inherited' &&
+        asBirthDateString(person.birthDate) === birthDateCandidate.value &&
+        person.birthDateSourceProfileType === birthDateSourceProfileType &&
+        person.birthDateSourceProfileId === birthDateSourceProfileId;
+      if (!birthDateUnchanged) {
+        updates.birthDate = birthDateCandidate.value;
+        updates.birthDateSource = 'inherited';
+        updates.birthDateSourceProfileType = birthDateSourceProfileType;
+        updates.birthDateSourceProfileId = birthDateSourceProfileId;
+        updates.birthDateSourceUpdatedAt = now;
+      }
     } else if (person.birthDateSource === 'inherited' && birthDateCandidates.length === 0) {
       updates.birthDate = null;
       updates.birthDateSource = 'none';

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -242,6 +242,8 @@ export interface IFaceIdentityBackfillJob extends IBaseJob {
   stage?: 'person' | 'space-person';
   cursor?: string;
   continuationId?: string;
+  /** Number of full re-scan passes this chain has already taken; capped to prevent endless loops. */
+  continuationCount?: number;
 }
 
 export interface ISharedSpaceFaceMatchJob extends IBaseJob {

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -853,6 +853,49 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it('does not rewrite already-consistent space people on repeated identity backfill passes', async () => {
+    const { ctx, sut } = setup(await getKyselyDB());
+    const { user } = await ctx.newUser();
+    try {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const identity = await sut.ensurePersonIdentity(person.id);
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'backfill' });
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identity.id, representativeFaceId: assetFace.id })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, assetFace.id);
+
+      // The first pass settles the derived counts (and may legitimately bump updatedAt doing so).
+      await sut.backfillSpacePersonIdentities({ limit: 100 });
+      const settled = await ctx.database
+        .selectFrom('shared_space_person')
+        .select(['faceCount', 'assetCount', 'updatedAt'])
+        .where('id', '=', spacePerson.id)
+        .executeTakeFirstOrThrow();
+      expect(settled.faceCount).toBe(1);
+
+      // A person whose identity and counts already match its faces must not be rewritten by the
+      // next pass. The unconditional recount UPDATE fires the updatedAt trigger for every scanned
+      // row, which on a real library rewrites the entire shared_space_person table once per pass —
+      // constant write load and updatedAt churn for sync watchers.
+      await sut.backfillSpacePersonIdentities({ limit: 100 });
+      const afterSecondPass = await ctx.database
+        .selectFrom('shared_space_person')
+        .select(['faceCount', 'assetCount', 'updatedAt'])
+        .where('id', '=', spacePerson.id)
+        .executeTakeFirstOrThrow();
+      expect(afterSecondPass).toEqual(settled);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('preserves manual space representative faces during space identity backfill', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();
@@ -1153,7 +1196,7 @@ describe(FaceIdentityRepository.name, () => {
       const { asset } = await ctx.newAsset({ ownerId: sourceOwner.id });
       const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: sourcePerson.id });
       const targetIdentity = await sut.ensurePersonIdentity(otherOwnerTargetPerson.id);
-      await sut.ensurePersonIdentity(sourcePerson.id);
+      const sourceIdentity = await sut.ensurePersonIdentity(sourcePerson.id);
       await sut.linkFace({
         assetFaceId: assetFace.id,
         identityId: targetIdentity.id,
@@ -1169,9 +1212,18 @@ describe(FaceIdentityRepository.name, () => {
         .executeTakeFirstOrThrow();
 
       expect(updatedFace.personId).toBe(sourcePerson.id);
-      expect(await getPersonalIdentityMismatchRows(ctx, [assetFace.id])).toHaveLength(1);
+      // The source owner has no person referencing the other owner's identity, so the face cannot
+      // move anywhere. The mismatch must still be resolved — by realigning the link to the face's
+      // current person — because leftover work makes handleFaceIdentityBackfill re-queue forever.
+      const link = await ctx.database
+        .selectFrom('face_identity_face')
+        .select('identityId')
+        .where('assetFaceId', '=', assetFace.id)
+        .executeTakeFirstOrThrow();
+      expect(link.identityId).toBe(sourceIdentity.id);
+      expect(await getPersonalIdentityMismatchRows(ctx, [assetFace.id])).toEqual([]);
       await expect(sut.getBackfillWork()).resolves.toEqual({
-        hasPersonalIdentityWork: true,
+        hasPersonalIdentityWork: false,
         hasSpacePersonIdentityWork: false,
         hasSharedSpaceProjectionWork: false,
       });
@@ -3698,6 +3750,54 @@ describe(FaceIdentityRepository.name, () => {
           .where('assetFaceId', '=', corruptFace.id)
           .executeTakeFirstOrThrow();
         expect(link.identityId).toBe(identityB.id);
+        const backfillWork = await sut.getBackfillWork();
+        expect(backfillWork.hasPersonalIdentityWork).toBe(false);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('realigns a face whose linked identity has no person for the owner', async () => {
+      const { ctx, sut } = setup(await getKyselyDB());
+      const { user } = await ctx.newUser();
+      try {
+        // A face on person B is (corruptly) linked to an identity that NO person of this owner
+        // references — the leftover state a scoped/cross-user merge can produce. There is no target
+        // person to move the face onto, so repair must realign the link to the face's current person.
+        // Skipping it leaves person.identityId DISTINCT FROM face_identity_face.identityId, so
+        // getBackfillWork() reports work forever and handleFaceIdentityBackfill re-queues in an
+        // endless loop of full-table passes.
+        const { person } = await ctx.newPerson({ ownerId: user.id });
+        const personIdentity = await sut.ensurePersonIdentity(person.id);
+        const foreignIdentity = await ctx.database
+          .insertInto('face_identity')
+          .values({ type: 'person' })
+          .returningAll()
+          .executeTakeFirstOrThrow();
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+        await sut.linkFace({
+          assetFaceId: assetFace.id,
+          identityId: foreignIdentity.id,
+          source: 'shared-space-evidence',
+        });
+
+        await sut.backfillPersonalIdentities({ limit: 100 });
+
+        const row = await ctx.database
+          .selectFrom('asset_face')
+          .select('personId')
+          .where('id', '=', assetFace.id)
+          .executeTakeFirstOrThrow();
+        expect(row.personId).toBe(person.id);
+
+        const link = await ctx.database
+          .selectFrom('face_identity_face')
+          .select('identityId')
+          .where('assetFaceId', '=', assetFace.id)
+          .executeTakeFirstOrThrow();
+        expect(link.identityId).toBe(personIdentity.id);
+
         const backfillWork = await sut.getBackfillWork();
         expect(backfillWork.hasPersonalIdentityWork).toBe(false);
       } finally {


### PR DESCRIPTION
## Problem

The admin job queue showed **People Identity Maintenance (`peopleBackfill`) permanently at Active: 1**. On a 220k-asset / 25,647-shared-space-person test restore, every `shared_space_person` row had its `updatedAt` rewritten once per ~30 minutes, indefinitely (full sequential id-order passes at ~25-30 rows/s).

## Root cause

Two defects combining into one loop:

1. **Convergence hole** — `handleFaceIdentityBackfill` only terminates when `getBackfillWork()` reports no identity mismatches, re-queueing itself via alternating `continuationId` with **no pass limit**. But `repairPersonalIdentityAssignments` skipped mismatched faces whose linked identity has **no same-owner person** (leftover from scoped/cross-user merges) without realigning them, so work never cleared and the chain re-scanned both tables forever. The sibling path of this failure mode was already fixed in #652 (embedding guard realign); this path escaped.
2. **Write churn** — every space-person-stage pass called `recountSpacePersons` for every scanned row, and the unconditional `UPDATE` fired the `updatedAt` trigger even when counts were unchanged — rewriting the entire `shared_space_person` table once per pass (constant write load + sync-watcher churn).

## Fix (TDD, failing test first for each part)

- **Realign stranded faces** to their current person's identity when no target person exists for the mismatched group — mismatch resolved, `getBackfillWork()` clears. Also updates a May-era test that asserted the leftover `hasPersonalIdentityWork: true` behavior (predates the #652 "resolve instead of leaving perpetual work" philosophy).
- **No-op-aware recount** — `IS DISTINCT FROM` guard so rows with correct counts aren't rewritten; second pass over a consistent table writes nothing.
- **Continuation pass cap (5)** as defense-in-depth, mirroring `SHARED_SPACE_DEDUP_MAX_PASSES`: `continuationCount` threads through the job chain; at the cap the job logs an error and stops, leaving the next bootstrap/maintenance/manual trigger to start fresh.

## Verification

- New medium tests: no-target realign clears work; repeated space-person pass leaves `updatedAt` untouched
- New unit tests: count increments, threads through cursor-page requeues, stops at cap with error log
- Full server unit suite 4602 passed; medium suite green except 3 pre-existing exif environment failures (identical on untouched baseline); `tsc --noEmit`, eslint, prettier clean

Diagnostic for live confirmation (rows sustaining the loop):

```sql
SELECT count(*) FROM asset_face af
JOIN person p ON p.id = af."personId"
JOIN face_identity_face fif ON fif."assetFaceId" = af.id
JOIN asset a ON a.id = af."assetId"
WHERE af."deletedAt" IS NULL AND af."isVisible" = true AND a."deletedAt" IS NULL
  AND p."identityId" IS DISTINCT FROM fif."identityId"
  AND NOT EXISTS (SELECT 1 FROM person tp
                  WHERE tp."ownerId" = p."ownerId" AND tp."identityId" = fif."identityId");
```

## Follow-up (found during RC validation on the personal instance): no-op inherited-metadata rewrites

While validating `peoplebackfill-loop-rc1` live, repeated manual backfill passes still rewrote a residual set of `shared_space_person` rows each pass — exactly the rows with `nameSource = 'inherited'` (16/16 on the personal instance, every pass, verified via `row_to_json` before/after diff: only `nameSourceUpdatedAt`/`updatedAt`/`updateId` changed).

Root cause: `inheritSpacePersonMetadata` rebuilt the name/birthDate updates — including a fresh `nameSourceUpdatedAt` stamp — whenever an inheritable source and a candidate existed, even when the value and its source profile were identical. The metadata backfill (`SharedSpacePersonMetadataBackfill`, queued at chain end, nightly, and on person edits) scans every space person, so every scan rewrote every inherited-metadata row. On instances where most space people inherit their names (e.g. the rc4 test box), this alone reproduces full-table `updatedAt` churn per pass.

Fix (`ecdf99d`): skip the update when the inherited value **and** its provenance (`*SourceProfileType`/`*SourceProfileId`) are unchanged; a value or source-profile change still writes as before. TDD'd with two new unit tests (no-op skip + provenance-change still writes).
