### PR TITLE
fix(web): let non-owners reveal asset file path in info panel

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel-path.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel-path.spec.ts
@@ -1,0 +1,144 @@
+import { renderWithTooltips } from '$tests/helpers';
+import { AssetTypeEnum, AssetVisibility, type AssetResponseDto } from '@immich/sdk';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/svelte';
+import DetailPanel from './detail-panel.svelte';
+
+// Regression probe for "file storage path no longer displayed below the filename in rc4".
+// The path is rendered by `detail-panel.svelte` only when the asset-viewer manager's
+// persisted `isShowAssetPath` toggle (localStorage key `asset-viewer-show-path`, default false)
+// is on. These tests pin that contract so we can tell a real code regression apart from the
+// toggle simply being off (e.g. fresh localStorage on a different origin).
+
+const { getAllAlbumsMock, getAssetInfoMock, assetViewerManagerMock } = vi.hoisted(() => ({
+  getAllAlbumsMock: vi.fn(),
+  getAssetInfoMock: vi.fn(),
+  // Mutable so individual tests can flip the persisted path toggle.
+  assetViewerManagerMock: {
+    closeDetailPanel: vi.fn(),
+    closeEditFacesPanel: vi.fn(),
+    isEditFacesPanelOpen: false,
+    isShowAssetPath: false,
+    openEditFacesPanel: vi.fn(),
+    toggleAssetPath: vi.fn(),
+    toggleFaceEditMode: vi.fn(),
+  },
+}));
+
+vi.mock('@immich/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@immich/sdk')>();
+  return {
+    ...actual,
+    getAllAlbums: getAllAlbumsMock,
+    getAssetInfo: getAssetInfoMock,
+  };
+});
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({
+  authManager: {
+    authenticated: true,
+    user: { id: 'owner-1' },
+    isSharedLink: false,
+    params: {},
+    preferences: { tags: { enabled: false }, ratings: { enabled: false } },
+  },
+}));
+
+vi.mock('$lib/managers/asset-viewer-manager.svelte', () => ({
+  assetViewerManager: assetViewerManagerMock,
+}));
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: { value: { map: false, smartSearch: false } },
+}));
+
+const ORIGINAL_PATH = '/photos/berlin/2026/2026_04/20260416_173726.jpg';
+
+const buildAsset = (overrides: Partial<AssetResponseDto> = {}): AssetResponseDto => ({
+  id: 'asset-1',
+  ownerId: 'owner-1',
+  libraryId: 'library-1',
+  type: AssetTypeEnum.Image,
+  originalPath: ORIGINAL_PATH,
+  originalFileName: '20260416_173726.jpg',
+  originalMimeType: 'image/jpeg',
+  thumbhash: 'thumbhash',
+  createdAt: '2026-04-16T17:37:26.000Z',
+  fileCreatedAt: '2026-04-16T17:37:26.000Z',
+  fileModifiedAt: '2026-04-16T17:37:26.000Z',
+  localDateTime: '2026-04-16T17:37:26.000Z',
+  updatedAt: '2026-04-16T17:37:26.000Z',
+  isFavorite: false,
+  isArchived: false,
+  isTrashed: false,
+  duration: null,
+  checksum: 'checksum',
+  isOffline: false,
+  hasMetadata: false,
+  visibility: AssetVisibility.Timeline,
+  width: 4000,
+  height: 3000,
+  isEdited: false,
+  people: [],
+  unassignedFaces: [],
+  ...overrides,
+});
+
+describe('DetailPanel file path display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllAlbumsMock.mockResolvedValue([]);
+    getAssetInfoMock.mockResolvedValue(undefined);
+    assetViewerManagerMock.isShowAssetPath = false;
+  });
+
+  it('hides the file path when the persisted toggle is off (the rc4 default state)', async () => {
+    assetViewerManagerMock.isShowAssetPath = false;
+
+    renderWithTooltips(DetailPanel, { asset: buildAsset(), currentAlbum: null });
+
+    // Filename is always shown; the path is not, until the user toggles it on.
+    await waitFor(() => expect(screen.getByText('20260416_173726.jpg')).toBeInTheDocument());
+    expect(screen.queryByText(ORIGINAL_PATH)).not.toBeInTheDocument();
+  });
+
+  it('shows the file path below the filename when the persisted toggle is on', async () => {
+    assetViewerManagerMock.isShowAssetPath = true;
+
+    renderWithTooltips(DetailPanel, { asset: buildAsset(), currentAlbum: null });
+
+    await waitFor(() => expect(screen.getByText(ORIGINAL_PATH)).toBeInTheDocument());
+  });
+
+  // Option 1: the "show file location" toggle is gated on the path being present, not on
+  // ownership — so a non-owner who can see an external-library asset can still reveal its path.
+  it('shows the file-location toggle to a non-owner when originalPath is present', async () => {
+    renderWithTooltips(DetailPanel, {
+      asset: buildAsset({ ownerId: 'owner-2' }),
+      currentAlbum: null,
+    });
+
+    await waitFor(() => expect(screen.getByLabelText('show_file_location')).toBeInTheDocument());
+  });
+
+  it('shows the file-location toggle to the owner', async () => {
+    renderWithTooltips(DetailPanel, {
+      asset: buildAsset({ ownerId: 'owner-1' }),
+      currentAlbum: null,
+    });
+
+    await waitFor(() => expect(screen.getByLabelText('show_file_location')).toBeInTheDocument());
+  });
+
+  it('hides the file-location toggle when there is no path (e.g. sanitized shared-link view)', async () => {
+    renderWithTooltips(DetailPanel, {
+      asset: buildAsset({ ownerId: 'owner-2', originalPath: '' }),
+      currentAlbum: null,
+    });
+
+    await waitFor(() => expect(screen.getByText('20260416_173726.jpg')).toBeInTheDocument());
+    expect(screen.queryByLabelText('show_file_location')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -326,7 +326,7 @@
         <div>
           <p class="break-all flex place-items-center gap-2 whitespace-pre-wrap">
             {asset.originalFileName}
-            {#if isOwner}
+            {#if asset.originalPath}
               <IconButton
                 icon={mdiInformationOutline}
                 aria-label={$t('show_file_location')}


### PR DESCRIPTION
## Problem

A user reported the file storage path "disappeared" from the asset Info panel on one instance but not another. Investigation showed it's **not a regression** — the path display is the same across stable `v4.56.7`, `main`, and the rolling rebase.

The path is revealed by an ⓘ "Show file location" toggle whose state is a per-browser `localStorage` preference (`asset-viewer-show-path`, default off). The catch: the **toggle button was gated on `isOwner`**, while the path text itself is not. So a logged-in user viewing assets they don't own — exactly the **external/shared library** case — had no control to turn the path on, even though the server already sends them `originalPath`.

(The two screenshots in the report were also two different hostnames, i.e. two different `localStorage` origins — but the underlying gap is the owner-gated button.)

## Fix

Gate the toggle button on `asset.originalPath` instead of `isOwner`:

```diff
- {#if isOwner}
+ {#if asset.originalPath}
```

- Any logged-in viewer who receives a path can now reveal it.
- **No new data exposure:** `originalPath` was already in the DTO for these viewers.
- **Shared-link / sanitized views** omit `originalPath` server-side (`mapAsset` `stripMetadata` branch) → `{#if asset.originalPath}` is false → no button, nothing to reveal.

## Tests

New `detail-panel-path.spec.ts` (5 tests):
- hides the path when the persisted toggle is off
- shows the path when the toggle is on
- **shows the toggle to a non-owner when `originalPath` is present** (RED before fix, GREEN after)
- shows the toggle to the owner
- hides the toggle when there's no path (sanitized shared-link view)

Existing `detail-panel.spec.ts` still passes; eslint clean.

## Follow-up

The rolling-rebase branch (`DetailPanel.svelte`, PascalCase) has the identical block and needs the same one-liner on next fork-sync.