### PR TITLE
fix(ci): adapt rebase-smoke to #688 path visibility; free disk for SM-E2E

### DIFF
--- a/.github/workflows/storage-migration-e2e.yml
+++ b/.github/workflows/storage-migration-e2e.yml
@@ -28,6 +28,15 @@ jobs:
           ref: ${{ inputs.branch || 'main' }}
           persist-credentials: false
           submodules: 'recursive'
+      - name: Free disk space
+        working-directory: ./
+        # The job builds the full server image and runs a MinIO container on the same
+        # runner; when the runner image ships with little free disk, MinIO hits its
+        # minimum-free-drive threshold and rejects every migration upload.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Setup Node

--- a/e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
+++ b/e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
@@ -125,7 +125,7 @@ test.describe('Rebase Smoke — UI Permission Matrix', () => {
     await expect(page.locator('[data-testid="detail-panel-filename"]')).toContainText('rebase-smoke.jpg');
   });
 
-  test('Test 5 — editor detail panel: edit controls hidden, file path hidden', async ({ context, page }) => {
+  test('Test 5 — editor detail panel: edit controls hidden, file path revealable', async ({ context, page }) => {
     await utils.setAuthCookies(context, editor.accessToken);
     await page.goto(`/spaces/${space.id}/photos/${asset.id}`);
     await page.waitForSelector('#immich-asset-viewer');
@@ -135,10 +135,12 @@ test.describe('Rebase Smoke — UI Permission Matrix', () => {
     // the pencil indicator is omitted, and the title attribute is empty. Assert on the title
     // (locale-proof via empty string) as the owner-only gate.
     await expect(page.locator('[data-testid="detail-panel-edit-date-button"]')).toHaveAttribute('title', '');
-    await expect(page.getByLabel('Show file location')).toHaveCount(0);
+    // Since #688 the "Show file location" toggle is gated on asset.originalPath (which the
+    // server sends to space members), not on ownership — so editors can reveal the path too.
+    await expect(page.getByLabel('Show file location')).toBeVisible();
   });
 
-  test('Test 6 — viewer detail panel: edit controls hidden, file path hidden', async ({ context, page }) => {
+  test('Test 6 — viewer detail panel: edit controls hidden, file path revealable', async ({ context, page }) => {
     await utils.setAuthCookies(context, viewer.accessToken);
     await page.goto(`/spaces/${space.id}/photos/${asset.id}`);
     await page.waitForSelector('#immich-asset-viewer');
@@ -146,7 +148,8 @@ test.describe('Rebase Smoke — UI Permission Matrix', () => {
     await expect(page.locator('#detail-panel')).toBeVisible();
     // Viewer has same UI gating as editor for these owner-only controls.
     await expect(page.locator('[data-testid="detail-panel-edit-date-button"]')).toHaveAttribute('title', '');
-    await expect(page.getByLabel('Show file location')).toHaveCount(0);
+    // Since #688 the file-path toggle follows asset.originalPath, not ownership (see Test 5).
+    await expect(page.getByLabel('Show file location')).toBeVisible();
   });
 
   test('Test 7 — stranger: blocked on /spaces/:id direct URL', async ({ context, page }) => {


### PR DESCRIPTION
Two CI repairs surfaced by the rolling-rebase batch-236 CI run (both verified green there on `rebase/upstream-batch-236`):

**1. rebase-smoke permission-matrix vs #688**
Tests 5/6 still asserted the pre-#688 owner-only gating of the *Show file location* toggle (`toHaveCount(0)` for editor/viewer). #688 deliberately gates the toggle on `asset.originalPath` — which the server sends to space members — so editors/viewers now see it. Updated the assertions and titles. `gallery-rebase-smoke.yml` doesn't run on PRs, so #688 merged with this latently red on main.

**2. Storage Migration E2E runner disk exhaustion**
Three consecutive SM-E2E runs failed with MinIO rejecting every migration upload: `Storage backend has reached its minimum free drive threshold`. The job builds the full server image and runs MinIO on the same runner, and the current runner image ships with too little free disk. Added a *Free disk space* step (~25GB of preinstalled toolchains + docker image prune). Without this the nightly 06:00 UTC cron will keep failing.