### PR TITLE
fix(person): resolve identity birthday/name for the owner's single-person view

### DIFF
--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -1172,6 +1172,19 @@ export class FaceIdentityRepository {
     return people[0];
   }
 
+  /**
+   * Resolve the identity-wide person view for a viewer who already holds a person row for that
+   * identity (typically the library owner accessing their own person). Mirrors the read-time
+   * name/birthday resolution used by {@link getAccessiblePersonByProfileId}, so an owner viewing a
+   * single person sees a birthday set on a sibling shared-space profile of the same identity rather
+   * than the raw (often empty) `person.birthDate`. Not decorated with `@GenerateSql`: it issues the
+   * exact `hydrateAccessiblePeople` query already documented under that method.
+   */
+  async getResolvedPersonByIdentityId(userId: string, identityId: string): Promise<PersonResponseDto | undefined> {
+    const people = await this.hydrateAccessiblePeople({ userId, identityIds: [identityId], withHidden: false });
+    return people[0];
+  }
+
   async resolveRepairRefs(actorUserId: string, dto: MergeScopedPeopleDto): Promise<RepairRefsResolution> {
     const refs = [dto.target, ...dto.sources];
     const profiles: RepairProfile[] = [];

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -65,6 +65,7 @@ describe(PersonService.name, () => {
     faceIdentityMock.getAccessiblePeopleStatistics ??= vi.fn();
     faceIdentityMock.getAccessiblePeopleFaceStatistics ??= vi.fn();
     faceIdentityMock.getAccessiblePersonByProfileId ??= vi.fn();
+    faceIdentityMock.getResolvedPersonByIdentityId ??= vi.fn();
     faceIdentityMock.getAccessiblePersonStatistics ??= vi.fn();
     faceIdentityMock.getAccessibleProfileIdentityId ??= vi.fn();
     faceIdentityMock.hasBackfillWork ??= vi.fn();
@@ -596,6 +597,63 @@ describe(PersonService.name, () => {
 
       expect((mocks.faceIdentity as any).getAccessiblePersonByProfileId).toHaveBeenCalledWith(auth.user.id, profileId);
       expect(mocks.person.getById).not.toHaveBeenCalled();
+    });
+
+    it("should resolve the identity-wide birthday and name for the owner's own person", async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create({
+        ownerId: auth.user.id,
+        identityId: newUuid(),
+        name: 'Owner Local Name',
+        birthDate: null,
+      });
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+      (mocks.faceIdentity as any).getResolvedPersonByIdentityId.mockResolvedValue({
+        id: person.id,
+        name: 'Karolin',
+        birthDate: '2014-02-14',
+      });
+
+      await expect(sut.getById(auth, person.id)).resolves.toEqual(
+        expect.objectContaining({ id: person.id, name: 'Karolin', birthDate: '2014-02-14' }),
+      );
+      expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).toHaveBeenCalledWith(
+        auth.user.id,
+        person.identityId,
+      );
+    });
+
+    it('should not resolve via identity when the owned person has no identity', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create({ ownerId: auth.user.id, identityId: null, birthDate: null });
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+
+      await expect(sut.getById(auth, person.id)).resolves.toEqual(
+        expect.objectContaining({ id: person.id, birthDate: null }),
+      );
+      expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the raw person when identity resolution finds nothing', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create({
+        ownerId: auth.user.id,
+        identityId: newUuid(),
+        name: 'Owner Local Name',
+        birthDate: null,
+      });
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+      (mocks.faceIdentity as any).getResolvedPersonByIdentityId.mockResolvedValue(void 0);
+
+      await expect(sut.getById(auth, person.id)).resolves.toEqual(
+        expect.objectContaining({ id: person.id, name: 'Owner Local Name', birthDate: null }),
+      );
     });
   });
 

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -280,7 +280,22 @@ export class PersonService extends BaseService {
   async getById(auth: AuthDto, id: string): Promise<PersonResponseDto> {
     const allowedIds = await this.checkAccess({ auth, permission: Permission.PersonRead, ids: [id] });
     if (allowedIds.has(id)) {
-      return this.findOrFail(id).then(mapPerson);
+      const person = await this.findOrFail(id);
+      const response = mapPerson(person);
+      // Name and birthday set in a shared space are resolved at read time (never written back to
+      // `person`). The owner accessing their own person short-circuits the resolver, so overlay the
+      // identity-wide resolution here — otherwise they see the raw, often-empty `person.birthDate`.
+      if (person.identityId) {
+        const resolved = await this.faceIdentityRepository.getResolvedPersonByIdentityId(
+          auth.user.id,
+          person.identityId,
+        );
+        if (resolved) {
+          response.name = resolved.name;
+          response.birthDate = resolved.birthDate;
+        }
+      }
+      return response;
     }
 
     const accessiblePerson = await this.faceIdentityRepository.getAccessiblePersonByProfileId(auth.user.id, id);

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -1708,6 +1708,46 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  it("resolves a space-set birthday by the owner's own identity id", async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    // Owner's library person: has the NAME, but no birthday — exactly the owner detail-view scenario.
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Ina' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    const identity = await sut.ensurePersonIdentity(person.id);
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+    const spacePerson = await ctx.database
+      .insertInto('shared_space_person')
+      .values({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: assetFace.id,
+        type: 'person',
+        birthDate: '2014-02-14',
+        birthDateSource: 'manual',
+        birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await ctx.database
+      .insertInto('shared_space_person_face')
+      .values({ personId: spacePerson.id, assetFaceId: assetFace.id })
+      .execute();
+
+    try {
+      const result = await sut.getResolvedPersonByIdentityId(user.id, identity.id);
+
+      expect(result).toEqual(expect.objectContaining({ id: person.id, name: 'Ina', birthDate: '2014-02-14' }));
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('prefers the owner birthday over a more-recent space birthday', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();


### PR DESCRIPTION
## Problem

Follow-up to #686. After rc5, the library owner (admin) still sees **no birthday** on a person whose birthday was set by a shared-space editor — on the single-person detail view (`GET /api/people/{id}`). Other space users see it correctly.

## Root cause

#686's read-time resolver (`hydrateAccessiblePeople` / the `birthdate_rn` window) is correct and complete. The gap is *which owner path reaches it*:

- `getById` **short-circuits to a raw `findOrFail`** whenever the caller has direct `PersonRead` access — which the owner always does for their own people. So it returns the raw, often-empty `person.birthDate` and never calls the resolver. The resolver branch (`getAccessiblePersonByProfileId`) only runs for **non-owners**.
- The #686 design assumed the single-person view always flows through the resolver; that only holds for non-owners.
- Name "looked fine" only because the owner's own raw `person.name` already matched — a space **rename** wouldn't have shown either (same bug, latent).

(The web `/people` **list** already works — it sends `withSharedSpaces=true` → the #686 path. A bare `GET /api/people` without that flag hits the library-only `getAllForUser` path; left as-is by design.)

## Fix

- `getById` now overlays the identity-resolved **name + birthDate** onto the owner's response when the person has an `identityId`, falling back to the raw row otherwise.
- New thin repo wrapper `getResolvedPersonByIdentityId` reuses the exact, already-tested `hydrateAccessiblePeople` SQL — **read-time only, no write-back**, consistent with #686's design. No schema change, no SQL-doc regeneration.
- Resolving name too closes the latent space-rename-invisible-to-owner twin.

## Tests (TDD)

- **Unit** (`person.service.spec.ts`): owner `getById` resolves identity-wide name+birthday; guards for no-identity (no resolver call) and resolver-miss (raw fallback). Watched the main test fail returning `birthDate: null` — the exact symptom — before passing.
- **Medium / real Postgres** (`face-identity.repository.spec.ts`): a space-set birthday resolves by the owner's own `identityId`. Verified RED (`... is not a function`) then green.

## Verification

- `person.service.spec.ts`: 4607 passed
- face-identity medium spec: 109 passed (3 unrelated EXIF medium failures confirmed pre-existing on clean HEAD)
- `tsc --noEmit` clean · ESLint on touched files clean