### PR TITLE
fix(web): make timeline grouping bar transparent in spaces and albums

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -509,7 +509,7 @@
         <div class="flex flex-1 flex-col overflow-hidden pl-4">
           {#if isBrowseTimeline && !assetMultiSelectManager.selectionActive}
             <div
-              class="hidden shrink-0 items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-900 md:flex"
+              class="mb-2 hidden shrink-0 items-center gap-2 bg-transparent px-4 py-2 dark:bg-transparent md:flex"
               data-testid="timeline-desktop-grouping-control"
             >
               <TimelineGroupingControl grouping={timelineGrouping} onGroupingChange={handleTimelineGroupingChange} />

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1054,7 +1054,7 @@
     <div class="flex flex-1 flex-col overflow-hidden pl-4">
       {#if viewMode === 'view' && !showSearchResults && !assetMultiSelectManager.selectionActive}
         <div
-          class="hidden shrink-0 items-center gap-2 border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-900 md:flex"
+          class="mb-2 hidden shrink-0 items-center gap-2 bg-transparent px-4 py-2 dark:bg-transparent md:flex"
           data-testid="timeline-desktop-grouping-control"
         >
           <TimelineGroupingControl grouping={timelineGrouping} onGroupingChange={handleTimelineGroupingChange} />


### PR DESCRIPTION
## Problem

The timeline grouping pill (Years / Months / All) sat on a blue-tinted panel in **dark mode** on the **spaces** and **albums** pages. Light mode looked fine. The main timeline (`/photos`) was never affected.

## Cause

Three pages inline `TimelineGroupingControl` in their own wrapper `<div>` rather than using the shared transparent `TimelineRouteGroupingBar`:

- **Photos (main timeline)** — `bg-transparent dark:bg-transparent`, no border ✓
- **Spaces** — `bg-gray-50 ... dark:bg-gray-900` + `border-b` ✗
- **Albums** — same gray/bordered wrapper ✗

In the theme, `dark:bg-gray-900` renders as the blue-tinted panel; `bg-gray-50` was subtle enough in light mode to look fine.

## Fix

Aligned the spaces and albums wrappers to the exact class string the main timeline uses (`mb-2 ... bg-transparent ... dark:bg-transparent`, no border). Pure Tailwind class swap — no structural or import changes.