### PR TITLE
fix(mobile): drain in-flight HTTP before gentle sync isolate teardown

### DIFF
--- a/mobile/lib/infrastructure/repositories/network.repository.dart
+++ b/mobile/lib/infrastructure/repositories/network.repository.dart
@@ -120,7 +120,16 @@ class NetworkRepository {
   static Future<void> shutdown({Duration timeout = const Duration(milliseconds: 1500)}) async {
     final draining = _draining;
     _draining = null;
-    await draining?.shutdown(timeout: timeout);
+    if (draining == null) {
+      return;
+    }
+    await draining.shutdown(timeout: timeout);
+    // The client is now closed. A pooled worker isolate may be reused for
+    // another task, where [init] would otherwise short-circuit on the unchanged
+    // native session pointer and hand back this dead client. Clear both so the
+    // next [init] rebuilds a live client.
+    _client = null;
+    _clientPointer = null;
   }
 
   static Future<void> setHeaders(Map<String, String> headers, List<String> serverUrls, {String? token}) async {

--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/services/log.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/network.repository.dart';
 import 'package:immich_mobile/providers/infrastructure/cancel.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/utils/bootstrap.dart';
@@ -37,6 +38,14 @@ Cancelable<T?> runInIsolateGentle<T>({
         BackgroundIsolateBinaryMessenger.ensureInitialized(token);
         DartPluginRegistrant.ensureInitialized();
 
+        // iOS shares one native URLSession across isolates via cupertino_http.
+        // If this isolate is torn down while a request is in flight, the
+        // request's delegate later fires into the now-dead isolate and aborts
+        // the process (SIGABRT in a Dart FFI callback). Track in-flight requests
+        // so they can be drained before teardown. Must run before initDomain
+        // (which calls NetworkRepository.init). See [DrainingHttpClient].
+        NetworkRepository.enableShutdownTracking();
+
         final (drift, logDb) = await Bootstrap.initDomain(shouldBufferLogs: false, listenStoreUpdates: false);
         final ref = ProviderContainer(
           overrides: [
@@ -55,6 +64,11 @@ Cancelable<T?> runInIsolateGentle<T>({
           log.severe("Error in runInIsolateGentle ${debugLabel == null ? '' : ' for $debugLabel'}", error, stack);
         } finally {
           try {
+            // Abort and drain in-flight HTTP requests while this isolate is
+            // still alive, so no cupertino_http delegate can call back into it
+            // after teardown. No-op unless shutdown tracking was enabled above.
+            await NetworkRepository.shutdown();
+
             ref.dispose();
 
             await Store.dispose();

--- a/mobile/test/infrastructure/repositories/network_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/network_repository_test.dart
@@ -111,4 +111,43 @@ void main() {
 
     expect(NetworkRepository.client, isA<DrainingHttpClient>());
   });
+
+  // Guards the contract the gentle-isolate teardown relies on: when tracking is
+  // enabled, shutdown must drain and close the underlying client so no in-flight
+  // request can call back into a dead isolate. See [DrainingHttpClient].
+  test('shutdown drains and closes the tracked client', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    NetworkRepository.enableShutdownTracking();
+    await NetworkRepository.init();
+
+    await NetworkRepository.shutdown();
+
+    expect(built.single.closed, isTrue);
+  });
+
+  // Gentle isolates call shutdown unconditionally at teardown, including on
+  // platforms / runs where tracking was never enabled. That must be harmless.
+  test('shutdown is a safe no-op when tracking is disabled', () async {
+    await NetworkRepository.init();
+
+    await NetworkRepository.shutdown();
+
+    expect(built.single.closed, isFalse);
+  });
+
+  // A gentle worker isolate can be reused for another task after it drained and
+  // closed its client. The shared native session pointer is unchanged, so init
+  // must NOT short-circuit — it has to rebuild a live client, or the reused
+  // isolate would keep using a closed one.
+  test('init rebuilds after shutdown even when the pointer is unchanged', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    NetworkRepository.enableShutdownTracking();
+    await NetworkRepository.init();
+
+    await NetworkRepository.shutdown();
+    await NetworkRepository.init();
+
+    expect(factoryCalls, 2);
+    expect(NetworkRepository.client, isA<DrainingHttpClient>());
+  });
 }


### PR DESCRIPTION
## Summary

Fixes an iOS background-sync crash (SIGABRT) caused by tearing down a worker_manager "gentle" isolate while a `/sync/stream` response is still streaming over the shared native URLSession (cupertino_http).

When the gentle isolate is destroyed mid-stream, the request's `_StreamingTaskDelegate` later fires `didReceive:` into the now-dead isolate and aborts the process (Dart FFI callback `DLRT_GetFfiCallbackMetadata`).

## Changes

- Extend the existing `DrainingHttpClient` teardown (previously only wired into the background-worker entrypoint, #657) to `runInIsolateGentle`: enable shutdown tracking before `initDomain` and drain in-flight requests in the teardown `finally`, so their delegates fire while the isolate is still alive.
- Clear the cached client/pointer in `NetworkRepository.shutdown` so a reused pooled worker isolate rebuilds a live client instead of short-circuiting `init()` onto the closed one.

## Testing

- 16/16 mobile unit tests green (`network_repository_test.dart` +39 lines of new coverage).
- Validated on-device against a personal instance: syncs and populates, SIGABRT no longer recurs during background sync.

## Notes

The empty-timeline symptom seen during investigation was a server-side AssetsV1 deprecation on staging (the rolling-rebase build expects AssetsV2), **not** related to this fix — confirmed by raw curl and by the build working against the personal instance.