### PR TITLE
fix(pet-detection): clear existing detections when the queue is reset

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -80,6 +80,7 @@
     "confirm_delete_library_assets": "Are you sure you want to delete this library? This will delete {count, plural, one {# contained asset} other {all # contained assets}} from Immich and cannot be undone. Files will remain on disk.",
     "confirm_email_below": "To confirm, type \"{email}\" below",
     "confirm_reprocess_all_faces": "Are you sure you want to reprocess all faces? This will also clear named people.",
+    "confirm_reprocess_all_pets": "Are you sure you want to reset pet detection? This will delete all detected pets and their faces before reprocessing.",
     "confirm_user_password_reset": "Are you sure you want to reset {user}'s password?",
     "confirm_user_pin_code_reset": "Are you sure you want to reset {user}'s PIN code?",
     "copy_config_to_clipboard_description": "Copy the current system config as a JSON object to the clipboard",

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -243,6 +243,21 @@ export class PersonRepository {
     await this.db.deleteFrom('asset_face').where('asset_face.sourceType', '=', sourceType).execute();
   }
 
+  async deleteAllPets(): Promise<void> {
+    await this.db.transaction().execute(async (trx) => {
+      // Delete pet faces before the pet people they belong to: asset_face.personId is
+      // ON DELETE SET NULL, so removing the people first would orphan (not delete) the faces.
+      await trx
+        .deleteFrom('asset_face')
+        .where('asset_face.personId', 'in', (eb) =>
+          eb.selectFrom('person').select('person.id').where('person.type', '=', 'pet'),
+        )
+        .execute();
+
+      await trx.deleteFrom('person').where('person.type', '=', 'pet').execute();
+    });
+  }
+
   getAllFaces(options: GetAllFacesOptions = {}) {
     return this.db
       .selectFrom('asset_face')

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -117,6 +117,34 @@ describe(PetDetectionService.name, () => {
       expect(mocks.job.queueAll).toHaveBeenCalledWith([{ name: JobName.PetDetection, data: { id: asset.id } }]);
       expectNoQueuedJobNames(mocks, petFaceIsolationJobNames);
     });
+
+    it('should clear existing pet detections before requeuing when force is true', async () => {
+      const asset = AssetFactory.create();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { enabled: true, petDetection: { enabled: true } },
+      });
+      mocks.assetJob.streamForPetDetectionJob.mockReturnValue(makeStream([asset]));
+
+      expect(await sut.handleQueuePetDetection({ force: true })).toEqual(JobStatus.Success);
+
+      expect(mocks.person.deleteAllPets).toHaveBeenCalledTimes(1);
+      // Existing pet labels must be gone before any reprocessing job is queued.
+      expect(mocks.person.deleteAllPets.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.job.queueAll.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should not clear existing pet detections when force is false', async () => {
+      const asset = AssetFactory.create();
+      mocks.systemMetadata.get.mockResolvedValue({
+        machineLearning: { enabled: true, petDetection: { enabled: true } },
+      });
+      mocks.assetJob.streamForPetDetectionJob.mockReturnValue(makeStream([asset]));
+
+      expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Success);
+
+      expect(mocks.person.deleteAllPets).not.toHaveBeenCalled();
+    });
   });
 
   describe('handlePetDetection', () => {

--- a/server/src/services/pet-detection.service.ts
+++ b/server/src/services/pet-detection.service.ts
@@ -15,6 +15,12 @@ export class PetDetectionService extends BaseService {
       return JobStatus.Skipped;
     }
 
+    if (force) {
+      // A reset must clear existing pet people/faces so stale labels disappear immediately,
+      // rather than lingering throughout the reprocessing window (and duplicating on re-detect).
+      await this.personRepository.deleteAllPets();
+    }
+
     let jobs: JobItem[] = [];
     const assets = this.assetJobRepository.streamForPetDetectionJob(force);
 

--- a/server/test/medium/specs/repositories/person.repository.spec.ts
+++ b/server/test/medium/specs/repositories/person.repository.spec.ts
@@ -727,4 +727,36 @@ describe(PersonRepository.name, () => {
       );
     });
   });
+
+  describe('deleteAllPets', () => {
+    it('deletes pet people and their faces while preserving human people and faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      // Pet detection result: a 'pet'-typed person with a detected face.
+      const { person: pet } = await ctx.newPerson({ ownerId: user.id, name: 'dog', type: 'pet', species: 'dog' });
+      await ctx.newAssetFace({ assetId: asset.id, personId: pet.id });
+
+      // Human face/person from facial recognition — must survive a pet reset.
+      const { person: human } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+      const { result: humanFaceId } = await ctx.newAssetFace({ assetId: asset.id, personId: human.id });
+
+      await sut.deleteAllPets();
+
+      const people = await ctx.database
+        .selectFrom('person')
+        .select(['id', 'type'])
+        .where('ownerId', '=', user.id)
+        .execute();
+      const faces = await ctx.database
+        .selectFrom('asset_face')
+        .select(['id', 'personId'])
+        .where('assetId', '=', asset.id)
+        .execute();
+
+      expect(people).toEqual([expect.objectContaining({ id: human.id })]);
+      expect(faces).toEqual([expect.objectContaining({ id: humanFaceId, personId: human.id })]);
+    });
+  });
 });

--- a/web/src/routes/admin/queues/QueuePanel.svelte
+++ b/web/src/routes/admin/queues/QueuePanel.svelte
@@ -80,7 +80,7 @@
       disabled: !featureFlags.ocr,
     },
     [QueueName.PetDetection]: {
-      allText: $t('all'),
+      allText: $t('reset'),
       missingText: $t('missing'),
     },
     [QueueName.Classification]: {
@@ -113,8 +113,18 @@
           if (!confirmed) {
             return;
           }
-          break;
         }
+        break;
+      }
+
+      case QueueName.PetDetection: {
+        if (dto.force) {
+          const confirmed = await modalManager.showDialog({ prompt: $t('admin.confirm_reprocess_all_pets') });
+          if (!confirmed) {
+            return;
+          }
+        }
+        break;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #694. Resetting the **Pet Detection** queue confirmed success and requeued 220k+ assets, but **never removed the people/faces from the previous run** — so old pet labels lingered on assets throughout the entire reprocessing window (and would duplicate on re-detect), despite the success notification.

The pet-detection queue-all path mirrored facial recognition's `handleQueueDetectFaces` in every respect *except* the force-reset cleanup: face detection deletes ML faces before requeuing, pet detection deleted nothing. This adds the missing step — and brings the UI in line, since the reset is now destructive.

## Server

- **`PersonRepository.deleteAllPets()`** — deletes all `person.type = 'pet'` people and their `asset_face` rows. Faces are deleted **before** the people they belong to, inside a transaction, because `asset_face.personId` is `ON DELETE SET NULL` — deleting people first would orphan (not delete) the faces. Pet-scoped on `type='pet'` rather than `sourceType`, so human ML faces are untouched.
- **`PetDetectionService.handleQueuePetDetection`** — on `force`, calls `deleteAllPets()` before streaming/requeuing, so stale labels disappear immediately instead of lingering.

### Why pet-scoped (not `handlePersonCleanup`)

Reusing the face-reset's `handlePersonCleanup()` would delete *faceless human* people too — wrong for a pet reset. So the deletion is keyed strictly on `person.type = 'pet'`.

## Web

The queue's force button now wipes all pet data, so it's treated like the face-detection reset:

- Relabel **"all" → "reset"** on the Pet Detection card.
- Add a **confirmation dialog** (`confirm_reprocess_all_pets`) before the destructive reset runs — previously one click wiped every detected pet with no warning.
- Moved the existing face-detection `break` out of the force branch so the new `PetDetection` case can't be reached by switch fall-through.

## Test Plan (TDD)

- [x] **Repository (medium, real DB):** `deleteAllPets` removes pet people + pet faces while preserving human people + human faces — written failing first (`sut.deleteAllPets is not a function`), then green. `person.repository.spec.ts` 24/24.
- [x] **Service (unit):** `force: true` calls `deleteAllPets` exactly once and *before* any job is queued; `force: false` never calls it — written failing first (spy called 0 times), then green. Full server unit suite 4609 passing.
- [x] **Web:** `check:svelte` 0 errors, `tsc --noEmit` clean, eslint clean, prettier clean, i18n `format:fix` no diff. (UI confirm/label change mirrors the existing untested face-detection guard; no bespoke component test added.)
- [ ] **Manual:** Admin → Jobs → Pet Detection → click **Reset** → confirm dialog appears → after confirming, existing pet labels are cleared and reprocessing requeues. **Missing** still processes only un-detected assets without clearing.