### PR TITLE
fix(asset): show age for space-propagated birthdays in asset detail view

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -464,6 +464,49 @@ describe(AssetService.name, () => {
       expect((result as any).people.length).toBeGreaterThan(0);
     });
 
+    it('should overlay identity-resolved birthday for owner viewing their own asset', async () => {
+      // A birthday set in a shared space is resolved at read time against the face identity and is
+      // never written back to `person.birthDate`. When the owner views their own asset (no space
+      // context), the raw person row has a null birthDate, so the detail view shows no age unless
+      // the identity-wide resolution is overlaid here (mirroring PersonService.getById).
+      const asset = AssetFactory.from({ ownerId: authStub.admin.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Raw Name', identityId: 'identity-1', birthDate: null }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.faceIdentity.getResolvedPersonByIdentityId.mockResolvedValue({
+        id: 'person-1',
+        name: 'Resolved Name',
+        birthDate: '1990-05-15',
+      } as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(mocks.faceIdentity.getResolvedPersonByIdentityId).toHaveBeenCalledWith(
+        authStub.admin.user.id,
+        'identity-1',
+      );
+      expect((result as any).people).toHaveLength(1);
+      // Mirrors PersonService.getById: both name and birthday are taken from the identity resolution.
+      expect((result as any).people[0].birthDate).toBe('1990-05-15');
+      expect((result as any).people[0].name).toBe('Resolved Name');
+    });
+
+    it('should not resolve identity metadata for an owner person without an identity', async () => {
+      const asset = AssetFactory.from({ ownerId: authStub.admin.user.id })
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person', identityId: null, birthDate: null }))
+        .build();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect(mocks.faceIdentity.getResolvedPersonByIdentityId).not.toHaveBeenCalled();
+      expect((result as any).people[0].birthDate).toBeNull();
+    });
+
     it('should strip people when asset is not in the specified space', async () => {
       const asset = AssetFactory.from()
         .exif()

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -1,10 +1,11 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
+import { ShallowDehydrateObject } from 'kysely';
 import _ from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import { isAbsolute } from 'node:path';
 import { JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
-import { AssetFile } from 'src/database';
+import { AssetFace, AssetFile } from 'src/database';
 import { OnJob } from 'src/decorators';
 import { AssetResponseDto, SanitizedAssetResponseDto, mapAsset } from 'src/dtos/asset-response.dto';
 import {
@@ -31,6 +32,7 @@ import {
   TrimParameters,
 } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
+import { PersonResponseDto } from 'src/dtos/person.dto';
 import {
   AssetFileType,
   AssetStatus,
@@ -125,7 +127,13 @@ export class AssetService extends BaseService {
         this.applySpacePeople(data, spacePersonMap);
         data.people = data.people.filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
       }
-    } else if (data.ownerId !== auth.user.id) {
+    } else if (data.ownerId === auth.user.id) {
+      // The owner is viewing their own asset with no space context. A name or birthday set in a
+      // shared space is resolved at read time against the face identity and is never written back
+      // to `person` (see PersonService.getById). Without overlaying that resolution here, the raw
+      // person row carries a null birthDate and the asset detail view shows no age.
+      await this.applyResolvedPersonMetadata(auth, data, asset.faces ?? []);
+    } else {
       data.unassignedFaces = [];
 
       // No spaceId — try to find a space containing this asset for this user
@@ -145,6 +153,47 @@ export class AssetService extends BaseService {
     }
 
     return data;
+  }
+
+  private async applyResolvedPersonMetadata(
+    auth: AuthDto,
+    data: AssetResponseDto,
+    faces: ShallowDehydrateObject<AssetFace>[],
+  ) {
+    const people = data.people;
+    if (!people?.length) {
+      return;
+    }
+
+    const identityByPersonId = new Map<string, string>();
+    for (const face of faces) {
+      if (face.person?.id && face.person.identityId) {
+        identityByPersonId.set(face.person.id, face.person.identityId);
+      }
+    }
+    if (identityByPersonId.size === 0) {
+      return;
+    }
+
+    const uniqueIdentityIds = [...new Set(identityByPersonId.values())];
+    const resolvedByIdentity = new Map<string, PersonResponseDto>();
+    await Promise.all(
+      uniqueIdentityIds.map(async (identityId) => {
+        const resolved = await this.faceIdentityRepository.getResolvedPersonByIdentityId(auth.user.id, identityId);
+        if (resolved) {
+          resolvedByIdentity.set(identityId, resolved);
+        }
+      }),
+    );
+
+    for (const person of people) {
+      const identityId = identityByPersonId.get(person.id);
+      const resolved = identityId ? resolvedByIdentity.get(identityId) : undefined;
+      if (resolved) {
+        person.name = resolved.name;
+        person.birthDate = resolved.birthDate;
+      }
+    }
   }
 
   private applySpacePeople(data: AssetResponseDto, spacePersonMap: Map<string, LinkedSpacePerson>) {

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -91,6 +91,66 @@ const createAccessibleSpaceIdentity = async (
   return { space, spacePerson, identity };
 };
 
+// One real-life person (identity I) appears in three places: Alice's library person (no birthday),
+// space S where Bob set the birthday, and Dave's own library person (no birthday, never shared into
+// S). Used by the birthday-visibility permission matrix to prove who may read the space-set birthday
+// via `getResolvedPersonByIdentityId` — the resolver the owner asset-detail view
+// (`AssetService.applyResolvedPersonMetadata`) relies on.
+const seedBirthdayPermissionWorld = async (ctx: ReturnType<typeof setup>['ctx'], sut: FaceIdentityRepository) => {
+  const { user: alice } = await ctx.newUser();
+  const { user: bob } = await ctx.newUser();
+  const { user: carol } = await ctx.newUser();
+  const { user: dave } = await ctx.newUser();
+
+  // Alice owns the global person + asset; this face anchors the shared identity.
+  const { person: alicePerson } = await ctx.newPerson({ ownerId: alice.id, name: 'Ina' });
+  const { asset: aliceAsset } = await ctx.newAsset({ ownerId: alice.id, visibility: AssetVisibility.Timeline });
+  const { assetFace: aliceFace } = await ctx.newAssetFace({ assetId: aliceAsset.id, personId: alicePerson.id });
+  const identity = await sut.ensurePersonIdentity(alicePerson.id);
+  await sut.linkFace({ assetFaceId: aliceFace.id, identityId: identity.id, source: 'owner-person' });
+
+  // Space S: Alice (owner) + Bob (viewer, timeline on). The birthday is set here.
+  const { space: spaceS } = await ctx.newSharedSpace({ createdById: alice.id });
+  await ctx.newSharedSpaceMember({ spaceId: spaceS.id, userId: alice.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceMember({ spaceId: spaceS.id, userId: bob.id, role: SharedSpaceRole.Viewer });
+  await ctx.newSharedSpaceAsset({ spaceId: spaceS.id, assetId: aliceAsset.id, addedById: alice.id });
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: spaceS.id,
+      identityId: identity.id,
+      name: '',
+      representativeFaceId: aliceFace.id,
+      type: 'person',
+      birthDate: '2014-02-14',
+      birthDateSource: 'manual',
+      birthDateSourceUpdatedAt: new Date('2026-06-10T20:41:12.000Z'),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await linkSpaceFace(ctx, spacePerson.id, aliceFace.id);
+
+  // Dave has the SAME person in his own library (same identity) via his own asset, but is not a
+  // member of space S and never set a birthday — he must never inherit Bob's space-set birthday.
+  const { person: davePerson } = await ctx.newPerson({ ownerId: dave.id, name: 'Ina' });
+  await ctx.database.updateTable('person').set({ identityId: identity.id }).where('id', '=', davePerson.id).execute();
+  const { asset: daveAsset } = await ctx.newAsset({ ownerId: dave.id, visibility: AssetVisibility.Timeline });
+  const { assetFace: daveFace } = await ctx.newAssetFace({ assetId: daveAsset.id, personId: davePerson.id });
+  await sut.linkFace({ assetFaceId: daveFace.id, identityId: identity.id, source: 'owner-person' });
+
+  // Carol is a registered user with no person, asset, or space membership touching this identity.
+  return {
+    identity,
+    spaceS,
+    expectedBirthDate: '2014-02-14',
+    userIds: [alice.id, bob.id, carol.id, dave.id],
+    alice,
+    bob,
+    carol,
+    dave,
+  };
+};
+
 const newIdentityFace = async (
   ctx: ReturnType<typeof setup>['ctx'],
   sut: FaceIdentityRepository,
@@ -2031,6 +2091,76 @@ describe(FaceIdentityRepository.name, () => {
     } finally {
       await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
     }
+  });
+
+  // Matrix: who may read a birthday set inside a shared space. The resolver here
+  // (getResolvedPersonByIdentityId) is the same one AssetService uses to overlay the birthday on the
+  // owner's asset-detail view, so this guards against leaking a space-set birthday to users who are
+  // not entitled to it.
+  describe('birthday visibility permission matrix', () => {
+    it('shows the space-set birthday to the asset owner who is a member of the space', async () => {
+      const { ctx, sut } = setup();
+      const world = await seedBirthdayPermissionWorld(ctx, sut);
+
+      try {
+        const result = await sut.getResolvedPersonByIdentityId(world.alice.id, world.identity.id);
+        expect(result?.birthDate).toBe(world.expectedBirthDate);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', 'in', world.userIds).execute();
+      }
+    });
+
+    it('shows the space-set birthday to a fellow space member with the space in their timeline', async () => {
+      const { ctx, sut } = setup();
+      const world = await seedBirthdayPermissionWorld(ctx, sut);
+
+      try {
+        const result = await sut.getResolvedPersonByIdentityId(world.bob.id, world.identity.id);
+        expect(result?.birthDate).toBe(world.expectedBirthDate);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', 'in', world.userIds).execute();
+      }
+    });
+
+    it('hides the birthday from a member who has removed the space from their timeline', async () => {
+      const { ctx, sut } = setup();
+      const world = await seedBirthdayPermissionWorld(ctx, sut);
+      await setMemberTimeline(ctx, { spaceId: world.spaceS.id, userId: world.bob.id, showInTimeline: false });
+
+      try {
+        const result = await sut.getResolvedPersonByIdentityId(world.bob.id, world.identity.id);
+        expect(result).toBeUndefined();
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', 'in', world.userIds).execute();
+      }
+    });
+
+    it('does not leak the birthday to a user who shares the identity but not the space', async () => {
+      const { ctx, sut } = setup();
+      const world = await seedBirthdayPermissionWorld(ctx, sut);
+
+      try {
+        const result = await sut.getResolvedPersonByIdentityId(world.dave.id, world.identity.id);
+        // Dave resolves the same person (he shares the identity via his own library) but must never
+        // inherit the birthday that was only set inside a space he does not belong to.
+        expect(result).toBeDefined();
+        expect(result?.birthDate).toBeNull();
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', 'in', world.userIds).execute();
+      }
+    });
+
+    it('returns nothing to a user with no access to the identity', async () => {
+      const { ctx, sut } = setup();
+      const world = await seedBirthdayPermissionWorld(ctx, sut);
+
+      try {
+        const result = await sut.getResolvedPersonByIdentityId(world.carol.id, world.identity.id);
+        expect(result).toBeUndefined();
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', 'in', world.userIds).execute();
+      }
+    });
   });
 
   it('filters unnamed identity-grouped people below the configured minimum face count', async () => {


### PR DESCRIPTION
## Problem

When a birthday is set on a named person by a space member (non-admin) and propagates to the owner/admin, the **person profile shows the birthday correctly**, but the **asset detail panel shows no age** for that person on a photo. Setting the birthday directly as the owner makes the age appear.

## Root cause

A birthday (or name) set on a person in a shared space is **resolved at read time** against the person's *face identity* and is **never written back** to the global `person.birthDate` column.

- `PersonService.getById` (the person profile) explicitly overlays this identity-wide resolution via `faceIdentityRepository.getResolvedPersonByIdentityId` — so the profile shows the propagated birthday.
- `AssetService.get` did **not**. When the owner views their own asset with no space context, control falls through all the space branches and `data.people[]` keep the raw `person.birthDate` — which is `null` for a space-propagated birthday. The web age guard `{#if person.birthDate}` then fails, so no age is rendered.

Setting the birthday *directly* as the owner writes `person.birthDate`, which is why that path already worked.

## Fix

Overlay the same identity-wide name/birthday resolution in `AssetService.get` for the owner-viewing-own-asset path, mirroring `PersonService.getById`. People with a face identity get their resolved name + birthday; people without an identity are untouched.

## Tests

Added unit tests in `asset.service.spec.ts`:
- owner viewing own asset gets the identity-resolved birthday **and** name overlaid (and the resolver is queried with the right identity id);
- a person without an identity is left untouched and the resolver is not called.

RED confirmed (test fails without the fix because the resolver is never called), GREEN after. Full server unit suite passes (4611), `tsc --noEmit` and ESLint clean.