### PR TITLE
fix(web): sum day buckets per month in filter panel temporal picker

### DIFF
--- a/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
@@ -41,6 +41,36 @@ describe('temporal-utils', () => {
     expect(months[1]).toEqual({ month: 2, label: 'Feb', count: 0 });
   });
 
+  it('should sum day-granularity buckets that fall within the same month', () => {
+    // The photos timeline feeds day-granularity buckets (many per month).
+    // getMonthsForYear must accumulate them, not overwrite — otherwise month
+    // totals collapse to a single day's count while year totals stay correct.
+    const dayBuckets = [
+      { timeBucket: '2024-01-05', count: 10 },
+      { timeBucket: '2024-01-12', count: 7 },
+      { timeBucket: '2024-01-20', count: 3 },
+      { timeBucket: '2024-03-02', count: 8 },
+      { timeBucket: '2023-01-15', count: 999 },
+    ];
+    const months = getMonthsForYear(dayBuckets, 2024);
+    expect(months[0]).toEqual({ month: 1, label: 'Jan', count: 20 });
+    expect(months[2]).toEqual({ month: 3, label: 'Mar', count: 8 });
+    expect(months[1]).toEqual({ month: 2, label: 'Feb', count: 0 });
+  });
+
+  it('should keep month totals consistent with the year total for day buckets', () => {
+    const dayBuckets = [
+      { timeBucket: '2024-06-01', count: 5 },
+      { timeBucket: '2024-06-15', count: 25 },
+      { timeBucket: '2024-06-30', count: 8 },
+    ];
+    const [year2024] = aggregateYears(dayBuckets);
+    const months = getMonthsForYear(dayBuckets, 2024);
+    const monthTotal = months.reduce((sum, m) => sum + m.count, 0);
+    expect(monthTotal).toBe(year2024.count);
+    expect(year2024.count).toBe(38);
+  });
+
   it('should handle empty buckets', () => {
     const years = aggregateYears([]);
     expect(years).toHaveLength(0);

--- a/web/src/lib/components/filter-panel/temporal-utils.ts
+++ b/web/src/lib/components/filter-panel/temporal-utils.ts
@@ -33,7 +33,8 @@ export function getMonthsForYear(buckets: Array<{ timeBucket: string; count: num
   for (const b of buckets) {
     const d = new Date(b.timeBucket);
     if (d.getUTCFullYear() === year) {
-      monthMap.set(d.getUTCMonth() + 1, b.count);
+      const month = d.getUTCMonth() + 1;
+      monthMap.set(month, (monthMap.get(month) ?? 0) + b.count);
     }
   }
   return MONTH_LABELS.map((label, i) => ({


### PR DESCRIPTION
## Problem

The filter panel's year/month picker (Timeline filter) shows **correct year counts but wildly low month counts**. e.g. 2024 shows 10,849 photos, but drilling into months shows Jan 12, Feb 2, Mar 8… (single-day counts).

## Root cause

The picker is fed **day-granularity** time buckets on the photos timeline (`DEFAULT_TIMELINE_GROUPING = 'day'`). In `web/src/lib/components/filter-panel/temporal-utils.ts`:

- `aggregateYears` **accumulates** per year → year totals correct.
- `getMonthsForYear` **overwrote** the per-month count with each bucket (`monthMap.set(month, b.count)`) → with many day-buckets per month, only the last day's count survived.

### Why v4.57.0

`getMonthsForYear` shipped with overwrite logic in #138, back when the picker received one bucket *per month* (overwrite == set, so it worked). #625 ("timeline grouping display modes") made `day` the default grouping, so the picker now receives many buckets per month — that's the regression, landing in v4.57.0.

## Fix

Accumulate per-month counts, mirroring `aggregateYears`:

```ts
const month = d.getUTCMonth() + 1;
monthMap.set(month, (monthMap.get(month) ?? 0) + b.count);
```

The fix is in the shared util, so it corrects the picker for photos, spaces, albums, and map. Backward-compatible: with one bucket per month, accumulation equals the old set.

## Testing (TDD)

- Added 2 regression tests with day-granularity buckets (multiple per month) — confirmed they **fail** before the fix (Jan = 3 instead of 20; month total = 8 instead of 38) and **pass** after.
- Full web suite: **238/238 files, 3143 tests pass**.
- `tsc --noEmit` clean.