### PR TITLE
fix(person): grant shared-space members access to the representative-face picker

### DIFF
--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -839,6 +839,65 @@ describe(PersonService.name, () => {
         result.stream.destroy();
       }
     });
+
+    it('lists picker face crops for a shared-space member who does not own the person', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create({ faceAssetId: 'face-1' });
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.person.checkSharedSpaceAccess.mockResolvedValue(new Set([person.id]));
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.person.getRepresentativeFaces.mockResolvedValue([
+        {
+          ...AssetFaceFactory.create({ id: 'face-1', assetId: 'asset-1', personId: person.id }),
+          fileCreatedAt: new Date('2024-01-01T00:00:00.000Z'),
+          representativeFaceId: person.faceAssetId,
+        },
+      ]);
+
+      await expect(sut.getFacesForPicker(auth, person.id, { page: 1, size: 10 })).resolves.toEqual({
+        faces: [expect.objectContaining({ id: 'face-1', assetId: 'asset-1', isRepresentative: true })],
+        hasNextPage: false,
+      });
+      expect(mocks.access.person.checkSharedSpaceAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
+    });
+
+    it('updates the representative face for a shared-space member who does not own the person', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create({ identityId: 'identity-1' });
+      const face = AssetFaceFactory.create({ id: 'face-1', assetId: 'asset-1', personId: person.id });
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.person.checkSharedSpaceAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([face.assetId]));
+      mocks.person.getRepresentativeFaceForUpdate.mockResolvedValue(face);
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.person.update.mockResolvedValue({ ...person, faceAssetId: face.id });
+
+      await expect(sut.updateRepresentativeFace(auth, person.id, { assetFaceId: face.id })).resolves.toEqual(
+        expect.objectContaining({ id: person.id }),
+      );
+
+      expect(mocks.person.update).toHaveBeenCalledWith({ id: person.id, faceAssetId: face.id });
+      expect(mocks.access.person.checkSharedSpaceAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
+    });
+
+    it('rejects a representative face update when the actor cannot read the chosen face asset', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create();
+      const face = AssetFaceFactory.create({ id: 'face-1', assetId: 'asset-1', personId: person.id });
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.person.checkSharedSpaceAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set());
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.person.getRepresentativeFaceForUpdate.mockResolvedValue(face);
+
+      await expect(sut.updateRepresentativeFace(auth, person.id, { assetFaceId: face.id })).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mocks.person.update).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+    });
   });
 
   describe('update', () => {
@@ -850,6 +909,18 @@ describe(PersonService.name, () => {
       await expect(sut.update(auth, person.id, { name: 'Person 1' })).rejects.toBeInstanceOf(BadRequestException);
       expect(mocks.person.update).not.toHaveBeenCalled();
       expect(mocks.access.person.checkOwnerAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
+    });
+
+    it('does not let a shared-space member rename a person they do not own', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.person.checkSharedSpaceAccess.mockResolvedValue(new Set([person.id]));
+
+      await expect(sut.update(auth, person.id, { name: 'Renamed' })).rejects.toBeInstanceOf(BadRequestException);
+      expect(mocks.person.update).not.toHaveBeenCalled();
     });
 
     it('should throw an error when personId is invalid', async () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -356,7 +356,10 @@ export class PersonService extends BaseService {
     id: string,
     dto: RepresentativeFaceUpdateDto,
   ): Promise<PersonResponseDto> {
-    await this.requireAccess({ auth, permission: Permission.PersonUpdate, ids: [id] });
+    // Setting the representative face manages the person's thumbnail, which shared-space members
+    // can also do — so gate on person.read (owner | shared space) rather than owner-only
+    // person.update. The chosen face is still gated on asset.read below.
+    await this.requireAccess({ auth, permission: Permission.PersonRead, ids: [id] });
     const current = await this.findOrFail(id);
     const face = await this.personRepository.getRepresentativeFaceForUpdate({
       personId: id,

--- a/server/src/utils/access.spec.ts
+++ b/server/src/utils/access.spec.ts
@@ -418,6 +418,79 @@ describe('library-linked space asset access', () => {
   });
 });
 
+describe('space person access via checkOtherAccess', () => {
+  describe('PersonRead', () => {
+    it('should grant access when the person is visible through a shared space', async () => {
+      const accessMock = newAccessRepositoryMock();
+      const auth = makeAuth();
+      const personId = newUuid();
+
+      accessMock.person.checkSharedSpaceAccess.mockResolvedValue(new Set([personId]));
+
+      const result = await checkAccess(accessMock as any, {
+        auth,
+        permission: Permission.PersonRead,
+        ids: new Set([personId]),
+      });
+
+      expect(result).toEqual(new Set([personId]));
+      expect(accessMock.person.checkSharedSpaceAccess).toHaveBeenCalledWith(auth.user.id, new Set([personId]));
+    });
+
+    it('should not consult shared-space access when owner access is already granted', async () => {
+      const accessMock = newAccessRepositoryMock();
+      const auth = makeAuth();
+      const personId = newUuid();
+
+      accessMock.person.checkOwnerAccess.mockResolvedValue(new Set([personId]));
+
+      const result = await checkAccess(accessMock as any, {
+        auth,
+        permission: Permission.PersonRead,
+        ids: new Set([personId]),
+      });
+
+      expect(result).toEqual(new Set([personId]));
+      expect(accessMock.person.checkSharedSpaceAccess).toHaveBeenCalledWith(auth.user.id, new Set());
+    });
+
+    it('should deny access when the user is neither owner nor shared-space member', async () => {
+      const accessMock = newAccessRepositoryMock();
+      const auth = makeAuth();
+      const personId = newUuid();
+
+      const result = await checkAccess(accessMock as any, {
+        auth,
+        permission: Permission.PersonRead,
+        ids: new Set([personId]),
+      });
+
+      expect(result).toEqual(new Set());
+    });
+  });
+
+  describe('PersonUpdate / PersonDelete / PersonMerge (owner-only, space should NOT grant)', () => {
+    for (const permission of [Permission.PersonUpdate, Permission.PersonDelete, Permission.PersonMerge]) {
+      it(`should not grant ${permission} via shared-space membership`, async () => {
+        const accessMock = newAccessRepositoryMock();
+        const auth = makeAuth();
+        const personId = newUuid();
+
+        accessMock.person.checkSharedSpaceAccess.mockResolvedValue(new Set([personId]));
+
+        const result = await checkAccess(accessMock as any, {
+          auth,
+          permission,
+          ids: new Set([personId]),
+        });
+
+        expect(result).toEqual(new Set());
+        expect(accessMock.person.checkSharedSpaceAccess).not.toHaveBeenCalled();
+      });
+    }
+  });
+});
+
 describe('checkOtherAccess default case', () => {
   it('should return an empty set for an unhandled permission', async () => {
     const accessMock = newAccessRepositoryMock();

--- a/server/src/utils/access.ts
+++ b/server/src/utils/access.ts
@@ -302,7 +302,15 @@ const checkOtherAccess = async (access: AccessRepository, request: OtherAccessRe
       return access.person.checkFaceOwnerAccess(auth.user.id, ids);
     }
 
-    case Permission.PersonRead:
+    case Permission.PersonRead: {
+      // Owners always have access; shared-space members may also read a person (e.g. the
+      // representative-face picker and thumbnails) when the person's faces appear on assets
+      // shared with them. Mutations (update/delete/merge) stay owner-only below.
+      const isOwner = await access.person.checkOwnerAccess(auth.user.id, ids);
+      const isShared = await access.person.checkSharedSpaceAccess(auth.user.id, setDifference(ids, isOwner));
+      return setUnion(isOwner, isShared);
+    }
+
     case Permission.PersonUpdate:
     case Permission.PersonDelete:
     case Permission.PersonMerge: {


### PR DESCRIPTION
## Summary

Fixes #659.

A non-admin user with editor access to shared assets could not use **Select representative face**: the dialog opened but showed *"Unable to load faces"* and the server returned `Not found or no person.read access`. Admins were unaffected.

### Root cause

`checkOtherAccess` in `server/src/utils/access.ts` lumped `PersonRead` / `PersonUpdate` / `PersonDelete` / `PersonMerge` into a single case that only granted **owner** access. A shared-space member who can see a person's faces on shared assets was therefore denied `person.read`, so `getFacesForPicker` (and the follow-on representative-face write) failed. The fork already establishes the correct precedent for the same person's thumbnail: `getThumbnail` uses owner **OR** `checkSharedSpaceAccess`.

### Changes

- **`server/src/utils/access.ts`** — split the combined case. `PersonRead` now grants **owner | shared-space member**; `PersonUpdate` / `PersonDelete` / `PersonMerge` stay **owner-only**, so renaming, hiding, deleting, and merging the owner's person are *not* exposed to shared-space members.
- **`server/src/services/person.service.ts`** — `updateRepresentativeFace` now gates on `person.read` (owner | shared space) instead of owner-only `person.update`; the selected face is still gated on `asset.read`, so the actor must genuinely have access to that face's asset.

This fixes both the reported read failure (loading faces + face crops) and the follow-on write (applying the selection).

### Note on scope

Access is granted to any shared-space **member** (viewer or editor), matching the existing `getThumbnail` / `requireThumbnailAccess` behavior for the same person. The separate *space-profile* endpoints (`updateSpacePersonRepresentativeFace`) enforce Editor role; if we want the regular endpoint to also require editor-role for the write, that's a follow-up needing a new `checkSharedSpaceEditAccess` person repository method.

## Testing (TDD)

- New tests added first and verified to fail (one reproducing the literal `Not found or no person.read access` error), then made to pass.
- `server/src/utils/access.spec.ts`: `PersonRead` grants via shared space; owner short-circuit; `PersonUpdate`/`PersonDelete`/`PersonMerge` do **not** grant via shared-space membership.
- `server/src/services/person.service.spec.ts`: shared-space member can list picker faces and set the representative face; representative-face update rejected when the actor cannot read the chosen face's asset; shared-space member still cannot rename a person.
- Full server unit suite: **4625 passed**, 9 skipped, no regressions. `tsc --noEmit` clean; eslint clean on touched files. No SQL/`@GenerateSql` changes.