### PR TITLE
fix(album): show map pins to all shared-album readers (#656)

### DIFF
--- a/server/src/queries/map.repository.sql
+++ b/server/src/queries/map.repository.sql
@@ -20,45 +20,6 @@ where
 order by
   "fileCreatedAt" desc
 
--- MapRepository.getAlbumMapMarkers (scoped)
-select
-  "id",
-  "asset_exif"."latitude" as "lat",
-  "asset_exif"."longitude" as "lon",
-  "asset_exif"."city",
-  "asset_exif"."state",
-  "asset_exif"."country"
-from
-  "asset"
-  inner join "asset_exif" on "asset"."id" = "asset_exif"."assetId"
-  and "asset_exif"."latitude" is not null
-  and "asset_exif"."longitude" is not null
-  inner join "album_asset" on "asset"."id" = "album_asset"."assetId"
-where
-  "asset"."deletedAt" is null
-  and "album_asset"."albumId" = $1
-  and (
-    "asset"."ownerId" in ($2)
-    or exists (
-      select
-      from
-        "shared_space_asset"
-      where
-        "asset"."id" = "shared_space_asset"."assetId"
-        and "shared_space_asset"."spaceId" in ($3)
-    )
-    or exists (
-      select
-      from
-        "shared_space_library"
-      where
-        "asset"."libraryId" = "shared_space_library"."libraryId"
-        and "shared_space_library"."spaceId" in ($4)
-    )
-  )
-order by
-  "fileCreatedAt" desc
-
 -- MapRepository.getMapMarkers
 select
   "id",

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -23,11 +23,6 @@ export interface MapMarkerSearchOptions {
   timelineSpaceIds?: string[];
 }
 
-export interface AlbumMapMarkerSearchOptions {
-  ownerIds: string[];
-  timelineSpaceIds?: string[];
-}
-
 export interface GeoPoint {
   latitude: number;
   longitude: number;
@@ -76,42 +71,11 @@ export class MapRepository {
     this.logger.log('Geodata import completed');
   }
 
-  @GenerateSql(
-    { params: [DummyValue.UUID] },
-    { name: 'scoped', params: [DummyValue.UUID, { ownerIds: [DummyValue.UUID], timelineSpaceIds: [DummyValue.UUID] }] },
-  )
-  getAlbumMapMarkers(albumId: string, options?: AlbumMapMarkerSearchOptions) {
-    const query = this.mapMarkersQuery()
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getAlbumMapMarkers(albumId: string) {
+    return this.mapMarkersQuery()
       .innerJoin('album_asset', 'asset.id', 'album_asset.assetId')
-      .where('album_asset.albumId', '=', albumId);
-
-    if (!options) {
-      return query.execute();
-    }
-
-    return query
-      .where((eb) => {
-        const expression: Expression<SqlBool>[] = [eb('asset.ownerId', 'in', options.ownerIds)];
-
-        if (options.timelineSpaceIds?.length) {
-          expression.push(
-            eb.exists((eb) =>
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('asset.id', '=', 'shared_space_asset.assetId')
-                .where('shared_space_asset.spaceId', 'in', options.timelineSpaceIds!),
-            ),
-            eb.exists((eb) =>
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('asset.libraryId', '=', 'shared_space_library.libraryId')
-                .where('shared_space_library.spaceId', 'in', options.timelineSpaceIds!),
-            ),
-          );
-        }
-
-        return eb.or(expression);
-      })
+      .where('album_asset.albumId', '=', albumId)
       .execute();
   }
 

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -6,10 +6,9 @@ import { AlbumUserFactory } from 'test/factories/album-user.factory';
 import { AlbumFactory } from 'test/factories/album.factory';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
-import { PartnerFactory } from 'test/factories/partner.factory';
 import { UserFactory } from 'test/factories/user.factory';
 import { authStub } from 'test/fixtures/auth.stub';
-import { getForAlbum, getForPartner } from 'test/mappers';
+import { getForAlbum } from 'test/mappers';
 import { newUuid } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
 
@@ -112,33 +111,75 @@ describe(AlbumService.name, () => {
   });
 
   describe('getMapMarkers', () => {
-    it('passes owner, partner, and timeline-enabled spaces to album map lookup', async () => {
+    const albumMarkers = [
+      {
+        id: '0a8b6c1d-0000-4000-8000-000000000001',
+        lat: 48.2082,
+        lon: 16.3738,
+        city: 'Vienna',
+        state: 'Vienna',
+        country: 'Austria',
+      },
+    ];
+
+    // Regression test for #656: a Viewer-role member of a shared album must see
+    // pins for every geotagged asset in the album, even though those assets are
+    // owned by the album owner (a different user), not the viewer.
+    it('returns all album markers for a viewer regardless of asset owner', async () => {
       const auth = AuthFactory.create();
       const albumId = newUuid();
-      const partnerId = newUuid();
-      const spaceId = newUuid();
-      const partner = PartnerFactory.create({ sharedById: partnerId, sharedWithId: auth.user.id, inTimeline: true });
-      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([albumId]));
-      mocks.partner.getAll.mockResolvedValue([getForPartner(partner)]);
-      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId }]);
-      mocks.map.getAlbumMapMarkers.mockResolvedValue([]);
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set([albumId]));
+      mocks.map.getAlbumMapMarkers.mockResolvedValue(albumMarkers);
 
-      await sut.getMapMarkers(auth, albumId);
+      await expect(sut.getMapMarkers(auth, albumId)).resolves.toEqual(albumMarkers);
 
-      expect(mocks.sharedSpace.getSpaceIdsForTimeline).toHaveBeenCalledWith(auth.user.id);
-      expect(mocks.map.getAlbumMapMarkers).toHaveBeenCalledWith(albumId, {
-        ownerIds: [auth.user.id, partnerId],
-        timelineSpaceIds: [spaceId],
-      });
+      expect(mocks.map.getAlbumMapMarkers).toHaveBeenCalledWith(albumId);
+      expect(mocks.partner.getAll).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
     });
 
-    it('keeps shared-link album map lookup on the existing album-link path', async () => {
+    it('returns all album markers for the album owner', async () => {
+      const auth = AuthFactory.create();
+      const albumId = newUuid();
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([albumId]));
+      mocks.map.getAlbumMapMarkers.mockResolvedValue(albumMarkers);
+
+      await expect(sut.getMapMarkers(auth, albumId)).resolves.toEqual(albumMarkers);
+
+      expect(mocks.map.getAlbumMapMarkers).toHaveBeenCalledWith(albumId);
+      expect(mocks.partner.getAll).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();
+    });
+
+    it('throws when the user has no album read access', async () => {
+      const auth = AuthFactory.create();
+      const albumId = newUuid();
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set());
+
+      await expect(sut.getMapMarkers(auth, albumId)).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(mocks.map.getAlbumMapMarkers).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list for shared links without showExif', async () => {
+      const auth = AuthFactory.from().sharedLink({ showExif: false }).build();
+      const albumId = newUuid();
+      mocks.access.album.checkSharedLinkAccess.mockResolvedValue(new Set([albumId]));
+
+      await expect(sut.getMapMarkers(auth, albumId)).resolves.toEqual([]);
+
+      expect(mocks.map.getAlbumMapMarkers).not.toHaveBeenCalled();
+    });
+
+    it('returns all album markers for shared links with showExif', async () => {
       const auth = AuthFactory.from().sharedLink({ showExif: true }).build();
       const albumId = newUuid();
       mocks.access.album.checkSharedLinkAccess.mockResolvedValue(new Set([albumId]));
-      mocks.map.getAlbumMapMarkers.mockResolvedValue([]);
+      mocks.map.getAlbumMapMarkers.mockResolvedValue(albumMarkers);
 
-      await sut.getMapMarkers(auth, albumId);
+      await expect(sut.getMapMarkers(auth, albumId)).resolves.toEqual(albumMarkers);
 
       expect(mocks.partner.getAll).not.toHaveBeenCalled();
       expect(mocks.sharedSpace.getSpaceIdsForTimeline).not.toHaveBeenCalled();

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -19,7 +19,7 @@ import { MapMarkerResponseDto } from 'src/dtos/map.dto';
 import { Permission } from 'src/enum';
 import { AlbumAssetCount, AlbumInfoOptions } from 'src/repositories/album.repository';
 import { BaseService } from 'src/services/base.service';
-import { addAssets, getMyPartnerIds, removeAssets } from 'src/utils/asset.util';
+import { addAssets, removeAssets } from 'src/utils/asset.util';
 import { asDateString } from 'src/utils/date';
 import { getPreferences } from 'src/utils/preferences';
 
@@ -120,21 +120,11 @@ export class AlbumService extends BaseService {
       return [];
     }
 
-    if (auth.sharedLink) {
-      return this.mapRepository.getAlbumMapMarkers(id);
-    }
-
-    const partnerIds = await getMyPartnerIds({
-      userId: auth.user.id,
-      repository: this.partnerRepository,
-      timelineEnabled: true,
-    });
-    const spaceRows = await this.sharedSpaceRepository.getSpaceIdsForTimeline(auth.user.id);
-
-    return this.mapRepository.getAlbumMapMarkers(id, {
-      ownerIds: [auth.user.id, ...partnerIds],
-      timelineSpaceIds: spaceRows.length > 0 ? spaceRows.map((row) => row.spaceId) : undefined,
-    });
+    // Album membership (verified above via AlbumRead) is the access boundary: every reader of the
+    // album — owner, editor, or viewer — sees pins for all geotagged assets in it, just like the
+    // album grid does. Do not scope by asset owner here; doing so hid the owner's pins from
+    // viewers of a shared album (#656).
+    return this.mapRepository.getAlbumMapMarkers(id);
   }
 
   async create(auth: AuthDto, dto: CreateAlbumDto): Promise<AlbumResponseDto> {


### PR DESCRIPTION
## Problem

Fixes #656. When a Viewer-role member opened the map view inside a shared album, the map rendered but showed **no location pins**, even though the same photos had GPS coordinates visible to the album owner and were visible in the album grid.

## Root cause

`AlbumService.getMapMarkers` (introduced in #495) scoped the album map-markers query to the requester's own assets:

```ts
ownerIds: [auth.user.id, ...partnerIds]
```

In a shared album the geotagged photos belong to the **album owner**, so a Viewer's `ownerIds` matched nothing → zero pins. The album grid (`withAssets`) and the shared-link map path both return *all* album assets with no owner filter, so the map was inconsistent with everything else.

## Fix

Album read access (`AlbumRead`, already verified via `requireAccess`) is the correct access boundary. Every reader — owner, editor, or viewer — now gets markers for all geotagged assets in the album. The repository helper `getAlbumMapMarkers` is reverted to the upstream single-query form, removing the now-dead owner/timeline-space scoping branch (also reduces fork divergence).

## Tests

`album.service.spec.ts` — replaced the test that encoded the buggy owner-scoping with full coverage:

- Viewer sees all album markers regardless of asset owner (regression test for #656)
- Album owner sees all markers
- No album read access → `BadRequestException`, repository not called
- Shared link without `showExif` → empty list
- Shared link with `showExif` → all markers

## Verification

- New tests confirmed RED before the fix, GREEN after
- Full server unit suite: **4618 passed, 0 failed**
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean
- `make sql` regenerated (`map.repository.sql` `(scoped)` block removed)

## Out of scope

The issue's minor "Immich logo in map modal header" branding note is not addressed here — there is no logo reference in the modal/map code; it's the map-tile attribution / build-time `apply-branding` pipeline, tracked separately.