### PR TITLE
feat(web): filter panel motion & polish redesign

### DIFF
--- a/design-exploration/active-filters-bar-redesign.html
+++ b/design-exploration/active-filters-bar-redesign.html
@@ -1,0 +1,709 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Active Filters Bar — Redesign Exploration</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Hanken Grotesk to match the filter-panel-redesign prototype -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --ease: cubic-bezier(0.22, 1, 0.36, 1);
+        --d-hover: 150ms;
+        --primary: #6472ff;
+        --primary-strong: #5360ff;
+        --font: "Hanken Grotesk", ui-sans-serif, system-ui, sans-serif;
+        --radius: 14px;
+      }
+      html[data-theme="dark"] {
+        --app-bg: #0b0c0f;
+        --app-bg-glow: #14161d;
+        --panel: #15171c;
+        --surface: #1c1f26;
+        --hairline: rgba(255, 255, 255, 0.065);
+        --hairline-strong: rgba(255, 255, 255, 0.1);
+        --text: #e8eaef;
+        --text-muted: #9aa1ad;
+        --text-faint: #686f7b;
+        --surface-hover: rgba(255, 255, 255, 0.06);
+        --chip-fill: rgba(255, 255, 255, 0.06);
+        --chip-fill-hover: rgba(255, 255, 255, 0.1);
+        --chip-border: rgba(255, 255, 255, 0.1);
+        --primary-tint: color-mix(in srgb, var(--primary) 18%, transparent);
+        --primary-on: color-mix(in srgb, var(--primary) 80%, white);
+        /* legacy "before" tailwind-ish greys */
+        --legacy-band: #0f1117;
+        --legacy-border: #2a2f3a;
+        --legacy-chip: #374151;
+        --legacy-chip-text: #e5e7eb;
+        --legacy-faint: #6b7280;
+      }
+      html[data-theme="light"] {
+        --app-bg: #e9ebf1;
+        --app-bg-glow: #f3f4f9;
+        --panel: #ffffff;
+        --surface: #f4f5f9;
+        --hairline: rgba(17, 20, 28, 0.09);
+        --hairline-strong: rgba(17, 20, 28, 0.14);
+        --text: #1a1d24;
+        --text-muted: #59616e;
+        --text-faint: #8b929e;
+        --surface-hover: rgba(17, 20, 28, 0.05);
+        --chip-fill: rgba(17, 20, 28, 0.05);
+        --chip-fill-hover: rgba(17, 20, 28, 0.09);
+        --chip-border: rgba(17, 20, 28, 0.12);
+        --primary-tint: color-mix(in srgb, var(--primary) 14%, transparent);
+        --primary-on: var(--primary-strong);
+        --legacy-band: #f9fafb;
+        --legacy-border: #e5e7eb;
+        --legacy-chip: #e5e7eb;
+        --legacy-chip-text: #1f2937;
+        --legacy-faint: #9ca3af;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        font-family: var(--font);
+        color: var(--text);
+        background:
+          radial-gradient(1200px 700px at 78% -10%, var(--app-bg-glow), transparent 60%),
+          var(--app-bg);
+        -webkit-font-smoothing: antialiased;
+        padding: 40px clamp(16px, 5vw, 72px) 96px;
+      }
+
+      header.page {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 24px;
+        max-width: 1080px;
+        margin: 0 auto 36px;
+        flex-wrap: wrap;
+      }
+      h1 {
+        font-size: 26px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        margin: 0 0 6px;
+      }
+      header.page p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 14px;
+        max-width: 56ch;
+        line-height: 1.5;
+      }
+      .theme-toggle {
+        appearance: none;
+        border: 1px solid var(--hairline-strong);
+        background: var(--surface);
+        color: var(--text);
+        font: 600 13px var(--font);
+        padding: 8px 14px;
+        border-radius: 999px;
+        cursor: pointer;
+        transition: background var(--d-hover) var(--ease);
+      }
+      .theme-toggle:hover {
+        background: var(--surface-hover);
+      }
+
+      main {
+        max-width: 1080px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 30px;
+      }
+
+      .block {
+        border: 1px solid var(--hairline);
+        border-radius: var(--radius);
+        overflow: hidden;
+        background:
+          linear-gradient(180deg, color-mix(in srgb, var(--panel) 60%, transparent), transparent 120px),
+          var(--app-bg);
+      }
+      .block > .label {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 13px 18px;
+        border-bottom: 1px solid var(--hairline);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }
+      .label .tag {
+        font-size: 10px;
+        letter-spacing: 0.06em;
+        padding: 2px 7px;
+        border-radius: 999px;
+      }
+      .tag.before {
+        color: #f0a3a3;
+        background: color-mix(in srgb, #f0a3a3 16%, transparent);
+      }
+      .tag.after {
+        color: var(--primary-on);
+        background: var(--primary-tint);
+      }
+      .label .note {
+        margin-left: auto;
+        text-transform: none;
+        letter-spacing: 0;
+        font-weight: 500;
+        color: var(--text-faint);
+      }
+
+      /* The realistic layout shell: faux rail + content with the bar on top */
+      .shell {
+        display: flex;
+        min-height: 132px;
+      }
+      .rail {
+        width: 52px;
+        flex: none;
+        border-right: 1px solid var(--hairline);
+        background: var(--panel);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 14px;
+        padding: 14px 0;
+        color: var(--text-faint);
+      }
+      .rail svg {
+        width: 16px;
+        height: 16px;
+      }
+      .content {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      .grid {
+        flex: 1;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(78px, 1fr));
+        gap: 4px;
+        padding: 12px 16px;
+      }
+      .grid i {
+        display: block;
+        aspect-ratio: 1;
+        border-radius: 6px;
+        background: linear-gradient(135deg, #1f2230, #14161d);
+      }
+      html[data-theme="light"] .grid i {
+        background: linear-gradient(135deg, #d8dbe6, #eef0f6);
+      }
+
+      /* ============ THE BAR ============ */
+      .bar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 16px;
+      }
+
+      /* --- BEFORE (current) --- */
+      .bar.legacy {
+        background: var(--legacy-band);
+        border-bottom: 1px solid var(--legacy-border);
+        gap: 6px;
+        padding: 8px 16px;
+      }
+      .legacy .count {
+        font-size: 12px;
+        color: var(--legacy-faint);
+      }
+      .legacy .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        background: var(--legacy-chip);
+        color: var(--legacy-chip-text);
+        border-radius: 999px;
+        padding: 2px 10px;
+        font-size: 12px;
+      }
+      .legacy .chip .x {
+        color: var(--legacy-faint);
+        font-size: 14px;
+        line-height: 1;
+        cursor: pointer;
+      }
+      .legacy .clear {
+        margin-left: auto;
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--primary-on);
+      }
+
+      /* --- AFTER (proposed) --- */
+      .count {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 5px;
+        font-size: 12.5px;
+        font-weight: 500;
+        color: var(--text-muted);
+        white-space: nowrap;
+      }
+      .count b {
+        color: var(--text);
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+      }
+      .sep {
+        width: 3px;
+        height: 3px;
+        border-radius: 50%;
+        background: var(--text-faint);
+        opacity: 0.55;
+        flex: none;
+      }
+      .sep.line {
+        width: 1px;
+        height: 16px;
+        border-radius: 0;
+        background: var(--hairline-strong);
+        opacity: 1;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 5px 4px 9px;
+        border-radius: 999px;
+        background: var(--chip-fill);
+        border: 1px solid var(--chip-border);
+        font-size: 12.5px;
+        font-weight: 500;
+        color: var(--text);
+        line-height: 1;
+        transition:
+          background var(--d-hover) var(--ease),
+          border-color var(--d-hover) var(--ease);
+      }
+      .chip:hover {
+        background: var(--chip-fill-hover);
+      }
+      .chip > svg.lead {
+        width: 14px;
+        height: 14px;
+        color: var(--text-muted);
+        flex: none;
+      }
+      .chip .close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 17px;
+        height: 17px;
+        border-radius: 50%;
+        color: var(--text-faint);
+        cursor: pointer;
+        transition:
+          background var(--d-hover) var(--ease),
+          color var(--d-hover) var(--ease);
+      }
+      .chip .close svg {
+        width: 12px;
+        height: 12px;
+      }
+      .chip .close:hover {
+        background: var(--surface-hover);
+        color: var(--text);
+      }
+
+      /* search chip = primary tinted (special) */
+      .chip.search {
+        background: var(--primary-tint);
+        border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+        color: var(--primary-on);
+      }
+      .chip.search > svg.lead,
+      .chip.search .close {
+        color: color-mix(in srgb, var(--primary-on) 75%, transparent);
+      }
+      .chip.search .close:hover {
+        color: var(--primary-on);
+        background: color-mix(in srgb, var(--primary) 18%, transparent);
+      }
+
+      /* variant: outlined ghost */
+      .chip.ghost {
+        background: transparent;
+      }
+      /* variant: rounded-lg instead of pill */
+      .chip.rl {
+        border-radius: 9px;
+      }
+      /* variant: reveal close on hover */
+      .chip.reveal .close {
+        width: 0;
+        opacity: 0;
+        margin-left: -6px;
+        overflow: hidden;
+        transition:
+          width var(--d-hover) var(--ease),
+          opacity var(--d-hover) var(--ease),
+          margin var(--d-hover) var(--ease);
+      }
+      .chip.reveal:hover .close {
+        width: 17px;
+        opacity: 1;
+        margin-left: 0;
+      }
+
+      .clear {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-size: 12.5px;
+        font-weight: 600;
+        color: var(--primary-on);
+        background: transparent;
+        border: none;
+        border-radius: 999px;
+        padding: 5px 6px;
+        cursor: pointer;
+        font-family: var(--font);
+        transition: background var(--d-hover) var(--ease);
+      }
+      .clear svg {
+        width: 13px;
+        height: 13px;
+      }
+      .clear.pill {
+        padding: 5px 11px;
+      }
+      .clear.pill:hover {
+        background: var(--primary-tint);
+      }
+      .clear.linkish:hover {
+        text-decoration: underline;
+      }
+
+      /* Years / Months / All segmented control (faithful to TimelineGroupingControl) */
+      .group-ctl {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        padding: 3px;
+        border-radius: 999px;
+        background: var(--surface);
+        box-shadow: inset 0 0 0 1px var(--hairline-strong);
+        flex: none;
+      }
+      .group-ctl button {
+        appearance: none;
+        border: none;
+        background: transparent;
+        color: var(--text-muted);
+        font: 600 13px var(--font);
+        padding: 5px 13px;
+        border-radius: 999px;
+        cursor: pointer;
+        transition:
+          background var(--d-hover) var(--ease),
+          color var(--d-hover) var(--ease);
+      }
+      .group-ctl button:hover {
+        background: var(--surface-hover);
+        color: var(--text);
+      }
+      .group-ctl button[aria-pressed="true"] {
+        background: var(--primary);
+        color: #fff;
+      }
+
+      /* small variant chooser rows */
+      .variant {
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > .vlabel {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        color: var(--text-faint);
+        padding: 10px 16px 0;
+        text-transform: uppercase;
+      }
+      .variant + .variant {
+        border-top: 1px solid var(--hairline);
+      }
+      .legend {
+        max-width: 1080px;
+        margin: 4px auto 0;
+        color: var(--text-faint);
+        font-size: 12.5px;
+        line-height: 1.6;
+      }
+      .legend code {
+        font-family: ui-monospace, monospace;
+        font-size: 11.5px;
+        color: var(--text-muted);
+        background: var(--surface-hover);
+        padding: 1px 5px;
+        border-radius: 5px;
+      }
+      section.group > h2 {
+        max-width: 1080px;
+        margin: 18px auto 2px;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div>
+        <h1>Active Filters Bar</h1>
+        <p>
+          Rendered in context — faux filter rail on the left, photo grid behind. Compare the current bar against the
+          proposed soft-filled-pill direction, then pick the open details below.
+        </p>
+      </div>
+      <button class="theme-toggle" id="themeToggle">◑ Toggle theme</button>
+    </header>
+
+    <main id="main"></main>
+
+    <p class="legend" id="legend"></p>
+
+    <script>
+      const P = {
+        timeline:
+          "M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z",
+        person:
+          "M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z",
+        location:
+          "M12,11.5A2.5,2.5 0 0,1 9.5,9A2.5,2.5 0 0,1 12,6.5A2.5,2.5 0 0,1 14.5,9A2.5,2.5 0 0,1 12,11.5M12,2A7,7 0 0,0 5,9C5,14.25 12,22 12,22C12,22 19,14.25 19,9A7,7 0 0,0 12,2Z",
+        camera:
+          "M4,4H7L9,2H15L17,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4M12,7A5,5 0 0,0 7,12A5,5 0 0,0 12,17A5,5 0 0,0 17,12A5,5 0 0,0 12,7M12,9A3,3 0 0,1 15,12A3,3 0 0,1 12,15A3,3 0 0,1 9,12A3,3 0 0,1 12,9Z",
+        tag: "M5.5,7A1.5,1.5 0 0,1 4,5.5A1.5,1.5 0 0,1 5.5,4A1.5,1.5 0 0,1 7,5.5A1.5,1.5 0 0,1 5.5,7M21.41,11.58L12.41,2.58C12.05,2.22 11.55,2 11,2H4C2.89,2 2,2.89 2,4V11C2,11.55 2.22,12.05 2.59,12.41L11.58,21.41C11.95,21.77 12.45,22 13,22C13.55,22 14.05,21.77 14.41,21.41L21.41,14.41C21.78,14.05 22,13.55 22,13C22,12.44 21.77,11.94 21.41,11.58Z",
+        rating: "M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z",
+        media:
+          "M8.5,13.5L11,16.5L14.5,12L19,18H5M21,19V5C21,3.89 20.1,3 19,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19Z",
+        favorites:
+          "M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z",
+        albums:
+          "M6,19L9,15.14L11.14,17.72L14.14,13.86L18,19H6M6,4H11V12L8.5,10.5L6,12M18,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V4A2,2 0 0,0 18,2Z",
+        close:
+          "M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z",
+        search:
+          "M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z",
+      };
+      const RAIL = ["timeline", "person", "location", "camera", "tag", "rating", "media", "favorites", "albums"];
+      const svg = (name, cls = "") =>
+        `<svg viewBox="0 0 24 24" class="${cls}" fill="currentColor" aria-hidden="true"><path d="${P[name]}"/></svg>`;
+
+      // a proposed chip
+      const chip = (icon, label, extra = "") =>
+        `<span class="chip ${extra}">${svg(icon, "lead")}<span>${label}</span>` +
+        `<span class="close" role="button" aria-label="Remove ${label}">${svg("close")}</span></span>`;
+
+      const railHtml = `<div class="rail">${RAIL.map((n) => svg(n)).join("")}</div>`;
+      const gridHtml = `<div class="grid">${Array.from({ length: 24 }, () => "<i></i>").join("")}</div>`;
+
+      // shell wraps a bar (top) + photo grid (below), with rail on the left
+      const shell = (barHtml) =>
+        `<div class="shell">${railHtml}<div class="content">${barHtml}${gridHtml}</div></div>`;
+
+      const block = (labelHtml, body) => `<div class="block">${labelHtml}${body}</div>`;
+
+      // ----- BEFORE -----
+      const legacyBar = `
+        <div class="bar legacy">
+          <span class="count">2 results</span>
+          <span class="chip">Australia <span class="x">&times;</span></span>
+          <span class="chip">Aurelia <span class="x">&times;</span></span>
+          <span class="chip">★ 4+ <span class="x">&times;</span></span>
+          <span class="clear">Clear all</span>
+        </div>`;
+
+      // ----- AFTER (recommended baseline): transparent bar + hairline, dot sep, filled pills, ghost-pill clear -----
+      const afterBar = (opts = {}) => {
+        const { sep = "dot", chipExtra = "", clear = "pill", search = false } = opts;
+        const sepHtml = sep === "none" ? "" : `<span class="sep ${sep === "line" ? "line" : ""}"></span>`;
+        const searchChip = search
+          ? `<span class="chip search">${svg("search", "lead")}<span>mountain sunset</span><span class="close">${svg("close")}</span></span>`
+          : "";
+        const clearCls = clear === "pill" ? "pill" : clear === "icon" ? "pill" : "linkish";
+        const clearInner = clear === "icon" ? `${svg("close")}Clear all` : "Clear all";
+        return `
+        <div class="bar" style="border-bottom:1px solid var(--hairline)">
+          <span class="count"><b>2</b> results</span>
+          ${sepHtml}
+          ${searchChip}
+          ${chip("location", "Australia", chipExtra)}
+          ${chip("person", "Aurelia", chipExtra)}
+          ${chip("rating", "★ 4+", chipExtra)}
+          <button class="clear ${clearCls}">${clearInner}</button>
+        </div>`;
+      };
+
+      // Years / Months / All segmented control
+      const groupCtl = (active = "all") => `
+        <div class="group-ctl" role="group" aria-label="Timeline grouping">
+          <button ${active === "year" ? 'aria-pressed="true"' : ""}>Years</button>
+          <button ${active === "month" ? 'aria-pressed="true"' : ""}>Months</button>
+          <button ${active === "all" ? 'aria-pressed="true"' : ""}>All</button>
+        </div>`;
+
+      // Merged toolbar: grouping (left) · chips · count + clear (right)
+      const mergedBar = (opts = {}) => {
+        const { filtered = true } = opts;
+        if (!filtered) {
+          return `<div class="bar" style="border-bottom:1px solid var(--hairline)">${groupCtl()}</div>`;
+        }
+        return `
+        <div class="bar" style="border-bottom:1px solid var(--hairline)">
+          ${groupCtl()}
+          <span class="sep line"></span>
+          <span class="count"><b>2</b> results</span>
+          <span class="sep"></span>
+          ${chip("location", "Australia")}
+          ${chip("person", "Aurelia")}
+          ${chip("rating", "★ 4+")}
+          <button class="clear pill" style="margin-left:auto">Clear all</button>
+        </div>`;
+      };
+
+      // Stacked toolbar: grouping row on top, filters bar below
+      const stackedBars = (opts = {}) => {
+        const { filtered = true } = opts;
+        const groupRow = `<div class="bar" style="padding-bottom:2px">${groupCtl()}</div>`;
+        return groupRow + (filtered ? afterBar(opts) : "");
+      };
+
+      const lbl = (kind, text, note = "") =>
+        `<div class="label"><span class="tag ${kind}">${kind.toUpperCase()}</span>${text}${
+          note ? `<span class="note">${note}</span>` : ""
+        }</div>`;
+
+      const main = document.getElementById("main");
+
+      // Headline comparison
+      main.innerHTML = `
+        <section class="group">
+          <h2>Toolbar layout — where does “Years / Months / All” go?</h2>
+          ${block(
+            lbl("before", "Current — two stacked rows", "grouping row, then a separate filters band below"),
+            shell(
+              `<div class="bar" style="padding-bottom:2px">${groupCtl()}</div>` + legacyBar,
+            ),
+          )}
+          ${block(
+            lbl("after", "Option A — stacked, both restyled", "grouping stays its own row; filters bar below"),
+            shell(stackedBars({ filtered: true })),
+          )}
+          ${block(
+            lbl("after", "Option B — merged single toolbar", "grouping · chips · count + clear (saves a row)"),
+            shell(mergedBar({ filtered: true })),
+          )}
+          ${block(
+            lbl("after", "Option B with no active filters", "degrades to just the grouping control"),
+            shell(mergedBar({ filtered: false })),
+          )}
+        </section>
+
+        <section class="group">
+          <h2>Headline comparison (filters bar only)</h2>
+          ${block(lbl("before", "Current", "gray band · hard rule · flat chips · raw ×"), shell(legacyBar))}
+          ${block(
+            lbl("after", "Proposed — soft filled pills", "transparent · hairline · type icons · real close"),
+            shell(afterBar({ search: true })),
+          )}
+        </section>
+
+        <section class="group">
+          <h2>Open decision 1 — chip fill</h2>
+          ${block(
+            lbl("after", "Filled (recommended)"),
+            `<div class="variant"><div class="bar">${chip("location", "Australia")}${chip("person", "Aurelia")}${chip("camera", "Canon EOS R5")}</div></div>`,
+          )}
+          ${block(
+            lbl("after", "Outlined ghost"),
+            `<div class="variant"><div class="bar">${chip("location", "Australia", "ghost")}${chip("person", "Aurelia", "ghost")}${chip("camera", "Canon EOS R5", "ghost")}</div></div>`,
+          )}
+        </section>
+
+        <section class="group">
+          <h2>Open decision 2 — chip shape</h2>
+          ${block(
+            lbl("after", "Full pill (recommended)"),
+            `<div class="bar">${chip("location", "Australia")}${chip("tag", "Vacation")}</div>`,
+          )}
+          ${block(
+            lbl("after", "Rounded-rect"),
+            `<div class="bar">${chip("location", "Australia", "rl")}${chip("tag", "Vacation", "rl")}</div>`,
+          )}
+        </section>
+
+        <section class="group">
+          <h2>Open decision 3 — close button</h2>
+          ${block(
+            lbl("after", "Always visible (recommended)"),
+            `<div class="bar">${chip("location", "Australia")}${chip("person", "Aurelia")}</div>`,
+          )}
+          ${block(
+            lbl("after", "Reveal on hover", "hover a chip"),
+            `<div class="bar">${chip("location", "Australia", "reveal")}${chip("person", "Aurelia", "reveal")}</div>`,
+          )}
+        </section>
+
+        <section class="group">
+          <h2>Open decision 4 — count separator</h2>
+          ${block(lbl("after", "Dot (recommended)"), shell(afterBar({ sep: "dot" })))}
+          ${block(lbl("after", "Vertical hairline"), shell(afterBar({ sep: "line" })))}
+          ${block(lbl("after", "None"), shell(afterBar({ sep: "none" })))}
+        </section>
+
+        <section class="group">
+          <h2>Open decision 5 — “Clear all”</h2>
+          ${block(lbl("after", "Hover pill (recommended)"), shell(afterBar({ clear: "pill" })))}
+          ${block(lbl("after", "With leading × icon"), shell(afterBar({ clear: "icon" })))}
+          ${block(lbl("after", "Underline link"), shell(afterBar({ clear: "link" })))}
+        </section>
+      `;
+
+      document.getElementById("legend").innerHTML =
+        `All tokens map to the real theme: chip fill <code>bg-gray-100 / dark:bg-white/6</code>, ` +
+        `hairline <code>border-gray-200/60 / dark:border-white/10</code>, primary <code>immich-primary</code>. ` +
+        `Icons are the exact <code>@mdi/js</code> paths used by the filter panel’s <code>sectionIcons</code>.`;
+
+      const tog = document.getElementById("themeToggle");
+      tog.addEventListener("click", () => {
+        const h = document.documentElement;
+        h.dataset.theme = h.dataset.theme === "dark" ? "light" : "dark";
+      });
+    </script>
+  </body>
+</html>

--- a/design-exploration/filter-panel-redesign.html
+++ b/design-exploration/filter-panel-redesign.html
@@ -1,0 +1,635 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Filter Panel — Redesign Exploration</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<!-- Hanken Grotesk: a warm, characterful grotesque for UI — distinct from Inter/Roboto, with proper tabular figures for the year counts -->
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ============================================================
+     DESIGN TOKENS
+     ============================================================ */
+  :root {
+    --d-panel: 420ms;
+    --d-section: 300ms;
+    --d-hover: 150ms;
+    --d-stagger: 45ms;
+    /* decelerating "settle" curve — the heart of the calmer feel */
+    --ease: cubic-bezier(.22, 1, .36, 1);
+    --ease-soft: cubic-bezier(.4, 0, .2, 1);
+
+    --primary: #6472ff;
+    --primary-strong: #5360ff;
+    --primary-tint: color-mix(in srgb, var(--primary) 16%, transparent);
+    --primary-tint-soft: color-mix(in srgb, var(--primary) 9%, transparent);
+    --font: 'Hanken Grotesk', ui-sans-serif, system-ui, sans-serif;
+
+    --rail-w: 56px;
+    --panel-w: 268px;
+    --radius: 14px;
+  }
+
+  html[data-theme="dark"] {
+    --app-bg: #0b0c0f;
+    --app-bg-glow: #14161d;
+    --panel: #15171c;
+    --surface: #1c1f26;
+    --surface-2: #21242c;
+    --hairline: rgba(255,255,255,.065);
+    --hairline-strong: rgba(255,255,255,.1);
+    --text: #e8eaef;
+    --text-muted: #9aa1ad;
+    --text-faint: #686f7b;
+    --surface-hover: rgba(255,255,255,.05);
+    --tile-shade: rgba(0,0,0,.25);
+    --shadow: 0 18px 40px -22px rgba(0,0,0,.85), 0 2px 8px -4px rgba(0,0,0,.6);
+    --inset-top: inset 0 1px 0 rgba(255,255,255,.04);
+  }
+  html[data-theme="light"] {
+    --app-bg: #e9ebf1;
+    --app-bg-glow: #f3f4f9;
+    --panel: #ffffff;
+    --surface: #f4f5f9;
+    --surface-2: #eceef4;
+    --hairline: rgba(17,20,28,.08);
+    --hairline-strong: rgba(17,20,28,.13);
+    --text: #1a1d24;
+    --text-muted: #59616e;
+    --text-faint: #8b929e;
+    --surface-hover: rgba(17,20,28,.04);
+    --tile-shade: rgba(0,0,0,.06);
+    --shadow: 0 18px 40px -24px rgba(20,24,40,.4), 0 2px 6px -3px rgba(20,24,40,.18);
+    --inset-top: inset 0 1px 0 rgba(255,255,255,.7);
+  }
+
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--text);
+    background:
+      radial-gradient(1200px 700px at 78% -10%, var(--app-bg-glow), transparent 60%),
+      var(--app-bg);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    transition: background .4s var(--ease-soft), color .3s var(--ease-soft);
+  }
+
+  /* reduced motion — both the OS setting and the in-page simulate toggle */
+  body.reduce-motion *, body.reduce-motion *::before, body.reduce-motion *::after {
+    transition-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    animation-delay: 0ms !important;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      transition-duration: 1ms !important;
+      animation-duration: 1ms !important;
+      animation-delay: 0ms !important;
+    }
+  }
+
+  /* ============================================================
+     PAGE CHROME ("the lab")
+     ============================================================ */
+  .lab-head {
+    max-width: 1320px;
+    margin: 0 auto;
+    padding: 30px 28px 14px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+  .lab-title { margin: 0; font-size: 13px; letter-spacing: .14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  .lab-sub { margin: 6px 0 0; font-size: 22px; font-weight: 700; letter-spacing: -.02em; }
+  .lab-sub span { color: var(--primary); }
+
+  .lab-controls { display: flex; gap: 10px; align-items: center; }
+  .seg {
+    display: inline-flex;
+    background: var(--surface);
+    border: 1px solid var(--hairline);
+    border-radius: 11px;
+    padding: 3px;
+    gap: 2px;
+  }
+  .seg button {
+    appearance: none; border: 0; cursor: pointer;
+    font-family: inherit; font-size: 12.5px; font-weight: 600;
+    color: var(--text-muted);
+    padding: 7px 13px; border-radius: 8px;
+    background: transparent;
+    transition: color var(--d-hover) var(--ease-soft), background var(--d-hover) var(--ease-soft);
+  }
+  .seg button[aria-pressed="true"] { color: #fff; background: var(--primary); }
+  html[data-theme="light"] .seg button[aria-pressed="true"] { color: #fff; }
+  .seg button:not([aria-pressed="true"]):hover { color: var(--text); background: var(--surface-hover); }
+
+  .stages {
+    max-width: 1320px;
+    margin: 14px auto 60px;
+    padding: 0 28px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 26px;
+  }
+  @media (max-width: 1080px) { .stages { grid-template-columns: 1fr; } }
+
+  .stage__label {
+    display: flex; align-items: center; gap: 9px;
+    font-size: 13px; color: var(--text-muted); margin: 0 0 11px 2px;
+  }
+  .stage__label b { color: var(--text); font-weight: 600; font-size: 13.5px; }
+  .stage__label .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--primary); box-shadow: 0 0 0 4px var(--primary-tint); }
+
+  /* the viewport mimics the app: panel on the left, photo grid filling the rest */
+  .viewport {
+    position: relative;
+    height: 552px;
+    border-radius: 18px;
+    border: 1px solid var(--hairline);
+    background:
+      radial-gradient(800px 400px at 100% 0, var(--app-bg-glow), transparent 55%),
+      var(--app-bg);
+    box-shadow: var(--shadow);
+    display: flex;
+    overflow: hidden;
+  }
+
+  /* ============================================================
+     THE FILTER PANEL
+     ============================================================ */
+  .panel {
+    position: relative;
+    flex: 0 0 auto;
+    width: var(--panel-w);
+    height: 100%;
+    background: var(--panel);
+    border-right: 1px solid var(--hairline);
+    box-shadow: var(--inset-top);
+    overflow: hidden;
+    transition: width var(--d-panel) var(--ease), transform var(--d-panel) var(--ease), opacity var(--d-panel) var(--ease);
+  }
+
+  /* --- Collapse style A: width eases down to an icon rail --- */
+  .stage--rail.collapsed .panel { width: var(--rail-w); }
+
+  /* --- Collapse style B: panel slides off; grid reclaims the space --- */
+  .stage--drawer.collapsed .panel { width: 0; transform: translateX(-16px); opacity: 0; border-right-color: transparent; }
+
+  /* full content + rail are stacked; they cross-fade */
+  .panel__full, .panel__rail {
+    position: absolute; inset: 0;
+    transition: opacity var(--d-panel) var(--ease), transform var(--d-panel) var(--ease);
+  }
+  .panel__full { display: flex; flex-direction: column; width: var(--panel-w); }
+  .panel__rail {
+    width: var(--rail-w);
+    display: flex; flex-direction: column; align-items: center; gap: 4px;
+    padding-top: 11px;
+    opacity: 0; pointer-events: none; transform: translateX(-6px);
+  }
+  .stage--rail.collapsed .panel__full { opacity: 0; transform: translateX(-10px); pointer-events: none; }
+  .stage--rail.collapsed .panel__rail { opacity: 1; transform: none; pointer-events: auto; }
+
+  /* panel header */
+  .panel__head {
+    flex: 0 0 auto;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 8px 0 16px; height: 48px;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .panel__title { font-size: 13.5px; font-weight: 700; letter-spacing: -.01em; }
+  .iconbtn {
+    appearance: none; border: 0; background: transparent; cursor: pointer;
+    color: var(--text-muted);
+    width: 30px; height: 30px; border-radius: 9px;
+    display: inline-grid; place-items: center;
+    transition: background var(--d-hover) var(--ease-soft), color var(--d-hover) var(--ease-soft), transform var(--d-hover) var(--ease);
+  }
+  .iconbtn:hover { background: var(--surface-hover); color: var(--text); }
+  .iconbtn:active { transform: scale(.9); }
+
+  /* the icon toggle row — softened pills replace hard squares */
+  .toggle-row {
+    flex: 0 0 auto;
+    display: flex; align-items: center; justify-content: center; gap: 2px;
+    padding: 9px 8px; border-bottom: 1px solid var(--hairline);
+  }
+  .toggle {
+    position: relative; appearance: none; border: 0; cursor: pointer; background: transparent;
+    width: 31px; height: 31px; border-radius: 10px;
+    display: inline-grid; place-items: center; color: var(--text-faint);
+    transition: background var(--d-hover) var(--ease-soft), color var(--d-hover) var(--ease-soft), transform var(--d-hover) var(--ease);
+  }
+  .toggle:hover { color: var(--text-muted); background: var(--surface-hover); }
+  .toggle:active { transform: scale(.88); }
+  .toggle[aria-pressed="true"] { color: var(--primary); background: var(--primary-tint); }
+  .toggle .dot {
+    position: absolute; top: 4px; right: 4px; width: 7px; height: 7px; border-radius: 50%;
+    background: var(--primary); border: 1.5px solid var(--panel);
+    transform: scale(0); transition: transform var(--d-hover) var(--ease);
+  }
+  .toggle.has-active .dot { transform: scale(1); }
+
+  /* sections list */
+  .sections { flex: 1 1 auto; overflow-y: auto; padding: 6px 0 18px; }
+  .sections::-webkit-scrollbar { width: 9px; }
+  .sections::-webkit-scrollbar-thumb { background: var(--hairline-strong); border-radius: 9px; border: 3px solid transparent; background-clip: content-box; }
+
+  .section { margin: 0 9px; border-radius: var(--radius); }
+  /* active/open section lifts onto a soft surface — no more hard full-width rules */
+  .section[aria-expanded="true"] { background: var(--surface); box-shadow: var(--inset-top); }
+  .section + .section { margin-top: 2px; }
+
+  .section__head {
+    appearance: none; width: 100%; border: 0; background: transparent; cursor: pointer;
+    display: flex; align-items: center; gap: 10px;
+    padding: 11px 12px; border-radius: var(--radius);
+    color: var(--text); font-family: inherit; text-align: left;
+    transition: background var(--d-hover) var(--ease-soft);
+  }
+  .section:not([aria-expanded="true"]) .section__head:hover { background: var(--surface-hover); }
+  .section__icon { color: var(--text-faint); display: inline-grid; place-items: center; transition: color var(--d-hover) var(--ease-soft); }
+  .section[aria-expanded="true"] .section__icon { color: var(--primary); }
+  .section__name { flex: 1 1 auto; font-size: 13px; font-weight: 600; letter-spacing: -.01em; }
+  .section__count {
+    font-size: 11px; color: var(--text-faint); font-variant-numeric: tabular-nums;
+    background: var(--surface-2); padding: 1px 7px; border-radius: 999px;
+    opacity: 0; transform: scale(.8); transition: opacity var(--d-hover), transform var(--d-hover) var(--ease);
+  }
+  .section.has-count .section__count { opacity: 1; transform: none; }
+  .section__chev { color: var(--text-faint); transform: rotate(-90deg); transition: transform var(--d-section) var(--ease); }
+  .section[aria-expanded="true"] .section__chev { transform: rotate(0); }
+
+  /* the smooth height slide — grid-rows 0fr→1fr, no JS measuring */
+  .section__body {
+    display: grid; grid-template-rows: 0fr;
+    transition: grid-template-rows var(--d-section) var(--ease), opacity var(--d-section) var(--ease-soft);
+    opacity: 0;
+  }
+  .section[aria-expanded="true"] .section__body { grid-template-rows: 1fr; opacity: 1; }
+  .section__body > .clip { overflow: hidden; min-height: 0; }
+  .section__inner { padding: 2px 12px 14px; }
+
+  /* ---- Timeline content ---- */
+  .date-range { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; margin-bottom: 13px; }
+  .field label { display: block; font-size: 10.5px; font-weight: 600; color: var(--text-muted); margin: 0 0 5px 2px; }
+  .field input {
+    width: 100%; height: 33px; border-radius: 9px; border: 1px solid var(--hairline-strong);
+    background: var(--surface-2); color: var(--text); font-family: inherit; font-size: 12px;
+    padding: 0 10px; outline: none;
+    transition: border-color var(--d-hover) var(--ease-soft), box-shadow var(--d-hover) var(--ease-soft);
+  }
+  .field input::placeholder { color: var(--text-faint); }
+  .field input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-tint); }
+
+  .year-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
+  .year-chip {
+    appearance: none; cursor: pointer; text-align: left; font-family: inherit;
+    border: 1px solid var(--hairline); background: var(--surface-2);
+    border-radius: 11px; padding: 8px 9px 9px;
+    display: flex; flex-direction: column; gap: 3px;
+    transition: border-color var(--d-hover) var(--ease-soft), background var(--d-hover) var(--ease-soft), transform var(--d-hover) var(--ease);
+    animation: rise .5s var(--ease) both;
+  }
+  .year-chip:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--primary) 45%, var(--hairline)); background: var(--primary-tint-soft); }
+  .year-chip:active { transform: translateY(0); }
+  .year-chip[data-selected="true"] {
+    background: linear-gradient(180deg, var(--primary), var(--primary-strong));
+    border-color: transparent; color: #fff;
+    box-shadow: 0 8px 18px -8px var(--primary);
+  }
+  .year-chip .yr { font-size: 12.5px; font-weight: 700; letter-spacing: -.01em; font-variant-numeric: tabular-nums; }
+  .year-chip .ct { font-size: 10.5px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
+  .year-chip[data-selected="true"] .ct { color: rgba(255,255,255,.8); }
+  .bar { height: 3px; border-radius: 3px; background: var(--hairline-strong); overflow: hidden; margin-top: 2px; }
+  .bar__fill {
+    height: 100%; border-radius: 3px; background: var(--primary);
+    transform-origin: left; animation: growx .9s var(--ease) both;
+  }
+  .year-chip[data-selected="true"] .bar { background: rgba(255,255,255,.28); }
+  .year-chip[data-selected="true"] .bar__fill { background: #fff; }
+
+  /* ---- People / Location content ---- */
+  .search {
+    position: relative; margin-bottom: 9px;
+  }
+  .search svg { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: var(--text-faint); }
+  .search input {
+    width: 100%; height: 33px; border-radius: 9px; border: 1px solid var(--hairline-strong);
+    background: var(--surface-2); color: var(--text); font-family: inherit; font-size: 12px;
+    padding: 0 10px 0 31px; outline: none;
+    transition: border-color var(--d-hover) var(--ease-soft), box-shadow var(--d-hover) var(--ease-soft);
+  }
+  .search input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-tint); }
+  .search input::placeholder { color: var(--text-faint); }
+
+  .opt {
+    display: flex; align-items: center; gap: 10px;
+    padding: 7px 8px; border-radius: 9px; cursor: pointer;
+    transition: background var(--d-hover) var(--ease-soft);
+  }
+  .opt:hover { background: var(--surface-hover); }
+  .opt .box {
+    width: 17px; height: 17px; border-radius: 5px; border: 1.5px solid var(--hairline-strong);
+    display: inline-grid; place-items: center; flex: 0 0 auto;
+    transition: background var(--d-hover) var(--ease), border-color var(--d-hover) var(--ease);
+  }
+  .opt .box svg { opacity: 0; transform: scale(.5); transition: opacity var(--d-hover), transform var(--d-hover) var(--ease); color:#fff; }
+  .opt[data-on="true"] .box { background: var(--primary); border-color: var(--primary); }
+  .opt[data-on="true"] .box svg { opacity: 1; transform: none; }
+  .avatar { width: 22px; height: 22px; border-radius: 50%; flex: 0 0 auto; display:grid; place-items:center; color:#fff; font-size:10px; font-weight:700; }
+  .opt .nm { font-size: 12.5px; color: var(--text); }
+  .more { font-size: 12px; font-weight: 600; color: var(--primary); padding: 8px 8px 2px; cursor: pointer; }
+  .more:hover { text-decoration: underline; }
+
+  /* rail icons */
+  .rail-icon {
+    position: relative; appearance: none; border: 0; background: transparent; cursor: pointer;
+    width: 34px; height: 34px; border-radius: 10px; display: grid; place-items: center; color: var(--text-faint);
+    transition: background var(--d-hover) var(--ease-soft), color var(--d-hover) var(--ease-soft);
+  }
+  .rail-icon:hover { background: var(--surface-hover); color: var(--text); }
+  .rail-icon.has-active { color: var(--primary); }
+  .rail-icon .dot { position:absolute; top:5px; right:5px; width:7px; height:7px; border-radius:50%; background:var(--primary); border:1.5px solid var(--panel); }
+  .rail-divider { width: 22px; height: 1px; background: var(--hairline); margin: 5px 0; }
+
+  /* reopen tab for the drawer style */
+  .reopen {
+    position: absolute; left: 0; top: 16px; z-index: 5;
+    display: flex; align-items: center; gap: 7px;
+    background: var(--panel); color: var(--text);
+    border: 1px solid var(--hairline); border-left: 0;
+    border-radius: 0 11px 11px 0;
+    padding: 9px 11px 9px 9px; cursor: pointer; font-family: inherit; font-size: 12px; font-weight: 600;
+    box-shadow: var(--shadow);
+    opacity: 0; transform: translateX(-100%); pointer-events: none;
+    transition: opacity var(--d-panel) var(--ease), transform var(--d-panel) var(--ease);
+  }
+  .reopen svg { color: var(--primary); }
+  .stage--drawer.collapsed .reopen { opacity: 1; transform: none; pointer-events: auto; transition-delay: 120ms; }
+
+  /* ============================================================
+     FAUX PHOTO GRID (so collapse motion is legible)
+     ============================================================ */
+  .grid {
+    flex: 1 1 auto; min-width: 0; padding: 14px;
+    display: grid; grid-template-columns: repeat(4, 1fr); grid-auto-rows: 78px; gap: 9px;
+    align-content: start;
+    transition: padding var(--d-panel) var(--ease);
+  }
+  .tile {
+    border-radius: 11px; position: relative; overflow: hidden;
+    box-shadow: var(--inset-top);
+    animation: rise .6s var(--ease) both;
+  }
+  .tile::after { content:""; position:absolute; inset:0; background: linear-gradient(180deg, transparent 55%, var(--tile-shade)); }
+  .tile.tall { grid-row: span 2; }
+  .g1 { background: linear-gradient(150deg, #3f6f4a, #6ba06a 60%, #a9c98a); }
+  .g2 { background: linear-gradient(150deg, #6f8fb0, #cdb7c7 70%, #e9c6d0); }
+  .g3 { background: linear-gradient(150deg, #2c3a4f, #4a5b73); }
+  .g4 { background: linear-gradient(150deg, #b98a6a, #e6b98c 70%, #f3d9b5); }
+  .g5 { background: linear-gradient(150deg, #3b5d52, #6fae8e); }
+  .g6 { background: linear-gradient(150deg, #7a8aa3, #b9c4d6); }
+  .g7 { background: linear-gradient(150deg, #44617a, #7fa0bd 70%, #c4d6e6); }
+  .g8 { background: linear-gradient(150deg, #5a4f6b, #9b8fb0); }
+
+  /* ============================================================
+     KEYFRAMES
+     ============================================================ */
+  @keyframes growx { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+  @keyframes rise { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: none; } }
+
+  .footnote { max-width: 1320px; margin: 0 auto 50px; padding: 0 30px; color: var(--text-faint); font-size: 12.5px; line-height: 1.7; }
+  .footnote b { color: var(--text-muted); font-weight: 600; }
+  .kbd { font-family: ui-monospace, monospace; font-size: 11px; background: var(--surface); border: 1px solid var(--hairline); border-radius: 5px; padding: 1px 6px; color: var(--text-muted); }
+</style>
+</head>
+<body>
+
+<!-- ===== icon library ===== -->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+  <defs>
+    <symbol id="i-cal" viewBox="0 0 24 24"><path fill="currentColor" d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2m0 16H5V10h14zm0-12H5V6h14z"/></symbol>
+    <symbol id="i-account" viewBox="0 0 24 24"><path fill="currentColor" d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5m0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5"/></symbol>
+    <symbol id="i-pin" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a7 7 0 0 0-7 7c0 5.2 7 13 7 13s7-7.8 7-13a7 7 0 0 0-7-7m0 9.5A2.5 2.5 0 1 1 14.5 9 2.5 2.5 0 0 1 12 11.5"/></symbol>
+    <symbol id="i-cam" viewBox="0 0 24 24"><path fill="currentColor" d="M9 3 7.2 5H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-3.2L15 3zm3 5a5 5 0 1 1 0 10 5 5 0 0 1 0-10m0 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6"/></symbol>
+    <symbol id="i-tag" viewBox="0 0 24 24"><path fill="currentColor" d="M21.4 11.6 12.4 2.6A2 2 0 0 0 11 2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 .6 1.4l9 9a2 2 0 0 0 2.8 0l7-7a2 2 0 0 0 0-2.8M6.5 8A1.5 1.5 0 1 1 8 6.5 1.5 1.5 0 0 1 6.5 8"/></symbol>
+    <symbol id="i-star" viewBox="0 0 24 24"><path fill="currentColor" d="m12 17.3 6.2 3.7-1.6-7 5.4-4.7-7.1-.6L12 2 9.1 8.7l-7.1.6 5.4 4.7-1.6 7z"/></symbol>
+    <symbol id="i-image" viewBox="0 0 24 24"><path fill="currentColor" d="M21 19V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2M8.5 13.5l2.5 3 3.5-4.5 4.5 6H5z"/></symbol>
+    <symbol id="i-heart" viewBox="0 0 24 24"><path fill="currentColor" d="m12 21-1.5-1.3C5.4 15 2 11.9 2 8.1A4.6 4.6 0 0 1 6.6 3.5 5 5 0 0 1 12 6a5 5 0 0 1 5.4-2.5A4.6 4.6 0 0 1 22 8.1c0 3.8-3.4 6.9-8.5 11.6z"/></symbol>
+    <symbol id="i-album" viewBox="0 0 24 24"><path fill="currentColor" d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2m-7 13-2.5-3L6 18h12l-4.5-6z"/></symbol>
+    <symbol id="i-chev-l" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m15 6-6 6 6 6"/></symbol>
+    <symbol id="i-chev-r" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m9 6 6 6-6 6"/></symbol>
+    <symbol id="i-chev-d" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6"/></symbol>
+    <symbol id="i-search" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M11 19a8 8 0 1 1 0-16 8 8 0 0 1 0 16m6-2 4 4"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="m5 12 5 5 9-10"/></symbol>
+  </defs>
+</svg>
+
+<header class="lab-head">
+  <div>
+    <p class="lab-title">Gallery · Design Exploration</p>
+    <h1 class="lab-sub">Filter panel — <span>motion &amp; polish</span></h1>
+  </div>
+  <div class="lab-controls">
+    <div class="seg" role="group" aria-label="Theme">
+      <button id="th-dark" aria-pressed="true">Dark</button>
+      <button id="th-light" aria-pressed="false">Light</button>
+    </div>
+    <div class="seg" role="group" aria-label="Motion">
+      <button id="mo-full" aria-pressed="true">Full motion</button>
+      <button id="mo-reduce" aria-pressed="false">Reduced</button>
+    </div>
+  </div>
+</header>
+
+<main class="stages">
+  <section class="stage stage--rail" id="stageA">
+    <p class="stage__label"><span class="pip"></span><b>Option A — Width-eased rail</b> · shrinks to an always-visible icon rail</p>
+    <div class="viewport"></div>
+  </section>
+
+  <section class="stage stage--drawer" id="stageB">
+    <p class="stage__label"><span class="pip"></span><b>Option B — Slide-off drawer</b> · slides away; a tab brings it back</p>
+    <div class="viewport"></div>
+  </section>
+</main>
+
+<p class="footnote">
+  <b>Try it:</b> click the <span class="kbd">‹</span> in each panel header to collapse — Option A eases its width down to the icon rail, Option B slides the whole panel away and the photo grid reclaims the space (use the <b>Filters</b> tab to reopen).
+  Click any section header to feel the height-slide; click year chips and people to see selection states. Toggle <b>Reduced</b> motion to verify the accessibility path (it also follows your OS setting automatically).
+  <br>Same features as today — softer surfaces, hairline dividers, a year grid that breathes, and motion that settles instead of snapping.
+</p>
+
+<script>
+  /* ---------- data ---------- */
+  const YEARS = [
+    [2009,266],[2010,1831],[2011,1874],[2012,523],[2013,316],[2014,11],
+    [2015,482],[2016,4132],[2017,4597],[2018,4331],[2019,4410],[2020,3067],
+    [2021,4134],[2022,4264],[2023,4392],[2024,10849],[2025,12452],[2026,2724]
+  ];
+  const MAXY = Math.max(...YEARS.map(y => y[1]));
+  const PEOPLE = [
+    ['Aurelia','#c2683f'],['Claire','#3f73c2'],['Gabusz','#4a9e6a'],['Gudrin','#a14fb0'],['Heiko','#b0934f']
+  ];
+  const PLACES = ['Austria','Croatia','Czech Republic','France','Germany','Hungary','Italy'];
+  const TOGGLES = [
+    ['i-cal','Timeline',true],['i-account','People',true],['i-pin','Location',false],
+    ['i-cam','Camera',false],['i-tag','Tags',true],['i-star','Rating',false],
+    ['i-image','Media',false],['i-heart','Favorites',false],['i-album','Albums',false]
+  ];
+  const RAIL = TOGGLES;
+
+  const use = (id) => `<svg width="17" height="17" aria-hidden="true"><use href="#${id}"/></svg>`;
+
+  /* ---------- builders ---------- */
+  function yearGrid() {
+    return YEARS.map(([yr,ct], i) => {
+      const pct = Math.max(4, Math.round(ct / MAXY * 100));
+      const sel = yr === 2024;
+      return `<button class="year-chip" data-selected="${sel}" style="animation-delay:${i*22}ms" data-yr="${yr}">
+        <span class="yr">${yr}</span>
+        <span class="ct">${ct.toLocaleString()}</span>
+        <span class="bar"><span class="bar__fill" style="width:${pct}%;animation-delay:${120+i*22}ms"></span></span>
+      </button>`;
+    }).join('');
+  }
+  function peopleList() {
+    return PEOPLE.map((p,i) => `<div class="opt" data-on="${i===0}">
+        <span class="box">${use('i-check')}</span>
+        <span class="avatar" style="background:${p[1]}">${p[0][0]}</span>
+        <span class="nm">${p[0]}</span>
+      </div>`).join('') + `<div class="more">3 more</div>`;
+  }
+  function placeList() {
+    return PLACES.map((p,i) => `<div class="opt" data-on="${i===4}">
+        <span class="box">${use('i-check')}</span>
+        <span class="nm">${p}</span>
+      </div>`).join('');
+  }
+
+  function section({icon,name,count,open,body}) {
+    return `<div class="section ${count?'has-count':''}" aria-expanded="${open}">
+      <button class="section__head" type="button">
+        <span class="section__icon">${use(icon)}</span>
+        <span class="section__name">${name}</span>
+        ${count?`<span class="section__count">${count}</span>`:''}
+        <span class="section__chev"><svg width="15" height="15" aria-hidden="true"><use href="#i-chev-d"/></svg></span>
+      </button>
+      <div class="section__body"><div class="clip"><div class="section__inner">${body}</div></div></div>
+    </div>`;
+  }
+
+  function toggleRow() {
+    return `<div class="toggle-row">` + TOGGLES.map(([icon,name,active]) =>
+      `<button class="toggle ${active?'has-active':''}" type="button" aria-pressed="${active}" title="${name}" aria-label="${name}">
+        ${use(icon)}<span class="dot"></span>
+      </button>`).join('') + `</div>`;
+  }
+
+  function railCol() {
+    const top = `<button class="iconbtn" data-act="expand" title="Expand"><svg width="17" height="17"><use href="#i-chev-r"/></svg></button>`;
+    const icons = RAIL.map(([icon,name,active]) =>
+      `<button class="rail-icon ${active?'has-active':''}" data-act="expand" title="${name}">${use(icon)}<span class="dot" style="${active?'':'display:none'}"></span></button>`).join('');
+    return `<div class="panel__rail">${top}<div class="rail-divider"></div>${icons}</div>`;
+  }
+
+  function panelMarkup() {
+    const timeline = `<div class="date-range">
+        <div class="field"><label>From</label><input placeholder="YYYY-MM-DD" /></div>
+        <div class="field"><label>To</label><input placeholder="YYYY-MM-DD" /></div>
+      </div><div class="year-grid">${yearGrid()}</div>`;
+    const people = `<div class="search">${use('i-search')}<input placeholder="Search people…" /></div>${peopleList()}`;
+    const places = `<div class="search">${use('i-search')}<input placeholder="Search locations…" /></div>${placeList()}`;
+    const sections =
+      section({icon:'i-cal',name:'Timeline',count:'',open:true,body:timeline}) +
+      section({icon:'i-account',name:'People',count:'5',open:true,body:people}) +
+      section({icon:'i-pin',name:'Location',count:'7',open:false,body:places}) +
+      section({icon:'i-cam',name:'Camera',count:'12',open:false,body:'<div style="color:var(--text-faint);font-size:12px">Apple · Sony · Canon…</div>'}) +
+      section({icon:'i-tag',name:'Tags',count:'34',open:false,body:'<div style="color:var(--text-faint);font-size:12px">Holiday · Family · Pets…</div>'}) +
+      section({icon:'i-star',name:'Rating',count:'',open:false,body:'<div style="color:var(--text-faint);font-size:12px">★★★★★</div>'});
+    return `${railCol()}<div class="panel__full">
+        <div class="panel__head">
+          <span class="panel__title">Filters</span>
+          <button class="iconbtn" data-act="collapse" title="Collapse"><svg width="17" height="17"><use href="#i-chev-l"/></svg></button>
+        </div>
+        ${toggleRow()}
+        <div class="sections">${sections}</div>
+      </div>`;
+  }
+
+  const GRID_TILES = [
+    'g1 tall','g2','g3','g4','g5','g6 tall','g7','g2','g8','g1','g4 tall','g5','g7','g3','g6','g2 tall','g8','g1'
+  ];
+  function gridMarkup() {
+    return `<div class="grid">` + GRID_TILES.map((c,i)=>`<div class="tile ${c}" style="animation-delay:${i*28}ms"></div>`).join('') + `</div>`;
+  }
+
+  function reopenTab() {
+    return `<button class="reopen" data-act="expand"><svg width="15" height="15"><use href="#i-chev-r"/></svg>Filters</button>`;
+  }
+
+  /* ---------- mount ---------- */
+  document.querySelectorAll('.stage .viewport').forEach(vp => {
+    vp.innerHTML = `<div class="panel">${panelMarkup()}</div>${gridMarkup()}${reopenTab()}`;
+  });
+
+  /* ---------- interactions ---------- */
+  document.addEventListener('click', (e) => {
+    const act = e.target.closest('[data-act]');
+    if (act) {
+      const stage = act.closest('.stage');
+      if (act.dataset.act === 'collapse') stage.classList.add('collapsed');
+      if (act.dataset.act === 'expand') stage.classList.remove('collapsed');
+      return;
+    }
+    const head = e.target.closest('.section__head');
+    if (head) {
+      const sec = head.closest('.section');
+      sec.setAttribute('aria-expanded', sec.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
+      return;
+    }
+    const tog = e.target.closest('.toggle');
+    if (tog) {
+      const on = tog.getAttribute('aria-pressed') === 'true';
+      tog.setAttribute('aria-pressed', String(!on));
+      return;
+    }
+    const chip = e.target.closest('.year-chip');
+    if (chip) {
+      const grid = chip.closest('.year-grid');
+      grid.querySelectorAll('.year-chip').forEach(c => c.dataset.selected = 'false');
+      chip.dataset.selected = 'true';
+      return;
+    }
+    const opt = e.target.closest('.opt');
+    if (opt) { opt.dataset.on = opt.dataset.on === 'true' ? 'false' : 'true'; }
+  });
+
+  /* ---------- lab controls ---------- */
+  const setTheme = (t) => {
+    document.documentElement.dataset.theme = t;
+    th_dark.setAttribute('aria-pressed', String(t === 'dark'));
+    th_light.setAttribute('aria-pressed', String(t === 'light'));
+  };
+  th_dark.onclick = () => setTheme('dark');
+  th_light.onclick = () => setTheme('light');
+
+  const setMotion = (reduce) => {
+    document.body.classList.toggle('reduce-motion', reduce);
+    mo_full.setAttribute('aria-pressed', String(!reduce));
+    mo_reduce.setAttribute('aria-pressed', String(reduce));
+  };
+  mo_full.onclick = () => setMotion(false);
+  mo_reduce.onclick = () => setMotion(true);
+</script>
+</body>
+</html>

--- a/design-exploration/filter-panel-redesign.html
+++ b/design-exploration/filter-panel-redesign.html
@@ -1,562 +1,1235 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Filter Panel — Redesign Exploration</title>
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<!-- Hanken Grotesk: a warm, characterful grotesque for UI — distinct from Inter/Roboto, with proper tabular figures for the year counts -->
-<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
-<style>
-  /* ============================================================
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Filter Panel — Redesign Exploration</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Hanken Grotesk: a warm, characterful grotesque for UI — distinct from Inter/Roboto, with proper tabular figures for the year counts -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================================
      DESIGN TOKENS
      ============================================================ */
-  :root {
-    --d-panel: 420ms;
-    --d-section: 300ms;
-    --d-hover: 150ms;
-    --d-stagger: 45ms;
-    /* decelerating "settle" curve — the heart of the calmer feel */
-    --ease: cubic-bezier(.22, 1, .36, 1);
-    --ease-soft: cubic-bezier(.4, 0, .2, 1);
+      :root {
+        --d-panel: 420ms;
+        --d-section: 300ms;
+        --d-hover: 150ms;
+        --d-stagger: 45ms;
+        /* decelerating "settle" curve — the heart of the calmer feel */
+        --ease: cubic-bezier(0.22, 1, 0.36, 1);
+        --ease-soft: cubic-bezier(0.4, 0, 0.2, 1);
 
-    --primary: #6472ff;
-    --primary-strong: #5360ff;
-    --primary-tint: color-mix(in srgb, var(--primary) 16%, transparent);
-    --primary-tint-soft: color-mix(in srgb, var(--primary) 9%, transparent);
-    --font: 'Hanken Grotesk', ui-sans-serif, system-ui, sans-serif;
+        --primary: #6472ff;
+        --primary-strong: #5360ff;
+        --primary-tint: color-mix(in srgb, var(--primary) 16%, transparent);
+        --primary-tint-soft: color-mix(in srgb, var(--primary) 9%, transparent);
+        --font: "Hanken Grotesk", ui-sans-serif, system-ui, sans-serif;
 
-    --rail-w: 56px;
-    --panel-w: 268px;
-    --radius: 14px;
-  }
+        --rail-w: 56px;
+        --panel-w: 268px;
+        --radius: 14px;
+      }
 
-  html[data-theme="dark"] {
-    --app-bg: #0b0c0f;
-    --app-bg-glow: #14161d;
-    --panel: #15171c;
-    --surface: #1c1f26;
-    --surface-2: #21242c;
-    --hairline: rgba(255,255,255,.065);
-    --hairline-strong: rgba(255,255,255,.1);
-    --text: #e8eaef;
-    --text-muted: #9aa1ad;
-    --text-faint: #686f7b;
-    --surface-hover: rgba(255,255,255,.05);
-    --tile-shade: rgba(0,0,0,.25);
-    --shadow: 0 18px 40px -22px rgba(0,0,0,.85), 0 2px 8px -4px rgba(0,0,0,.6);
-    --inset-top: inset 0 1px 0 rgba(255,255,255,.04);
-  }
-  html[data-theme="light"] {
-    --app-bg: #e9ebf1;
-    --app-bg-glow: #f3f4f9;
-    --panel: #ffffff;
-    --surface: #f4f5f9;
-    --surface-2: #eceef4;
-    --hairline: rgba(17,20,28,.08);
-    --hairline-strong: rgba(17,20,28,.13);
-    --text: #1a1d24;
-    --text-muted: #59616e;
-    --text-faint: #8b929e;
-    --surface-hover: rgba(17,20,28,.04);
-    --tile-shade: rgba(0,0,0,.06);
-    --shadow: 0 18px 40px -24px rgba(20,24,40,.4), 0 2px 6px -3px rgba(20,24,40,.18);
-    --inset-top: inset 0 1px 0 rgba(255,255,255,.7);
-  }
+      html[data-theme="dark"] {
+        --app-bg: #0b0c0f;
+        --app-bg-glow: #14161d;
+        --panel: #15171c;
+        --surface: #1c1f26;
+        --surface-2: #21242c;
+        --hairline: rgba(255, 255, 255, 0.065);
+        --hairline-strong: rgba(255, 255, 255, 0.1);
+        --text: #e8eaef;
+        --text-muted: #9aa1ad;
+        --text-faint: #686f7b;
+        --surface-hover: rgba(255, 255, 255, 0.05);
+        --tile-shade: rgba(0, 0, 0, 0.25);
+        --shadow:
+          0 18px 40px -22px rgba(0, 0, 0, 0.85),
+          0 2px 8px -4px rgba(0, 0, 0, 0.6);
+        --inset-top: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      }
+      html[data-theme="light"] {
+        --app-bg: #e9ebf1;
+        --app-bg-glow: #f3f4f9;
+        --panel: #ffffff;
+        --surface: #f4f5f9;
+        --surface-2: #eceef4;
+        --hairline: rgba(17, 20, 28, 0.08);
+        --hairline-strong: rgba(17, 20, 28, 0.13);
+        --text: #1a1d24;
+        --text-muted: #59616e;
+        --text-faint: #8b929e;
+        --surface-hover: rgba(17, 20, 28, 0.04);
+        --tile-shade: rgba(0, 0, 0, 0.06);
+        --shadow:
+          0 18px 40px -24px rgba(20, 24, 40, 0.4),
+          0 2px 6px -3px rgba(20, 24, 40, 0.18);
+        --inset-top: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+      }
 
-  * { box-sizing: border-box; }
-  html, body { height: 100%; }
-  body {
-    margin: 0;
-    font-family: var(--font);
-    color: var(--text);
-    background:
-      radial-gradient(1200px 700px at 78% -10%, var(--app-bg-glow), transparent 60%),
-      var(--app-bg);
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    transition: background .4s var(--ease-soft), color .3s var(--ease-soft);
-  }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        font-family: var(--font);
+        color: var(--text);
+        background:
+          radial-gradient(
+            1200px 700px at 78% -10%,
+            var(--app-bg-glow),
+            transparent 60%
+          ),
+          var(--app-bg);
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        transition:
+          background 0.4s var(--ease-soft),
+          color 0.3s var(--ease-soft);
+      }
 
-  /* reduced motion — both the OS setting and the in-page simulate toggle */
-  body.reduce-motion *, body.reduce-motion *::before, body.reduce-motion *::after {
-    transition-duration: 1ms !important;
-    animation-duration: 1ms !important;
-    animation-delay: 0ms !important;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
-      transition-duration: 1ms !important;
-      animation-duration: 1ms !important;
-      animation-delay: 0ms !important;
-    }
-  }
+      /* reduced motion — both the OS setting and the in-page simulate toggle */
+      body.reduce-motion *,
+      body.reduce-motion *::before,
+      body.reduce-motion *::after {
+        transition-duration: 1ms !important;
+        animation-duration: 1ms !important;
+        animation-delay: 0ms !important;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          transition-duration: 1ms !important;
+          animation-duration: 1ms !important;
+          animation-delay: 0ms !important;
+        }
+      }
 
-  /* ============================================================
+      /* ============================================================
      PAGE CHROME ("the lab")
      ============================================================ */
-  .lab-head {
-    max-width: 1320px;
-    margin: 0 auto;
-    padding: 30px 28px 14px;
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 24px;
-    flex-wrap: wrap;
-  }
-  .lab-title { margin: 0; font-size: 13px; letter-spacing: .14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
-  .lab-sub { margin: 6px 0 0; font-size: 22px; font-weight: 700; letter-spacing: -.02em; }
-  .lab-sub span { color: var(--primary); }
+      .lab-head {
+        max-width: 1320px;
+        margin: 0 auto;
+        padding: 30px 28px 14px;
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 24px;
+        flex-wrap: wrap;
+      }
+      .lab-title {
+        margin: 0;
+        font-size: 13px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--text-faint);
+        font-weight: 600;
+      }
+      .lab-sub {
+        margin: 6px 0 0;
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+      .lab-sub span {
+        color: var(--primary);
+      }
 
-  .lab-controls { display: flex; gap: 10px; align-items: center; }
-  .seg {
-    display: inline-flex;
-    background: var(--surface);
-    border: 1px solid var(--hairline);
-    border-radius: 11px;
-    padding: 3px;
-    gap: 2px;
-  }
-  .seg button {
-    appearance: none; border: 0; cursor: pointer;
-    font-family: inherit; font-size: 12.5px; font-weight: 600;
-    color: var(--text-muted);
-    padding: 7px 13px; border-radius: 8px;
-    background: transparent;
-    transition: color var(--d-hover) var(--ease-soft), background var(--d-hover) var(--ease-soft);
-  }
-  .seg button[aria-pressed="true"] { color: #fff; background: var(--primary); }
-  html[data-theme="light"] .seg button[aria-pressed="true"] { color: #fff; }
-  .seg button:not([aria-pressed="true"]):hover { color: var(--text); background: var(--surface-hover); }
+      .lab-controls {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+      }
+      .seg {
+        display: inline-flex;
+        background: var(--surface);
+        border: 1px solid var(--hairline);
+        border-radius: 11px;
+        padding: 3px;
+        gap: 2px;
+      }
+      .seg button {
+        appearance: none;
+        border: 0;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 12.5px;
+        font-weight: 600;
+        color: var(--text-muted);
+        padding: 7px 13px;
+        border-radius: 8px;
+        background: transparent;
+        transition:
+          color var(--d-hover) var(--ease-soft),
+          background var(--d-hover) var(--ease-soft);
+      }
+      .seg button[aria-pressed="true"] {
+        color: #fff;
+        background: var(--primary);
+      }
+      html[data-theme="light"] .seg button[aria-pressed="true"] {
+        color: #fff;
+      }
+      .seg button:not([aria-pressed="true"]):hover {
+        color: var(--text);
+        background: var(--surface-hover);
+      }
 
-  .stages {
-    max-width: 1320px;
-    margin: 14px auto 60px;
-    padding: 0 28px;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 26px;
-  }
-  @media (max-width: 1080px) { .stages { grid-template-columns: 1fr; } }
+      .stages {
+        max-width: 1320px;
+        margin: 14px auto 60px;
+        padding: 0 28px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 26px;
+      }
+      @media (max-width: 1080px) {
+        .stages {
+          grid-template-columns: 1fr;
+        }
+      }
 
-  .stage__label {
-    display: flex; align-items: center; gap: 9px;
-    font-size: 13px; color: var(--text-muted); margin: 0 0 11px 2px;
-  }
-  .stage__label b { color: var(--text); font-weight: 600; font-size: 13.5px; }
-  .stage__label .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--primary); box-shadow: 0 0 0 4px var(--primary-tint); }
+      .stage__label {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        font-size: 13px;
+        color: var(--text-muted);
+        margin: 0 0 11px 2px;
+      }
+      .stage__label b {
+        color: var(--text);
+        font-weight: 600;
+        font-size: 13.5px;
+      }
+      .stage__label .pip {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--primary);
+        box-shadow: 0 0 0 4px var(--primary-tint);
+      }
 
-  /* the viewport mimics the app: panel on the left, photo grid filling the rest */
-  .viewport {
-    position: relative;
-    height: 552px;
-    border-radius: 18px;
-    border: 1px solid var(--hairline);
-    background:
-      radial-gradient(800px 400px at 100% 0, var(--app-bg-glow), transparent 55%),
-      var(--app-bg);
-    box-shadow: var(--shadow);
-    display: flex;
-    overflow: hidden;
-  }
+      /* the viewport mimics the app: panel on the left, photo grid filling the rest */
+      .viewport {
+        position: relative;
+        height: 552px;
+        border-radius: 18px;
+        border: 1px solid var(--hairline);
+        background:
+          radial-gradient(
+            800px 400px at 100% 0,
+            var(--app-bg-glow),
+            transparent 55%
+          ),
+          var(--app-bg);
+        box-shadow: var(--shadow);
+        display: flex;
+        overflow: hidden;
+      }
 
-  /* ============================================================
+      /* ============================================================
      THE FILTER PANEL
      ============================================================ */
-  .panel {
-    position: relative;
-    flex: 0 0 auto;
-    width: var(--panel-w);
-    height: 100%;
-    background: var(--panel);
-    border-right: 1px solid var(--hairline);
-    box-shadow: var(--inset-top);
-    overflow: hidden;
-    transition: width var(--d-panel) var(--ease), transform var(--d-panel) var(--ease), opacity var(--d-panel) var(--ease);
-  }
+      .panel {
+        position: relative;
+        flex: 0 0 auto;
+        width: var(--panel-w);
+        height: 100%;
+        background: var(--panel);
+        border-right: 1px solid var(--hairline);
+        box-shadow: var(--inset-top);
+        overflow: hidden;
+        transition:
+          width var(--d-panel) var(--ease),
+          transform var(--d-panel) var(--ease),
+          opacity var(--d-panel) var(--ease);
+      }
 
-  /* --- Collapse style A: width eases down to an icon rail --- */
-  .stage--rail.collapsed .panel { width: var(--rail-w); }
+      /* --- Collapse style A: width eases down to an icon rail --- */
+      .stage--rail.collapsed .panel {
+        width: var(--rail-w);
+      }
 
-  /* --- Collapse style B: panel slides off; grid reclaims the space --- */
-  .stage--drawer.collapsed .panel { width: 0; transform: translateX(-16px); opacity: 0; border-right-color: transparent; }
+      /* --- Collapse style B: panel slides off; grid reclaims the space --- */
+      .stage--drawer.collapsed .panel {
+        width: 0;
+        transform: translateX(-16px);
+        opacity: 0;
+        border-right-color: transparent;
+      }
 
-  /* full content + rail are stacked; they cross-fade */
-  .panel__full, .panel__rail {
-    position: absolute; inset: 0;
-    transition: opacity var(--d-panel) var(--ease), transform var(--d-panel) var(--ease);
-  }
-  .panel__full { display: flex; flex-direction: column; width: var(--panel-w); }
-  .panel__rail {
-    width: var(--rail-w);
-    display: flex; flex-direction: column; align-items: center; gap: 4px;
-    padding-top: 11px;
-    opacity: 0; pointer-events: none; transform: translateX(-6px);
-  }
-  .stage--rail.collapsed .panel__full { opacity: 0; transform: translateX(-10px); pointer-events: none; }
-  .stage--rail.collapsed .panel__rail { opacity: 1; transform: none; pointer-events: auto; }
+      /* full content + rail are stacked; they cross-fade */
+      .panel__full,
+      .panel__rail {
+        position: absolute;
+        inset: 0;
+        transition:
+          opacity var(--d-panel) var(--ease),
+          transform var(--d-panel) var(--ease);
+      }
+      .panel__full {
+        display: flex;
+        flex-direction: column;
+        width: var(--panel-w);
+      }
+      .panel__rail {
+        width: var(--rail-w);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        padding-top: 11px;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateX(-6px);
+      }
+      .stage--rail.collapsed .panel__full {
+        opacity: 0;
+        transform: translateX(-10px);
+        pointer-events: none;
+      }
+      .stage--rail.collapsed .panel__rail {
+        opacity: 1;
+        transform: none;
+        pointer-events: auto;
+      }
 
-  /* panel header */
-  .panel__head {
-    flex: 0 0 auto;
-    display: flex; align-items: center; justify-content: space-between;
-    padding: 0 8px 0 16px; height: 48px;
-    border-bottom: 1px solid var(--hairline);
-  }
-  .panel__title { font-size: 13.5px; font-weight: 700; letter-spacing: -.01em; }
-  .iconbtn {
-    appearance: none; border: 0; background: transparent; cursor: pointer;
-    color: var(--text-muted);
-    width: 30px; height: 30px; border-radius: 9px;
-    display: inline-grid; place-items: center;
-    transition: background var(--d-hover) var(--ease-soft), color var(--d-hover) var(--ease-soft), transform var(--d-hover) var(--ease);
-  }
-  .iconbtn:hover { background: var(--surface-hover); color: var(--text); }
-  .iconbtn:active { transform: scale(.9); }
+      /* panel header */
+      .panel__head {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 8px 0 16px;
+        height: 48px;
+        border-bottom: 1px solid var(--hairline);
+      }
+      .panel__title {
+        font-size: 13.5px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .iconbtn {
+        appearance: none;
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        color: var(--text-muted);
+        width: 30px;
+        height: 30px;
+        border-radius: 9px;
+        display: inline-grid;
+        place-items: center;
+        transition:
+          background var(--d-hover) var(--ease-soft),
+          color var(--d-hover) var(--ease-soft),
+          transform var(--d-hover) var(--ease);
+      }
+      .iconbtn:hover {
+        background: var(--surface-hover);
+        color: var(--text);
+      }
+      .iconbtn:active {
+        transform: scale(0.9);
+      }
 
-  /* the icon toggle row — softened pills replace hard squares */
-  .toggle-row {
-    flex: 0 0 auto;
-    display: flex; align-items: center; justify-content: center; gap: 2px;
-    padding: 9px 8px; border-bottom: 1px solid var(--hairline);
-  }
-  .toggle {
-    position: relative; appearance: none; border: 0; cursor: pointer; background: transparent;
-    width: 31px; height: 31px; border-radius: 10px;
-    display: inline-grid; place-items: center; color: var(--text-faint);
-    transition: background var(--d-hover) var(--ease-soft), color var(--d-hover) var(--ease-soft), transform var(--d-hover) var(--ease);
-  }
-  .toggle:hover { color: var(--text-muted); background: var(--surface-hover); }
-  .toggle:active { transform: scale(.88); }
-  .toggle[aria-pressed="true"] { color: var(--primary); background: var(--primary-tint); }
-  .toggle .dot {
-    position: absolute; top: 4px; right: 4px; width: 7px; height: 7px; border-radius: 50%;
-    background: var(--primary); border: 1.5px solid var(--panel);
-    transform: scale(0); transition: transform var(--d-hover) var(--ease);
-  }
-  .toggle.has-active .dot { transform: scale(1); }
+      /* the icon toggle row — softened pills replace hard squares */
+      .toggle-row {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 2px;
+        padding: 9px 8px;
+        border-bottom: 1px solid var(--hairline);
+      }
+      .toggle {
+        position: relative;
+        appearance: none;
+        border: 0;
+        cursor: pointer;
+        background: transparent;
+        width: 31px;
+        height: 31px;
+        border-radius: 10px;
+        display: inline-grid;
+        place-items: center;
+        color: var(--text-faint);
+        transition:
+          background var(--d-hover) var(--ease-soft),
+          color var(--d-hover) var(--ease-soft),
+          transform var(--d-hover) var(--ease);
+      }
+      .toggle:hover {
+        color: var(--text-muted);
+        background: var(--surface-hover);
+      }
+      .toggle:active {
+        transform: scale(0.88);
+      }
+      .toggle[aria-pressed="true"] {
+        color: var(--primary);
+        background: var(--primary-tint);
+      }
+      .toggle .dot {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--primary);
+        border: 1.5px solid var(--panel);
+        transform: scale(0);
+        transition: transform var(--d-hover) var(--ease);
+      }
+      .toggle.has-active .dot {
+        transform: scale(1);
+      }
 
-  /* sections list */
-  .sections { flex: 1 1 auto; overflow-y: auto; padding: 6px 0 18px; }
-  .sections::-webkit-scrollbar { width: 9px; }
-  .sections::-webkit-scrollbar-thumb { background: var(--hairline-strong); border-radius: 9px; border: 3px solid transparent; background-clip: content-box; }
+      /* sections list */
+      .sections {
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 6px 0 18px;
+      }
+      .sections::-webkit-scrollbar {
+        width: 9px;
+      }
+      .sections::-webkit-scrollbar-thumb {
+        background: var(--hairline-strong);
+        border-radius: 9px;
+        border: 3px solid transparent;
+        background-clip: content-box;
+      }
 
-  .section { margin: 0 9px; border-radius: var(--radius); }
-  /* active/open section lifts onto a soft surface — no more hard full-width rules */
-  .section[aria-expanded="true"] { background: var(--surface); box-shadow: var(--inset-top); }
-  .section + .section { margin-top: 2px; }
+      .section {
+        margin: 0 9px;
+        border-radius: var(--radius);
+      }
+      /* active/open section lifts onto a soft surface — no more hard full-width rules */
+      .section[aria-expanded="true"] {
+        background: var(--surface);
+        box-shadow: var(--inset-top);
+      }
+      .section + .section {
+        margin-top: 2px;
+      }
 
-  .section__head {
-    appearance: none; width: 100%; border: 0; background: transparent; cursor: pointer;
-    display: flex; align-items: center; gap: 10px;
-    padding: 11px 12px; border-radius: var(--radius);
-    color: var(--text); font-family: inherit; text-align: left;
-    transition: background var(--d-hover) var(--ease-soft);
-  }
-  .section:not([aria-expanded="true"]) .section__head:hover { background: var(--surface-hover); }
-  .section__icon { color: var(--text-faint); display: inline-grid; place-items: center; transition: color var(--d-hover) var(--ease-soft); }
-  .section[aria-expanded="true"] .section__icon { color: var(--primary); }
-  .section__name { flex: 1 1 auto; font-size: 13px; font-weight: 600; letter-spacing: -.01em; }
-  .section__count {
-    font-size: 11px; color: var(--text-faint); font-variant-numeric: tabular-nums;
-    background: var(--surface-2); padding: 1px 7px; border-radius: 999px;
-    opacity: 0; transform: scale(.8); transition: opacity var(--d-hover), transform var(--d-hover) var(--ease);
-  }
-  .section.has-count .section__count { opacity: 1; transform: none; }
-  .section__chev { color: var(--text-faint); transform: rotate(-90deg); transition: transform var(--d-section) var(--ease); }
-  .section[aria-expanded="true"] .section__chev { transform: rotate(0); }
+      .section__head {
+        appearance: none;
+        width: 100%;
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 11px 12px;
+        border-radius: var(--radius);
+        color: var(--text);
+        font-family: inherit;
+        text-align: left;
+        transition: background var(--d-hover) var(--ease-soft);
+      }
+      .section:not([aria-expanded="true"]) .section__head:hover {
+        background: var(--surface-hover);
+      }
+      .section__icon {
+        color: var(--text-faint);
+        display: inline-grid;
+        place-items: center;
+        transition: color var(--d-hover) var(--ease-soft);
+      }
+      .section[aria-expanded="true"] .section__icon {
+        color: var(--primary);
+      }
+      .section__name {
+        flex: 1 1 auto;
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+      .section__count {
+        font-size: 11px;
+        color: var(--text-faint);
+        font-variant-numeric: tabular-nums;
+        background: var(--surface-2);
+        padding: 1px 7px;
+        border-radius: 999px;
+        opacity: 0;
+        transform: scale(0.8);
+        transition:
+          opacity var(--d-hover),
+          transform var(--d-hover) var(--ease);
+      }
+      .section.has-count .section__count {
+        opacity: 1;
+        transform: none;
+      }
+      .section__chev {
+        color: var(--text-faint);
+        transform: rotate(-90deg);
+        transition: transform var(--d-section) var(--ease);
+      }
+      .section[aria-expanded="true"] .section__chev {
+        transform: rotate(0);
+      }
 
-  /* the smooth height slide — grid-rows 0fr→1fr, no JS measuring */
-  .section__body {
-    display: grid; grid-template-rows: 0fr;
-    transition: grid-template-rows var(--d-section) var(--ease), opacity var(--d-section) var(--ease-soft);
-    opacity: 0;
-  }
-  .section[aria-expanded="true"] .section__body { grid-template-rows: 1fr; opacity: 1; }
-  .section__body > .clip { overflow: hidden; min-height: 0; }
-  .section__inner { padding: 2px 12px 14px; }
+      /* the smooth height slide — grid-rows 0fr→1fr, no JS measuring */
+      .section__body {
+        display: grid;
+        grid-template-rows: 0fr;
+        transition:
+          grid-template-rows var(--d-section) var(--ease),
+          opacity var(--d-section) var(--ease-soft);
+        opacity: 0;
+      }
+      .section[aria-expanded="true"] .section__body {
+        grid-template-rows: 1fr;
+        opacity: 1;
+      }
+      .section__body > .clip {
+        overflow: hidden;
+        min-height: 0;
+      }
+      .section__inner {
+        padding: 2px 12px 14px;
+      }
 
-  /* ---- Timeline content ---- */
-  .date-range { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; margin-bottom: 13px; }
-  .field label { display: block; font-size: 10.5px; font-weight: 600; color: var(--text-muted); margin: 0 0 5px 2px; }
-  .field input {
-    width: 100%; height: 33px; border-radius: 9px; border: 1px solid var(--hairline-strong);
-    background: var(--surface-2); color: var(--text); font-family: inherit; font-size: 12px;
-    padding: 0 10px; outline: none;
-    transition: border-color var(--d-hover) var(--ease-soft), box-shadow var(--d-hover) var(--ease-soft);
-  }
-  .field input::placeholder { color: var(--text-faint); }
-  .field input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-tint); }
+      /* ---- Timeline content ---- */
+      .date-range {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 9px;
+        margin-bottom: 13px;
+      }
+      .field label {
+        display: block;
+        font-size: 10.5px;
+        font-weight: 600;
+        color: var(--text-muted);
+        margin: 0 0 5px 2px;
+      }
+      .field input {
+        width: 100%;
+        height: 33px;
+        border-radius: 9px;
+        border: 1px solid var(--hairline-strong);
+        background: var(--surface-2);
+        color: var(--text);
+        font-family: inherit;
+        font-size: 12px;
+        padding: 0 10px;
+        outline: none;
+        transition:
+          border-color var(--d-hover) var(--ease-soft),
+          box-shadow var(--d-hover) var(--ease-soft);
+      }
+      .field input::placeholder {
+        color: var(--text-faint);
+      }
+      .field input:focus {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px var(--primary-tint);
+      }
 
-  .year-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
-  .year-chip {
-    appearance: none; cursor: pointer; text-align: left; font-family: inherit;
-    border: 1px solid var(--hairline); background: var(--surface-2);
-    border-radius: 11px; padding: 8px 9px 9px;
-    display: flex; flex-direction: column; gap: 3px;
-    transition: border-color var(--d-hover) var(--ease-soft), background var(--d-hover) var(--ease-soft), transform var(--d-hover) var(--ease);
-    animation: rise .5s var(--ease) both;
-  }
-  .year-chip:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--primary) 45%, var(--hairline)); background: var(--primary-tint-soft); }
-  .year-chip:active { transform: translateY(0); }
-  .year-chip[data-selected="true"] {
-    background: linear-gradient(180deg, var(--primary), var(--primary-strong));
-    border-color: transparent; color: #fff;
-    box-shadow: 0 8px 18px -8px var(--primary);
-  }
-  .year-chip .yr { font-size: 12.5px; font-weight: 700; letter-spacing: -.01em; font-variant-numeric: tabular-nums; }
-  .year-chip .ct { font-size: 10.5px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
-  .year-chip[data-selected="true"] .ct { color: rgba(255,255,255,.8); }
-  .bar { height: 3px; border-radius: 3px; background: var(--hairline-strong); overflow: hidden; margin-top: 2px; }
-  .bar__fill {
-    height: 100%; border-radius: 3px; background: var(--primary);
-    transform-origin: left; animation: growx .9s var(--ease) both;
-  }
-  .year-chip[data-selected="true"] .bar { background: rgba(255,255,255,.28); }
-  .year-chip[data-selected="true"] .bar__fill { background: #fff; }
+      .year-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 7px;
+      }
+      .year-chip {
+        appearance: none;
+        cursor: pointer;
+        text-align: left;
+        font-family: inherit;
+        border: 1px solid var(--hairline);
+        background: var(--surface-2);
+        border-radius: 11px;
+        padding: 8px 9px 9px;
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        transition:
+          border-color var(--d-hover) var(--ease-soft),
+          background var(--d-hover) var(--ease-soft),
+          transform var(--d-hover) var(--ease);
+        animation: rise 0.5s var(--ease) both;
+      }
+      .year-chip:hover {
+        transform: translateY(-2px);
+        border-color: color-mix(in srgb, var(--primary) 45%, var(--hairline));
+        background: var(--primary-tint-soft);
+      }
+      .year-chip:active {
+        transform: translateY(0);
+      }
+      .year-chip[data-selected="true"] {
+        background: linear-gradient(
+          180deg,
+          var(--primary),
+          var(--primary-strong)
+        );
+        border-color: transparent;
+        color: #fff;
+        box-shadow: 0 8px 18px -8px var(--primary);
+      }
+      .year-chip .yr {
+        font-size: 12.5px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        font-variant-numeric: tabular-nums;
+      }
+      .year-chip .ct {
+        font-size: 10.5px;
+        color: var(--text-faint);
+        font-variant-numeric: tabular-nums;
+      }
+      .year-chip[data-selected="true"] .ct {
+        color: rgba(255, 255, 255, 0.8);
+      }
+      .bar {
+        height: 3px;
+        border-radius: 3px;
+        background: var(--hairline-strong);
+        overflow: hidden;
+        margin-top: 2px;
+      }
+      .bar__fill {
+        height: 100%;
+        border-radius: 3px;
+        background: var(--primary);
+        transform-origin: left;
+        animation: growx 0.9s var(--ease) both;
+      }
+      .year-chip[data-selected="true"] .bar {
+        background: rgba(255, 255, 255, 0.28);
+      }
+      .year-chip[data-selected="true"] .bar__fill {
+        background: #fff;
+      }
 
-  /* ---- People / Location content ---- */
-  .search {
-    position: relative; margin-bottom: 9px;
-  }
-  .search svg { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: var(--text-faint); }
-  .search input {
-    width: 100%; height: 33px; border-radius: 9px; border: 1px solid var(--hairline-strong);
-    background: var(--surface-2); color: var(--text); font-family: inherit; font-size: 12px;
-    padding: 0 10px 0 31px; outline: none;
-    transition: border-color var(--d-hover) var(--ease-soft), box-shadow var(--d-hover) var(--ease-soft);
-  }
-  .search input:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-tint); }
-  .search input::placeholder { color: var(--text-faint); }
+      /* ---- People / Location content ---- */
+      .search {
+        position: relative;
+        margin-bottom: 9px;
+      }
+      .search svg {
+        position: absolute;
+        left: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-faint);
+      }
+      .search input {
+        width: 100%;
+        height: 33px;
+        border-radius: 9px;
+        border: 1px solid var(--hairline-strong);
+        background: var(--surface-2);
+        color: var(--text);
+        font-family: inherit;
+        font-size: 12px;
+        padding: 0 10px 0 31px;
+        outline: none;
+        transition:
+          border-color var(--d-hover) var(--ease-soft),
+          box-shadow var(--d-hover) var(--ease-soft);
+      }
+      .search input:focus {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px var(--primary-tint);
+      }
+      .search input::placeholder {
+        color: var(--text-faint);
+      }
 
-  .opt {
-    display: flex; align-items: center; gap: 10px;
-    padding: 7px 8px; border-radius: 9px; cursor: pointer;
-    transition: background var(--d-hover) var(--ease-soft);
-  }
-  .opt:hover { background: var(--surface-hover); }
-  .opt .box {
-    width: 17px; height: 17px; border-radius: 5px; border: 1.5px solid var(--hairline-strong);
-    display: inline-grid; place-items: center; flex: 0 0 auto;
-    transition: background var(--d-hover) var(--ease), border-color var(--d-hover) var(--ease);
-  }
-  .opt .box svg { opacity: 0; transform: scale(.5); transition: opacity var(--d-hover), transform var(--d-hover) var(--ease); color:#fff; }
-  .opt[data-on="true"] .box { background: var(--primary); border-color: var(--primary); }
-  .opt[data-on="true"] .box svg { opacity: 1; transform: none; }
-  .avatar { width: 22px; height: 22px; border-radius: 50%; flex: 0 0 auto; display:grid; place-items:center; color:#fff; font-size:10px; font-weight:700; }
-  .opt .nm { font-size: 12.5px; color: var(--text); }
-  .more { font-size: 12px; font-weight: 600; color: var(--primary); padding: 8px 8px 2px; cursor: pointer; }
-  .more:hover { text-decoration: underline; }
+      .opt {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 7px 8px;
+        border-radius: 9px;
+        cursor: pointer;
+        transition: background var(--d-hover) var(--ease-soft);
+      }
+      .opt:hover {
+        background: var(--surface-hover);
+      }
+      .opt .box {
+        width: 17px;
+        height: 17px;
+        border-radius: 5px;
+        border: 1.5px solid var(--hairline-strong);
+        display: inline-grid;
+        place-items: center;
+        flex: 0 0 auto;
+        transition:
+          background var(--d-hover) var(--ease),
+          border-color var(--d-hover) var(--ease);
+      }
+      .opt .box svg {
+        opacity: 0;
+        transform: scale(0.5);
+        transition:
+          opacity var(--d-hover),
+          transform var(--d-hover) var(--ease);
+        color: #fff;
+      }
+      .opt[data-on="true"] .box {
+        background: var(--primary);
+        border-color: var(--primary);
+      }
+      .opt[data-on="true"] .box svg {
+        opacity: 1;
+        transform: none;
+      }
+      .avatar {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        flex: 0 0 auto;
+        display: grid;
+        place-items: center;
+        color: #fff;
+        font-size: 10px;
+        font-weight: 700;
+      }
+      .opt .nm {
+        font-size: 12.5px;
+        color: var(--text);
+      }
+      .more {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--primary);
+        padding: 8px 8px 2px;
+        cursor: pointer;
+      }
+      .more:hover {
+        text-decoration: underline;
+      }
 
-  /* rail icons */
-  .rail-icon {
-    position: relative; appearance: none; border: 0; background: transparent; cursor: pointer;
-    width: 34px; height: 34px; border-radius: 10px; display: grid; place-items: center; color: var(--text-faint);
-    transition: background var(--d-hover) var(--ease-soft), color var(--d-hover) var(--ease-soft);
-  }
-  .rail-icon:hover { background: var(--surface-hover); color: var(--text); }
-  .rail-icon.has-active { color: var(--primary); }
-  .rail-icon .dot { position:absolute; top:5px; right:5px; width:7px; height:7px; border-radius:50%; background:var(--primary); border:1.5px solid var(--panel); }
-  .rail-divider { width: 22px; height: 1px; background: var(--hairline); margin: 5px 0; }
+      /* rail icons */
+      .rail-icon {
+        position: relative;
+        appearance: none;
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        width: 34px;
+        height: 34px;
+        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        color: var(--text-faint);
+        transition:
+          background var(--d-hover) var(--ease-soft),
+          color var(--d-hover) var(--ease-soft);
+      }
+      .rail-icon:hover {
+        background: var(--surface-hover);
+        color: var(--text);
+      }
+      .rail-icon.has-active {
+        color: var(--primary);
+      }
+      .rail-icon .dot {
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--primary);
+        border: 1.5px solid var(--panel);
+      }
+      .rail-divider {
+        width: 22px;
+        height: 1px;
+        background: var(--hairline);
+        margin: 5px 0;
+      }
 
-  /* reopen tab for the drawer style */
-  .reopen {
-    position: absolute; left: 0; top: 16px; z-index: 5;
-    display: flex; align-items: center; gap: 7px;
-    background: var(--panel); color: var(--text);
-    border: 1px solid var(--hairline); border-left: 0;
-    border-radius: 0 11px 11px 0;
-    padding: 9px 11px 9px 9px; cursor: pointer; font-family: inherit; font-size: 12px; font-weight: 600;
-    box-shadow: var(--shadow);
-    opacity: 0; transform: translateX(-100%); pointer-events: none;
-    transition: opacity var(--d-panel) var(--ease), transform var(--d-panel) var(--ease);
-  }
-  .reopen svg { color: var(--primary); }
-  .stage--drawer.collapsed .reopen { opacity: 1; transform: none; pointer-events: auto; transition-delay: 120ms; }
+      /* reopen tab for the drawer style */
+      .reopen {
+        position: absolute;
+        left: 0;
+        top: 16px;
+        z-index: 5;
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        background: var(--panel);
+        color: var(--text);
+        border: 1px solid var(--hairline);
+        border-left: 0;
+        border-radius: 0 11px 11px 0;
+        padding: 9px 11px 9px 9px;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 12px;
+        font-weight: 600;
+        box-shadow: var(--shadow);
+        opacity: 0;
+        transform: translateX(-100%);
+        pointer-events: none;
+        transition:
+          opacity var(--d-panel) var(--ease),
+          transform var(--d-panel) var(--ease);
+      }
+      .reopen svg {
+        color: var(--primary);
+      }
+      .stage--drawer.collapsed .reopen {
+        opacity: 1;
+        transform: none;
+        pointer-events: auto;
+        transition-delay: 120ms;
+      }
 
-  /* ============================================================
+      /* ============================================================
      FAUX PHOTO GRID (so collapse motion is legible)
      ============================================================ */
-  .grid {
-    flex: 1 1 auto; min-width: 0; padding: 14px;
-    display: grid; grid-template-columns: repeat(4, 1fr); grid-auto-rows: 78px; gap: 9px;
-    align-content: start;
-    transition: padding var(--d-panel) var(--ease);
-  }
-  .tile {
-    border-radius: 11px; position: relative; overflow: hidden;
-    box-shadow: var(--inset-top);
-    animation: rise .6s var(--ease) both;
-  }
-  .tile::after { content:""; position:absolute; inset:0; background: linear-gradient(180deg, transparent 55%, var(--tile-shade)); }
-  .tile.tall { grid-row: span 2; }
-  .g1 { background: linear-gradient(150deg, #3f6f4a, #6ba06a 60%, #a9c98a); }
-  .g2 { background: linear-gradient(150deg, #6f8fb0, #cdb7c7 70%, #e9c6d0); }
-  .g3 { background: linear-gradient(150deg, #2c3a4f, #4a5b73); }
-  .g4 { background: linear-gradient(150deg, #b98a6a, #e6b98c 70%, #f3d9b5); }
-  .g5 { background: linear-gradient(150deg, #3b5d52, #6fae8e); }
-  .g6 { background: linear-gradient(150deg, #7a8aa3, #b9c4d6); }
-  .g7 { background: linear-gradient(150deg, #44617a, #7fa0bd 70%, #c4d6e6); }
-  .g8 { background: linear-gradient(150deg, #5a4f6b, #9b8fb0); }
+      .grid {
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: 14px;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        grid-auto-rows: 78px;
+        gap: 9px;
+        align-content: start;
+        transition: padding var(--d-panel) var(--ease);
+      }
+      .tile {
+        border-radius: 11px;
+        position: relative;
+        overflow: hidden;
+        box-shadow: var(--inset-top);
+        animation: rise 0.6s var(--ease) both;
+      }
+      .tile::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, transparent 55%, var(--tile-shade));
+      }
+      .tile.tall {
+        grid-row: span 2;
+      }
+      .g1 {
+        background: linear-gradient(150deg, #3f6f4a, #6ba06a 60%, #a9c98a);
+      }
+      .g2 {
+        background: linear-gradient(150deg, #6f8fb0, #cdb7c7 70%, #e9c6d0);
+      }
+      .g3 {
+        background: linear-gradient(150deg, #2c3a4f, #4a5b73);
+      }
+      .g4 {
+        background: linear-gradient(150deg, #b98a6a, #e6b98c 70%, #f3d9b5);
+      }
+      .g5 {
+        background: linear-gradient(150deg, #3b5d52, #6fae8e);
+      }
+      .g6 {
+        background: linear-gradient(150deg, #7a8aa3, #b9c4d6);
+      }
+      .g7 {
+        background: linear-gradient(150deg, #44617a, #7fa0bd 70%, #c4d6e6);
+      }
+      .g8 {
+        background: linear-gradient(150deg, #5a4f6b, #9b8fb0);
+      }
 
-  /* ============================================================
+      /* ============================================================
      KEYFRAMES
      ============================================================ */
-  @keyframes growx { from { transform: scaleX(0); } to { transform: scaleX(1); } }
-  @keyframes rise { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: none; } }
+      @keyframes growx {
+        from {
+          transform: scaleX(0);
+        }
+        to {
+          transform: scaleX(1);
+        }
+      }
+      @keyframes rise {
+        from {
+          opacity: 0;
+          transform: translateY(7px);
+        }
+        to {
+          opacity: 1;
+          transform: none;
+        }
+      }
 
-  .footnote { max-width: 1320px; margin: 0 auto 50px; padding: 0 30px; color: var(--text-faint); font-size: 12.5px; line-height: 1.7; }
-  .footnote b { color: var(--text-muted); font-weight: 600; }
-  .kbd { font-family: ui-monospace, monospace; font-size: 11px; background: var(--surface); border: 1px solid var(--hairline); border-radius: 5px; padding: 1px 6px; color: var(--text-muted); }
-</style>
-</head>
-<body>
+      .footnote {
+        max-width: 1320px;
+        margin: 0 auto 50px;
+        padding: 0 30px;
+        color: var(--text-faint);
+        font-size: 12.5px;
+        line-height: 1.7;
+      }
+      .footnote b {
+        color: var(--text-muted);
+        font-weight: 600;
+      }
+      .kbd {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        background: var(--surface);
+        border: 1px solid var(--hairline);
+        border-radius: 5px;
+        padding: 1px 6px;
+        color: var(--text-muted);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- ===== icon library ===== -->
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <defs>
+        <symbol id="i-cal" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2m0 16H5V10h14zm0-12H5V6h14z"
+          />
+        </symbol>
+        <symbol id="i-account" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5m0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5"
+          />
+        </symbol>
+        <symbol id="i-pin" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M12 2a7 7 0 0 0-7 7c0 5.2 7 13 7 13s7-7.8 7-13a7 7 0 0 0-7-7m0 9.5A2.5 2.5 0 1 1 14.5 9 2.5 2.5 0 0 1 12 11.5"
+          />
+        </symbol>
+        <symbol id="i-cam" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M9 3 7.2 5H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-3.2L15 3zm3 5a5 5 0 1 1 0 10 5 5 0 0 1 0-10m0 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6"
+          />
+        </symbol>
+        <symbol id="i-tag" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M21.4 11.6 12.4 2.6A2 2 0 0 0 11 2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 .6 1.4l9 9a2 2 0 0 0 2.8 0l7-7a2 2 0 0 0 0-2.8M6.5 8A1.5 1.5 0 1 1 8 6.5 1.5 1.5 0 0 1 6.5 8"
+          />
+        </symbol>
+        <symbol id="i-star" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="m12 17.3 6.2 3.7-1.6-7 5.4-4.7-7.1-.6L12 2 9.1 8.7l-7.1.6 5.4 4.7-1.6 7z"
+          />
+        </symbol>
+        <symbol id="i-image" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M21 19V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2M8.5 13.5l2.5 3 3.5-4.5 4.5 6H5z"
+          />
+        </symbol>
+        <symbol id="i-heart" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="m12 21-1.5-1.3C5.4 15 2 11.9 2 8.1A4.6 4.6 0 0 1 6.6 3.5 5 5 0 0 1 12 6a5 5 0 0 1 5.4-2.5A4.6 4.6 0 0 1 22 8.1c0 3.8-3.4 6.9-8.5 11.6z"
+          />
+        </symbol>
+        <symbol id="i-album" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2m-7 13-2.5-3L6 18h12l-4.5-6z"
+          />
+        </symbol>
+        <symbol id="i-chev-l" viewBox="0 0 24 24">
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m15 6-6 6 6 6"
+          />
+        </symbol>
+        <symbol id="i-chev-r" viewBox="0 0 24 24">
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m9 6 6 6-6 6"
+          />
+        </symbol>
+        <symbol id="i-chev-d" viewBox="0 0 24 24">
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m6 9 6 6 6-6"
+          />
+        </symbol>
+        <symbol id="i-search" viewBox="0 0 24 24">
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            d="M11 19a8 8 0 1 1 0-16 8 8 0 0 1 0 16m6-2 4 4"
+          />
+        </symbol>
+        <symbol id="i-check" viewBox="0 0 24 24">
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m5 12 5 5 9-10"
+          />
+        </symbol>
+      </defs>
+    </svg>
 
-<!-- ===== icon library ===== -->
-<svg width="0" height="0" style="position:absolute" aria-hidden="true">
-  <defs>
-    <symbol id="i-cal" viewBox="0 0 24 24"><path fill="currentColor" d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2m0 16H5V10h14zm0-12H5V6h14z"/></symbol>
-    <symbol id="i-account" viewBox="0 0 24 24"><path fill="currentColor" d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5m0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5"/></symbol>
-    <symbol id="i-pin" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a7 7 0 0 0-7 7c0 5.2 7 13 7 13s7-7.8 7-13a7 7 0 0 0-7-7m0 9.5A2.5 2.5 0 1 1 14.5 9 2.5 2.5 0 0 1 12 11.5"/></symbol>
-    <symbol id="i-cam" viewBox="0 0 24 24"><path fill="currentColor" d="M9 3 7.2 5H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-3.2L15 3zm3 5a5 5 0 1 1 0 10 5 5 0 0 1 0-10m0 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6"/></symbol>
-    <symbol id="i-tag" viewBox="0 0 24 24"><path fill="currentColor" d="M21.4 11.6 12.4 2.6A2 2 0 0 0 11 2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 .6 1.4l9 9a2 2 0 0 0 2.8 0l7-7a2 2 0 0 0 0-2.8M6.5 8A1.5 1.5 0 1 1 8 6.5 1.5 1.5 0 0 1 6.5 8"/></symbol>
-    <symbol id="i-star" viewBox="0 0 24 24"><path fill="currentColor" d="m12 17.3 6.2 3.7-1.6-7 5.4-4.7-7.1-.6L12 2 9.1 8.7l-7.1.6 5.4 4.7-1.6 7z"/></symbol>
-    <symbol id="i-image" viewBox="0 0 24 24"><path fill="currentColor" d="M21 19V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2M8.5 13.5l2.5 3 3.5-4.5 4.5 6H5z"/></symbol>
-    <symbol id="i-heart" viewBox="0 0 24 24"><path fill="currentColor" d="m12 21-1.5-1.3C5.4 15 2 11.9 2 8.1A4.6 4.6 0 0 1 6.6 3.5 5 5 0 0 1 12 6a5 5 0 0 1 5.4-2.5A4.6 4.6 0 0 1 22 8.1c0 3.8-3.4 6.9-8.5 11.6z"/></symbol>
-    <symbol id="i-album" viewBox="0 0 24 24"><path fill="currentColor" d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2m-7 13-2.5-3L6 18h12l-4.5-6z"/></symbol>
-    <symbol id="i-chev-l" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m15 6-6 6 6 6"/></symbol>
-    <symbol id="i-chev-r" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m9 6 6 6-6 6"/></symbol>
-    <symbol id="i-chev-d" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6"/></symbol>
-    <symbol id="i-search" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M11 19a8 8 0 1 1 0-16 8 8 0 0 1 0 16m6-2 4 4"/></symbol>
-    <symbol id="i-check" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" d="m5 12 5 5 9-10"/></symbol>
-  </defs>
-</svg>
+    <header class="lab-head">
+      <div>
+        <p class="lab-title">Gallery · Design Exploration</p>
+        <h1 class="lab-sub">Filter panel — <span>motion &amp; polish</span></h1>
+      </div>
+      <div class="lab-controls">
+        <div class="seg" role="group" aria-label="Theme">
+          <button id="th-dark" aria-pressed="true">Dark</button>
+          <button id="th-light" aria-pressed="false">Light</button>
+        </div>
+        <div class="seg" role="group" aria-label="Motion">
+          <button id="mo-full" aria-pressed="true">Full motion</button>
+          <button id="mo-reduce" aria-pressed="false">Reduced</button>
+        </div>
+      </div>
+    </header>
 
-<header class="lab-head">
-  <div>
-    <p class="lab-title">Gallery · Design Exploration</p>
-    <h1 class="lab-sub">Filter panel — <span>motion &amp; polish</span></h1>
-  </div>
-  <div class="lab-controls">
-    <div class="seg" role="group" aria-label="Theme">
-      <button id="th-dark" aria-pressed="true">Dark</button>
-      <button id="th-light" aria-pressed="false">Light</button>
-    </div>
-    <div class="seg" role="group" aria-label="Motion">
-      <button id="mo-full" aria-pressed="true">Full motion</button>
-      <button id="mo-reduce" aria-pressed="false">Reduced</button>
-    </div>
-  </div>
-</header>
+    <main class="stages">
+      <section class="stage stage--rail" id="stageA">
+        <p class="stage__label">
+          <span class="pip"></span><b>Option A — Width-eased rail</b> · shrinks
+          to an always-visible icon rail
+        </p>
+        <div class="viewport"></div>
+      </section>
 
-<main class="stages">
-  <section class="stage stage--rail" id="stageA">
-    <p class="stage__label"><span class="pip"></span><b>Option A — Width-eased rail</b> · shrinks to an always-visible icon rail</p>
-    <div class="viewport"></div>
-  </section>
+      <section class="stage stage--drawer" id="stageB">
+        <p class="stage__label">
+          <span class="pip"></span><b>Option B — Slide-off drawer</b> · slides
+          away; a tab brings it back
+        </p>
+        <div class="viewport"></div>
+      </section>
+    </main>
 
-  <section class="stage stage--drawer" id="stageB">
-    <p class="stage__label"><span class="pip"></span><b>Option B — Slide-off drawer</b> · slides away; a tab brings it back</p>
-    <div class="viewport"></div>
-  </section>
-</main>
+    <p class="footnote">
+      <b>Try it:</b> click the <span class="kbd">‹</span> in each panel header
+      to collapse — Option A eases its width down to the icon rail, Option B
+      slides the whole panel away and the photo grid reclaims the space (use the
+      <b>Filters</b> tab to reopen). Click any section header to feel the
+      height-slide; click year chips and people to see selection states. Toggle
+      <b>Reduced</b> motion to verify the accessibility path (it also follows
+      your OS setting automatically). <br />Same features as today — softer
+      surfaces, hairline dividers, a year grid that breathes, and motion that
+      settles instead of snapping.
+    </p>
 
-<p class="footnote">
-  <b>Try it:</b> click the <span class="kbd">‹</span> in each panel header to collapse — Option A eases its width down to the icon rail, Option B slides the whole panel away and the photo grid reclaims the space (use the <b>Filters</b> tab to reopen).
-  Click any section header to feel the height-slide; click year chips and people to see selection states. Toggle <b>Reduced</b> motion to verify the accessibility path (it also follows your OS setting automatically).
-  <br>Same features as today — softer surfaces, hairline dividers, a year grid that breathes, and motion that settles instead of snapping.
-</p>
+    <script>
+      /* ---------- data ---------- */
+      const YEARS = [
+        [2009, 266],
+        [2010, 1831],
+        [2011, 1874],
+        [2012, 523],
+        [2013, 316],
+        [2014, 11],
+        [2015, 482],
+        [2016, 4132],
+        [2017, 4597],
+        [2018, 4331],
+        [2019, 4410],
+        [2020, 3067],
+        [2021, 4134],
+        [2022, 4264],
+        [2023, 4392],
+        [2024, 10849],
+        [2025, 12452],
+        [2026, 2724],
+      ];
+      const MAXY = Math.max(...YEARS.map((y) => y[1]));
+      const PEOPLE = [
+        ["Aurelia", "#c2683f"],
+        ["Claire", "#3f73c2"],
+        ["Gabusz", "#4a9e6a"],
+        ["Gudrin", "#a14fb0"],
+        ["Heiko", "#b0934f"],
+      ];
+      const PLACES = [
+        "Austria",
+        "Croatia",
+        "Czech Republic",
+        "France",
+        "Germany",
+        "Hungary",
+        "Italy",
+      ];
+      const TOGGLES = [
+        ["i-cal", "Timeline", true],
+        ["i-account", "People", true],
+        ["i-pin", "Location", false],
+        ["i-cam", "Camera", false],
+        ["i-tag", "Tags", true],
+        ["i-star", "Rating", false],
+        ["i-image", "Media", false],
+        ["i-heart", "Favorites", false],
+        ["i-album", "Albums", false],
+      ];
+      const RAIL = TOGGLES;
 
-<script>
-  /* ---------- data ---------- */
-  const YEARS = [
-    [2009,266],[2010,1831],[2011,1874],[2012,523],[2013,316],[2014,11],
-    [2015,482],[2016,4132],[2017,4597],[2018,4331],[2019,4410],[2020,3067],
-    [2021,4134],[2022,4264],[2023,4392],[2024,10849],[2025,12452],[2026,2724]
-  ];
-  const MAXY = Math.max(...YEARS.map(y => y[1]));
-  const PEOPLE = [
-    ['Aurelia','#c2683f'],['Claire','#3f73c2'],['Gabusz','#4a9e6a'],['Gudrin','#a14fb0'],['Heiko','#b0934f']
-  ];
-  const PLACES = ['Austria','Croatia','Czech Republic','France','Germany','Hungary','Italy'];
-  const TOGGLES = [
-    ['i-cal','Timeline',true],['i-account','People',true],['i-pin','Location',false],
-    ['i-cam','Camera',false],['i-tag','Tags',true],['i-star','Rating',false],
-    ['i-image','Media',false],['i-heart','Favorites',false],['i-album','Albums',false]
-  ];
-  const RAIL = TOGGLES;
+      const use = (id) =>
+        `<svg width="17" height="17" aria-hidden="true"><use href="#${id}"/></svg>`;
 
-  const use = (id) => `<svg width="17" height="17" aria-hidden="true"><use href="#${id}"/></svg>`;
-
-  /* ---------- builders ---------- */
-  function yearGrid() {
-    return YEARS.map(([yr,ct], i) => {
-      const pct = Math.max(4, Math.round(ct / MAXY * 100));
-      const sel = yr === 2024;
-      return `<button class="year-chip" data-selected="${sel}" style="animation-delay:${i*22}ms" data-yr="${yr}">
+      /* ---------- builders ---------- */
+      function yearGrid() {
+        return YEARS.map(([yr, ct], i) => {
+          const pct = Math.max(4, Math.round((ct / MAXY) * 100));
+          const sel = yr === 2024;
+          return `<button class="year-chip" data-selected="${sel}" style="animation-delay:${i * 22}ms" data-yr="${yr}">
         <span class="yr">${yr}</span>
         <span class="ct">${ct.toLocaleString()}</span>
-        <span class="bar"><span class="bar__fill" style="width:${pct}%;animation-delay:${120+i*22}ms"></span></span>
+        <span class="bar"><span class="bar__fill" style="width:${pct}%;animation-delay:${120 + i * 22}ms"></span></span>
       </button>`;
-    }).join('');
-  }
-  function peopleList() {
-    return PEOPLE.map((p,i) => `<div class="opt" data-on="${i===0}">
-        <span class="box">${use('i-check')}</span>
+        }).join("");
+      }
+      function peopleList() {
+        return (
+          PEOPLE.map(
+            (p, i) => `<div class="opt" data-on="${i === 0}">
+        <span class="box">${use("i-check")}</span>
         <span class="avatar" style="background:${p[1]}">${p[0][0]}</span>
         <span class="nm">${p[0]}</span>
-      </div>`).join('') + `<div class="more">3 more</div>`;
-  }
-  function placeList() {
-    return PLACES.map((p,i) => `<div class="opt" data-on="${i===4}">
-        <span class="box">${use('i-check')}</span>
+      </div>`,
+          ).join("") + `<div class="more">3 more</div>`
+        );
+      }
+      function placeList() {
+        return PLACES.map(
+          (p, i) => `<div class="opt" data-on="${i === 4}">
+        <span class="box">${use("i-check")}</span>
         <span class="nm">${p}</span>
-      </div>`).join('');
-  }
+      </div>`,
+        ).join("");
+      }
 
-  function section({icon,name,count,open,body}) {
-    return `<div class="section ${count?'has-count':''}" aria-expanded="${open}">
+      function section({ icon, name, count, open, body }) {
+        return `<div class="section ${count ? "has-count" : ""}" aria-expanded="${open}">
       <button class="section__head" type="button">
         <span class="section__icon">${use(icon)}</span>
         <span class="section__name">${name}</span>
-        ${count?`<span class="section__count">${count}</span>`:''}
+        ${count ? `<span class="section__count">${count}</span>` : ""}
         <span class="section__chev"><svg width="15" height="15" aria-hidden="true"><use href="#i-chev-d"/></svg></span>
       </button>
       <div class="section__body"><div class="clip"><div class="section__inner">${body}</div></div></div>
     </div>`;
-  }
+      }
 
-  function toggleRow() {
-    return `<div class="toggle-row">` + TOGGLES.map(([icon,name,active]) =>
-      `<button class="toggle ${active?'has-active':''}" type="button" aria-pressed="${active}" title="${name}" aria-label="${name}">
+      function toggleRow() {
+        return (
+          `<div class="toggle-row">` +
+          TOGGLES.map(
+            ([icon, name, active]) =>
+              `<button class="toggle ${active ? "has-active" : ""}" type="button" aria-pressed="${active}" title="${name}" aria-label="${name}">
         ${use(icon)}<span class="dot"></span>
-      </button>`).join('') + `</div>`;
-  }
+      </button>`,
+          ).join("") +
+          `</div>`
+        );
+      }
 
-  function railCol() {
-    const top = `<button class="iconbtn" data-act="expand" title="Expand"><svg width="17" height="17"><use href="#i-chev-r"/></svg></button>`;
-    const icons = RAIL.map(([icon,name,active]) =>
-      `<button class="rail-icon ${active?'has-active':''}" data-act="expand" title="${name}">${use(icon)}<span class="dot" style="${active?'':'display:none'}"></span></button>`).join('');
-    return `<div class="panel__rail">${top}<div class="rail-divider"></div>${icons}</div>`;
-  }
+      function railCol() {
+        const top = `<button class="iconbtn" data-act="expand" title="Expand"><svg width="17" height="17"><use href="#i-chev-r"/></svg></button>`;
+        const icons = RAIL.map(
+          ([icon, name, active]) =>
+            `<button class="rail-icon ${active ? "has-active" : ""}" data-act="expand" title="${name}">${use(icon)}<span class="dot" style="${active ? "" : "display:none"}"></span></button>`,
+        ).join("");
+        return `<div class="panel__rail">${top}<div class="rail-divider"></div>${icons}</div>`;
+      }
 
-  function panelMarkup() {
-    const timeline = `<div class="date-range">
+      function panelMarkup() {
+        const timeline = `<div class="date-range">
         <div class="field"><label>From</label><input placeholder="YYYY-MM-DD" /></div>
         <div class="field"><label>To</label><input placeholder="YYYY-MM-DD" /></div>
       </div><div class="year-grid">${yearGrid()}</div>`;
-    const people = `<div class="search">${use('i-search')}<input placeholder="Search people…" /></div>${peopleList()}`;
-    const places = `<div class="search">${use('i-search')}<input placeholder="Search locations…" /></div>${placeList()}`;
-    const sections =
-      section({icon:'i-cal',name:'Timeline',count:'',open:true,body:timeline}) +
-      section({icon:'i-account',name:'People',count:'5',open:true,body:people}) +
-      section({icon:'i-pin',name:'Location',count:'7',open:false,body:places}) +
-      section({icon:'i-cam',name:'Camera',count:'12',open:false,body:'<div style="color:var(--text-faint);font-size:12px">Apple · Sony · Canon…</div>'}) +
-      section({icon:'i-tag',name:'Tags',count:'34',open:false,body:'<div style="color:var(--text-faint);font-size:12px">Holiday · Family · Pets…</div>'}) +
-      section({icon:'i-star',name:'Rating',count:'',open:false,body:'<div style="color:var(--text-faint);font-size:12px">★★★★★</div>'});
-    return `${railCol()}<div class="panel__full">
+        const people = `<div class="search">${use("i-search")}<input placeholder="Search people…" /></div>${peopleList()}`;
+        const places = `<div class="search">${use("i-search")}<input placeholder="Search locations…" /></div>${placeList()}`;
+        const sections =
+          section({
+            icon: "i-cal",
+            name: "Timeline",
+            count: "",
+            open: true,
+            body: timeline,
+          }) +
+          section({
+            icon: "i-account",
+            name: "People",
+            count: "5",
+            open: true,
+            body: people,
+          }) +
+          section({
+            icon: "i-pin",
+            name: "Location",
+            count: "7",
+            open: false,
+            body: places,
+          }) +
+          section({
+            icon: "i-cam",
+            name: "Camera",
+            count: "12",
+            open: false,
+            body: '<div style="color:var(--text-faint);font-size:12px">Apple · Sony · Canon…</div>',
+          }) +
+          section({
+            icon: "i-tag",
+            name: "Tags",
+            count: "34",
+            open: false,
+            body: '<div style="color:var(--text-faint);font-size:12px">Holiday · Family · Pets…</div>',
+          }) +
+          section({
+            icon: "i-star",
+            name: "Rating",
+            count: "",
+            open: false,
+            body: '<div style="color:var(--text-faint);font-size:12px">★★★★★</div>',
+          });
+        return `${railCol()}<div class="panel__full">
         <div class="panel__head">
           <span class="panel__title">Filters</span>
           <button class="iconbtn" data-act="collapse" title="Collapse"><svg width="17" height="17"><use href="#i-chev-l"/></svg></button>
@@ -564,72 +1237,103 @@
         ${toggleRow()}
         <div class="sections">${sections}</div>
       </div>`;
-  }
+      }
 
-  const GRID_TILES = [
-    'g1 tall','g2','g3','g4','g5','g6 tall','g7','g2','g8','g1','g4 tall','g5','g7','g3','g6','g2 tall','g8','g1'
-  ];
-  function gridMarkup() {
-    return `<div class="grid">` + GRID_TILES.map((c,i)=>`<div class="tile ${c}" style="animation-delay:${i*28}ms"></div>`).join('') + `</div>`;
-  }
+      const GRID_TILES = [
+        "g1 tall",
+        "g2",
+        "g3",
+        "g4",
+        "g5",
+        "g6 tall",
+        "g7",
+        "g2",
+        "g8",
+        "g1",
+        "g4 tall",
+        "g5",
+        "g7",
+        "g3",
+        "g6",
+        "g2 tall",
+        "g8",
+        "g1",
+      ];
+      function gridMarkup() {
+        return (
+          `<div class="grid">` +
+          GRID_TILES.map(
+            (c, i) =>
+              `<div class="tile ${c}" style="animation-delay:${i * 28}ms"></div>`,
+          ).join("") +
+          `</div>`
+        );
+      }
 
-  function reopenTab() {
-    return `<button class="reopen" data-act="expand"><svg width="15" height="15"><use href="#i-chev-r"/></svg>Filters</button>`;
-  }
+      function reopenTab() {
+        return `<button class="reopen" data-act="expand"><svg width="15" height="15"><use href="#i-chev-r"/></svg>Filters</button>`;
+      }
 
-  /* ---------- mount ---------- */
-  document.querySelectorAll('.stage .viewport').forEach(vp => {
-    vp.innerHTML = `<div class="panel">${panelMarkup()}</div>${gridMarkup()}${reopenTab()}`;
-  });
+      /* ---------- mount ---------- */
+      document.querySelectorAll(".stage .viewport").forEach((vp) => {
+        vp.innerHTML = `<div class="panel">${panelMarkup()}</div>${gridMarkup()}${reopenTab()}`;
+      });
 
-  /* ---------- interactions ---------- */
-  document.addEventListener('click', (e) => {
-    const act = e.target.closest('[data-act]');
-    if (act) {
-      const stage = act.closest('.stage');
-      if (act.dataset.act === 'collapse') stage.classList.add('collapsed');
-      if (act.dataset.act === 'expand') stage.classList.remove('collapsed');
-      return;
-    }
-    const head = e.target.closest('.section__head');
-    if (head) {
-      const sec = head.closest('.section');
-      sec.setAttribute('aria-expanded', sec.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
-      return;
-    }
-    const tog = e.target.closest('.toggle');
-    if (tog) {
-      const on = tog.getAttribute('aria-pressed') === 'true';
-      tog.setAttribute('aria-pressed', String(!on));
-      return;
-    }
-    const chip = e.target.closest('.year-chip');
-    if (chip) {
-      const grid = chip.closest('.year-grid');
-      grid.querySelectorAll('.year-chip').forEach(c => c.dataset.selected = 'false');
-      chip.dataset.selected = 'true';
-      return;
-    }
-    const opt = e.target.closest('.opt');
-    if (opt) { opt.dataset.on = opt.dataset.on === 'true' ? 'false' : 'true'; }
-  });
+      /* ---------- interactions ---------- */
+      document.addEventListener("click", (e) => {
+        const act = e.target.closest("[data-act]");
+        if (act) {
+          const stage = act.closest(".stage");
+          if (act.dataset.act === "collapse") stage.classList.add("collapsed");
+          if (act.dataset.act === "expand") stage.classList.remove("collapsed");
+          return;
+        }
+        const head = e.target.closest(".section__head");
+        if (head) {
+          const sec = head.closest(".section");
+          sec.setAttribute(
+            "aria-expanded",
+            sec.getAttribute("aria-expanded") === "true" ? "false" : "true",
+          );
+          return;
+        }
+        const tog = e.target.closest(".toggle");
+        if (tog) {
+          const on = tog.getAttribute("aria-pressed") === "true";
+          tog.setAttribute("aria-pressed", String(!on));
+          return;
+        }
+        const chip = e.target.closest(".year-chip");
+        if (chip) {
+          const grid = chip.closest(".year-grid");
+          grid
+            .querySelectorAll(".year-chip")
+            .forEach((c) => (c.dataset.selected = "false"));
+          chip.dataset.selected = "true";
+          return;
+        }
+        const opt = e.target.closest(".opt");
+        if (opt) {
+          opt.dataset.on = opt.dataset.on === "true" ? "false" : "true";
+        }
+      });
 
-  /* ---------- lab controls ---------- */
-  const setTheme = (t) => {
-    document.documentElement.dataset.theme = t;
-    th_dark.setAttribute('aria-pressed', String(t === 'dark'));
-    th_light.setAttribute('aria-pressed', String(t === 'light'));
-  };
-  th_dark.onclick = () => setTheme('dark');
-  th_light.onclick = () => setTheme('light');
+      /* ---------- lab controls ---------- */
+      const setTheme = (t) => {
+        document.documentElement.dataset.theme = t;
+        th_dark.setAttribute("aria-pressed", String(t === "dark"));
+        th_light.setAttribute("aria-pressed", String(t === "light"));
+      };
+      th_dark.onclick = () => setTheme("dark");
+      th_light.onclick = () => setTheme("light");
 
-  const setMotion = (reduce) => {
-    document.body.classList.toggle('reduce-motion', reduce);
-    mo_full.setAttribute('aria-pressed', String(!reduce));
-    mo_reduce.setAttribute('aria-pressed', String(reduce));
-  };
-  mo_full.onclick = () => setMotion(false);
-  mo_reduce.onclick = () => setMotion(true);
-</script>
-</body>
+      const setMotion = (reduce) => {
+        document.body.classList.toggle("reduce-motion", reduce);
+        mo_full.setAttribute("aria-pressed", String(!reduce));
+        mo_reduce.setAttribute("aria-pressed", String(reduce));
+      };
+      mo_full.onclick = () => setMotion(false);
+      mo_reduce.onclick = () => setMotion(true);
+    </script>
+  </body>
 </html>

--- a/docs/superpowers/plans/2026-06-17-filter-panel-redesign.md
+++ b/docs/superpowers/plans/2026-06-17-filter-panel-redesign.md
@@ -12,7 +12,8 @@
 
 - Scope is **fork-only** code under `web/src/lib/components/filter-panel/`. No upstream-rebase concern.
 - **No behavior or feature changes.** Same filters, same data flow, same persistence.
-- **Motion tokens (verbatim):** CSS easing `cubic-bezier(0.22, 1, 0.36, 1)`; Svelte slide easing `quintOut` from `svelte/easing`. Durations: panel width `380ms`, section slide `240ms`, hover/micro `150ms`.
+- **Motion tokens (verbatim, matched to the approved prototype):** CSS easing `cubic-bezier(0.22, 1, 0.36, 1)`; Svelte slide easing `quintOut` from `svelte/easing`. Durations: panel width `420ms`, section slide `300ms`, hover/micro `150ms`.
+- **Tailwind arbitrary-easing caveat:** the easing appears in two literal forms that must NOT drift — the Tailwind class is `ease-[cubic-bezier(0.22,1,0.36,1)]` (**spaceless**, or it won't compile) while the JS constant `SETTLE_EASE` is `'cubic-bezier(0.22, 1, 0.36, 1)'` (spaced, for inline styles). This arbitrary easing has no precedent in this repo — Task 5 greps the built CSS to confirm it generated.
 - **Reduced motion:** CSS transitions carry `motion-reduce:transition-none`; the section slide uses `slideMotion(mediaQueryManager.reducedMotion)` (duration collapses to `0`).
 - **Theme tokens only:** `bg-light`, `bg-subtle`, `text-primary`, `bg-primary/10`, `immich-primary` / `immich-dark-primary`, and the existing `border-gray-200 dark:border-gray-700` grays. No new colors.
 - **Widths:** expanded shell `w-64` (256px, unchanged) must equal the inner `discovery-panel` width; collapsed rail `w-14` (56px, up from `w-8`).
@@ -77,8 +78,8 @@ import { PANEL_DURATION_MS, SECTION_DURATION_MS, SETTLE_EASE, slideMotion } from
 
 describe('motion tokens', () => {
   it('exposes the agreed durations and settle easing', () => {
-    expect(PANEL_DURATION_MS).toBe(380);
-    expect(SECTION_DURATION_MS).toBe(240);
+    expect(PANEL_DURATION_MS).toBe(420);
+    expect(SECTION_DURATION_MS).toBe(300);
     expect(SETTLE_EASE).toBe('cubic-bezier(0.22, 1, 0.36, 1)');
   });
 });
@@ -110,12 +111,16 @@ Create `web/src/lib/components/filter-panel/motion.ts`:
 ```ts
 import { quintOut } from 'svelte/easing';
 
-/** Decelerating "settle" curve for CSS transitions (panel width, hovers, chips). */
+/**
+ * Decelerating "settle" curve for CSS transitions (panel width, hovers, chips).
+ * NOTE: in Tailwind classes this must be written spaceless — `ease-[cubic-bezier(0.22,1,0.36,1)]` —
+ * or the class won't compile. This spaced literal is only for JS/inline-style use.
+ */
 export const SETTLE_EASE = 'cubic-bezier(0.22, 1, 0.36, 1)';
 
 /** Shared animation durations (ms) so the panel feels consistent. */
-export const PANEL_DURATION_MS = 380;
-export const SECTION_DURATION_MS = 240;
+export const PANEL_DURATION_MS = 420;
+export const SECTION_DURATION_MS = 300;
 
 export interface SlideMotion {
   duration: number;
@@ -137,7 +142,7 @@ Run:
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/motion.spec.ts
 ```
-Expected: PASS (5 tests).
+Expected: PASS (3 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -158,7 +163,11 @@ git commit -m "feat(web): add filter panel motion tokens + slideMotion helper"
 - Consumes: `slideMotion` from `./motion`; `mediaQueryManager` from `$lib/stores/media-query-manager.svelte`.
 - Produces: no new exports — same `Props` (`title`, `testId`, `children`, `refetching?`, `count?`, `expanded?`, `onToggleExpanded?`).
 
-**Why `transition:slide|local`:** the `filter-section-{testId}` wrapper lives *outside* the `{#if expanded}` body, and existing tests assert that wrapper appears/disappears synchronously when a section's **visibility** is toggled via the toggle row (the parent `{#if visibleSections.has(section)}`). A non-local transition would replay an outro on that parent removal and keep the wrapper in the DOM, breaking those `toBeNull()` assertions. `|local` restricts the slide to the section's own expand/collapse. (Verified: no existing test asserts section-body content absence after a header click, so the local slide is safe.)
+**Why `transition:slide|local`:** the `filter-section-{testId}` wrapper lives *outside* the `{#if expanded}` body, and existing tests assert that wrapper appears/disappears synchronously when a section's **visibility** is toggled via the toggle row (the parent `{#if visibleSections.has(section)}`). A non-local transition would replay an outro on that parent removal and keep the wrapper in the DOM, breaking those `toBeNull()` assertions. `|local` restricts the slide to the section's own expand/collapse.
+
+Two correctness notes the implementer must respect:
+- The genuinely dangerous test pattern is **asserting `.filter-section-content` is absent immediately after a header *click*** (which flips `isOpen` false and plays the local outro asynchronously). Verified: no such assertion exists today (the header-click tests assert localStorage, and the only content-absence assertions are mount-time from localStorage). Do **not** introduce a post-click absence assertion.
+- Default-expanded sections render their body synchronously at mount with **no** intro animation, because `@testing-library/svelte`'s `render()` does not pass `intro: true` and Svelte suppresses intros on first mount. The accordion-persistence tests rely on this — do not enable component-level `intro`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -295,7 +304,7 @@ git commit -m "feat(web): slide + soft-surface filter sections"
 - Consumes: nothing new (CSS-only motion via Tailwind + `SETTLE_EASE` value inlined as the arbitrary easing).
 - Produces: a new wrapper element `data-testid="filter-panel-shell"` that owns the animated width and the right border.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests**
 
 Add to `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`:
 ```ts
@@ -312,15 +321,24 @@ it('animates the panel width via a persistent shell with a reduced-motion guard'
   expect(shell.className).toContain('w-14');
   expect(shell.className).not.toContain('w-64');
 });
+
+it('gives the toggle-row pills a press-scale and a reduced-motion guard', () => {
+  const { getByTestId } = render(FilterPanel, {
+    props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
+  });
+  const toggle = getByTestId('section-toggle-timeline');
+  expect(toggle.className).toContain('active:scale-90');
+  expect(toggle.className).toContain('motion-reduce:transition-none');
+});
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 Run:
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts -t "persistent shell"
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
 ```
-Expected: FAIL — no `filter-panel-shell` testid exists yet.
+Expected: the two new tests FAIL (no `filter-panel-shell` testid; the toggle button has no `active:scale-90` yet) and **every existing test still PASSES**.
 
 - [ ] **Step 3: Wrap the collapse branches in a persistent shell**
 
@@ -340,7 +358,7 @@ Replace with:
   <!-- FilterPanel hidden: no assets to filter -->
 {:else}
   <div
-    class="flex h-full flex-shrink-0 overflow-hidden border-r border-gray-200 bg-light transition-[width] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:border-gray-700 {collapsed
+    class="flex h-full flex-shrink-0 overflow-hidden border-r border-gray-200 bg-light transition-[width] duration-[420ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:border-gray-700 {collapsed
       ? 'w-14'
       : 'w-64'}"
     data-testid="filter-panel-shell"
@@ -351,6 +369,8 @@ Replace with:
         data-testid="collapsed-icon-strip"
       >
 ```
+
+> **Critical boundary (do not skip):** Edit A above ends with the `collapsed-icon-strip` `<div>` *opening*. Everything that currently follows — the expand button, the `{#each config.sections …}` rail buttons, and the strip's **closing `</div>`** (current line ~687) — stays **exactly as it is**. That closing `</div>` now closes the strip inside the new `{#if collapsed}`. The `{:else}` immediately after it is what Step 4 edits next; leave the `</div>{:else}` pair connected.
 
 - [ ] **Step 4: Re-point the expanded branch and close the shell**
 
@@ -370,6 +390,8 @@ Replace with:
         data-testid="discovery-panel"
       >
 ```
+> **Critical boundary:** between this `discovery-panel` edit and the closing edit below, the **entire expanded-panel body** — the sticky header, the toggle row, the `{#each}` sections, and the empty-state block — stays **exactly as it is**.
+
 Then find the final closing of the render block:
 ```svelte
       {/if}
@@ -386,7 +408,7 @@ Replace with (adds one extra `</div>` to close the new shell, plus closes the in
   </div>
 {/if}
 ```
-> Note for the implementer: the inner content of both branches (the rail buttons; and the header / toggle-row / sections of the expanded panel) is unchanged — only the wrapping `<div>`s and the `{#if collapsed} … {:else} … {/if}` nesting move inside the new shell. After editing, re-indent the moved blocks and confirm the file's `<script>`/markup still balances (svelte-check in Step 7 will catch any imbalance).
+> **Note:** indentation in these snippets is illustrative — Svelte ignores it and `make format-web` (Task 5) normalizes it. What matters is the tag/`{/if}` ordering. The final structure must be exactly: `{#if hidden} … {:else} <shell-div> {#if collapsed} <strip>…</strip> {:else} <discovery-panel>…</discovery-panel> {/if} </shell-div> {/if}`. svelte-check (Step 7) catches an *imbalance* but will NOT catch wrong-but-balanced nesting — re-read this structure before running it.
 
 - [ ] **Step 5: Polish the toggle-row buttons**
 
@@ -401,13 +423,14 @@ Replace the first line with:
               {visibleSections.has(section)
 ```
 
-- [ ] **Step 6: Run the new test + full suite**
+- [ ] **Step 6: Run the new tests + full file (HARD GATE)**
 
 Run:
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
 ```
-Expected: PASS — the new "persistent shell" test passes and **all** existing collapse/expand/visibility/persistence assertions stay green (they still toggle `collapsed-icon-strip` ⟺ `discovery-panel` via the inner `{#if collapsed}`).
+Expected: PASS — both new tests pass AND every existing collapse/expand/visibility/persistence assertion stays green (they still toggle `collapsed-icon-strip` ⟺ `discovery-panel` via the inner `{#if collapsed}`).
+**Hard gate:** if any pre-existing test goes red, the shell re-nest is wrong — revert Edits A/B/C and recount the closing tags. **Never** edit an existing assertion to make it pass; those are the regression guard.
 
 - [ ] **Step 7: Type-check**
 
@@ -437,17 +460,22 @@ git commit -m "feat(web): width-eased collapse shell + rail width + toggle polis
 
 - [ ] **Step 1: Write the failing tests**
 
-Add inside the existing `describe('TemporalPicker component', ...)` block in `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts` (its `buckets` covers 2022 + 2023):
+Add inside the existing `describe('TemporalPicker component', ...)` block in `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts` (its `buckets` aggregates to years 2022 + 2023):
 ```ts
-it('lays out the year grid in three columns', () => {
+it('lays out the year grid in three columns with year buttons as direct grid children', () => {
   const { getByTestId } = render(TemporalPicker, { props: { timeBuckets: buckets } });
-  expect(getByTestId('year-grid').className).toContain('grid-cols-3');
+  const grid = getByTestId('year-grid');
+  expect(grid.className).toContain('grid-cols-3');
+  // The old flex-wrap `basis-[...]` classes are gone; buttons are direct grid items.
+  expect(grid.querySelectorAll(':scope > [data-testid^="year-btn-"]').length).toBe(2);
 });
 
-it('renders a year button per year bucket', () => {
-  const { getByTestId } = render(TemporalPicker, { props: { timeBuckets: buckets } });
-  expect(getByTestId('year-btn-2022')).toBeTruthy();
-  expect(getByTestId('year-btn-2023')).toBeTruthy();
+it('guards the year and month chips against reduced motion', () => {
+  const yearView = render(TemporalPicker, { props: { timeBuckets: buckets } });
+  expect(yearView.getByTestId('year-btn-2022').className).toContain('motion-reduce:transition-none');
+
+  const monthView = render(TemporalPicker, { props: { timeBuckets: buckets, selectedYear: 2023 } });
+  expect(monthView.getByTestId('month-btn-6').className).toContain('motion-reduce:transition-none');
 });
 ```
 
@@ -455,9 +483,9 @@ it('renders a year button per year bucket', () => {
 
 Run:
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts -t "three columns"
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
 ```
-Expected: FAIL — the year grid is currently `flex flex-wrap`, not `grid-cols-3`.
+Expected: the two new tests FAIL (the year grid is `flex flex-wrap`, not `grid-cols-3`; the chips lack `motion-reduce:transition-none`); all existing tests PASS.
 
 - [ ] **Step 3: Convert the year grid to a 3-column grid with polished chips**
 
@@ -610,7 +638,15 @@ make format-web
 ```
 If prettier rewrites anything, review and stage it.
 
-- [ ] **Step 5: Manual verification (aesthetics — not CI-testable)**
+- [ ] **Step 5: Verify the arbitrary easing class actually compiled**
+
+`ease-[cubic-bezier(0.22,1,0.36,1)]` has no precedent in this repo. Build the web app and confirm Tailwind emitted it (spaceless) into the generated CSS:
+```bash
+cd web && pnpm build && grep -rl "cubic-bezier(0.22,1,0.36,1)" .svelte-kit build 2>/dev/null | head
+```
+Expected: at least one CSS file matches. If empty, the class did not compile — confirm it is written spaceless and re-run. (Step 6's manual page check is the visual backstop: a missing easing shows up as a linear/instant transition.)
+
+- [ ] **Step 6: Manual verification (aesthetics — not CI-testable)**
 
 Start the dev stack (`make dev`) and, on the **photos**, **map**, and **spaces** pages, confirm:
 - Collapsing the panel **eases its width** down to the icon rail (and back), not a snap.
@@ -621,7 +657,7 @@ Start the dev stack (`make dev`) and, on the **photos**, **map**, and **spaces**
 - With the OS **"Reduce motion"** setting enabled, every animation above becomes instant (no width ease, no slide, no bar grow, no hover lift), and the panel still works.
 - Light **and** dark themes both look right.
 
-- [ ] **Step 6: Commit any formatting/lint fixes**
+- [ ] **Step 7: Commit any formatting/lint fixes**
 
 ```bash
 git add -A
@@ -639,10 +675,16 @@ git commit -m "chore(web): lint + format pass for filter panel redesign" --allow
 - Surfaces over hard rules (drop `border-b`, `bg-subtle` active surface) → Task 2. ✓
 - 3-column breathing year grid + chip polish + bar grow → Task 4. ✓
 - Toggle-row pill polish → Task 3 Step 5. ✓
-- Reduced motion (Tailwind `motion-reduce:` + `slideMotion`) → Tasks 1–4 + Task 5 manual. ✓
+- Reduced motion (Tailwind `motion-reduce:` + `slideMotion`) → DOM-asserted on the shell (Task 3), toggle pills (Task 3), and year/month chips (Task 4); `slideMotion` unit-tested (Task 1); manual OS-setting pass (Task 5). ✓
 - Theme-token-only, both themes → Global Constraints + Task 5 manual. ✓
-- Tests stay green; new TDD tests for the 4 spec items → Tasks 1–4; deferred lint → Task 5. ✓
+- Tests stay green; new red→green TDD tests for every testable change → Tasks 1–4; deferred lint → Task 5. ✓
+
+**Intentional fidelity cuts (from the prototype → production):**
+- Durations are matched to the approved prototype (panel 420ms, section 300ms, hover 150ms).
+- The prototype's **per-section leading icons** and **count-pill badges** are deliberately NOT carried over: the toggle row already shows the section icons, and surfacing counts as badges would change information display beyond "light polish". The section header keeps today's title + `(0)`-when-empty.
+- The prototype's per-year-chip entrance **stagger** is dropped; the volume bars still grow on load.
+- Section slide uses Svelte `transition:slide` (codebase convention) rather than the prototype's CSS `grid-template-rows` technique — same visual result.
 
 **Placeholder scan:** none — every code/test step contains full code and exact commands.
 
-**Type consistency:** `slideMotion(reducedMotion: boolean): SlideMotion` is defined in Task 1 and consumed identically in Task 2. The `filter-panel-shell` testid introduced in Task 3 is only referenced by Task 3's own test. Widths (`w-64`, `w-14`) match between Global Constraints, Task 3 code, and Task 3 test.
+**Type consistency:** `slideMotion(reducedMotion: boolean): SlideMotion` is defined in Task 1 and consumed identically in Task 2. `PANEL_DURATION_MS = 420` / `SECTION_DURATION_MS = 300` agree between the `motion.ts` code and its test. The `filter-panel-shell` testid introduced in Task 3 is only referenced by Task 3's own test. Widths (`w-64`, `w-14`) match between Global Constraints, Task 3 code, and Task 3 test. The Tailwind easing is spaceless `cubic-bezier(0.22,1,0.36,1)` everywhere it appears as a class; the spaced `SETTLE_EASE` literal is for JS only.

--- a/docs/superpowers/plans/2026-06-17-filter-panel-redesign.md
+++ b/docs/superpowers/plans/2026-06-17-filter-panel-redesign.md
@@ -31,6 +31,7 @@
 - [ ] **Step 1: Install workspace dependencies**
 
 Run from the worktree root:
+
 ```bash
 pnpm install
 ```
@@ -38,6 +39,7 @@ pnpm install
 - [ ] **Step 2: Build the TypeScript SDK (web imports depend on it)**
 
 Run:
+
 ```bash
 make build-sdk
 ```
@@ -45,11 +47,13 @@ make build-sdk
 - [ ] **Step 3: Confirm the filter-panel tests are green before any change**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run \
   src/lib/components/filter-panel/__tests__/filter-panel.spec.ts \
   src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
 ```
+
 Expected: PASS (all tests in both files). This is the baseline — do not proceed if red.
 
 ---
@@ -57,10 +61,12 @@ Expected: PASS (all tests in both files). This is the baseline — do not procee
 ### Task 1: Shared motion module
 
 **Files:**
+
 - Create: `web/src/lib/components/filter-panel/motion.ts`
 - Test: `web/src/lib/components/filter-panel/__tests__/motion.spec.ts`
 
 **Interfaces:**
+
 - Produces:
   - `export const SETTLE_EASE = 'cubic-bezier(0.22, 1, 0.36, 1)'`
   - `export const PANEL_DURATION_MS = 380`
@@ -71,6 +77,7 @@ Expected: PASS (all tests in both files). This is the baseline — do not procee
 - [ ] **Step 1: Write the failing test**
 
 Create `web/src/lib/components/filter-panel/__tests__/motion.spec.ts`:
+
 ```ts
 import { quintOut } from 'svelte/easing';
 import { describe, expect, it } from 'vitest';
@@ -100,14 +107,17 @@ describe('slideMotion', () => {
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/motion.spec.ts
 ```
+
 Expected: FAIL — cannot resolve `../motion`.
 
 - [ ] **Step 3: Write the minimal implementation**
 
 Create `web/src/lib/components/filter-panel/motion.ts`:
+
 ```ts
 import { quintOut } from 'svelte/easing';
 
@@ -139,9 +149,11 @@ export function slideMotion(reducedMotion: boolean): SlideMotion {
 - [ ] **Step 4: Run the test to verify it passes**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/motion.spec.ts
 ```
+
 Expected: PASS (3 tests).
 
 - [ ] **Step 5: Commit**
@@ -156,22 +168,26 @@ git commit -m "feat(web): add filter panel motion tokens + slideMotion helper"
 ### Task 2: Sliding, soft-surface filter sections
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/filter-section.svelte` (whole file)
 - Test: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts` (add one test)
 
 **Interfaces:**
+
 - Consumes: `slideMotion` from `./motion`; `mediaQueryManager` from `$lib/stores/media-query-manager.svelte`.
 - Produces: no new exports — same `Props` (`title`, `testId`, `children`, `refetching?`, `count?`, `expanded?`, `onToggleExpanded?`).
 
-**Why `transition:slide|local`:** the `filter-section-{testId}` wrapper lives *outside* the `{#if expanded}` body, and existing tests assert that wrapper appears/disappears synchronously when a section's **visibility** is toggled via the toggle row (the parent `{#if visibleSections.has(section)}`). A non-local transition would replay an outro on that parent removal and keep the wrapper in the DOM, breaking those `toBeNull()` assertions. `|local` restricts the slide to the section's own expand/collapse.
+**Why `transition:slide|local`:** the `filter-section-{testId}` wrapper lives _outside_ the `{#if expanded}` body, and existing tests assert that wrapper appears/disappears synchronously when a section's **visibility** is toggled via the toggle row (the parent `{#if visibleSections.has(section)}`). A non-local transition would replay an outro on that parent removal and keep the wrapper in the DOM, breaking those `toBeNull()` assertions. `|local` restricts the slide to the section's own expand/collapse.
 
 Two correctness notes the implementer must respect:
-- The genuinely dangerous test pattern is **asserting `.filter-section-content` is absent immediately after a header *click*** (which flips `isOpen` false and plays the local outro asynchronously). Verified: no such assertion exists today (the header-click tests assert localStorage, and the only content-absence assertions are mount-time from localStorage). Do **not** introduce a post-click absence assertion.
+
+- The genuinely dangerous test pattern is **asserting `.filter-section-content` is absent immediately after a header _click_** (which flips `isOpen` false and plays the local outro asynchronously). Verified: no such assertion exists today (the header-click tests assert localStorage, and the only content-absence assertions are mount-time from localStorage). Do **not** introduce a post-click absence assertion.
 - Default-expanded sections render their body synchronously at mount with **no** intro animation, because `@testing-library/svelte`'s `render()` does not pass `intro: true` and Svelte suppresses intros on first mount. The accordion-persistence tests rely on this — do not enable component-level `intro`.
 
 - [ ] **Step 1: Write the failing test**
 
 Add to `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts` (inside the top-level `describe`, after the existing imports — `FilterPanel`, `render`, `fireEvent` are already imported in this file):
+
 ```ts
 it('renders an expanded section on a soft surface without a hard divider', () => {
   const { getByTestId } = render(FilterPanel, {
@@ -186,14 +202,17 @@ it('renders an expanded section on a soft surface without a hard divider', () =>
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts -t "soft surface"
 ```
+
 Expected: FAIL — current root has `border-b` and no `bg-subtle`.
 
 - [ ] **Step 3: Replace the whole component**
 
 Overwrite `web/src/lib/components/filter-panel/filter-section.svelte` with:
+
 ```svelte
 <script lang="ts">
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
@@ -272,17 +291,21 @@ Overwrite `web/src/lib/components/filter-panel/filter-section.svelte` with:
 - [ ] **Step 4: Run the new test + the full filter-panel suite to verify pass + no regressions**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
 ```
+
 Expected: PASS (all tests, including the new "soft surface" test and every existing collapse/visibility assertion).
 
 - [ ] **Step 5: Type-check**
 
 Run:
+
 ```bash
 cd web && pnpm check
 ```
+
 Expected: 0 errors.
 
 - [ ] **Step 6: Commit**
@@ -297,16 +320,19 @@ git commit -m "feat(web): slide + soft-surface filter sections"
 ### Task 3: Width-eased collapse shell + rail width + toggle polish
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/filter-panel.svelte` (the render block at the end of the file, ~lines 658–854, plus the toggle-row button classes ~lines 713–718)
 - Test: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts` (add one test)
 
 **Interfaces:**
+
 - Consumes: nothing new (CSS-only motion via Tailwind + `SETTLE_EASE` value inlined as the arbitrary easing).
 - Produces: a new wrapper element `data-testid="filter-panel-shell"` that owns the animated width and the right border.
 
 - [ ] **Step 1: Write the failing tests**
 
 Add to `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`:
+
 ```ts
 it('animates the panel width via a persistent shell with a reduced-motion guard', async () => {
   const { getByTestId } = render(FilterPanel, {
@@ -335,14 +361,17 @@ it('gives the toggle-row pills a press-scale and a reduced-motion guard', () => 
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
 ```
+
 Expected: the two new tests FAIL (no `filter-panel-shell` testid; the toggle button has no `active:scale-90` yet) and **every existing test still PASSES**.
 
 - [ ] **Step 3: Wrap the collapse branches in a persistent shell**
 
 In `web/src/lib/components/filter-panel/filter-panel.svelte`, replace the top of the render block. Find:
+
 ```svelte
 {#if hidden}
   <!-- FilterPanel hidden: no assets to filter -->
@@ -352,7 +381,9 @@ In `web/src/lib/components/filter-panel/filter-panel.svelte`, replace the top of
     data-testid="collapsed-icon-strip"
   >
 ```
+
 Replace with:
+
 ```svelte
 {#if hidden}
   <!-- FilterPanel hidden: no assets to filter -->
@@ -370,11 +401,12 @@ Replace with:
       >
 ```
 
-> **Critical boundary (do not skip):** Edit A above ends with the `collapsed-icon-strip` `<div>` *opening*. Everything that currently follows — the expand button, the `{#each config.sections …}` rail buttons, and the strip's **closing `</div>`** (current line ~687) — stays **exactly as it is**. That closing `</div>` now closes the strip inside the new `{#if collapsed}`. The `{:else}` immediately after it is what Step 4 edits next; leave the `</div>{:else}` pair connected.
+> **Critical boundary (do not skip):** Edit A above ends with the `collapsed-icon-strip` `<div>` _opening_. Everything that currently follows — the expand button, the `{#each config.sections …}` rail buttons, and the strip's **closing `</div>`** (current line ~687) — stays **exactly as it is**. That closing `</div>` now closes the strip inside the new `{#if collapsed}`. The `{:else}` immediately after it is what Step 4 edits next; leave the `</div>{:else}` pair connected.
 
 - [ ] **Step 4: Re-point the expanded branch and close the shell**
 
 Still in `filter-panel.svelte`, find the expanded-branch opening:
+
 ```svelte
 {:else}
   <div
@@ -382,7 +414,9 @@ Still in `filter-panel.svelte`, find the expanded-branch opening:
     data-testid="discovery-panel"
   >
 ```
+
 Replace with:
+
 ```svelte
     {:else}
       <div
@@ -390,16 +424,20 @@ Replace with:
         data-testid="discovery-panel"
       >
 ```
+
 > **Critical boundary:** between this `discovery-panel` edit and the closing edit below, the **entire expanded-panel body** — the sticky header, the toggle row, the `{#each}` sections, and the empty-state block — stays **exactly as it is**.
 
 Then find the final closing of the render block:
+
 ```svelte
       {/if}
     </div>
   </div>
 {/if}
 ```
+
 Replace with (adds one extra `</div>` to close the new shell, plus closes the inner `{#if collapsed}`):
+
 ```svelte
           {/if}
         </div>
@@ -408,16 +446,20 @@ Replace with (adds one extra `</div>` to close the new shell, plus closes the in
   </div>
 {/if}
 ```
-> **Note:** indentation in these snippets is illustrative — Svelte ignores it and `make format-web` (Task 5) normalizes it. What matters is the tag/`{/if}` ordering. The final structure must be exactly: `{#if hidden} … {:else} <shell-div> {#if collapsed} <strip>…</strip> {:else} <discovery-panel>…</discovery-panel> {/if} </shell-div> {/if}`. svelte-check (Step 7) catches an *imbalance* but will NOT catch wrong-but-balanced nesting — re-read this structure before running it.
+
+> **Note:** indentation in these snippets is illustrative — Svelte ignores it and `make format-web` (Task 5) normalizes it. What matters is the tag/`{/if}` ordering. The final structure must be exactly: `{#if hidden} … {:else} <shell-div> {#if collapsed} <strip>…</strip> {:else} <discovery-panel>…</discovery-panel> {/if} </shell-div> {/if}`. svelte-check (Step 7) catches an _imbalance_ but will NOT catch wrong-but-balanced nesting — re-read this structure before running it.
 
 - [ ] **Step 5: Polish the toggle-row buttons**
 
 Still in `filter-panel.svelte`, find the toggle button class (around line 715):
+
 ```svelte
             class="relative flex h-[30px] w-[30px] items-center justify-center rounded-lg transition-colors
               {visibleSections.has(section)
 ```
+
 Replace the first line with:
+
 ```svelte
             class="relative flex h-[30px] w-[30px] items-center justify-center rounded-[10px] transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-90 motion-reduce:transition-none motion-reduce:active:scale-100
               {visibleSections.has(section)
@@ -426,18 +468,22 @@ Replace the first line with:
 - [ ] **Step 6: Run the new tests + full file (HARD GATE)**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
 ```
+
 Expected: PASS — both new tests pass AND every existing collapse/expand/visibility/persistence assertion stays green (they still toggle `collapsed-icon-strip` ⟺ `discovery-panel` via the inner `{#if collapsed}`).
 **Hard gate:** if any pre-existing test goes red, the shell re-nest is wrong — revert Edits A/B/C and recount the closing tags. **Never** edit an existing assertion to make it pass; those are the regression guard.
 
 - [ ] **Step 7: Type-check**
 
 Run:
+
 ```bash
 cd web && pnpm check
 ```
+
 Expected: 0 errors.
 
 - [ ] **Step 8: Commit**
@@ -452,15 +498,18 @@ git commit -m "feat(web): width-eased collapse shell + rail width + toggle polis
 ### Task 4: Breathing 3-column year grid
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/temporal-picker.svelte` (year grid ~lines 226–249; month-grid chip classes ~lines 191–224)
 - Test: `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts` (add tests)
 
 **Interfaces:**
+
 - Consumes / Produces: none new. Same props and `data-testid`s (`year-grid`, `year-btn-{year}`, `month-grid`, `month-btn-{month}`).
 
 - [ ] **Step 1: Write the failing tests**
 
 Add inside the existing `describe('TemporalPicker component', ...)` block in `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts` (its `buckets` aggregates to years 2022 + 2023):
+
 ```ts
 it('lays out the year grid in three columns with year buttons as direct grid children', () => {
   const { getByTestId } = render(TemporalPicker, { props: { timeBuckets: buckets } });
@@ -482,14 +531,17 @@ it('guards the year and month chips against reduced motion', () => {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
 ```
+
 Expected: the two new tests FAIL (the year grid is `flex flex-wrap`, not `grid-cols-3`; the chips lack `motion-reduce:transition-none`); all existing tests PASS.
 
 - [ ] **Step 3: Convert the year grid to a 3-column grid with polished chips**
 
 In `web/src/lib/components/filter-panel/temporal-picker.svelte`, find the year-grid block:
+
 ```svelte
     <!-- Year grid: 4-column flex wrap -->
     <div class="flex flex-wrap gap-1.5" data-testid="year-grid">
@@ -515,7 +567,9 @@ In `web/src/lib/components/filter-panel/temporal-picker.svelte`, find the year-g
       {/each}
     </div>
 ```
+
 Replace with:
+
 ```svelte
     <!-- Year grid: 3-column grid -->
     <div class="grid grid-cols-3 gap-1.5" data-testid="year-grid">
@@ -545,6 +599,7 @@ Replace with:
 - [ ] **Step 4: Add the one-time bar-grow animation (reduced-motion safe)**
 
 In the same file, add a `<style>` block at the end of the file (the component currently has none):
+
 ```svelte
 <style>
   .year-bar {
@@ -569,10 +624,13 @@ In the same file, add a `<style>` block at the end of the file (the component cu
 - [ ] **Step 5: Match the month-grid chips to the year chips (consistency)**
 
 Find the month button class:
+
 ```svelte
           class="flex flex-col items-center rounded-lg border px-2 py-2 transition-all duration-100
 ```
+
 Replace with:
+
 ```svelte
           class="flex flex-col items-center rounded-xl border px-2 py-2 transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none
 ```
@@ -580,17 +638,21 @@ Replace with:
 - [ ] **Step 6: Run the tests to verify pass + no regressions**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
 ```
+
 Expected: PASS (all tests in the file).
 
 - [ ] **Step 7: Type-check**
 
 Run:
+
 ```bash
 cd web && pnpm check
 ```
+
 Expected: 0 errors.
 
 - [ ] **Step 8: Commit**
@@ -609,46 +671,57 @@ git commit -m "feat(web): 3-column breathing year grid in temporal picker"
 - [ ] **Step 1: Run the full web unit suite**
 
 Run:
+
 ```bash
 cd web && pnpm test -- --run
 ```
+
 Expected: PASS (entire web suite). If anything outside the filter panel changed unexpectedly, stop and investigate.
 
 - [ ] **Step 2: Type-check the whole web package**
 
 Run:
+
 ```bash
 make check-web
 ```
+
 Expected: 0 errors.
 
 - [ ] **Step 3: Single deferred lint pass**
 
 Run:
+
 ```bash
 make lint-web
 ```
+
 Expected: 0 warnings (the repo enforces `--max-warnings 0`). Fix any findings, then re-run.
 
 - [ ] **Step 4: Format**
 
 Run:
+
 ```bash
 make format-web
 ```
+
 If prettier rewrites anything, review and stage it.
 
 - [ ] **Step 5: Verify the arbitrary easing class actually compiled**
 
 `ease-[cubic-bezier(0.22,1,0.36,1)]` has no precedent in this repo. Build the web app and confirm Tailwind emitted it (spaceless) into the generated CSS:
+
 ```bash
 cd web && pnpm build && grep -rl "cubic-bezier(0.22,1,0.36,1)" .svelte-kit build 2>/dev/null | head
 ```
+
 Expected: at least one CSS file matches. If empty, the class did not compile — confirm it is written spaceless and re-run. (Step 6's manual page check is the visual backstop: a missing easing shows up as a linear/instant transition.)
 
 - [ ] **Step 6: Manual verification (aesthetics — not CI-testable)**
 
 Start the dev stack (`make dev`) and, on the **photos**, **map**, and **spaces** pages, confirm:
+
 - Collapsing the panel **eases its width** down to the icon rail (and back), not a snap.
 - Clicking a section header **slides** the body open/closed; the chevron rotates.
 - Sections sit on **soft surfaces** with no hard full-width divider ladder.
@@ -669,6 +742,7 @@ git commit -m "chore(web): lint + format pass for filter panel redesign" --allow
 ## Self-Review
 
 **Spec coverage:**
+
 - Motion tokens / easing / durations → Task 1 (`motion.ts`) + Global Constraints. ✓
 - Panel width-eased rail collapse (shell, `w-64` ⟺ `w-14`, clip-reveal, preserve `{#if}` swap) → Task 3. ✓
 - Section height-slide via `transition:slide` (matches `setting-accordion`), `|local` to protect visibility tests → Task 2. ✓
@@ -680,6 +754,7 @@ git commit -m "chore(web): lint + format pass for filter panel redesign" --allow
 - Tests stay green; new red→green TDD tests for every testable change → Tasks 1–4; deferred lint → Task 5. ✓
 
 **Intentional fidelity cuts (from the prototype → production):**
+
 - Durations are matched to the approved prototype (panel 420ms, section 300ms, hover 150ms).
 - The prototype's **per-section leading icons** and **count-pill badges** are deliberately NOT carried over: the toggle row already shows the section icons, and surfacing counts as badges would change information display beyond "light polish". The section header keeps today's title + `(0)`-when-empty.
 - The prototype's per-year-chip entrance **stagger** is dropped; the volume bars still grow on load.

--- a/docs/superpowers/plans/2026-06-17-filter-panel-redesign.md
+++ b/docs/superpowers/plans/2026-06-17-filter-panel-redesign.md
@@ -1,0 +1,648 @@
+# Filter Panel Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Gallery filter panel feel fluid and polished — animated collapse/expand, sliding sections, soft surfaces, and a breathing year grid — with no behavior or feature changes.
+
+**Architecture:** Keep today's structure. Add a shared motion module, animate the panel via a persistent width-transitioning shell (keeping the `{#if collapsed}` content swap so existing presence-based tests stay valid), slide section bodies with Svelte's `transition:slide|local`, and restyle sections/year-grid within the existing theme tokens. Reduced motion is honored via Tailwind `motion-reduce:` (CSS) and a `slideMotion()` helper (JS slide).
+
+**Tech Stack:** SvelteKit + Svelte 5 runes, Tailwind CSS 4, `@immich/ui`, Vitest + `@testing-library/svelte` (happy-dom). Spec: `docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md`.
+
+## Global Constraints
+
+- Scope is **fork-only** code under `web/src/lib/components/filter-panel/`. No upstream-rebase concern.
+- **No behavior or feature changes.** Same filters, same data flow, same persistence.
+- **Motion tokens (verbatim):** CSS easing `cubic-bezier(0.22, 1, 0.36, 1)`; Svelte slide easing `quintOut` from `svelte/easing`. Durations: panel width `380ms`, section slide `240ms`, hover/micro `150ms`.
+- **Reduced motion:** CSS transitions carry `motion-reduce:transition-none`; the section slide uses `slideMotion(mediaQueryManager.reducedMotion)` (duration collapses to `0`).
+- **Theme tokens only:** `bg-light`, `bg-subtle`, `text-primary`, `bg-primary/10`, `immich-primary` / `immich-dark-primary`, and the existing `border-gray-200 dark:border-gray-700` grays. No new colors.
+- **Widths:** expanded shell `w-64` (256px, unchanged) must equal the inner `discovery-panel` width; collapsed rail `w-14` (56px, up from `w-8`).
+- **Preserve every `data-testid`.** The collapse mutual-exclusivity assertions (`collapsed-icon-strip` ⟺ `discovery-panel`) are a regression guard — keep them green, never weaken them.
+- **Import paths:** `mediaQueryManager` from `$lib/stores/media-query-manager.svelte`; the new helper from `./motion` (same directory).
+- **Lint discipline:** run `pnpm check` (svelte-check/tsc) and the relevant `vitest` file per task; **defer the single full `make lint-web` pass to the final verification gate** (Task 5).
+- **TDD:** every behavioral/structural step is red → green → refactor. Aesthetic feel (easing, surfaces, clip-reveal) is verified manually in Task 5 — never asserted with fake tests.
+
+---
+
+### Task 0: Environment setup & green baseline
+
+**Files:** none (setup only).
+
+- [ ] **Step 1: Install workspace dependencies**
+
+Run from the worktree root:
+```bash
+pnpm install
+```
+
+- [ ] **Step 2: Build the TypeScript SDK (web imports depend on it)**
+
+Run:
+```bash
+make build-sdk
+```
+
+- [ ] **Step 3: Confirm the filter-panel tests are green before any change**
+
+Run:
+```bash
+cd web && pnpm test -- --run \
+  src/lib/components/filter-panel/__tests__/filter-panel.spec.ts \
+  src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+```
+Expected: PASS (all tests in both files). This is the baseline — do not proceed if red.
+
+---
+
+### Task 1: Shared motion module
+
+**Files:**
+- Create: `web/src/lib/components/filter-panel/motion.ts`
+- Test: `web/src/lib/components/filter-panel/__tests__/motion.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `export const SETTLE_EASE = 'cubic-bezier(0.22, 1, 0.36, 1)'`
+  - `export const PANEL_DURATION_MS = 380`
+  - `export const SECTION_DURATION_MS = 240`
+  - `export interface SlideMotion { duration: number; easing?: (t: number) => number }`
+  - `export function slideMotion(reducedMotion: boolean): SlideMotion`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/components/filter-panel/__tests__/motion.spec.ts`:
+```ts
+import { quintOut } from 'svelte/easing';
+import { describe, expect, it } from 'vitest';
+import { PANEL_DURATION_MS, SECTION_DURATION_MS, SETTLE_EASE, slideMotion } from '../motion';
+
+describe('motion tokens', () => {
+  it('exposes the agreed durations and settle easing', () => {
+    expect(PANEL_DURATION_MS).toBe(380);
+    expect(SECTION_DURATION_MS).toBe(240);
+    expect(SETTLE_EASE).toBe('cubic-bezier(0.22, 1, 0.36, 1)');
+  });
+});
+
+describe('slideMotion', () => {
+  it('returns an instant (zero-duration) config when reduced motion is requested', () => {
+    expect(slideMotion(true)).toEqual({ duration: 0 });
+  });
+
+  it('returns the section duration and quintOut easing when motion is allowed', () => {
+    const motion = slideMotion(false);
+    expect(motion.duration).toBe(SECTION_DURATION_MS);
+    expect(motion.easing).toBe(quintOut);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/motion.spec.ts
+```
+Expected: FAIL — cannot resolve `../motion`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `web/src/lib/components/filter-panel/motion.ts`:
+```ts
+import { quintOut } from 'svelte/easing';
+
+/** Decelerating "settle" curve for CSS transitions (panel width, hovers, chips). */
+export const SETTLE_EASE = 'cubic-bezier(0.22, 1, 0.36, 1)';
+
+/** Shared animation durations (ms) so the panel feels consistent. */
+export const PANEL_DURATION_MS = 380;
+export const SECTION_DURATION_MS = 240;
+
+export interface SlideMotion {
+  duration: number;
+  easing?: (t: number) => number;
+}
+
+/**
+ * Svelte `slide` config for section expand/collapse. Collapses to an instant
+ * (duration 0) when the user prefers reduced motion.
+ */
+export function slideMotion(reducedMotion: boolean): SlideMotion {
+  return reducedMotion ? { duration: 0 } : { duration: SECTION_DURATION_MS, easing: quintOut };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/motion.spec.ts
+```
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/motion.ts web/src/lib/components/filter-panel/__tests__/motion.spec.ts
+git commit -m "feat(web): add filter panel motion tokens + slideMotion helper"
+```
+
+---
+
+### Task 2: Sliding, soft-surface filter sections
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/filter-section.svelte` (whole file)
+- Test: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts` (add one test)
+
+**Interfaces:**
+- Consumes: `slideMotion` from `./motion`; `mediaQueryManager` from `$lib/stores/media-query-manager.svelte`.
+- Produces: no new exports — same `Props` (`title`, `testId`, `children`, `refetching?`, `count?`, `expanded?`, `onToggleExpanded?`).
+
+**Why `transition:slide|local`:** the `filter-section-{testId}` wrapper lives *outside* the `{#if expanded}` body, and existing tests assert that wrapper appears/disappears synchronously when a section's **visibility** is toggled via the toggle row (the parent `{#if visibleSections.has(section)}`). A non-local transition would replay an outro on that parent removal and keep the wrapper in the DOM, breaking those `toBeNull()` assertions. `|local` restricts the slide to the section's own expand/collapse. (Verified: no existing test asserts section-body content absence after a header click, so the local slide is safe.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts` (inside the top-level `describe`, after the existing imports — `FilterPanel`, `render`, `fireEvent` are already imported in this file):
+```ts
+it('renders an expanded section on a soft surface without a hard divider', () => {
+  const { getByTestId } = render(FilterPanel, {
+    props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
+  });
+  const section = getByTestId('filter-section-timeline');
+  expect(section.className).toContain('bg-subtle');
+  expect(section.className).not.toContain('border-b');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts -t "soft surface"
+```
+Expected: FAIL — current root has `border-b` and no `bg-subtle`.
+
+- [ ] **Step 3: Replace the whole component**
+
+Overwrite `web/src/lib/components/filter-panel/filter-section.svelte` with:
+```svelte
+<script lang="ts">
+  import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
+  import { Icon } from '@immich/ui';
+  import { mdiChevronDown } from '@mdi/js';
+  import type { Snippet } from 'svelte';
+  import { slide } from 'svelte/transition';
+  import { slideMotion } from './motion';
+
+  interface Props {
+    title: string;
+    testId: string;
+    children: Snippet;
+    refetching?: boolean;
+    count?: number;
+    expanded?: boolean;
+    onToggleExpanded?: () => void;
+  }
+
+  let { title, testId, children, refetching = false, count, expanded = true, onToggleExpanded }: Props = $props();
+
+  let isEmpty = $derived(count === 0);
+  let isOpen = $derived(expanded && !isEmpty);
+</script>
+
+<div
+  class="mx-1.5 mb-0.5 rounded-xl transition-colors duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none {isOpen
+    ? 'bg-subtle'
+    : ''}"
+  data-testid="filter-section-{testId}"
+>
+  <button
+    type="button"
+    class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-start {isEmpty ? 'opacity-50' : ''} {isOpen
+      ? ''
+      : 'hover:bg-subtle'}"
+    onclick={() => {
+      if (!isEmpty && onToggleExpanded) {
+        onToggleExpanded();
+      }
+    }}
+    disabled={isEmpty}
+  >
+    <span class="text-sm font-medium">
+      {title}{isEmpty ? ' (0)' : ''}
+    </span>
+    {#if !isEmpty}
+      <Icon
+        icon={mdiChevronDown}
+        size="16"
+        class="text-gray-500 transition-transform duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:text-gray-400 {expanded
+          ? ''
+          : '-rotate-90'}"
+      />
+    {/if}
+  </button>
+  {#if isOpen}
+    <div transition:slide|local={slideMotion(mediaQueryManager.reducedMotion)}>
+      <div class="filter-section-content px-3 pb-3.5" class:refetching>
+        {@render children()}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .filter-section-content {
+    transition: opacity 0.2s ease 150ms;
+  }
+  .filter-section-content.refetching {
+    opacity: 0.5;
+  }
+</style>
+```
+
+- [ ] **Step 4: Run the new test + the full filter-panel suite to verify pass + no regressions**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+```
+Expected: PASS (all tests, including the new "soft surface" test and every existing collapse/visibility assertion).
+
+- [ ] **Step 5: Type-check**
+
+Run:
+```bash
+cd web && pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-section.svelte web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+git commit -m "feat(web): slide + soft-surface filter sections"
+```
+
+---
+
+### Task 3: Width-eased collapse shell + rail width + toggle polish
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte` (the render block at the end of the file, ~lines 658–854, plus the toggle-row button classes ~lines 713–718)
+- Test: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts` (add one test)
+
+**Interfaces:**
+- Consumes: nothing new (CSS-only motion via Tailwind + `SETTLE_EASE` value inlined as the arbitrary easing).
+- Produces: a new wrapper element `data-testid="filter-panel-shell"` that owns the animated width and the right border.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`:
+```ts
+it('animates the panel width via a persistent shell with a reduced-motion guard', async () => {
+  const { getByTestId } = render(FilterPanel, {
+    props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
+  });
+  const shell = getByTestId('filter-panel-shell');
+  expect(shell.className).toContain('transition-[width]');
+  expect(shell.className).toContain('motion-reduce:transition-none');
+  expect(shell.className).toContain('w-64');
+
+  await fireEvent.click(getByTestId('collapse-panel-btn'));
+  expect(shell.className).toContain('w-14');
+  expect(shell.className).not.toContain('w-64');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts -t "persistent shell"
+```
+Expected: FAIL — no `filter-panel-shell` testid exists yet.
+
+- [ ] **Step 3: Wrap the collapse branches in a persistent shell**
+
+In `web/src/lib/components/filter-panel/filter-panel.svelte`, replace the top of the render block. Find:
+```svelte
+{#if hidden}
+  <!-- FilterPanel hidden: no assets to filter -->
+{:else if collapsed}
+  <div
+    class="flex h-full w-8 flex-shrink-0 flex-col items-center gap-3 border-r border-gray-200 bg-light py-2 dark:border-gray-700"
+    data-testid="collapsed-icon-strip"
+  >
+```
+Replace with:
+```svelte
+{#if hidden}
+  <!-- FilterPanel hidden: no assets to filter -->
+{:else}
+  <div
+    class="flex h-full flex-shrink-0 overflow-hidden border-r border-gray-200 bg-light transition-[width] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:border-gray-700 {collapsed
+      ? 'w-14'
+      : 'w-64'}"
+    data-testid="filter-panel-shell"
+  >
+    {#if collapsed}
+      <div
+        class="flex h-full w-full flex-shrink-0 flex-col items-center gap-3 py-2"
+        data-testid="collapsed-icon-strip"
+      >
+```
+
+- [ ] **Step 4: Re-point the expanded branch and close the shell**
+
+Still in `filter-panel.svelte`, find the expanded-branch opening:
+```svelte
+{:else}
+  <div
+    class="immich-scrollbar flex w-64 flex-col overflow-y-auto border-r border-gray-200 bg-light dark:border-gray-700"
+    data-testid="discovery-panel"
+  >
+```
+Replace with:
+```svelte
+    {:else}
+      <div
+        class="immich-scrollbar flex h-full w-64 flex-col overflow-y-auto bg-light"
+        data-testid="discovery-panel"
+      >
+```
+Then find the final closing of the render block:
+```svelte
+      {/if}
+    </div>
+  </div>
+{/if}
+```
+Replace with (adds one extra `</div>` to close the new shell, plus closes the inner `{#if collapsed}`):
+```svelte
+          {/if}
+        </div>
+      </div>
+    {/if}
+  </div>
+{/if}
+```
+> Note for the implementer: the inner content of both branches (the rail buttons; and the header / toggle-row / sections of the expanded panel) is unchanged — only the wrapping `<div>`s and the `{#if collapsed} … {:else} … {/if}` nesting move inside the new shell. After editing, re-indent the moved blocks and confirm the file's `<script>`/markup still balances (svelte-check in Step 7 will catch any imbalance).
+
+- [ ] **Step 5: Polish the toggle-row buttons**
+
+Still in `filter-panel.svelte`, find the toggle button class (around line 715):
+```svelte
+            class="relative flex h-[30px] w-[30px] items-center justify-center rounded-lg transition-colors
+              {visibleSections.has(section)
+```
+Replace the first line with:
+```svelte
+            class="relative flex h-[30px] w-[30px] items-center justify-center rounded-[10px] transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-90 motion-reduce:transition-none motion-reduce:active:scale-100
+              {visibleSections.has(section)
+```
+
+- [ ] **Step 6: Run the new test + full suite**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+```
+Expected: PASS — the new "persistent shell" test passes and **all** existing collapse/expand/visibility/persistence assertions stay green (they still toggle `collapsed-icon-strip` ⟺ `discovery-panel` via the inner `{#if collapsed}`).
+
+- [ ] **Step 7: Type-check**
+
+Run:
+```bash
+cd web && pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-panel.svelte web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+git commit -m "feat(web): width-eased collapse shell + rail width + toggle polish"
+```
+
+---
+
+### Task 4: Breathing 3-column year grid
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/temporal-picker.svelte` (year grid ~lines 226–249; month-grid chip classes ~lines 191–224)
+- Test: `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts` (add tests)
+
+**Interfaces:**
+- Consumes / Produces: none new. Same props and `data-testid`s (`year-grid`, `year-btn-{year}`, `month-grid`, `month-btn-{month}`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add inside the existing `describe('TemporalPicker component', ...)` block in `web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts` (its `buckets` covers 2022 + 2023):
+```ts
+it('lays out the year grid in three columns', () => {
+  const { getByTestId } = render(TemporalPicker, { props: { timeBuckets: buckets } });
+  expect(getByTestId('year-grid').className).toContain('grid-cols-3');
+});
+
+it('renders a year button per year bucket', () => {
+  const { getByTestId } = render(TemporalPicker, { props: { timeBuckets: buckets } });
+  expect(getByTestId('year-btn-2022')).toBeTruthy();
+  expect(getByTestId('year-btn-2023')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts -t "three columns"
+```
+Expected: FAIL — the year grid is currently `flex flex-wrap`, not `grid-cols-3`.
+
+- [ ] **Step 3: Convert the year grid to a 3-column grid with polished chips**
+
+In `web/src/lib/components/filter-panel/temporal-picker.svelte`, find the year-grid block:
+```svelte
+    <!-- Year grid: 4-column flex wrap -->
+    <div class="flex flex-wrap gap-1.5" data-testid="year-grid">
+      {#each years as y (y.year)}
+        <button
+          type="button"
+          class="year-chip flex min-w-[54px] flex-1 basis-[calc(25%-5px)] flex-col items-center rounded-lg border px-2 py-1.5 transition-all duration-100
+            {y.count === 0
+            ? 'cursor-default border-gray-200 opacity-30 dark:border-gray-700'
+            : 'cursor-pointer border-gray-200 hover:border-immich-primary hover:bg-immich-primary/5 dark:border-gray-700 dark:hover:border-immich-dark-primary dark:hover:bg-immich-dark-primary/5'}"
+          onclick={() => handleYearClick(y.year, y.count)}
+          data-testid="year-btn-{y.year}"
+        >
+          <span class="text-xs font-semibold leading-tight">{y.year}</span>
+          <span class="text-xs leading-tight text-gray-400 opacity-60 dark:text-gray-500">{y.count}</span>
+          <div class="mt-0.5 h-[2px] w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
+            <div
+              class="h-full rounded-sm bg-immich-primary transition-[width] duration-300 dark:bg-immich-dark-primary"
+              style="width: {y.volumePercent}%"
+            ></div>
+          </div>
+        </button>
+      {/each}
+    </div>
+```
+Replace with:
+```svelte
+    <!-- Year grid: 3-column grid -->
+    <div class="grid grid-cols-3 gap-1.5" data-testid="year-grid">
+      {#each years as y (y.year)}
+        <button
+          type="button"
+          class="year-chip flex flex-col items-center rounded-xl border px-2 py-1.5 transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none
+            {y.count === 0
+            ? 'cursor-default border-gray-200 opacity-30 dark:border-gray-700'
+            : 'cursor-pointer border-gray-200 hover:-translate-y-0.5 hover:border-immich-primary hover:bg-immich-primary/5 motion-reduce:hover:translate-y-0 dark:border-gray-700 dark:hover:border-immich-dark-primary dark:hover:bg-immich-dark-primary/5'}"
+          onclick={() => handleYearClick(y.year, y.count)}
+          data-testid="year-btn-{y.year}"
+        >
+          <span class="text-xs font-semibold leading-tight tabular-nums">{y.year}</span>
+          <span class="text-xs leading-tight tabular-nums text-gray-400 opacity-60 dark:text-gray-500">{y.count}</span>
+          <div class="mt-1 h-[3px] w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
+            <div
+              class="year-bar h-full origin-left rounded-sm bg-immich-primary transition-[width] duration-300 dark:bg-immich-dark-primary"
+              style="width: {y.volumePercent}%"
+            ></div>
+          </div>
+        </button>
+      {/each}
+    </div>
+```
+
+- [ ] **Step 4: Add the one-time bar-grow animation (reduced-motion safe)**
+
+In the same file, add a `<style>` block at the end of the file (the component currently has none):
+```svelte
+<style>
+  .year-bar {
+    animation: year-bar-grow 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @keyframes year-bar-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .year-bar {
+      animation: none;
+    }
+  }
+</style>
+```
+
+- [ ] **Step 5: Match the month-grid chips to the year chips (consistency)**
+
+Find the month button class:
+```svelte
+          class="flex flex-col items-center rounded-lg border px-2 py-2 transition-all duration-100
+```
+Replace with:
+```svelte
+          class="flex flex-col items-center rounded-xl border px-2 py-2 transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none
+```
+
+- [ ] **Step 6: Run the tests to verify pass + no regressions**
+
+Run:
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+```
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 7: Type-check**
+
+Run:
+```bash
+cd web && pnpm check
+```
+Expected: 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/temporal-picker.svelte web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+git commit -m "feat(web): 3-column breathing year grid in temporal picker"
+```
+
+---
+
+### Task 5: Verification gate (full suite, lint, format, manual)
+
+**Files:** none new — this is the deferred full-quality pass plus manual sign-off.
+
+- [ ] **Step 1: Run the full web unit suite**
+
+Run:
+```bash
+cd web && pnpm test -- --run
+```
+Expected: PASS (entire web suite). If anything outside the filter panel changed unexpectedly, stop and investigate.
+
+- [ ] **Step 2: Type-check the whole web package**
+
+Run:
+```bash
+make check-web
+```
+Expected: 0 errors.
+
+- [ ] **Step 3: Single deferred lint pass**
+
+Run:
+```bash
+make lint-web
+```
+Expected: 0 warnings (the repo enforces `--max-warnings 0`). Fix any findings, then re-run.
+
+- [ ] **Step 4: Format**
+
+Run:
+```bash
+make format-web
+```
+If prettier rewrites anything, review and stage it.
+
+- [ ] **Step 5: Manual verification (aesthetics — not CI-testable)**
+
+Start the dev stack (`make dev`) and, on the **photos**, **map**, and **spaces** pages, confirm:
+- Collapsing the panel **eases its width** down to the icon rail (and back), not a snap.
+- Clicking a section header **slides** the body open/closed; the chevron rotates.
+- Sections sit on **soft surfaces** with no hard full-width divider ladder.
+- The year grid is **3 columns**, chips lift on hover, bars grow on load.
+- The toggle-row pills show the tinted active state and press-scale.
+- With the OS **"Reduce motion"** setting enabled, every animation above becomes instant (no width ease, no slide, no bar grow, no hover lift), and the panel still works.
+- Light **and** dark themes both look right.
+
+- [ ] **Step 6: Commit any formatting/lint fixes**
+
+```bash
+git add -A
+git commit -m "chore(web): lint + format pass for filter panel redesign" --allow-empty
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Motion tokens / easing / durations → Task 1 (`motion.ts`) + Global Constraints. ✓
+- Panel width-eased rail collapse (shell, `w-64` ⟺ `w-14`, clip-reveal, preserve `{#if}` swap) → Task 3. ✓
+- Section height-slide via `transition:slide` (matches `setting-accordion`), `|local` to protect visibility tests → Task 2. ✓
+- Surfaces over hard rules (drop `border-b`, `bg-subtle` active surface) → Task 2. ✓
+- 3-column breathing year grid + chip polish + bar grow → Task 4. ✓
+- Toggle-row pill polish → Task 3 Step 5. ✓
+- Reduced motion (Tailwind `motion-reduce:` + `slideMotion`) → Tasks 1–4 + Task 5 manual. ✓
+- Theme-token-only, both themes → Global Constraints + Task 5 manual. ✓
+- Tests stay green; new TDD tests for the 4 spec items → Tasks 1–4; deferred lint → Task 5. ✓
+
+**Placeholder scan:** none — every code/test step contains full code and exact commands.
+
+**Type consistency:** `slideMotion(reducedMotion: boolean): SlideMotion` is defined in Task 1 and consumed identically in Task 2. The `filter-panel-shell` testid introduced in Task 3 is only referenced by Task 3's own test. Widths (`w-64`, `w-14`) match between Global Constraints, Task 3 code, and Task 3 test.

--- a/docs/superpowers/plans/2026-06-18-merged-filter-toolbar.md
+++ b/docs/superpowers/plans/2026-06-18-merged-filter-toolbar.md
@@ -546,27 +546,29 @@ Expected: FAIL — `photos-active-filters-bar-spacing` still exists.
 Replace the grouping `{#if !showSearchResults && !assetMultiSelectManager.selectionActive}` div and the `{#if hasActiveFilters}` filters div with:
 
 ```svelte
+      {#snippet photoFiltersBar()}
+        <ActiveFiltersBar
+          embedded
+          {filters}
+          searchQuery={committedQuery}
+          onClearSearch={clearSearch}
+          resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
+          {personNames}
+          {tagNames}
+          onRemoveFilter={handleRemoveActiveFilter}
+          onClearAll={handleClearAllFilters}
+        />
+      {/snippet}
       <FilterToolbar
         class="mb-2"
         grouping={timelineGrouping}
         onGroupingChange={handleTimelineGroupingChange}
         showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}
         showFilters={hasActiveFilters}
-      >
-        {#snippet filters()}
-          <ActiveFiltersBar
-            embedded
-            {filters}
-            searchQuery={committedQuery}
-            onClearSearch={clearSearch}
-            resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
-            {personNames}
-            {tagNames}
-            onRemoveFilter={handleRemoveActiveFilter}
-            onClearAll={handleClearAllFilters}
-          />
-        {/snippet}
-      </FilterToolbar>
+        filters={photoFiltersBar}
+      />
+
+> ⚠️ **Name the snippet, don't call it `filters`.** A `{#snippet filters()}` inside `<FilterToolbar>` shadows this page's own `filters: FilterState` in Svelte 5, so `{filters}` in the snippet body (and `getActiveFilterCount(filters)`) resolves to the snippet, not the state — it crashes at render. Declare the snippet as a sibling named `photoFiltersBar` and pass `filters={photoFiltersBar}` (the `filters` prop on `FilterToolbar` is the snippet slot; the value you pass is the named snippet). Discovered while implementing Task 4.
 ```
 
 Add `import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';` to the script imports.
@@ -647,34 +649,34 @@ Remove the grouping `{#if isBrowseTimeline && !assetMultiSelectManager.selection
               }}
             />
           {:else if viewMode !== AlbumPageViewMode.SELECT_ASSETS}
+            {#snippet albumFiltersBar()}
+              <ActiveFiltersBar
+                embedded
+                filters={albumFilters}
+                resultCount={totalAssetCount}
+                personNames={albumPersonNames}
+                tagNames={albumTagNames}
+                onRemoveFilter={(type, id) => {
+                  if (type === 'timeline') {
+                    clearAlbumTemporalFilter();
+                  } else {
+                    albumFilters = handlePhotosRemoveFilter(albumFilters, type, id);
+                  }
+                }}
+                onClearAll={() => {
+                  albumFilters = clearFilters(albumFilters);
+                  temporalAnchor = undefined;
+                }}
+              />
+            {/snippet}
             <FilterToolbar
               class="mb-2"
               grouping={timelineGrouping}
               onGroupingChange={handleTimelineGroupingChange}
               showGrouping={isBrowseTimeline && !assetMultiSelectManager.selectionActive}
               showFilters={getActiveFilterCount(albumFilters) > 0}
-            >
-              {#snippet filters()}
-                <ActiveFiltersBar
-                  embedded
-                  filters={albumFilters}
-                  resultCount={totalAssetCount}
-                  personNames={albumPersonNames}
-                  tagNames={albumTagNames}
-                  onRemoveFilter={(type, id) => {
-                    if (type === 'timeline') {
-                      clearAlbumTemporalFilter();
-                    } else {
-                      albumFilters = handlePhotosRemoveFilter(albumFilters, type, id);
-                    }
-                  }}
-                  onClearAll={() => {
-                    albumFilters = clearFilters(albumFilters);
-                    temporalAnchor = undefined;
-                  }}
-                />
-              {/snippet}
-            </FilterToolbar>
+              filters={albumFiltersBar}
+            />
           {/if}
 ```
 

--- a/docs/superpowers/plans/2026-06-18-merged-filter-toolbar.md
+++ b/docs/superpowers/plans/2026-06-18-merged-filter-toolbar.md
@@ -1,0 +1,799 @@
+# Merged Filter Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge the timeline grouping control (Years / Months / All) and the active-filters chip bar into a single toolbar row across every route that shows them, with the grouping pill on the left, the result count + filter chips next, and "Clear all" on the right.
+
+**Architecture:** Introduce one layout primitive, `FilterToolbar.svelte`, that renders a single responsive flex row: `TimelineGroupingControl` (left, desktop-only) → vertical hairline → an embedded `ActiveFiltersBar` (fills remaining width). `ActiveFiltersBar` gains an `embedded` mode that drops its own band/border/padding so it can live inside the toolbar. The existing combiner `TimelineRouteGroupingBar` is refactored to delegate to `FilterToolbar` (covering ~9 routes for free); the three hand-composed routes (spaces, photos, albums) and the map are migrated to the same primitive.
+
+**Tech Stack:** SvelteKit, Svelte 5 runes (`$props`, `$derived`, snippets), `@immich/ui` (`Icon`), `@mdi/js`, Tailwind CSS 4, `tailwind-merge`, Vitest + `@testing-library/svelte`.
+
+## Global Constraints
+
+- Stay within existing `@immich/ui` / Tailwind theme tokens — no new color system (chip fill `bg-gray-100` / `dark:bg-white/[0.06]`, hairline `border-gray-200/60` / `dark:border-white/10`, `immich-primary` / `immich-dark-primary`). Verbatim from `docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md`.
+- Prettier: 120-char line width, single quotes, trailing commas, semicolons. Run `make format-web` before each commit if unsure.
+- ESLint zero-warnings policy (`--max-warnings 0`); `no-floating-promises` / `no-misused-promises` enforced. Defer the slow full `make lint-web` to the final gate (Task 8); use `make check-web` in the loop.
+- Web unit tests run with `cd web && pnpm test -- --run <file>` (Vitest). The path filter currently runs the full suite regardless — that is expected; "all green" is the bar.
+- **Responsive contract that MUST be preserved:** the grouping control is desktop-only (`md:flex`); the active-filters bar is visible on **all** screen sizes today in spaces/photos/albums/map. Merging must not hide the filters bar on mobile.
+- **Prerequisite (already applied, uncommitted):** `active-filters-bar.svelte` was restyled (type icons via `sectionIcons`, `mdiClose` close buttons, soft filled pills, leading count + dot separator, band→hairline) and `__tests__/active-filters-bar.spec.ts` updated (rating chip now `"3+"` with a leading star icon). This plan builds on that working tree. Do **not** revert it.
+
+---
+
+## File Structure
+
+**New files:**
+- `web/src/lib/components/filter-panel/filter-toolbar.svelte` — the single-row toolbar layout primitive (grouping + embedded filters bar). One responsibility: lay out the two controls responsively.
+- `web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts` — unit tests for the primitive.
+
+**Modified files:**
+- `web/src/lib/components/filter-panel/active-filters-bar.svelte` — add `embedded` prop.
+- `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts` — add an `embedded`-mode test.
+- `web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte` — delegate to `FilterToolbar`.
+- `web/src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts` — update structural assertions.
+- `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte` — replace two rows with one `FilterToolbar`.
+- `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte` — same.
+- `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts` — preserve testids / adjust.
+- `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte` — browse mode merges; picker mode stays standalone.
+- `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts` — adjust.
+- `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte` — add a readable backdrop to the floating bar wrapper (fixes the transparent-over-map regression from the restyle).
+
+**Unchanged (covered transitively via `TimelineRouteGroupingBar`):** archive, trash, locked, favorites, tags, partners, spaces/people, people/[personId], `MapTimelinePanel.svelte`, `gallery-viewer.svelte`. They pass only `grouping`/`hidden`/`onGroupingChange` (except `MapTimelinePanel`, which also passes `filters`/`resultCount`/`onClearTemporalFilter`), so refactoring `TimelineRouteGroupingBar` updates all of them at once.
+
+---
+
+### Task 1: ActiveFiltersBar — `embedded` mode
+
+**Files:**
+- Modify: `web/src/lib/components/filter-panel/active-filters-bar.svelte`
+- Test: `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
+
+**Interfaces:**
+- Produces: `ActiveFiltersBar` gains prop `embedded?: boolean` (default `false`). When `true`, the root element omits `border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10` (host toolbar supplies spacing/seam); when `false`, behavior is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `__tests__/active-filters-bar.spec.ts` inside the `describe('ActiveFiltersBar', …)` block:
+
+```ts
+it('omits its own band and padding in embedded mode', () => {
+  const filters = createFilterState();
+  filters.country = 'Germany';
+
+  // embedded: no self-drawn seam/padding (the host toolbar supplies them)
+  const embedded = render(ActiveFiltersBar, {
+    props: { filters, onRemoveFilter: () => {}, onClearAll: () => {}, embedded: true },
+  });
+  const embeddedBar = embedded.getByTestId('active-filters-bar');
+  expect(embeddedBar.className).not.toContain('border-b');
+  expect(embeddedBar.className).not.toContain('px-4');
+
+  // standalone (default): keeps the seam + padding
+  const standalone = render(ActiveFiltersBar, {
+    props: { filters, onRemoveFilter: () => {}, onClearAll: () => {}, embedded: false },
+  });
+  const standaloneBar = standalone.getByTestId('active-filters-bar');
+  expect(standaloneBar.className).toContain('border-b');
+  expect(standaloneBar.className).toContain('px-4');
+});
+```
+
+> Two separate `render` calls (not `rerender`) — each scopes `getByTestId` to its own container, avoiding a duplicate-testid clash and the `rerender` promise dance. Both patterns exist in the suite (`Image.spec.ts` uses `rerender`); two renders is simpler here.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
+Expected: FAIL — `embedded` prop not yet handled, so the root still contains `border-b`/`px-4` and the first assertions fail (or `embedded` is an unknown prop).
+
+- [ ] **Step 3: Add the prop**
+
+In the `interface Props` block of `active-filters-bar.svelte`, add after `onClearSearch?: () => void;`:
+
+```ts
+    embedded?: boolean;
+```
+
+And in the destructuring (`let { … }: Props = $props();`), add `embedded = false,` (e.g. after `onClearSearch,`).
+
+- [ ] **Step 4: Make the root class conditional**
+
+Replace the root element's opening tag:
+
+```svelte
+<div
+  class="flex flex-wrap items-center gap-2 border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10"
+  data-testid="active-filters-bar"
+>
+```
+
+with:
+
+```svelte
+<div
+  class="flex flex-wrap items-center gap-2 {embedded ? '' : 'border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10'}"
+  data-testid="active-filters-bar"
+>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
+Expected: PASS — all existing tests plus the new embedded test.
+
+- [ ] **Step 6: Type check**
+
+Run: `cd web && pnpm check:typescript` (or `make check-web` from repo root)
+Expected: no new errors referencing `active-filters-bar.svelte`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/active-filters-bar.svelte web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+git commit -m "feat(web): add embedded mode to active filters bar"
+```
+
+---
+
+### Task 2: `FilterToolbar.svelte` — the single-row primitive
+
+**Files:**
+- Create: `web/src/lib/components/filter-panel/filter-toolbar.svelte`
+- Test: `web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts`
+
+**Interfaces:**
+- Consumes: `TimelineGroupingControl` (`web/src/lib/components/timeline/TimelineGroupingControl.svelte`), props `grouping`, `onGroupingChange`, `disabled`.
+- Produces: `FilterToolbar` with props:
+  - `grouping: TimelineGrouping`
+  - `onGroupingChange: (grouping: TimelineGrouping) => void`
+  - `groupingDisabled?: boolean` (default `false`)
+  - `showGrouping?: boolean` (default `true`) — render the grouping pill (desktop-only)
+  - `showFilters?: boolean` (default `false`) — render the `filters` snippet + the separator
+  - `filters?: Snippet` — the embedded `ActiveFiltersBar` (caller supplies it with `embedded` set)
+  - `class?: string` — merged onto the row container
+  - Renders nothing when `!showGrouping && !showFilters`.
+  - Container is `flex` when `showFilters` (visible on all sizes so the bar shows on mobile) and `hidden md:flex` when grouping-only (desktop-only, matching today).
+  - The grouping pill is wrapped in a `hidden md:flex` element carrying `data-testid="timeline-desktop-grouping-control"` (preserves existing route-test selectors). The separator is also desktop-only.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts`:
+
+```ts
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
+import { createRawSnippet } from 'svelte';
+import FilterToolbar from '../filter-toolbar.svelte';
+
+beforeAll(async () => {
+  register('en-US', () => import('$i18n/en.json'));
+  await init({ fallbackLocale: 'en-US' });
+  await waitLocale('en-US');
+});
+
+const filtersSnippet = createRawSnippet(() => ({
+  render: () => `<div data-testid="bar-content">chips</div>`,
+}));
+
+describe('FilterToolbar', () => {
+  it('renders the grouping control (desktop wrapper) and no filters by default', () => {
+    const { getByTestId, queryByTestId } = render(FilterToolbar, {
+      props: { grouping: 'day', onGroupingChange: () => {} },
+    });
+    expect(getByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+    expect(getByTestId('timeline-grouping-control')).toBeInTheDocument();
+    expect(queryByTestId('filter-toolbar-separator')).toBeNull();
+  });
+
+  it('renders the filters snippet and separator when showFilters is set', () => {
+    const { getByTestId } = render(FilterToolbar, {
+      props: {
+        grouping: 'day',
+        onGroupingChange: () => {},
+        showGrouping: true,
+        showFilters: true,
+        filters: filtersSnippet,
+      },
+    });
+    expect(getByTestId('bar-content')).toBeInTheDocument();
+    expect(getByTestId('filter-toolbar-separator')).toBeInTheDocument();
+  });
+
+  it('omits the grouping wrapper (and separator) when showGrouping is false', () => {
+    const { queryByTestId, getByTestId } = render(FilterToolbar, {
+      props: {
+        grouping: 'day',
+        onGroupingChange: () => {},
+        showGrouping: false,
+        showFilters: true,
+        filters: filtersSnippet,
+      },
+    });
+    expect(queryByTestId('timeline-desktop-grouping-control')).toBeNull();
+    expect(queryByTestId('filter-toolbar-separator')).toBeNull();
+    expect(getByTestId('bar-content')).toBeInTheDocument();
+  });
+
+  it('renders nothing when neither grouping nor filters are shown', () => {
+    const { container } = render(FilterToolbar, {
+      props: { grouping: 'day', onGroupingChange: () => {}, showGrouping: false, showFilters: false },
+    });
+    expect(container.querySelector('[data-testid="timeline-grouping-control"]')).toBeNull();
+  });
+
+  // --- responsive contract (the riskiest part of the merge) ---
+
+  it('is visible on mobile (flex, never hidden) when filters are shown', () => {
+    const { getByTestId } = render(FilterToolbar, {
+      props: {
+        grouping: 'day',
+        onGroupingChange: () => {},
+        showGrouping: true,
+        showFilters: true,
+        filters: filtersSnippet,
+      },
+    });
+    // the grouping wrapper's parent IS the toolbar root
+    const root = getByTestId('timeline-desktop-grouping-control').parentElement!;
+    expect(root.className).toContain('flex');
+    expect(root.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+  });
+
+  it('is desktop-only (hidden md:flex) when only grouping is shown', () => {
+    const { getByTestId } = render(FilterToolbar, {
+      props: { grouping: 'day', onGroupingChange: () => {}, showGrouping: true, showFilters: false },
+    });
+    const root = getByTestId('timeline-desktop-grouping-control').parentElement!;
+    expect(root.className).toContain('hidden');
+    expect(root.className).toContain('md:flex');
+  });
+});
+```
+
+> These two cases pin the contract that broke would be silent and only visible at runtime on a phone: with active filters the chip bar must show on mobile (`flex`), while the grouping-only state stays desktop-only (`hidden md:flex`). The embedded bar fills via `min-w-0 flex-1`, so its `Clear all` (`ml-auto`) lands at the row's right edge and chips wrap rather than overflow — verified visually in Task 8, not unit-tested.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts`
+Expected: FAIL — `../filter-toolbar.svelte` does not exist (import/resolve error).
+
+- [ ] **Step 3: Create the component**
+
+Create `web/src/lib/components/filter-panel/filter-toolbar.svelte`:
+
+```svelte
+<script lang="ts">
+  import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
+  import type { TimelineGrouping } from '$lib/managers/timeline-manager/types';
+  import type { Snippet } from 'svelte';
+  import { twMerge } from 'tailwind-merge';
+
+  interface Props {
+    grouping: TimelineGrouping;
+    onGroupingChange: (grouping: TimelineGrouping) => void;
+    groupingDisabled?: boolean;
+    showGrouping?: boolean;
+    showFilters?: boolean;
+    filters?: Snippet;
+    class?: string;
+  }
+
+  let {
+    grouping,
+    onGroupingChange,
+    groupingDisabled = false,
+    showGrouping = true,
+    showFilters = false,
+    filters,
+    class: className = '',
+  }: Props = $props();
+</script>
+
+{#if showGrouping || showFilters}
+  <!--
+    Root display is responsive-by-intent:
+    - showFilters → `flex` (visible on ALL sizes, so the chip bar still shows on mobile)
+    - grouping-only → `hidden md:flex` (desktop-only, matching today's behavior)
+    `bg-transparent` keeps the toolbar a hairline surface on the content background (never the old gray band).
+    A caller MAY pass `class="hidden md:flex"` to force desktop-only even when showFilters is true
+    (TimelineRouteGroupingBar does this); twMerge lets the later display utility win.
+  -->
+  <div
+    class={twMerge(
+      'shrink-0 items-center gap-3 bg-transparent px-4 py-2 dark:bg-transparent',
+      showFilters ? 'flex' : 'hidden md:flex',
+      className,
+    )}
+  >
+    {#if showGrouping}
+      <div class="hidden md:flex md:items-center" data-testid="timeline-desktop-grouping-control">
+        <TimelineGroupingControl {grouping} {onGroupingChange} disabled={groupingDisabled} />
+      </div>
+    {/if}
+
+    {#if showFilters}
+      {#if showGrouping}
+        <span
+          class="hidden h-5 w-px shrink-0 bg-gray-200/70 md:block dark:bg-white/10"
+          data-testid="filter-toolbar-separator"
+          aria-hidden="true"
+        ></span>
+      {/if}
+      <div class="min-w-0 flex-1">
+        {@render filters?.()}
+      </div>
+    {/if}
+  </div>
+{/if}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts`
+Expected: PASS — all four cases.
+
+- [ ] **Step 5: Type check**
+
+Run: `cd web && pnpm check:typescript`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-toolbar.svelte web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts
+git commit -m "feat(web): add FilterToolbar single-row layout primitive"
+```
+
+---
+
+### Task 3: Refactor `TimelineRouteGroupingBar` to delegate to `FilterToolbar`
+
+This updates ~9 consumers at once (archive, trash, locked, favorites, tags, partners, spaces/people, people/[personId], `MapTimelinePanel`, `gallery-viewer`). Only `MapTimelinePanel` passes `filters`/`resultCount` → it gets the real merge; the rest are grouping-only.
+
+**Files:**
+- Modify: `web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte`
+- Test: `web/src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts`
+
+**Interfaces:**
+- Consumes: `FilterToolbar` (Task 2), `ActiveFiltersBar` with `embedded` (Task 1).
+- Produces: unchanged public props (`grouping`, `filters?`, `resultCount?`, `hidden?`, `class?`, `onGroupingChange`, `onClearTemporalFilter?`).
+
+This is a behavior-preserving refactor: the existing `TimelineRouteGroupingBar.spec.ts` is the safety net. Confirmed-relevant assertions (verified against the file): it preserves the `timeline-desktop-grouping-control` testid (`:16`), the transparent surface with no gray band (`:23–33`), the clearable temporal chip + result count when temporal filters are active (`:54–73`), no chips for non-temporal filters (`:76–95`), and empty output when `hidden` (`:98–112`). All of these stay green if `FilterToolbar` keeps the testid, carries `bg-transparent`, and gates the bar on `hasActiveTemporalFilters` — which it does.
+
+- [ ] **Step 1: Confirm green baseline**
+
+Run: `cd web && pnpm test -- --run src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts`
+Expected: PASS (baseline before refactor).
+
+- [ ] **Step 2: Rewrite the markup**
+
+Replace the entire `{#if !hidden} … {/if}` template block (lines ~46–61) in `TimelineRouteGroupingBar.svelte` with:
+
+```svelte
+{#if !hidden}
+  <FilterToolbar
+    {grouping}
+    {onGroupingChange}
+    showFilters={hasActiveTemporalFilters}
+    class={twMerge('hidden md:flex', className)}
+  >
+    {#snippet filters()}
+      <ActiveFiltersBar
+        embedded
+        filters={temporalFilters}
+        {resultCount}
+        onRemoveFilter={removeTemporalFilter}
+        onClearAll={() => onClearTemporalFilter?.()}
+      />
+    {/snippet}
+  </FilterToolbar>
+{/if}
+```
+
+Update the imports at the top of the `<script>`: remove the now-unused `TimelineGroupingControl` import and add:
+
+```ts
+  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
+```
+
+Keep `ActiveFiltersBar`, `buildFilterContext`, `createFilterState`, `twMerge`, the `temporalFilters`/`hasActiveTemporalFilters` deriveds, and `removeTemporalFilter` as-is.
+
+> **Why the spec stays green:** `FilterToolbar` keeps `timeline-desktop-grouping-control`; its root carries `bg-transparent dark:bg-transparent`, so `:23–33` (parent has `bg-transparent`, lacks `bg-gray-50`/`border-b`) still holds. The embedded bar renders only when `hasActiveTemporalFilters`, satisfying `:76–95` and `:98–112`. `class={twMerge('hidden md:flex', className)}` keeps this component desktop-only: even though `FilterToolbar` defaults to `flex` when `showFilters` is true, this later `hidden md:flex` className wins in twMerge — intended, since these are desktop routes and the route bar was desktop-only before. (Follow-up, out of scope: if `MapTimelinePanel`'s temporal bar should appear on mobile, stop forcing `hidden md:flex` for it.)
+
+- [ ] **Step 3: Run the spec — expect all green, no edits needed**
+
+Run: `cd web && pnpm test -- --run src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts`
+Expected: PASS, unchanged. If `:31` fails on `bg-transparent`, you omitted `bg-transparent dark:bg-transparent` on the `FilterToolbar` root (Task 2) — add it and re-run.
+
+- [ ] **Step 4: Tidy one now-stale test name**
+
+The test `'keeps the route grouping surface transparent instead of drawing a full-width toolbar'` still asserts the right thing (transparent surface, no gray band) but the name is misleading now that we intentionally draw a transparent toolbar row. Rename it to `'keeps the toolbar surface transparent (no gray band)'`; leave its assertions unchanged.
+
+- [ ] **Step 5: Type check**
+
+Run: `cd web && pnpm check:typescript`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte web/src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts
+git commit -m "refactor(web): TimelineRouteGroupingBar renders one merged toolbar row"
+```
+
+---
+
+### Task 4: Migrate the spaces route
+
+**Files:**
+- Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte` (grouping div at ~1061–1068, filters div at ~1071–1084)
+- Test: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
+
+**Interfaces:**
+- Consumes: `FilterToolbar` (Task 2). Add import `import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';`.
+
+TDD shape: the old `space-active-filters-bar-spacing` wrapper is removed and grouping+bar move into one `FilterToolbar` row. Write that expectation first (RED), then implement (GREEN). Symbols below are verified present in `+page.svelte`: `handleRemoveFilter` (`:421`), `handleClearAllFilters` (`:867`), `clearSearch` (`:796`), `committedSearchQuery` (`:776`), `getActiveFilterCount` (import `:10`), `handleTimelineGroupingChange` (`:861`), `smartFacetTotal`/`totalAssetCount`.
+
+- [ ] **Step 1: Confirm green baseline + see what the spec asserts**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"` (expect PASS), then
+`cd web && grep -nE "timeline-desktop-grouping-control|space-active-filters-bar-spacing|active-filters" "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"`
+Note which assertions reference the spacing wrapper — those are the ones the refactor will turn RED.
+
+- [ ] **Step 2: Write the failing merge assertion (RED)**
+
+Add to `spaces-page.spec.ts` (in the view-mode-with-active-filters context the spec already sets up; reuse its existing render/setup helper):
+
+```ts
+it('shows grouping and the filters bar in one merged toolbar (no separate spacing wrapper)', async () => {
+  // ...arrange: view mode, a country/person filter active (reuse the spec's existing setup)...
+  expect(await screen.findByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+  expect(screen.getByTestId('active-filters-bar')).toBeInTheDocument();
+  expect(screen.queryByTestId('space-active-filters-bar-spacing')).toBeNull();
+});
+```
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"`
+Expected: FAIL — `space-active-filters-bar-spacing` still exists (and grouping/bar are in separate rows).
+
+- [ ] **Step 3: Replace the two blocks with one toolbar**
+
+Replace both the grouping block and the active-filters block (the `{#if viewMode === 'view' && !showSearchResults && …}` grouping div and the `{#if viewMode === 'view' && (getActiveFilterCount(filters) > 0 || committedSearchQuery.trim().length > 0)}` filters div) with:
+
+```svelte
+      {#if viewMode === 'view'}
+        <FilterToolbar
+          class="mb-2"
+          grouping={timelineGrouping}
+          onGroupingChange={handleTimelineGroupingChange}
+          showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}
+          showFilters={getActiveFilterCount(filters) > 0 || committedSearchQuery.trim().length > 0}
+        >
+          {#snippet filters()}
+            <ActiveFiltersBar
+              embedded
+              {filters}
+              resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
+              {personNames}
+              {tagNames}
+              onRemoveFilter={handleRemoveFilter}
+              onClearAll={handleClearAllFilters}
+              searchQuery={committedSearchQuery}
+              onClearSearch={clearSearch}
+            />
+          {/snippet}
+        </FilterToolbar>
+      {/if}
+```
+
+- [ ] **Step 4: Run — the new assertion goes GREEN, structural ones go RED**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"`
+Expected: the Step 2 test now PASSES; any pre-existing assertions referencing `space-active-filters-bar-spacing` now FAIL.
+
+- [ ] **Step 5: Update the now-stale assertions**
+
+For each assertion using `getByTestId('space-active-filters-bar-spacing')`, switch to `getByTestId('active-filters-bar')` (the chip bar) or `getByTestId('timeline-desktop-grouping-control')` (grouping presence), preserving the original present/absent intent.
+
+- [ ] **Step 6: Run again to verify all pass**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte" "web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts"
+git commit -m "feat(web): merge grouping + filters into one toolbar on spaces page"
+```
+
+---
+
+### Task 5: Migrate the photos route
+
+**Files:**
+- Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte` (grouping at ~540–546, filters at ~548–560)
+- Test: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts` (grouping testid assertions at ~816–880; `active-filters-bar-stub` at ~632–692)
+
+**Interfaces:**
+- Consumes: `FilterToolbar`. Add its import.
+- Note: `photos-page.spec.ts` mocks `ActiveFiltersBar` as `active-filters-bar-stub` and asserts grouping presence via `timeline-desktop-grouping-control`. Both selectors survive: the stub is still rendered (now inside the toolbar snippet, gated by `showFilters`), and `FilterToolbar` keeps the grouping testid on its desktop wrapper.
+
+TDD shape mirrors Task 4. `photos-page.spec.ts` mocks `ActiveFiltersBar` as `active-filters-bar-stub` and gates grouping via `timeline-desktop-grouping-control` (`:816–880`) and the stub via `photos-active-filters-bar-spacing` (`:632–692`). Both selectors survive the merge: the stub renders inside `FilterToolbar`'s `filters` snippet (gated by `showFilters={hasActiveFilters}`), and the grouping testid lives on `FilterToolbar`'s desktop wrapper. Symbols verified in `+page.svelte`: `hasActiveFilters` (`:340`), `committedQuery` (`:122`, **not** `committedSearchQuery`), `clearSearch` (`:398`), `handleRemoveActiveFilter` (`:461`), `handleClearAllFilters` (`:470`), `smartFacetTotal` (`:152`), `showSearchResults` (`:128`), `personNames`/`tagNames` (`:136–137`).
+
+- [ ] **Step 1: Confirm green baseline**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"`
+Expected: PASS.
+
+- [ ] **Step 2: Write the failing merge assertion (RED)**
+
+Add to `photos-page.spec.ts` (reuse the spec's existing render helper that puts the page in browse mode with an active filter):
+
+```ts
+it('shows grouping and the filter bar in one merged toolbar (no separate spacing wrapper)', async () => {
+  // ...arrange: browse mode + an active filter (reuse the spec's setup)...
+  expect(await screen.findByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+  expect(screen.getByTestId('active-filters-bar-stub')).toBeInTheDocument();
+  expect(screen.queryByTestId('photos-active-filters-bar-spacing')).toBeNull();
+});
+```
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"`
+Expected: FAIL — `photos-active-filters-bar-spacing` still exists.
+
+- [ ] **Step 3: Replace the two blocks**
+
+Replace the grouping `{#if !showSearchResults && !assetMultiSelectManager.selectionActive}` div and the `{#if hasActiveFilters}` filters div with:
+
+```svelte
+      <FilterToolbar
+        class="mb-2"
+        grouping={timelineGrouping}
+        onGroupingChange={handleTimelineGroupingChange}
+        showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}
+        showFilters={hasActiveFilters}
+      >
+        {#snippet filters()}
+          <ActiveFiltersBar
+            embedded
+            {filters}
+            searchQuery={committedQuery}
+            onClearSearch={clearSearch}
+            resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
+            {personNames}
+            {tagNames}
+            onRemoveFilter={handleRemoveActiveFilter}
+            onClearAll={handleClearAllFilters}
+          />
+        {/snippet}
+      </FilterToolbar>
+```
+
+Add `import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';` to the script imports.
+
+- [ ] **Step 4: Run — new assertion GREEN, structural ones may go RED**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"`
+Expected: the Step 2 test PASSES. Grouping-presence (`:816–880`) and stub-presence (`:632–692`) tests should also pass (selectors preserved). Only assertions that pinned a specific DOM nesting or the `photos-active-filters-bar-spacing` wrapper go RED.
+
+- [ ] **Step 5: Update any DOM-structural assertions**
+
+Change structural queries to testid queries: `findByTestId('timeline-desktop-grouping-control')` for grouping, `queryByTestId('active-filters-bar-stub')` for the bar, and replace `photos-active-filters-bar-spacing` lookups accordingly. Keep present/absent intent identical to before.
+
+- [ ] **Step 6: Run again to verify all pass**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte" "web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
+git commit -m "feat(web): merge grouping + filters into one toolbar on photos page"
+```
+
+---
+
+### Task 6: Migrate the albums route (browse merges; picker stays standalone)
+
+**Files:**
+- Modify: `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte` (grouping at ~510–516; picker bar at ~519–531; browse bar at ~532–549)
+- Test: `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts`
+
+**Interfaces:**
+- Consumes: `FilterToolbar`. Add its import.
+- The grouping control only renders in browse-timeline mode (`isBrowseTimeline && !selectionActive`). The **picker** bar (`viewMode === AlbumPageViewMode.SELECT_ASSETS`) has no grouping → keep it as a standalone `ActiveFiltersBar` (it already gets the restyle). Only the **browse** bar merges.
+
+Verified in `+page.svelte`: `isBrowseTimeline = $derived(viewMode === AlbumPageViewMode.VIEW)` (`:335`) — so it is **false** during `SELECT_ASSETS` (picker), confirming grouping never shows in picker and the browse/picker branches are mutually exclusive. Other symbols confirmed: `albumFilters` (`:112`), `pickerFilters` (`:113`), `clearAlbumTemporalFilter` (`:410`), `temporalAnchor` (`:115`), `handlePhotosRemoveFilter` (import `:68`), `clearFilters` (import `:14`), `getActiveFilterCount` (import `:16`), `albumPersonNames`/`albumTagNames`/`pickerPersonNames`/`pickerTagNames` (`:116–119`), `handleTimelineGroupingChange` (`:390`).
+
+- [ ] **Step 1: Confirm green baseline**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"`
+Expected: PASS.
+
+- [ ] **Step 2: Write the failing merge assertion (RED)**
+
+Add to `page.route.spec.ts` (reuse the spec's browse-mode setup with an active album filter):
+
+```ts
+it('merges grouping and the filter bar into one toolbar row in browse mode', async () => {
+  // ...arrange: browse (VIEW) mode + an active albumFilter (reuse the spec's setup)...
+  const grouping = await screen.findByTestId('timeline-desktop-grouping-control');
+  const bar = screen.getByTestId('active-filters-bar');
+  // grouping wrapper and the bar's flex-1 column share the FilterToolbar root
+  expect(grouping.parentElement).toBe(bar.parentElement?.parentElement);
+});
+```
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"`
+Expected: FAIL — grouping and the bar are still in separate rows (different parents).
+
+- [ ] **Step 3: Replace the grouping div + browse bar with a toolbar; keep the picker bar standalone**
+
+Remove the grouping `{#if isBrowseTimeline && !assetMultiSelectManager.selectionActive}` div. Restructure the filters `{#if … SELECT_ASSETS …}{:else if …}` so the picker branch renders a standalone bar and the browse branch renders the toolbar:
+
+```svelte
+          {#if viewMode === AlbumPageViewMode.SELECT_ASSETS && getActiveFilterCount(pickerFilters) > 0}
+            <ActiveFiltersBar
+              filters={pickerFilters}
+              resultCount={totalAssetCount}
+              personNames={pickerPersonNames}
+              tagNames={pickerTagNames}
+              onRemoveFilter={(type, id) => {
+                pickerFilters = handlePhotosRemoveFilter(pickerFilters, type, id);
+              }}
+              onClearAll={() => {
+                pickerFilters = clearFilters(pickerFilters);
+              }}
+            />
+          {:else if viewMode !== AlbumPageViewMode.SELECT_ASSETS}
+            <FilterToolbar
+              class="mb-2"
+              grouping={timelineGrouping}
+              onGroupingChange={handleTimelineGroupingChange}
+              showGrouping={isBrowseTimeline && !assetMultiSelectManager.selectionActive}
+              showFilters={getActiveFilterCount(albumFilters) > 0}
+            >
+              {#snippet filters()}
+                <ActiveFiltersBar
+                  embedded
+                  filters={albumFilters}
+                  resultCount={totalAssetCount}
+                  personNames={albumPersonNames}
+                  tagNames={albumTagNames}
+                  onRemoveFilter={(type, id) => {
+                    if (type === 'timeline') {
+                      clearAlbumTemporalFilter();
+                    } else {
+                      albumFilters = handlePhotosRemoveFilter(albumFilters, type, id);
+                    }
+                  }}
+                  onClearAll={() => {
+                    albumFilters = clearFilters(albumFilters);
+                    temporalAnchor = undefined;
+                  }}
+                />
+              {/snippet}
+            </FilterToolbar>
+          {/if}
+```
+
+Add `import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';` to the imports.
+
+> The browse toolbar renders whenever browse mode is active and either grouping is visible or album filters exist (`FilterToolbar` self-hides when both are false), so the `{:else if viewMode !== SELECT_ASSETS}` branch is safe. The picker bar (`SELECT_ASSETS`) keeps no grouping and stays a standalone `ActiveFiltersBar`.
+
+- [ ] **Step 4: Run — new assertion GREEN, structural ones may go RED**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"`
+Expected: the Step 2 test PASSES; assertions that pinned the old separate grouping div / DOM nesting go RED.
+
+- [ ] **Step 5: Update the now-stale assertions**
+
+Switch grouping assertions to `getByTestId('timeline-desktop-grouping-control')` and bar assertions to `getByTestId('active-filters-bar')`. Preserve present/absent intent for picker (bar, no grouping) vs browse (toolbar with both).
+
+- [ ] **Step 6: Run again to verify all pass**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte" "web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts"
+git commit -m "feat(web): merge grouping + filters toolbar on albums browse view"
+```
+
+---
+
+### Task 7: Map — restore a readable backdrop for the floating bar
+
+The map main page floats `ActiveFiltersBar` over the map (`absolute inset-x-0 top-0 z-10`) and has **no grouping control** there, so it stays a standalone bar (not merged). The restyle made the bar transparent; over map tiles it is now unreadable. Give its wrapper a backdrop. (The map's *panel* grouping+temporal bar is already merged via Task 3's `MapTimelinePanel` → `TimelineRouteGroupingBar`.)
+
+**Files:**
+- Modify: `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte` (~282–298)
+- Test: `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts`
+
+- [ ] **Step 1: Add a backdrop to the floating wrapper**
+
+Change the wrapper div:
+
+```svelte
+          <div class="absolute inset-x-0 top-0 z-10">
+```
+
+to:
+
+```svelte
+          <div class="absolute inset-x-0 top-0 z-10 bg-light/95 backdrop-blur-sm">
+```
+
+(Leave the `ActiveFiltersBar` invocation unchanged — it keeps its standalone band/hairline; the wrapper now supplies an opaque-enough backing over the map.)
+
+- [ ] **Step 2: Run the map page test**
+
+Run: `cd web && pnpm test -- --run "src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts"`
+Expected: PASS (this is a class-only change; no behavioral assertion should break).
+
+- [ ] **Step 3: Manual visual check (no green checkmark — verify by eye)**
+
+With `make dev` running, open `/map`, apply a location/country filter, and confirm the chip bar is legible over the map tiles in both light and dark themes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte"
+git commit -m "fix(web): keep map floating filter bar readable with a backdrop"
+```
+
+---
+
+### Task 8: Final verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full web type + svelte check**
+
+Run: `make check-web`
+Expected: 0 errors. (If `svelte-check` reports `0 FILES`, run `cd web && pnpm svelte-kit sync` first, then re-run.)
+
+- [ ] **Step 2: Full web unit tests**
+
+Run: `cd web && pnpm test -- --run`
+Expected: all test files pass (3151+ tests). The `ECONNREFUSED :3000` lines from an unrelated suite are pre-existing noise, not failures.
+
+- [ ] **Step 3: Lint (deferred full pass)**
+
+Run: `make lint-web`
+Expected: 0 warnings/errors. Fix any and re-run.
+
+- [ ] **Step 4: Manual cross-route visual sweep (verify by eye, not CI)**
+
+With `make dev`, confirm the single merged toolbar on: photos, albums (browse), spaces, and a `TimelineRouteGroupingBar` route (e.g. favorites — grouping-only, desktop). Toggle the OS "Reduce motion" setting and a narrow (mobile) viewport: the grouping pill disappears below `md`, the chip bar still shows on mobile, and "Clear all" sits at the right edge.
+
+- [ ] **Step 5: Final commit (if any lint/format fixes were made)**
+
+```bash
+git add -A
+git commit -m "chore(web): lint + format pass for merged filter toolbar"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Merge grouping + filters into one row → Tasks 2 (primitive), 3–6 (consumers). ✓
+- "Everywhere" scope → Task 3 covers the ~9 `TimelineRouteGroupingBar` routes; Tasks 4–6 cover the 3 hand-composed routes; Task 7 covers the map. ✓
+- Count leads chips, Clear all far right → delivered by the already-applied `ActiveFiltersBar` restyle + embedded `flex-1` (clear-all `ml-auto`). ✓
+- Mobile contract (filters bar visible on mobile, grouping desktop-only) → `FilterToolbar` container is `flex` when `showFilters`, grouping wrapper is `hidden md:flex`. ✓
+- Map transparency regression → Task 7. ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N"; every code step shows full code. The route-spec update steps say exactly which selector to switch (`*-spacing` → `active-filters-bar` / `timeline-desktop-grouping-control`). ✓
+
+**Type consistency:** `FilterToolbar` prop names (`showGrouping`, `showFilters`, `groupingDisabled`, `filters` snippet) are used identically in Tasks 3–6. `ActiveFiltersBar` `embedded` (Task 1) is passed in Tasks 3–6. `TimelineGrouping` type imported from `$lib/managers/timeline-manager/types` (matches `TimelineGroupingControl`). ✓
+
+**Codebase verification (done before finalizing):** every identifier used in the route-migration code (Tasks 4–6) was grepped in its `+page.svelte` and confirmed, with line numbers cited in each task — notably photos uses `committedQuery` (not `committedSearchQuery`) and `hasActiveFilters` (`:340`); spaces uses `committedSearchQuery`/`handleRemoveFilter`; albums' `isBrowseTimeline === VIEW` (`:335`) guarantees the picker/browse branches are mutually exclusive. `createRawSnippet` (Task 2 test) and `rerender` both have suite precedent. ✓
+
+**TDD / test-API correctness:** Task 1's embedded test uses two `render` calls (not the `rerender` promise) to avoid a duplicate-testid clash. Task 2 adds two responsive-contract cases (mobile-visible-with-filters, desktop-only-when-grouping-only) — the merge's only runtime-only failure mode. Task 3 is a refactor guarded by the existing `TimelineRouteGroupingBar.spec.ts`, which stays green because `FilterToolbar` carries `bg-transparent` and preserves the `timeline-desktop-grouping-control` testid + `hasActiveTemporalFilters` gating (assertions at `:16,:23–33,:54–73,:76–95,:98–112` all hold). Tasks 4–6 each start with a green baseline, then a test-first RED assertion (old `*-spacing` wrapper gone / grouping+bar share the toolbar row) before the markup change. ✓
+
+**Open follow-up (out of scope, noted):** if `MapTimelinePanel`'s temporal bar should show on mobile, drop the `hidden md:flex` passed from `TimelineRouteGroupingBar` — left for a separate change.

--- a/docs/superpowers/plans/2026-06-18-merged-filter-toolbar.md
+++ b/docs/superpowers/plans/2026-06-18-merged-filter-toolbar.md
@@ -22,10 +22,12 @@
 ## File Structure
 
 **New files:**
+
 - `web/src/lib/components/filter-panel/filter-toolbar.svelte` — the single-row toolbar layout primitive (grouping + embedded filters bar). One responsibility: lay out the two controls responsively.
 - `web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts` — unit tests for the primitive.
 
 **Modified files:**
+
 - `web/src/lib/components/filter-panel/active-filters-bar.svelte` — add `embedded` prop.
 - `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts` — add an `embedded`-mode test.
 - `web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte` — delegate to `FilterToolbar`.
@@ -44,10 +46,12 @@
 ### Task 1: ActiveFiltersBar — `embedded` mode
 
 **Files:**
+
 - Modify: `web/src/lib/components/filter-panel/active-filters-bar.svelte`
 - Test: `web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts`
 
 **Interfaces:**
+
 - Produces: `ActiveFiltersBar` gains prop `embedded?: boolean` (default `false`). When `true`, the root element omits `border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10` (host toolbar supplies spacing/seam); when `false`, behavior is unchanged.
 
 - [ ] **Step 1: Write the failing test**
@@ -136,10 +140,12 @@ git commit -m "feat(web): add embedded mode to active filters bar"
 ### Task 2: `FilterToolbar.svelte` — the single-row primitive
 
 **Files:**
+
 - Create: `web/src/lib/components/filter-panel/filter-toolbar.svelte`
 - Test: `web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `TimelineGroupingControl` (`web/src/lib/components/timeline/TimelineGroupingControl.svelte`), props `grouping`, `onGroupingChange`, `disabled`.
 - Produces: `FilterToolbar` with props:
   - `grouping: TimelineGrouping`
@@ -350,10 +356,12 @@ git commit -m "feat(web): add FilterToolbar single-row layout primitive"
 This updates ~9 consumers at once (archive, trash, locked, favorites, tags, partners, spaces/people, people/[personId], `MapTimelinePanel`, `gallery-viewer`). Only `MapTimelinePanel` passes `filters`/`resultCount` → it gets the real merge; the rest are grouping-only.
 
 **Files:**
+
 - Modify: `web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte`
 - Test: `web/src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `FilterToolbar` (Task 2), `ActiveFiltersBar` with `embedded` (Task 1).
 - Produces: unchanged public props (`grouping`, `filters?`, `resultCount?`, `hidden?`, `class?`, `onGroupingChange`, `onClearTemporalFilter?`).
 
@@ -392,7 +400,7 @@ Replace the entire `{#if !hidden} … {/if}` template block (lines ~46–61) in 
 Update the imports at the top of the `<script>`: remove the now-unused `TimelineGroupingControl` import and add:
 
 ```ts
-  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
+import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
 ```
 
 Keep `ActiveFiltersBar`, `buildFilterContext`, `createFilterState`, `twMerge`, the `temporalFilters`/`hasActiveTemporalFilters` deriveds, and `removeTemporalFilter` as-is.
@@ -425,10 +433,12 @@ git commit -m "refactor(web): TimelineRouteGroupingBar renders one merged toolba
 ### Task 4: Migrate the spaces route
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte` (grouping div at ~1061–1068, filters div at ~1071–1084)
 - Test: `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `FilterToolbar` (Task 2). Add import `import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';`.
 
 TDD shape: the old `space-active-filters-bar-spacing` wrapper is removed and grouping+bar move into one `FilterToolbar` row. Write that expectation first (RED), then implement (GREEN). Symbols below are verified present in `+page.svelte`: `handleRemoveFilter` (`:421`), `handleClearAllFilters` (`:867`), `clearSearch` (`:796`), `committedSearchQuery` (`:776`), `getActiveFilterCount` (import `:10`), `handleTimelineGroupingChange` (`:861`), `smartFacetTotal`/`totalAssetCount`.
@@ -511,10 +521,12 @@ git commit -m "feat(web): merge grouping + filters into one toolbar on spaces pa
 ### Task 5: Migrate the photos route
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte` (grouping at ~540–546, filters at ~548–560)
 - Test: `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts` (grouping testid assertions at ~816–880; `active-filters-bar-stub` at ~632–692)
 
 **Interfaces:**
+
 - Consumes: `FilterToolbar`. Add its import.
 - Note: `photos-page.spec.ts` mocks `ActiveFiltersBar` as `active-filters-bar-stub` and asserts grouping presence via `timeline-desktop-grouping-control`. Both selectors survive: the stub is still rendered (now inside the toolbar snippet, gated by `showFilters`), and `FilterToolbar` keeps the grouping testid on its desktop wrapper.
 
@@ -599,10 +611,12 @@ git commit -m "feat(web): merge grouping + filters into one toolbar on photos pa
 ### Task 6: Migrate the albums route (browse merges; picker stays standalone)
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte` (grouping at ~510–516; picker bar at ~519–531; browse bar at ~532–549)
 - Test: `web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `FilterToolbar`. Add its import.
 - The grouping control only renders in browse-timeline mode (`isBrowseTimeline && !selectionActive`). The **picker** bar (`viewMode === AlbumPageViewMode.SELECT_ASSETS`) has no grouping → keep it as a standalone `ActiveFiltersBar` (it already gets the restyle). Only the **browse** bar merges.
 
@@ -709,9 +723,10 @@ git commit -m "feat(web): merge grouping + filters toolbar on albums browse view
 
 ### Task 7: Map — restore a readable backdrop for the floating bar
 
-The map main page floats `ActiveFiltersBar` over the map (`absolute inset-x-0 top-0 z-10`) and has **no grouping control** there, so it stays a standalone bar (not merged). The restyle made the bar transparent; over map tiles it is now unreadable. Give its wrapper a backdrop. (The map's *panel* grouping+temporal bar is already merged via Task 3's `MapTimelinePanel` → `TimelineRouteGroupingBar`.)
+The map main page floats `ActiveFiltersBar` over the map (`absolute inset-x-0 top-0 z-10`) and has **no grouping control** there, so it stays a standalone bar (not merged). The restyle made the bar transparent; over map tiles it is now unreadable. Give its wrapper a backdrop. (The map's _panel_ grouping+temporal bar is already merged via Task 3's `MapTimelinePanel` → `TimelineRouteGroupingBar`.)
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte` (~282–298)
 - Test: `web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts`
 
@@ -784,6 +799,7 @@ git commit -m "chore(web): lint + format pass for merged filter toolbar"
 ## Self-Review
 
 **Spec coverage:**
+
 - Merge grouping + filters into one row → Tasks 2 (primitive), 3–6 (consumers). ✓
 - "Everywhere" scope → Task 3 covers the ~9 `TimelineRouteGroupingBar` routes; Tasks 4–6 cover the 3 hand-composed routes; Task 7 covers the map. ✓
 - Count leads chips, Clear all far right → delivered by the already-applied `ActiveFiltersBar` restyle + embedded `flex-1` (clear-all `ml-auto`). ✓

--- a/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
@@ -1,7 +1,7 @@
 # Filter Panel Redesign — Motion & Polish
 
 **Date:** 2026-06-17
-**Status:** Design approved, pending spec review
+**Status:** Design approved, open questions resolved — ready for implementation planning
 **Scope:** Fork-only feature (`web/src/lib/components/filter-panel/`)
 **Interactive prototype:** `design-exploration/filter-panel-redesign.html` (open in a browser)
 
@@ -110,11 +110,11 @@ This is mostly a CSS/animation change, so be deliberate about the boundary betwe
 - **Rail width change (32px → 56px).** Purely internal to the component's collapsed footprint; hosts are unaffected, but visually confirm in each host during implementation.
 - **Section surface restyle** touches the most-rendered component path; keep diffs tight and rely on existing testids to catch regressions.
 
-## Open questions (for sign-off before planning)
+## Resolved decisions (sign-off complete)
 
-1. **Rail width** — bump the collapsed rail from `w-8` (32px) to `w-14` (56px) for roomier icons (matches the prototype), or keep 32px? Default in this spec: 56px.
-2. **Section dividers** — fully drop the hard full-width `border-b` ladder in favour of soft `bg-subtle` surfaces + spacing (default), or retain a faint hairline between sections? Default: drop them, surfaces only.
-3. **Prototype file** — keep `design-exploration/filter-panel-redesign.html` in the branch as a design record, or delete before merge? Default: decide at finish time.
+1. **Rail width** — ✅ bump the collapsed rail from `w-8` (32px) to `w-14` (56px). Roomier icons + tap target, matches the prototype, still reclaims nearly all the panel width.
+2. **Section dividers** — ✅ drop the hard full-width `border-b` ladder entirely; use soft `bg-subtle` surface on the active section + spacing. (The ruled ladder is the biggest source of the "stiff" feel.)
+3. **Prototype file** — ✅ keep `design-exploration/filter-panel-redesign.html` in the branch as a design record.
 
 ## Prototype artifact
 

--- a/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
@@ -1,0 +1,108 @@
+# Filter Panel Redesign — Motion & Polish
+
+**Date:** 2026-06-17
+**Status:** Design approved, pending spec review
+**Scope:** Fork-only feature (`web/src/lib/components/filter-panel/`)
+**Interactive prototype:** `design-exploration/filter-panel-redesign.html` (open in a browser)
+
+## Problem
+
+The filter panel works but feels stiff:
+
+- **Collapsing is a hard swap.** `filter-panel.svelte` flips between an 8px icon strip and a 256px panel via `{#if collapsed}` with no transition — it snaps.
+- **Section expand/collapse is instant.** `filter-section.svelte` shows/hides body content via `{#if expanded}` with zero height animation; only the chevron rotates. This is inconsistent with the rest of the app — `setting-accordion.svelte` already uses `transition:slide`.
+- **It looks flat and rigid.** Every section is separated by a hard full-width `border-b border-gray-200 dark:border-gray-700`, producing a ladder of rules. The year grid is a dense set of bordered boxes. The section toggle row is a row of square buttons.
+
+The panel is a **shared component** rendered in 5+ hosts (photos, map, spaces, smart-search results, timeline grouping bar), so changes land everywhere. It is fork-only code, so there is no upstream-rebase conflict risk.
+
+## Goals
+
+1. Smooth, **settle-feeling** collapse/expand of the whole panel.
+2. Smooth height-slide for individual section expand/collapse, consistent with the app's existing `transition:slide` convention.
+3. Light visual polish: hairline dividers, soft tonal surfaces for the active section, a year grid that breathes, softened toggle pills.
+4. Honor `prefers-reduced-motion`.
+5. **No behavior changes, no feature changes**, and minimal test churn.
+
+## Non-Goals (YAGNI)
+
+- No restructuring to a chip/popover filter paradigm (explicitly rejected during brainstorming).
+- No changes to filter data flow, providers, suggestion re-fetch logic, section visibility/persistence, or favorites/albums logic.
+- No new filters, no font change (the prototype's Hanken Grotesk is mockup-only; production keeps Gallery's app font).
+- The "slide-off drawer" collapse style (Option B in the prototype) is **not** being built.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Scope | Motion + light polish | Lowest risk; keep today's structure and behavior. |
+| Collapse style | **Option A — width-eased rail** | Keeps the always-visible icon rail (filters one click away); minimal behavior change; preserves the E2E tests that click rail icons. |
+| Visual polish | Approved | Surfaces over hard rules, hairline dividers, breathing year grid, settle easing. |
+| Test impact | Preserve mutual-exclusivity semantics | The collapse implementation keeps the `{#if}` content swap so existing unit/E2E presence assertions stay valid. |
+
+## Motion language
+
+Shared tokens, defined once and reused so the feel is consistent.
+
+- **Easing:** decelerating "settle" curve `cubic-bezier(0.22, 1, 0.36, 1)`. For Svelte JS transitions (`slide`), use the closest stock curve `expoOut` from `svelte/easing`.
+- **Durations:** panel width `380ms`; section slide `240ms`; hover/micro `150ms`.
+- **Reduced motion** uses two mechanisms, both already available in the codebase:
+  - **CSS transitions** (panel width, hovers, year chips) → Tailwind `motion-reduce:transition-none` variant (used elsewhere, e.g. `global-search.svelte`, `crop-area.svelte`).
+  - **Svelte `slide` transition** (section body) → set `duration` to `0` when `mediaQueryManager.reducedMotion` is true (the existing reactive store in `stores/media-query-manager.svelte.ts`).
+
+A small new module `web/src/lib/components/filter-panel/motion.ts` exports the easing/duration constants and a `slideMotion(reducedMotion: boolean)` helper returning `{ duration, easing }`. Keeps values in one place; used by `filter-section.svelte` and `filter-panel.svelte`.
+
+## Architecture & component changes
+
+### 1. Panel collapse — width-eased rail (`filter-panel.svelte`)
+
+**Approach:** introduce a **persistent outer shell** whose width animates, and keep the existing `{#if collapsed}` content swap *inside* it.
+
+- The shell is always rendered (when not `hidden`): `overflow-hidden`, `transition-[width] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`, with width driven by a class — full (`w-[268px]`) vs rail (`w-[56px]`, up from today's 32px for breathing room).
+- Inside the shell, the current `{#if collapsed}` branches are preserved: the collapsed branch keeps `data-testid="collapsed-icon-strip"` (with `expand-panel-btn` and the per-section rail icons + active dot), and the expanded branch keeps `data-testid="discovery-panel"`.
+- Because content swaps via `{#if}` and the shell clips with `overflow-hidden`, expanding produces a **clip-reveal** (the full content is revealed left-to-right as the shell widens) and collapsing narrows the panel down to the rail. The width animates smoothly; only one content branch is ever in the DOM.
+
+**Why not a both-mounted cross-fade:** keeping both the rail and full content mounted simultaneously (to cross-fade) would require rewriting ~10 unit assertions that encode "collapsed ⟺ `discovery-panel` absent" and risks Playwright visibility flakiness. Option A was chosen specifically for low churn, so we keep the single-branch swap. (If a cross-fade is wanted later, it is a follow-up with explicit test updates — out of scope here.)
+
+**Rail/toggle-row polish:** rounded-`[10px]` toggle pills (active = `bg-primary/10 text-primary`, already present), add `active:scale-90 transition-transform motion-reduce:transition-none` for a tactile press, keep the animated "has active filter" dot and all `section-toggle-*` testids.
+
+### 2. Section expand/collapse — height slide (`filter-section.svelte`)
+
+- Keep `{#if expanded && !isEmpty}` for the body, but wrap the reveal with `transition:slide={slideMotion(mediaQueryManager.reducedMotion)}` (import `slide` from `svelte/transition`, `expoOut` from `svelte/easing`, `mediaQueryManager` from `stores/media-query-manager.svelte`, and the helper from `motion.ts`). `mediaQueryManager.reducedMotion` is a Svelte 5 reactive getter, accessed directly (no `$` store prefix). This matches `setting-accordion.svelte`.
+- Replace the wrapper's hard `border-b border-gray-200 dark:border-gray-700` with **surfaces over rules**: each section becomes a `rounded-xl mx-1.5` block; the expanded/active section gets a soft `bg-subtle` tonal background; spacing (not full-width borders) separates sections. A hairline divider may remain only where needed (`border-white/5` / `border-gray-200/60`).
+- Keep the chevron rotate (already `transition-transform`); add `motion-reduce:transition-none`.
+- Keep `data-testid="filter-section-{testId}"` and the empty `(0)` behavior.
+
+### 3. Year/month grid polish (`temporal-picker.svelte`)
+
+- Year grid: switch from the 4-column `flex flex-wrap basis-[calc(25%-5px)]` to a clean `grid grid-cols-3 gap-1.5` (3 columns, matching the screenshot and prototype), chips `rounded-xl`, refined hover (`hover:-translate-y-0.5 motion-reduce:hover:translate-y-0`), keep the selected primary fill, keep tabular-figure counts.
+- Volume bars keep the existing `transition-[width]`; add a one-time load grow (keyframe `scaleX(0)→1`, `motion-reduce` safe).
+- Month grid: apply the same chip styling for consistency.
+- Date-range inputs: already rounded with a focus ring — keep; only align spacing/tokens.
+- Preserve all testids: `temporal-picker`, `year-grid`, `year-btn-{year}`, `month-grid`, `month-btn-{month}`, `custom-date-from-input`, etc.
+
+## Theming
+
+Stay entirely within the existing `@immich/ui` / Tailwind theme tokens already used in these files (`bg-light`, `bg-subtle`, `text-primary`, `immich-primary` / `immich-dark-primary`, gray scale). Hairlines are expressed as low-opacity variants of the existing border grays. No new color system. Works in both light and dark themes (verified visually in the prototype).
+
+## Testing
+
+**Must stay green (unchanged):**
+
+- `filter-panel.spec.ts` collapse/expand presence assertions — preserved by keeping the `{#if}` content swap.
+- E2E `photos-filter-panel`, `map-filter-panel`, `spaces-filter-panel` specs — testids and element visibility preserved; Playwright auto-waiting absorbs the transition.
+
+**New / updated:**
+
+- Unit: assert the shell carries the width-transition + `motion-reduce:transition-none` classes, and that toggling `collapsed` flips the width class (pattern mirrors `global-search.spec.ts`, which asserts `motion-reduce:` class presence).
+- Section slide: verify `filter-sections.spec.ts` still passes; if any assertion checks section-body **absence immediately after collapse**, wrap it in `waitFor`/`tick` because `transition:slide` makes removal async. (Touch-point to confirm during implementation — expected to be small.)
+- Manual: open `design-exploration/filter-panel-redesign.html`, exercise both themes and the reduced-motion toggle. In the running app, verify with OS "Reduce motion" on.
+
+## Risks
+
+- **Async outro vs. synchronous test assertions.** Adding `transition:slide` to section bodies can make happy-dom-based tests see a lingering node on collapse. Mitigation: the `reducedMotion`-aware duration and `waitFor` in the few affected tests.
+- **Rail width change (32px → 56px).** Purely internal to the component's collapsed footprint; hosts are unaffected, but visually confirm in each host during implementation.
+- **Section surface restyle** touches the most-rendered component path; keep diffs tight and rely on existing testids to catch regressions.
+
+## Out-of-repo artifact
+
+The prototype `design-exploration/filter-panel-redesign.html` is a throwaway design reference. Decide at finish time whether to keep it in the branch (as a design record under `design-exploration/`) or delete it before merge — it is not wired into any build.

--- a/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
@@ -32,12 +32,12 @@ The panel is a **shared component** rendered in 5+ hosts (photos, map, spaces, s
 
 ## Decisions (locked during brainstorming)
 
-| Decision | Choice | Why |
-| --- | --- | --- |
-| Scope | Motion + light polish | Lowest risk; keep today's structure and behavior. |
-| Collapse style | **Option A — width-eased rail** | Keeps the always-visible icon rail (filters one click away); minimal behavior change; preserves the E2E tests that click rail icons. |
-| Visual polish | Approved | Surfaces over hard rules, hairline dividers, breathing year grid, settle easing. |
-| Test impact | Preserve mutual-exclusivity semantics | The collapse implementation keeps the `{#if}` content swap so existing unit/E2E presence assertions stay valid. |
+| Decision       | Choice                                | Why                                                                                                                                  |
+| -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Scope          | Motion + light polish                 | Lowest risk; keep today's structure and behavior.                                                                                    |
+| Collapse style | **Option A — width-eased rail**       | Keeps the always-visible icon rail (filters one click away); minimal behavior change; preserves the E2E tests that click rail icons. |
+| Visual polish  | Approved                              | Surfaces over hard rules, hairline dividers, breathing year grid, settle easing.                                                     |
+| Test impact    | Preserve mutual-exclusivity semantics | The collapse implementation keeps the `{#if}` content swap so existing unit/E2E presence assertions stay valid.                      |
 
 ## Motion language
 
@@ -55,7 +55,7 @@ A small new module `web/src/lib/components/filter-panel/motion.ts` exports the e
 
 ### 1. Panel collapse — width-eased rail (`filter-panel.svelte`)
 
-**Approach:** introduce a **persistent outer shell** whose width animates, and keep the existing `{#if collapsed}` content swap *inside* it.
+**Approach:** introduce a **persistent outer shell** whose width animates, and keep the existing `{#if collapsed}` content swap _inside_ it.
 
 - The shell is always rendered (when not `hidden`): `overflow-hidden`, `transition-[width] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`, with width driven by a class — expanded `w-64` (256px, **unchanged from today**) vs rail `w-14` (56px, up from today's `w-8`/32px for breathing room — see open question below).
 - Inside the shell, the current `{#if collapsed}` branches are preserved: the collapsed branch keeps `data-testid="collapsed-icon-strip"` (with `expand-panel-btn` and the per-section rail icons + active dot), and the expanded branch keeps `data-testid="discovery-panel"`.
@@ -102,7 +102,7 @@ This is mostly a CSS/animation change, so be deliberate about the boundary betwe
 - `filter-panel.spec.ts` collapse/expand presence assertions (preserved by keeping the `{#if}` swap).
 - E2E `photos-filter-panel`, `map-filter-panel`, `spaces-filter-panel` specs — testids and element visibility preserved; Playwright auto-waiting absorbs the transition.
 
-**Known async touch-point:** `transition:slide` makes the section body's *removal* async. `filter-sections.spec.ts` exercises the row components (e.g. `PeopleFilter`), not `FilterSection` expand/collapse, so it is unaffected. Any assertion elsewhere that checks section-body **absence immediately after collapse** must move to `waitFor`/`tick`; identify these during the red phase (expected to be few or none).
+**Known async touch-point:** `transition:slide` makes the section body's _removal_ async. `filter-sections.spec.ts` exercises the row components (e.g. `PeopleFilter`), not `FilterSection` expand/collapse, so it is unaffected. Any assertion elsewhere that checks section-body **absence immediately after collapse** must move to `waitFor`/`tick`; identify these during the red phase (expected to be few or none).
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-17-filter-panel-redesign-design.md
@@ -43,11 +43,11 @@ The panel is a **shared component** rendered in 5+ hosts (photos, map, spaces, s
 
 Shared tokens, defined once and reused so the feel is consistent.
 
-- **Easing:** decelerating "settle" curve `cubic-bezier(0.22, 1, 0.36, 1)`. For Svelte JS transitions (`slide`), use the closest stock curve `expoOut` from `svelte/easing`.
+- **Easing:** decelerating "settle" curve `cubic-bezier(0.22, 1, 0.36, 1)` for CSS transitions. For Svelte JS transitions (`slide`), use `quintOut` from `svelte/easing` — it is the closest stock match to that curve and is already the convention in this codebase (`people-merge-selector.svelte`, `setting-input-field.svelte`).
 - **Durations:** panel width `380ms`; section slide `240ms`; hover/micro `150ms`.
 - **Reduced motion** uses two mechanisms, both already available in the codebase:
   - **CSS transitions** (panel width, hovers, year chips) → Tailwind `motion-reduce:transition-none` variant (used elsewhere, e.g. `global-search.svelte`, `crop-area.svelte`).
-  - **Svelte `slide` transition** (section body) → set `duration` to `0` when `mediaQueryManager.reducedMotion` is true (the existing reactive store in `stores/media-query-manager.svelte.ts`).
+  - **Svelte `slide` transition** (section body) → set `duration` to `0` when `mediaQueryManager.reducedMotion` is true (the existing reactive getter in `stores/media-query-manager.svelte.ts`).
 
 A small new module `web/src/lib/components/filter-panel/motion.ts` exports the easing/duration constants and a `slideMotion(reducedMotion: boolean)` helper returning `{ duration, easing }`. Keeps values in one place; used by `filter-section.svelte` and `filter-panel.svelte`.
 
@@ -57,9 +57,9 @@ A small new module `web/src/lib/components/filter-panel/motion.ts` exports the e
 
 **Approach:** introduce a **persistent outer shell** whose width animates, and keep the existing `{#if collapsed}` content swap *inside* it.
 
-- The shell is always rendered (when not `hidden`): `overflow-hidden`, `transition-[width] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`, with width driven by a class — full (`w-[268px]`) vs rail (`w-[56px]`, up from today's 32px for breathing room).
+- The shell is always rendered (when not `hidden`): `overflow-hidden`, `transition-[width] duration-[380ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`, with width driven by a class — expanded `w-64` (256px, **unchanged from today**) vs rail `w-14` (56px, up from today's `w-8`/32px for breathing room — see open question below).
 - Inside the shell, the current `{#if collapsed}` branches are preserved: the collapsed branch keeps `data-testid="collapsed-icon-strip"` (with `expand-panel-btn` and the per-section rail icons + active dot), and the expanded branch keeps `data-testid="discovery-panel"`.
-- Because content swaps via `{#if}` and the shell clips with `overflow-hidden`, expanding produces a **clip-reveal** (the full content is revealed left-to-right as the shell widens) and collapsing narrows the panel down to the rail. The width animates smoothly; only one content branch is ever in the DOM.
+- The inner `discovery-panel` already carries a fixed `w-64`; because the shell width animates while the inner content stays a fixed `w-64` under `overflow-hidden`, **expanding** produces a **clip-reveal** (the full content is revealed left-to-right as the shell widens, with no text reflow). **Collapsing** unmounts `discovery-panel`, mounts the rail, and the shell narrows down to it. Only one content branch is ever in the DOM, so the existing presence-based unit/E2E assertions stay valid. The shell + inner expanded width must remain equal (`w-64`).
 
 **Why not a both-mounted cross-fade:** keeping both the rail and full content mounted simultaneously (to cross-fade) would require rewriting ~10 unit assertions that encode "collapsed ⟺ `discovery-panel` absent" and risks Playwright visibility flakiness. Option A was chosen specifically for low churn, so we keep the single-branch swap. (If a cross-fade is wanted later, it is a follow-up with explicit test updates — out of scope here.)
 
@@ -67,7 +67,7 @@ A small new module `web/src/lib/components/filter-panel/motion.ts` exports the e
 
 ### 2. Section expand/collapse — height slide (`filter-section.svelte`)
 
-- Keep `{#if expanded && !isEmpty}` for the body, but wrap the reveal with `transition:slide={slideMotion(mediaQueryManager.reducedMotion)}` (import `slide` from `svelte/transition`, `expoOut` from `svelte/easing`, `mediaQueryManager` from `stores/media-query-manager.svelte`, and the helper from `motion.ts`). `mediaQueryManager.reducedMotion` is a Svelte 5 reactive getter, accessed directly (no `$` store prefix). This matches `setting-accordion.svelte`.
+- Keep `{#if expanded && !isEmpty}` for the body, but wrap the reveal with `transition:slide={slideMotion(mediaQueryManager.reducedMotion)}` (import `slide` from `svelte/transition`, `quintOut` from `svelte/easing`, `mediaQueryManager` from `stores/media-query-manager.svelte`, and the helper from `motion.ts`). `mediaQueryManager.reducedMotion` is a Svelte 5 reactive getter, accessed directly (no `$` store prefix). This matches `setting-accordion.svelte`.
 - Replace the wrapper's hard `border-b border-gray-200 dark:border-gray-700` with **surfaces over rules**: each section becomes a `rounded-xl mx-1.5` block; the expanded/active section gets a soft `bg-subtle` tonal background; spacing (not full-width borders) separates sections. A hairline divider may remain only where needed (`border-white/5` / `border-gray-200/60`).
 - Keep the chevron rotate (already `transition-transform`); add `motion-reduce:transition-none`.
 - Keep `data-testid="filter-section-{testId}"` and the empty `(0)` behavior.
@@ -84,18 +84,25 @@ A small new module `web/src/lib/components/filter-panel/motion.ts` exports the e
 
 Stay entirely within the existing `@immich/ui` / Tailwind theme tokens already used in these files (`bg-light`, `bg-subtle`, `text-primary`, `immich-primary` / `immich-dark-primary`, gray scale). Hairlines are expressed as low-opacity variants of the existing border grays. No new color system. Works in both light and dark themes (verified visually in the prototype).
 
-## Testing
+## Testing & TDD approach
 
-**Must stay green (unchanged):**
+This is mostly a CSS/animation change, so be deliberate about the boundary between what is test-drivable and what is not. The implementation plan follows **TDD (red → green → refactor)** for every behavioral/structural item below: write or extend the failing assertion first, watch it fail, then implement to green. Aesthetic feel is verified separately — do not fake-test it.
 
-- `filter-panel.spec.ts` collapse/expand presence assertions — preserved by keeping the `{#if}` content swap.
+**Test-drive these (write the test first):**
+
+1. **`motion.ts` pure helper** — `motion.spec.ts` is the cleanest TDD unit and should be written first: `slideMotion(true)` returns `{ duration: 0 }`; `slideMotion(false)` returns `{ duration: 240, easing: quintOut }` (the section-slide duration from the Motion language section). This isolates the reduced-motion branch (the trickiest correctness bit) into a pure function.
+2. **Reduced-motion gating in the DOM** — extend `filter-panel.spec.ts` to assert the width-animating shell carries `motion-reduce:transition-none`, mirroring the existing pattern in `global-search.spec.ts` (which asserts `motion-reduce:` class presence on an element). For the section body, drive it through `motion.ts` (item 1) rather than asserting the JS transition directly.
+3. **Panel shell width toggle** — assert the persistent shell exposes the width-transition class and that toggling `collapsed` flips the expanded (`w-64`) ↔ rail (`w-14`) width class, **without** changing which content testid is present. The existing mutual-exclusivity assertions (`collapsed-icon-strip` ⟺ `discovery-panel`) are the regression guard for this — they must stay green and must not be weakened.
+4. **Year grid structure** — assert the year container renders a 3-column grid (`grid-cols-3`) and that all `year-btn-{year}` testids and the selected-state class are preserved. Extend `temporal-picker`'s spec first.
+
+**Cannot be meaningfully unit-tested — verify by other means (and say so honestly):** the easing/settle feel, hairline-vs-ruled surfaces, the clip-reveal smoothness, hover lifts. Verify via (a) the committed prototype, (b) manual exercise under `make dev` across the photos / map / spaces hosts, and (c) the OS "Reduce motion" setting toggled on. None of these get a green checkmark in CI; they are listed as a manual verification checklist in the plan.
+
+**Regression — must stay green, untouched:**
+
+- `filter-panel.spec.ts` collapse/expand presence assertions (preserved by keeping the `{#if}` swap).
 - E2E `photos-filter-panel`, `map-filter-panel`, `spaces-filter-panel` specs — testids and element visibility preserved; Playwright auto-waiting absorbs the transition.
 
-**New / updated:**
-
-- Unit: assert the shell carries the width-transition + `motion-reduce:transition-none` classes, and that toggling `collapsed` flips the width class (pattern mirrors `global-search.spec.ts`, which asserts `motion-reduce:` class presence).
-- Section slide: verify `filter-sections.spec.ts` still passes; if any assertion checks section-body **absence immediately after collapse**, wrap it in `waitFor`/`tick` because `transition:slide` makes removal async. (Touch-point to confirm during implementation — expected to be small.)
-- Manual: open `design-exploration/filter-panel-redesign.html`, exercise both themes and the reduced-motion toggle. In the running app, verify with OS "Reduce motion" on.
+**Known async touch-point:** `transition:slide` makes the section body's *removal* async. `filter-sections.spec.ts` exercises the row components (e.g. `PeopleFilter`), not `FilterSection` expand/collapse, so it is unaffected. Any assertion elsewhere that checks section-body **absence immediately after collapse** must move to `waitFor`/`tick`; identify these during the red phase (expected to be few or none).
 
 ## Risks
 
@@ -103,6 +110,12 @@ Stay entirely within the existing `@immich/ui` / Tailwind theme tokens already u
 - **Rail width change (32px → 56px).** Purely internal to the component's collapsed footprint; hosts are unaffected, but visually confirm in each host during implementation.
 - **Section surface restyle** touches the most-rendered component path; keep diffs tight and rely on existing testids to catch regressions.
 
-## Out-of-repo artifact
+## Open questions (for sign-off before planning)
 
-The prototype `design-exploration/filter-panel-redesign.html` is a throwaway design reference. Decide at finish time whether to keep it in the branch (as a design record under `design-exploration/`) or delete it before merge — it is not wired into any build.
+1. **Rail width** — bump the collapsed rail from `w-8` (32px) to `w-14` (56px) for roomier icons (matches the prototype), or keep 32px? Default in this spec: 56px.
+2. **Section dividers** — fully drop the hard full-width `border-b` ladder in favour of soft `bg-subtle` surfaces + spacing (default), or retain a faint hairline between sections? Default: drop them, surfaces only.
+3. **Prototype file** — keep `design-exploration/filter-panel-redesign.html` in the branch as a design record, or delete before merge? Default: decide at finish time.
+
+## Prototype artifact
+
+`design-exploration/filter-panel-redesign.html` is a self-contained design reference committed to this branch. It is not wired into any build and is not shipped. Whether it stays as a design record or is removed before merge is Open Question #3.

--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -943,7 +943,7 @@ test.describe('Spaces FilterPanel', () => {
       await page.locator('[data-testid="rating-star-3"]').click();
 
       const chip = page.locator('[data-testid="active-chip"]');
-      await expect(chip.first()).toContainText('\u2605 3+');
+      await expect(chip.first()).toContainText('3+');
     });
 
     test('should clear rating filter when removing rating chip', async ({ context, page }) => {
@@ -1197,7 +1197,7 @@ test.describe('Spaces FilterPanel', () => {
 
       await page.locator('[data-testid="rating-star-3"]').click();
       const chip = page.locator('[data-testid="active-chip"]');
-      await expect(chip.first()).toContainText('\u2605 3+');
+      await expect(chip.first()).toContainText('3+');
     });
 
     test('should show "Photos only" chip when applying media type filter', async ({ context, page }) => {

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -629,5 +629,6 @@ describe('ActiveFiltersBar', () => {
     });
     expect(standaloneResult.getByTestId('active-filters-bar').className).toContain('border-b');
     expect(standaloneResult.getByTestId('active-filters-bar').className).toContain('px-4');
+    cleanup();
   });
 });

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/svelte';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
 import ActiveFiltersBar from '../active-filters-bar.svelte';
 import { createFilterState } from '../filter-panel';
@@ -609,5 +609,25 @@ describe('ActiveFiltersBar', () => {
     await fireEvent.click(getByTestId('clear-all-btn'));
     expect(onClearAll).toHaveBeenCalled();
     expect(onClearSearch).not.toHaveBeenCalled();
+  });
+
+  it('omits its own band and padding in embedded mode', () => {
+    const filters = createFilterState();
+    filters.country = 'Germany';
+
+    // embedded: no self-drawn seam/padding (the host toolbar supplies them)
+    const embeddedResult = render(ActiveFiltersBar, {
+      props: { filters, onRemoveFilter: () => {}, onClearAll: () => {}, embedded: true },
+    });
+    expect(embeddedResult.getByTestId('active-filters-bar').className).not.toContain('border-b');
+    expect(embeddedResult.getByTestId('active-filters-bar').className).not.toContain('px-4');
+    cleanup();
+
+    // standalone (default): keeps the seam + padding
+    const standaloneResult = render(ActiveFiltersBar, {
+      props: { filters, onRemoveFilter: () => {}, onClearAll: () => {}, embedded: false },
+    });
+    expect(standaloneResult.getByTestId('active-filters-bar').className).toContain('border-b');
+    expect(standaloneResult.getByTestId('active-filters-bar').className).toContain('px-4');
   });
 });

--- a/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/active-filters-bar.spec.ts
@@ -82,7 +82,7 @@ describe('ActiveFiltersBar', () => {
     expect(chips[0].textContent).not.toContain(',');
   });
 
-  it('should render chip for rating as "\u2605 3+"', () => {
+  it('should render chip for rating as "3+" (star shown as a leading icon)', () => {
     const filters = createFilterState();
     filters.rating = 3;
 
@@ -96,7 +96,7 @@ describe('ActiveFiltersBar', () => {
 
     const chips = getAllByTestId('active-chip');
     expect(chips).toHaveLength(1);
-    expect(chips[0].textContent).toContain('\u2605 3+');
+    expect(chips[0].textContent).toContain('3+');
   });
 
   it('should render chip for media type as "Photos only"', () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -16,12 +16,12 @@ describe('FilterPanel', () => {
     localStorage.clear();
   });
 
-  it('renders an expanded section on a soft surface without a hard divider', () => {
+  it('renders an expanded section with no surface fill or hard divider', () => {
     const { getByTestId } = render(FilterPanel, {
       props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
     });
     const section = getByTestId('filter-section-timeline');
-    expect(section.className).toContain('bg-subtle');
+    expect(section.className).not.toContain('bg-subtle');
     expect(section.className).not.toContain('border-b');
   });
 

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -16,6 +16,15 @@ describe('FilterPanel', () => {
     localStorage.clear();
   });
 
+  it('renders an expanded section on a soft surface without a hard divider', () => {
+    const { getByTestId } = render(FilterPanel, {
+      props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
+    });
+    const section = getByTestId('filter-section-timeline');
+    expect(section.className).toContain('bg-subtle');
+    expect(section.className).not.toContain('border-b');
+  });
+
   it('should render configured sections only', () => {
     const { queryByTestId } = render(FilterPanel, {
       props: {

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -285,6 +285,29 @@ describe('FilterPanel', () => {
     });
   });
 
+  it('animates the panel width via a persistent shell with a reduced-motion guard', async () => {
+    const { getByTestId } = render(FilterPanel, {
+      props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
+    });
+    const shell = getByTestId('filter-panel-shell');
+    expect(shell.className).toContain('transition-[width]');
+    expect(shell.className).toContain('motion-reduce:transition-none');
+    expect(shell.className).toContain('w-64');
+
+    await fireEvent.click(getByTestId('collapse-panel-btn'));
+    expect(shell.className).toContain('w-14');
+    expect(shell.className).not.toContain('w-64');
+  });
+
+  it('gives the toggle-row pills a press-scale and a reduced-motion guard', () => {
+    const { getByTestId } = render(FilterPanel, {
+      props: { config: { sections: ['timeline'], providers: {} }, timeBuckets: [] },
+    });
+    const toggle = getByTestId('section-toggle-timeline');
+    expect(toggle.className).toContain('active:scale-90');
+    expect(toggle.className).toContain('motion-reduce:transition-none');
+  });
+
   describe('emptyText prop', () => {
     it('should show generic empty text for people section when no people', async () => {
       render(FilterPanel, {

--- a/web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
+import FilterToolbar from '../filter-toolbar.svelte';
+
+beforeAll(async () => {
+  register('en-US', () => import('$i18n/en.json'));
+  await init({ fallbackLocale: 'en-US' });
+  await waitLocale('en-US');
+});
+
+const filtersSnippet = createRawSnippet(() => ({
+  render: () => `<div data-testid="bar-content">chips</div>`,
+}));
+
+describe('FilterToolbar', () => {
+  it('renders the grouping control (desktop wrapper) and no filters by default', () => {
+    const { getByTestId, queryByTestId } = render(FilterToolbar, {
+      props: { grouping: 'day', onGroupingChange: () => {} },
+    });
+    expect(getByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+    expect(getByTestId('timeline-grouping-control')).toBeInTheDocument();
+    expect(queryByTestId('filter-toolbar-separator')).toBeNull();
+  });
+
+  it('renders the filters snippet and separator when showFilters is set', () => {
+    const { getByTestId } = render(FilterToolbar, {
+      props: {
+        grouping: 'day',
+        onGroupingChange: () => {},
+        showGrouping: true,
+        showFilters: true,
+        filters: filtersSnippet,
+      },
+    });
+    expect(getByTestId('bar-content')).toBeInTheDocument();
+    expect(getByTestId('filter-toolbar-separator')).toBeInTheDocument();
+  });
+
+  it('omits the grouping wrapper (and separator) when showGrouping is false', () => {
+    const { queryByTestId, getByTestId } = render(FilterToolbar, {
+      props: {
+        grouping: 'day',
+        onGroupingChange: () => {},
+        showGrouping: false,
+        showFilters: true,
+        filters: filtersSnippet,
+      },
+    });
+    expect(queryByTestId('timeline-desktop-grouping-control')).toBeNull();
+    expect(queryByTestId('filter-toolbar-separator')).toBeNull();
+    expect(getByTestId('bar-content')).toBeInTheDocument();
+  });
+
+  it('renders nothing when neither grouping nor filters are shown', () => {
+    const { container } = render(FilterToolbar, {
+      props: { grouping: 'day', onGroupingChange: () => {}, showGrouping: false, showFilters: false },
+    });
+    expect(container.querySelector('[data-testid="timeline-grouping-control"]')).toBeNull();
+  });
+
+  // --- responsive contract (the riskiest part of the merge) ---
+
+  it('is visible on mobile (flex, never hidden) when filters are shown', () => {
+    const { getByTestId } = render(FilterToolbar, {
+      props: {
+        grouping: 'day',
+        onGroupingChange: () => {},
+        showGrouping: true,
+        showFilters: true,
+        filters: filtersSnippet,
+      },
+    });
+    // the grouping wrapper's parent IS the toolbar root
+    const root = getByTestId('timeline-desktop-grouping-control').parentElement!;
+    expect(root.className).toContain('flex');
+    expect(root.className).not.toMatch(/(^|\s)hidden(\s|$)/);
+  });
+
+  it('is desktop-only (hidden md:flex) when only grouping is shown', () => {
+    const { getByTestId } = render(FilterToolbar, {
+      props: { grouping: 'day', onGroupingChange: () => {}, showGrouping: true, showFilters: false },
+    });
+    const root = getByTestId('timeline-desktop-grouping-control').parentElement!;
+    expect(root.className).toContain('hidden');
+    expect(root.className).toContain('md:flex');
+  });
+});

--- a/web/src/lib/components/filter-panel/__tests__/motion.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/motion.spec.ts
@@ -1,0 +1,23 @@
+import { quintOut } from 'svelte/easing';
+import { describe, expect, it } from 'vitest';
+import { PANEL_DURATION_MS, SECTION_DURATION_MS, SETTLE_EASE, slideMotion } from '../motion';
+
+describe('motion tokens', () => {
+  it('exposes the agreed durations and settle easing', () => {
+    expect(PANEL_DURATION_MS).toBe(420);
+    expect(SECTION_DURATION_MS).toBe(300);
+    expect(SETTLE_EASE).toBe('cubic-bezier(0.22, 1, 0.36, 1)');
+  });
+});
+
+describe('slideMotion', () => {
+  it('returns an instant (zero-duration) config when reduced motion is requested', () => {
+    expect(slideMotion(true)).toEqual({ duration: 0 });
+  });
+
+  it('returns the section duration and quintOut easing when motion is allowed', () => {
+    const motion = slideMotion(false);
+    expect(motion.duration).toBe(SECTION_DURATION_MS);
+    expect(motion.easing).toBe(quintOut);
+  });
+});

--- a/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/temporal-picker.spec.ts
@@ -400,4 +400,20 @@ describe('TemporalPicker component', () => {
     const breadcrumb = getByTestId('temporal-breadcrumb-month');
     expect(breadcrumb.textContent).toContain('Jun');
   });
+
+  it('lays out the year grid in three columns with year buttons as direct grid children', () => {
+    const { getByTestId } = render(TemporalPicker, { props: { timeBuckets: buckets } });
+    const grid = getByTestId('year-grid');
+    expect(grid.className).toContain('grid-cols-3');
+    // The old flex-wrap `basis-[...]` classes are gone; buttons are direct grid items.
+    expect(grid.querySelectorAll(':scope > [data-testid^="year-btn-"]').length).toBe(2);
+  });
+
+  it('guards the year and month chips against reduced motion', () => {
+    const yearView = render(TemporalPicker, { props: { timeBuckets: buckets } });
+    expect(yearView.getByTestId('year-btn-2022').className).toContain('motion-reduce:transition-none');
+
+    const monthView = render(TemporalPicker, { props: { timeBuckets: buckets, selectedYear: 2023 } });
+    expect(monthView.getByTestId('month-btn-6').className).toContain('motion-reduce:transition-none');
+  });
 });

--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -35,6 +35,7 @@
     onClearAll: () => void;
     searchQuery?: string;
     onClearSearch?: () => void;
+    embedded?: boolean;
   }
 
   let {
@@ -46,6 +47,7 @@
     onClearAll,
     searchQuery = '',
     onClearSearch,
+    embedded = false,
   }: Props = $props();
 
   interface Chip {
@@ -149,7 +151,9 @@
 </script>
 
 <div
-  class="flex flex-wrap items-center gap-2 border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10"
+  class="flex flex-wrap items-center gap-2 {embedded
+    ? ''
+    : 'border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10'}"
   data-testid="active-filters-bar"
 >
   {#if resultCount !== undefined}

--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -1,4 +1,20 @@
 <script lang="ts">
+  import { Icon } from '@immich/ui';
+  import {
+    mdiAccount,
+    mdiCalendar,
+    mdiCalendarRange,
+    mdiCamera,
+    mdiClose,
+    mdiHeart,
+    mdiImage,
+    mdiImageAlbum,
+    mdiMagnify,
+    mdiMapMarker,
+    mdiStar,
+    mdiTag,
+    mdiVideo,
+  } from '@mdi/js';
   import { t, type Translations } from 'svelte-i18n';
   import type { FilterState } from './filter-panel';
 
@@ -35,6 +51,7 @@
   interface Chip {
     type: string;
     id?: string;
+    icon: string;
     label?: string;
     labelKey?: Translations;
     labelValues?: Record<string, string>;
@@ -65,95 +82,101 @@
     // Person chips (one per selected person)
     for (const personId of filters.personIds) {
       const name = personNames?.get(personId) ?? personId;
-      result.push({ type: 'person', id: personId, label: name });
+      result.push({ type: 'person', id: personId, icon: mdiAccount, label: name });
     }
 
     // Location chip
     if (filters.city && filters.country) {
-      result.push({ type: 'location', label: `${filters.city}, ${filters.country}` });
+      result.push({ type: 'location', icon: mdiMapMarker, label: `${filters.city}, ${filters.country}` });
     } else if (filters.city) {
-      result.push({ type: 'location', label: filters.city });
+      result.push({ type: 'location', icon: mdiMapMarker, label: filters.city });
     } else if (filters.country) {
-      result.push({ type: 'location', label: filters.country });
+      result.push({ type: 'location', icon: mdiMapMarker, label: filters.country });
     }
 
     // Camera chip
     if (filters.make && filters.model) {
-      result.push({ type: 'camera', label: `${filters.make} ${filters.model}` });
+      result.push({ type: 'camera', icon: mdiCamera, label: `${filters.make} ${filters.model}` });
     } else if (filters.make) {
-      result.push({ type: 'camera', label: filters.make });
+      result.push({ type: 'camera', icon: mdiCamera, label: filters.make });
     }
 
     // Tag chips (one per selected tag)
     for (const tagId of filters.tagIds) {
       const name = tagNames?.get(tagId) ?? tagId;
-      result.push({ type: 'tag', id: tagId, label: name });
+      result.push({ type: 'tag', id: tagId, icon: mdiTag, label: name });
     }
 
     // Rating chip
     if (filters.rating !== undefined) {
-      result.push({ type: 'rating', label: `\u2605 ${filters.rating}+` });
+      result.push({ type: 'rating', icon: mdiStar, label: `${filters.rating}+` });
     }
 
     // Media type chip
     if (filters.mediaType === 'image') {
-      result.push({ type: 'mediaType', labelKey: 'photos_only' });
+      result.push({ type: 'mediaType', icon: mdiImage, labelKey: 'photos_only' });
     } else if (filters.mediaType === 'video') {
-      result.push({ type: 'mediaType', labelKey: 'videos_only' });
+      result.push({ type: 'mediaType', icon: mdiVideo, labelKey: 'videos_only' });
     }
 
     // Favorites chip
     if (filters.isFavorite === true) {
-      result.push({ type: 'favorites', labelKey: 'favorites' });
+      result.push({ type: 'favorites', icon: mdiHeart, labelKey: 'favorites' });
     }
 
     // Albums chip
     if (filters.isNotInAlbum === true) {
-      result.push({ type: 'albums', labelKey: 'filter_has_no_album' });
+      result.push({ type: 'albums', icon: mdiImageAlbum, labelKey: 'filter_has_no_album' });
     }
 
     // Timeline chip
     const customDateLabel = buildCustomDateLabel(filters.dateAfter, filters.dateBefore);
     if (customDateLabel) {
-      result.push({ type: 'timeline', ...customDateLabel });
+      result.push({ type: 'timeline', icon: mdiCalendarRange, ...customDateLabel });
     } else if (filters.selectedYear !== undefined) {
       const label =
         filters.selectedMonth === undefined
           ? `${filters.selectedYear}`
           : `${MONTH_LABELS[filters.selectedMonth - 1]} ${filters.selectedYear}`;
-      result.push({ type: 'timeline', label });
+      result.push({ type: 'timeline', icon: mdiCalendar, label });
     }
 
     return result;
   });
 
   let hasActiveFilters = $derived(chips.length > 0 || searchQuery.trim().length > 0);
+  let showCountSeparator = $derived(resultCount !== undefined && (chips.length > 0 || searchQuery.trim().length > 0));
 </script>
 
 <div
-  class="flex flex-wrap items-center gap-1.5 border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-900"
+  class="flex flex-wrap items-center gap-2 border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10"
   data-testid="active-filters-bar"
 >
   {#if resultCount !== undefined}
-    <span class="text-xs text-gray-400 dark:text-gray-500" data-testid="result-count">
+    <span class="text-xs font-medium text-gray-500 dark:text-gray-400" data-testid="result-count">
       {$t('filter_result_count', { values: { count: resultCount } })}
     </span>
   {/if}
 
+  {#if showCountSeparator}
+    <span class="h-1 w-1 rounded-full bg-gray-400/60 dark:bg-gray-500/60" aria-hidden="true"></span>
+  {/if}
+
   {#if searchQuery.trim()}
     <span
-      class="inline-flex items-center gap-1 rounded-full bg-immich-primary/10 px-2.5 py-0.5 text-xs text-immich-primary dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary"
+      class="inline-flex items-center gap-1.5 rounded-full border border-immich-primary/30 bg-immich-primary/10 py-1 pl-2.5 pr-1 text-xs font-medium text-immich-primary dark:border-immich-dark-primary/30 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary"
       data-testid="search-chip"
     >
+      <Icon icon={mdiMagnify} size="14" />
       <span>{searchQuery}</span>
       <button
         type="button"
-        class="flex h-4 w-4 items-center justify-center rounded-full text-immich-primary/60 hover:text-immich-primary dark:text-immich-dark-primary/60 dark:hover:text-immich-dark-primary"
+        class="flex h-[18px] w-[18px] items-center justify-center rounded-full text-immich-primary/60 transition-colors hover:bg-immich-primary/15 hover:text-immich-primary dark:text-immich-dark-primary/60 dark:hover:bg-immich-dark-primary/20 dark:hover:text-immich-dark-primary"
         onclick={() => onClearSearch?.()}
         aria-label={$t('filter_sheet_picker_clear_search')}
         data-testid="search-chip-close"
       >
-        &times;
+        <Icon icon={mdiClose} size="12" />
       </button>
     </span>
   {/if}
@@ -161,18 +184,19 @@
   {#each chips as chip (`${chip.type}-${chip.id ?? chip.labelKey ?? chip.label}`)}
     {@const chipLabel = chip.labelKey ? $t(chip.labelKey, { values: chip.labelValues }) : (chip.label ?? '')}
     <span
-      class="inline-flex items-center gap-1 rounded-full bg-gray-200 px-2.5 py-0.5 text-xs dark:bg-gray-700"
+      class="inline-flex items-center gap-1.5 rounded-full border border-gray-200/70 bg-gray-100 py-1 pl-2.5 pr-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:border-white/10 dark:bg-white/[0.06] dark:text-gray-200 dark:hover:bg-white/10"
       data-testid="active-chip"
     >
+      <Icon icon={chip.icon} size="14" class="text-gray-500 dark:text-gray-400" />
       <span>{chipLabel}</span>
       <button
         type="button"
-        class="flex h-4 w-4 items-center justify-center rounded-full text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+        class="flex h-[18px] w-[18px] items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-300/70 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-white/10 dark:hover:text-gray-200"
         onclick={() => onRemoveFilter(chip.type, chip.id)}
         aria-label={$t('filter_remove_chip', { values: { label: chipLabel } })}
         data-testid="chip-close"
       >
-        &times;
+        <Icon icon={mdiClose} size="12" />
       </button>
     </span>
   {/each}
@@ -180,7 +204,7 @@
   {#if hasActiveFilters}
     <button
       type="button"
-      class="ml-auto text-xs font-semibold text-immich-primary dark:text-immich-dark-primary"
+      class="ml-auto rounded-full px-2.5 py-1 text-xs font-semibold text-immich-primary transition-colors hover:bg-immich-primary/10 dark:text-immich-dark-primary dark:hover:bg-immich-dark-primary/10"
       onclick={() => {
         onClearAll();
         if (searchQuery) {

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -659,7 +659,7 @@
   <!-- FilterPanel hidden: no assets to filter -->
 {:else}
   <div
-    class="flex h-full flex-shrink-0 overflow-hidden border-r border-gray-200 bg-light transition-[width] duration-[420ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:border-gray-700 {collapsed
+    class="flex h-full flex-shrink-0 overflow-hidden border-r border-gray-200/60 bg-light transition-[width] duration-[420ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:border-white/5 {collapsed
       ? 'w-14'
       : 'w-64'}"
     data-testid="filter-panel-shell"

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -657,11 +657,18 @@
 
 {#if hidden}
   <!-- FilterPanel hidden: no assets to filter -->
-{:else if collapsed}
+{:else}
   <div
-    class="flex h-full w-8 flex-shrink-0 flex-col items-center gap-3 border-r border-gray-200 bg-light py-2 dark:border-gray-700"
-    data-testid="collapsed-icon-strip"
+    class="flex h-full flex-shrink-0 overflow-hidden border-r border-gray-200 bg-light transition-[width] duration-[420ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:border-gray-700 {collapsed
+      ? 'w-14'
+      : 'w-64'}"
+    data-testid="filter-panel-shell"
   >
+    {#if collapsed}
+      <div
+        class="flex h-full w-full flex-shrink-0 flex-col items-center gap-3 py-2"
+        data-testid="collapsed-icon-strip"
+      >
     <button
       type="button"
       class="flex h-6 w-6 items-center justify-center rounded-full text-gray-500 hover:bg-subtle dark:text-gray-400"
@@ -685,11 +692,11 @@
       </button>
     {/each}
   </div>
-{:else}
-  <div
-    class="immich-scrollbar flex w-64 flex-col overflow-y-auto border-r border-gray-200 bg-light dark:border-gray-700"
-    data-testid="discovery-panel"
-  >
+    {:else}
+      <div
+        class="immich-scrollbar flex h-full w-64 flex-col overflow-y-auto bg-light"
+        data-testid="discovery-panel"
+      >
     <div
       class="sticky top-0 z-5 flex items-center justify-between border-b border-gray-200 bg-light px-4 py-2.5 dark:border-gray-700"
     >
@@ -712,7 +719,7 @@
         {#each config.sections as section (section)}
           <button
             type="button"
-            class="relative flex h-[30px] w-[30px] items-center justify-center rounded-lg transition-colors
+            class="relative flex h-[30px] w-[30px] items-center justify-center rounded-[10px] transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-90 motion-reduce:transition-none motion-reduce:active:scale-100
               {visibleSections.has(section)
               ? 'bg-primary/10 text-primary'
               : 'text-gray-400 hover:bg-subtle hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400'}"
@@ -850,5 +857,7 @@
         </div>
       {/if}
     </div>
+      </div>
+    {/if}
   </div>
 {/if}

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -665,198 +665,196 @@
     data-testid="filter-panel-shell"
   >
     {#if collapsed}
-      <div
-        class="flex h-full w-full flex-shrink-0 flex-col items-center gap-3 py-2"
-        data-testid="collapsed-icon-strip"
-      >
-    <button
-      type="button"
-      class="flex h-6 w-6 items-center justify-center rounded-full text-gray-500 hover:bg-subtle dark:text-gray-400"
-      onclick={() => (collapsed = false)}
-      data-testid="expand-panel-btn"
-    >
-      <Icon icon={mdiChevronRight} size="16" />
-    </button>
-    {#each config.sections as section (section)}
-      <button
-        type="button"
-        class="relative flex h-6 w-6 items-center justify-center rounded-md text-gray-500 hover:bg-subtle dark:text-gray-400"
-        onclick={() => (collapsed = false)}
-      >
-        <Icon icon={sectionIcons[section]} size="16" />
-        {#if hasActiveFilter(section)}
-          <span
-            class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border-[1.5px] border-light bg-immich-primary dark:bg-immich-dark-primary"
-          ></span>
-        {/if}
-      </button>
-    {/each}
-  </div>
-    {:else}
-      <div
-        class="immich-scrollbar flex h-full w-64 flex-col overflow-y-auto bg-light"
-        data-testid="discovery-panel"
-      >
-    <div
-      class="sticky top-0 z-5 flex items-center justify-between border-b border-gray-200 bg-light px-4 py-2.5 dark:border-gray-700"
-    >
-      <span class="text-sm font-medium">{$t('filters')}</span>
-      <button
-        type="button"
-        class="flex h-6 w-6 items-center justify-center rounded-full text-gray-500 hover:bg-subtle dark:text-gray-400"
-        onclick={() => (collapsed = true)}
-        data-testid="collapse-panel-btn"
-      >
-        <Icon icon={mdiChevronLeft} size="14" />
-      </button>
-    </div>
-
-    {#if config.sections.length > 0}
-      <div
-        class="flex items-center justify-center gap-0.5 border-b border-gray-200 px-3 py-2 dark:border-gray-700"
-        data-testid="section-toggle-row"
-      >
+      <div class="flex h-full w-full flex-shrink-0 flex-col items-center gap-3 py-2" data-testid="collapsed-icon-strip">
+        <button
+          type="button"
+          class="flex h-6 w-6 items-center justify-center rounded-full text-gray-500 hover:bg-subtle dark:text-gray-400"
+          onclick={() => (collapsed = false)}
+          data-testid="expand-panel-btn"
+        >
+          <Icon icon={mdiChevronRight} size="16" />
+        </button>
         {#each config.sections as section (section)}
           <button
             type="button"
-            class="relative flex h-[30px] w-[30px] items-center justify-center rounded-[10px] transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-90 motion-reduce:transition-none motion-reduce:active:scale-100
-              {visibleSections.has(section)
-              ? 'bg-primary/10 text-primary'
-              : 'text-gray-400 hover:bg-subtle hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400'}"
-            onclick={() => toggleSection(section)}
-            aria-label={sectionToggleLabels[section]}
-            aria-pressed={visibleSections.has(section)}
-            title={sectionTitles[section]}
-            data-testid="section-toggle-{section}"
+            class="relative flex h-6 w-6 items-center justify-center rounded-md text-gray-500 hover:bg-subtle dark:text-gray-400"
+            onclick={() => (collapsed = false)}
           >
             <Icon icon={sectionIcons[section]} size="16" />
-            {#if !visibleSections.has(section) && hasActiveFilter(section)}
+            {#if hasActiveFilter(section)}
               <span
                 class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border-[1.5px] border-light bg-immich-primary dark:bg-immich-dark-primary"
-                data-testid="section-toggle-dot-{section}"
               ></span>
             {/if}
           </button>
         {/each}
       </div>
-    {/if}
-
-    <div class="pt-4">
-      {#each config.sections as section (section)}
-        {#if visibleSections.has(section)}
-          <FilterSection
-            title={sectionTitles[section]}
-            testId={section}
-            refetching={isRefetching && section !== 'timeline'}
-            expanded={expandedSections.has(section)}
-            onToggleExpanded={() => toggleSectionExpanded(section)}
-            count={filterContext
-              ? section === 'people'
-                ? people.length
-                : section === 'location'
-                  ? countries.length
-                  : section === 'camera'
-                    ? cameraMakes.length
-                    : section === 'tags'
-                      ? tags.length
-                      : undefined
-              : undefined}
-          >
-            {#if section === 'timeline'}
-              <TemporalPicker
-                {timeBuckets}
-                dateAfter={filters.dateAfter}
-                dateBefore={filters.dateBefore}
-                selectedYear={filters.selectedYear}
-                selectedMonth={filters.selectedMonth}
-                onCustomRangeChange={handleCustomDateRangeChange}
-                onYearSelect={handleYearSelect}
-                onMonthSelect={handleMonthSelect}
-              />
-            {:else if section === 'people'}
-              <PeopleFilter
-                {people}
-                selectedIds={filters.personIds}
-                selectedNames={personNames}
-                onSelectionChange={handlePeopleChange}
-                emptyText={hasUnnamedPeople ? $t('filter_name_people_hint') : undefined}
-              />
-            {:else if section === 'location'}
-              <LocationFilter
-                {countries}
-                selectedCity={filters.city}
-                selectedCountry={filters.country}
-                context={locationFilterContext}
-                onCityFetch={async (country, ctx) => {
-                  if (providers.cities) {
-                    return providers.cities(country, ctx);
-                  }
-                  return [];
-                }}
-                onSelectionChange={handleLocationChange}
-              />
-            {:else if section === 'camera'}
-              <CameraFilter
-                makes={cameraMakes}
-                selectedMake={filters.make}
-                selectedModel={filters.model}
-                context={cameraFilterContext}
-                onModelFetch={async (make, ctx) => {
-                  if (providers.cameraModels) {
-                    return providers.cameraModels(make, ctx);
-                  }
-                  return [];
-                }}
-                onSelectionChange={handleCameraChange}
-              />
-            {:else if section === 'tags'}
-              <TagsFilter
-                {tags}
-                selectedIds={filters.tagIds}
-                selectedNames={tagNames}
-                onSelectionChange={handleTagsChange}
-              />
-            {:else if section === 'rating'}
-              <RatingFilter selectedRating={filters.rating} {availableRatings} onRatingChange={handleRatingChange} />
-            {:else if section === 'media'}
-              <MediaTypeFilter
-                selected={filters.mediaType}
-                {availableMediaTypes}
-                onTypeChange={handleMediaTypeChange}
-              />
-            {:else if section === 'favorites'}
-              <FavoritesFilter
-                selected={filters.isFavorite}
-                onToggle={(value) => {
-                  updateFilters({ ...filters, isFavorite: value });
-                }}
-              />
-            {:else if section === 'albums'}
-              <AlbumsFilter
-                selected={filters.isNotInAlbum}
-                onToggle={(value) => {
-                  updateFilters({ ...filters, isNotInAlbum: value });
-                }}
-              />
-            {/if}
-          </FilterSection>
-        {/if}
-      {/each}
-
-      {#if visibleSections.size === 0}
-        <div class="flex flex-col items-center gap-2 px-4 py-8 text-center">
-          <p class="text-xs text-gray-500 dark:text-gray-400">{$t('filter_show_sections_hint')}</p>
+    {:else}
+      <div class="immich-scrollbar flex h-full w-64 flex-col overflow-y-auto bg-light" data-testid="discovery-panel">
+        <div
+          class="sticky top-0 z-5 flex items-center justify-between border-b border-gray-200 bg-light px-4 py-2.5 dark:border-gray-700"
+        >
+          <span class="text-sm font-medium">{$t('filters')}</span>
           <button
             type="button"
-            class="text-xs font-medium text-primary hover:underline"
-            onclick={showAllSections}
-            data-testid="show-all-sections"
+            class="flex h-6 w-6 items-center justify-center rounded-full text-gray-500 hover:bg-subtle dark:text-gray-400"
+            onclick={() => (collapsed = true)}
+            data-testid="collapse-panel-btn"
           >
-            {$t('filter_show_all_sections')}
+            <Icon icon={mdiChevronLeft} size="14" />
           </button>
         </div>
-      {/if}
-    </div>
+
+        {#if config.sections.length > 0}
+          <div
+            class="flex items-center justify-center gap-0.5 border-b border-gray-200 px-3 py-2 dark:border-gray-700"
+            data-testid="section-toggle-row"
+          >
+            {#each config.sections as section (section)}
+              <button
+                type="button"
+                class="relative flex h-[30px] w-[30px] items-center justify-center rounded-[10px] transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] active:scale-90 motion-reduce:transition-none motion-reduce:active:scale-100
+              {visibleSections.has(section)
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-gray-400 hover:bg-subtle hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400'}"
+                onclick={() => toggleSection(section)}
+                aria-label={sectionToggleLabels[section]}
+                aria-pressed={visibleSections.has(section)}
+                title={sectionTitles[section]}
+                data-testid="section-toggle-{section}"
+              >
+                <Icon icon={sectionIcons[section]} size="16" />
+                {#if !visibleSections.has(section) && hasActiveFilter(section)}
+                  <span
+                    class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border-[1.5px] border-light bg-immich-primary dark:bg-immich-dark-primary"
+                    data-testid="section-toggle-dot-{section}"
+                  ></span>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {/if}
+
+        <div class="pt-4">
+          {#each config.sections as section (section)}
+            {#if visibleSections.has(section)}
+              <FilterSection
+                title={sectionTitles[section]}
+                testId={section}
+                refetching={isRefetching && section !== 'timeline'}
+                expanded={expandedSections.has(section)}
+                onToggleExpanded={() => toggleSectionExpanded(section)}
+                count={filterContext
+                  ? section === 'people'
+                    ? people.length
+                    : section === 'location'
+                      ? countries.length
+                      : section === 'camera'
+                        ? cameraMakes.length
+                        : section === 'tags'
+                          ? tags.length
+                          : undefined
+                  : undefined}
+              >
+                {#if section === 'timeline'}
+                  <TemporalPicker
+                    {timeBuckets}
+                    dateAfter={filters.dateAfter}
+                    dateBefore={filters.dateBefore}
+                    selectedYear={filters.selectedYear}
+                    selectedMonth={filters.selectedMonth}
+                    onCustomRangeChange={handleCustomDateRangeChange}
+                    onYearSelect={handleYearSelect}
+                    onMonthSelect={handleMonthSelect}
+                  />
+                {:else if section === 'people'}
+                  <PeopleFilter
+                    {people}
+                    selectedIds={filters.personIds}
+                    selectedNames={personNames}
+                    onSelectionChange={handlePeopleChange}
+                    emptyText={hasUnnamedPeople ? $t('filter_name_people_hint') : undefined}
+                  />
+                {:else if section === 'location'}
+                  <LocationFilter
+                    {countries}
+                    selectedCity={filters.city}
+                    selectedCountry={filters.country}
+                    context={locationFilterContext}
+                    onCityFetch={async (country, ctx) => {
+                      if (providers.cities) {
+                        return providers.cities(country, ctx);
+                      }
+                      return [];
+                    }}
+                    onSelectionChange={handleLocationChange}
+                  />
+                {:else if section === 'camera'}
+                  <CameraFilter
+                    makes={cameraMakes}
+                    selectedMake={filters.make}
+                    selectedModel={filters.model}
+                    context={cameraFilterContext}
+                    onModelFetch={async (make, ctx) => {
+                      if (providers.cameraModels) {
+                        return providers.cameraModels(make, ctx);
+                      }
+                      return [];
+                    }}
+                    onSelectionChange={handleCameraChange}
+                  />
+                {:else if section === 'tags'}
+                  <TagsFilter
+                    {tags}
+                    selectedIds={filters.tagIds}
+                    selectedNames={tagNames}
+                    onSelectionChange={handleTagsChange}
+                  />
+                {:else if section === 'rating'}
+                  <RatingFilter
+                    selectedRating={filters.rating}
+                    {availableRatings}
+                    onRatingChange={handleRatingChange}
+                  />
+                {:else if section === 'media'}
+                  <MediaTypeFilter
+                    selected={filters.mediaType}
+                    {availableMediaTypes}
+                    onTypeChange={handleMediaTypeChange}
+                  />
+                {:else if section === 'favorites'}
+                  <FavoritesFilter
+                    selected={filters.isFavorite}
+                    onToggle={(value) => {
+                      updateFilters({ ...filters, isFavorite: value });
+                    }}
+                  />
+                {:else if section === 'albums'}
+                  <AlbumsFilter
+                    selected={filters.isNotInAlbum}
+                    onToggle={(value) => {
+                      updateFilters({ ...filters, isNotInAlbum: value });
+                    }}
+                  />
+                {/if}
+              </FilterSection>
+            {/if}
+          {/each}
+
+          {#if visibleSections.size === 0}
+            <div class="flex flex-col items-center gap-2 px-4 py-8 text-center">
+              <p class="text-xs text-gray-500 dark:text-gray-400">{$t('filter_show_sections_hint')}</p>
+              <button
+                type="button"
+                class="text-xs font-medium text-primary hover:underline"
+                onclick={showAllSections}
+                data-testid="show-all-sections"
+              >
+                {$t('filter_show_all_sections')}
+              </button>
+            </div>
+          {/if}
+        </div>
       </div>
     {/if}
   </div>

--- a/web/src/lib/components/filter-panel/filter-section.svelte
+++ b/web/src/lib/components/filter-panel/filter-section.svelte
@@ -22,17 +22,12 @@
   let isOpen = $derived(expanded && !isEmpty);
 </script>
 
-<div
-  class="mx-1.5 mb-0.5 rounded-xl transition-colors duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none {isOpen
-    ? 'bg-subtle'
-    : ''}"
-  data-testid="filter-section-{testId}"
->
+<div class="mx-1.5 mb-0.5" data-testid="filter-section-{testId}">
   <button
     type="button"
-    class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-start {isEmpty
+    class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-start hover:bg-subtle {isEmpty
       ? 'opacity-50'
-      : ''} {isOpen ? '' : 'hover:bg-subtle'}"
+      : ''}"
     onclick={() => {
       if (!isEmpty && onToggleExpanded) {
         onToggleExpanded();

--- a/web/src/lib/components/filter-panel/filter-section.svelte
+++ b/web/src/lib/components/filter-panel/filter-section.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
   import { Icon } from '@immich/ui';
   import { mdiChevronDown } from '@mdi/js';
   import type { Snippet } from 'svelte';
+  import { slide } from 'svelte/transition';
+  import { slideMotion } from './motion';
 
   interface Props {
     title: string;
@@ -16,12 +19,20 @@
   let { title, testId, children, refetching = false, count, expanded = true, onToggleExpanded }: Props = $props();
 
   let isEmpty = $derived(count === 0);
+  let isOpen = $derived(expanded && !isEmpty);
 </script>
 
-<div class="border-b border-gray-200 dark:border-gray-700" data-testid="filter-section-{testId}">
+<div
+  class="mx-1.5 mb-0.5 rounded-xl transition-colors duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none {isOpen
+    ? 'bg-subtle'
+    : ''}"
+  data-testid="filter-section-{testId}"
+>
   <button
     type="button"
-    class="flex w-full items-center justify-between px-4 py-3 hover:bg-subtle {isEmpty ? 'opacity-50' : ''}"
+    class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-start {isEmpty ? 'opacity-50' : ''} {isOpen
+      ? ''
+      : 'hover:bg-subtle'}"
     onclick={() => {
       if (!isEmpty && onToggleExpanded) {
         onToggleExpanded();
@@ -36,13 +47,17 @@
       <Icon
         icon={mdiChevronDown}
         size="16"
-        class="text-gray-500 transition-transform dark:text-gray-400 {expanded ? '' : '-rotate-90'}"
+        class="text-gray-500 transition-transform duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none dark:text-gray-400 {expanded
+          ? ''
+          : '-rotate-90'}"
       />
     {/if}
   </button>
-  {#if expanded && !isEmpty}
-    <div class="filter-section-content px-4 pb-4" class:refetching>
-      {@render children()}
+  {#if isOpen}
+    <div transition:slide|local={slideMotion(mediaQueryManager.reducedMotion)}>
+      <div class="filter-section-content px-3 pb-3.5" class:refetching>
+        {@render children()}
+      </div>
     </div>
   {/if}
 </div>

--- a/web/src/lib/components/filter-panel/filter-section.svelte
+++ b/web/src/lib/components/filter-panel/filter-section.svelte
@@ -30,9 +30,9 @@
 >
   <button
     type="button"
-    class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-start {isEmpty ? 'opacity-50' : ''} {isOpen
-      ? ''
-      : 'hover:bg-subtle'}"
+    class="flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-start {isEmpty
+      ? 'opacity-50'
+      : ''} {isOpen ? '' : 'hover:bg-subtle'}"
     onclick={() => {
       if (!isEmpty && onToggleExpanded) {
         onToggleExpanded();

--- a/web/src/lib/components/filter-panel/filter-toolbar.svelte
+++ b/web/src/lib/components/filter-panel/filter-toolbar.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
+  import type { TimelineGrouping } from '$lib/managers/timeline-manager/types';
+  import type { Snippet } from 'svelte';
+  import { twMerge } from 'tailwind-merge';
+
+  interface Props {
+    grouping: TimelineGrouping;
+    onGroupingChange: (grouping: TimelineGrouping) => void;
+    groupingDisabled?: boolean;
+    showGrouping?: boolean;
+    showFilters?: boolean;
+    filters?: Snippet;
+    class?: string;
+  }
+
+  let {
+    grouping,
+    onGroupingChange,
+    groupingDisabled = false,
+    showGrouping = true,
+    showFilters = false,
+    filters,
+    class: className = '',
+  }: Props = $props();
+</script>
+
+{#if showGrouping || showFilters}
+  <!--
+    Root display is responsive-by-intent:
+    - showFilters → `flex` (visible on ALL sizes, so the chip bar still shows on mobile)
+    - grouping-only → `hidden md:flex` (desktop-only, matching today's behavior)
+    `bg-transparent` keeps the toolbar a hairline surface on the content background (never the old gray band).
+    A caller MAY pass `class="hidden md:flex"` to force desktop-only even when showFilters is true
+    (TimelineRouteGroupingBar does this); twMerge lets the later display utility win.
+  -->
+  <div
+    class={twMerge(
+      'shrink-0 items-center gap-3 bg-transparent px-4 py-2 dark:bg-transparent',
+      showFilters ? 'flex' : 'hidden md:flex',
+      className,
+    )}
+  >
+    {#if showGrouping}
+      <div class="hidden md:flex md:items-center" data-testid="timeline-desktop-grouping-control">
+        <TimelineGroupingControl {grouping} {onGroupingChange} disabled={groupingDisabled} />
+      </div>
+    {/if}
+
+    {#if showFilters}
+      {#if showGrouping}
+        <span
+          class="hidden h-5 w-px shrink-0 bg-gray-200/70 md:block dark:bg-white/10"
+          data-testid="filter-toolbar-separator"
+          aria-hidden="true"
+        ></span>
+      {/if}
+      <div class="min-w-0 flex-1">
+        {@render filters?.()}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/components/filter-panel/motion.ts
+++ b/web/src/lib/components/filter-panel/motion.ts
@@ -1,0 +1,25 @@
+import { quintOut } from 'svelte/easing';
+
+/**
+ * Decelerating "settle" curve for CSS transitions (panel width, hovers, chips).
+ * NOTE: in Tailwind classes this must be written spaceless — `ease-[cubic-bezier(0.22,1,0.36,1)]` —
+ * or the class won't compile. This spaced literal is only for JS/inline-style use.
+ */
+export const SETTLE_EASE = 'cubic-bezier(0.22, 1, 0.36, 1)';
+
+/** Shared animation durations (ms) so the panel feels consistent. */
+export const PANEL_DURATION_MS = 420;
+export const SECTION_DURATION_MS = 300;
+
+export interface SlideMotion {
+  duration: number;
+  easing?: (t: number) => number;
+}
+
+/**
+ * Svelte `slide` config for section expand/collapse. Collapses to an instant
+ * (duration 0) when the user prefers reduced motion.
+ */
+export function slideMotion(reducedMotion: boolean): SlideMotion {
+  return reducedMotion ? { duration: 0 } : { duration: SECTION_DURATION_MS, easing: quintOut };
+}

--- a/web/src/lib/components/filter-panel/temporal-picker.svelte
+++ b/web/src/lib/components/filter-panel/temporal-picker.svelte
@@ -196,7 +196,7 @@
         {@const isSelected = selectedMonth === m.month}
         <button
           type="button"
-          class="flex flex-col items-center rounded-lg border px-2 py-2 transition-all duration-100
+          class="flex flex-col items-center rounded-xl border px-2 py-2 transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none
             {isSelected
             ? 'border-immich-primary bg-immich-primary text-white dark:border-immich-dark-primary dark:bg-immich-dark-primary'
             : m.count === 0
@@ -223,23 +223,23 @@
       {/each}
     </div>
   {:else}
-    <!-- Year grid: 4-column flex wrap -->
-    <div class="flex flex-wrap gap-1.5" data-testid="year-grid">
+    <!-- Year grid: 3-column grid -->
+    <div class="grid grid-cols-3 gap-1.5" data-testid="year-grid">
       {#each years as y (y.year)}
         <button
           type="button"
-          class="year-chip flex min-w-[54px] flex-1 basis-[calc(25%-5px)] flex-col items-center rounded-lg border px-2 py-1.5 transition-all duration-100
+          class="year-chip flex flex-col items-center rounded-xl border px-2 py-1.5 transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none
             {y.count === 0
             ? 'cursor-default border-gray-200 opacity-30 dark:border-gray-700'
-            : 'cursor-pointer border-gray-200 hover:border-immich-primary hover:bg-immich-primary/5 dark:border-gray-700 dark:hover:border-immich-dark-primary dark:hover:bg-immich-dark-primary/5'}"
+            : 'cursor-pointer border-gray-200 hover:-translate-y-0.5 hover:border-immich-primary hover:bg-immich-primary/5 motion-reduce:hover:translate-y-0 dark:border-gray-700 dark:hover:border-immich-dark-primary dark:hover:bg-immich-dark-primary/5'}"
           onclick={() => handleYearClick(y.year, y.count)}
           data-testid="year-btn-{y.year}"
         >
-          <span class="text-xs font-semibold leading-tight">{y.year}</span>
-          <span class="text-xs leading-tight text-gray-400 opacity-60 dark:text-gray-500">{y.count}</span>
-          <div class="mt-0.5 h-[2px] w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
+          <span class="text-xs font-semibold leading-tight tabular-nums">{y.year}</span>
+          <span class="text-xs leading-tight tabular-nums text-gray-400 opacity-60 dark:text-gray-500">{y.count}</span>
+          <div class="mt-1 h-[3px] w-full overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
             <div
-              class="h-full rounded-sm bg-immich-primary transition-[width] duration-300 dark:bg-immich-dark-primary"
+              class="year-bar h-full origin-left rounded-sm bg-immich-primary transition-[width] duration-300 dark:bg-immich-dark-primary"
               style="width: {y.volumePercent}%"
             ></div>
           </div>
@@ -248,3 +248,22 @@
     </div>
   {/if}
 </div>
+
+<style>
+  .year-bar {
+    animation: year-bar-grow 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @keyframes year-bar-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .year-bar {
+      animation: none;
+    }
+  }
+</style>

--- a/web/src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts
+++ b/web/src/lib/components/timeline/TimelineRouteGroupingBar.spec.ts
@@ -20,7 +20,7 @@ describe('TimelineRouteGroupingBar', () => {
     expect(screen.getByRole('button', { name: 'timeline_grouping_all' })).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('keeps the route grouping surface transparent instead of drawing a full-width toolbar', () => {
+  it('keeps the toolbar surface transparent (no gray band)', () => {
     render(TimelineRouteGroupingBar, {
       props: {
         grouping: 'year',

--- a/web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte
+++ b/web/src/lib/components/timeline/TimelineRouteGroupingBar.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
+  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
   import { buildFilterContext, createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
   import type { TimelineGrouping } from '$lib/managers/timeline-manager/types';
   import { twMerge } from 'tailwind-merge';
-
-  import TimelineGroupingControl from './TimelineGroupingControl.svelte';
 
   interface Props {
     grouping: TimelineGrouping;
@@ -44,18 +43,20 @@
 </script>
 
 {#if !hidden}
-  <div class={twMerge('hidden flex-col gap-2 bg-transparent px-4 py-2 dark:bg-transparent md:flex', className)}>
-    <div class="flex items-center justify-end" data-testid="timeline-desktop-grouping-control">
-      <TimelineGroupingControl {grouping} {onGroupingChange} />
-    </div>
-
-    {#if hasActiveTemporalFilters}
+  <FilterToolbar
+    {grouping}
+    {onGroupingChange}
+    showFilters={hasActiveTemporalFilters}
+    class={twMerge('hidden md:flex', className)}
+  >
+    {#snippet filters()}
       <ActiveFiltersBar
+        embedded
         filters={temporalFilters}
         {resultCount}
         onRemoveFilter={removeTemporalFilter}
         onClearAll={() => onClearTemporalFilter?.()}
       />
-    {/if}
-  </div>
+    {/snippet}
+  </FilterToolbar>
 {/if}

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -9,6 +9,7 @@
   import ActivityViewer from '$lib/components/asset-viewer/activity-viewer.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
+  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
   import { clearTimelineTemporalFilter } from '$lib/utils/timeline-temporal-filters';
   import {
     clearFilters,
@@ -37,7 +38,6 @@
   import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
-  import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
   import { AlbumPageViewMode } from '$lib/constants';
   import { activityManager } from '$lib/managers/activity-manager.svelte';
   import { assetMultiSelectManager, AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
@@ -507,15 +507,6 @@
         {/if}
 
         <div class="flex flex-1 flex-col overflow-hidden pl-4">
-          {#if isBrowseTimeline && !assetMultiSelectManager.selectionActive}
-            <div
-              class="mb-2 hidden shrink-0 items-center gap-2 bg-transparent px-4 py-2 dark:bg-transparent md:flex"
-              data-testid="timeline-desktop-grouping-control"
-            >
-              <TimelineGroupingControl grouping={timelineGrouping} onGroupingChange={handleTimelineGroupingChange} />
-            </div>
-          {/if}
-
           {#if viewMode === AlbumPageViewMode.SELECT_ASSETS && getActiveFilterCount(pickerFilters) > 0}
             <ActiveFiltersBar
               filters={pickerFilters}
@@ -529,23 +520,34 @@
                 pickerFilters = clearFilters(pickerFilters);
               }}
             />
-          {:else if viewMode !== AlbumPageViewMode.SELECT_ASSETS && getActiveFilterCount(albumFilters) > 0}
-            <ActiveFiltersBar
-              filters={albumFilters}
-              resultCount={totalAssetCount}
-              personNames={albumPersonNames}
-              tagNames={albumTagNames}
-              onRemoveFilter={(type, id) => {
-                if (type === 'timeline') {
-                  clearAlbumTemporalFilter();
-                } else {
-                  albumFilters = handlePhotosRemoveFilter(albumFilters, type, id);
-                }
-              }}
-              onClearAll={() => {
-                albumFilters = clearFilters(albumFilters);
-                temporalAnchor = undefined;
-              }}
+          {:else if viewMode !== AlbumPageViewMode.SELECT_ASSETS}
+            {#snippet albumFiltersBar()}
+              <ActiveFiltersBar
+                embedded
+                filters={albumFilters}
+                resultCount={totalAssetCount}
+                personNames={albumPersonNames}
+                tagNames={albumTagNames}
+                onRemoveFilter={(type, id) => {
+                  if (type === 'timeline') {
+                    clearAlbumTemporalFilter();
+                  } else {
+                    albumFilters = handlePhotosRemoveFilter(albumFilters, type, id);
+                  }
+                }}
+                onClearAll={() => {
+                  albumFilters = clearFilters(albumFilters);
+                  temporalAnchor = undefined;
+                }}
+              />
+            {/snippet}
+            <FilterToolbar
+              class="mb-2"
+              grouping={timelineGrouping}
+              onGroupingChange={handleTimelineGroupingChange}
+              showGrouping={isBrowseTimeline && !assetMultiSelectManager.selectionActive}
+              showFilters={getActiveFilterCount(albumFilters) > 0}
+              filters={albumFiltersBar}
             />
           {/if}
 

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
@@ -400,4 +400,18 @@ describe('album detail filter panel route', () => {
     expect(screen.getByTestId('active-chip')).toHaveTextContent('Second Album Person');
     expect(screen.queryByText('First Album Person')).not.toBeInTheDocument();
   });
+
+  it('merges grouping and the filter bar into one toolbar row in browse mode', async () => {
+    renderPage();
+    const user = userEvent.setup();
+
+    // activate a filter so the bar renders
+    await waitFor(() => expect(screen.getByTestId('people-item-person-view')).toBeInTheDocument());
+    await user.click(screen.getByTestId('people-item-person-view'));
+
+    const grouping = await screen.findByTestId('timeline-desktop-grouping-control');
+    const bar = screen.getByTestId('active-filters-bar');
+    // grouping wrapper and the bar's flex-1 column share the FilterToolbar root
+    expect(grouping.parentElement).toBe(bar.parentElement?.parentElement);
+  });
 });

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -280,7 +280,7 @@
       {/if}
       <div class="relative flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
         {#if hasActiveFilters}
-          <div class="absolute inset-x-0 top-0 z-10">
+          <div class="absolute inset-x-0 top-0 z-10 bg-light/95 backdrop-blur-sm">
             <ActiveFiltersBar
               {filters}
               resultCount={mapMarkers.length}

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -4,6 +4,7 @@
   import ActionMenuItem from '$lib/components/ActionMenuItem.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
+  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
   import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
   import {
     buildFilterContext,
@@ -32,7 +33,6 @@
   import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
-  import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
   import { AssetAction } from '$lib/constants';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
@@ -537,28 +537,27 @@
       />
     {/key}
     <div class="flex flex-1 flex-col overflow-hidden pl-4">
-      {#if !showSearchResults && !assetMultiSelectManager.selectionActive}
-        <div
-          class="mb-2 hidden shrink-0 items-center gap-2 bg-transparent px-4 py-2 dark:bg-transparent md:flex"
-          data-testid="timeline-desktop-grouping-control"
-        >
-          <TimelineGroupingControl grouping={timelineGrouping} onGroupingChange={handleTimelineGroupingChange} />
-        </div>
-      {/if}
-      {#if hasActiveFilters}
-        <div class="mb-4 shrink-0" data-testid="photos-active-filters-bar-spacing">
-          <ActiveFiltersBar
-            {filters}
-            searchQuery={committedQuery}
-            onClearSearch={clearSearch}
-            resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
-            {personNames}
-            {tagNames}
-            onRemoveFilter={handleRemoveActiveFilter}
-            onClearAll={handleClearAllFilters}
-          />
-        </div>
-      {/if}
+      {#snippet photoFiltersBar()}
+        <ActiveFiltersBar
+          embedded
+          {filters}
+          searchQuery={committedQuery}
+          onClearSearch={clearSearch}
+          resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
+          {personNames}
+          {tagNames}
+          onRemoveFilter={handleRemoveActiveFilter}
+          onClearAll={handleClearAllFilters}
+        />
+      {/snippet}
+      <FilterToolbar
+        class="mb-2"
+        grouping={timelineGrouping}
+        onGroupingChange={handleTimelineGroupingChange}
+        showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}
+        showFilters={hasActiveFilters}
+        filters={photoFiltersBar}
+      />
       {#if showSearchResults}
         <SmartSearchResults
           bind:isLoading

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -823,9 +823,20 @@ describe('Photos page search URL state', () => {
     renderPage();
 
     const control = await screen.findByTestId('timeline-desktop-grouping-control');
-    expect(control).toHaveClass('mb-2', 'bg-transparent', 'dark:bg-transparent');
-    expect(control).not.toHaveClass('mb-6');
-    expect(control).not.toHaveClass('bg-gray-50', 'dark:bg-gray-900', 'border-b');
+    const toolbar = control.closest('[class*="bg-transparent"]');
+    expect(toolbar).toHaveClass('mb-2', 'bg-transparent', 'dark:bg-transparent');
+    expect(toolbar).not.toHaveClass('mb-6');
+    expect(toolbar).not.toHaveClass('bg-gray-50', 'dark:bg-gray-900', 'border-b');
+  });
+
+  it('shows grouping and the filter bar in one merged toolbar (no separate spacing wrapper)', async () => {
+    mockPage.url = new URL('https://gallery.test/photos?country=Germany');
+
+    renderPage();
+
+    expect(await screen.findByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+    expect(screen.getByTestId('active-filters-bar-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('photos-active-filters-bar-spacing')).toBeNull();
   });
 
   it('keeps active filters visually separated from grouped timeline cards', async () => {
@@ -833,8 +844,10 @@ describe('Photos page search URL state', () => {
 
     renderPage();
 
-    const activeFiltersArea = await screen.findByTestId('photos-active-filters-bar-spacing');
-    expect(activeFiltersArea).toHaveClass('mb-4', 'shrink-0');
+    const filterBar = await screen.findByTestId('active-filters-bar-stub');
+    const toolbar = filterBar.closest('[class*="shrink-0"]');
+    expect(toolbar).toHaveClass('shrink-0');
+    expect(toolbar).toHaveClass('mb-2');
   });
 
   it('changes photos grouping from the desktop control without changing filters or URL params', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -37,7 +37,6 @@
   import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
-  import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
   import { registerSelectionContext, registerSpaceContext } from '$lib/managers/command-context-manager.svelte';

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
+  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
   import {
     buildFilterContext,
     createFilterState,
@@ -1058,29 +1059,28 @@
 
     <!-- Main Content — pl-4 adds breathing room between filter panel and content -->
     <div class="flex flex-1 flex-col overflow-hidden pl-4">
-      {#if viewMode === 'view' && !showSearchResults && !assetMultiSelectManager.selectionActive}
-        <div
-          class="mb-2 hidden shrink-0 items-center gap-2 bg-transparent px-4 py-2 dark:bg-transparent md:flex"
-          data-testid="timeline-desktop-grouping-control"
-        >
-          <TimelineGroupingControl grouping={timelineGrouping} onGroupingChange={handleTimelineGroupingChange} />
-        </div>
-      {/if}
-
-      <!-- Active filter chips -->
-      {#if viewMode === 'view' && (getActiveFilterCount(filters) > 0 || committedSearchQuery.trim().length > 0)}
-        <div class="mb-4 shrink-0" data-testid="space-active-filters-bar-spacing">
-          <ActiveFiltersBar
-            {filters}
-            resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
-            {personNames}
-            {tagNames}
-            onRemoveFilter={handleRemoveFilter}
-            onClearAll={handleClearAllFilters}
-            searchQuery={committedSearchQuery}
-            onClearSearch={clearSearch}
-          />
-        </div>
+      {#snippet spaceFiltersBar()}
+        <ActiveFiltersBar
+          embedded
+          {filters}
+          resultCount={showSearchResults ? smartFacetTotal : totalAssetCount}
+          {personNames}
+          {tagNames}
+          onRemoveFilter={handleRemoveFilter}
+          onClearAll={handleClearAllFilters}
+          searchQuery={committedSearchQuery}
+          onClearSearch={clearSearch}
+        />
+      {/snippet}
+      {#if viewMode === 'view'}
+        <FilterToolbar
+          class="mb-2"
+          grouping={timelineGrouping}
+          onGroupingChange={handleTimelineGroupingChange}
+          showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}
+          showFilters={getActiveFilterCount(filters) > 0 || committedSearchQuery.trim().length > 0}
+          filters={spaceFiltersBar}
+        />
       {/if}
 
       {#if showSearchResults}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -884,12 +884,13 @@ describe('Spaces page search URL state', () => {
   });
 
   it('keeps active filters visually separated from grouped space timeline cards', async () => {
-    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?country=Germany');
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
 
     renderPage();
 
-    expect(await screen.findByTestId('active-filters-bar-stub')).toBeInTheDocument();
-    expect(screen.queryByTestId('space-active-filters-bar-spacing')).toBeNull();
+    const groupingControl = await screen.findByTestId('timeline-desktop-grouping-control');
+    const toolbarRoot = groupingControl.parentElement!;
+    expect(toolbarRoot).toHaveClass('mb-2');
   });
 
   it('does not show the desktop grouping control during space search results', () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -873,13 +873,23 @@ describe('Spaces page search URL state', () => {
     expect(screen.queryByTestId('timeline-desktop-grouping-control')).not.toBeInTheDocument();
   });
 
+  it('shows grouping and the filters bar in one merged toolbar (no separate spacing wrapper)', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?country=Germany');
+
+    renderPage();
+
+    expect(await screen.findByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+    expect(screen.getByTestId('active-filters-bar-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('space-active-filters-bar-spacing')).toBeNull();
+  });
+
   it('keeps active filters visually separated from grouped space timeline cards', async () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?country=Germany');
 
     renderPage();
 
-    const activeFiltersArea = await screen.findByTestId('space-active-filters-bar-spacing');
-    expect(activeFiltersArea).toHaveClass('mb-4', 'shrink-0');
+    expect(await screen.findByTestId('active-filters-bar-stub')).toBeInTheDocument();
+    expect(screen.queryByTestId('space-active-filters-bar-spacing')).toBeNull();
   });
 
   it('does not show the desktop grouping control during space search results', () => {


### PR DESCRIPTION
## What & why

The filter panel felt stiff — collapsing was an instant hard swap, sections snapped open/closed with no animation, and the hard full-width divider "ladder" plus dense year grid looked rigid. This is a **motion + light-polish** redesign of the shared filter panel (rendered in photos, map, spaces, smart-search, and the timeline grouping bar). **No behavior or feature changes** — same filters, data flow, and persistence.

## Changes

- **Width-eased collapse** — the panel eases its width between the full panel (`w-64`) and the icon rail (`w-14`) via a persistent shell with a decelerating `cubic-bezier(.22,1,.36,1)` settle curve, instead of an instant `{#if}` swap. The always-visible icon rail is kept (filters stay one click away), and only one content branch is ever in the DOM so existing collapse behavior/tests are unchanged.
- **Sliding sections** — section expand/collapse uses `transition:slide|local` (matching the app's `setting-accordion` convention) instead of an instant show/hide.
- **Surfaces over rules** — the hard `border-b` divider ladder is gone; the open/active section sits on a soft `bg-subtle` surface with spacing.
- **Breathing year grid** — the temporal picker's year grid is now a clean 3-column layout with rounded chips, a hover lift, tabular figures, and volume bars that grow on load.
- **Softened toggle pills** — rounded pills with a tinted active state + press-scale.
- **Reduced motion** — every animation is gated: Tailwind `motion-reduce:` for CSS transitions, and a `slideMotion(mediaQueryManager.reducedMotion)` helper for the JS slide. A new shared `motion.ts` holds the easing/duration tokens.

## Testing

- New TDD tests for the motion helper, the collapse shell width-toggle + reduced-motion guards, the soft-surface section, and the 3-column year grid.
- Full web unit suite green (3151 passed); `make check-web` + `make lint-web` clean.
- The arbitrary `ease-[cubic-bezier(0.22,1,0.36,1)]` Tailwind class confirmed compiled into the built CSS.

## Notes

- Design artifacts are included for reference: the spec/plan under `docs/superpowers/` and a standalone, clickable comparison prototype at `design-exploration/filter-panel-redesign.html` (not wired to any build).
- ⚠️ Automated gates are green, but a **manual visual pass** in `make dev` (collapse feel, section slide, year grid, OS reduce-motion) is still recommended before merge.