### PR TITLE
fix(mobile): use globally-monotonic versionCode for store uploads

### DIFF
--- a/.github/workflows/gallery-build-mobile.yml
+++ b/.github/workflows/gallery-build-mobile.yml
@@ -184,13 +184,24 @@ jobs:
         working-directory: ./mobile
         run: |
           version_name=$(awk -F'[ +]' '/^version:/ {print $2}' pubspec.yaml)
-          # Monotonic, trigger-independent version code: commit count on the
-          # current ref, plus an attempt offset so re-runs at the same SHA
-          # don't collide with Play Store / TestFlight versionCodes already
-          # uploaded on a previous attempt. First attempt is unchanged from
-          # the previous behavior; retries get +1, +2, etc.
-          base_count=$(git -C .. rev-list --count HEAD)
-          version_code=$((base_count + GITHUB_RUN_ATTEMPT - 1))
+          # Globally-monotonic versionCode: minutes since the Unix epoch at
+          # build time, plus an attempt offset.
+          #
+          # The previous scheme (`git rev-list --count HEAD`) was branch-relative.
+          # Every branch publishes to the SAME de.opennoodle.gallery Play Store /
+          # TestFlight tracks, but the rolling upstream-rebase branches carry
+          # ~700+ more commits than main. An RC mobile build dispatched from one
+          # of those branches therefore uploaded a HIGHER versionCode than a
+          # later main release could produce, and Play rejected the main rollout
+          # with "does not allow any existing users to upgrade to the newly added
+          # APKs" (existing internal testers were already on the higher RC code).
+          #
+          # Wall-clock minutes are monotonic across every branch and trigger:
+          # whatever is built last always gets the highest code. ~29.7M today —
+          # far above any commit count and far below Android's 2.1e9 ceiling
+          # (good past the year 5000). Minute granularity plus the per-attempt
+          # offset keeps same-run re-runs collision-free.
+          version_code=$(( $(date +%s) / 60 + GITHUB_RUN_ATTEMPT - 1 ))
           echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
           echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
           echo "Building $version_name ($version_code) attempt=$GITHUB_RUN_ATTEMPT"


### PR DESCRIPTION
## Problem

The latest **Release Mobile** run failed at the Play Store upload step ([run 27809765023](https://github.com/open-noodle/gallery/actions/runs/27809765023/job/82297235597)):

> Google Api Error: Invalid request - You cannot rollout this release because it does not allow any existing users to upgrade to the newly added APKs.

The AAB built and signed fine — the failure is the rollout, not the build.

## Root cause

The Android `versionCode` is computed in `gallery-build-mobile.yml` as `git rev-list --count HEAD` — a **branch-relative** commit count. The failed main release computed **10476**.

But every branch publishes to the **same** `de.opennoodle.gallery` Play / TestFlight tracks, and the rolling upstream-rebase branches carry ~700+ more commits than main (`explore/pi-agent-brainstorm-rolling` = 12207, `rebase/upstream-rolling-…active` = 11126). An RC mobile build dispatched from one of those branches uploaded a **higher** versionCode (~11k–12.2k) to the internal track. A later main release at 10476 is now *below* that, so existing internal testers are already on a higher code → nobody can "upgrade" → Google rejects the rollout. Commit count is **not globally monotonic across branches**.

## Fix

Switch `versionCode` to **wall-clock minutes since the Unix epoch** (~29.7M today):

```bash
version_code=$(( $(date +%s) / 60 + GITHUB_RUN_ATTEMPT - 1 ))
```

- Monotonic across **every branch and trigger** — whatever builds last gets the highest code.
- The jump to ~29.7M clears the stuck RC codes, and stays far below Android's 2.1e9 ceiling (~3,900 years headroom).
- Attempt offset retained for same-minute re-run safety.
- **iOS unaffected** — already derives its build number from `latest_testflight_build_number + 1` (store-monotonic).

## Note

One-way ratchet: once main uploads a ~29.7M code, any branch still on the old commit-count scheme (~12k) cannot publish to the internal track until it rebases main / cherry-picks this commit. Rolling branches pick it up on their next rebase.