### PR TITLE
fix(web): reach all assets in "All" timeline on large libraries (#713)

### DIFF
--- a/docs/plans/2026-06-19-timeline-all-view-height-cap-plan.md
+++ b/docs/plans/2026-06-19-timeline-all-view-height-cap-plan.md
@@ -1,0 +1,759 @@
+# Timeline "All" view height-cap fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every asset reachable in the flat "All" timeline on libraries large enough to exceed the browser's maximum element height, without changing behavior for normal-sized libraries.
+
+**Architecture:** Introduce scroll-space scaling in `VirtualScrollManager`: cap the scroll element's DOM height at a browser-safe maximum, and map scroll positions between a true "logical" space and the capped "DOM" space. Content is positioned relative to the live scroll via a `renderOffset` so no coordinate ever exceeds the cap. Scale is exactly `1` below the cap, so the change is inert for normal libraries.
+
+**Tech Stack:** SvelteKit + Svelte 5 runes (`$state`/`$derived`), TypeScript, Vitest + `@testing-library/svelte` (happy-dom).
+
+**Spec:** `docs/plans/2026-06-19-timeline-all-view-height-cap.md` (read it first — this plan implements it verbatim).
+
+## Global Constraints
+
+- **TDD, red→green, every change.** Write the failing test, run it, see it fail for the expected reason, implement the minimum, see it pass, commit. (Spec §6.)
+- **Zero behavior change at `scrollScale == 1`** (all libraries below the cap): `domHeight == totalViewerHeight`, conversions are identity, `renderOffset == 0`. Existing tests must stay green unchanged. (Spec §2, §4.4.)
+- **Cap value:** `MAX_SCROLL_HEIGHT = isFirefox ? 17_000_000 : 33_000_000`, where the Firefox UA check is **inlined** in `VirtualScrollManager.svelte.ts` (NOT imported from `asset-utils`, which would create the circular import `asset-utils → TimelineManager → VirtualScrollManager`). (Spec §3, §8.)
+- **`clamp` is already imported** from `lodash-es` in `timeline-manager.svelte.ts` (line 40) — do not add a new import.
+- **No relative imports** — use the `$lib/` alias. **TypeScript strict.** **ESLint zero-warnings** (full `lint` runs once as the final gate, not per-task).
+- **Run a single spec:** `cd web && pnpm test -- --run <path>`. **Type/Svelte check:** `make check-web`. **Lint:** `make lint-web`.
+- Prettier any touched markdown under `docs/` before committing.
+
+---
+
+## File Structure
+
+| File                                                                            | Responsibility                                                                          | Action |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------ |
+| `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts`      | Generic scaling engine: cap, conversions, logical/DOM scroll position, `renderOffset`   | Modify |
+| `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts` | Unit tests for the scaling engine                                                       | Create |
+| `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts`              | Override `domScrollTop`; convert `scrollTo`/`scrollBy`                                  | Modify |
+| `web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts`         | Scroll-conversion, reachability (symptom #1), anchor (symptom #2), stability            | Modify |
+| `web/src/lib/components/timeline/Timeline.svelte`                               | `domHeight` height; `renderOffset` transforms; route mixers through logical `scrollTop` | Modify |
+| `web/src/lib/components/timeline/Timeline.spec.ts`                              | Component transform/height assertions                                                   | Modify |
+| `web/src/lib/components/timeline/TimelineRepresentativeBuckets.svelte`          | `renderOffset` prop on bucket transform                                                 | Modify |
+| `web/src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts`         | Bucket transform assertion                                                              | Modify |
+
+`timeline-anchor.ts` is **not** modified — its snap-back symptom is fixed entirely by `scrollTo` converting logical→DOM (verified by a test, Task 2).
+
+---
+
+## Task 1: Scaling engine in `VirtualScrollManager`
+
+Adds the cap, conversions, logical scroll position, and `renderOffset`. Fully unit-tested with a minimal test subclass (no DOM, no SvelteKit).
+
+**Files:**
+
+- Modify: `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts`
+- Test: `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts` (create)
+
+**Interfaces:**
+
+- Consumes: existing `totalViewerHeight`, `viewportHeight`, `#scrollTop` (`$state`), `updateViewportProximities()`.
+- Produces (used by Task 2 and Task 3):
+  - `maxScrollHeight: number` (public `$state`, overridable in tests)
+  - `get domHeight(): number`
+  - `get logicalScrollMax(): number`
+  - `get domScrollMax(): number`
+  - `get scrollScale(): number`
+  - `domToLogical(dom: number): number`
+  - `logicalToDom(logical: number): number`
+  - `get domScrollTop(): number` (base returns `0`; subclass overrides)
+  - `get scrollTop(): number` (now **logical**)
+  - `get renderOffset(): number`
+
+- [ ] **Step 1: Write the failing math + scroll-position tests**
+
+Create `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { VirtualScrollManager } from './VirtualScrollManager.svelte';
+
+class TestScroller extends VirtualScrollManager {
+  #dom = 0;
+  override get domScrollTop() {
+    return this.#dom;
+  }
+  setDomScrollTop(value: number) {
+    this.#dom = value;
+  }
+}
+
+function makeScroller({ body, viewport, cap }: { body: number; viewport: number; cap?: number }) {
+  const scroller = new TestScroller();
+  scroller.bodySectionHeight = body;
+  scroller.viewportHeight = viewport;
+  if (cap !== undefined) {
+    scroller.maxScrollHeight = cap;
+  }
+  return scroller;
+}
+
+describe('VirtualScrollManager scaling', () => {
+  it('1. is identity below the cap', () => {
+    const s = makeScroller({ body: 10_000, viewport: 1000, cap: 1_000_000 });
+    expect(s.domHeight).toBe(10_000); // == totalViewerHeight
+    expect(s.scrollScale).toBe(1);
+    expect(s.domToLogical(500)).toBe(500);
+    expect(s.logicalToDom(500)).toBe(500);
+
+    s.setDomScrollTop(500);
+    s.updateSlidingWindow();
+    expect(s.scrollTop).toBe(500); // logical
+    expect(s.renderOffset).toBe(0);
+  });
+
+  it('2. leaves scale at 1 exactly at the cap', () => {
+    const s = makeScroller({ body: 10_000, viewport: 1000, cap: 10_000 });
+    expect(s.domHeight).toBe(10_000);
+    expect(s.scrollScale).toBe(1);
+  });
+
+  it('3. clamps domHeight and scales above the cap', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    expect(s.domHeight).toBe(10_000);
+    expect(s.scrollScale).toBeGreaterThan(0);
+    expect(s.scrollScale).toBeLessThan(1);
+  });
+
+  it('4. maps both endpoints so the tail is reachable', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    expect(s.logicalToDom(0)).toBe(0);
+    expect(s.logicalToDom(s.logicalScrollMax)).toBeCloseTo(s.domScrollMax, 6);
+  });
+
+  it('5. round-trips dom↔logical', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    for (const x of [0, 50_000, s.logicalScrollMax]) {
+      expect(s.domToLogical(s.logicalToDom(x))).toBeCloseTo(x, 6);
+    }
+  });
+
+  it('6. keeps the bottom item bounded within the capped DOM height', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    s.setDomScrollTop(s.domScrollMax);
+    s.updateSlidingWindow();
+    expect(s.scrollTop).toBeCloseTo(s.logicalScrollMax, 6); // 99_000
+    expect(s.renderOffset).toBeCloseTo(-90_000, 6);
+    // an item at logical top == total lands exactly at domHeight, not at 100_000px
+    expect(s.totalViewerHeight + s.renderOffset).toBeCloseTo(s.domHeight, 6);
+  });
+
+  it('7. guards against divide-by-zero when content fits the viewport', () => {
+    const s = makeScroller({ body: 500, viewport: 1000, cap: 10_000 });
+    expect(s.logicalScrollMax).toBe(0);
+    expect(s.domToLogical(123)).toBe(0);
+    expect(s.logicalToDom(123)).toBe(0);
+    expect(s.scrollScale).toBe(1);
+    expect(Number.isFinite(s.domToLogical(123))).toBe(true);
+  });
+
+  it('8. renderOffset reads cached state, updating only after updateSlidingWindow', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    s.setDomScrollTop(s.domScrollMax);
+    expect(s.renderOffset).toBe(0); // cached state not yet refreshed
+    s.updateSlidingWindow();
+    expect(s.renderOffset).toBeCloseTo(-90_000, 6);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts`
+Expected: FAIL — e.g. `s.domHeight` is `undefined` / `s.domToLogical is not a function` / `s.maxScrollHeight` setter has no effect.
+
+- [ ] **Step 3: Implement the scaling engine**
+
+In `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts`:
+
+Add a module const directly below the existing `import { debounce } from 'lodash-es';` line:
+
+```ts
+// Largest element height the browser renders before clamping the scroll container: Firefox ≈ 17.9M,
+// Chrome/Safari ≈ 33.5M. The Firefox check is inlined (not imported from asset-utils's `isFirefox`)
+// to avoid the circular import asset-utils → TimelineManager → VirtualScrollManager.
+const MAX_SCROLL_HEIGHT =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox') ? 17_000_000 : 33_000_000;
+```
+
+Add a public `$state` field and a private cached-DOM `$state` field next to the existing `#scrollTop = $state(0);` declaration:
+
+```ts
+  maxScrollHeight = $state(MAX_SCROLL_HEIGHT);
+  #cachedDomScrollTop = $state(0);
+```
+
+Replace the existing placeholder getter:
+
+```ts
+  get scrollTop() {
+    return 0;
+  }
+```
+
+with the logical accessor plus the DOM accessor and the scaling getters/methods:
+
+```ts
+  get domScrollTop(): number {
+    return 0;
+  }
+
+  get scrollTop(): number {
+    return this.domToLogical(this.domScrollTop);
+  }
+
+  get renderOffset(): number {
+    return this.#cachedDomScrollTop - this.#scrollTop;
+  }
+
+  get domHeight(): number {
+    return Math.min(this.totalViewerHeight, this.maxScrollHeight);
+  }
+
+  get logicalScrollMax(): number {
+    return Math.max(0, this.totalViewerHeight - this.viewportHeight);
+  }
+
+  get domScrollMax(): number {
+    return Math.max(0, this.domHeight - this.viewportHeight);
+  }
+
+  get scrollScale(): number {
+    return this.logicalScrollMax > 0 ? this.domScrollMax / this.logicalScrollMax : 1;
+  }
+
+  domToLogical(dom: number): number {
+    return this.domScrollMax > 0 ? (dom * this.logicalScrollMax) / this.domScrollMax : 0;
+  }
+
+  logicalToDom(logical: number): number {
+    return this.logicalScrollMax > 0 ? (logical * this.domScrollMax) / this.logicalScrollMax : 0;
+  }
+```
+
+Replace the existing `updateSlidingWindow()` body so it caches both the logical and raw-DOM scroll positions:
+
+```ts
+  updateSlidingWindow() {
+    const domScrollTop = this.domScrollTop;
+    const scrollTop = this.domToLogical(domScrollTop);
+    if (this.#scrollTop !== scrollTop || this.#cachedDomScrollTop !== domScrollTop) {
+      this.#cachedDomScrollTop = domScrollTop;
+      this.#scrollTop = scrollTop;
+      this.updateViewportProximities();
+    }
+  }
+```
+
+Leave `maxScroll` and `maxScrollPercent` unchanged (they remain logical).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts \
+        web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
+git commit -m "feat(web): scroll-space scaling engine in VirtualScrollManager (#713)"
+```
+
+---
+
+## Task 2: `TimelineManager` scroll conversion + reachability/anchor tests
+
+Routes the timeline's DOM element through the scaling engine: `domScrollTop` reads the element, `scrollTo`/`scrollBy` convert logical→DOM. Proves symptom #1 (tail reachable) and symptom #2 (no anchor snap-back).
+
+**Files:**
+
+- Modify: `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts:162-178`
+- Test: `web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1's `logicalToDom`, `domToLogical`, `domScrollMax`, `scrollTop`, `renderOffset`, `maxScrollHeight`.
+- Produces: `scrollTo`/`scrollBy` operate in logical coordinates; `get domScrollTop()` returns the element's raw `scrollTop`. (`scrollTop` inherited from base is now logical.)
+
+- [ ] **Step 1: Write the failing scroll-conversion tests**
+
+Append to `web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts` (the file already imports `sdkMock`, `timelineAssetFactory`, `toResponseDto`, `fromISODateTimeUTCToObject`, `tick`, and `TimelineManager`). Also add this import near the top with the other imports:
+
+```ts
+import { scrollTimelineToTemporalAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
+```
+
+Then add the describe block:
+
+```ts
+describe('TimelineManager scroll scaling', () => {
+  let timelineManager: TimelineManager;
+  let fakeEl: { scrollTop: number; scrollTo: (o: { top: number }) => void };
+
+  function deriveLocalDateTime(arg: TimelineAsset): TimelineAsset {
+    return { ...arg, localDateTime: arg.fileCreatedAt };
+  }
+
+  const bucketAssets: Record<string, TimelineAsset[]> = {
+    '2024-03-01': timelineAssetFactory
+      .buildList(1)
+      .map((asset) =>
+        deriveLocalDateTime({ ...asset, fileCreatedAt: fromISODateTimeUTCToObject('2024-03-01T00:00:00.000Z') }),
+      ),
+    '2024-02-01': timelineAssetFactory
+      .buildList(100)
+      .map((asset) =>
+        deriveLocalDateTime({ ...asset, fileCreatedAt: fromISODateTimeUTCToObject('2024-02-01T00:00:00.000Z') }),
+      ),
+    '2024-01-01': timelineAssetFactory
+      .buildList(3)
+      .map((asset) =>
+        deriveLocalDateTime({ ...asset, fileCreatedAt: fromISODateTimeUTCToObject('2024-01-01T00:00:00.000Z') }),
+      ),
+  };
+  const bucketAssetsResponse: Record<string, TimeBucketAssetResponseDto> = Object.fromEntries(
+    Object.entries(bucketAssets).map(([key, assets]) => [key, toResponseDto(...assets)]),
+  );
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    timelineManager = new TimelineManager();
+    sdkMock.getTimeBuckets.mockResolvedValue([
+      { count: 1, timeBucket: '2024-03-01' },
+      { count: 100, timeBucket: '2024-02-01' },
+      { count: 3, timeBucket: '2024-01-01' },
+    ]);
+    sdkMock.getTimeBucket.mockImplementation(({ timeBucket }) => Promise.resolve(bucketAssetsResponse[timeBucket]));
+    await timelineManager.updateViewport({ width: 1588, height: 1000 });
+    await tick();
+
+    fakeEl = {
+      scrollTop: 0,
+      scrollTo({ top }: { top: number }) {
+        this.scrollTop = top; // manager already clamped; store verbatim
+      },
+    };
+    timelineManager.scrollableElement = fakeEl as unknown as HTMLElement;
+  });
+
+  it('9. is inert below the cap', () => {
+    // totalViewerHeight == 8337, viewport == 1000, default cap is huge
+    expect(timelineManager.domHeight).toBe(timelineManager.totalViewerHeight);
+    expect(timelineManager.scrollScale).toBe(1);
+    timelineManager.scrollTo(1000);
+    expect(fakeEl.scrollTop).toBe(1000);
+    expect(timelineManager.scrollTop).toBe(1000);
+    expect(timelineManager.renderOffset).toBe(0);
+  });
+
+  it('10. reaches the tail under forced scaling (symptom #1)', () => {
+    timelineManager.maxScrollHeight = 4000; // domHeight 4000, domScrollMax 3000, logicalScrollMax 7337
+    timelineManager.scrollTo(timelineManager.maxScroll); // 7337
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // 3000
+    expect(timelineManager.scrollTop).toBeCloseTo(timelineManager.maxScroll, 6); // 7337
+  });
+
+  it('11. clamps scrollTo beyond the logical max', () => {
+    timelineManager.maxScrollHeight = 4000;
+    timelineManager.scrollTo(10 * timelineManager.totalViewerHeight);
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6);
+  });
+
+  it('12. scrollBy moves the logical position by the given delta', () => {
+    timelineManager.maxScrollHeight = 4000;
+    timelineManager.scrollTo(2000);
+    timelineManager.scrollBy(1000);
+    expect(timelineManager.scrollTop).toBeCloseTo(3000, 6);
+  });
+
+  it('13. exposes a logical scrollTop end-to-end', () => {
+    timelineManager.maxScrollHeight = 4000;
+    fakeEl.scrollTop = timelineManager.domScrollMax; // 3000 (raw DOM)
+    timelineManager.updateSlidingWindow();
+    expect(timelineManager.scrollTop).toBeCloseTo(timelineManager.maxScroll, 6); // 7337
+    expect(timelineManager.visibleWindow.top).toBeCloseTo(timelineManager.maxScroll, 6);
+  });
+
+  it('14. scrollBy preserves the logical delta the height compensation relies on', () => {
+    timelineManager.maxScrollHeight = 4000;
+    timelineManager.scrollTo(1500);
+    const before = timelineManager.scrollTop;
+    timelineManager.scrollBy(500); // mirrors month.height setter compensation
+    expect(timelineManager.scrollTop - before).toBeCloseTo(500, 6);
+  });
+
+  it('15. preserves a deep anchor across Years/Months → All (symptom #2)', () => {
+    timelineManager.maxScrollHeight = 4000;
+    const reached = scrollTimelineToTemporalAnchor(timelineManager, { year: 2024, month: 1 });
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // 3000, reachable — not clamped short
+    expect(reached).toBe(true);
+  });
+});
+```
+
+Add these named imports to the existing `@immich/sdk` import (it already imports `AssetVisibility`, `TimeBucketSize`, `AssetResponseDto`, `TimeBucketAssetResponseDto`) — `TimeBucketAssetResponseDto` is already imported, so no change is needed there. Confirm `TimelineAsset` is imported (it is, from `./types`).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts -t "scroll scaling"`
+Expected: FAIL — `scrollTo(1000)` sets `fakeEl.scrollTop` correctly only by luck at scale 1, but tests 10–15 fail because `maxScrollHeight` does not yet affect `domHeight` in `TimelineManager` (its `bodySectionHeight` is derived, so `domHeight`/conversions come from Task 1, but `scrollTo` still writes the raw logical value and there is no `domScrollTop` override → `scrollTop` reads `0`). Concretely expect "expected 7337 to be close to 3000" / "expected 0 to be close to 7337".
+
+- [ ] **Step 3: Implement the conversion in `TimelineManager`**
+
+In `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts`, replace lines 162-178:
+
+```ts
+  override get scrollTop(): number {
+    return this.#scrollableElement?.scrollTop ?? 0;
+  }
+
+  set scrollableElement(element: HTMLElement | undefined) {
+    this.#scrollableElement = element;
+  }
+
+  scrollTo(top: number) {
+    this.#scrollableElement?.scrollTo({ top });
+    this.updateSlidingWindow();
+  }
+
+  scrollBy(y: number) {
+    this.#scrollableElement?.scrollBy(0, y);
+    this.updateSlidingWindow();
+  }
+```
+
+with:
+
+```ts
+  override get domScrollTop(): number {
+    return this.#scrollableElement?.scrollTop ?? 0;
+  }
+
+  set scrollableElement(element: HTMLElement | undefined) {
+    this.#scrollableElement = element;
+  }
+
+  scrollTo(top: number) {
+    this.#scrollableElement?.scrollTo({ top: clamp(this.logicalToDom(top), 0, this.domScrollMax) });
+    this.updateSlidingWindow();
+  }
+
+  scrollBy(y: number) {
+    this.scrollTo(this.scrollTop + y);
+  }
+```
+
+(`scrollTop` is now inherited from the base as `domToLogical(domScrollTop)`. `clamp` is already imported from `lodash-es` at line 40.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts`
+Expected: PASS — the new "scroll scaling" block (7 tests) and all pre-existing TimelineManager tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts \
+        web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+git commit -m "feat(web): map timeline scroll between logical and capped DOM space (#713)"
+```
+
+---
+
+## Task 3: Template wiring — `renderOffset` + `domHeight` in the components
+
+Applies the engine to the DOM: caps the scroll element height, offsets every absolutely-positioned child by `renderOffset`, and routes the three logical/DOM mixer reads through the logical `scrollTop`. Adds `data-testid`s so the transforms are assertable.
+
+**Files:**
+
+- Modify: `web/src/lib/components/timeline/TimelineRepresentativeBuckets.svelte`
+- Modify: `web/src/lib/components/timeline/Timeline.svelte`
+- Test: `web/src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts`
+- Test: `web/src/lib/components/timeline/Timeline.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `timelineManager.domHeight`, `timelineManager.renderOffset`, `timelineManager.scrollTop` (logical).
+- Produces: `TimelineRepresentativeBuckets` gains a `renderOffset?: number` prop (default `0`).
+
+- [ ] **Step 1: Write the failing representative-bucket test**
+
+In `web/src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts`, add a test inside the existing `describe`:
+
+```ts
+it('offsets bucket transforms by renderOffset', () => {
+  render(TimelineRepresentativeBuckets, {
+    grouping: 'year',
+    buckets: [bucket(2016, 120)],
+    visibleWindow: { top: 100, bottom: 600 },
+    renderOffset: 50,
+  });
+
+  expect(screen.getByTestId('timeline-bucket-shell-2016-01-01')).toHaveStyle('transform: translateY(170px)');
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd web && pnpm test -- --run src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts -t "renderOffset"`
+Expected: FAIL — `transform: translateY(120px)` (renderOffset ignored), "expected … translateY(170px)".
+
+- [ ] **Step 3: Add the `renderOffset` prop to `TimelineRepresentativeBuckets.svelte`**
+
+Add to the `Props` interface (after `disabled?: boolean;`):
+
+```ts
+    renderOffset?: number;
+```
+
+Add to the destructure (after `disabled = false,`):
+
+```ts
+    renderOffset = 0,
+```
+
+Change the bucket shell `style` (line 70) from:
+
+```svelte
+        style={`position: absolute; height: ${bucket.height}px; width: 100%; transform: translateY(${bucket.top}px);`}
+```
+
+to:
+
+```svelte
+        style={`position: absolute; height: ${bucket.height}px; width: 100%; transform: translateY(${bucket.top + renderOffset}px);`}
+```
+
+- [ ] **Step 4: Run the representative-bucket spec to verify it passes**
+
+Run: `cd web && pnpm test -- --run src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts`
+Expected: PASS — the new test plus all existing ones (default `renderOffset = 0` keeps `translateY(120px)` etc.).
+
+- [ ] **Step 5: Write the failing Timeline component tests**
+
+In `web/src/lib/components/timeline/Timeline.spec.ts`:
+
+Add `domHeight` and `renderOffset` to the hoisted `testState` (after `maxScroll: 1,`):
+
+```ts
+  domHeight: 296,
+  renderOffset: 0,
+```
+
+Add matching getters to the `TimelineManagerMock` class (after the `totalViewerHeight = 296;` line):
+
+```ts
+    get domHeight() {
+      return testState.domHeight;
+    }
+    get renderOffset() {
+      return testState.renderOffset;
+    }
+```
+
+Reset them in the top-level `beforeEach` (alongside the other `testState` resets):
+
+```ts
+testState.domHeight = 296;
+testState.renderOffset = 0;
+```
+
+Add a new describe block at the end of the file:
+
+```ts
+describe('Timeline scroll-space scaling', () => {
+  beforeEach(() => {
+    testState.grouping = 'day';
+    testState.assetCount = 1;
+    testState.viewportHeight = 600;
+    testState.viewportWidth = 390;
+    testState.domHeight = 296;
+    testState.renderOffset = 0;
+    testState.months = [];
+  });
+
+  it('sizes the virtual timeline to domHeight, not totalViewerHeight', () => {
+    testState.domHeight = 200; // < totalViewerHeight (296)
+    const { container } = renderTimeline();
+    const virtual = container.querySelector('#virtual-timeline') as HTMLElement;
+    expect(virtual).toHaveStyle({ height: '200px' });
+  });
+
+  it('offsets the month skeleton transform by renderOffset', () => {
+    testState.renderOffset = 50;
+    testState.months = [
+      {
+        viewId: 'month:2015-01',
+        isInOrNearViewport: false,
+        isLoaded: false,
+        top: 1200,
+        height: 240,
+        title: 'Jan 2015',
+      },
+    ];
+    renderTimeline();
+    expect(screen.getByTestId('timeline-month-skeleton')).toHaveStyle('transform: translate3d(0, 1250px, 0)');
+  });
+
+  it('offsets the lead-out spacer transform by renderOffset', () => {
+    // topSectionHeight 0 + bodySectionHeight 296 + renderOffset 50 = 346
+    testState.renderOffset = 50;
+    const { getByTestId } = renderTimeline();
+    expect(getByTestId('timeline-leadout')).toHaveStyle('transform: translate3d(0, 346px, 0)');
+  });
+});
+```
+
+- [ ] **Step 6: Run them to verify they fail**
+
+Run: `cd web && pnpm test -- --run src/lib/components/timeline/Timeline.spec.ts -t "scroll-space scaling"`
+Expected: FAIL — `#virtual-timeline` still uses `totalViewerHeight`; no `timeline-month-skeleton`/`timeline-leadout` testids; transforms omit `renderOffset`.
+
+- [ ] **Step 7: Apply the `Timeline.svelte` template changes**
+
+`web/src/lib/components/timeline/Timeline.svelte`:
+
+a. The `#virtual-timeline` height (line 733):
+
+```svelte
+    style:height={timelineManager.totalViewerHeight + 'px'}
+```
+
+→
+
+```svelte
+    style:height={timelineManager.domHeight + 'px'}
+```
+
+b. The shared month offset const (line 762):
+
+```svelte
+        {@const absoluteHeight = timelineMonth.top}
+```
+
+→
+
+```svelte
+        {@const absoluteHeight = timelineMonth.top + timelineManager.renderOffset}
+```
+
+c. Add a `data-testid` to the skeleton wrapper div (the `{#if !timelineMonth.isLoaded}` block, the `<div>` opening at line 765):
+
+```svelte
+          <div
+            data-testid="timeline-month-skeleton"
+            style:height={timelineMonth.height + 'px'}
+```
+
+d. Pass `renderOffset` to the representative buckets (in the `<TimelineRepresentativeBuckets …>` props, near line 750):
+
+```svelte
+        visibleWindow={timelineManager.visibleWindow}
+        renderOffset={timelineManager.renderOffset}
+```
+
+e. The lead-out spacer (line 831-837): add the `data-testid` and the `renderOffset` term:
+
+```svelte
+    <div
+      data-testid="timeline-leadout"
+      style:height={timelineManager.bottomSectionHeight + 'px'}
+      style:position="absolute"
+      style:left="0"
+      style:right="0"
+      style:transform={`translate3d(0,${timelineManager.topSectionHeight + timelineManager.bodySectionHeight + timelineManager.renderOffset}px,0)`}
+    ></div>
+```
+
+f. Route the three mixer reads through the logical `scrollTop`:
+
+- Line 231: `const currentTop = scrollableElement?.scrollTop || 0;` → `const currentTop = timelineManager.scrollTop;`
+- Line 420: `timelineScrollPercent = Math.min(1, scrollableElement.scrollTop / maxScroll);` → `timelineScrollPercent = Math.min(1, timelineManager.scrollTop / maxScroll);`
+- Line 426: `let top = scrollableElement.scrollTop;` → `let top = timelineManager.scrollTop;`
+
+> The mixer edits (f) are identity at `scrollScale == 1`, so existing `Timeline.spec.ts` tests stay green; under scaling they read the correct logical position. They are verified indirectly by the logical-`scrollTop` tests in Task 2 (tests 9, 13) and by manual verification (Task 4 / Spec §9), since `handleTimelineScroll`/`scrollToAssetPosition` are driven by real scroll events not exercised by the manager-only harness.
+
+- [ ] **Step 8: Run the component tests to verify they pass**
+
+Run: `cd web && pnpm test -- --run src/lib/components/timeline/Timeline.spec.ts src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts`
+Expected: PASS — new scaling tests plus all pre-existing component tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/lib/components/timeline/Timeline.svelte \
+        web/src/lib/components/timeline/Timeline.spec.ts \
+        web/src/lib/components/timeline/TimelineRepresentativeBuckets.svelte \
+        web/src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts
+git commit -m "feat(web): render timeline content in capped DOM space via renderOffset (#713)"
+```
+
+---
+
+## Task 4: Regression gate + recorded manual verification
+
+Confirms the whole web suite is green, types/Svelte check pass, lint passes, and the user-facing behavior is verified on a large library (the one path the unit tests cannot exercise).
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the timeline-area specs**
+
+Run: `cd web && pnpm test -- --run src/lib/managers/timeline-manager src/lib/managers/VirtualScrollManager src/lib/components/timeline`
+Expected: PASS — all timeline manager, scaling-engine, and component specs.
+
+- [ ] **Step 2: Run the full web unit suite**
+
+Run: `cd web && pnpm test -- --run`
+Expected: PASS — no regressions in dependent components (especially `timeline-anchor.spec.ts`, which is unchanged).
+
+- [ ] **Step 3: Type/Svelte check**
+
+Run: `make check-web`
+Expected: 0 errors (svelte-check + `tsc --noEmit`).
+
+- [ ] **Step 4: Lint (final gate)**
+
+Run: `make lint-web`
+Expected: 0 warnings/errors.
+
+- [ ] **Step 5: Recorded manual verification (Spec §9)**
+
+Requires a library large enough to exceed the cap (≈ 300k+ assets, or temporarily lower `maxScrollHeight` in dev to force scaling). On `make dev`, perform and record the result of each:
+
+1. "All" view → scroll to the very bottom: the oldest assets render; no fixed-date cutoff.
+2. Years (or Months) → open a pre-cutoff date → switch to "All": stays on that date; no snap-back.
+3. Deep-link `/photos/<id>` for an old asset: scrolls to and focuses it.
+4. Normal-sized library: scrolling, scrubber, deep-linking behave exactly as before (`scrollScale == 1`).
+5. Repeat 1–2 in Firefox (lower cap engages scaling sooner).
+
+Record pass/fail for each in the PR description. If forced to skip (no large library available), say so explicitly — do not imply coverage that was not performed.
+
+- [ ] **Step 6: Commit any final formatting**
+
+```bash
+git add -A
+git commit -m "chore(web): finalize #713 height-cap fix" --allow-empty
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+
+- §4.1 coordinate model → Task 1 (Steps 3, code: `domHeight`/`logicalScrollMax`/`domScrollMax`/`scrollScale`/`domToLogical`/`logicalToDom`, cap const).
+- §4.2 rendering / `renderOffset` → Task 1 (`renderOffset` getter) + Task 3 (transforms, `domHeight` height, representative `renderOffset`, top section left static).
+- §4.3 single logical source → Task 1 (logical `scrollTop`, cached `updateSlidingWindow`) + Task 2 (`domScrollTop` override, `scrollTo`/`scrollBy`) + Task 3 (mixers f).
+- §4.4 inert below cap → Tasks 1 (test 1), 2 (test 9), 3 (default props), 4 (full suite).
+- §5 edge cases 1–7,10,11 → Task 1 tests 1–7 + Task 2 tests 9,10,11. Edge 9 (stability) → Task 2 test 14. Edge 12 (representative) → Task 3. Edges 8/13/14/15/16/17/18 → covered by behavior + manual (Task 4) and noted as not-unit-testable in §6.5.
+- §6 TDD plan → Tasks 1–4 follow red→green; coverage boundary §6.5 reflected in Task 3 Step 7 note + Task 4 Step 5.
+- §7 limitations → documented; tests use exact-arithmetic fake element (no DOM rounding), consistent with §7.
+- §8 files touched → matches the File Structure table; circular-import avoidance honored (Task 1 inline const).
+
+**Placeholder scan:** none — every code/test step contains complete content.
+
+**Type consistency:** method/getter names are identical across tasks — `domHeight`, `domScrollMax`, `logicalScrollMax`, `scrollScale`, `domToLogical`, `logicalToDom`, `domScrollTop`, `scrollTop`, `renderOffset`, `maxScrollHeight`. `TimelineRepresentativeBuckets` prop `renderOffset` matches the Timeline.svelte pass-through. Test fixture mirrors the existing `init` describe (3 buckets → `totalViewerHeight == 8337`).

--- a/docs/plans/2026-06-19-timeline-all-view-height-cap-plan.md
+++ b/docs/plans/2026-06-19-timeline-all-view-height-cap-plan.md
@@ -141,13 +141,21 @@ describe('VirtualScrollManager scaling', () => {
     expect(s.totalViewerHeight + s.renderOffset).toBeCloseTo(s.domHeight, 6);
   });
 
-  it('7. guards against divide-by-zero when content fits the viewport', () => {
-    const s = makeScroller({ body: 500, viewport: 1000, cap: 10_000 });
-    expect(s.logicalScrollMax).toBe(0);
-    expect(s.domToLogical(123)).toBe(0);
-    expect(s.logicalToDom(123)).toBe(0);
-    expect(s.scrollScale).toBe(1);
-    expect(Number.isFinite(s.domToLogical(123))).toBe(true);
+  it('7. guards against divide-by-zero and NaN at the geometry edges', () => {
+    // (a) content fits the viewport → logicalScrollMax == 0 (spec edge #4/#5)
+    const fits = makeScroller({ body: 500, viewport: 1000, cap: 10_000 });
+    expect(fits.logicalScrollMax).toBe(0);
+    expect(fits.domToLogical(123)).toBe(0);
+    expect(fits.logicalToDom(123)).toBe(0);
+    expect(fits.scrollScale).toBe(1);
+    expect(Number.isFinite(fits.domToLogical(123))).toBe(true);
+
+    // (b) zero-height viewport (transient, before layout) → no NaN/Infinity (spec edge #6)
+    const noViewport = makeScroller({ body: 100_000, viewport: 0, cap: 10_000 });
+    expect(noViewport.domHeight).toBe(10_000);
+    expect(Number.isFinite(noViewport.domToLogical(5000))).toBe(true);
+    expect(Number.isFinite(noViewport.logicalToDom(50_000))).toBe(true);
+    expect(Number.isFinite(noViewport.scrollScale)).toBe(true);
   });
 
   it('8. renderOffset reads cached state, updating only after updateSlidingWindow', () => {
@@ -357,10 +365,14 @@ describe('TimelineManager scroll scaling', () => {
     expect(timelineManager.scrollTop).toBeCloseTo(timelineManager.maxScroll, 6); // 7337
   });
 
-  it('11. clamps scrollTo beyond the logical max', () => {
+  it('11. clamps scrollTo to [0, domScrollMax]', () => {
     timelineManager.maxScrollHeight = 4000;
     timelineManager.scrollTo(10 * timelineManager.totalViewerHeight);
-    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6);
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // clamped to bottom
+    timelineManager.scrollTo(0); // top reachable (spec edge #11)
+    expect(fakeEl.scrollTop).toBe(0);
+    timelineManager.scrollTo(-5000); // negative clamped to 0
+    expect(fakeEl.scrollTop).toBe(0);
   });
 
   it('12. scrollBy moves the logical position by the given delta', () => {
@@ -400,7 +412,7 @@ Add these named imports to the existing `@immich/sdk` import (it already imports
 - [ ] **Step 2: Run the tests to verify they fail**
 
 Run: `cd web && pnpm test -- --run src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts -t "scroll scaling"`
-Expected: FAIL — `scrollTo(1000)` sets `fakeEl.scrollTop` correctly only by luck at scale 1, but tests 10–15 fail because `maxScrollHeight` does not yet affect `domHeight` in `TimelineManager` (its `bodySectionHeight` is derived, so `domHeight`/conversions come from Task 1, but `scrollTo` still writes the raw logical value and there is no `domScrollTop` override → `scrollTop` reads `0`). Concretely expect "expected 7337 to be close to 3000" / "expected 0 to be close to 7337".
+Expected: tests **10–15 FAIL**. Before this task `scrollTo` still writes the raw logical value (no logical→DOM conversion) and there is no `domScrollTop` override, so under a forced small `maxScrollHeight` the element receives the un-scaled value — concretely "expected 7337 to be close to 3000". Test **9 ("inert below the cap") passes already** — it is a regression guard asserting scale-1 behavior is unchanged, not a red driver; it must stay green before and after.
 
 - [ ] **Step 3: Implement the conversion in `TimelineManager`**
 
@@ -596,14 +608,19 @@ describe('Timeline scroll-space scaling', () => {
       },
     ];
     renderTimeline();
-    expect(screen.getByTestId('timeline-month-skeleton')).toHaveStyle('transform: translate3d(0, 1250px, 0)');
+    // assert on the raw inline style so CSS normalization (e.g. `0`→`0px`) can't cause a false negative;
+    // the template emits exactly `translate3d(0,${top + renderOffset}px,0)`
+    const skeleton = screen.getByTestId('timeline-month-skeleton');
+    expect(skeleton.getAttribute('style')).toMatch(/translate3d\(\s*0(?:px)?\s*,\s*1250px\s*,\s*0(?:px)?\s*\)/);
   });
 
   it('offsets the lead-out spacer transform by renderOffset', () => {
     // topSectionHeight 0 + bodySectionHeight 296 + renderOffset 50 = 346
     testState.renderOffset = 50;
     const { getByTestId } = renderTimeline();
-    expect(getByTestId('timeline-leadout')).toHaveStyle('transform: translate3d(0, 346px, 0)');
+    expect(getByTestId('timeline-leadout').getAttribute('style')).toMatch(
+      /translate3d\(\s*0(?:px)?\s*,\s*346px\s*,\s*0(?:px)?\s*\)/,
+    );
   });
 });
 ```
@@ -749,7 +766,23 @@ git commit -m "chore(web): finalize #713 height-cap fix" --allow-empty
 - §4.2 rendering / `renderOffset` → Task 1 (`renderOffset` getter) + Task 3 (transforms, `domHeight` height, representative `renderOffset`, top section left static).
 - §4.3 single logical source → Task 1 (logical `scrollTop`, cached `updateSlidingWindow`) + Task 2 (`domScrollTop` override, `scrollTo`/`scrollBy`) + Task 3 (mixers f).
 - §4.4 inert below cap → Tasks 1 (test 1), 2 (test 9), 3 (default props), 4 (full suite).
-- §5 edge cases 1–7,10,11 → Task 1 tests 1–7 + Task 2 tests 9,10,11. Edge 9 (stability) → Task 2 test 14. Edge 12 (representative) → Task 3. Edges 8/13/14/15/16/17/18 → covered by behavior + manual (Task 4) and noted as not-unit-testable in §6.5.
+- §5 edge cases, item by item:
+  - 1 (below cap) → Task 1 test 1, Task 2 test 9.
+  - 2 (at cap) → Task 1 test 2.
+  - 3 (above cap) → Task 1 test 3, Task 2 test 10.
+  - 4 (`logicalScrollMax == 0`) → Task 1 test 7(a).
+  - 5 (`domScrollMax == 0`) → Task 1 test 7(a).
+  - 6 (zero-height viewport) → Task 1 test 7(b).
+  - 7 (Firefox vs others) → **not unit-tested by design**: a module-eval UA ternary; tests override `maxScrollHeight` instead, and reachability under a small cap is proven (Task 2 test 10). The per-browser cap value is a trivial constant.
+  - 8 (resize) → covered by behavior (heights recompute → derived `domHeight`/`scrollScale`/`renderOffset`); not separately unit-tested.
+  - 9 (async height stability) → Task 2 test 14 (logical-delta invariant).
+  - 10 (`scrollTo > max`) → Task 2 test 11.
+  - 11 (`scrollTo(0)` / negative) → Task 2 test 11.
+  - 12 (representative grouping) → Task 3 (representative renderOffset test; scale 1 in practice).
+  - 13 (scrubber drag) / 15 (deep link) → behavior + recorded manual (Task 4 Step 5).
+  - 14 (scrubber arrow nudge) / 17 (live insert) → no code path change; behavior + manual.
+  - 16 (`limitedScroll`) → **not unit-tested by design**: only fires when content < 2× viewport, where `scrollScale` is always 1, so the existing path is provably unaffected; the inert-below-cap tests (Task 1 test 1, Task 2 test 9) cover scale-1 behavior.
+  - 18 (DOM rounding) → §7 limitation; unit tests use an exact-arithmetic fake element.
 - §6 TDD plan → Tasks 1–4 follow red→green; coverage boundary §6.5 reflected in Task 3 Step 7 note + Task 4 Step 5.
 - §7 limitations → documented; tests use exact-arithmetic fake element (no DOM rounding), consistent with §7.
 - §8 files touched → matches the File Structure table; circular-import avoidance honored (Task 1 inline const).

--- a/docs/plans/2026-06-19-timeline-all-view-height-cap.md
+++ b/docs/plans/2026-06-19-timeline-all-view-height-cap.md
@@ -115,7 +115,7 @@ emitted coordinate **stays bounded near the viewport** (never emits a 25M transf
 which can itself glitch renderers):
 
 ```
-renderOffset = cachedDomScrollTop − cachedLogicalScrollTop   // 0 when scrollScale == 1
+renderOffset = cachedDomScrollTop − cachedLogicalScrollTop   // = #cachedDomScrollTop − #scrollTop (§4.3); 0 when scrollScale == 1
 domY(item)   = item.top + renderOffset                       // always ≈ domScrollTop ± viewport
 ```
 
@@ -180,7 +180,7 @@ accessor.
 - `override get domScrollTop()` → `this.#scrollableElement?.scrollTop ?? 0` (replaces the old
   `override get scrollTop()`).
 - `scrollTo(logicalTop)` → `this.#scrollableElement?.scrollTo({ top: clamp(this.logicalToDom(logicalTop), 0, this.domScrollMax) })`,
-  then `updateSlidingWindow()`.
+  then `updateSlidingWindow()`. (`clamp` is already imported from `lodash-es` in this file; no new import.)
 - `scrollBy(logicalDelta)` → `this.scrollTo(this.scrollTop + logicalDelta)` (absolute remap;
   correct under any scale). Replaces the direct `#scrollableElement.scrollBy`.
 
@@ -224,6 +224,8 @@ then `scrollTo` maps logical→DOM. This is what fixes symptom #2.
 | 14  | Scrubber arrow-key nudge (`scrollableElement.scrollBy({behavior:'smooth'})`) | DOM-space nudge; `onscroll` → `updateSlidingWindow` converts. Moves ~`delta/scale` logical px (consistent coarsening). No change needed.                                |
 | 15  | Deep link `/photos/<id>` to an old asset                                     | `findTimelineMonthForAsset` loads the month; `scrollToAssetPosition` → `scrollTo(logical)` → DOM. Reachable.                                                            |
 | 16  | `limitedScroll` (content < 2× viewport)                                      | only triggers when `total` is tiny → `scrollScale` always `1`; path unaffected.                                                                                         |
+| 17  | Live asset insert/remove (websocket upsert)                                  | changes `total` → `domHeight`/`scrollScale`/`renderOffset` recompute (same mechanism as resize #8); above-viewport inserts compensated via the `month.height` setter.   |
+| 18  | DOM `scrollTop` integer rounding                                             | browser rounds `scrollTop`; at `scrollScale < 1` a landing target is reached within ≤ ~`1/scrollScale` logical px (≪ one row). Reachability unaffected (see §7).        |
 
 ## 6. Strict TDD plan
 
@@ -274,13 +276,12 @@ Reuse the existing fixture (3 buckets, `totalViewerHeight == 8337`, viewport 158
 injected fake scroll element:
 
 ```ts
+// `scrollTo` already clamps, so the fake stores the value verbatim. `scrollBy` is unused
+// (manager.scrollBy routes through manager.scrollTo → fakeEl.scrollTo).
 const fakeEl = {
   scrollTop: 0,
   scrollTo({ top }) {
     this.scrollTop = top;
-  },
-  scrollBy(_x, y) {
-    this.scrollTop += y;
   },
 } as unknown as HTMLElement;
 timelineManager.scrollableElement = fakeEl;
@@ -297,9 +298,12 @@ timelineManager.scrollableElement = fakeEl;
 12. **scrollBy is logical.** under scaling, `scrollBy(d)` ⇒ `scrollTop` increases by ≈ `d` logical.
 13. **scrollTop is logical end-to-end.** set `fakeEl.scrollTop = domScrollMax; updateSlidingWindow()`
     ⇒ `timelineManager.scrollTop == logical max`, `visibleWindow.top == logical max`.
-14. **Logical scroll stability on height change (edge #9).** scroll into a later month under
-    scaling; grow an earlier month's height; assert `getTimelineTopVisibleAnchor` returns the same
-    month before and after (logical position preserved).
+14. **Logical scroll stability on height change (edge #9).** Deterministic core: under scaling,
+    `scrollBy(Δ)` moves `timelineManager.scrollTop` by exactly `Δ` (logical) — the invariant the
+    existing `month.height` compensation depends on (the setter calls `scrollBy(heightDelta)` when
+    an earlier month grows, lines 297–298 of `timeline-month.svelte.ts`). Because that magnitude is
+    preserved in logical space, the top-visible month stays fixed. (The compensation logic itself
+    is unchanged by this fix; only its `scrollBy`/`scrollTo` calls now convert to DOM space.)
 
 ### 6.3 Anchor regression (symptom #2)
 
@@ -312,12 +316,35 @@ Add to the timeline-manager spec (real manager + fake element + forced small cap
     i.e. no snap-back to the cap boundary.
 16. **Existing anchor unit tests stay green** (clamping to `maxScroll` unchanged).
 
-### 6.4 Full-suite regression
+### 6.4 Component template wiring
 
-17. `cd web && pnpm test -- --run src/lib/managers/timeline-manager` and the new
+17. **`renderOffset` applied to every absolutely-positioned site.** A focused
+    `@testing-library/svelte` component test (the project already uses it) renders `Timeline` with
+    a stubbed manager forced to `scrollScale < 1` and asserts each rendered month/bucket
+    `translate3d` Y equals `top + renderOffset` (skeleton month, loaded month, lead-out spacer,
+    representative bucket), and that `#virtual-timeline` height equals `domHeight`. A forgotten
+    `renderOffset` on one site misplaces that element only under `scrollScale < 1`, which the
+    manager-only tests cannot catch.
+    - **Fallback:** if component-level transform assertions prove impractical in this harness, this
+      item degrades to manual verification (§9 steps 1–2), which must then be performed **and
+      recorded** before merge — not silently skipped.
+
+### 6.5 Coverage boundary (honest accounting)
+
+- **Fully unit-tested (logic):** the scaling model, conversions, `scrollScale`/`domHeight`, logical
+  `scrollTop`, `renderOffset` value + reactivity, `scrollTo`/`scrollBy`, clamping, divide-by-zero
+  guards, tail reachability (symptom #1), anchor snap-back (symptom #2), logical stability
+  invariant.
+- **Indirectly covered:** the three `Timeline.svelte` mixer fixes consume
+  `timelineManager.scrollTop`, whose logical value is asserted by tests 9 and 13.
+- **Template wiring:** covered by item 17 (component test, or recorded manual fallback).
+
+### 6.6 Full-suite regression
+
+18. `cd web && pnpm test -- --run src/lib/managers/timeline-manager` and the new
     `VirtualScrollManager` spec all green.
-18. `cd web && pnpm test` (web unit suite) green — confirms no regression in dependent components.
-19. `make check-web` (svelte-check + tsc) clean.
+19. `cd web && pnpm test` (web unit suite) green — confirms no regression in dependent components.
+20. `make check-web` (svelte-check + tsc) clean.
 
 ## 7. Accepted limitations
 
@@ -328,6 +355,11 @@ Add to the timeline-manager spec (real manager + fake element + forced small cap
   keeps the _logical_ viewport position stable; the proportional DOM remap can introduce ≤ a few px
   of visual drift while month heights firm up on huge libraries. Imperceptible in practice and far
   better than total unreachability. Pixel-exact at `scrollScale == 1` (all normal libraries).
+- **`scrollTo` landing precision at `scrollScale < 1`.** Browsers round `scrollTop` to an integer
+  (device-pixel), so a logical target lands within ≤ ~`1/scrollScale` logical px (≪ one ~235px
+  row even at small scale). Reachability and which month/row is shown are unaffected; only exact
+  intra-row alignment drifts. Exact at `scrollScale == 1`. (Unit tests use an exact-arithmetic fake
+  element, so they assert the ideal mapping.)
 
 ## 8. Files touched
 
@@ -340,9 +372,10 @@ Add to the timeline-manager spec (real manager + fake element + forced small cap
 | `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts`   | **new** — scaling math tests                                                                                            |
 | `web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts`           | scroll-conversion + reachability + stability tests                                                                      |
 | `web/src/lib/managers/timeline-manager/timeline-anchor.spec.ts` (or manager spec) | symptom-#2 regression                                                                                                   |
+| `web/src/lib/components/timeline/Timeline.svelte.spec.ts`                         | **new (or recorded manual fallback)** — item 17 template-wiring test                                                    |
 
-Reuses `isFirefox` from `web/src/lib/utils/asset-utils.ts`. No new files beyond the spec; no new
-classes; no upstream-file restructuring.
+Reuses `isFirefox` from `web/src/lib/utils/asset-utils.ts`. New files are limited to the two spec
+files; no new production files, no new classes, no upstream-file restructuring.
 
 ## 9. Manual verification
 

--- a/docs/plans/2026-06-19-timeline-all-view-height-cap.md
+++ b/docs/plans/2026-06-19-timeline-all-view-height-cap.md
@@ -1,0 +1,357 @@
+# Fix: "All" timeline view hard-stops at a fixed date on large libraries (#713)
+
+- **Issue:** [open-noodle/gallery#713](https://github.com/open-noodle/gallery/issues/713)
+- **Date:** 2026-06-19
+- **Status:** Approved design — ready for implementation plan
+- **Area:** `web/` (SvelteKit timeline)
+
+## 1. Problem
+
+On a library with 563k+ assets, the flat **"All"** timeline (the `day` grouping)
+stops rendering at a fixed date (≈ December 2008). Older assets (1926–2007) are
+never reachable by scrolling, even though they appear correctly in the **Months**
+and **Years** views. Navigating to a pre-2008 date in Months/Years and switching
+back to "All" snaps the view back to ≈ December 2008.
+
+### Root cause
+
+The "All" view renders one tall scroll container whose height is set **directly**
+to the summed pixel height of every month, and positions each month at its absolute
+cumulative pixel offset:
+
+- `web/src/lib/components/timeline/Timeline.svelte` — `#virtual-timeline` height is
+  `style:height={timelineManager.totalViewerHeight + 'px'}`; each month is placed at
+  `translate3d(0, ${timelineMonth.top}px, 0)`.
+- `web/src/lib/managers/timeline-manager/timeline-month.svelte.ts` — `#top` is a pure
+  cumulative offset (`newTop = previousMonth.#top + previousMonth.#height`).
+- `web/src/lib/managers/timeline-manager/internal/layout-support.svelte.ts` — month
+  heights are full-resolution justified-layout pixels. **No scaling/compression exists
+  anywhere.**
+
+For 563k assets the cumulative height reaches ≈ 30–40M px, which exceeds the
+**browser maximum renderable element height** (Firefox ≈ 17.9M px;
+Chrome/Safari ≈ 33.5M px). The browser silently clamps the scroll container's
+rendered height, so any month positioned past the cap can never be scrolled into
+view. "December 2008" is simply where the cumulative height crosses the cap on that
+library.
+
+This explains both symptoms:
+
+1. **Fixed date cutoff** — months beyond the clamped height are unreachable. (Note it
+   is a fixed _date_, not a fixed _count_; there is no count cap in the code. A clamped
+   cumulative height is the only thing that produces a date cutoff.)
+2. **Snap-back from Years/Months → All** — `timeline-anchor.ts:getScrollTopForTarget`
+   computes the target's logical `top` (up to 30M+), and `scrollTo` writes it straight
+   to the element; the browser clamps `scrollTop` to the real (capped) maximum, landing
+   at ≈ December 2008.
+
+Months/Years views work because they render far fewer, smaller representative buckets
+that stay under the cap.
+
+This is upstream Immich's architecture (the timeline files come from upstream; the
+grouping display modes — PR #625 — are fork-only but sit on top of the same flat
+day-view scroller). There is no upstream fix to pull.
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- All assets reachable in "All" view regardless of total count, on all supported
+  browsers (Firefox included).
+- Years/Months → All preserves the navigated position (fixes symptom #2).
+- **Zero behavior change for normal-sized libraries** (below the cap): scale is exactly
+  `1`, all coordinates and transforms identical to today.
+- Minimal, contained, upstream-styled change (rebase-clean; plausibly contributable to
+  immich-app/immich). No new manager classes, no architectural rework.
+
+### Non-goals (YAGNI)
+
+- Pixel-precise wheel scrolling at extreme scale. Accepted: above the cap the scrollbar
+  represents the whole compressed timeline, so wheel/trackpad scrolling is coarser
+  (~1.9× on the reported library under Firefox). The date scrubber, keyboard, and
+  jump-to-asset stay exact. Approved during brainstorming.
+- Server/data-layer changes. The data is already correct and indexed.
+- Reworking the scrubber, justified layout, or month-loading logic.
+
+## 3. Decisions (from brainstorming)
+
+| Decision           | Choice                                                        |
+| ------------------ | ------------------------------------------------------------- |
+| Divergence         | Minimal & upstreamable — smallest diff to shared scroll logic |
+| Mechanism          | Scroll-space scaling (cap DOM height, map scroll ↔ logical)   |
+| Cap value          | **Browser-aware**: Firefox → 17,000,000; others → 33,000,000  |
+| Precision tradeoff | Coarser scroll only past the cap is acceptable                |
+
+## 4. Design
+
+### 4.1 Coordinate model
+
+Two coordinate spaces:
+
+- **Logical space** — the true cumulative layout (`month.top`, `totalViewerHeight`,
+  `maxScroll`). May reach 30M+ px. _All_ existing layout / intersection / proximity /
+  scrubber / anchor math stays in logical space, unchanged.
+- **DOM space** — what the browser actually scrolls. The scroll element's height is
+  capped at a browser-safe maximum so it never exceeds the render limit.
+
+```
+maxScrollHeight   = isFirefox ? 17_000_000 : 33_000_000   // instance value, overridable in tests
+domHeight         = min(totalViewerHeight, maxScrollHeight)   // = #virtual-timeline height
+logicalScrollMax  = max(0, totalViewerHeight - viewportHeight)
+domScrollMax      = max(0, domHeight - viewportHeight)
+scrollScale       = logicalScrollMax > 0 ? domScrollMax / logicalScrollMax : 1   // ≤ 1; exactly 1 below cap
+
+domToLogical(d)   = domScrollMax     > 0 ? d * logicalScrollMax / domScrollMax : 0
+logicalToDom(l)   = logicalScrollMax > 0 ? l * domScrollMax / logicalScrollMax : 0
+```
+
+Float64 represents integers exactly up to 2^53, far above 33M — no precision loss.
+
+### 4.2 Rendering: position content relative to the live scroll
+
+Content cannot be placed at its absolute logical `top` (might be 25M while the element is
+only 17M). Instead each visible child is positioned relative to the current scroll so the
+emitted coordinate **stays bounded near the viewport** (never emits a 25M transform,
+which can itself glitch renderers):
+
+```
+renderOffset = cachedDomScrollTop − cachedLogicalScrollTop   // 0 when scrollScale == 1
+domY(item)   = item.top + renderOffset                       // always ≈ domScrollTop ± viewport
+```
+
+DOM changes (all in `Timeline.svelte` unless noted):
+
+- `#virtual-timeline` height → `timelineManager.domHeight` (was `totalViewerHeight`).
+- Day-view month divs (skeleton **and** loaded) →
+  `translate3d(0, ${timelineMonth.top + timelineManager.renderOffset}px, 0)`.
+- Lead-out spacer →
+  `translate3d(0, ${topSectionHeight + bodySectionHeight + timelineManager.renderOffset}px, 0)`.
+- Representative buckets (`TimelineRepresentativeBuckets.svelte`) — pass `renderOffset`
+  as a prop; `translateY(${bucket.top + renderOffset}px)`. (In practice these are always
+  under the cap, so `renderOffset == 0`; applied uniformly for correctness.)
+- **Top section stays static at DOM `top: 0` (unchanged).** It lives at the very top of
+  the scroll element and scrolls away naturally; near the top `renderOffset ≈ 0`, so it
+  aligns with the first month (whose logical `top` already includes `topSectionHeight`).
+  Giving it `renderOffset` would emit a large negative transform when scrolled far down —
+  avoided.
+
+### 4.3 Single source of truth for scroll position
+
+The deeper cause is several call sites reading raw `scrollableElement.scrollTop` (DOM) and
+mixing it with logical coordinates. At `scrollScale == 1` they coincide, hiding the bug;
+under scaling they diverge. Fix by routing every scroll-position read through one **logical**
+accessor.
+
+`VirtualScrollManager` (base — holds the generic scaling math):
+
+- `get domScrollTop()` → raw DOM scroll position. Base returns `0`; overridden by
+  `TimelineManager` to read the element.
+- `get scrollTop()` → **logical** = `domToLogical(this.domScrollTop)`. (Replaces the base's
+  `return 0` and the subclass's raw-DOM override. Identity at scale 1, so every existing
+  imperative caller — `timeline-anchor.ts` — keeps working.)
+- `maxScrollHeight` — instance `$state` initialized to the browser-aware constant (overridable
+  in tests).
+- `domHeight`, `domScrollMax`, `logicalScrollMax`, `scrollScale`, `domToLogical`,
+  `logicalToDom` — as in §4.1. `maxScroll` / `maxScrollPercent` stay **logical** (unchanged).
+- Cached reactive state for rendering: keep the existing `#scrollTop` `$state` (cached
+  **logical**) and add `#cachedDomScrollTop` `$state` (cached raw DOM). `updateSlidingWindow`
+  sets both from the live values on every scroll:
+
+  ```
+  updateSlidingWindow() {
+    const domTop = this.domScrollTop;            // live DOM read (non-reactive)
+    const logicalTop = this.domToLogical(domTop);
+    if (this.#scrollTop !== logicalTop || this.#cachedDomScrollTop !== domTop) {
+      this.#cachedDomScrollTop = domTop;
+      this.#scrollTop = logicalTop;
+      this.updateViewportProximities();
+    }
+  }
+  ```
+
+- `get renderOffset()` → `this.#cachedDomScrollTop − this.#scrollTop` (both `$state` →
+  reactive; templates update on scroll). **Reactivity note:** `renderOffset` must read the
+  cached `$state`, never `this.domScrollTop` directly — a live DOM property read is not
+  reactive in Svelte 5 and the transforms would not update on scroll.
+- `visibleWindow` continues to use `#scrollTop` (now guaranteed logical) — unchanged.
+
+`TimelineManager`:
+
+- `override get domScrollTop()` → `this.#scrollableElement?.scrollTop ?? 0` (replaces the old
+  `override get scrollTop()`).
+- `scrollTo(logicalTop)` → `this.#scrollableElement?.scrollTo({ top: clamp(this.logicalToDom(logicalTop), 0, this.domScrollMax) })`,
+  then `updateSlidingWindow()`.
+- `scrollBy(logicalDelta)` → `this.scrollTo(this.scrollTop + logicalDelta)` (absolute remap;
+  correct under any scale). Replaces the direct `#scrollableElement.scrollBy`.
+
+`Timeline.svelte` — replace logical/DOM mixers with the logical accessor:
+
+- `scrollToAssetPosition`: `const currentTop = scrollableElement?.scrollTop || 0;` →
+  `const currentTop = timelineManager.scrollTop;` (compared against logical `assetTop`).
+- `handleTimelineScroll`: `let top = scrollableElement.scrollTop;` →
+  `let top = timelineManager.scrollTop;` (walks logical month heights).
+- `handleTimelineScroll` limited-scroll branch: `scrollableElement.scrollTop / maxScroll` →
+  `timelineManager.scrollTop / maxScroll` (both logical; identical at scale 1).
+
+`timeline-anchor.ts` — **no change**. `getScrollTopForTarget` clamps to logical `maxScroll`,
+then `scrollTo` maps logical→DOM. This is what fixes symptom #2.
+
+### 4.4 Why this is consistent and minimal
+
+- The only places that touch DOM scroll are `domScrollTop`, `scrollTo`/`scrollBy`,
+  `updateSlidingWindow`, and the `renderOffset` transforms. Everything else is logical and
+  untouched.
+- At `scrollScale == 1`: `domHeight == totalViewerHeight`, conversions are identity,
+  `renderOffset == 0`, transforms are byte-for-byte today's. The change is inert below the cap.
+
+## 5. Edge cases (full enumeration)
+
+| #   | Case                                                                         | Behavior                                                                                                                                                                |
+| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `total ≤ cap` (normal libraries)                                             | `scrollScale = 1`, `domHeight = total`, identity conversions, `renderOffset = 0`. No behavior change.                                                                   |
+| 2   | `total == cap` exactly                                                       | `domHeight = total`, `scrollScale = 1`.                                                                                                                                 |
+| 3   | `total > cap` (large libraries)                                              | `domHeight = cap`, `scrollScale < 1`; oldest month reachable.                                                                                                           |
+| 4   | `logicalScrollMax == 0` (content ≤ viewport, empty/tiny)                     | conversions return `0`, `scrollScale = 1`; no divide-by-zero.                                                                                                           |
+| 5   | `domScrollMax == 0`                                                          | `domToLogical` returns `0`; no divide-by-zero.                                                                                                                          |
+| 6   | `viewportHeight == 0` / `hasEmptyViewport`                                   | existing guards short-circuit geometry; conversions are safe.                                                                                                           |
+| 7   | Firefox vs others                                                            | `maxScrollHeight` differs; both browsers reach all assets.                                                                                                              |
+| 8   | Resize / column-count change                                                 | month heights recompute → `total`/`domHeight`/`scrollScale`/`renderOffset` recompute; viewport tracked via logical `#scrollTop`.                                        |
+| 9   | Async height resolution (estimate → actual)                                  | existing `scrollBy(heightDelta)` compensation keeps the **logical** viewport position stable. Pixel-exact at scale 1; ≤ a few px drift at scale < 1 (accepted, see §7). |
+| 10  | `scrollTo(top)` with `top > logicalScrollMax`                                | clamped to `domScrollMax`.                                                                                                                                              |
+| 11  | `scrollTo(0)`                                                                | DOM `0`; top reachable.                                                                                                                                                 |
+| 12  | Representative Months/Years grouping                                         | far below cap → `scrollScale = 1`, `renderOffset = 0`; unchanged.                                                                                                       |
+| 13  | Scrubber drag on large library                                               | `onScrub` computes logical target → `scrollTo` maps to DOM → lands on the right date.                                                                                   |
+| 14  | Scrubber arrow-key nudge (`scrollableElement.scrollBy({behavior:'smooth'})`) | DOM-space nudge; `onscroll` → `updateSlidingWindow` converts. Moves ~`delta/scale` logical px (consistent coarsening). No change needed.                                |
+| 15  | Deep link `/photos/<id>` to an old asset                                     | `findTimelineMonthForAsset` loads the month; `scrollToAssetPosition` → `scrollTo(logical)` → DOM. Reachable.                                                            |
+| 16  | `limitedScroll` (content < 2× viewport)                                      | only triggers when `total` is tiny → `scrollScale` always `1`; path unaffected.                                                                                         |
+
+## 6. Strict TDD plan
+
+**Discipline:** every change is written test-first. Each numbered item below is a red→green
+cycle: write the failing test, run it (`cd web && pnpm test -- --run <file>`), see it fail for
+the expected reason, implement the minimum to pass, then refactor. No production line is written
+before a failing test demands it. Run the full timeline suite green before moving on.
+
+### 6.1 New `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts`
+
+Pure scaling math via a minimal test subclass that exposes a settable raw DOM position and lets
+heights be set directly (base `topSectionHeight`/`bodySectionHeight`/`bottomSectionHeight` are
+writable `$state`):
+
+```ts
+class TestScroller extends VirtualScrollManager {
+  #dom = 0;
+  override get domScrollTop() {
+    return this.#dom;
+  }
+  setDomScrollTop(v: number) {
+    this.#dom = v;
+  }
+}
+```
+
+Tests:
+
+1. **Below cap → identity.** body=10_000, viewport=1000, maxScrollHeight=1_000_000 ⇒
+   `domHeight == totalViewerHeight`, `scrollScale == 1`, `domToLogical(x) == x`,
+   `logicalToDom(x) == x`; after `setDomScrollTop(500); updateSlidingWindow()` ⇒
+   `scrollTop == 500`, `renderOffset == 0`.
+2. **At cap.** total == maxScrollHeight ⇒ `domHeight == total`, `scrollScale == 1`.
+3. **Above cap → clamp + scale.** body=100_000, viewport=1000, maxScrollHeight=10_000 ⇒
+   `domHeight == 10_000`, `0 < scrollScale < 1`.
+4. **Endpoints reachable.** `logicalToDom(0) == 0`; `logicalToDom(logicalScrollMax) == domScrollMax`.
+5. **Round-trip.** `domToLogical(logicalToDom(x)) ≈ x` for x in {0, mid, logicalScrollMax}.
+6. **renderOffset bounded near viewport.** at bottom (`setDomScrollTop(domScrollMax)`), an item at
+   logical `total` maps to `domY == domHeight` (≤ cap), not a multi-million-px value.
+7. **Divide-by-zero guards.** viewport ≥ total ⇒ `logicalScrollMax == 0` ⇒ conversions return `0`,
+   `scrollScale == 1`, no `NaN`/`Infinity`.
+8. **Reactivity.** `renderOffset` reads cached `$state`: it changes only after
+   `updateSlidingWindow()`, not on a bare `setDomScrollTop`.
+
+### 6.2 Additions to `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts` spec
+
+Reuse the existing fixture (3 buckets, `totalViewerHeight == 8337`, viewport 1588×1000) plus an
+injected fake scroll element:
+
+```ts
+const fakeEl = {
+  scrollTop: 0,
+  scrollTo({ top }) {
+    this.scrollTop = top;
+  },
+  scrollBy(_x, y) {
+    this.scrollTop += y;
+  },
+} as unknown as HTMLElement;
+timelineManager.scrollableElement = fakeEl;
+```
+
+9. **Default (below cap) is inert.** With default `maxScrollHeight`, `domHeight == 8337`,
+   `scrollScale == 1`; `scrollTo(1000)` ⇒ `fakeEl.scrollTop == 1000`, `timelineManager.scrollTop == 1000`,
+   `renderOffset == 0`.
+10. **Forced scaling reaches the tail (fixes symptom #1).** set `maxScrollHeight = 4000`
+    (logicalScrollMax 7337, domScrollMax 3000); `scrollTo(timelineManager.maxScroll)` ⇒
+    `fakeEl.scrollTop == 3000` (== domScrollMax) and `timelineManager.scrollTop == 7337`
+    (== logical max) — the oldest content is reachable, not clamped short.
+11. **scrollTo clamps.** `scrollTo(10 * total)` ⇒ `fakeEl.scrollTop == domScrollMax`.
+12. **scrollBy is logical.** under scaling, `scrollBy(d)` ⇒ `scrollTop` increases by ≈ `d` logical.
+13. **scrollTop is logical end-to-end.** set `fakeEl.scrollTop = domScrollMax; updateSlidingWindow()`
+    ⇒ `timelineManager.scrollTop == logical max`, `visibleWindow.top == logical max`.
+14. **Logical scroll stability on height change (edge #9).** scroll into a later month under
+    scaling; grow an earlier month's height; assert `getTimelineTopVisibleAnchor` returns the same
+    month before and after (logical position preserved).
+
+### 6.3 Anchor regression (symptom #2)
+
+Add to the timeline-manager spec (real manager + fake element + forced small cap), or extend
+`timeline-anchor.spec.ts`:
+
+15. **Years/Months → All preserves deep position.** with `maxScrollHeight` forced small, set a
+    temporal anchor on the **oldest** month and call `scrollTimelineToTemporalAnchor`; assert
+    `fakeEl.scrollTop == domScrollMax`, the call returns `true`, and `targetIsInViewport` holds —
+    i.e. no snap-back to the cap boundary.
+16. **Existing anchor unit tests stay green** (clamping to `maxScroll` unchanged).
+
+### 6.4 Full-suite regression
+
+17. `cd web && pnpm test -- --run src/lib/managers/timeline-manager` and the new
+    `VirtualScrollManager` spec all green.
+18. `cd web && pnpm test` (web unit suite) green — confirms no regression in dependent components.
+19. `make check-web` (svelte-check + tsc) clean.
+
+## 7. Accepted limitations
+
+- **Scroll coarsening past the cap.** On the reported 563k library: Chrome/Safari unaffected
+  (`scrollScale == 1`); Firefox ≈ 1.9× coarser wheel/trackpad. Scrubber/keyboard/jump-to-asset
+  remain exact.
+- **Sub-pixel scroll drift during async height resolution at `scrollScale < 1`.** The compensation
+  keeps the _logical_ viewport position stable; the proportional DOM remap can introduce ≤ a few px
+  of visual drift while month heights firm up on huge libraries. Imperceptible in practice and far
+  better than total unreachability. Pixel-exact at `scrollScale == 1` (all normal libraries).
+
+## 8. Files touched
+
+| File                                                                              | Change                                                                                                                  |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts`        | scaling model, conversions, logical `scrollTop`, `domScrollTop`, `renderOffset`, cached DOM `$state`, `maxScrollHeight` |
+| `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts`                | override `domScrollTop`; `scrollTo`/`scrollBy` conversion                                                               |
+| `web/src/lib/components/timeline/Timeline.svelte`                                 | `domHeight` height; `renderOffset` transforms; 3 logical/DOM mixer fixes                                                |
+| `web/src/lib/components/timeline/TimelineRepresentativeBuckets.svelte`            | `renderOffset` prop on `translateY`                                                                                     |
+| `web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts`   | **new** — scaling math tests                                                                                            |
+| `web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts`           | scroll-conversion + reachability + stability tests                                                                      |
+| `web/src/lib/managers/timeline-manager/timeline-anchor.spec.ts` (or manager spec) | symptom-#2 regression                                                                                                   |
+
+Reuses `isFirefox` from `web/src/lib/utils/asset-utils.ts`. No new files beyond the spec; no new
+classes; no upstream-file restructuring.
+
+## 9. Manual verification
+
+Requires a large library (or synthetic data exceeding the cap). On `make dev`:
+
+1. "All" view: scroll to the very bottom — the oldest assets (pre-2008) render; no fixed cutoff.
+2. Years (or Months) → click a pre-2008 entry → switch to "All": the view stays on that date; no
+   snap-back to 2008.
+3. Deep-link `/photos/<id>` for a pre-2008 asset: scrolls to and focuses it.
+4. Normal-sized library: scrolling, scrubber, and deep-linking behave exactly as before
+   (`scrollScale == 1`).
+5. Repeat 1–2 in Firefox (lower cap → scaling engages earlier).

--- a/docs/plans/2026-06-19-timeline-all-view-height-cap.md
+++ b/docs/plans/2026-06-19-timeline-all-view-height-cap.md
@@ -95,7 +95,13 @@ Two coordinate spaces:
   capped at a browser-safe maximum so it never exceeds the render limit.
 
 ```
-maxScrollHeight   = isFirefox ? 17_000_000 : 33_000_000   // instance value, overridable in tests
+maxScrollHeight   = MAX_SCROLL_HEIGHT   // instance $state, overridable in tests; default below
+
+// Module const in VirtualScrollManager. The Firefox UA check is INLINED rather than imported
+// from asset-utils (`isFirefox`), because asset-utils imports TimelineManager, which imports
+// VirtualScrollManager — importing it here would create a circular dependency.
+MAX_SCROLL_HEIGHT = (typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox'))
+                      ? 17_000_000 : 33_000_000
 domHeight         = min(totalViewerHeight, maxScrollHeight)   // = #virtual-timeline height
 logicalScrollMax  = max(0, totalViewerHeight - viewportHeight)
 domScrollMax      = max(0, domHeight - viewportHeight)
@@ -374,8 +380,10 @@ Add to the timeline-manager spec (real manager + fake element + forced small cap
 | `web/src/lib/managers/timeline-manager/timeline-anchor.spec.ts` (or manager spec) | symptom-#2 regression                                                                                                   |
 | `web/src/lib/components/timeline/Timeline.svelte.spec.ts`                         | **new (or recorded manual fallback)** — item 17 template-wiring test                                                    |
 
-Reuses `isFirefox` from `web/src/lib/utils/asset-utils.ts`. New files are limited to the two spec
-files; no new production files, no new classes, no upstream-file restructuring.
+Inlines the Firefox UA check as a module const in `VirtualScrollManager.svelte.ts` — importing
+`isFirefox` from `asset-utils.ts` would create a circular dependency (asset-utils → TimelineManager
+→ VirtualScrollManager). New files are limited to the two spec files; no new production files, no
+new classes, no upstream-file restructuring.
 
 ## 9. Manual verification
 

--- a/web/src/lib/components/timeline/Timeline.spec.ts
+++ b/web/src/lib/components/timeline/Timeline.spec.ts
@@ -497,4 +497,15 @@ describe('Timeline scroll-space scaling', () => {
       /translate3d\(\s*0(?:px)?\s*,\s*346px\s*,\s*0(?:px)?\s*\)/,
     );
   });
+
+  it('offsets the lead-in/top section transform by renderOffset so it stays flush with the first month', () => {
+    // The top section renders at logical position 0, so its DOM position must be `0 + renderOffset`.
+    // Without this, an above-cap library (renderOffset != 0) draws the first month over the still-visible
+    // lead-in as it scrolls, because months use `top + renderOffset` and the top section did not.
+    testState.renderOffset = 50;
+    const { getByTestId } = renderTimeline();
+    expect(getByTestId('timeline-top-section').getAttribute('style')).toMatch(
+      /translate3d\(\s*0(?:px)?\s*,\s*50px\s*,\s*0(?:px)?\s*\)/,
+    );
+  });
 });

--- a/web/src/lib/components/timeline/Timeline.spec.ts
+++ b/web/src/lib/components/timeline/Timeline.spec.ts
@@ -43,6 +43,8 @@ const testState = vi.hoisted(() => ({
   scrollTop: 0,
   maxScroll: 1,
   scrollToUpdatesAfterCalls: 1,
+  domHeight: 296,
+  renderOffset: 0,
 }));
 
 vi.mock('$app/navigation', () => ({
@@ -119,6 +121,12 @@ vi.mock('$lib/managers/timeline-manager/timeline-manager.svelte', () => ({
     bodySectionHeight = 296;
     bottomSectionHeight = 0;
     totalViewerHeight = 296;
+    get domHeight() {
+      return testState.domHeight;
+    }
+    get renderOffset() {
+      return testState.renderOffset;
+    }
     get viewportHeight() {
       return testState.viewportHeight;
     }
@@ -227,6 +235,8 @@ describe('Timeline representative grouping integration', () => {
     testState.scrollTop = 0;
     testState.maxScroll = 1;
     testState.scrollToUpdatesAfterCalls = 1;
+    testState.domHeight = 296;
+    testState.renderOffset = 0;
     testState.representativeBucket = {
       grouping: 'year',
       timeBucket: '2015-01-01',
@@ -439,5 +449,52 @@ describe('Timeline representative grouping integration', () => {
     });
 
     expect(screen.getByText('No assets found')).toBeInTheDocument();
+  });
+});
+
+describe('Timeline scroll-space scaling', () => {
+  beforeEach(() => {
+    testState.grouping = 'day';
+    testState.assetCount = 1;
+    testState.viewportHeight = 600;
+    testState.viewportWidth = 390;
+    testState.domHeight = 296;
+    testState.renderOffset = 0;
+    testState.months = [];
+  });
+
+  it('sizes the virtual timeline to domHeight, not totalViewerHeight', () => {
+    testState.domHeight = 200; // < totalViewerHeight (296)
+    const { container } = renderTimeline();
+    const virtual = container.querySelector('#virtual-timeline') as HTMLElement;
+    expect(virtual).toHaveStyle({ height: '200px' });
+  });
+
+  it('offsets the month skeleton transform by renderOffset', () => {
+    testState.renderOffset = 50;
+    testState.months = [
+      {
+        viewId: 'month:2015-01',
+        isInOrNearViewport: false,
+        isLoaded: false,
+        top: 1200,
+        height: 240,
+        title: 'Jan 2015',
+      },
+    ];
+    renderTimeline();
+    // assert on the raw inline style so CSS normalization (e.g. `0`→`0px`) can't cause a false negative;
+    // the template emits exactly `translate3d(0,${top + renderOffset}px,0)`
+    const skeleton = screen.getByTestId('timeline-month-skeleton');
+    expect(skeleton.getAttribute('style')).toMatch(/translate3d\(\s*0(?:px)?\s*,\s*1250px\s*,\s*0(?:px)?\s*\)/);
+  });
+
+  it('offsets the lead-out spacer transform by renderOffset', () => {
+    // topSectionHeight 0 + bodySectionHeight 296 + renderOffset 50 = 346
+    testState.renderOffset = 50;
+    const { getByTestId } = renderTimeline();
+    expect(getByTestId('timeline-leadout').getAttribute('style')).toMatch(
+      /translate3d\(\s*0(?:px)?\s*,\s*346px\s*,\s*0(?:px)?\s*\)/,
+    );
   });
 });

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -739,9 +739,11 @@
     <section
       bind:clientHeight={timelineManager.topSectionHeight}
       class:invisible
+      data-testid="timeline-top-section"
       style:position="absolute"
       style:left="0"
       style:right="0"
+      style:transform={`translate3d(0,${timelineManager.renderOffset}px,0)`}
     >
       {@render children?.()}
       {#if isEmpty}

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -243,7 +243,7 @@
       return;
     }
 
-    const currentTop = scrollableElement?.scrollTop || 0;
+    const currentTop = timelineManager.scrollTop;
     const viewportHeight = visibleBottom - visibleTop;
 
     // Calculate the minimum scroll needed to bring the asset into view.
@@ -433,13 +433,13 @@
       // edge case - scroll limited due to size of content, must adjust -  use the overall percent instead
       const maxScroll = timelineManager.maxScroll;
 
-      timelineScrollPercent = Math.min(1, scrollableElement.scrollTop / maxScroll);
+      timelineScrollPercent = Math.min(1, timelineManager.scrollTop / maxScroll);
       viewportTopMonth = undefined;
       viewportTopMonthScrollPercent = 0;
     } else {
       timelineScrollPercent = 0;
 
-      let top = scrollableElement.scrollTop;
+      let top = timelineManager.scrollTop;
       let maxScrollPercent = timelineManager.maxScrollPercent;
 
       const monthsLength = timelineManager.months.length;
@@ -734,7 +734,7 @@
     bind:this={timelineElement}
     id="virtual-timeline"
     class:invisible
-    style:height={timelineManager.totalViewerHeight + 'px'}
+    style:height={timelineManager.domHeight + 'px'}
   >
     <section
       bind:clientHeight={timelineManager.topSectionHeight}
@@ -755,6 +755,7 @@
         grouping={activeGrouping}
         buckets={timelineManager.timelineBuckets}
         visibleWindow={timelineManager.visibleWindow}
+        renderOffset={timelineManager.renderOffset}
         locale={$lang}
         disabled={isSelectionMode || assetInteraction.selectionActive}
         {onTimelineBucketActivate}
@@ -769,10 +770,11 @@
       {#key timelineManager.reloadToken}
         {#each timelineManager.months as timelineMonth (timelineMonth.viewId)}
           {@const isInOrNearViewport = timelineMonth.isInOrNearViewport}
-          {@const absoluteHeight = timelineMonth.top}
+          {@const absoluteHeight = timelineMonth.top + timelineManager.renderOffset}
 
           {#if !timelineMonth.isLoaded}
             <div
+              data-testid="timeline-month-skeleton"
               style:height={timelineMonth.height + 'px'}
               style:position="absolute"
               style:transform={`translate3d(0,${absoluteHeight}px,0)`}
@@ -840,11 +842,12 @@
     {/if}
     <!-- spacer for leadout -->
     <div
+      data-testid="timeline-leadout"
       style:height={timelineManager.bottomSectionHeight + 'px'}
       style:position="absolute"
       style:left="0"
       style:right="0"
-      style:transform={`translate3d(0,${timelineManager.topSectionHeight + timelineManager.bodySectionHeight}px,0)`}
+      style:transform={`translate3d(0,${timelineManager.topSectionHeight + timelineManager.bodySectionHeight + timelineManager.renderOffset}px,0)`}
     ></div>
   </section>
 </section>

--- a/web/src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts
+++ b/web/src/lib/components/timeline/TimelineRepresentativeBuckets.spec.ts
@@ -226,4 +226,15 @@ describe('TimelineRepresentativeBuckets', () => {
 
     expect(onRequestCovers).not.toHaveBeenCalled();
   });
+
+  it('offsets bucket transforms by renderOffset', () => {
+    render(TimelineRepresentativeBuckets, {
+      grouping: 'year',
+      buckets: [bucket(2016, 120)],
+      visibleWindow: { top: 100, bottom: 600 },
+      renderOffset: 50,
+    });
+
+    expect(screen.getByTestId('timeline-bucket-shell-2016-01-01')).toHaveStyle('transform: translateY(170px)');
+  });
 });

--- a/web/src/lib/components/timeline/TimelineRepresentativeBuckets.svelte
+++ b/web/src/lib/components/timeline/TimelineRepresentativeBuckets.svelte
@@ -28,6 +28,7 @@
     visibleWindow: VisibleWindow;
     locale?: string;
     disabled?: boolean;
+    renderOffset?: number;
     onTimelineBucketActivate?: (bucket: ActivatableTimelineBucket) => void;
     onRequestCovers?: (timeBuckets: string[]) => void;
   }
@@ -38,6 +39,7 @@
     visibleWindow,
     locale = 'en-US',
     disabled = false,
+    renderOffset = 0,
     onTimelineBucketActivate,
     onRequestCovers,
   }: Props = $props();
@@ -67,7 +69,7 @@
   <div data-testid="timeline-representative-buckets" data-grouping={grouping}>
     {#each visibleBuckets as bucket (bucket.viewId)}
       <div
-        style={`position: absolute; height: ${bucket.height}px; width: 100%; transform: translateY(${bucket.top}px);`}
+        style={`position: absolute; height: ${bucket.height}px; width: 100%; transform: translateY(${bucket.top + renderOffset}px);`}
         data-testid={`timeline-bucket-shell-${bucket.timeBucket}`}
       >
         <div class="mx-auto h-full max-w-5xl px-4" data-testid="timeline-bucket-frame">

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { VirtualScrollManager } from './VirtualScrollManager.svelte';
+
+class TestScroller extends VirtualScrollManager {
+  #dom = 0;
+  override get domScrollTop() {
+    return this.#dom;
+  }
+  setDomScrollTop(value: number) {
+    this.#dom = value;
+  }
+}
+
+function makeScroller({ body, viewport, cap }: { body: number; viewport: number; cap?: number }) {
+  const scroller = new TestScroller();
+  scroller.bodySectionHeight = body;
+  scroller.viewportHeight = viewport;
+  if (cap !== undefined) {
+    scroller.maxScrollHeight = cap;
+  }
+  return scroller;
+}
+
+describe('VirtualScrollManager scaling', () => {
+  it('1. is identity below the cap', () => {
+    const s = makeScroller({ body: 10_000, viewport: 1000, cap: 1_000_000 });
+    expect(s.domHeight).toBe(10_000); // == totalViewerHeight
+    expect(s.scrollScale).toBe(1);
+    expect(s.domToLogical(500)).toBe(500);
+    expect(s.logicalToDom(500)).toBe(500);
+
+    s.setDomScrollTop(500);
+    s.updateSlidingWindow();
+    expect(s.scrollTop).toBe(500); // logical
+    expect(s.renderOffset).toBe(0);
+  });
+
+  it('2. leaves scale at 1 exactly at the cap', () => {
+    const s = makeScroller({ body: 10_000, viewport: 1000, cap: 10_000 });
+    expect(s.domHeight).toBe(10_000);
+    expect(s.scrollScale).toBe(1);
+  });
+
+  it('3. clamps domHeight and scales above the cap', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    expect(s.domHeight).toBe(10_000);
+    expect(s.scrollScale).toBeGreaterThan(0);
+    expect(s.scrollScale).toBeLessThan(1);
+  });
+
+  it('4. maps both endpoints so the tail is reachable', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    expect(s.logicalToDom(0)).toBe(0);
+    expect(s.logicalToDom(s.logicalScrollMax)).toBeCloseTo(s.domScrollMax, 6);
+  });
+
+  it('5. round-trips dom↔logical', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    for (const x of [0, 50_000, s.logicalScrollMax]) {
+      expect(s.domToLogical(s.logicalToDom(x))).toBeCloseTo(x, 6);
+    }
+  });
+
+  it('6. keeps the bottom item bounded within the capped DOM height', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    s.setDomScrollTop(s.domScrollMax);
+    s.updateSlidingWindow();
+    expect(s.scrollTop).toBeCloseTo(s.logicalScrollMax, 6); // 99_000
+    expect(s.renderOffset).toBeCloseTo(-90_000, 6);
+    // an item at logical top == total lands exactly at domHeight, not at 100_000px
+    expect(s.totalViewerHeight + s.renderOffset).toBeCloseTo(s.domHeight, 6);
+  });
+
+  it('7. guards against divide-by-zero and NaN at the geometry edges', () => {
+    // (a) content fits the viewport → logicalScrollMax == 0 (spec edge #4/#5)
+    const fits = makeScroller({ body: 500, viewport: 1000, cap: 10_000 });
+    expect(fits.logicalScrollMax).toBe(0);
+    expect(fits.domToLogical(123)).toBe(0);
+    expect(fits.logicalToDom(123)).toBe(0);
+    expect(fits.scrollScale).toBe(1);
+    expect(Number.isFinite(fits.domToLogical(123))).toBe(true);
+
+    // (b) zero-height viewport (transient, before layout) → no NaN/Infinity (spec edge #6)
+    const noViewport = makeScroller({ body: 100_000, viewport: 0, cap: 10_000 });
+    expect(noViewport.domHeight).toBe(10_000);
+    expect(Number.isFinite(noViewport.domToLogical(5000))).toBe(true);
+    expect(Number.isFinite(noViewport.logicalToDom(50_000))).toBe(true);
+    expect(Number.isFinite(noViewport.scrollScale)).toBe(true);
+  });
+
+  it('8. renderOffset reads cached state, updating only after updateSlidingWindow', () => {
+    const s = makeScroller({ body: 100_000, viewport: 1000, cap: 10_000 });
+    s.setDomScrollTop(s.domScrollMax);
+    expect(s.renderOffset).toBe(0); // cached state not yet refreshed
+    s.updateSlidingWindow();
+    expect(s.renderOffset).toBeCloseTo(-90_000, 6);
+  });
+});

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { VirtualScrollManager } from './VirtualScrollManager.svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BROWSER_MAX_SCROLL_DEVICE_PX,
+  maxScrollHeightForDevicePixelRatio,
+  VirtualScrollManager,
+} from './VirtualScrollManager.svelte';
 
 class TestScroller extends VirtualScrollManager {
   #dom = 0;
@@ -94,5 +98,77 @@ describe('VirtualScrollManager scaling', () => {
     expect(s.renderOffset).toBe(0); // cached state not yet refreshed
     s.updateSlidingWindow();
     expect(s.renderOffset).toBeCloseTo(-90_000, 6);
+  });
+});
+
+// Regression: #713 follow-up. The browser's element-height ceiling is expressed in DEVICE
+// pixels, but the cap was a flat CSS-pixel constant. On a HiDPI display every CSS pixel costs
+// `devicePixelRatio` device pixels, so a 33,000,000px CSS request asks for 66,000,000 device
+// pixels on a 2x screen. The browser silently clamps the element to ~16,777,214px while
+// domScrollMax keeps being computed from the *requested* 33,000,000 — so domToLogical divides
+// by a scroll range that does not exist and the tail of the timeline becomes unreachable
+// (observed: 750k assets stuck at ~2023, exactly 50.8% of the library).
+describe('VirtualScrollManager HiDPI scroll cap', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('9. keeps the requested height under the browser device-pixel ceiling at every dpr', () => {
+    for (const dpr of [1, 1.25, 1.5, 2, 2.5, 3]) {
+      const cssPx = maxScrollHeightForDevicePixelRatio(dpr);
+      expect(cssPx * dpr).toBeLessThanOrEqual(BROWSER_MAX_SCROLL_DEVICE_PX);
+      expect(cssPx).toBeGreaterThan(0);
+    }
+  });
+
+  it('10. falls back to a 1x budget for absent or nonsensical devicePixelRatio values', () => {
+    const oneX = maxScrollHeightForDevicePixelRatio(1);
+    for (const bogus of [0, -2, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(maxScrollHeightForDevicePixelRatio(bogus)).toBe(oneX);
+    }
+  });
+
+  it('11. a manager built on a 2x display caps at half the 1x budget', () => {
+    vi.stubGlobal('devicePixelRatio', 1);
+    const oneX = new TestScroller().maxScrollHeight;
+
+    vi.stubGlobal('devicePixelRatio', 2);
+    const twoX = new TestScroller().maxScrollHeight;
+
+    expect(twoX).toBe(maxScrollHeightForDevicePixelRatio(2));
+    expect(twoX).toBeLessThan(oneX);
+    expect(twoX * 2).toBeLessThanOrEqual(BROWSER_MAX_SCROLL_DEVICE_PX);
+  });
+
+  it('13. re-derives the cap when the display dpr changes under a live manager', () => {
+    vi.stubGlobal('devicePixelRatio', 1);
+    const s = new TestScroller();
+    s.bodySectionHeight = 75_520_000;
+    s.viewportHeight = 941;
+    expect(s.maxScrollHeight).toBe(maxScrollHeightForDevicePixelRatio(1));
+
+    // Dragging the window onto a 2x monitor changes dpr; the accompanying geometry update is
+    // the manager's only signal. Without re-deriving, the cap stays at the 1x budget and the
+    // browser clamps the element right back to half of it.
+    vi.stubGlobal('devicePixelRatio', 2);
+    s.viewportHeight = 940;
+
+    expect(s.maxScrollHeight).toBe(maxScrollHeightForDevicePixelRatio(2));
+    expect(s.domHeight * 2).toBeLessThanOrEqual(BROWSER_MAX_SCROLL_DEVICE_PX);
+  });
+
+  it('12. maps the logical tail into a DOM range the 2x browser can actually deliver', () => {
+    vi.stubGlobal('devicePixelRatio', 2);
+    const s = new TestScroller();
+    s.bodySectionHeight = 75_520_000; // the reported 750k-asset library
+    s.viewportHeight = 941;
+
+    // The element the browser will actually lay out, in device pixels.
+    expect(s.domHeight * 2).toBeLessThanOrEqual(BROWSER_MAX_SCROLL_DEVICE_PX);
+
+    // Scrolling to the real bottom must land on the last logical pixel, not ~50% of it.
+    s.setDomScrollTop(s.domScrollMax);
+    s.updateSlidingWindow();
+    expect(s.scrollTop).toBeCloseTo(s.logicalScrollMax, 6);
   });
 });

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   BROWSER_MAX_SCROLL_DEVICE_PX,
   maxScrollHeightForDevicePixelRatio,
+  SCROLL_CEILING_FIREFOX_PX,
   VirtualScrollManager,
 } from './VirtualScrollManager.svelte';
 
@@ -155,6 +156,32 @@ describe('VirtualScrollManager HiDPI scroll cap', () => {
 
     expect(s.maxScrollHeight).toBe(maxScrollHeightForDevicePixelRatio(2));
     expect(s.domHeight * 2).toBeLessThanOrEqual(BROWSER_MAX_SCROLL_DEVICE_PX);
+  });
+
+  // Firefox is a separate ceiling, not a dpr problem. It happily lays out an element up to
+  // nscoord_MAX (17,895,697px) but caps the *scrollable range* at half that. Measured on a 750k
+  // library at dpr 1: a 17,537,784px element reported scrollHeight 8,947,850 and refused to
+  // scroll past 8,946,658 — so domScrollMax was ~2x the range the browser would actually give,
+  // stranding the timeline at ~51% exactly like the Chrome HiDPI case.
+  it('14. keeps the request inside Firefox’s scrollable range, not its layout ceiling', () => {
+    const s = new TestScroller();
+    s.bodySectionHeight = 62_760_582; // the reported Firefox library
+    s.viewportHeight = 1192;
+    // set last: the geometry setters re-derive the cap from the running engine
+    s.maxScrollHeight = maxScrollHeightForDevicePixelRatio(1, SCROLL_CEILING_FIREFOX_PX);
+
+    expect(s.domHeight).toBeLessThanOrEqual(SCROLL_CEILING_FIREFOX_PX);
+
+    s.setDomScrollTop(s.domScrollMax);
+    s.updateSlidingWindow();
+    expect(s.scrollTop).toBeCloseTo(s.logicalScrollMax, 6);
+  });
+
+  it('15. never exceeds the Firefox scroll ceiling at any dpr', () => {
+    for (const dpr of [1, 1.5, 2, 3]) {
+      const cssPx = maxScrollHeightForDevicePixelRatio(dpr, SCROLL_CEILING_FIREFOX_PX);
+      expect(cssPx * dpr).toBeLessThanOrEqual(SCROLL_CEILING_FIREFOX_PX);
+    }
   });
 
   it('12. maps the logical tail into a DOM range the 2x browser can actually deliver', () => {

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
@@ -202,6 +202,17 @@ export abstract class VirtualScrollManager {
     }
   }
 
+  // Re-derive the cached DOM↔logical scroll mapping from the current DOM scrollTop under the
+  // present scale. A geometry change (viewport resize, width reflow) shifts domScrollMax/
+  // logicalScrollMax without a scroll event, so the cached logical position — and therefore
+  // renderOffset — would otherwise stay computed against the old scale and teleport the timeline
+  // on the next scroll. Unlike updateSlidingWindow this skips the change guard: the DOM scrollTop
+  // may be unchanged while the scale is not.
+  protected resyncScrollMapping(): void {
+    this.#cachedDomScrollTop = this.domScrollTop;
+    this.#scrollTop = this.domToLogical(this.#cachedDomScrollTop);
+  }
+
   refreshLayout() {
     this.updateViewportProximities();
   }

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
@@ -1,10 +1,32 @@
 import { debounce } from 'lodash-es';
 
-// Largest element height the browser renders before clamping the scroll container: Firefox ≈ 17.9M,
-// Chrome/Safari ≈ 33.5M. The Firefox check is inlined (not imported from asset-utils's `isFirefox`)
-// to avoid the circular import asset-utils → TimelineManager → VirtualScrollManager.
-const MAX_SCROLL_HEIGHT =
-  typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox') ? 17_000_000 : 33_000_000;
+// Largest element height the browser lays out before clamping the scroll container, in DEVICE
+// pixels: Chrome/Safari saturate LayoutUnit at 2^31/64, Firefox nscoord at 2^30/60. The Firefox
+// check is inlined (not imported from asset-utils's `isFirefox`) to avoid the circular import
+// asset-utils → TimelineManager → VirtualScrollManager.
+const IS_FIREFOX = typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox');
+export const BROWSER_MAX_SCROLL_DEVICE_PX = IS_FIREFOX ? 17_895_697 : 33_554_428;
+
+// Headroom below the ceiling so the browser's own layout rounding never trips it.
+const SCROLL_HEIGHT_SAFETY = 0.98;
+
+/**
+ * CSS-pixel height budget for the scroll container on a display of the given devicePixelRatio.
+ *
+ * The ceiling above is a *device*-pixel limit, so on a HiDPI screen each CSS pixel spends `dpr`
+ * of it. Asking for a flat CSS-pixel height gets silently clamped — the element comes back
+ * ~`1/dpr` of what was requested while `domScrollMax` keeps being derived from the requested
+ * value, so `domToLogical` divides by a scroll range that does not exist and the tail of the
+ * list becomes unreachable. Dividing here keeps the request under the ceiling so nothing clamps.
+ *
+ * Firefox's nscoord limit is nominally in CSS pixels rather than device pixels; dividing anyway
+ * is deliberately conservative — it only shrinks the DOM range (slightly more compression), and
+ * never lets the request exceed the real ceiling on either engine.
+ */
+export function maxScrollHeightForDevicePixelRatio(dpr: number): number {
+  const ratio = Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
+  return Math.floor((BROWSER_MAX_SCROLL_DEVICE_PX * SCROLL_HEIGHT_SAFETY) / ratio);
+}
 
 type LayoutOptions = {
   headerHeight: number;
@@ -25,7 +47,7 @@ export abstract class VirtualScrollManager {
   #viewportHeight = $state(0);
   #viewportWidth = $state(0);
   #scrollTop = $state(0);
-  maxScrollHeight = $state(MAX_SCROLL_HEIGHT);
+  maxScrollHeight = $state(maxScrollHeightForDevicePixelRatio(globalThis.devicePixelRatio));
   #cachedDomScrollTop = $state(0);
   #rowHeight = $state(235);
   #headerHeight = $state(48);
@@ -153,10 +175,22 @@ export abstract class VirtualScrollManager {
     return this.#suspendTransitions;
   }
 
+  // dpr changes when the window moves between displays of different density (or on browser zoom).
+  // There is no dedicated event for it, but such a move always lands as a geometry update here,
+  // so re-derive the budget then — otherwise the cap stays at the old display's value and the
+  // browser clamps the element behind our back again.
+  #refreshScrollCap() {
+    const next = maxScrollHeightForDevicePixelRatio(globalThis.devicePixelRatio);
+    if (this.maxScrollHeight !== next) {
+      this.maxScrollHeight = next;
+    }
+  }
+
   set viewportWidth(value: number) {
     const changed = value !== this.#viewportWidth;
     this.#viewportWidth = value;
     this.suspendTransitions = true;
+    this.#refreshScrollCap();
     void this.updateViewportGeometry(changed);
   }
 
@@ -167,6 +201,7 @@ export abstract class VirtualScrollManager {
   set viewportHeight(value: number) {
     this.#viewportHeight = value;
     this.#suspendTransitions = true;
+    this.#refreshScrollCap();
     void this.updateViewportGeometry(false);
   }
 

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
@@ -1,11 +1,22 @@
 import { debounce } from 'lodash-es';
 
-// Largest element height the browser lays out before clamping the scroll container, in DEVICE
-// pixels: Chrome/Safari saturate LayoutUnit at 2^31/64, Firefox nscoord at 2^30/60. The Firefox
-// check is inlined (not imported from asset-utils's `isFirefox`) to avoid the circular import
-// asset-utils → TimelineManager → VirtualScrollManager.
+// Largest *scrollable range* the engine will actually deliver. This is not the same as the
+// largest element it will lay out, and the two engines differ in both value and unit:
+//
+//   Chromium/WebKit — saturates LayoutUnit at 2^31/64 = 33,554,428 DEVICE pixels, and scrolls the
+//     full element. On a 2x display a 33,000,000px CSS request becomes 66,000,000 device pixels
+//     and the element comes back silently halved, hence the dpr division below.
+//   Firefox — lays out up to nscoord_MAX (2^30/60 = 17,895,697px) but caps the scrollable range
+//     at half of it. Measured on a 750k-asset library at dpr 1: a 17,537,784px element reported
+//     scrollHeight 8,947,850 and would not scroll past 8,946,658. Using the layout ceiling here
+//     leaves domScrollMax ~2x the range the browser grants, stranding the tail at ~51%.
+//
+// The Firefox check is inlined (not imported from asset-utils's `isFirefox`) to avoid the
+// circular import asset-utils → TimelineManager → VirtualScrollManager.
 const IS_FIREFOX = typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox');
-export const BROWSER_MAX_SCROLL_DEVICE_PX = IS_FIREFOX ? 17_895_697 : 33_554_428;
+export const SCROLL_CEILING_FIREFOX_PX = 8_947_848; // nscoord_MAX / 2
+export const SCROLL_CEILING_CHROMIUM_PX = 33_554_428; // LayoutUnit saturation, device px
+export const BROWSER_MAX_SCROLL_DEVICE_PX = IS_FIREFOX ? SCROLL_CEILING_FIREFOX_PX : SCROLL_CEILING_CHROMIUM_PX;
 
 // Headroom below the ceiling so the browser's own layout rounding never trips it.
 const SCROLL_HEIGHT_SAFETY = 0.98;
@@ -19,13 +30,16 @@ const SCROLL_HEIGHT_SAFETY = 0.98;
  * value, so `domToLogical` divides by a scroll range that does not exist and the tail of the
  * list becomes unreachable. Dividing here keeps the request under the ceiling so nothing clamps.
  *
- * Firefox's nscoord limit is nominally in CSS pixels rather than device pixels; dividing anyway
- * is deliberately conservative — it only shrinks the DOM range (slightly more compression), and
+ * Firefox's ceiling is nominally in CSS pixels rather than device pixels (only measured at dpr 1
+ * so far); dividing anyway is deliberately conservative — it only shrinks the DOM range, and
  * never lets the request exceed the real ceiling on either engine.
  */
-export function maxScrollHeightForDevicePixelRatio(dpr: number): number {
+export function maxScrollHeightForDevicePixelRatio(
+  dpr: number,
+  ceiling: number = BROWSER_MAX_SCROLL_DEVICE_PX,
+): number {
   const ratio = Number.isFinite(dpr) && dpr > 0 ? dpr : 1;
-  return Math.floor((BROWSER_MAX_SCROLL_DEVICE_PX * SCROLL_HEIGHT_SAFETY) / ratio);
+  return Math.floor((ceiling * SCROLL_HEIGHT_SAFETY) / ratio);
 }
 
 type LayoutOptions = {

--- a/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
+++ b/web/src/lib/managers/VirtualScrollManager/VirtualScrollManager.svelte.ts
@@ -1,5 +1,11 @@
 import { debounce } from 'lodash-es';
 
+// Largest element height the browser renders before clamping the scroll container: Firefox ≈ 17.9M,
+// Chrome/Safari ≈ 33.5M. The Firefox check is inlined (not imported from asset-utils's `isFirefox`)
+// to avoid the circular import asset-utils → TimelineManager → VirtualScrollManager.
+const MAX_SCROLL_HEIGHT =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox') ? 17_000_000 : 33_000_000;
+
 type LayoutOptions = {
   headerHeight: number;
   rowHeight: number;
@@ -19,6 +25,8 @@ export abstract class VirtualScrollManager {
   #viewportHeight = $state(0);
   #viewportWidth = $state(0);
   #scrollTop = $state(0);
+  maxScrollHeight = $state(MAX_SCROLL_HEIGHT);
+  #cachedDomScrollTop = $state(0);
   #rowHeight = $state(235);
   #headerHeight = $state(48);
   #gap = $state(12);
@@ -37,8 +45,40 @@ export abstract class VirtualScrollManager {
     this.setLayoutOptions();
   }
 
-  get scrollTop() {
+  get domScrollTop(): number {
     return 0;
+  }
+
+  get scrollTop(): number {
+    return this.domToLogical(this.domScrollTop);
+  }
+
+  get renderOffset(): number {
+    return this.#cachedDomScrollTop - this.#scrollTop;
+  }
+
+  get domHeight(): number {
+    return Math.min(this.totalViewerHeight, this.maxScrollHeight);
+  }
+
+  get logicalScrollMax(): number {
+    return Math.max(0, this.totalViewerHeight - this.viewportHeight);
+  }
+
+  get domScrollMax(): number {
+    return Math.max(0, this.domHeight - this.viewportHeight);
+  }
+
+  get scrollScale(): number {
+    return this.logicalScrollMax > 0 ? this.domScrollMax / this.logicalScrollMax : 1;
+  }
+
+  domToLogical(dom: number): number {
+    return this.domScrollMax > 0 ? (dom * this.logicalScrollMax) / this.domScrollMax : 0;
+  }
+
+  logicalToDom(logical: number): number {
+    return this.logicalScrollMax > 0 ? (logical * this.domScrollMax) / this.logicalScrollMax : 0;
   }
 
   get justifiedLayoutOptions() {
@@ -153,8 +193,10 @@ export abstract class VirtualScrollManager {
   }
 
   updateSlidingWindow() {
-    const scrollTop = this.scrollTop;
-    if (this.#scrollTop !== scrollTop) {
+    const domScrollTop = this.domScrollTop;
+    const scrollTop = this.domToLogical(domScrollTop);
+    if (this.#scrollTop !== scrollTop || this.#cachedDomScrollTop !== domScrollTop) {
+      this.#cachedDomScrollTop = domScrollTop;
       this.#scrollTop = scrollTop;
       this.updateViewportProximities();
     }

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -1357,4 +1357,17 @@ describe('TimelineManager scroll scaling', () => {
     expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // 3000, reachable — not clamped short
     expect(reached).toBe(true);
   });
+
+  it('16. re-derives the DOM↔logical mapping on a geometry change so renderOffset never goes stale', () => {
+    timelineManager.maxScrollHeight = 4000; // force scaling: domScrollMax 3000, logicalScrollMax 7337
+    timelineManager.scrollTo(2000); // logical; DOM scrollTop is now well below the logical position
+    // Invariant after any scroll: renderOffset === domScrollTop − logicalScrollTop.
+    expect(timelineManager.renderOffset).toBeCloseTo(fakeEl.scrollTop - timelineManager.scrollTop, 6);
+
+    // A viewport resize changes the scale WITHOUT a scroll event. The cached logical position must be
+    // re-derived under the new scale, otherwise the next scroll teleports the timeline by the drift.
+    timelineManager.viewportHeight = 500; // was 1000
+
+    expect(timelineManager.renderOffset).toBeCloseTo(fakeEl.scrollTop - timelineManager.scrollTop, 6);
+  });
 });

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -10,6 +10,7 @@ import { tick } from 'svelte';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import { getTimelineMonthByDate } from '$lib/managers/timeline-manager/internal/search-support.svelte';
+import { scrollTimelineToTemporalAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
 import { AbortError } from '$lib/utils';
 import { fromISODateTimeUTCToObject } from '$lib/utils/timeline-util';
 import { assetFactory, timelineAssetFactory, toResponseDto } from '@test-data/factories/asset-factory';
@@ -1247,5 +1248,113 @@ describe('TimelineManager', () => {
         Settings.resetCaches();
       }
     });
+  });
+});
+
+describe('TimelineManager scroll scaling', () => {
+  let timelineManager: TimelineManager;
+  let fakeEl: { scrollTop: number; scrollTo: (o: { top: number }) => void };
+
+  function deriveLocalDateTime(arg: TimelineAsset): TimelineAsset {
+    return { ...arg, localDateTime: arg.fileCreatedAt };
+  }
+
+  const bucketAssets: Record<string, TimelineAsset[]> = {
+    '2024-03-01': timelineAssetFactory
+      .buildList(1)
+      .map((asset) =>
+        deriveLocalDateTime({ ...asset, fileCreatedAt: fromISODateTimeUTCToObject('2024-03-01T00:00:00.000Z') }),
+      ),
+    '2024-02-01': timelineAssetFactory
+      .buildList(100)
+      .map((asset) =>
+        deriveLocalDateTime({ ...asset, fileCreatedAt: fromISODateTimeUTCToObject('2024-02-01T00:00:00.000Z') }),
+      ),
+    '2024-01-01': timelineAssetFactory
+      .buildList(3)
+      .map((asset) =>
+        deriveLocalDateTime({ ...asset, fileCreatedAt: fromISODateTimeUTCToObject('2024-01-01T00:00:00.000Z') }),
+      ),
+  };
+  const bucketAssetsResponse: Record<string, TimeBucketAssetResponseDto> = Object.fromEntries(
+    Object.entries(bucketAssets).map(([key, assets]) => [key, toResponseDto(...assets)]),
+  );
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    timelineManager = new TimelineManager();
+    sdkMock.getTimeBuckets.mockResolvedValue([
+      { count: 1, timeBucket: '2024-03-01' },
+      { count: 100, timeBucket: '2024-02-01' },
+      { count: 3, timeBucket: '2024-01-01' },
+    ]);
+    sdkMock.getTimeBucket.mockImplementation(({ timeBucket }) => Promise.resolve(bucketAssetsResponse[timeBucket]));
+    await timelineManager.updateViewport({ width: 1588, height: 1000 });
+    await tick();
+
+    fakeEl = {
+      scrollTop: 0,
+      scrollTo({ top }: { top: number }) {
+        this.scrollTop = top; // manager already clamped; store verbatim
+      },
+    };
+    timelineManager.scrollableElement = fakeEl as unknown as HTMLElement;
+  });
+
+  it('9. is inert below the cap', () => {
+    // totalViewerHeight == 8337, viewport == 1000, default cap is huge
+    expect(timelineManager.domHeight).toBe(timelineManager.totalViewerHeight);
+    expect(timelineManager.scrollScale).toBe(1);
+    timelineManager.scrollTo(1000);
+    expect(fakeEl.scrollTop).toBe(1000);
+    expect(timelineManager.scrollTop).toBe(1000);
+    expect(timelineManager.renderOffset).toBe(0);
+  });
+
+  it('10. reaches the tail under forced scaling (symptom #1)', () => {
+    timelineManager.maxScrollHeight = 4000; // domHeight 4000, domScrollMax 3000, logicalScrollMax 7337
+    timelineManager.scrollTo(timelineManager.maxScroll); // 7337
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // 3000
+    expect(timelineManager.scrollTop).toBeCloseTo(timelineManager.maxScroll, 6); // 7337
+  });
+
+  it('11. clamps scrollTo to [0, domScrollMax]', () => {
+    timelineManager.maxScrollHeight = 4000;
+    timelineManager.scrollTo(10 * timelineManager.totalViewerHeight);
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // clamped to bottom
+    timelineManager.scrollTo(0); // top reachable (spec edge #11)
+    expect(fakeEl.scrollTop).toBe(0);
+    timelineManager.scrollTo(-5000); // negative clamped to 0
+    expect(fakeEl.scrollTop).toBe(0);
+  });
+
+  it('12. scrollBy moves the logical position by the given delta', () => {
+    timelineManager.maxScrollHeight = 4000;
+    timelineManager.scrollTo(2000);
+    timelineManager.scrollBy(1000);
+    expect(timelineManager.scrollTop).toBeCloseTo(3000, 6);
+  });
+
+  it('13. exposes a logical scrollTop end-to-end', () => {
+    timelineManager.maxScrollHeight = 4000;
+    fakeEl.scrollTop = timelineManager.domScrollMax; // 3000 (raw DOM)
+    timelineManager.updateSlidingWindow();
+    expect(timelineManager.scrollTop).toBeCloseTo(timelineManager.maxScroll, 6); // 7337
+    expect(timelineManager.visibleWindow.top).toBeCloseTo(timelineManager.maxScroll, 6);
+  });
+
+  it('14. scrollBy preserves the logical delta the height compensation relies on', () => {
+    timelineManager.maxScrollHeight = 4000;
+    timelineManager.scrollTo(1500);
+    const before = timelineManager.scrollTop;
+    timelineManager.scrollBy(500); // mirrors month.height setter compensation
+    expect(timelineManager.scrollTop - before).toBeCloseTo(500, 6);
+  });
+
+  it('15. preserves a deep anchor across Years/Months → All (symptom #2)', () => {
+    timelineManager.maxScrollHeight = 4000;
+    const reached = scrollTimelineToTemporalAnchor(timelineManager, { year: 2024, month: 1 });
+    expect(fakeEl.scrollTop).toBeCloseTo(timelineManager.domScrollMax, 6); // 3000, reachable — not clamped short
+    expect(reached).toBe(true);
   });
 });

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -133,7 +133,7 @@ export class TimelineManager extends VirtualScrollManager {
   #websocketSupport: WebsocketSupport | undefined;
   #options: TimelineManagerOptions = TimelineManager.#INIT_OPTIONS;
   #updatingViewportProximities = false;
-  #scrollableElement: HTMLElement | undefined = $state();
+  #scrollableElement: HTMLElement | undefined = $state.raw();
   #showAssetOwners = new PersistedLocalStorage<boolean>('album-show-asset-owners', false);
   #unsubscribes: Array<() => void> = [];
   #initSequence = 0;
@@ -163,7 +163,7 @@ export class TimelineManager extends VirtualScrollManager {
     );
   }
 
-  override get scrollTop(): number {
+  override get domScrollTop(): number {
     return this.#scrollableElement?.scrollTop ?? 0;
   }
 
@@ -172,13 +172,12 @@ export class TimelineManager extends VirtualScrollManager {
   }
 
   scrollTo(top: number) {
-    this.#scrollableElement?.scrollTo({ top });
+    this.#scrollableElement?.scrollTo({ top: clamp(this.logicalToDom(top), 0, this.domScrollMax) });
     this.updateSlidingWindow();
   }
 
   scrollBy(y: number) {
-    this.#scrollableElement?.scrollBy(0, y);
-    this.updateSlidingWindow();
+    this.scrollTo(this.scrollTop + y);
   }
 
   async *assetsIterator(options?: {

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -450,11 +450,15 @@ export class TimelineManager extends VirtualScrollManager {
     }
     if (this.grouping !== 'day') {
       layoutTimelineBuckets(this.timelineBuckets);
+      this.resyncScrollMapping();
       return;
     }
     for (const month of this.months) {
       updateGeometry(this, month, { invalidateHeight: changedWidth });
     }
+    // Geometry may have changed the scale (viewport resize / width reflow), so re-derive the
+    // DOM↔logical mapping before recomputing proximities off the logical scrollTop.
+    this.resyncScrollMapping();
     this.updateViewportProximities();
     if (changedWidth) {
       this.#createScrubberMonths();


### PR DESCRIPTION
Closes #713

## Problem

On large libraries (e.g. 563k assets) the flat **"All"** timeline view hard-stops at a fixed date (~December 2008). Older assets are unreachable by scrolling, and navigating to a pre-cutoff date in Months/Years then switching to "All" snaps back to the cutoff. The data exists and is correct (it renders in Months/Years views).

**Root cause:** the "All" view sets `#virtual-timeline` height directly to the summed pixel height of every month and positions each month at its absolute cumulative offset. On huge libraries that total exceeds the **browser's maximum renderable element height**, so the browser clamps the scroll container and everything past the cap becomes unreachable. The fixed date is just where the cumulative height crosses the cap. This is upstream Immich's architecture — no upstream fix to pull.

## Fix — scroll-space scaling

Decouple the scroll element's DOM height from the timeline's logical height:

- Cap the DOM element height at a **browser-aware** maximum.
- Map scroll positions between true **logical** space and the capped **DOM** space (`domToLogical`/`logicalToDom`).
- Position visible content relative to the live scroll via a `renderOffset`, so no emitted coordinate ever exceeds the cap.
- Route all scroll-position reads through a single **logical** `scrollTop`, which also fixes the Years/Months→All snap-back.

**Scale is exactly `1` below the cap → zero behavior change for normal-sized libraries.** Above the cap, the only tradeoff is coarser wheel/trackpad scrolling (the scrubber, keyboard, and jump-to-asset stay exact); see the spec's accepted-limitations section.

## Follow-up: the cap constants were wrong on both engines

The first round of this PR capped at flat CSS-pixel constants (Firefox 17M / others 33M). Manual verification on a real 750k-asset library (see Testing) showed the bug **still reproduced on both engines**, for two different reasons. Both produce the identical symptom: `domScrollMax` ends up roughly 2× the scroll range the browser actually grants, so `domToLogical` divides by a range that does not exist and the timeline strands at ~51% of the library.

**Chromium — the ceiling is in _device_ pixels, not CSS pixels.** LayoutUnit saturates at `2^31/64 = 33,554,428` **device** px. On a HiDPI display each CSS pixel spends `devicePixelRatio` of that budget, so a 33,000,000px CSS request asks for 66,000,000 device px on a 2× screen and the element comes back silently halved.

Measured, `dpr: 2`, 750k assets:

| | |
|---|---|
| requested height | `33,000,000px` |
| actual `offsetHeight` | `16,777,214` (= 33,554,428 / 2) |
| believed `domScrollMax` | `32,999,059` |
| real max `scrollTop` | `16,776,443` → **50.8% of the library**, stuck mid-2023 |

At `dpr: 1` nothing clamps — which is why this never reproduced on a non-Retina display.

**Firefox — it grants only half its layout ceiling as scroll range.** Firefox lays out an element up to `nscoord_MAX` (`2^30/60 = 17,895,697px`) but caps the *scrollable* range at half of it. This is **not** dpr-related; it reproduced at `dpr: 1`.

Measured, `dpr: 1`, 750k assets:

| | |
|---|---|
| requested height | `17,537,800px` |
| actual `offsetHeight` | `17,537,784` — honored, **no clamp** |
| container `scrollHeight` | `8,947,850` (≈ `nscoord_MAX / 2`) |
| real max `scrollTop` | `8,946,658` → **~51% of the library** |

Both ceilings are now named explicitly, selected by engine, divided by `devicePixelRatio`, and given 2% headroom:

```ts
export const SCROLL_CEILING_FIREFOX_PX = 8_947_848; // nscoord_MAX / 2
export const SCROLL_CEILING_CHROMIUM_PX = 33_554_428; // LayoutUnit saturation, device px
```

The budget is also re-derived on viewport geometry changes, so dragging the window between displays of different density does not silently reintroduce the clamp.

> Firefox's ceiling is nominally in CSS pixels rather than device pixels (only measured at `dpr: 1` so far). Dividing by dpr there anyway is deliberately conservative — it only shrinks the DOM range, and never lets the request exceed the real ceiling on either engine.

## Design & plan

- Design spec: `docs/plans/2026-06-19-timeline-all-view-height-cap.md`
- Implementation plan: `docs/plans/2026-06-19-timeline-all-view-height-cap-plan.md`

## Changes

- `VirtualScrollManager.svelte.ts` — scaling engine (cap, conversions, `scrollScale`, logical `scrollTop`, `domScrollTop`, `renderOffset`, cached `updateSlidingWindow`); per-engine scroll ceilings, dpr-scaled budget, re-derive on geometry change.
- `timeline-manager.svelte.ts` — `domScrollTop` override; `scrollTo`/`scrollBy` convert logical↔DOM. (`#scrollableElement` uses `$state.raw()` to avoid Svelte 5 deep-proxying a DOM reference.)
- `Timeline.svelte` / `TimelineRepresentativeBuckets.svelte` — height bound to `domHeight`; transforms offset by `renderOffset`; mixer reads routed through logical `scrollTop`.

## Testing

**Manual verification on a large library — performed.** A 750,057-asset library was seeded into a local dev instance (700k assets at 10k/month spanning 2020-09 → 2026-06, plus 50k in 2000; every row referencing a single file on disk, so no extra storage). Confirmed **fixed in both Chrome and Firefox** against that library: the timeline now scrolls the full range down to the oldest asset instead of stranding at ~51%.

This is what surfaced both cap bugs above — neither was reachable from the automated tests, and neither reproduces at `dpr: 1` on Chromium.

**Automated:**

- `VirtualScrollManager` spec — **15 tests**: conversions, clamping, endpoint reachability, round-trip, divide-by-zero / zero-viewport guards, `renderOffset` reactivity, plus regression coverage for both cap bugs (device-pixel budget across `dpr` 1→3, dpr-change re-derivation, Firefox scroll-range ceiling).
- `timeline-manager` spec (7 tests): inert below cap, tail reachable (symptom #1), `scrollTo` clamp, logical `scrollBy`/`scrollTop`, stability invariant, anchor preserved (symptom #2).
- Component tests: `domHeight` height + `renderOffset` transforms (skeleton, lead-out, representative bucket).
- Local run of the touched areas (`src/lib/managers` + `src/lib/components/timeline`): **911 passed / 0 failed** across 32 files; `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` all clean. The full web suite runs in CI.

The regression test that would have caught the original Chromium bug is the invariant `maxScrollHeightForDevicePixelRatio(dpr) * dpr <= BROWSER_MAX_SCROLL_DEVICE_PX` across `dpr` 1→3 — the previous spec only ever exercised the cap at `dpr: 1`.
