### PR TITLE
fix(search): populate album filter facets for viewer-role users (#655)

### DIFF
--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -464,11 +464,13 @@ describe(SearchRepository.name, () => {
   });
 
   describe('album-scoped suggestions', () => {
-    // A shared album's assets are owned by the album owner, not the viewer. AlbumRead
-    // access is verified by the service before these queries run, so album membership is
-    // the only scope — no owner or shared-space restriction is added, otherwise viewers
-    // would see empty People/Location/Camera/Tag facets (issue #655).
-    it('buildFilteredAssetIds scopes to album membership only, without an owner restriction', () => {
+    // Album facets cover assets the user may legitimately see in the album: those
+    // contributed by an album participant (owner or shared user), owned by the user, or
+    // reachable via a timeline-opted-in shared space. The participant cases are what let
+    // viewers see facets for the album owner's assets (issue #655); the shared-space
+    // union is gated on timeline opt-in so a space asset that landed in an album never
+    // leaks to non-members.
+    it('buildFilteredAssetIds widens album scope to album participants, no spaces without timeline opt-in', () => {
       const sql = compileFilteredAssetIds(sut, {
         albumId: '11111111-1111-1111-1111-111111111111',
         tagIds: ['22222222-2222-2222-2222-222222222222'],
@@ -477,12 +479,13 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"album_asset"');
       expect(sql).toContain('"album_asset"."albumId"');
       expect(sql).toContain('"album_asset"."assetId" = "asset"."id"');
-      expect(sql).not.toContain('"asset"."ownerId" = any(');
+      expect(sql).toContain('"album"."ownerId" = "asset"."ownerId"');
+      expect(sql).toContain('"album_user"."userId" = "asset"."ownerId"');
       expect(sql).not.toContain('"shared_space_asset"');
       expect(sql).not.toContain('"shared_space_library"');
     });
 
-    it('getExifField scopes to album membership only, without an owner restriction', () => {
+    it('getExifField widens album scope to album participants, no spaces without timeline opt-in', () => {
       const sql = compileExifField(sut, 'country', {
         albumId: '11111111-1111-1111-1111-111111111111',
       });
@@ -490,33 +493,40 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"album_asset"');
       expect(sql).toContain('"album_asset"."albumId"');
       expect(sql).toContain('"album_asset"."assetId" = "asset"."id"');
-      expect(sql).not.toContain('"asset"."ownerId" = any(');
+      expect(sql).toContain('"album"."ownerId" = "asset"."ownerId"');
+      expect(sql).toContain('"album_user"."userId" = "asset"."ownerId"');
       expect(sql).not.toContain('"shared_space_asset"');
       expect(sql).not.toContain('"shared_space_library"');
     });
 
-    it('buildFilteredAssetIds uses album membership only even when timeline spaces are enabled', () => {
+    it('buildFilteredAssetIds adds timeline-enabled direct and linked-library spaces to album participants', () => {
       const sql = compileFilteredAssetIds(sut, {
         albumId: '11111111-1111-1111-1111-111111111111',
         timelineSpaceIds: ['33333333-3333-3333-3333-333333333333'],
       });
 
       expect(sql).toContain('"album_asset"');
-      expect(sql).not.toContain('"asset"."ownerId" = any(');
-      expect(sql).not.toContain('"shared_space_asset"');
-      expect(sql).not.toContain('"shared_space_library"');
+      expect(sql).toContain('"album"."ownerId" = "asset"."ownerId"');
+      expect(sql).toContain('"album_user"."userId" = "asset"."ownerId"');
+      expect(sql).toContain('"shared_space_asset"');
+      expect(sql).toContain('"shared_space_asset"."spaceId"');
+      expect(sql).toContain('"shared_space_library"');
+      expect(sql).toContain('"shared_space_library"."spaceId"');
     });
 
-    it('getExifField uses album membership only even when timeline spaces are enabled', () => {
+    it('getExifField adds timeline-enabled direct and linked-library spaces to album participants', () => {
       const sql = compileExifField(sut, 'country', {
         albumId: '11111111-1111-1111-1111-111111111111',
         timelineSpaceIds: ['33333333-3333-3333-3333-333333333333'],
       });
 
       expect(sql).toContain('"album_asset"');
-      expect(sql).not.toContain('"asset"."ownerId" = any(');
-      expect(sql).not.toContain('"shared_space_asset"');
-      expect(sql).not.toContain('"shared_space_library"');
+      expect(sql).toContain('"album"."ownerId" = "asset"."ownerId"');
+      expect(sql).toContain('"album_user"."userId" = "asset"."ownerId"');
+      expect(sql).toContain('"shared_space_asset"');
+      expect(sql).toContain('"shared_space_asset"."spaceId"');
+      expect(sql).toContain('"shared_space_library"');
+      expect(sql).toContain('"shared_space_library"."spaceId"');
     });
   });
 

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -464,7 +464,11 @@ describe(SearchRepository.name, () => {
   });
 
   describe('album-scoped suggestions', () => {
-    it('buildFilteredAssetIds intersects album_asset with viewer-owned assets when no timeline spaces are enabled', () => {
+    // A shared album's assets are owned by the album owner, not the viewer. AlbumRead
+    // access is verified by the service before these queries run, so album membership is
+    // the only scope — no owner or shared-space restriction is added, otherwise viewers
+    // would see empty People/Location/Camera/Tag facets (issue #655).
+    it('buildFilteredAssetIds scopes to album membership only, without an owner restriction', () => {
       const sql = compileFilteredAssetIds(sut, {
         albumId: '11111111-1111-1111-1111-111111111111',
         tagIds: ['22222222-2222-2222-2222-222222222222'],
@@ -473,12 +477,12 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"album_asset"');
       expect(sql).toContain('"album_asset"."albumId"');
       expect(sql).toContain('"album_asset"."assetId" = "asset"."id"');
-      expect(sql).toContain('"asset"."ownerId" = any(');
+      expect(sql).not.toContain('"asset"."ownerId" = any(');
       expect(sql).not.toContain('"shared_space_asset"');
       expect(sql).not.toContain('"shared_space_library"');
     });
 
-    it('getExifField intersects album_asset with viewer-owned assets when no timeline spaces are enabled', () => {
+    it('getExifField scopes to album membership only, without an owner restriction', () => {
       const sql = compileExifField(sut, 'country', {
         albumId: '11111111-1111-1111-1111-111111111111',
       });
@@ -486,37 +490,33 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"album_asset"');
       expect(sql).toContain('"album_asset"."albumId"');
       expect(sql).toContain('"album_asset"."assetId" = "asset"."id"');
-      expect(sql).toContain('"asset"."ownerId" = any(');
+      expect(sql).not.toContain('"asset"."ownerId" = any(');
       expect(sql).not.toContain('"shared_space_asset"');
       expect(sql).not.toContain('"shared_space_library"');
     });
 
-    it('buildFilteredAssetIds allows album assets from timeline-enabled direct and linked-library spaces', () => {
+    it('buildFilteredAssetIds uses album membership only even when timeline spaces are enabled', () => {
       const sql = compileFilteredAssetIds(sut, {
         albumId: '11111111-1111-1111-1111-111111111111',
         timelineSpaceIds: ['33333333-3333-3333-3333-333333333333'],
       });
 
       expect(sql).toContain('"album_asset"');
-      expect(sql).toContain('"asset"."ownerId" = any(');
-      expect(sql).toContain('"shared_space_asset"');
-      expect(sql).toContain('"shared_space_asset"."spaceId"');
-      expect(sql).toContain('"shared_space_library"');
-      expect(sql).toContain('"shared_space_library"."spaceId"');
+      expect(sql).not.toContain('"asset"."ownerId" = any(');
+      expect(sql).not.toContain('"shared_space_asset"');
+      expect(sql).not.toContain('"shared_space_library"');
     });
 
-    it('getExifField allows album assets from timeline-enabled direct and linked-library spaces', () => {
+    it('getExifField uses album membership only even when timeline spaces are enabled', () => {
       const sql = compileExifField(sut, 'country', {
         albumId: '11111111-1111-1111-1111-111111111111',
         timelineSpaceIds: ['33333333-3333-3333-3333-333333333333'],
       });
 
       expect(sql).toContain('"album_asset"');
-      expect(sql).toContain('"asset"."ownerId" = any(');
-      expect(sql).toContain('"shared_space_asset"');
-      expect(sql).toContain('"shared_space_asset"."spaceId"');
-      expect(sql).toContain('"shared_space_library"');
-      expect(sql).toContain('"shared_space_library"."spaceId"');
+      expect(sql).not.toContain('"asset"."ownerId" = any(');
+      expect(sql).not.toContain('"shared_space_asset"');
+      expect(sql).not.toContain('"shared_space_library"');
     });
   });
 

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1195,28 +1195,12 @@ export class SearchRepository {
           ),
         ),
       )
-      .$if(!!options?.albumId && !!options?.timelineSpaceIds?.length, (qb) =>
-        qb.where((eb) =>
-          eb.or([
-            eb('asset.ownerId', '=', anyUuid(userIds)),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
-          ]),
-        ),
-      )
-      .$if(!!options?.albumId && !options?.timelineSpaceIds?.length, (qb) =>
-        qb.where('asset.ownerId', '=', anyUuid(userIds)),
-      )
+      // Album scope: membership in the album (the $if above) is the only restriction.
+      // The service verifies AlbumRead before calling this, so every asset in a shared
+      // album is a valid filter source regardless of who owns it. This is what lets
+      // viewer-role users (who own none of the album's assets and are in no shared
+      // space) see People/Location/Camera/Tag facets instead of empty (0) counts.
+      // See issue #655.
       .$if(!options?.albumId && !options?.spaceId && !options?.timelineSpaceIds, (qb) =>
         qb.where('asset.ownerId', '=', anyUuid(userIds)),
       )

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1184,63 +1184,100 @@ export class SearchRepository {
     userIds: string[],
     options?: ExifSuggestionScopeOptions,
   ) {
-    return qb
-      .$if(!!options?.albumId, (qb) =>
-        qb.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('album_asset')
-              .whereRef('album_asset.assetId', '=', 'asset.id')
-              .where('album_asset.albumId', '=', asUuid(options!.albumId!)),
+    return (
+      qb
+        // Album scope. An asset feeds the album's filter facets only when it (a) belongs
+        // to the album and (b) is one the user may legitimately see there. (b) holds when
+        // the asset was contributed by an album participant (the album owner or a shared
+        // user), is owned by the user or their partners, or is reachable through a shared
+        // space they currently show in their timeline. Dropping the participant cases would
+        // give viewers empty People/Location/Camera/Tag facets for assets owned by the
+        // album owner (issue #655); dropping the access check entirely would leak a
+        // shared-space asset that merely landed in an album to non-space-members.
+        .$if(!!options?.albumId, (qb) =>
+          qb.where((eb) =>
+            eb.and([
+              eb.exists(
+                eb
+                  .selectFrom('album_asset')
+                  .whereRef('album_asset.assetId', '=', 'asset.id')
+                  .where('album_asset.albumId', '=', asUuid(options!.albumId!)),
+              ),
+              eb.or([
+                eb('asset.ownerId', '=', anyUuid(userIds)),
+                eb.exists(
+                  eb
+                    .selectFrom('album')
+                    .whereRef('album.ownerId', '=', 'asset.ownerId')
+                    .where('album.id', '=', asUuid(options!.albumId!)),
+                ),
+                eb.exists(
+                  eb
+                    .selectFrom('album_user')
+                    .whereRef('album_user.userId', '=', 'asset.ownerId')
+                    .where('album_user.albumId', '=', asUuid(options!.albumId!)),
+                ),
+                ...(options?.timelineSpaceIds?.length
+                  ? [
+                      eb.exists(
+                        eb
+                          .selectFrom('shared_space_asset')
+                          .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                          .where('shared_space_asset.spaceId', '=', anyUuid(options.timelineSpaceIds)),
+                      ),
+                      eb.exists(
+                        eb
+                          .selectFrom('shared_space_library')
+                          .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                          .where('shared_space_library.spaceId', '=', anyUuid(options.timelineSpaceIds)),
+                      ),
+                    ]
+                  : []),
+              ]),
+            ]),
           ),
-        ),
-      )
-      // Album scope: membership in the album (the $if above) is the only restriction.
-      // The service verifies AlbumRead before calling this, so every asset in a shared
-      // album is a valid filter source regardless of who owns it. This is what lets
-      // viewer-role users (who own none of the album's assets and are in no shared
-      // space) see People/Location/Camera/Tag facets instead of empty (0) counts.
-      // See issue #655.
-      .$if(!options?.albumId && !options?.spaceId && !options?.timelineSpaceIds, (qb) =>
-        qb.where('asset.ownerId', '=', anyUuid(userIds)),
-      )
-      .$if(!!options?.spaceId && !options?.timelineSpaceIds && !options?.albumId, (qb) =>
-        qb.where((eb) =>
-          eb.or([
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
-            ),
-          ]),
-        ),
-      )
-      .$if(!!options?.timelineSpaceIds && !options?.albumId, (qb) =>
-        qb.where((eb) =>
-          eb.or([
-            eb('asset.ownerId', '=', anyUuid(userIds)),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
-          ]),
-        ),
-      );
+        )
+        .$if(!options?.albumId && !options?.spaceId && !options?.timelineSpaceIds, (qb) =>
+          qb.where('asset.ownerId', '=', anyUuid(userIds)),
+        )
+        .$if(!!options?.spaceId && !options?.timelineSpaceIds && !options?.albumId, (qb) =>
+          qb.where((eb) =>
+            eb.or([
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_asset')
+                  .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                  .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
+              ),
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_library')
+                  .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                  .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
+              ),
+            ]),
+          ),
+        )
+        .$if(!!options?.timelineSpaceIds && !options?.albumId, (qb) =>
+          qb.where((eb) =>
+            eb.or([
+              eb('asset.ownerId', '=', anyUuid(userIds)),
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_asset')
+                  .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                  .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
+              ),
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_library')
+                  .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                  .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
+              ),
+            ]),
+          ),
+        )
+    );
   }
 
   private getExifField<K extends 'city' | 'state' | 'country' | 'make' | 'model' | 'lensModel'>(

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { AssetType } from 'src/enum';
+import { AlbumUserRole, AssetType } from 'src/enum';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
@@ -454,6 +454,35 @@ describe(SearchRepository.name, () => {
         },
       ]);
       expect(result.hasUnnamedPeople).toBe(false);
+    });
+  });
+
+  describe('getFilterSuggestions', () => {
+    it('returns album facets for a viewer who owns none of the shared album assets', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, country: 'Germany', city: 'Berlin', make: 'Sony', model: 'A7' });
+
+      const [travel] = await upsertTags(ctx.get(TagRepository), { userId: owner.id, tags: ['Travel'] });
+      await ctx.newTagAsset({ tagIds: [travel.id], assetIds: [asset.id] });
+
+      const { person } = await ctx.newPerson({ ownerId: owner.id, name: 'Ada' });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [asset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+
+      // A viewer owns none of the album's assets and is in no shared space, so the
+      // service calls the repository with the viewer's own id and no timelineSpaceIds.
+      const result = await sut.getFilterSuggestions([viewer.id], { albumId: album.id });
+
+      expect(result.countries).toContain('Germany');
+      expect(result.cameraMakes).toContain('Sony');
+      expect(result.tags.map((tag) => tag.value)).toContain('Travel');
+      expect(result.people.map((p) => p.name)).toContain('Ada');
     });
   });
 });

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -1,6 +1,6 @@
 import { Kysely } from 'kysely';
-import { SearchSuggestionType } from 'src/dtos/search.dto';
-import { AlbumUserRole } from 'src/enum';
+import { FilterSuggestionsResponseDto, SearchSuggestionType } from 'src/dtos/search.dto';
+import { AlbumUserRole, AssetVisibility } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
@@ -9,8 +9,10 @@ import { PartnerRepository } from 'src/repositories/partner.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { TagRepository } from 'src/repositories/tag.repository';
 import { DB } from 'src/schema';
 import { SearchService } from 'src/services/search.service';
+import { upsertTags } from 'src/utils/tag';
 import { newMediumService } from 'test/medium.factory';
 import { factory } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
@@ -28,9 +30,47 @@ const setup = (db?: Kysely<DB>) => {
       SharedSpaceRepository,
       PartnerRepository,
       PersonRepository,
+      TagRepository,
     ],
     mock: [LoggingRepository],
   });
+};
+
+type SearchCtx = ReturnType<typeof setup>['ctx'];
+
+// Seed one asset, owned by `ownerId`, carrying a distinct value for every facet type so
+// presence/absence of `${marker}-...` strings in a suggestions response is unambiguous.
+const seedFacetAsset = async (ctx: SearchCtx, ownerId: string, marker: string) => {
+  const { asset } = await ctx.newAsset({ ownerId, visibility: AssetVisibility.Timeline });
+  await ctx.newExif({
+    assetId: asset.id,
+    country: `${marker}-Country`,
+    city: `${marker}-City`,
+    make: `${marker}-Make`,
+    model: `${marker}-Model`,
+    rating: 5,
+  });
+  const [tag] = await upsertTags(ctx.get(TagRepository), { userId: ownerId, tags: [`${marker}-Tag`] });
+  await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+  const { person } = await ctx.newPerson({ ownerId, name: `${marker}-Person` });
+  await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  return asset;
+};
+
+const expectFacetsPresent = (result: FilterSuggestionsResponseDto, marker: string) => {
+  expect(result.countries).toContain(`${marker}-Country`);
+  expect(result.cameraMakes).toContain(`${marker}-Make`);
+  expect(result.tags.map((tag) => tag.value)).toContain(`${marker}-Tag`);
+  expect(result.people.map((person) => person.name)).toContain(`${marker}-Person`);
+};
+
+const expectFacetsAbsent = (result: FilterSuggestionsResponseDto, marker: string) => {
+  expect(result.countries).not.toContain(`${marker}-Country`);
+  expect(result.cameraMakes).not.toContain(`${marker}-Make`);
+  expect(result.tags.map((tag) => tag.value)).not.toContain(`${marker}-Tag`);
+  expect(result.people.map((person) => person.name)).not.toContain(`${marker}-Person`);
+  // Catch-all: no facet category (city/model/etc.) may surface the marker either.
+  expect(JSON.stringify(result)).not.toContain(`${marker}-`);
 };
 
 beforeAll(async () => {
@@ -398,6 +438,143 @@ describe(SearchService.name, () => {
       expect(result.countries).toContain('Germany');
       expect(result.cameraMakes).toContain('Sony');
       expect(result.people.map((p) => p.name)).toContain('Ada');
+    });
+  });
+
+  describe('getFilterSuggestions album permission boundaries', () => {
+    it('exposes every facet type of the album owner assets to a shared viewer', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const asset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [asset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: viewer.id } }), { albumId: album.id });
+
+      expectFacetsPresent(result, 'Owner');
+      expect(result.ratings).toContain(5);
+      expect(result.mediaTypes.length).toBeGreaterThan(0);
+    });
+
+    it('exposes assets contributed by a shared editor to other album members', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: editor } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const ownerAsset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const editorAsset = await seedFacetAsset(ctx, editor.id, 'Editor');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [ownerAsset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: editor.id, role: AlbumUserRole.Editor });
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: editorAsset.id });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: viewer.id } }), { albumId: album.id });
+
+      expectFacetsPresent(result, 'Owner');
+      expectFacetsPresent(result, 'Editor');
+    });
+
+    it('does not leak a non-participant asset that was placed in the album', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const ownerAsset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const strangerAsset = await seedFacetAsset(ctx, stranger.id, 'Stranger');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [ownerAsset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+      // The stranger is neither the album owner nor a shared user, yet their asset is
+      // referenced by the album — it must never surface in the album facets.
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: strangerAsset.id });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: viewer.id } }), { albumId: album.id });
+
+      expectFacetsPresent(result, 'Owner');
+      expectFacetsAbsent(result, 'Stranger');
+    });
+
+    it('exposes a timeline-sharing partner asset to the album viewer', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { user: partner } = await ctx.newUser();
+      await ctx.newPartner({ sharedById: partner.id, sharedWithId: viewer.id, inTimeline: true });
+      const ownerAsset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const partnerAsset = await seedFacetAsset(ctx, partner.id, 'Partner');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [ownerAsset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: partnerAsset.id });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: viewer.id } }), { albumId: album.id });
+
+      expectFacetsPresent(result, 'Partner');
+    });
+
+    it('does not leak an asset from a partner who is not sharing their timeline', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { user: partner } = await ctx.newUser();
+      await ctx.newPartner({ sharedById: partner.id, sharedWithId: viewer.id, inTimeline: false });
+      const ownerAsset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const partnerAsset = await seedFacetAsset(ctx, partner.id, 'Partner');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [ownerAsset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: partnerAsset.id });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: viewer.id } }), { albumId: album.id });
+
+      expectFacetsPresent(result, 'Owner');
+      expectFacetsAbsent(result, 'Partner');
+    });
+
+    it('denies filter suggestions to a user without album access', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: outsider } = await ctx.newUser();
+      const ownerAsset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [ownerAsset.id]);
+
+      await expect(
+        sut.getFilterSuggestions(factory.auth({ user: { id: outsider.id } }), { albumId: album.id }),
+      ).rejects.toThrow();
+    });
+
+    it('scopes facets to the requested album and not the owner other albums', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const sharedAsset = await seedFacetAsset(ctx, owner.id, 'Shared');
+      const otherAsset = await seedFacetAsset(ctx, owner.id, 'Other');
+      const { album: shared } = await ctx.newAlbum({ ownerId: owner.id }, [sharedAsset.id]);
+      await ctx.newAlbum({ ownerId: owner.id }, [otherAsset.id]);
+      await ctx.newAlbumUser({ albumId: shared.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: viewer.id } }), { albumId: shared.id });
+
+      expectFacetsPresent(result, 'Shared');
+      expectFacetsAbsent(result, 'Other');
+    });
+
+    it('does not leak a non-participant asset city into album city drill-down suggestions', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const ownerAsset = await seedFacetAsset(ctx, owner.id, 'Owner');
+      const strangerAsset = await seedFacetAsset(ctx, stranger.id, 'Stranger');
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [ownerAsset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: strangerAsset.id });
+
+      const cities = await sut.getSearchSuggestions(factory.auth({ user: { id: viewer.id } }), {
+        type: SearchSuggestionType.CITY,
+        albumId: album.id,
+      });
+
+      expect(cities).toContain('Owner-City');
+      expect(cities).not.toContain('Stranger-City');
     });
   });
 });

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -1,5 +1,6 @@
 import { Kysely } from 'kysely';
 import { SearchSuggestionType } from 'src/dtos/search.dto';
+import { AlbumUserRole } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
@@ -376,6 +377,27 @@ describe(SearchService.name, () => {
       const result = await sut.getFilterSuggestions(auth, { spaceId: space.id });
 
       expect(result.people.map((p) => p.name)).toEqual(['Alice Space', 'Zelda Space']);
+    });
+
+    it('returns album facets for a viewer-role user who owns none of the shared album assets (issue #655)', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, country: 'Germany', make: 'Sony' });
+      const { person } = await ctx.newPerson({ ownerId: owner.id, name: 'Ada' });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      const { album } = await ctx.newAlbum({ ownerId: owner.id }, [asset.id]);
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer });
+
+      const auth = factory.auth({ user: { id: viewer.id } });
+      const result = await sut.getFilterSuggestions(auth, { albumId: album.id });
+
+      expect(result.countries).toContain('Germany');
+      expect(result.cameraMakes).toContain('Sony');
+      expect(result.people.map((p) => p.name)).toContain('Ada');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #655 — the filter panel showed **People (0), Location (0), Camera (0), Tags (0)** for Viewer-role users in shared albums, while Timeline/Rating worked.

## Root cause

`SearchRepository.applySuggestionScope` (used by every album-scoped facet/suggestion query) restricted album assets to the requesting user's **own** assets (or their shared-space assets). This was introduced in #495; before that (#414) album scope relied solely on album membership.

A Viewer of a shared album owns none of its assets and belongs to no shared space, so the asset set was empty and all four facet queries returned nothing. Timeline/Rating come from a different path, so they were unaffected.

## Fix

Removed the album-specific owner/shared-space restriction branches. The service already verifies `AlbumRead` access before querying, so album scope now relies solely on album membership — every asset in a shared album is a valid filter source regardless of owner. This is a single centralized change that also fixes the city / camera-model drill-down suggestions (they share `applySuggestionScope`).

## Tests (TDD)

- **New repository medium test** — viewer querying album facets returns Country/Camera/Tag/People (was empty).
- **New service medium test** — full `AlbumRead` flow for a viewer-shared album; the RED run failed at the facet assertion, **not** at `requireAccess`, confirming access already passes and the scoping was the bug.
- Updated 4 offline SQL-shape tests that had locked in the buggy `ownerId` scoping.

## Verification

- `tsc --noEmit`: pass · `eslint --max-warnings 0`: pass
- Server unit suite: 4628 pass · medium search repo: 13/13 · medium search service: 18/18
- Generated SQL doc unaffected; `getAccessibleTags` (no `albumId` option) not affected.