### PR TITLE
fix(pet-detection): clear pets on reset even when detection is disabled (#718)

### DIFF
--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -1290,6 +1290,11 @@ delete from "shared_space_person_face"
 -- SharedSpaceRepository.deleteAllPersons
 delete from "shared_space_person"
 
+-- SharedSpaceRepository.deleteAllPets
+delete from "shared_space_person"
+where
+  "type" = $1
+
 -- SharedSpaceRepository.recountPersons
 update "shared_space_person"
 set

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1861,6 +1861,15 @@ export class SharedSpaceRepository {
     await this.db.deleteFrom('shared_space_person').execute();
   }
 
+  @GenerateSql({ params: [] })
+  async deleteAllPets() {
+    // Mirror PersonRepository.deleteAllPets() for the shared-space copies: a pet-detection
+    // reset must clear propagated pet people from every space's People view too. Deleting the
+    // shared_space_person row cascades to its shared_space_person_face and _alias children, so
+    // only pet-typed rows are removed and human people are left untouched.
+    await this.db.deleteFrom('shared_space_person').where('type', '=', 'pet').execute();
+  }
+
   @GenerateSql({ params: [[DummyValue.UUID]] })
   async recountPersons(personIds: string[], db: Kysely<DB> | Transaction<DB> = this.db) {
     if (personIds.length === 0) {

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -53,6 +53,8 @@ describe(PetDetectionService.name, () => {
       visibility: AssetVisibility.Timeline,
       previewFile: '/uploads/user-id/thumbs/path.jpg',
     });
+    // SharedSpaceRepository is a strict mock, so the reset path's deleteAllPets needs an implementation.
+    mocks.sharedSpace.deleteAllPets.mockResolvedValue(void 0);
   });
 
   it('should work', () => {
@@ -144,6 +146,18 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Success);
 
       expect(mocks.person.deleteAllPets).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPets).not.toHaveBeenCalled();
+    });
+
+    it('should also clear pet detections from shared spaces on a force reset', async () => {
+      // Pets propagate into shared spaces as shared_space_person rows (#718 follow-up); the
+      // personal purge alone leaves them lingering in a space's People view, so the reset must
+      // clear the space copies too. Like the personal purge, this is not gated on detection
+      // being enabled — here it runs with detection disabled and still clears both.
+      expect(await sut.handleQueuePetDetection({ force: true })).toEqual(JobStatus.Skipped);
+
+      expect(mocks.person.deleteAllPets).toHaveBeenCalledTimes(1);
+      expect(mocks.sharedSpace.deleteAllPets).toHaveBeenCalledTimes(1);
     });
 
     it('should clear existing pet detections on a force reset even when pet detection is disabled', async () => {
@@ -165,6 +179,7 @@ describe(PetDetectionService.name, () => {
       expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Skipped);
 
       expect(mocks.person.deleteAllPets).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteAllPets).not.toHaveBeenCalled();
       expect(mocks.assetJob.streamForPetDetectionJob).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
     });

--- a/server/src/services/pet-detection.service.spec.ts
+++ b/server/src/services/pet-detection.service.spec.ts
@@ -145,6 +145,29 @@ describe(PetDetectionService.name, () => {
 
       expect(mocks.person.deleteAllPets).not.toHaveBeenCalled();
     });
+
+    it('should clear existing pet detections on a force reset even when pet detection is disabled', async () => {
+      // Regression test for #718: a user turns pet detection off (so pets stop
+      // reappearing), then clicks Reset. The confirmation dialog promises deletion,
+      // so the reset must still purge every detected pet — the deletion cannot be
+      // short-circuited by the "pet detection disabled" early return. With detection
+      // off there is nothing to reprocess, so no jobs are requeued.
+      expect(await sut.handleQueuePetDetection({ force: true })).toEqual(JobStatus.Skipped);
+
+      expect(mocks.person.deleteAllPets).toHaveBeenCalledTimes(1);
+      expect(mocks.assetJob.streamForPetDetectionJob).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
+
+    it('should not clear existing pet detections when force is false and pet detection is disabled', async () => {
+      // A plain "missing"-style run (force: false) while detection is disabled must
+      // remain a no-op: nothing is deleted and nothing is requeued.
+      expect(await sut.handleQueuePetDetection({ force: false })).toEqual(JobStatus.Skipped);
+
+      expect(mocks.person.deleteAllPets).not.toHaveBeenCalled();
+      expect(mocks.assetJob.streamForPetDetectionJob).not.toHaveBeenCalled();
+      expect(mocks.job.queueAll).not.toHaveBeenCalled();
+    });
   });
 
   describe('handlePetDetection', () => {

--- a/server/src/services/pet-detection.service.ts
+++ b/server/src/services/pet-detection.service.ts
@@ -21,6 +21,9 @@ export class PetDetectionService extends BaseService {
       // there. The confirmation dialog promises that deletion, so the purge must happen even
       // when detection is disabled — only the reprocessing requeue below is gated on it.
       await this.personRepository.deleteAllPets();
+      // Pets also propagate into shared spaces as their own person rows, so clear those copies
+      // too — otherwise the pets linger in every space's People view after a reset.
+      await this.sharedSpaceRepository.deleteAllPets();
     }
 
     if (!isPetDetectionEnabled(machineLearning)) {

--- a/server/src/services/pet-detection.service.ts
+++ b/server/src/services/pet-detection.service.ts
@@ -11,14 +11,20 @@ export class PetDetectionService extends BaseService {
   @OnJob({ name: JobName.PetDetectionQueueAll, queue: QueueName.PetDetection })
   async handleQueuePetDetection({ force }: JobOf<JobName.PetDetectionQueueAll>): Promise<JobStatus> {
     const { machineLearning } = await this.getConfig({ withCache: false });
-    if (!isPetDetectionEnabled(machineLearning)) {
-      return JobStatus.Skipped;
-    }
 
     if (force) {
       // A reset must clear existing pet people/faces so stale labels disappear immediately,
       // rather than lingering throughout the reprocessing window (and duplicating on re-detect).
+      //
+      // This runs *before* the enabled check on purpose (#718): users turn pet detection off
+      // precisely so detected pets stop coming back, then hit Reset to wipe the ones already
+      // there. The confirmation dialog promises that deletion, so the purge must happen even
+      // when detection is disabled — only the reprocessing requeue below is gated on it.
       await this.personRepository.deleteAllPets();
+    }
+
+    if (!isPetDetectionEnabled(machineLearning)) {
+      return JobStatus.Skipped;
     }
 
     let jobs: JobItem[] = [];

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -3290,4 +3290,52 @@ describe(SharedSpaceRepository.name, () => {
       expect(results.find((r) => r.id === asset.id)).toBeDefined();
     });
   });
+
+  describe('deleteAllPets', () => {
+    it('deletes pet space people and their faces while preserving human space people and faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+
+      // A pet space person (propagated from pet detection) with a detected face.
+      const { assetFace: petFace } = await ctx.newAssetFace({ assetId: asset.id });
+      const petPerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, name: 'dog', type: 'pet' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await sut.addPersonFaces([{ personId: petPerson.id, assetFaceId: petFace.id }], { skipRecount: true });
+
+      // A human space person with a face — a pet reset must leave it untouched.
+      const { assetFace: humanFace } = await ctx.newAssetFace({ assetId: asset.id });
+      const humanPerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, name: 'Alice', type: 'person' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await sut.addPersonFaces([{ personId: humanPerson.id, assetFaceId: humanFace.id }], { skipRecount: true });
+
+      await sut.deleteAllPets();
+
+      const people = await ctx.database
+        .selectFrom('shared_space_person')
+        .select(['id', 'type'])
+        .where('spaceId', '=', space.id)
+        .execute();
+      // shared_space_person_face cascades on the pet person delete, so only the human link remains.
+      // Scope to this space's persons — the medium DB is shared across tests, so an unfiltered
+      // query would pick up face links created by other specs.
+      const faces = await ctx.database
+        .selectFrom('shared_space_person_face')
+        .innerJoin('shared_space_person', 'shared_space_person.id', 'shared_space_person_face.personId')
+        .select(['shared_space_person_face.personId', 'shared_space_person_face.assetFaceId'])
+        .where('shared_space_person.spaceId', '=', space.id)
+        .execute();
+
+      expect(people).toEqual([expect.objectContaining({ id: humanPerson.id, type: 'person' })]);
+      expect(faces).toEqual([expect.objectContaining({ personId: humanPerson.id, assetFaceId: humanFace.id })]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Fixes #718. Resetting Pet Detection never clears pets from the People overview when the user has **turned pet detection off** beforehand — which is the natural way to stop pets from reappearing. The confirmation dialog promises deletion, but nothing is deleted and nothing is queued (Active 0 / Waiting 0), exactly as reported on v4.57.1 (after #695). Additionally, pets that had propagated into **shared spaces** were never cleared by a reset.

## Root cause

In `handleQueuePetDetection`, the force-reset purge (`deleteAllPets()`, added in #695) sat **after** the `isPetDetectionEnabled` early-return:

```ts
if (!isPetDetectionEnabled(machineLearning)) return JobStatus.Skipped;  // bails when OFF
if (force) await this.personRepository.deleteAllPets();                 // never reached when OFF
```

So with detection disabled, the handler returns `Skipped` before deleting anything. The deletion itself is fine — all FK refs to `asset_face`/`person` are CASCADE/SET NULL, confirmed by the existing medium test.

Separately, pets propagate into shared spaces as their own `shared_space_person` rows (`type='pet'`), which `PersonRepository.deleteAllPets()` doesn't touch — so they survived a reset in every space's People view.

## Fix

1. **Hoist the purge above the enabled check.** A reset always clears pets; only the reprocessing requeue stays gated on detection being enabled:
   - **disabled + reset** → pets purged, nothing requeued → they stay gone (what the user wants).
   - **enabled + reset** → purge then reprocess (unchanged).
2. **Propagate to shared spaces.** New `SharedSpaceRepository.deleteAllPets()` deletes `shared_space_person` rows of `type='pet'` (faces/aliases cascade); the reset calls it alongside the personal purge.

## Why tests didn't catch it

The service spec covered the two axes independently but never the failing cell: every force-reset / `deleteAllPets` test mocked detection **enabled**; every "disabled" test used **`force: false`**; and `deleteAllPets` was mocked, so an unreachable call site looked fine. `force: true` + **disabled** had zero coverage. The shared-space copies had no reset coverage at all.

## Tests added

- Service unit: `force:true`+disabled purges personal **and** shared-space pets; `force:false` purges neither (personal + space).
- Repository medium: `SharedSpaceRepository.deleteAllPets()` deletes pet space-people + their faces while preserving human space-people + faces.

## Verification

- `pet-detection.service.spec.ts` 27/27 — RED before each fix, GREEN after.
- `shared-space.repository.spec.ts` medium 128/128 (incl. new test, full-suite isolation verified).
- `queue` + `job` service specs 179/179; `tsc --noEmit` clean; `eslint` clean; SQL doc regenerated for the new query.