### PR TITLE
fix(web): boot loader sits on a gray strip over black (re-skin follow-up)

### DIFF
--- a/web/src/styles/gallery-theme.css
+++ b/web/src/styles/gallery-theme.css
@@ -125,6 +125,19 @@
 .dark {
   --gallery-chrome: #1e1f20;
 }
+/* The pre-hydration boot screen (app.html's #stencil loader) hard-codes the
+ * html background to black/white for FOUC prevention. Once this theme loads,
+ * the chrome-tinted <body> paints only a band around the centered loader — the
+ * stencil's tall top/bottom margins collapse the body box down to a strip — so
+ * the loader ends up sitting on a chrome strip floating over the black html.
+ * Paint the html root with the same chrome so the boot backdrop is seamless and
+ * matches the running app's page tint (html shows otherwise only on overscroll).
+ * :root.dark / :root:not(.dark) (specificity 0,2,0) outranks app.html's inline
+ * html.dark / html.light (0,1,1); the matched class also resolves the var. */
+:root.dark,
+:root:not(.dark) {
+  background-color: var(--gallery-chrome);
+}
 body {
   background-color: var(--gallery-chrome);
 }


### PR DESCRIPTION
## Problem

After the tonal re-skin (#724), the initial loading-spinner screen shows the colorful loader on a **gray strip floating over a black background**, instead of a uniform backdrop.

## Root cause

`app.html`'s pre-hydration `#stencil` loader hard-codes `html.dark { background-color: black }` (FOUC prevention). The re-skin added an **unlayered** `body { background-color: var(--gallery-chrome) }` (`#1e1f20`, a gray) that wins over the body's `bg-light` utility. The spinner's tall margins (`margin-top: calc(50vh - 75px)`, `margin-bottom: 100vh`) collapse the body's painted box down to a strip around the loader — so the loader ends up on a gray chrome band over the black html.

Before the re-skin, `bg-light` resolved to a near-black surface that matched the black html, so the seam was invisible.

## Fix

Paint the `html` root with the same `--gallery-chrome` so the boot backdrop is seamless and matches the running app's page tint (html otherwise shows only on overscroll). `:root.dark` / `:root:not(.dark)` (specificity 0,2,0) outranks `app.html`'s inline `html.dark` / `html.light` (0,1,1). Kept entirely inside `gallery-theme.css` to respect the re-skin's fork-owned theme-layer scope guard.

## Verification

- Reproduced the bug and validated the fix with a headless screenshot of `app.html`'s verbatim inline CSS + the exact chrome values — uniform backdrop in both dark and light mode.
- All 3263 web unit tests pass (incl. `gallery-theme.spec.ts`, `reskin-scope.spec.ts`, `contrast.spec.ts`).
- Prettier-clean; the CSS token parser and re-skin e2e specs are unaffected (no snapshot update).