### PR TITLE
fix(spaces): space-albums review-fix follow-ups

### DIFF
--- a/docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md
+++ b/docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md
@@ -1,0 +1,687 @@
+# Space Albums — Review-Fix Follow-up Implementation Plan
+
+> **For `/impl-loop` (and agentic workers):** This is the brainstormed spec with **numbered,
+> TDD-first, ordered, self-contained slices**. Design rationale + edge-case catalogue live in
+> `docs/superpowers/specs/2026-06-29-space-albums-review-fixes-followup-design.md`. Each slice: write
+> the named failing test(s) FIRST (RED), then the minimal implementation (GREEN), then the slice
+> gate. Steps use checkbox (`- [ ]`) syntax. Slices are sequenced by dependency/risk; implement in
+> order. `REQUIRED SUB-SKILL`: `superpowers:test-driven-development` for every slice;
+> `superpowers:subagent-driven-development` to execute.
+
+**Goal:** Fix every finding from the three post-#726 reviews of `feat/space-albums` @ `5f0076cd6e`
+(RBAC `sa-rbac-k7`, server-faces `sa-faces-m3`, mobile `sa-mobile-p2`) — the people-projection
+ship-blocker, owner-account/soft-delete/asset-delete face cleanup, sync-stream + `user_has_album_path`
++ route-param consistency, and the mobile add-photos/link-picker/polish gaps. Product-only items
+(faces F6, RBAC F4/F5) are noted, not implemented.
+
+**Architecture:** Server fixes are Kysely SQL-predicate edits mirroring the existing
+`shared_space_library` branch / the `onAlbumDelete` cleanup sequence, one new fork migration
+(`user_has_album_path`), and small service-handler additions. Mobile fixes add one server-only action,
+a mapper field, and three UI polish edits. No new event types are required for the album path
+(`AlbumDelete` already exists from #726); owner-account/asset-delete cleanup reuse it or call the repo
+sequence directly.
+
+**Tech Stack:** NestJS 11 + Kysely (server), zod DTOs, SvelteKit/Svelte 5 (web — none in scope this
+round), Flutter/Riverpod/Drift (mobile), Vitest (server unit + medium via testcontainers), Playwright
++ Vitest (e2e), `flutter test` (mobile).
+
+## Global Constraints
+
+- **Toolchain:** server type-check/lint `make check-server` / `make lint-server` (`tsc` + eslint,
+  `--max-warnings 0`); server unit `cd server && pnpm test -- --run <path>`; server medium (real DB,
+  needs Docker) `cd server && pnpm test:medium -- --run <path>`; e2e per `e2e/` README; mobile
+  `mise //mobile:analyze` + `cd mobile && flutter test <path>` (CI `Static Code Analysis` /
+  `Unit Test Mobile` are authoritative — local mobile runs are version-skew-prone). Do **not** invoke
+  bare `vitest`.
+- **Line numbers are anchors @ `5f0076cd6e`** — `shared-space.repository.ts` is ~2647 lines and
+  shifts. **Re-grep by symbol name + scoping construct before editing.** Every cited method name and
+  signature was verified at this commit.
+- **The A1 invariant:** every album read/stat/face/count/sync SQL branch MUST filter `album.deletedAt
+  is null` via a non-deleted `album` join. New branches include it from the start.
+- **Clone source for every predicate change:** the adjacent `shared_space_library` branch in the same
+  method. For face cleanup: the `onAlbumDelete` handler sequence in `shared-space.service.ts`.
+- **Server imports:** no relative imports — use the `src/` alias. Strict TS.
+  `no-floating-promises` / `no-misused-promises` enforced (`await` or `void` every promise).
+- **No OpenAPI regen** for any slice **except possibly Slice 9** (R-F3 param validation) — see that
+  slice's gate.
+- **`recountPersons` takes `personIds: string[]`** (not a `spaceId`), with an optional
+  `db`/transaction arg. There is **no** singular `recountPerson`.
+
+---
+
+## Slice 1: Album branch in the space people-projection read/stat/face queries (faces F1) — HIGH, ship-blocker
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts` — the 7 people-projection queries (see
+  table). Each currently scopes via an `eb.or([...])` / `asset_scope` CTE listing only
+  `shared_space_asset` + `shared_space_library`.
+- Test: `server/test/medium/specs/repositories/shared-space.repository.spec.ts` (extend — reuse its
+  `addAlbum(...)` helper, already used ~`:3294+`).
+
+**Interfaces:** no signature changes — same methods, additional album branch in each scoping site.
+
+**The 7 queries and their scoping site** (anchor by method name; verify line by grep):
+
+| # | Method | Scoping construct to extend |
+| --- | --- | --- |
+| 1 | `getSpaceRepresentativeFaces` (called by `getSpacePersonFaces`) | `eb.or([...])` (asset + library EXISTS) |
+| 2 | `getSpacePersonStatistics` | `asset_scope` CTE (asset UNION library) |
+| 3 | `countPersonsBySpaceId` (svc `getSpacePeopleStatistics`) | `asset_scope` CTE **and** the `detectedFaceCount` subquery **and** `datePersonFilter` |
+| 4 | `getPeopleFaceStatisticsBySpaceId` (svc `getSpacePeopleFaceStatistics`) | `asset_scope` CTE |
+| 5 | `getPersonsBySpaceId` | in-space EXISTS `eb.or([...])` (carries date filter) |
+| 6 | `getSpaceRepresentativeFaceForUpdate` | `eb.or([...])` |
+| 7 | `getIdentityEvidenceForSpacePerson` | `eb.or([...])` |
+
+**Canonical album branch** (member-/space-scoped `EXISTS` form, mirrors the library branch + A1 join):
+
+```ts
+eb.exists(
+  eb
+    .selectFrom('shared_space_album')
+    .innerJoin('album', (j) =>
+      j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+    )
+    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+    .whereRef('album_asset.assetId', '=', 'asset.id') // or 'asset_face.assetId' — match the sibling library branch's join column
+    .where('shared_space_album.spaceId', '=', spaceId),
+),
+```
+
+For the `asset_scope` CTE form (queries 2/3/4), add a third `UNION` arm mirroring the library arm,
+including the **same** `asset.deletedAt is null`, `asset.isOffline = false`, `visibilityFilter`, and
+the `takenAfter`/`takenBefore` date filters:
+
+```ts
+.union(
+  eb
+    .selectFrom('shared_space_album')
+    .innerJoin('album', (j) => j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null))
+    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+    .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+    .select('asset.id as assetId')
+    .where('shared_space_album.spaceId', '=', spaceId)
+    .where('asset.deletedAt', 'is', null)
+    .where('asset.isOffline', '=', false)
+    // + the same visibility + takenAfter/takenBefore predicates the library arm uses
+)
+```
+
+- [ ] **Step 1 (RED): comprehensive medium test** in `shared-space.repository.spec.ts`, a new
+  `describe('people projection — album-linked space', …)`. Seed a face-recognition-enabled space `S`;
+  link album `A` (via `addAlbum`) with image assets that are **not** direct-added and **not** in any
+  linked library; run/seed the projection so a space person `P` has `shared_space_person_face` rows on
+  `A`'s assets (mirror the existing direct/library projection seeding). Assert, **before** the fix
+  (RED):
+  - `getSpaceRepresentativeFaces(S, [P])` (via `getSpacePersonFaces`) returns a **non-empty** face
+    list for `P` (RED: empty).
+  - `getSpacePersonStatistics(S, P)` returns `assets > 0 && faces > 0` matching the projection's
+    `assetCount`/`faceCount` (RED: 0/0).
+  - `countPersonsBySpaceId(S)` includes `P` and its `detectedFaceCount` includes `A`'s faces (RED:
+    undercount / `P` absent).
+  - `getPeopleFaceStatisticsBySpaceId(S)` detected/assigned/unassigned counts include `A`'s faces
+    (RED: exclude).
+  - `getPersonsBySpaceId(S)` lists `P`; **with a date filter** spanning `A`'s `takenAt`, `P` is still
+    listed; with an out-of-range filter `P` is excluded (RED: `P` absent even in-range).
+  - `getSpaceRepresentativeFaceForUpdate(S, P)` can return an album face id (RED: none).
+  - `getIdentityEvidenceForSpacePerson(S, P)` evidence includes `A`'s faces (RED: empty).
+  - **Multi-path control:** a person `Q` whose faces are on an asset that is **both** in `A` **and**
+    direct-added → counts are **not doubled** (assert `getSpacePersonStatistics(S, Q).faces` equals
+    the distinct face count, and `getPersonsBySpaceId` lists `Q` once).
+  - **Trashed-album control:** soft-delete `A` (`UPDATE album SET "deletedAt" = now()`), then assert
+    an album-only person disappears from `getPersonsBySpaceId` and `getSpacePersonStatistics` returns
+    0 (this also pins F3's read behavior).
+- [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space.repository.spec.ts`
+- [ ] **Step 3 (GREEN): add the album branch** to all 7 scoping sites (and the two extra sites inside
+  `countPersonsBySpaceId`: the `detectedFaceCount` subquery and `datePersonFilter`). Match each
+  sibling's join column (`asset.id` vs `asset_face.assetId`) and scope key (`spaceId` literal vs
+  `shared_space_person.spaceId` ref). Do **not** modify `recountPersons` or `getPersonAssetIds` (they
+  read the projection directly by design). Grep to confirm none missed: `grep -n
+  "shared_space_library" server/src/repositories/shared-space.repository.ts` within the people block —
+  every people-projection hit must now have a paired `shared_space_album` branch.
+- [ ] **Step 4: Run; verify PASS.** Re-run the spec; then run the broader recognition specs to confirm
+  no regression on direct/library spaces:
+  `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space-face-matching.spec.ts`
+- [ ] **Step 5: slice gate.** `make check-server`; commit
+  `fix(spaces): album-linked faces appear in space people read/stats/faces (faces F1)`.
+
+---
+
+## Slice 2: Face-pipeline gates honor `album.deletedAt` (faces F3a)
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts` — `isAssetInSpace` (album branch
+  ~`:2321`) and `getSpaceIdsForAsset` (album branch ~`:2476`).
+- Test: `server/test/medium/specs/repositories/shared-space-album.repository.spec.ts` (extend — has
+  album fixtures + `isFaceInSpace`/path tests already).
+
+**Interfaces:** no signature changes.
+
+Both album branches `innerJoin('album_asset', …)` directly without joining `album`, so they resolve a
+**soft-deleted** album's assets as in-space. Add the non-deleted `album` join (A1 invariant):
+
+```ts
+.innerJoin('album', (j) => j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null))
+```
+
+- [ ] **Step 1 (RED):** in `shared-space-album.repository.spec.ts`, link album `A` (with asset `X`)
+  into face-enabled space `S`. Assert `isAssetInSpace(S, X) === true` and `getSpaceIdsForAsset(X)`
+  includes `S`. Then soft-delete `A` and assert `isAssetInSpace(S, X) === false` and
+  `getSpaceIdsForAsset(X)` **excludes** `S` (RED: both still true/included).
+- [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space-album.repository.spec.ts`
+- [ ] **Step 3 (GREEN):** add the non-deleted `album` join to both album branches.
+- [ ] **Step 4: Run; verify PASS.**
+- [ ] **Step 5: slice gate.** `make check-server`; commit
+  `fix(spaces): face-pipeline gates exclude soft-deleted albums (faces F3a)`.
+
+---
+
+## Slice 3: Owner-account HARD delete cleans space faces (faces F2)
+
+**Files:**
+
+- Modify: `server/src/services/user.service.ts` — `handleUserDelete` (~`:274`), **before**
+  `albumRepository.deleteAll(user.id)` (~`:326`).
+- Possibly add: a `albumRepository` query to enumerate a user's album ids (if none exists, reuse the
+  owner predicate `isAlbumOwned`).
+- Test: `server/test/medium/specs/services/shared-space-album.service.spec.ts` (extend);
+  `server/src/services/user.service.spec.ts` (unit — assert the emit/sweep is invoked before delete).
+
+**Interfaces:**
+
+- Consumes (already present, reused from `onAlbumDelete`): `eventRepository.emit('AlbumDelete', {
+  albumId })` (awaited in-process), or directly `sharedSpaceRepository.getSpacesLinkedToAlbum`,
+  `getAlbumAssetIdsWithoutOtherSpacePath`, `removePersonFacesByAssetIds`, `deleteOrphanedPersons`,
+  `queueSpacePersonMetadataBackfill`.
+
+- [ ] **Step 1: Confirm emit ordering.** `handleUserDelete` emits only `UserDelete` today; verify
+  `eventRepository.emit` awaits handlers in-process (it does for `AlbumAssetsAdd/Remove`/`AlbumDelete`).
+  The cleanup must run while `album_asset` rows still exist (i.e. **before** `deleteAll` and before the
+  user/asset cascade).
+- [ ] **Step 2 (RED): medium test** in `shared-space-album.service.spec.ts`. Alice owns album `A` with
+  photos from **Alice and Bob**; Bob's face-enabled space `S` links `A`; the projection has space
+  persons derived from `A`'s faces (assert `assetCount > 0` pre-delete). A second asset `Z` in `A` is
+  **also** direct-added to `S`. Hard-delete Alice via `userService.handleUserDelete({ id: alice })`.
+  Assert:
+  - `shared_space_person_face` rows for `A`'s assets that are now path-less are **removed** and
+    zero-face `shared_space_person` rows are gone (`deleteOrphanedPersons` ran).
+  - the face on `Z` is **retained** (survives via the direct path).
+  - control: a face-enabled space that did **not** link `A` is untouched.
+  (RED: faces stranded, orphan persons remain.)
+- [ ] **Step 3: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/services/shared-space-album.service.spec.ts`
+- [ ] **Step 4 (GREEN):** in `handleUserDelete`, before `albumRepository.deleteAll(user.id)`,
+  enumerate the user's album ids and `await this.eventRepository.emit('AlbumDelete', { albumId })` for
+  each (reusing the tested `onAlbumDelete` cleanup). If a bulk sweep is preferred for large accounts,
+  call the `getSpacesLinkedToAlbum → … → deleteOrphanedPersons` sequence directly per album. Mind
+  `no-floating-promises`.
+- [ ] **Step 5: Run; verify PASS.** Add/confirm the `user.service.spec.ts` unit assertion that the
+  emit/sweep happens before `deleteAll`.
+- [ ] **Step 6: slice gate.** `make check-server`; commit
+  `fix(spaces): clean space faces when an album owner's account is hard-deleted (faces F2)`.
+
+> Edge note: a deleted user's **direct-added / library** assets in other spaces (not via an album)
+> can still leave stale faces — that is the F5 class (Slice 6), not this slice.
+
+---
+
+## Slice 4: Owner-account SOFT delete cleanup + restore re-projection (faces F3b)
+
+**Files:**
+
+- Modify: `server/src/services/user-admin.service.ts` — `delete()` soft-delete path (~`:98–117`,
+  `softDeleteAll(id)` ~`:105`) and `restore()` (~`:119–125`, `restoreAll(id)` ~`:121`).
+- Modify: `server/src/services/shared-space.service.ts` — add the cleanup + re-projection entry
+  points (reuse `onAlbumDelete`'s sequence; for restore, re-queue face matching per linking
+  face-enabled space).
+- Test: `server/test/medium/specs/services/shared-space-album.service.spec.ts` (extend).
+
+**Interfaces:** reuse `getSpacesLinkedToAlbum`, `getAlbumAssetIdsWithoutOtherSpacePath`,
+`removePersonFacesByAssetIds`, `deleteOrphanedPersons`, `queueSpacePersonMetadataBackfill`; for
+restore, the existing per-(space,asset) face-match queue (`SharedSpaceFaceMatch` /
+`SharedSpaceFaceMatchAll`) used by `addMember`/`onAlbumAssetsAdd`.
+
+**Depends on:** Slice 2 (gates) so no new faces are added during the window while we clean.
+
+- [ ] **Step 1 (RED): medium test** — owner-account soft-delete. Bob's face-enabled space `S` links
+  Alice's album `A`; projection has album-sourced people with `assetCount > 0`. Soft-delete Alice's
+  account (drive `userAdminService.delete(auth, alice, {})` — non-force, the soft path). Assert the
+  album-sourced `shared_space_person_face` rows are **removed**, zero-face persons gone, and (with
+  Slice 1 in place) the people read surfaces return empty for `A`-only people. (RED: faces persist.)
+- [ ] **Step 2 (RED): medium test** — restore. After the soft-delete above, restore Alice
+  (`userAdminService.restore(auth, alice)`); assert a face re-match is queued per linking face-enabled
+  space (assert the job enqueue, or — if the test runs the worker — that the album-sourced people
+  re-appear). (RED: nothing re-queued.)
+- [ ] **Step 3: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/services/shared-space-album.service.spec.ts`
+- [ ] **Step 4 (GREEN): cleanup on soft-delete.** From the soft-delete path, for each of the user's
+  albums run the `onAlbumDelete` cleanup sequence per face-enabled linking space (the `album_asset`
+  rows still exist on soft-delete). Wire it via a small shared-space method invoked from
+  `user-admin.service.delete()` (inject `SharedSpaceService`/repo as the codebase already does) — do
+  **not** invent a public API/event surface beyond an internal call.
+- [ ] **Step 5 (GREEN): re-projection on restore.** From the restore path, for each restored album,
+  for each linking face-enabled space, queue face matching (mirror `addMember`'s
+  `queueSpacePersonMetadataBackfill` + per-space `SharedSpaceFaceMatchAll`).
+- [ ] **Step 6: Run; verify PASS.**
+- [ ] **Step 7: slice gate.** `make check-server`; commit
+  `fix(spaces): clean/re-project space faces on owner-account soft-delete and restore (faces F3b)`.
+
+> Decision baked in: this implements the **eager** cleanup the report recommends (consistency with A1
+> + clears `getSpacePersonThumbnail` exposure). The lazy alternative is noted in the design's Product
+> decisions; do not switch without a captain decision.
+
+---
+
+## Slice 5: Album-adder branch in metadata inheritance (faces F4)
+
+**Files:**
+
+- Modify: `server/src/repositories/shared-space.repository.ts` — `getSpacePersonAssetAdderIds`
+  (~`:1494`).
+- Test: `server/test/medium/specs/repositories/shared-space.repository.spec.ts` (extend).
+
+**Interfaces:** no signature change — add a third unioned subquery.
+
+`getSpacePersonAssetAdderIds` collects from `shared_space_asset.addedById` + `shared_space_library.addedById`
+but omits `shared_space_album.addedById`. Mirror the **library** subquery's person linkage
+(`shared_space_person_face → asset_face → asset`) but join the album path and select
+`shared_space_album.addedById`:
+
+```ts
+const albumRows = await this.db
+  .selectFrom('shared_space_person_face')
+  .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+  .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+  .innerJoin('album_asset', 'album_asset.assetId', 'asset.id')
+  .innerJoin('shared_space_album', (join) =>
+    join.onRef('shared_space_album.albumId', '=', 'album_asset.albumId').on('shared_space_album.spaceId', '=', spaceId),
+  )
+  .innerJoin('album', (j) => j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null))
+  .select('shared_space_album.addedById as userId')
+  .distinct()
+  .where('shared_space_person_face.personId', '=', personId)
+  .where('asset.deletedAt', 'is', null)
+  .where('asset.isOffline', '=', false)
+  .where('shared_space_album.addedById', 'is not', null)
+  .execute();
+```
+
+Union its `userId`s with the existing direct + library rows.
+
+- [ ] **Step 1 (RED): medium test** in `shared-space.repository.spec.ts`: a space person whose faces
+  are only on an album-linked asset → `getSpacePersonAssetAdderIds(S, P)` includes the album's
+  `addedById` (RED: omitted).
+- [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space.repository.spec.ts`
+- [ ] **Step 3 (GREEN):** add the album-adder subquery + union.
+- [ ] **Step 4: Run; verify PASS.**
+- [ ] **Step 5: slice gate.** `make check-server`; commit
+  `fix(spaces): include album-linker as asset adder for metadata inheritance (faces F4)`.
+
+---
+
+## Slice 6: Asset-delete orphan cleanup handler (faces F5)
+
+**Files:**
+
+- Modify: `server/src/services/shared-space.service.ts` — add an `@OnEvent({ name: 'AssetDelete' })`
+  handler (beside the existing `onAlbum*` handlers).
+- Possibly modify: `server/src/services/asset.service.ts` — enrich the `AssetDelete` payload **only
+  if** Step 1 shows the event fires after the `asset_face` cascade (so affected persons can't be read
+  post-hoc).
+- Test: `server/test/medium/specs/services/shared-space-album.service.spec.ts` (extend) +
+  `server/src/services/shared-space.service.spec.ts` (unit — handler dispatch).
+
+**Interfaces:** consumes `recountPersons(personIds: string[], db?)` + `deleteOrphanedPersons(spaceId)`;
+needs the set of affected spaces (`getSpaceIdsForAsset`) and affected person ids.
+
+- [ ] **Step 1: Confirm timing (open item).** Determine whether `AssetDelete` (`asset.service.ts:485`)
+  fires **before or after** the `asset → asset_face → shared_space_person_face` cascade. If **before**:
+  the handler can query affected `(spaceId, personId)` from `shared_space_person_face` then recount
+  after. If **after**: the rows are already gone — capture affected spaces/persons in the payload
+  (enrich the event) or recount all persons for the spaces the asset belonged to. Document the chosen
+  path in the slice plan.
+- [ ] **Step 2 (RED): medium test** — face-enabled space `S` (album- or direct-sourced); a person `P`
+  has faces on assets `X` and `Y`. Hard-delete `X`. Assert `P`'s `assetCount`/`faceCount` are
+  recounted (decremented) and, if `X` was `P`'s only asset, `P` is removed as a zero-face orphan.
+  Control: a person in a space not containing `X` is untouched. (RED: counts stale, orphan remains.)
+- [ ] **Step 3: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/services/shared-space-album.service.spec.ts`
+- [ ] **Step 4 (GREEN):** add `onAssetDelete` — for each affected face-enabled space, `recountPersons`
+  the affected person ids and `deleteOrphanedPersons(spaceId)`. Keep it idempotent and guarded
+  (`try/catch` + logger, like `onAlbumDelete`).
+- [ ] **Step 5: Run; verify PASS.** Add the unit dispatch assertion in `shared-space.service.spec.ts`.
+- [ ] **Step 6: slice gate.** `make check-server`; commit
+  `fix(spaces): recount space people and drop orphans on asset delete (faces F5)`.
+
+> Pre-existing/broad: this also covers direct/library spaces. Lowest-priority engineering slice; the
+> timing question in Step 1 is the only real risk.
+
+---
+
+## Slice 7: Album-asset sync streams exclude soft-deleted albums (RBAC F1)
+
+**Files:**
+
+- Modify: `server/src/repositories/sync.repository.ts` — `SharedSpaceAlbumAssetSync.getBackfill`
+  (~`:1508`), `getUpdates` (~`:1527`), `getCreates` (~`:1549`); `SharedSpaceAlbumAssetExifSync`
+  backfill/updates/creates (~`:1574/:1585/:1598`); `SharedSpaceAlbumToAssetSync.getUpserts` (~`:1489`);
+  `SharedSpaceAlbumSync.getCreatedAfter` (~`:1367`).
+- Test: `server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts`,
+  `…-album-asset-exif-sync.spec.ts`, `…-album-to-asset-sync.spec.ts`,
+  `shared-space-album-sync.spec.ts` (extend — the metadata stream's soft-delete test at ~`:103/:176`
+  is the template).
+
+**Interfaces:** reuse the existing `accessibleSpaceAlbums(eb, userId)` helper (~`:1112`, already joins
+`album` + filters `album.deletedAt is null`), or add an `INNER JOIN album … AND album.deletedAt is
+null` to each stream — match whichever the sibling `getUpserts`/`getDeletes` streams use.
+
+The grant-gated streams currently filter on `shared_space_album_user` only:
+
+```ts
+.innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+.where('shared_space_album_user.userId', '=', userId)
+```
+
+Add the non-deleted-album scope (mirror `SharedSpaceAlbumSync.getUpserts` ~`:1399`):
+
+```ts
+.where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+```
+
+(For `getBackfill`, which is keyed by `albumId` param with no grant join, add an `album.deletedAt is
+null` guard so a backfill for a soft-deleted album returns nothing.)
+
+- [ ] **Step 1 (RED): medium tests** in each asset/exif/to-asset spec: grant member `M` access to
+  album `A` (linked to face-enabled space `S`), confirm the stream returns `A`'s asset/exif/to-asset
+  rows; soft-delete `A`; assert the stream now returns **none** for `M` (RED: still streamed). Also
+  assert `SharedSpaceAlbumSync.getCreatedAfter` no longer creates the album for `M` after soft-delete.
+- [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/sync/shared-space-album-asset-sync.spec.ts test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts`
+- [ ] **Step 3 (GREEN):** add `accessibleSpaceAlbums` / `album.deletedAt` scope to the eight stream
+  methods.
+- [ ] **Step 4: Run; verify PASS.**
+- [ ] **Step 5: slice gate.** `make check-server`; commit
+  `fix(spaces): stop syncing soft-deleted album assets to space members (RBAC F1)`.
+
+---
+
+## Slice 8: `user_has_album_path` honors `album.deletedAt` on all branches (RBAC F2)
+
+**Files:**
+
+- Modify: `server/src/schema/functions.ts` — `user_has_album_path` (~`:520`, body `:526-551`): add a
+  non-deleted `album` join + `a.deletedAt IS NULL` to branch 2 (other-space member) and branch 3
+  (other-space creator), matching branch 1.
+- Add: a new fork migration
+  `server/src/schema/migrations-gallery/1779300000000-FixUserHasAlbumPathSoftDeleted.ts` (round
+  timestamp **after** `1779200000000` — verify no collision) that `CREATE OR REPLACE FUNCTION
+  user_has_album_path(...)` with the corrected body.
+- Test: `server/test/medium/specs/sync/user-has-album-path.spec.ts` (extend) and/or
+  `shared-space-album-delete-triggers.spec.ts`.
+
+**Interfaces:** SQL function only; no TS signature change. Per CLAUDE.md, fork migrations live in
+`migrations-gallery/` (never touched by rebases) and `postbuild` merges them into `dist`.
+
+- [ ] **Step 1 (RED): medium test** in `user-has-album-path.spec.ts`: album `A` linked to two spaces
+  `S1`, `S2`; user `M` is a member of `S2` only. `user_has_album_path(A, M, S1)` returns `true`
+  (branch 2). Soft-delete `A`; assert it now returns `false` (RED: still `true` — under-revocation).
+  Add a branch-3 (other-space creator) variant. Confirm branch 1 (`album_user`) already returns
+  `false` for a soft-deleted album (regression guard).
+- [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/sync/user-has-album-path.spec.ts`
+- [ ] **Step 3 (GREEN):** edit `functions.ts` (so the schema source matches), then write the fork
+  migration with `CREATE OR REPLACE FUNCTION user_has_album_path` adding the `album.deletedAt` guard to
+  branches 2 & 3. Keep both copies byte-identical to avoid drift.
+- [ ] **Step 4: Run; verify PASS.** Also run `shared-space-album-delete-triggers.spec.ts` to confirm
+  the grant-revocation gating still behaves (a leave where the only other path is a now-soft-deleted
+  album should revoke the grant).
+- [ ] **Step 5: slice gate.** `make check-server` (and confirm `pnpm build` postbuild copies the new
+  migration); commit
+  `fix(spaces): exclude soft-deleted albums from user_has_album_path grant retention (RBAC F2)`.
+
+---
+
+## Slice 9: Validate the `albumId` route param → 400, not 500 (RBAC F3)
+
+**Files:**
+
+- Modify: `server/src/controllers/shared-space.controller.ts` — `linkAlbum` (~`:609`),
+  `updateSharedSpaceAlbum` (~`:623`), `unlinkAlbum` (~`:637`).
+- Add: a zod param DTO in `server/src/dtos/shared-space.dto.ts` (e.g.
+  `SharedSpaceAlbumParamDto = z.object({ id: z.uuidv4(), albumId: z.uuidv4() })`) mirroring
+  `UUIDParamDto` (`validation.ts:112`).
+- Test: `e2e/src/specs/server/api/shared-space-album.e2e-spec.ts` (extend).
+
+**Interfaces:** replace `@Param() { id }: UUIDParamDto, @Param('albumId') albumId: string` with
+`@Param() { id, albumId }: SharedSpaceAlbumParamDto` on all three endpoints.
+
+- [ ] **Step 1 (RED): e2e test** in `shared-space-album.e2e-spec.ts`: as an authorized space
+  Owner/Editor, call `PUT /shared-spaces/:id/albums/not-a-uuid` and assert status **400** (RED:
+  currently 500). Add the same for `PATCH` and `DELETE`.
+- [ ] **Step 2: Run; verify FAIL.** Run the e2e API suite for the spec.
+- [ ] **Step 3 (GREEN):** add the DTO and switch the three handlers to it.
+- [ ] **Step 4: OpenAPI gate (decision point).** Build the server and check whether the generated spec
+  changes (`cd server && pnpm build && pnpm sync:open-api`, then `git diff` the spec). **If it
+  changes**, this is the one slice that runs the regen workflow: `make open-api` (TS SDK + Dart),
+  commit the regenerated clients. **If it does not change**, no regen. If the team prefers strictly
+  no-regen, instead use a runtime-only UUID guard that emits no param format metadata — resolve at
+  plan-review.
+- [ ] **Step 5: Run; verify PASS.**
+- [ ] **Step 6: slice gate.** `make check-server`; commit
+  `fix(spaces): validate albumId route param (400 not 500) (RBAC F3)`.
+
+---
+
+## Slice 10: Mobile — server-only add path for absorbed albums (mobile F1) — HIGH
+
+**Files:**
+
+- Modify: `mobile/lib/providers/infrastructure/space_album_actions.dart` — add `addAssets` (mirror
+  `link`/`unlink`); add the `DriftAlbumApiRepository` dependency to the class + provider.
+- Modify: `mobile/lib/pages/library/spaces/space_album_detail.page.dart` — `_addPhotos` (~`:45-67`,
+  call at `:55`) routes through `SpaceAlbumActions.addAssets` instead of
+  `remoteAlbumProvider.notifier.addAssetsToAlbum`.
+- Test: `mobile/test/providers/infrastructure/space_album_actions_test.dart` (extend),
+  `mobile/test/medium/repositories/space_album_repository_test.dart` (regression, real Drift DB).
+
+**Interfaces:** new `Future<int> SpaceAlbumActions.addAssets(String albumId, List<String> assetIds)`
+calling `driftAlbumApiRepository.addAssets(albumId, assetIds)` (`drift_album_api_repository.dart:51-69`,
+provider `:10`) then `_syncManager.syncRemote()`. **No** local `remote_album_asset_entity` write.
+
+```dart
+Future<int> addAssets(String albumId, List<String> assetIds) async {
+  if (assetIds.isEmpty) return 0;
+  final result = await _albumApiRepo.addAssets(albumId, assetIds); // server is source of truth
+  await _syncManager.syncRemote();                                  // surfaces via spaceAlbum() watch
+  return result.added.length;
+}
+```
+
+- [ ] **Step 1 (RED): unit test** in `space_album_actions_test.dart` (mocktail): `addAssets` calls
+  `DriftAlbumApiRepository.addAssets` then `syncRemote()`, returns the added count, and **never**
+  touches the local album repository. Assert it does **not** call `RemoteAlbumRepository.addAssets`.
+- [ ] **Step 2 (RED): regression test** in `space_album_repository_test.dart` (real Drift DB, FK ON):
+  pin that the old path fails — `DriftRemoteAlbumRepository.addAssets('absorbed-album', [assetId])`
+  (no `remote_album` row) throws FK 787 — then assert the new server-only path performs no local
+  junction insert (no FK violation). (Mirrors the empirical repro in the report.)
+- [ ] **Step 3: Run; verify FAIL/repro.** `cd mobile && flutter test test/providers/infrastructure/space_album_actions_test.dart test/medium/repositories/space_album_repository_test.dart`
+- [ ] **Step 4 (GREEN):** implement `SpaceAlbumActions.addAssets`; point `_addPhotos` at it; on
+  success show the success toast, on real failure show the error toast (the false-failure is gone).
+- [ ] **Step 5: Run; verify PASS.** `mise //mobile:analyze` clean on touched files.
+- [ ] **Step 6: slice gate.** Commit
+  `fix(spaces/mobile): add photos to absorbed linked albums without false failure (mobile F1)`.
+
+> Edge: owner case (album in `remote_album`) still works via the server-only path (no double insert);
+> remove path is already a safe no-op and is unchanged.
+
+---
+
+## Slice 11: Mobile — populate `currentUserRole` so editor-owned albums are linkable (mobile F2)
+
+**Files:**
+
+- Modify: `mobile/lib/infrastructure/repositories/remote_album.repository.dart` — the album queries
+  (`getAll` ~`:22-82`, `get` ~`:84-131`, and the `toDto` mapper ~`:570-587`) to read the current
+  user's `remote_album_user.role` and pass `currentUserRole` into `RemoteAlbum`.
+- Test: `mobile/test/medium/repositories/space_album_repository_test.dart` or
+  `mobile/test/.../remote_album_repository_test.dart` (real Drift DB — assert mapping);
+  `mobile/test/utils/space_link_album_candidates_test.dart` already proves the gate once populated.
+
+**Interfaces:** the queries already `leftOuterJoin remoteAlbumUserEntity` (for `isShared`); add a
+current-user-keyed read of `.role`. `toDto` gains a `currentUserRole` param.
+
+- [ ] **Step 1 (RED): medium repo test** — seed an album shared with the current user as **editor**
+  (a `remote_album_user` row, role=editor) that the user does **not** own; assert the mapped
+  `RemoteAlbum.currentUserRole == AlbumUserRole.editor` (RED: `null`). Add owner and viewer variants.
+- [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/medium/repositories/space_album_repository_test.dart`
+- [ ] **Step 3 (GREEN):** read the current user's role in the album query and thread it through
+  `toDto(... currentUserRole: ...)`. The current user id is already available to these queries (used
+  for owner/shared computation) — reuse it.
+- [ ] **Step 4: Run; verify PASS.** Confirm `space_link_album_candidates_test.dart` still passes (the
+  editor branch is now reachable with real data).
+- [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
+  `fix(spaces/mobile): offer editable (not just owned) albums in the link picker (mobile F2)`.
+
+> Alternative (product): if editor-linking is out of scope for mobile v1, instead drop the `isEditor`
+> branch + "or can edit" wording. The design grants the capability, so this slice implements it; do
+> not switch without a captain decision.
+
+---
+
+## Slice 12: Mobile — detail header subtitle "{count} photos · in {space.name}" (mobile F3)
+
+**Files:**
+
+- Modify: `mobile/lib/pages/library/spaces/space_album_detail.page.dart` — `SpaceAlbumAppBar`
+  (~`:191-208`, title at `:196`) to add a subtitle; source the space name (watch the space-metadata
+  provider used by `space_detail.page.dart`, or pass it as a route param).
+- Test: `mobile/test/presentation/pages/space_album_detail_page_test.dart` (extend — it pumps
+  `SpaceAlbumAppBar` directly).
+
+**Interfaces:** `assetCount` from `SpaceAlbum.assetCount` (already resolved via `spaceAlbumsProvider`);
+space name from the space-metadata source.
+
+- [ ] **Step 1 (RED): widget test** — pump `SpaceAlbumDetailPage`/`SpaceAlbumAppBar` with a known
+  `assetCount` and space name; assert the subtitle text `"{count} photos · in {space.name}"` renders
+  (RED: absent).
+- [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/presentation/pages/space_album_detail_page_test.dart`
+- [ ] **Step 3 (GREEN):** add the subtitle (e.g. an app-bar `bottom`/two-line title) using the count +
+  space name; guard for the loading state (no subtitle until resolved — see Slice 14).
+- [ ] **Step 4: Run; verify PASS.**
+- [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
+  `fix(spaces/mobile): show photo count + space on album detail header (mobile F3)`.
+
+---
+
+## Slice 13: Mobile — real album covers (mobile F4)
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart` (~`:168-222`, icon
+  `:198`), `mobile/lib/pages/library/spaces/space_albums.page.dart` (~`:154-247`, icon `:176`),
+  `mobile/lib/pages/library/spaces/space_link_album.page.dart` (`_AlbumCover` ~`:202-219`, icon
+  `:217`).
+- Reuse: `mobile/lib/presentation/widgets/album/album_tile.dart:20,36-64`
+  (`assetServiceProvider.getRemoteAsset(thumbnailAssetId)` + `Thumbnail.remote` in a `FutureBuilder`,
+  icon as fallback).
+- Test: `mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart` (+ list/link page
+  tests) (extend).
+
+**Interfaces:** `thumbnailAssetId` is on `SpaceAlbum`/`RemoteAlbum`; the cover widgets need a `ref`
+(make them `ConsumerWidget` where they aren't already).
+
+- [ ] **Step 1 (RED): widget test** — render a cover for an album with a `thumbnailAssetId`; assert a
+  `Thumbnail`/image renders (not the placeholder icon). With a null `thumbnailAssetId`, assert the
+  placeholder icon still renders. (RED: always the icon.)
+- [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/presentation/widgets/spaces/space_albums_shelf_test.dart`
+- [ ] **Step 3 (GREEN):** port the `album_tile.dart` `FutureBuilder` cover pattern into the three
+  cover sites, keeping the icon as the no-thumbnail / loading / error fallback.
+- [ ] **Step 4: Run; verify PASS.**
+- [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
+  `fix(spaces/mobile): render real album cover thumbnails (mobile F4)`.
+
+---
+
+## Slice 14: Mobile — guard the timeline toggle before album metadata loads (mobile F5)
+
+**Files:**
+
+- Modify: `mobile/lib/pages/library/spaces/space_album_detail.page.dart` — `_toggleTimeline`
+  (~`:69-72`) and the kebab render (`SpaceAlbumAppBar`/`SpaceAlbumKebab` ~`:198-204`).
+- Test: `mobile/test/presentation/pages/space_album_detail_page_test.dart` /
+  `space_b6_mutations_test.dart` (extend).
+
+**Interfaces:** the kebab currently renders as soon as `canEdit` is known; the toggle no-ops when the
+album stream is still `null`.
+
+- [ ] **Step 1 (RED): widget test** — render the detail page with `canEdit == true` but the
+  `spaceAlbumsProvider` stream **unresolved**; assert the timeline toggle is **disabled** (or tapping
+  it surfaces a "still loading" affordance) rather than silently no-opping. Once the album resolves,
+  assert the toggle is enabled and fires `toggleTimeline`. (RED: toggle enabled + silent no-op while
+  loading.)
+- [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/presentation/pages/space_album_detail_page_test.dart`
+- [ ] **Step 3 (GREEN):** disable the toggle entry until `album != null` (gate on the album stream,
+  not just `canEdit`), or show a transient "still loading" toast on early tap.
+- [ ] **Step 4: Run; verify PASS.**
+- [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
+  `fix(spaces/mobile): disable timeline toggle until album metadata loads (mobile F5)`.
+
+---
+
+## Product decisions (noted, NOT scheduled)
+
+These need a captain decision before any code; the slices above do not touch them.
+
+- **faces F6** — should the space headline count / recent strip / "N new" badge gate on
+  `showInTimeline` (today they include album assets regardless, consistent with each other but
+  exceeding the timeline). Cheap either way; it's a "what does the space's photo count mean" call.
+- **RBAC F4** — confirm the transitive-write model is intended (album-editor who is a space Editor can
+  re-share the album's write surface to that space's Editors).
+- **RBAC F5** — whether a space *creator* can be membership-removed at all, and whether sync should
+  then follow membership (pre-existing shared-space infra, broader than albums).
+- **F3b eagerness** — eager cleanup-on-soft-delete (implemented in Slice 4) vs lazy reliance on Slice
+  1 read-scoping + Slice 2 gates (leaves `getSpacePersonThumbnail` exposure). Slice 4 proceeds with
+  eager per the report's recommendation; flip only on a captain decision.
+
+## Deferred (flagged, not scheduled — pre-existing or out of scope)
+
+- Mobile: hardcoded English strings (route through `.t(context:)`); detail query `visibility==timeline`
+  vs "all photos" nuance.
+- Web: in-space picker empty-state, sequential per-album link calls, `gray-*` vs `@immich/ui` tokens
+  (no web work in this round).
+- `AssetUpdate` has no album branch (`access.repository.ts`) — RBAC + faces both call it likely
+  intentional; confirm as a product decision if revisited.
+
+## Self-Review
+
+**Finding coverage:** faces F1→S1, faces F3a→S2, faces F2→S3, faces F3b→S4, faces F4→S5, faces
+F5→S6, faces F6→noted; RBAC F1→S7, RBAC F2→S8, RBAC F3→S9, RBAC F4/F5→noted; mobile F1→S10, mobile
+F2→S11, mobile F3→S12, mobile F4→S13, mobile F5→S14. Every engineering finding maps to exactly one
+slice; every product/informational finding is in [Product decisions](#product-decisions-noted-not-scheduled).
+
+**TDD:** each slice names the exact failing test file + assertions FIRST, the RED command, the GREEN
+implementation, and a slice gate. Edge cases are enumerated inline (S1 multi-path/trashed/date/repr;
+S3/S4 surviving-others/own-orphans/multi-space/direct-also/restore; S10 owner/non-owner/remove/empty).
+
+**Ordering/independence:** ship-blockers first (S1, S10). S2 (gates) precedes S4 (soft-delete cleanup)
+so no faces are added mid-clean; S1's `album.deletedAt` join makes the soft-delete read behavior in
+S2/S4/S8 observable. Otherwise slices are independent and individually committable.
+
+**Type/symbol consistency:** `recountPersons(personIds: string[], db?)` (S6 — not `spaceId`, no
+singular variant). `getAlbumAssetIdsWithoutOtherSpacePath(spaceId, albumId)` (album-excluding — S3/S4)
+vs `getAssetIdsWithoutOtherSpacePath(spaceId, assetIds)` (direct-removal). `AlbumDelete` event already
+exists (#726) and is reused by S3; no new album event type. R-F2 edits **both** `functions.ts` and a
+new `migrations-gallery/` file. R-F3 is the only slice that may need OpenAPI regen.
+
+**No-placeholder scan:** canonical patches shown for S1 (EXISTS + asset_scope), S2, S5 (full album
+subquery), S7 (grant→accessibleSpaceAlbums), S10 (`addAssets`). S3/S4/S6 reuse the verified
+`onAlbumDelete` sequence; S8 is a `CREATE OR REPLACE FUNCTION`; S9 a zod DTO; S11–S14 reference exact
+clone-source lines.
+
+## Open items (resolve at plan-review / first touch)
+
+- **S6** — confirm `AssetDelete` emit ordering vs the `asset_face` cascade; choose read-before-delete
+  vs enriched-payload accordingly.
+- **S8** — confirm `1779300000000` doesn't collide with any existing fork migration timestamp; confirm
+  `postbuild` copies the new file into `dist/schema/migrations`.
+- **S9** — confirm whether the zod param DTO changes the generated OpenAPI spec; regen iff it does.
+- **S4** — confirm the injection path for shared-space cleanup from `user-admin.service` (mirror how
+  the codebase already cross-injects services); keep it an internal call, not a new public surface.
+- **S12** — confirm the cleanest space-name source for the detail page (space-metadata provider vs
+  route param).

--- a/docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md
+++ b/docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md
@@ -11,8 +11,9 @@
 **Goal:** Fix every finding from the three post-#726 reviews of `feat/space-albums` @ `5f0076cd6e`
 (RBAC `sa-rbac-k7`, server-faces `sa-faces-m3`, mobile `sa-mobile-p2`) — the people-projection
 ship-blocker, owner-account/soft-delete/asset-delete face cleanup, sync-stream + `user_has_album_path`
-+ route-param consistency, and the mobile add-photos/link-picker/polish gaps. Product-only items
-(faces F6, RBAC F4/F5) are noted, not implemented.
+
+- route-param consistency, and the mobile add-photos/link-picker/polish gaps. Product-only items
+  (faces F6, RBAC F4/F5) are noted, not implemented.
 
 **Architecture:** Server fixes are Kysely SQL-predicate edits mirroring the existing
 `shared_space_library` branch / the `onAlbumDelete` cleanup sequence, one new fork migration
@@ -23,7 +24,8 @@ sequence directly.
 
 **Tech Stack:** NestJS 11 + Kysely (server), zod DTOs, SvelteKit/Svelte 5 (web — none in scope this
 round), Flutter/Riverpod/Drift (mobile), Vitest (server unit + medium via testcontainers), Playwright
-+ Vitest (e2e), `flutter test` (mobile).
+
+- Vitest (e2e), `flutter test` (mobile).
 
 ## Global Constraints
 
@@ -37,7 +39,7 @@ round), Flutter/Riverpod/Drift (mobile), Vitest (server unit + medium via testco
   shifts. **Re-grep by symbol name + scoping construct before editing.** Every cited method name and
   signature was verified at this commit.
 - **The A1 invariant:** every album read/stat/face/count/sync SQL branch MUST filter `album.deletedAt
-  is null` via a non-deleted `album` join. New branches include it from the start.
+is null` via a non-deleted `album` join. New branches include it from the start.
 - **Clone source for every predicate change:** the adjacent `shared_space_library` branch in the same
   method. For face cleanup: the `onAlbumDelete` handler sequence in `shared-space.service.ts`.
 - **Server imports:** no relative imports — use the `src/` alias. Strict TS.
@@ -63,15 +65,15 @@ round), Flutter/Riverpod/Drift (mobile), Vitest (server unit + medium via testco
 
 **The 7 queries and their scoping site** (anchor by method name; verify line by grep):
 
-| # | Method | Scoping construct to extend |
-| --- | --- | --- |
-| 1 | `getSpaceRepresentativeFaces` (called by `getSpacePersonFaces`) | `eb.or([...])` (asset + library EXISTS) |
-| 2 | `getSpacePersonStatistics` | `asset_scope` CTE (asset UNION library) |
-| 3 | `countPersonsBySpaceId` (svc `getSpacePeopleStatistics`) | `asset_scope` CTE **and** the `detectedFaceCount` subquery **and** `datePersonFilter` |
-| 4 | `getPeopleFaceStatisticsBySpaceId` (svc `getSpacePeopleFaceStatistics`) | `asset_scope` CTE |
-| 5 | `getPersonsBySpaceId` | in-space EXISTS `eb.or([...])` (carries date filter) |
-| 6 | `getSpaceRepresentativeFaceForUpdate` | `eb.or([...])` |
-| 7 | `getIdentityEvidenceForSpacePerson` | `eb.or([...])` |
+| #   | Method                                                                  | Scoping construct to extend                                                           |
+| --- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | `getSpaceRepresentativeFaces` (called by `getSpacePersonFaces`)         | `eb.or([...])` (asset + library EXISTS)                                               |
+| 2   | `getSpacePersonStatistics`                                              | `asset_scope` CTE (asset UNION library)                                               |
+| 3   | `countPersonsBySpaceId` (svc `getSpacePeopleStatistics`)                | `asset_scope` CTE **and** the `detectedFaceCount` subquery **and** `datePersonFilter` |
+| 4   | `getPeopleFaceStatisticsBySpaceId` (svc `getSpacePeopleFaceStatistics`) | `asset_scope` CTE                                                                     |
+| 5   | `getPersonsBySpaceId`                                                   | in-space EXISTS `eb.or([...])` (carries date filter)                                  |
+| 6   | `getSpaceRepresentativeFaceForUpdate`                                   | `eb.or([...])`                                                                        |
+| 7   | `getIdentityEvidenceForSpacePerson`                                     | `eb.or([...])`                                                                        |
 
 **Canonical album branch** (member-/space-scoped `EXISTS` form, mirrors the library branch + A1 join):
 
@@ -108,11 +110,11 @@ the `takenAfter`/`takenBefore` date filters:
 ```
 
 - [ ] **Step 1 (RED): comprehensive medium test** in `shared-space.repository.spec.ts`, a new
-  `describe('people projection — album-linked space', …)`. Seed a face-recognition-enabled space `S`;
-  link album `A` (via `addAlbum`) with image assets that are **not** direct-added and **not** in any
-  linked library; run/seed the projection so a space person `P` has `shared_space_person_face` rows on
-  `A`'s assets (mirror the existing direct/library projection seeding). Assert, **before** the fix
-  (RED):
+      `describe('people projection — album-linked space', …)`. Seed a face-recognition-enabled space `S`;
+      link album `A` (via `addAlbum`) with image assets that are **not** direct-added and **not** in any
+      linked library; run/seed the projection so a space person `P` has `shared_space_person_face` rows on
+      `A`'s assets (mirror the existing direct/library projection seeding). Assert, **before** the fix
+      (RED):
   - `getSpaceRepresentativeFaces(S, [P])` (via `getSpacePersonFaces`) returns a **non-empty** face
     list for `P` (RED: empty).
   - `getSpacePersonStatistics(S, P)` returns `assets > 0 && faces > 0` matching the projection's
@@ -133,17 +135,17 @@ the `takenAfter`/`takenBefore` date filters:
     0 (this also pins F3's read behavior).
 - [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space.repository.spec.ts`
 - [ ] **Step 3 (GREEN): add the album branch** to all 7 scoping sites (and the two extra sites inside
-  `countPersonsBySpaceId`: the `detectedFaceCount` subquery and `datePersonFilter`). Match each
-  sibling's join column (`asset.id` vs `asset_face.assetId`) and scope key (`spaceId` literal vs
-  `shared_space_person.spaceId` ref). Do **not** modify `recountPersons` or `getPersonAssetIds` (they
-  read the projection directly by design). Grep to confirm none missed: `grep -n
-  "shared_space_library" server/src/repositories/shared-space.repository.ts` within the people block —
-  every people-projection hit must now have a paired `shared_space_album` branch.
+      `countPersonsBySpaceId`: the `detectedFaceCount` subquery and `datePersonFilter`). Match each
+      sibling's join column (`asset.id` vs `asset_face.assetId`) and scope key (`spaceId` literal vs
+      `shared_space_person.spaceId` ref). Do **not** modify `recountPersons` or `getPersonAssetIds` (they
+      read the projection directly by design). Grep to confirm none missed: `grep -n
+"shared_space_library" server/src/repositories/shared-space.repository.ts` within the people block —
+      every people-projection hit must now have a paired `shared_space_album` branch.
 - [ ] **Step 4: Run; verify PASS.** Re-run the spec; then run the broader recognition specs to confirm
-  no regression on direct/library spaces:
-  `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space-face-matching.spec.ts`
+      no regression on direct/library spaces:
+      `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space-face-matching.spec.ts`
 - [ ] **Step 5: slice gate.** `make check-server`; commit
-  `fix(spaces): album-linked faces appear in space people read/stats/faces (faces F1)`.
+      `fix(spaces): album-linked faces appear in space people read/stats/faces (faces F1)`.
 
 ---
 
@@ -166,14 +168,14 @@ Both album branches `innerJoin('album_asset', …)` directly without joining `al
 ```
 
 - [ ] **Step 1 (RED):** in `shared-space-album.repository.spec.ts`, link album `A` (with asset `X`)
-  into face-enabled space `S`. Assert `isAssetInSpace(S, X) === true` and `getSpaceIdsForAsset(X)`
-  includes `S`. Then soft-delete `A` and assert `isAssetInSpace(S, X) === false` and
-  `getSpaceIdsForAsset(X)` **excludes** `S` (RED: both still true/included).
+      into face-enabled space `S`. Assert `isAssetInSpace(S, X) === true` and `getSpaceIdsForAsset(X)`
+      includes `S`. Then soft-delete `A` and assert `isAssetInSpace(S, X) === false` and
+      `getSpaceIdsForAsset(X)` **excludes** `S` (RED: both still true/included).
 - [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space-album.repository.spec.ts`
 - [ ] **Step 3 (GREEN):** add the non-deleted `album` join to both album branches.
 - [ ] **Step 4: Run; verify PASS.**
 - [ ] **Step 5: slice gate.** `make check-server`; commit
-  `fix(spaces): face-pipeline gates exclude soft-deleted albums (faces F3a)`.
+      `fix(spaces): face-pipeline gates exclude soft-deleted albums (faces F3a)`.
 
 ---
 
@@ -191,34 +193,34 @@ Both album branches `innerJoin('album_asset', …)` directly without joining `al
 **Interfaces:**
 
 - Consumes (already present, reused from `onAlbumDelete`): `eventRepository.emit('AlbumDelete', {
-  albumId })` (awaited in-process), or directly `sharedSpaceRepository.getSpacesLinkedToAlbum`,
+albumId })` (awaited in-process), or directly `sharedSpaceRepository.getSpacesLinkedToAlbum`,
   `getAlbumAssetIdsWithoutOtherSpacePath`, `removePersonFacesByAssetIds`, `deleteOrphanedPersons`,
   `queueSpacePersonMetadataBackfill`.
 
 - [ ] **Step 1: Confirm emit ordering.** `handleUserDelete` emits only `UserDelete` today; verify
-  `eventRepository.emit` awaits handlers in-process (it does for `AlbumAssetsAdd/Remove`/`AlbumDelete`).
-  The cleanup must run while `album_asset` rows still exist (i.e. **before** `deleteAll` and before the
-  user/asset cascade).
+      `eventRepository.emit` awaits handlers in-process (it does for `AlbumAssetsAdd/Remove`/`AlbumDelete`).
+      The cleanup must run while `album_asset` rows still exist (i.e. **before** `deleteAll` and before the
+      user/asset cascade).
 - [ ] **Step 2 (RED): medium test** in `shared-space-album.service.spec.ts`. Alice owns album `A` with
-  photos from **Alice and Bob**; Bob's face-enabled space `S` links `A`; the projection has space
-  persons derived from `A`'s faces (assert `assetCount > 0` pre-delete). A second asset `Z` in `A` is
-  **also** direct-added to `S`. Hard-delete Alice via `userService.handleUserDelete({ id: alice })`.
-  Assert:
+      photos from **Alice and Bob**; Bob's face-enabled space `S` links `A`; the projection has space
+      persons derived from `A`'s faces (assert `assetCount > 0` pre-delete). A second asset `Z` in `A` is
+      **also** direct-added to `S`. Hard-delete Alice via `userService.handleUserDelete({ id: alice })`.
+      Assert:
   - `shared_space_person_face` rows for `A`'s assets that are now path-less are **removed** and
     zero-face `shared_space_person` rows are gone (`deleteOrphanedPersons` ran).
   - the face on `Z` is **retained** (survives via the direct path).
   - control: a face-enabled space that did **not** link `A` is untouched.
-  (RED: faces stranded, orphan persons remain.)
+    (RED: faces stranded, orphan persons remain.)
 - [ ] **Step 3: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/services/shared-space-album.service.spec.ts`
 - [ ] **Step 4 (GREEN):** in `handleUserDelete`, before `albumRepository.deleteAll(user.id)`,
-  enumerate the user's album ids and `await this.eventRepository.emit('AlbumDelete', { albumId })` for
-  each (reusing the tested `onAlbumDelete` cleanup). If a bulk sweep is preferred for large accounts,
-  call the `getSpacesLinkedToAlbum → … → deleteOrphanedPersons` sequence directly per album. Mind
-  `no-floating-promises`.
+      enumerate the user's album ids and `await this.eventRepository.emit('AlbumDelete', { albumId })` for
+      each (reusing the tested `onAlbumDelete` cleanup). If a bulk sweep is preferred for large accounts,
+      call the `getSpacesLinkedToAlbum → … → deleteOrphanedPersons` sequence directly per album. Mind
+      `no-floating-promises`.
 - [ ] **Step 5: Run; verify PASS.** Add/confirm the `user.service.spec.ts` unit assertion that the
-  emit/sweep happens before `deleteAll`.
+      emit/sweep happens before `deleteAll`.
 - [ ] **Step 6: slice gate.** `make check-server`; commit
-  `fix(spaces): clean space faces when an album owner's account is hard-deleted (faces F2)`.
+      `fix(spaces): clean space faces when an album owner's account is hard-deleted (faces F2)`.
 
 > Edge note: a deleted user's **direct-added / library** assets in other spaces (not via an album)
 > can still leave stale faces — that is the F5 class (Slice 6), not this slice.
@@ -244,30 +246,31 @@ restore, the existing per-(space,asset) face-match queue (`SharedSpaceFaceMatch`
 **Depends on:** Slice 2 (gates) so no new faces are added during the window while we clean.
 
 - [ ] **Step 1 (RED): medium test** — owner-account soft-delete. Bob's face-enabled space `S` links
-  Alice's album `A`; projection has album-sourced people with `assetCount > 0`. Soft-delete Alice's
-  account (drive `userAdminService.delete(auth, alice, {})` — non-force, the soft path). Assert the
-  album-sourced `shared_space_person_face` rows are **removed**, zero-face persons gone, and (with
-  Slice 1 in place) the people read surfaces return empty for `A`-only people. (RED: faces persist.)
+      Alice's album `A`; projection has album-sourced people with `assetCount > 0`. Soft-delete Alice's
+      account (drive `userAdminService.delete(auth, alice, {})` — non-force, the soft path). Assert the
+      album-sourced `shared_space_person_face` rows are **removed**, zero-face persons gone, and (with
+      Slice 1 in place) the people read surfaces return empty for `A`-only people. (RED: faces persist.)
 - [ ] **Step 2 (RED): medium test** — restore. After the soft-delete above, restore Alice
-  (`userAdminService.restore(auth, alice)`); assert a face re-match is queued per linking face-enabled
-  space (assert the job enqueue, or — if the test runs the worker — that the album-sourced people
-  re-appear). (RED: nothing re-queued.)
+      (`userAdminService.restore(auth, alice)`); assert a face re-match is queued per linking face-enabled
+      space (assert the job enqueue, or — if the test runs the worker — that the album-sourced people
+      re-appear). (RED: nothing re-queued.)
 - [ ] **Step 3: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/services/shared-space-album.service.spec.ts`
 - [ ] **Step 4 (GREEN): cleanup on soft-delete.** From the soft-delete path, for each of the user's
-  albums run the `onAlbumDelete` cleanup sequence per face-enabled linking space (the `album_asset`
-  rows still exist on soft-delete). Wire it via a small shared-space method invoked from
-  `user-admin.service.delete()` (inject `SharedSpaceService`/repo as the codebase already does) — do
-  **not** invent a public API/event surface beyond an internal call.
+      albums run the `onAlbumDelete` cleanup sequence per face-enabled linking space (the `album_asset`
+      rows still exist on soft-delete). Wire it via a small shared-space method invoked from
+      `user-admin.service.delete()` (inject `SharedSpaceService`/repo as the codebase already does) — do
+      **not** invent a public API/event surface beyond an internal call.
 - [ ] **Step 5 (GREEN): re-projection on restore.** From the restore path, for each restored album,
-  for each linking face-enabled space, queue face matching (mirror `addMember`'s
-  `queueSpacePersonMetadataBackfill` + per-space `SharedSpaceFaceMatchAll`).
+      for each linking face-enabled space, queue face matching (mirror `addMember`'s
+      `queueSpacePersonMetadataBackfill` + per-space `SharedSpaceFaceMatchAll`).
 - [ ] **Step 6: Run; verify PASS.**
 - [ ] **Step 7: slice gate.** `make check-server`; commit
-  `fix(spaces): clean/re-project space faces on owner-account soft-delete and restore (faces F3b)`.
+      `fix(spaces): clean/re-project space faces on owner-account soft-delete and restore (faces F3b)`.
 
 > Decision baked in: this implements the **eager** cleanup the report recommends (consistency with A1
-> + clears `getSpacePersonThumbnail` exposure). The lazy alternative is noted in the design's Product
-> decisions; do not switch without a captain decision.
+>
+> - clears `getSpacePersonThumbnail` exposure). The lazy alternative is noted in the design's Product
+>   decisions; do not switch without a captain decision.
 
 ---
 
@@ -308,13 +311,13 @@ const albumRows = await this.db
 Union its `userId`s with the existing direct + library rows.
 
 - [ ] **Step 1 (RED): medium test** in `shared-space.repository.spec.ts`: a space person whose faces
-  are only on an album-linked asset → `getSpacePersonAssetAdderIds(S, P)` includes the album's
-  `addedById` (RED: omitted).
+      are only on an album-linked asset → `getSpacePersonAssetAdderIds(S, P)` includes the album's
+      `addedById` (RED: omitted).
 - [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/repositories/shared-space.repository.spec.ts`
 - [ ] **Step 3 (GREEN):** add the album-adder subquery + union.
 - [ ] **Step 4: Run; verify PASS.**
 - [ ] **Step 5: slice gate.** `make check-server`; commit
-  `fix(spaces): include album-linker as asset adder for metadata inheritance (faces F4)`.
+      `fix(spaces): include album-linker as asset adder for metadata inheritance (faces F4)`.
 
 ---
 
@@ -334,22 +337,22 @@ Union its `userId`s with the existing direct + library rows.
 needs the set of affected spaces (`getSpaceIdsForAsset`) and affected person ids.
 
 - [ ] **Step 1: Confirm timing (open item).** Determine whether `AssetDelete` (`asset.service.ts:485`)
-  fires **before or after** the `asset → asset_face → shared_space_person_face` cascade. If **before**:
-  the handler can query affected `(spaceId, personId)` from `shared_space_person_face` then recount
-  after. If **after**: the rows are already gone — capture affected spaces/persons in the payload
-  (enrich the event) or recount all persons for the spaces the asset belonged to. Document the chosen
-  path in the slice plan.
+      fires **before or after** the `asset → asset_face → shared_space_person_face` cascade. If **before**:
+      the handler can query affected `(spaceId, personId)` from `shared_space_person_face` then recount
+      after. If **after**: the rows are already gone — capture affected spaces/persons in the payload
+      (enrich the event) or recount all persons for the spaces the asset belonged to. Document the chosen
+      path in the slice plan.
 - [ ] **Step 2 (RED): medium test** — face-enabled space `S` (album- or direct-sourced); a person `P`
-  has faces on assets `X` and `Y`. Hard-delete `X`. Assert `P`'s `assetCount`/`faceCount` are
-  recounted (decremented) and, if `X` was `P`'s only asset, `P` is removed as a zero-face orphan.
-  Control: a person in a space not containing `X` is untouched. (RED: counts stale, orphan remains.)
+      has faces on assets `X` and `Y`. Hard-delete `X`. Assert `P`'s `assetCount`/`faceCount` are
+      recounted (decremented) and, if `X` was `P`'s only asset, `P` is removed as a zero-face orphan.
+      Control: a person in a space not containing `X` is untouched. (RED: counts stale, orphan remains.)
 - [ ] **Step 3: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/services/shared-space-album.service.spec.ts`
 - [ ] **Step 4 (GREEN):** add `onAssetDelete` — for each affected face-enabled space, `recountPersons`
-  the affected person ids and `deleteOrphanedPersons(spaceId)`. Keep it idempotent and guarded
-  (`try/catch` + logger, like `onAlbumDelete`).
+      the affected person ids and `deleteOrphanedPersons(spaceId)`. Keep it idempotent and guarded
+      (`try/catch` + logger, like `onAlbumDelete`).
 - [ ] **Step 5: Run; verify PASS.** Add the unit dispatch assertion in `shared-space.service.spec.ts`.
 - [ ] **Step 6: slice gate.** `make check-server`; commit
-  `fix(spaces): recount space people and drop orphans on asset delete (faces F5)`.
+      `fix(spaces): recount space people and drop orphans on asset delete (faces F5)`.
 
 > Pre-existing/broad: this also covers direct/library spaces. Lowest-priority engineering slice; the
 > timing question in Step 1 is the only real risk.
@@ -390,15 +393,15 @@ Add the non-deleted-album scope (mirror `SharedSpaceAlbumSync.getUpserts` ~`:139
 null` guard so a backfill for a soft-deleted album returns nothing.)
 
 - [ ] **Step 1 (RED): medium tests** in each asset/exif/to-asset spec: grant member `M` access to
-  album `A` (linked to face-enabled space `S`), confirm the stream returns `A`'s asset/exif/to-asset
-  rows; soft-delete `A`; assert the stream now returns **none** for `M` (RED: still streamed). Also
-  assert `SharedSpaceAlbumSync.getCreatedAfter` no longer creates the album for `M` after soft-delete.
+      album `A` (linked to face-enabled space `S`), confirm the stream returns `A`'s asset/exif/to-asset
+      rows; soft-delete `A`; assert the stream now returns **none** for `M` (RED: still streamed). Also
+      assert `SharedSpaceAlbumSync.getCreatedAfter` no longer creates the album for `M` after soft-delete.
 - [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/sync/shared-space-album-asset-sync.spec.ts test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts`
 - [ ] **Step 3 (GREEN):** add `accessibleSpaceAlbums` / `album.deletedAt` scope to the eight stream
-  methods.
+      methods.
 - [ ] **Step 4: Run; verify PASS.**
 - [ ] **Step 5: slice gate.** `make check-server`; commit
-  `fix(spaces): stop syncing soft-deleted album assets to space members (RBAC F1)`.
+      `fix(spaces): stop syncing soft-deleted album assets to space members (RBAC F1)`.
 
 ---
 
@@ -412,7 +415,7 @@ null` guard so a backfill for a soft-deleted album returns nothing.)
 - Add: a new fork migration
   `server/src/schema/migrations-gallery/1779300000000-FixUserHasAlbumPathSoftDeleted.ts` (round
   timestamp **after** `1779200000000` — verify no collision) that `CREATE OR REPLACE FUNCTION
-  user_has_album_path(...)` with the corrected body.
+user_has_album_path(...)` with the corrected body.
 - Test: `server/test/medium/specs/sync/user-has-album-path.spec.ts` (extend) and/or
   `shared-space-album-delete-triggers.spec.ts`.
 
@@ -420,20 +423,20 @@ null` guard so a backfill for a soft-deleted album returns nothing.)
 `migrations-gallery/` (never touched by rebases) and `postbuild` merges them into `dist`.
 
 - [ ] **Step 1 (RED): medium test** in `user-has-album-path.spec.ts`: album `A` linked to two spaces
-  `S1`, `S2`; user `M` is a member of `S2` only. `user_has_album_path(A, M, S1)` returns `true`
-  (branch 2). Soft-delete `A`; assert it now returns `false` (RED: still `true` — under-revocation).
-  Add a branch-3 (other-space creator) variant. Confirm branch 1 (`album_user`) already returns
-  `false` for a soft-deleted album (regression guard).
+      `S1`, `S2`; user `M` is a member of `S2` only. `user_has_album_path(A, M, S1)` returns `true`
+      (branch 2). Soft-delete `A`; assert it now returns `false` (RED: still `true` — under-revocation).
+      Add a branch-3 (other-space creator) variant. Confirm branch 1 (`album_user`) already returns
+      `false` for a soft-deleted album (regression guard).
 - [ ] **Step 2: Run; verify FAIL.** `cd server && pnpm test:medium -- --run test/medium/specs/sync/user-has-album-path.spec.ts`
 - [ ] **Step 3 (GREEN):** edit `functions.ts` (so the schema source matches), then write the fork
-  migration with `CREATE OR REPLACE FUNCTION user_has_album_path` adding the `album.deletedAt` guard to
-  branches 2 & 3. Keep both copies byte-identical to avoid drift.
+      migration with `CREATE OR REPLACE FUNCTION user_has_album_path` adding the `album.deletedAt` guard to
+      branches 2 & 3. Keep both copies byte-identical to avoid drift.
 - [ ] **Step 4: Run; verify PASS.** Also run `shared-space-album-delete-triggers.spec.ts` to confirm
-  the grant-revocation gating still behaves (a leave where the only other path is a now-soft-deleted
-  album should revoke the grant).
+      the grant-revocation gating still behaves (a leave where the only other path is a now-soft-deleted
+      album should revoke the grant).
 - [ ] **Step 5: slice gate.** `make check-server` (and confirm `pnpm build` postbuild copies the new
-  migration); commit
-  `fix(spaces): exclude soft-deleted albums from user_has_album_path grant retention (RBAC F2)`.
+      migration); commit
+      `fix(spaces): exclude soft-deleted albums from user_has_album_path grant retention (RBAC F2)`.
 
 ---
 
@@ -452,19 +455,19 @@ null` guard so a backfill for a soft-deleted album returns nothing.)
 `@Param() { id, albumId }: SharedSpaceAlbumParamDto` on all three endpoints.
 
 - [ ] **Step 1 (RED): e2e test** in `shared-space-album.e2e-spec.ts`: as an authorized space
-  Owner/Editor, call `PUT /shared-spaces/:id/albums/not-a-uuid` and assert status **400** (RED:
-  currently 500). Add the same for `PATCH` and `DELETE`.
+      Owner/Editor, call `PUT /shared-spaces/:id/albums/not-a-uuid` and assert status **400** (RED:
+      currently 500). Add the same for `PATCH` and `DELETE`.
 - [ ] **Step 2: Run; verify FAIL.** Run the e2e API suite for the spec.
 - [ ] **Step 3 (GREEN):** add the DTO and switch the three handlers to it.
 - [ ] **Step 4: OpenAPI gate (decision point).** Build the server and check whether the generated spec
-  changes (`cd server && pnpm build && pnpm sync:open-api`, then `git diff` the spec). **If it
-  changes**, this is the one slice that runs the regen workflow: `make open-api` (TS SDK + Dart),
-  commit the regenerated clients. **If it does not change**, no regen. If the team prefers strictly
-  no-regen, instead use a runtime-only UUID guard that emits no param format metadata — resolve at
-  plan-review.
+      changes (`cd server && pnpm build && pnpm sync:open-api`, then `git diff` the spec). **If it
+      changes**, this is the one slice that runs the regen workflow: `make open-api` (TS SDK + Dart),
+      commit the regenerated clients. **If it does not change**, no regen. If the team prefers strictly
+      no-regen, instead use a runtime-only UUID guard that emits no param format metadata — resolve at
+      plan-review.
 - [ ] **Step 5: Run; verify PASS.**
 - [ ] **Step 6: slice gate.** `make check-server`; commit
-  `fix(spaces): validate albumId route param (400 not 500) (RBAC F3)`.
+      `fix(spaces): validate albumId route param (400 not 500) (RBAC F3)`.
 
 ---
 
@@ -494,18 +497,18 @@ Future<int> addAssets(String albumId, List<String> assetIds) async {
 ```
 
 - [ ] **Step 1 (RED): unit test** in `space_album_actions_test.dart` (mocktail): `addAssets` calls
-  `DriftAlbumApiRepository.addAssets` then `syncRemote()`, returns the added count, and **never**
-  touches the local album repository. Assert it does **not** call `RemoteAlbumRepository.addAssets`.
+      `DriftAlbumApiRepository.addAssets` then `syncRemote()`, returns the added count, and **never**
+      touches the local album repository. Assert it does **not** call `RemoteAlbumRepository.addAssets`.
 - [ ] **Step 2 (RED): regression test** in `space_album_repository_test.dart` (real Drift DB, FK ON):
-  pin that the old path fails — `DriftRemoteAlbumRepository.addAssets('absorbed-album', [assetId])`
-  (no `remote_album` row) throws FK 787 — then assert the new server-only path performs no local
-  junction insert (no FK violation). (Mirrors the empirical repro in the report.)
+      pin that the old path fails — `DriftRemoteAlbumRepository.addAssets('absorbed-album', [assetId])`
+      (no `remote_album` row) throws FK 787 — then assert the new server-only path performs no local
+      junction insert (no FK violation). (Mirrors the empirical repro in the report.)
 - [ ] **Step 3: Run; verify FAIL/repro.** `cd mobile && flutter test test/providers/infrastructure/space_album_actions_test.dart test/medium/repositories/space_album_repository_test.dart`
 - [ ] **Step 4 (GREEN):** implement `SpaceAlbumActions.addAssets`; point `_addPhotos` at it; on
-  success show the success toast, on real failure show the error toast (the false-failure is gone).
+      success show the success toast, on real failure show the error toast (the false-failure is gone).
 - [ ] **Step 5: Run; verify PASS.** `mise //mobile:analyze` clean on touched files.
 - [ ] **Step 6: slice gate.** Commit
-  `fix(spaces/mobile): add photos to absorbed linked albums without false failure (mobile F1)`.
+      `fix(spaces/mobile): add photos to absorbed linked albums without false failure (mobile F1)`.
 
 > Edge: owner case (album in `remote_album`) still works via the server-only path (no double insert);
 > remove path is already a safe no-op and is unchanged.
@@ -527,16 +530,16 @@ Future<int> addAssets(String albumId, List<String> assetIds) async {
 current-user-keyed read of `.role`. `toDto` gains a `currentUserRole` param.
 
 - [ ] **Step 1 (RED): medium repo test** — seed an album shared with the current user as **editor**
-  (a `remote_album_user` row, role=editor) that the user does **not** own; assert the mapped
-  `RemoteAlbum.currentUserRole == AlbumUserRole.editor` (RED: `null`). Add owner and viewer variants.
+      (a `remote_album_user` row, role=editor) that the user does **not** own; assert the mapped
+      `RemoteAlbum.currentUserRole == AlbumUserRole.editor` (RED: `null`). Add owner and viewer variants.
 - [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/medium/repositories/space_album_repository_test.dart`
 - [ ] **Step 3 (GREEN):** read the current user's role in the album query and thread it through
-  `toDto(... currentUserRole: ...)`. The current user id is already available to these queries (used
-  for owner/shared computation) — reuse it.
+      `toDto(... currentUserRole: ...)`. The current user id is already available to these queries (used
+      for owner/shared computation) — reuse it.
 - [ ] **Step 4: Run; verify PASS.** Confirm `space_link_album_candidates_test.dart` still passes (the
-  editor branch is now reachable with real data).
+      editor branch is now reachable with real data).
 - [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
-  `fix(spaces/mobile): offer editable (not just owned) albums in the link picker (mobile F2)`.
+      `fix(spaces/mobile): offer editable (not just owned) albums in the link picker (mobile F2)`.
 
 > Alternative (product): if editor-linking is out of scope for mobile v1, instead drop the `isEditor`
 > branch + "or can edit" wording. The design grants the capability, so this slice implements it; do
@@ -558,14 +561,14 @@ current-user-keyed read of `.role`. `toDto` gains a `currentUserRole` param.
 space name from the space-metadata source.
 
 - [ ] **Step 1 (RED): widget test** — pump `SpaceAlbumDetailPage`/`SpaceAlbumAppBar` with a known
-  `assetCount` and space name; assert the subtitle text `"{count} photos · in {space.name}"` renders
-  (RED: absent).
+      `assetCount` and space name; assert the subtitle text `"{count} photos · in {space.name}"` renders
+      (RED: absent).
 - [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/presentation/pages/space_album_detail_page_test.dart`
 - [ ] **Step 3 (GREEN):** add the subtitle (e.g. an app-bar `bottom`/two-line title) using the count +
-  space name; guard for the loading state (no subtitle until resolved — see Slice 14).
+      space name; guard for the loading state (no subtitle until resolved — see Slice 14).
 - [ ] **Step 4: Run; verify PASS.**
 - [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
-  `fix(spaces/mobile): show photo count + space on album detail header (mobile F3)`.
+      `fix(spaces/mobile): show photo count + space on album detail header (mobile F3)`.
 
 ---
 
@@ -587,14 +590,14 @@ space name from the space-metadata source.
 (make them `ConsumerWidget` where they aren't already).
 
 - [ ] **Step 1 (RED): widget test** — render a cover for an album with a `thumbnailAssetId`; assert a
-  `Thumbnail`/image renders (not the placeholder icon). With a null `thumbnailAssetId`, assert the
-  placeholder icon still renders. (RED: always the icon.)
+      `Thumbnail`/image renders (not the placeholder icon). With a null `thumbnailAssetId`, assert the
+      placeholder icon still renders. (RED: always the icon.)
 - [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/presentation/widgets/spaces/space_albums_shelf_test.dart`
 - [ ] **Step 3 (GREEN):** port the `album_tile.dart` `FutureBuilder` cover pattern into the three
-  cover sites, keeping the icon as the no-thumbnail / loading / error fallback.
+      cover sites, keeping the icon as the no-thumbnail / loading / error fallback.
 - [ ] **Step 4: Run; verify PASS.**
 - [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
-  `fix(spaces/mobile): render real album cover thumbnails (mobile F4)`.
+      `fix(spaces/mobile): render real album cover thumbnails (mobile F4)`.
 
 ---
 
@@ -611,16 +614,16 @@ space name from the space-metadata source.
 album stream is still `null`.
 
 - [ ] **Step 1 (RED): widget test** — render the detail page with `canEdit == true` but the
-  `spaceAlbumsProvider` stream **unresolved**; assert the timeline toggle is **disabled** (or tapping
-  it surfaces a "still loading" affordance) rather than silently no-opping. Once the album resolves,
-  assert the toggle is enabled and fires `toggleTimeline`. (RED: toggle enabled + silent no-op while
-  loading.)
+      `spaceAlbumsProvider` stream **unresolved**; assert the timeline toggle is **disabled** (or tapping
+      it surfaces a "still loading" affordance) rather than silently no-opping. Once the album resolves,
+      assert the toggle is enabled and fires `toggleTimeline`. (RED: toggle enabled + silent no-op while
+      loading.)
 - [ ] **Step 2: Run; verify FAIL.** `cd mobile && flutter test test/presentation/pages/space_album_detail_page_test.dart`
 - [ ] **Step 3 (GREEN):** disable the toggle entry until `album != null` (gate on the album stream,
-  not just `canEdit`), or show a transient "still loading" toast on early tap.
+      not just `canEdit`), or show a transient "still loading" toast on early tap.
 - [ ] **Step 4: Run; verify PASS.**
 - [ ] **Step 5: slice gate.** `mise //mobile:analyze` clean; commit
-  `fix(spaces/mobile): disable timeline toggle until album metadata loads (mobile F5)`.
+      `fix(spaces/mobile): disable timeline toggle until album metadata loads (mobile F5)`.
 
 ---
 
@@ -633,7 +636,7 @@ These need a captain decision before any code; the slices above do not touch the
   exceeding the timeline). Cheap either way; it's a "what does the space's photo count mean" call.
 - **RBAC F4** — confirm the transitive-write model is intended (album-editor who is a space Editor can
   re-share the album's write surface to that space's Editors).
-- **RBAC F5** — whether a space *creator* can be membership-removed at all, and whether sync should
+- **RBAC F5** — whether a space _creator_ can be membership-removed at all, and whether sync should
   then follow membership (pre-existing shared-space infra, broader than albums).
 - **F3b eagerness** — eager cleanup-on-soft-delete (implemented in Slice 4) vs lazy reliance on Slice
   1 read-scoping + Slice 2 gates (leaves `getSpacePersonThumbnail` exposure). Slice 4 proceeds with

--- a/docs/superpowers/specs/2026-06-29-space-albums-review-fixes-followup-design.md
+++ b/docs/superpowers/specs/2026-06-29-space-albums-review-fixes-followup-design.md
@@ -5,11 +5,11 @@
 After PR #726 ("space-albums review fixes") merged into `feat/space-albums`, **three independent
 adversarial reviews** were run against the branch at commit `5f0076cd6e` (post-#726):
 
-| Review | Scope | Verdict |
-| --- | --- | --- |
-| `sa-rbac-k7` | access-control / RBAC | model **SOUND**; no shippable security bug. LOW/consistency: sync-stream `album.deletedAt` parity, `user_has_album_path` nit, unvalidated `albumId` param → 500; two informational notes. |
-| `sa-faces-m3` | server correctness — face/person pipeline + membership/link lifecycle | **1 HIGH ship-blocker** (album branch never propagated to the space *people-projection* read/stat/face queries), **2 MEDIUM** (owner-account hard/soft delete face cleanup), 2 LOW, 1 product note. |
-| `sa-mobile-p2` | Flutter client | **1 HIGH** (add-photos false-failure for non-owner editors, reproduced), **1 MEDIUM** (link picker only offers owned albums / dead `currentUserRole`), 3 LOW. |
+| Review         | Scope                                                                 | Verdict                                                                                                                                                                                             |
+| -------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sa-rbac-k7`   | access-control / RBAC                                                 | model **SOUND**; no shippable security bug. LOW/consistency: sync-stream `album.deletedAt` parity, `user_has_album_path` nit, unvalidated `albumId` param → 500; two informational notes.           |
+| `sa-faces-m3`  | server correctness — face/person pipeline + membership/link lifecycle | **1 HIGH ship-blocker** (album branch never propagated to the space _people-projection_ read/stat/face queries), **2 MEDIUM** (owner-account hard/soft delete face cleanup), 2 LOW, 1 product note. |
+| `sa-mobile-p2` | Flutter client                                                        | **1 HIGH** (add-photos false-failure for non-owner editors, reproduced), **1 MEDIUM** (link picker only offers owned albums / dead `currentUserRole`), 3 LOW.                                       |
 
 This follow-up spec defines a TDD fix for **every** finding across all three reviews. The companion
 plan (`docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md`) slices them for
@@ -53,12 +53,12 @@ album-derived face data (owner-account delete, soft-delete, asset-delete), and t
 
 ### Group F — Server faces / people correctness (`sa-faces-m3`)
 
-#### F1 — Album-sourced space *people* are broken across every people-projection read/stat/face query — **HIGH, ship-blocker**
+#### F1 — Album-sourced space _people_ are broken across every people-projection read/stat/face query — **HIGH, ship-blocker**
 
 **The defect.** In the people-projection block of `server/src/repositories/shared-space.repository.ts`
 (~lines 793–1620), `shared_space_library` appears 29 times and `shared_space_album` appears **0**
-times. The album feature added the album branch to the *asset* surfaces (access predicates, timeline,
-counts — all in #726) but never to the *people* projection's read surfaces. The result is two sources
+times. The album feature added the album branch to the _asset_ surfaces (access predicates, timeline,
+counts — all in #726) but never to the _people_ projection's read surfaces. The result is two sources
 of truth that disagree:
 
 - **Projection write/grid INCLUDE album faces.** `recountPersons` (~`:2104`) recomputes
@@ -70,21 +70,21 @@ of truth that disagree:
   "in-space" scoping from an `eb.or([...])` / `asset_scope` CTE that contains **only**
   `shared_space_asset` + `shared_space_library`:
 
-  | # | Surface (service → repo method) | Scoping construct | Symptom for an album-sourced person |
-  | --- | --- | --- | --- |
-  | 1 | person faces strip / representative — `getSpacePersonFaces` → `getSpaceRepresentativeFaces` | `eb.or([...])` | **empty faces strip** though person + thumbnail exist |
-  | 2 | per-person stats — `getSpacePersonStatistics` | `asset_scope` CTE | **assets: 0, faces: 0** (contradicts the card's `assetCount>0`) |
-  | 3 | people header — `getSpacePeopleStatistics` → `countPersonsBySpaceId` (+ its `datePersonFilter` + `detectedFaceCount` subquery) | `asset_scope` CTE | **`detectedFaceCount` undercounts**; album-only people **drop under a date filter** |
-  | 4 | face stats — `getSpacePeopleFaceStatistics` → `getPeopleFaceStatisticsBySpaceId` | `asset_scope` CTE | detected/assigned/unassigned face counts **exclude album** |
-  | 5 | people list (+ date filter) — `getPersonsBySpaceId` | EXISTS `eb.or([...])` | album-only person **disappears** when filtering `takenAfter/takenBefore` |
-  | 6 | set representative face — `getSpaceRepresentativeFaceForUpdate` | `eb.or([...])` | **cannot pick an album face** as the representative |
-  | 7 | identity evidence — `getIdentityEvidenceForSpacePerson` | `eb.or([...])` | identity reconciliation evidence **omits album faces** |
+  | #   | Surface (service → repo method)                                                                                                | Scoping construct     | Symptom for an album-sourced person                                                 |
+  | --- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------- | ----------------------------------------------------------------------------------- |
+  | 1   | person faces strip / representative — `getSpacePersonFaces` → `getSpaceRepresentativeFaces`                                    | `eb.or([...])`        | **empty faces strip** though person + thumbnail exist                               |
+  | 2   | per-person stats — `getSpacePersonStatistics`                                                                                  | `asset_scope` CTE     | **assets: 0, faces: 0** (contradicts the card's `assetCount>0`)                     |
+  | 3   | people header — `getSpacePeopleStatistics` → `countPersonsBySpaceId` (+ its `datePersonFilter` + `detectedFaceCount` subquery) | `asset_scope` CTE     | **`detectedFaceCount` undercounts**; album-only people **drop under a date filter** |
+  | 4   | face stats — `getSpacePeopleFaceStatistics` → `getPeopleFaceStatisticsBySpaceId`                                               | `asset_scope` CTE     | detected/assigned/unassigned face counts **exclude album**                          |
+  | 5   | people list (+ date filter) — `getPersonsBySpaceId`                                                                            | EXISTS `eb.or([...])` | album-only person **disappears** when filtering `takenAfter/takenBefore`            |
+  | 6   | set representative face — `getSpaceRepresentativeFaceForUpdate`                                                                | `eb.or([...])`        | **cannot pick an album face** as the representative                                 |
+  | 7   | identity evidence — `getIdentityEvidenceForSpacePerson`                                                                        | `eb.or([...])`        | identity reconciliation evidence **omits album faces**                              |
 
   (#7 was not in the report's numbered table but is the same library-only pattern; it completes the
   "7 distinct queries" phrasing.)
 
-**Repro.** Create a face-recognition-enabled space; link an album whose photos are *not* directly
-added and *not* in a linked library. `handleSharedSpaceAlbumFaceSync` → `processSpaceFaceMatch`
+**Repro.** Create a face-recognition-enabled space; link an album whose photos are _not_ directly
+added and _not_ in a linked library. `handleSharedSpaceAlbumFaceSync` → `processSpaceFaceMatch`
 creates `shared_space_person` rows and `recountPersons` sets `assetCount > 0`. In the web People tab:
 the person shows with a thumbnail and the grid shows album photos, **but** opening the person shows an
 empty faces strip and "0 assets / 0 faces", the header `detectedFaceCount` ignores those faces, and a
@@ -92,7 +92,7 @@ date filter hides the person.
 
 **Why it's in scope (not a documented deferral).** "Linked-album photos participate in the space's
 face recognition … matched into space persons" is a Phase-1 goal
-(`2026-06-09-space-albums-design.md`), and PR #726 explicitly fixed B1 to make album-sourced *people*
+(`2026-06-09-space-albums-design.md`), and PR #726 explicitly fixed B1 to make album-sourced _people_
 **readable** (`PersonAccess.checkSharedSpaceAccess`). The statistics/face-listing surfaces remaining
 album-blind is an **incomplete implementation** of that goal. The #726 B-group fixed
 `tag/view/memory/search` but not the `shared-space.repository` people queries.
@@ -107,8 +107,9 @@ album-sourced person renders identical statistics, face strip, list-membership, 
 behavior to a direct/library-sourced person.
 
 **Edge cases the slice must cover.**
+
 - **Album-only person** (faces solely on album assets) — now fully visible/counted.
-- **Multi-path person** (faces on album *and* direct/library assets) — counted **once**, not
+- **Multi-path person** (faces on album _and_ direct/library assets) — counted **once**, not
   doubled. The branches are `eb.or` / `UNION`-by-asset, so a face whose asset matches multiple paths
   still yields one row per `(person, face)`; the test must assert no inflation.
 - **Trashed album** (soft-deleted) — the `album.deletedAt IS NULL` join means an album-only person
@@ -119,7 +120,7 @@ behavior to a direct/library-sourced person.
   people headers/lists include album people in-range and exclude out-of-range.
 - **Representative-face selection** — `getSpaceRepresentativeFaceForUpdate` must be able to choose an
   album-only face; the strip/representative read (`getSpaceRepresentativeFaces`) must then return it.
-- **`detectedFaceCount`** — the subquery inside `countPersonsBySpaceId` is a *second* scoping site in
+- **`detectedFaceCount`** — the subquery inside `countPersonsBySpaceId` is a _second_ scoping site in
   the same method; both must get the album branch or the header count stays wrong.
 
 #### F2 — Owner-account HARD delete bypasses space face cleanup → stranded faces + orphan persons — **MEDIUM**
@@ -155,7 +156,7 @@ non-face-enabled spaces (skipped).
 
 Account soft-delete (`user-admin.service.ts:105` → `albumRepository.softDeleteAll(id)`,
 `album.repository.ts:369` sets `album.deletedAt`) is the **only** writer of `album.deletedAt`. A1
-correctly hides such an album's *assets* from read/timeline/count, but two gaps remain on the **face**
+correctly hides such an album's _assets_ from read/timeline/count, but two gaps remain on the **face**
 pipeline:
 
 - **No cleanup on soft-delete.** There is no `AlbumSoftDelete` event (`onAlbumDelete` fires only on
@@ -169,12 +170,13 @@ pipeline:
 On restore (`user-admin.service.ts:121` `restoreAll`) it should re-converge; on hard delete it hits
 F2.
 
-**Note on interaction with F1.** Once F1 lands, the 7 people *read* surfaces carry `album.deletedAt
+**Note on interaction with F1.** Once F1 lands, the 7 people _read_ surfaces carry `album.deletedAt
 IS NULL`, so a soft-deleted album-only person already disappears from reads/stats. F3 still matters
 for: (a) the gates that keep **adding** faces during the window; (b) the raw projection
 (`recountPersons` counts, `getSpacePersonThumbnail` crop) that reads tables directly and stays stale.
 
 **Intended behavior.**
+
 - **F3a (gates):** add `INNER JOIN album … AND album.deletedAt IS NULL` to the album branches of
   `isAssetInSpace` and `getSpaceIdsForAsset`, so the pipeline stops projecting faces for
   soft-deleted albums (consistent with A1).
@@ -192,7 +194,7 @@ path in the same space (face retained), hard-delete-after-soft (F2 path), multi-
 `getSpacePersonAssetAdderIds` (~`:1494`) collects asset-adder user ids from
 `shared_space_asset.addedById` + `shared_space_library.addedById` but has **no
 `shared_space_album.addedById` branch** — unlike its sibling `getSpaceAssetAdder` (~`:1530`), which
-*does* include album. So an album-sourced space person doesn't treat the album-linker as an asset
+_does_ include album. So an album-sourced space person doesn't treat the album-linker as an asset
 adder, weakening name/birth-date inheritance for album-only people.
 
 **Intended behavior.** Add the album-adder subquery mirroring the library subquery, following the same
@@ -238,13 +240,13 @@ fires). Meanwhile `SharedSpaceAlbumSync.getUpserts` (~`:1396`) and
 
 **Why it's not a security hole.** Only users who already had legitimate access (past/current members
 with a grant) can reach it; no new user can. It also matches upstream personal-album sync. The
-space-albums-specific wrinkle is the *internal asymmetry* (metadata upsert filters `deletedAt`, asset
+space-albums-specific wrinkle is the _internal asymmetry_ (metadata upsert filters `deletedAt`, asset
 streams don't), which during the owner account-deletion grace window lets a fresh-syncing client
 backfill asset/exif rows for a trashed album without its parent metadata shell.
 
 **Intended behavior.** Add the `accessibleSpaceAlbums`/`album.deletedAt` scope to the four
 grant-gated album-asset streams so trashed-owner albums stop streaming, matching the A1 web fix and
-the sibling streams that already do this. Thematically this is the *sync* leg of the same
+the sibling streams that already do this. Thematically this is the _sync_ leg of the same
 "soft-deleted album should disappear everywhere" goal as F3.
 
 #### R-F2 — `user_has_album_path` branches 2 & 3 omit `album.deletedAt` — **LOW / cosmetic**
@@ -254,7 +256,7 @@ the sibling streams that already do this. Thematically this is the *sync* leg of
 (and as the schema source-of-truth in `server/src/schema/functions.ts:520`, body `:526-551`). Branch
 1 (`album_user`) filters `a.deletedAt IS NULL`; branch 2 (other-space member) and branch 3
 (other-space creator) join `shared_space_album` **without** an `album.deletedAt` check. Effect: a
-soft-deleted album still *linked* to another space is treated as a valid "path," so a grant is
+soft-deleted album still _linked_ to another space is treated as a valid "path," so a grant is
 **retained** (under-revocation) during the same owner-deletion window as R-F1/F3. Direction is
 grant-retention, not over-revocation, and all reads are independently `deletedAt`-guarded → **no read
 leak**; purely a consistency nit, fix alongside R-F1.
@@ -279,7 +281,7 @@ See the OpenAPI caveat in [Decisions](#decisions-baked-into-the-plan).
 
 An `album_user`-**editor** (not owner) who is also a space Editor may link an album into a space;
 thereafter **other** space Editors gain add/remove on that album via `checkSpaceLinkedAlbumAccess`.
-This is the documented model ("write follows space role"; linking requires album owner *or* editor) —
+This is the documented model ("write follows space role"; linking requires album owner _or_ editor) —
 flagged for product awareness, not a defect. **Not implemented.**
 
 #### R-F5 — `accessibleSpaces` creator path — **NOTE (informational, pre-existing infra)**
@@ -306,7 +308,7 @@ insert) → `remote_album.repository.dart:281-302` batch-inserts into `remote_al
 whose FK `albumId → RemoteAlbumEntity.id` (`remote_album_asset.entity.dart:14`) is enforced
 (`db.repository.dart:377,459` PRAGMA `foreign_keys = ON`). For a non-owner editor the album lives only
 in `shared_space_album` (absorbed) — no `remote_album` row → FK 787. The owner case works (the album
-*is* in `remote_album`). The **remove** path is safe (DELETE of absent junction rows is a no-op).
+_is_ in `remote_album`). The **remove** path is safe (DELETE of absent junction rows is a no-op).
 
 **Intended behavior.** Route the space-album add through a **server-only** path that does not touch
 the personal junction table — consistent with the "absorbed invariant" (space-album sync never writes
@@ -315,7 +317,7 @@ the personal junction table — consistent with the "absorbed invariant" (space-
 provider `:10`) then `_syncManager.syncRemote()`; the `spaceAlbum()` Drift watch already drives the
 grid. Point `SpaceAlbumDetailPage._addPhotos` at the new action.
 
-**Edge cases.** non-owner editor (absorbed album, no `remote_album` row — the bug), owner (album *is*
+**Edge cases.** non-owner editor (absorbed album, no `remote_album` row — the bug), owner (album _is_
 in `remote_album` — must still succeed via the new path, no double insert), remove path (already safe;
 unchanged), absorbed-album-with-no-remote-row (the core: no local junction write attempted), empty
 selection (no-op), server failure (toast shows a **real** error).
@@ -372,9 +374,9 @@ These are surfaced for the captain; the plan does **not** schedule them.
    strip would drop `showInTimeline=false` albums). Engineering-cheap either way; it's a product call
    about what "the space's photo count" means.
 2. **RBAC F4 — transitive write awareness.** Confirm the model is intended: granting album-edit to
-   someone who is a space Editor lets them re-share the album's *write* surface to that space's
+   someone who is a space Editor lets them re-share the album's _write_ surface to that space's
    Editors. No code change unless the model is to change.
-3. **RBAC F5 — creator sync path.** Decide whether a space *creator* can be membership-removed at all,
+3. **RBAC F5 — creator sync path.** Decide whether a space _creator_ can be membership-removed at all,
    and if so whether sync access should follow membership. Pre-existing shared-space infra, broader
    than albums.
 4. **F3b cleanup eagerness (mild).** The plan implements eager face cleanup on owner-account
@@ -399,9 +401,9 @@ These are surfaced for the captain; the plan does **not** schedule them.
 
 - **F1 fix shape:** add the album `EXISTS` / `asset_scope` branch mirroring the adjacent
   `shared_space_library` branch in each of the 7 queries, with `INNER JOIN album … AND
-  album.deletedAt IS NULL`. Carry the same date predicates into the `asset_scope`/`datePersonFilter`
+album.deletedAt IS NULL`. Carry the same date predicates into the `asset_scope`/`datePersonFilter`
   album branch. Do **not** touch `recountPersons`/`getPersonAssetIds` (they intentionally read the
-  projection directly — the fix is to make the *read* surfaces agree with them, scoped to non-deleted
+  projection directly — the fix is to make the _read_ surfaces agree with them, scoped to non-deleted
   albums).
 - **F2/F3 cleanup reuse:** reuse the exact `onAlbumDelete` cleanup sequence
   (`getSpacesLinkedToAlbum` → skip non-face-enabled → `getAlbumAssetIdsWithoutOtherSpacePath` →
@@ -421,8 +423,8 @@ These are surfaced for the captain; the plan does **not** schedule them.
   was strictly no-regen. If a no-regen path is preferred, use a runtime-only UUID guard that doesn't
   emit format metadata. Resolve at plan-review.
 - **M-F1 fix shape:** new `SpaceAlbumActions.addAssets` calling `DriftAlbumApiRepository.addAssets`
-  + `syncRemote()`; no local personal-junction write (absorbed invariant). Detail page routes through
-  it.
+  - `syncRemote()`; no local personal-junction write (absorbed invariant). Detail page routes through
+    it.
 
 ## Test Strategy
 

--- a/docs/superpowers/specs/2026-06-29-space-albums-review-fixes-followup-design.md
+++ b/docs/superpowers/specs/2026-06-29-space-albums-review-fixes-followup-design.md
@@ -1,0 +1,488 @@
+# Space Albums — Review-Fix Follow-up Spec (Design)
+
+## Summary
+
+After PR #726 ("space-albums review fixes") merged into `feat/space-albums`, **three independent
+adversarial reviews** were run against the branch at commit `5f0076cd6e` (post-#726):
+
+| Review | Scope | Verdict |
+| --- | --- | --- |
+| `sa-rbac-k7` | access-control / RBAC | model **SOUND**; no shippable security bug. LOW/consistency: sync-stream `album.deletedAt` parity, `user_has_album_path` nit, unvalidated `albumId` param → 500; two informational notes. |
+| `sa-faces-m3` | server correctness — face/person pipeline + membership/link lifecycle | **1 HIGH ship-blocker** (album branch never propagated to the space *people-projection* read/stat/face queries), **2 MEDIUM** (owner-account hard/soft delete face cleanup), 2 LOW, 1 product note. |
+| `sa-mobile-p2` | Flutter client | **1 HIGH** (add-photos false-failure for non-owner editors, reproduced), **1 MEDIUM** (link picker only offers owned albums / dead `currentUserRole`), 3 LOW. |
+
+This follow-up spec defines a TDD fix for **every** finding across all three reviews. The companion
+plan (`docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md`) slices them for
+`/impl-loop`. This document is the design rationale: the grouped problem set, intended behavior per
+fix, edge cases, and the decisions baked into the slices.
+
+It mirrors the structure of the prior round
+(`docs/superpowers/specs/2026-06-25-space-albums-review-fixes-design.md` →
+`…/plans/2026-06-25-space-albums-review-fixes.md`), which produced PR #726.
+
+**Engineering vs. product.** Findings that are pure product calls — the headline-count vs.
+`showInTimeline` divergence (faces F6), transitive-write awareness (RBAC F4), and the
+membership-removed creator path (RBAC F5) — are **noted, not implemented**, in
+[Product decisions](#product-decisions-noted-not-implemented-unless-decided). Everything else is an
+engineering slice.
+
+## Source reviews (authoritative finding list)
+
+- `/Users/pierre/dev/firstmate/data/sa-rbac-k7/report.md`
+- `/Users/pierre/dev/firstmate/data/sa-faces-m3/report.md`
+- `/Users/pierre/dev/firstmate/data/sa-mobile-p2/report.md`
+
+All `file:line` references below were re-verified against the worktree at `5f0076cd6e`. Because
+`server/src/repositories/shared-space.repository.ts` is ~2647 lines and shifts easily, **line numbers
+are anchors only — the durable anchor is the method name + the scoping construct** (`eb.or([...])` /
+`asset_scope` CTE / EXISTS). Re-grep by symbol before editing.
+
+## The unifying theme
+
+The product vision is "a full Immich experience per space — its own timeline, its own people, its
+own albums." PR #726 made album-linked assets first-class in the space **timeline**, **access
+predicates**, **counts**, and the secondary read surfaces (tags/folders/memories/search). The
+follow-up closes the **last** place the album branch was never propagated — the space **people
+projection** (faces F1, the ship-blocker) — plus the **lifecycle edges** that strand or hide
+album-derived face data (owner-account delete, soft-delete, asset-delete), and the remaining
+**consistency / robustness / client** gaps the reviews surfaced.
+
+---
+
+## Findings (grouped, verified against code @ `5f0076cd6e`)
+
+### Group F — Server faces / people correctness (`sa-faces-m3`)
+
+#### F1 — Album-sourced space *people* are broken across every people-projection read/stat/face query — **HIGH, ship-blocker**
+
+**The defect.** In the people-projection block of `server/src/repositories/shared-space.repository.ts`
+(~lines 793–1620), `shared_space_library` appears 29 times and `shared_space_album` appears **0**
+times. The album feature added the album branch to the *asset* surfaces (access predicates, timeline,
+counts — all in #726) but never to the *people* projection's read surfaces. The result is two sources
+of truth that disagree:
+
+- **Projection write/grid INCLUDE album faces.** `recountPersons` (~`:2104`) recomputes
+  `shared_space_person.assetCount` / `faceCount` from `shared_space_person_face` with **no path
+  scoping**, and `getPersonAssetIds` → `getSpacePersonAssets` (~`:1599–1670`) reads the projection
+  directly. So an album-only person shows in the list with a thumbnail and `assetCount > 0`, and the
+  asset grid shows the album photos.
+- **Read / statistics / face-listing EXCLUDE album faces.** Each of the following re-derives
+  "in-space" scoping from an `eb.or([...])` / `asset_scope` CTE that contains **only**
+  `shared_space_asset` + `shared_space_library`:
+
+  | # | Surface (service → repo method) | Scoping construct | Symptom for an album-sourced person |
+  | --- | --- | --- | --- |
+  | 1 | person faces strip / representative — `getSpacePersonFaces` → `getSpaceRepresentativeFaces` | `eb.or([...])` | **empty faces strip** though person + thumbnail exist |
+  | 2 | per-person stats — `getSpacePersonStatistics` | `asset_scope` CTE | **assets: 0, faces: 0** (contradicts the card's `assetCount>0`) |
+  | 3 | people header — `getSpacePeopleStatistics` → `countPersonsBySpaceId` (+ its `datePersonFilter` + `detectedFaceCount` subquery) | `asset_scope` CTE | **`detectedFaceCount` undercounts**; album-only people **drop under a date filter** |
+  | 4 | face stats — `getSpacePeopleFaceStatistics` → `getPeopleFaceStatisticsBySpaceId` | `asset_scope` CTE | detected/assigned/unassigned face counts **exclude album** |
+  | 5 | people list (+ date filter) — `getPersonsBySpaceId` | EXISTS `eb.or([...])` | album-only person **disappears** when filtering `takenAfter/takenBefore` |
+  | 6 | set representative face — `getSpaceRepresentativeFaceForUpdate` | `eb.or([...])` | **cannot pick an album face** as the representative |
+  | 7 | identity evidence — `getIdentityEvidenceForSpacePerson` | `eb.or([...])` | identity reconciliation evidence **omits album faces** |
+
+  (#7 was not in the report's numbered table but is the same library-only pattern; it completes the
+  "7 distinct queries" phrasing.)
+
+**Repro.** Create a face-recognition-enabled space; link an album whose photos are *not* directly
+added and *not* in a linked library. `handleSharedSpaceAlbumFaceSync` → `processSpaceFaceMatch`
+creates `shared_space_person` rows and `recountPersons` sets `assetCount > 0`. In the web People tab:
+the person shows with a thumbnail and the grid shows album photos, **but** opening the person shows an
+empty faces strip and "0 assets / 0 faces", the header `detectedFaceCount` ignores those faces, and a
+date filter hides the person.
+
+**Why it's in scope (not a documented deferral).** "Linked-album photos participate in the space's
+face recognition … matched into space persons" is a Phase-1 goal
+(`2026-06-09-space-albums-design.md`), and PR #726 explicitly fixed B1 to make album-sourced *people*
+**readable** (`PersonAccess.checkSharedSpaceAccess`). The statistics/face-listing surfaces remaining
+album-blind is an **incomplete implementation** of that goal. The #726 B-group fixed
+`tag/view/memory/search` but not the `shared-space.repository` people queries.
+
+**Untested.** No medium test calls any of these 7 read surfaces for an album-linked space — the gap
+passes CI (see [Test Strategy](#test-strategy)).
+
+**Intended behavior.** For each of the 7 queries, add the album `EXISTS`/`asset_scope` branch that
+mirrors the adjacent `shared_space_library` branch, with `INNER JOIN album ON album.id =
+shared_space_album.albumId AND album.deletedAt IS NULL` (the A1 invariant). After the fix, an
+album-sourced person renders identical statistics, face strip, list-membership, and date-filter
+behavior to a direct/library-sourced person.
+
+**Edge cases the slice must cover.**
+- **Album-only person** (faces solely on album assets) — now fully visible/counted.
+- **Multi-path person** (faces on album *and* direct/library assets) — counted **once**, not
+  doubled. The branches are `eb.or` / `UNION`-by-asset, so a face whose asset matches multiple paths
+  still yields one row per `(person, face)`; the test must assert no inflation.
+- **Trashed album** (soft-deleted) — the `album.deletedAt IS NULL` join means an album-only person
+  whose album is soft-deleted correctly **disappears** from all 7 surfaces (consistent with A1, and
+  with F3 below).
+- **Date filters** (`takenAfter`/`takenBefore`) — the album branch in the `asset_scope` CTE and
+  `datePersonFilter` must carry the same date predicates as the library branch, so date-filtered
+  people headers/lists include album people in-range and exclude out-of-range.
+- **Representative-face selection** — `getSpaceRepresentativeFaceForUpdate` must be able to choose an
+  album-only face; the strip/representative read (`getSpaceRepresentativeFaces`) must then return it.
+- **`detectedFaceCount`** — the subquery inside `countPersonsBySpaceId` is a *second* scoping site in
+  the same method; both must get the album branch or the header count stays wrong.
+
+#### F2 — Owner-account HARD delete bypasses space face cleanup → stranded faces + orphan persons — **MEDIUM**
+
+`handleUserDelete` (`server/src/services/user.service.ts` ~`:274`) hard-deletes the user's albums via
+`albumRepository.deleteAll(user.id)` (~`:326`, `album.repository.ts:373` = `deleteFrom('album')`),
+which **emits no event** — and `shared-space.service` has no `UserDelete` handler (its only `@OnEvent`
+handlers are `AlbumAssetsAdd`, `AlbumDelete`, `AlbumAssetsRemove`). So when a user who owns an album
+linked into someone else's face-enabled space is hard-deleted:
+
+- The `shared_space_album` link rows cascade away (FK `albumId → album ON DELETE CASCADE`) and the
+  delete-side trigger cleans the **grants** + link-sync rows ✅.
+- But the app-level `onAlbumDelete` face cleanup **never runs**, so `shared_space_person_face` rows for
+  the album's assets owned by **other** users (album contributors — those assets survive) are
+  **stranded**: the album path is gone, the projection rows remain → stale space people ❌.
+- The deleted user's **own** album assets are hard-deleted by the user cascade →
+  `asset_face → shared_space_person_face` cascade, potentially leaving **zero-face
+  `shared_space_person` orphans** (no `deleteOrphanedPersons` runs) ❌.
+
+These do **not** self-heal (`deleteAllOrphanedPersons` runs only under a forced full re-detection).
+
+**Intended behavior.** Owner-account hard delete must run the same space-face cleanup that
+`onAlbumDelete` performs, for each face-enabled linking space, **before** the albums/assets are
+deleted (so `album_asset` rows still exist for `getAlbumAssetIdsWithoutOtherSpacePath`).
+
+**Edge cases.** other users' surviving photos (faces cleaned), the deleted user's own photos
+(zero-face orphans removed by `deleteOrphanedPersons`), album linked to **multiple** spaces (loop all
+linking face-enabled spaces; per-space orphan calc), album asset **also** direct-added to the space
+(face **retained** via the direct path — `getAlbumAssetIdsWithoutOtherSpacePath` excludes it),
+non-face-enabled spaces (skipped).
+
+#### F3 — Owner-account SOFT delete leaves album faces visible/addable as space people; face-pipeline gates ignore `album.deletedAt` — **MEDIUM**
+
+Account soft-delete (`user-admin.service.ts:105` → `albumRepository.softDeleteAll(id)`,
+`album.repository.ts:369` sets `album.deletedAt`) is the **only** writer of `album.deletedAt`. A1
+correctly hides such an album's *assets* from read/timeline/count, but two gaps remain on the **face**
+pipeline:
+
+- **No cleanup on soft-delete.** There is no `AlbumSoftDelete` event (`onAlbumDelete` fires only on
+  hard delete), so existing `shared_space_person_face` rows persist → the album's faces keep appearing
+  as space people, and `getSpacePersonThumbnail` keeps serving a crop of the now-hidden assets.
+- **The two face-pipeline gates omit the `album.deletedAt IS NULL` filter** that every A1-fixed query
+  has: `isAssetInSpace` (~`:2298`, album branch ~`:2321`) and `getSpaceIdsForAsset` (~`:2458`, album
+  branch ~`:2476`). So during the soft-delete window a late-detected face on a trashed-album asset is
+  still **queued** (`getSpaceIdsForAsset`) and still **added** (`isAssetInSpace`).
+
+On restore (`user-admin.service.ts:121` `restoreAll`) it should re-converge; on hard delete it hits
+F2.
+
+**Note on interaction with F1.** Once F1 lands, the 7 people *read* surfaces carry `album.deletedAt
+IS NULL`, so a soft-deleted album-only person already disappears from reads/stats. F3 still matters
+for: (a) the gates that keep **adding** faces during the window; (b) the raw projection
+(`recountPersons` counts, `getSpacePersonThumbnail` crop) that reads tables directly and stays stale.
+
+**Intended behavior.**
+- **F3a (gates):** add `INNER JOIN album … AND album.deletedAt IS NULL` to the album branches of
+  `isAssetInSpace` and `getSpaceIdsForAsset`, so the pipeline stops projecting faces for
+  soft-deleted albums (consistent with A1).
+- **F3b (cleanup + restore):** on owner-account soft-delete, run the same orphan face cleanup as
+  `onAlbumDelete` for each face-enabled linking space (clears stale projection rows + thumbnail
+  exposure); on restore, re-queue face matching for the restored albums' assets per linking space so
+  people re-converge.
+
+**Edge cases.** soft-delete then read (album people gone), late-detected face during window (not
+added), restore (people re-projected), soft-delete of an album also reachable via a direct-add/library
+path in the same space (face retained), hard-delete-after-soft (F2 path), multi-space.
+
+#### F4 — Metadata inheritance omits the album-adder branch — **LOW**
+
+`getSpacePersonAssetAdderIds` (~`:1494`) collects asset-adder user ids from
+`shared_space_asset.addedById` + `shared_space_library.addedById` but has **no
+`shared_space_album.addedById` branch** — unlike its sibling `getSpaceAssetAdder` (~`:1530`), which
+*does* include album. So an album-sourced space person doesn't treat the album-linker as an asset
+adder, weakening name/birth-date inheritance for album-only people.
+
+**Intended behavior.** Add the album-adder subquery mirroring the library subquery, following the same
+person linkage (`shared_space_person_face → asset_face → asset → album_asset → shared_space_album`,
+`WHERE personId = … AND spaceId = …`, `addedById IS NOT NULL`).
+
+#### F5 — Asset hard-delete leaves stale space-person counts + orphans — **LOW (pre-existing, not album-specific)**
+
+Deleting a single asset (`asset.service.ts:485` emits `AssetDelete`) cascades
+`asset_face → shared_space_person_face`, but nothing recounts the affected persons or removes
+zero-face orphans (no shared-space `AssetDelete` handler). `assetCount`/`faceCount` go stale and
+zero-face persons linger until a forced full re-detection. Predates albums (affects direct/library
+spaces too) but reachable for album assets.
+
+**Intended behavior.** A new shared-space `AssetDelete` handler that, for the spaces the asset
+belonged to, recounts the affected persons (`recountPersons(personIds)`) and removes orphaned persons
+(`deleteOrphanedPersons`). **Timing caveat** (open item, mirrors #726's `AlbumDelete` question):
+verify whether `AssetDelete` fires **before or after** the `asset_face` cascade; if after, the
+affected `(spaceIds, personIds)` must be captured before deletion (richer event payload) or the
+handler must recount all persons in the affected spaces.
+
+#### F6 — Headline count vs. `showInTimeline` divergence — **NOTE (product)**
+
+`getAssetCount`/`getRecentAssets`/`getNewAssetCount` include album assets **regardless of
+`showInTimeline`**, while the timeline gates on `showInTimeline = true`. So a card's count can exceed
+what the timeline shows when a linked album has `showInTimeline = false`. The #726 C2 note already
+left "should the headline gate on `showInTimeline`" as a deferred product question. **Not
+implemented** — see [Product decisions](#product-decisions-noted-not-implemented-unless-decided).
+
+### Group R — RBAC / sync consistency (`sa-rbac-k7`)
+
+#### R-F1 — Album-asset sync streams don't apply the A1 `album.deletedAt` guard — **LOW / consistency**
+
+In `server/src/repositories/sync.repository.ts`, the album-asset/exif sync streams gate on the
+`shared_space_album_user` **grant only** and never exclude soft-deleted albums:
+`SharedSpaceAlbumAssetSync.getBackfill/getUpdates/getCreates` (~`:1508/:1527/:1549`),
+`SharedSpaceAlbumAssetExifSync.getBackfill/getUpdates/getCreates` (~`:1574/:1585/:1598`),
+`SharedSpaceAlbumToAssetSync.getUpserts` (~`:1489`), and `SharedSpaceAlbumSync.getCreatedAfter`
+(~`:1367`). The grant is **not** revoked on soft-delete (soft-delete is an `UPDATE`, no trigger
+fires). Meanwhile `SharedSpaceAlbumSync.getUpserts` (~`:1396`) and
+`SharedSpaceAlbumToAssetSync.getDeletes` (~`:1480`) **do** exclude soft-deleted albums via
+`accessibleSpaceAlbums` (~`:1112`, which joins `album` and filters `album.deletedAt IS NULL`).
+
+**Why it's not a security hole.** Only users who already had legitimate access (past/current members
+with a grant) can reach it; no new user can. It also matches upstream personal-album sync. The
+space-albums-specific wrinkle is the *internal asymmetry* (metadata upsert filters `deletedAt`, asset
+streams don't), which during the owner account-deletion grace window lets a fresh-syncing client
+backfill asset/exif rows for a trashed album without its parent metadata shell.
+
+**Intended behavior.** Add the `accessibleSpaceAlbums`/`album.deletedAt` scope to the four
+grant-gated album-asset streams so trashed-owner albums stop streaming, matching the A1 web fix and
+the sibling streams that already do this. Thematically this is the *sync* leg of the same
+"soft-deleted album should disappear everywhere" goal as F3.
+
+#### R-F2 — `user_has_album_path` branches 2 & 3 omit `album.deletedAt` — **LOW / cosmetic**
+
+`user_has_album_path(target_album_id, target_user_id, exclude_space_id)` is defined in
+`server/src/schema/migrations-gallery/1779100000000-AddSharedSpaceAlbumCreateSideTriggers.ts:14-42`
+(and as the schema source-of-truth in `server/src/schema/functions.ts:520`, body `:526-551`). Branch
+1 (`album_user`) filters `a.deletedAt IS NULL`; branch 2 (other-space member) and branch 3
+(other-space creator) join `shared_space_album` **without** an `album.deletedAt` check. Effect: a
+soft-deleted album still *linked* to another space is treated as a valid "path," so a grant is
+**retained** (under-revocation) during the same owner-deletion window as R-F1/F3. Direction is
+grant-retention, not over-revocation, and all reads are independently `deletedAt`-guarded → **no read
+leak**; purely a consistency nit, fix alongside R-F1.
+
+**Intended behavior.** A new fork migration `CREATE OR REPLACE FUNCTION user_has_album_path` adding
+`AND a.deletedAt IS NULL` (via a non-deleted `album` join) to branches 2 & 3, **plus** the matching
+edit to `functions.ts` so the schema source and migration stay in sync.
+
+#### R-F3 — Unvalidated `albumId` route param → 500 — **LOW / robustness**
+
+`server/src/controllers/shared-space.controller.ts` link/unlink/update endpoints
+(`PUT|PATCH|DELETE /shared-spaces/:id/albums/:albumId`, ~`:609/:623/:637`) use `@Param('albumId')
+albumId: string` with **no** UUID validation, while the space `id` uses the validated `UUIDParamDto`
+(`validation.ts:112` = `z.object({ id: z.uuidv4() })`). A non-UUID `albumId` reaches the service and
+yields a **500** (invalid-uuid SQL error) instead of a clean **400**. No authorization bypass (role
+checks run first). #726 explicitly deferred this.
+
+**Intended behavior.** Validate `albumId` as a UUID (mirroring `id`) so malformed input returns 400.
+See the OpenAPI caveat in [Decisions](#decisions-baked-into-the-plan).
+
+#### R-F4 — Transitive write expansion via album-editor linking — **NOTE (informational, by design)**
+
+An `album_user`-**editor** (not owner) who is also a space Editor may link an album into a space;
+thereafter **other** space Editors gain add/remove on that album via `checkSpaceLinkedAlbumAccess`.
+This is the documented model ("write follows space role"; linking requires album owner *or* editor) —
+flagged for product awareness, not a defect. **Not implemented.**
+
+#### R-F5 — `accessibleSpaces` creator path — **NOTE (informational, pre-existing infra)**
+
+`accessibleSpaces` (`sync.repository.ts:867`) grants sync via `shared_space.createdById` independent
+of membership, whereas read predicates are membership-only. If a space creator's membership row were
+ever removed by another owner, they'd retain **sync** access while reads deny them. This is shared
+shared-space infrastructure (identical for direct assets and libraries), **not** introduced by
+space-albums → out of scope. **Not implemented.**
+
+### Group M — Mobile / Flutter (`sa-mobile-p2`)
+
+#### M-F1 — "Add photos" to a non-owned linked album shows a false failure — **HIGH (reproduced)**
+
+A space **editor who is not the album's owner** opens a linked album's detail page, taps the kebab →
+**Add photos**, and gets a **"Failed to add photos"** toast even though the server add **succeeded**
+(the photos appear seconds later). Root cause: the detail page adds via the **personal-album** path,
+which writes the local personal junction table for an **absorbed** album that has no personal
+`remote_album` row → SQLite FK violation, rollback, rethrow, error toast:
+
+`space_album_detail.page.dart:55` `addAssetsToAlbum(...)` → `remote_album.provider.dart:231/248` →
+`remote_album.service.dart:178-184` (`addAssets` does the REST add **then** the local junction
+insert) → `remote_album.repository.dart:281-302` batch-inserts into `remote_album_asset_entity`,
+whose FK `albumId → RemoteAlbumEntity.id` (`remote_album_asset.entity.dart:14`) is enforced
+(`db.repository.dart:377,459` PRAGMA `foreign_keys = ON`). For a non-owner editor the album lives only
+in `shared_space_album` (absorbed) — no `remote_album` row → FK 787. The owner case works (the album
+*is* in `remote_album`). The **remove** path is safe (DELETE of absent junction rows is a no-op).
+
+**Intended behavior.** Route the space-album add through a **server-only** path that does not touch
+the personal junction table — consistent with the "absorbed invariant" (space-album sync never writes
+`remote_album*`). Add `SpaceAlbumActions.addAssets(albumId, assetIds)` that calls
+`DriftAlbumApiRepository.addAssets(albumId, assetIds)` (the REST add, `drift_album_api_repository.dart:51-69`,
+provider `:10`) then `_syncManager.syncRemote()`; the `spaceAlbum()` Drift watch already drives the
+grid. Point `SpaceAlbumDetailPage._addPhotos` at the new action.
+
+**Edge cases.** non-owner editor (absorbed album, no `remote_album` row — the bug), owner (album *is*
+in `remote_album` — must still succeed via the new path, no double insert), remove path (already safe;
+unchanged), absorbed-album-with-no-remote-row (the core: no local junction write attempted), empty
+selection (no-op), server failure (toast shows a **real** error).
+
+#### M-F2 — Link picker only offers OWNED albums; `currentUserRole` never populated — **MEDIUM**
+
+The design says the picker candidate list = albums the user **owns or can edit**, but
+`linkableAlbumCandidates` (`space_link_album_candidates.dart:21-23`) gates on `isOwner ||
+album.currentUserRole == AlbumUserRole.editor`, and `RemoteAlbum.currentUserRole`
+(`album.model.dart:38`, added by this branch) is **never populated** — the album mapper
+(`remote_album.repository.dart:570-587` `toDto`) omits it, and it's assigned nowhere in production
+`lib` (the only other `currentUserRole` hits are an unrelated `SharedSpaceRole` field in
+`space_detail.page.dart:447` / `space_bottom_sheet.widget.dart`). So `currentUserRole` is always
+`null`, the `isEditor` branch is dead, and only owned albums appear.
+
+**Intended behavior.** Populate `currentUserRole` in the album DB mapper by reading the current user's
+`remote_album_user.role` (the album queries already `leftOuterJoin remoteAlbumUserEntity` — add a
+current-user-keyed read and pass it into `toDto`). The existing filter then works as designed and
+editor-owned albums become linkable. (Alternative product call: if editor-linking is out of scope for
+mobile v1, drop the `isEditor` branch and the "or can edit" wording — noted, but the design grants the
+capability, so the slice **implements** it.)
+
+#### M-F3 — Detail header missing "{count} photos · in {space.name}" subtitle — **LOW**
+
+`SpaceAlbumDetailPage` app bar sets only the album name (`space_album_detail.page.dart:196`); the spec
+specifies a `{count} photos · in {space.name}` subtitle. `assetCount` is in hand
+(`SpaceAlbum.assetCount`, already resolved via `spaceAlbumsProvider`); the **space name** is not
+currently watched in this page and must be sourced (space-metadata provider or route param).
+
+#### M-F4 — Covers are always the placeholder icon — **LOW (known/deferred in #726)**
+
+Shelf, list cards, and link-picker rows render `Icons.photo_album_outlined` rather than the album
+cover (`space_albums_shelf.widget.dart:198`, `space_albums.page.dart:176`,
+`space_link_album.page.dart:202-219`). The reuse pattern is `album_tile.dart:20,36-64`
+(`assetServiceProvider.getRemoteAsset(thumbnailAssetId)` + `Thumbnail.remote` in a `FutureBuilder`
+with the icon as fallback). `thumbnailAssetId` is present on `SpaceAlbum`/`RemoteAlbum`.
+
+#### M-F5 — "Show/Hide in timeline" silently no-ops before album metadata loads — **LOW**
+
+`_toggleTimeline` (`space_album_detail.page.dart:69-72`) returns early if the album is `null`, but the
+kebab renders as soon as `canEdit` is known (`:198-204`, `showInTimeline: album?.showInTimeline ??
+true`). An editor who taps the toggle while metadata is still loading gets no feedback and no effect.
+Guard: disable the toggle (or show a "still loading" toast) until the album resolves.
+
+---
+
+## Product decisions (noted, not implemented unless decided)
+
+These are surfaced for the captain; the plan does **not** schedule them.
+
+1. **faces F6 — headline count gating on `showInTimeline`.** All three summary queries now
+   (post-#726 C2) include album assets regardless of `showInTimeline`, so a card's count can exceed
+   the timeline. Decide whether the headline should gate on `showInTimeline` (then the count/recent
+   strip would drop `showInTimeline=false` albums). Engineering-cheap either way; it's a product call
+   about what "the space's photo count" means.
+2. **RBAC F4 — transitive write awareness.** Confirm the model is intended: granting album-edit to
+   someone who is a space Editor lets them re-share the album's *write* surface to that space's
+   Editors. No code change unless the model is to change.
+3. **RBAC F5 — creator sync path.** Decide whether a space *creator* can be membership-removed at all,
+   and if so whether sync access should follow membership. Pre-existing shared-space infra, broader
+   than albums.
+4. **F3b cleanup eagerness (mild).** The plan implements eager face cleanup on owner-account
+   soft-delete + re-projection on restore (matches A1 intent and the report's recommendation). The
+   alternative — lazily relying on F1's read-scoping + F3a gates and accepting stale projection counts
+   until hard-delete/restore — is simpler but leaves `getSpacePersonThumbnail` exposing trashed-album
+   crops. The plan proceeds with the eager approach; flagged here as the one place with a defensible
+   alternative.
+
+## Non-goals
+
+- **No new API/DTO/endpoint surface** beyond the `albumId` param validation in R-F3 (which may touch
+  generated validation metadata — see Decisions). No new SDK methods. No changes to the
+  write-permission model, link/unlink authorization, the "absorbed" invariant, or trigger/grant
+  semantics (all verified correct by RBAC).
+- **No re-litigating #726.** A1 (trashed-album read/timeline/count), A2 (`removeAssets` multi-path),
+  A3 (`onAlbumDelete`), B1 (PersonRead), B2 (tag/view/memory/search), C2 (counts), the web
+  stale-timeline fix, and the mobile double-link fix are present and correct on this branch — verified.
+- **No mobile thumbnail/i18n beyond F4** (covers); other deferred mobile polish stays deferred.
+
+## Decisions baked into the plan
+
+- **F1 fix shape:** add the album `EXISTS` / `asset_scope` branch mirroring the adjacent
+  `shared_space_library` branch in each of the 7 queries, with `INNER JOIN album … AND
+  album.deletedAt IS NULL`. Carry the same date predicates into the `asset_scope`/`datePersonFilter`
+  album branch. Do **not** touch `recountPersons`/`getPersonAssetIds` (they intentionally read the
+  projection directly — the fix is to make the *read* surfaces agree with them, scoped to non-deleted
+  albums).
+- **F2/F3 cleanup reuse:** reuse the exact `onAlbumDelete` cleanup sequence
+  (`getSpacesLinkedToAlbum` → skip non-face-enabled → `getAlbumAssetIdsWithoutOtherSpacePath` →
+  `removePersonFacesByAssetIds` → `deleteOrphanedPersons` → `queueSpacePersonMetadataBackfill`). For
+  F2 (hard delete), emit `AlbumDelete` per owned album **before** `albumRepository.deleteAll`
+  (`eventRepository.emit` awaits handlers in-process; `album_asset` rows still exist) — or, if a bulk
+  sweep is preferred, call the repository sequence directly. For F3b (soft delete), trigger the same
+  cleanup from the owner-account soft-delete path and re-queue face matching on restore.
+- **R-F2 migration:** edit `functions.ts` **and** ship a new fork migration in
+  `server/src/schema/migrations-gallery/` with a round timestamp **after** `1779200000000` (e.g.
+  `1779300000000`) that `CREATE OR REPLACE FUNCTION user_has_album_path` with the `album.deletedAt`
+  guard on branches 2 & 3. Verify the timestamp doesn't collide (CLAUDE.md fork-migration rules).
+- **R-F3 validation + OpenAPI caveat:** mirror the existing `id` validation by folding `albumId` into
+  a zod param DTO (e.g. `{ id: z.uuidv4(), albumId: z.uuidv4() }`). **This is the one slice that may
+  alter the generated OpenAPI param metadata.** The slice gate must check whether the generated spec
+  changes; if it does, run the OpenAPI regen workflow (TS SDK + Dart) — unlike the #726 round which
+  was strictly no-regen. If a no-regen path is preferred, use a runtime-only UUID guard that doesn't
+  emit format metadata. Resolve at plan-review.
+- **M-F1 fix shape:** new `SpaceAlbumActions.addAssets` calling `DriftAlbumApiRepository.addAssets`
+  + `syncRemote()`; no local personal-junction write (absorbed invariant). Detail page routes through
+  it.
+
+## Test Strategy
+
+The reviews flagged many gaps as **untested**; closing them is part of every slice. Tests are
+**written first** (RED), then the implementation makes them green.
+
+### Server
+
+- **Unit** (`cd server && pnpm test -- --run <path>`): mocked repos via `newTestService`. Used for the
+  service-level wiring (e.g. F2 emit loop, F5 handler dispatch) where SQL isn't exercised. Files live
+  beside the source as `server/src/**/*.spec.ts`
+  (`shared-space.service.spec.ts`, `album.service.spec.ts`, `user.service.spec.ts`,
+  `user-admin.service.spec.ts`).
+- **Medium** (`cd server && pnpm test:medium -- --run <path>`, real Postgres via testcontainers /
+  Docker): the home for every SQL-predicate change. Key files and where each slice slots in:
+  - `server/test/medium/specs/repositories/shared-space.repository.spec.ts` — already exercises
+    `getPersonsBySpaceId`, `countPersonsBySpaceId`, `getSpacePersonStatistics`,
+    `getPeopleFaceStatisticsBySpaceId`, `getSpaceRepresentativeFaces`,
+    `getSpaceRepresentativeFaceForUpdate`, `getPersonAssetIds`, `recountPersons` for **direct/library**
+    spaces, and has an `addAlbum(...)` helper (used ~`:3294+`). **F1, F3a, F4** tests go here, reusing
+    `addAlbum` to build album-only and multi-path people.
+  - `server/test/medium/specs/services/shared-space-album.service.spec.ts` — album-link service flows.
+    **F2, F3b, F5** cleanup tests (drive the real `albumService.delete` / user-admin soft-delete /
+    asset delete and assert face-row outcomes).
+  - `server/test/medium/specs/repositories/shared-space-album.repository.spec.ts` — counts /
+    `getAssetIdsWithoutOtherSpacePath` / soft-deleted album leg. Count/consistency assertions.
+  - `server/test/medium/specs/services/shared-space-album-permissions.service.spec.ts` — access/RBAC
+    over the album leg.
+  - `server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts`,
+    `…-album-asset-exif-sync.spec.ts`, `…-album-to-asset-sync.spec.ts`, `…-album-sync.spec.ts`,
+    `user-has-album-path.spec.ts`, `shared-space-album-delete-triggers.spec.ts` — **R-F1** (soft-delete
+    exclusion on the four asset/exif/to-asset streams; currently only the metadata stream asserts it)
+    and **R-F2** (`user_has_album_path` soft-deleted-album path).
+- **E2E** (`e2e/`): `e2e/src/specs/server/api/shared-space-album.e2e-spec.ts` — **R-F3** malformed
+  `albumId` → **400** (today there's only a valid-UUID access-gate 400 case at ~`:122`).
+
+### Mobile
+
+Run: `cd mobile && flutter test <path>` (or `mise //mobile:test`); analyze `mise //mobile:analyze`.
+CI: "Static Code Analysis" + "Unit Test Mobile". Local mobile runs are version-skew-prone — rely on CI
+for the authoritative pass; still analyze touched files.
+
+- `mobile/test/providers/infrastructure/space_album_actions_test.dart` — mocktail unit test; the
+  **only** place that asserts the `syncRemote()` nudge. **M-F1** extends it for the new `addAssets`.
+- `mobile/test/medium/repositories/space_album_repository_test.dart` — real Drift DB. A focused
+  **M-F1** regression here (an absorbed album with no `remote_album` row) proves the server-only path
+  doesn't hit the junction FK. **M-F2** repo-mapper test asserts `toDto` populates `currentUserRole`
+  from `remote_album_user`.
+- `mobile/test/utils/space_link_album_candidates_test.dart` — pure unit; already sets
+  `currentUserRole`. Confirms the gate once the field is populated (**M-F2**).
+- `mobile/test/presentation/pages/space_album_detail_page_test.dart` /
+  `space_b6_mutations_test.dart` — widget tests for **M-F3** (subtitle), **M-F5** (toggle guard), and
+  the detail-page **M-F1** routing.
+- `mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart` (+ list/link page tests) —
+  **M-F4** cover rendering.
+
+### Ordering principle
+
+Slices are ordered ship-blocker-first (faces F1, mobile F1), then the owner-account/soft-delete
+cleanup cluster (faces F2/F3 + RBAC F1 + RBAC F2 — the "soft-deleted album disappears everywhere"
+theme), then LOW server/RBAC items, then mobile polish. Each slice is independently testable and
+committable; later slices do not depend on earlier ones except where noted (F3a's gates precede F3b's
+cleanup; F1's `album.deletedAt` join makes the soft-delete read behavior observable).

--- a/e2e/src/specs/server/api/shared-space-album.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-album.e2e-spec.ts
@@ -425,6 +425,36 @@ describe('/shared-spaces/:id/albums (T18)', () => {
     });
   });
 
+  // ─── RBAC F3: non-UUID albumId param → 400 (not 500) ─────────────────────
+  //
+  // The controller now uses SharedSpaceAlbumParamDto (z.uuidv4() for both id
+  // and albumId) so a non-UUID albumId is rejected by the ZodValidationPipe
+  // with a 400 before the service layer is reached.
+
+  describe('invalid albumId param → 400 (RBAC F3)', () => {
+    it('PUT with non-UUID albumId → 400 (not 500)', async () => {
+      const { status } = await request(app)
+        .put(`/shared-spaces/${spaceId}/albums/not-a-uuid`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('PATCH with non-UUID albumId → 400 (not 500)', async () => {
+      const { status } = await request(app)
+        .patch(`/shared-spaces/${spaceId}/albums/not-a-uuid`)
+        .set('Authorization', `Bearer ${owner.accessToken}`)
+        .send({ showInTimeline: true });
+      expect(status).toBe(400);
+    });
+
+    it('DELETE with non-UUID albumId → 400 (not 500)', async () => {
+      const { status } = await request(app)
+        .delete(`/shared-spaces/${spaceId}/albums/not-a-uuid`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+      expect(status).toBe(400);
+    });
+  });
+
   // ─── DELETE /shared-spaces/:id/albums/:albumId ────────────────────────────
 
   describe('DELETE /shared-spaces/:id/albums/:albumId', () => {

--- a/mobile/lib/domain/services/remote_album.service.dart
+++ b/mobile/lib/domain/services/remote_album.service.dart
@@ -55,12 +55,12 @@ class RemoteAlbumService {
     return _repository.watchAlbum(albumId);
   }
 
-  Future<List<RemoteAlbum>> getAll() {
-    return _repository.getAll();
+  Future<List<RemoteAlbum>> getAll({String? currentUserId}) {
+    return _repository.getAll(currentUserId: currentUserId);
   }
 
-  Future<RemoteAlbum?> get(String albumId) {
-    return _repository.get(albumId);
+  Future<RemoteAlbum?> get(String albumId, {String? currentUserId}) {
+    return _repository.get(albumId, currentUserId: currentUserId);
   }
 
   Future<List<RemoteAlbum>> sortAlbums(

--- a/mobile/lib/infrastructure/repositories/remote_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/remote_album.repository.dart
@@ -19,11 +19,18 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
   final Drift _db;
   const DriftRemoteAlbumRepository(this._db) : super(_db);
 
-  Future<List<RemoteAlbum>> getAll({Set<SortRemoteAlbumsBy> sortBy = const {SortRemoteAlbumsBy.updatedAt}}) {
+  Future<List<RemoteAlbum>> getAll({
+    Set<SortRemoteAlbumsBy> sortBy = const {SortRemoteAlbumsBy.updatedAt},
+    String? currentUserId,
+  }) {
     // Count non-trashed assets via the joined asset table. Filtering trashed assets in the
     // join condition (instead of the where clause) keeps albums whose assets are all trashed
     // in the result, the same way truly empty albums are kept
     final assetCount = _db.remoteAssetEntity.id.count(distinct: true);
+
+    // Alias used to read the current user's role without disturbing the
+    // existing leftOuterJoin on remoteAlbumUserEntity (used for isShared count).
+    final cuRole = currentUserId != null ? _db.alias(_db.remoteAlbumUserEntity, 'cu_role') : null;
 
     final query = _db.remoteAlbumEntity.select().join([
       leftOuterJoin(
@@ -49,12 +56,22 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
             _db.remoteAlbumUserEntity.role.equalsValue(AlbumUserRole.owner),
         useColumns: false,
       ),
+      if (cuRole != null)
+        leftOuterJoin(
+          cuRole,
+          cuRole.albumId.equalsExp(_db.remoteAlbumEntity.id) & cuRole.userId.equals(currentUserId!),
+          useColumns: false,
+        ),
     ]);
     query
       ..addColumns([assetCount])
       ..addColumns([_db.userEntity.name, _db.userEntity.id])
       ..addColumns([_db.remoteAlbumUserEntity.userId.count(distinct: true)])
       ..groupBy([_db.remoteAlbumEntity.id]);
+
+    if (cuRole != null) {
+      query.addColumns([cuRole.role]);
+    }
 
     if (sortBy.isNotEmpty) {
       final orderings = <OrderingTerm>[];
@@ -76,13 +93,18 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
                 ownerId: row.read(_db.userEntity.id)!,
                 ownerName: row.read(_db.userEntity.name)!,
                 isShared: row.read(_db.remoteAlbumUserEntity.userId.count(distinct: true))! > 0,
+                currentUserRole: cuRole != null ? row.readWithConverter(cuRole.role) : null,
               ),
         )
         .get();
   }
 
-  Future<RemoteAlbum?> get(String albumId) {
+  Future<RemoteAlbum?> get(String albumId, {String? currentUserId}) {
     final assetCount = _db.remoteAssetEntity.id.count(distinct: true);
+
+    // Alias used to read the current user's role without disturbing the
+    // existing leftOuterJoin on remoteAlbumUserEntity (used for isShared count).
+    final cuRole = currentUserId != null ? _db.alias(_db.remoteAlbumUserEntity, 'cu_role') : null;
 
     final query =
         _db.remoteAlbumEntity.select().join([
@@ -109,12 +131,22 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
                   _db.remoteAlbumUserEntity.role.equalsValue(AlbumUserRole.owner),
               useColumns: false,
             ),
+            if (cuRole != null)
+              leftOuterJoin(
+                cuRole,
+                cuRole.albumId.equalsExp(_db.remoteAlbumEntity.id) & cuRole.userId.equals(currentUserId!),
+                useColumns: false,
+              ),
           ])
           ..where(_db.remoteAlbumEntity.id.equals(albumId))
           ..addColumns([assetCount])
           ..addColumns([_db.userEntity.name, _db.userEntity.id])
           ..addColumns([_db.remoteAlbumUserEntity.userId.count(distinct: true)])
           ..groupBy([_db.remoteAlbumEntity.id]);
+
+    if (cuRole != null) {
+      query.addColumns([cuRole.role]);
+    }
 
     return query
         .map(
@@ -125,6 +157,7 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
                 ownerId: row.read(_db.userEntity.id)!,
                 ownerName: row.read(_db.userEntity.name)!,
                 isShared: row.read(_db.remoteAlbumUserEntity.userId.count(distinct: true))! > 0,
+                currentUserRole: cuRole != null ? row.readWithConverter(cuRole.role) : null,
               ),
         )
         .getSingleOrNull();
@@ -568,7 +601,13 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
 }
 
 extension on RemoteAlbumEntityData {
-  RemoteAlbum toDto({int assetCount = 0, required String ownerName, required String ownerId, required bool isShared}) {
+  RemoteAlbum toDto({
+    int assetCount = 0,
+    required String ownerName,
+    required String ownerId,
+    required bool isShared,
+    AlbumUserRole? currentUserRole,
+  }) {
     return RemoteAlbum(
       id: id,
       name: name,
@@ -582,6 +621,7 @@ extension on RemoteAlbumEntityData {
       assetCount: assetCount,
       ownerName: ownerName,
       isShared: isShared,
+      currentUserRole: currentUserRole,
     );
   }
 }

--- a/mobile/lib/pages/library/spaces/space_album_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_album_detail.page.dart
@@ -8,7 +8,6 @@ import 'package:immich_mobile/presentation/widgets/spaces/space_album_kebab.widg
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_route_scope.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
@@ -40,25 +39,27 @@ class SpaceAlbumDetailPage extends ConsumerStatefulWidget {
 
 class _SpaceAlbumDetailPageState extends ConsumerState<SpaceAlbumDetailPage> {
   /// Add photos to this album by pushing the asset-selection timeline, then
-  /// calling the regular album addAssets endpoint (D3 — server enforces
-  /// space-editor permission), then nudging sync.
+  /// calling the server-only add path (D3 — server enforces space-editor
+  /// permission), then nudging sync.
+  ///
+  /// Routes through [SpaceAlbumActions.addAssets] (REST add only, no local
+  /// `remote_album_asset` junction write) so an absorbed linked album — one
+  /// with no local `remote_album` row — does not hit the junction FK and
+  /// surface a false "Failed to add photos" toast (mobile F1).
   Future<void> _addPhotos() async {
     final newAssets = await context.pushRoute<Set<BaseAsset>>(DriftAssetSelectionTimelineRoute());
     if (newAssets == null || newAssets.isEmpty) return;
 
     // Filter to remote assets only (local assets can't be added to a space
     // album via the REST endpoint — the server requires remote asset ids).
-    final remoteAssets = newAssets.whereType<RemoteAsset>().toSet();
-    if (remoteAssets.isEmpty) return;
+    final remoteAssetIds = newAssets.whereType<RemoteAsset>().map((a) => a.id).toList();
+    if (remoteAssetIds.isEmpty) return;
 
     try {
-      final count = await ref.read(remoteAlbumProvider.notifier).addAssetsToAlbum(widget.albumId, remoteAssets);
+      final count = await ref.read(spaceAlbumActionsProvider).addAssets(widget.albumId, remoteAssetIds);
       if (context.mounted && count > 0) {
         ImmichToast.show(context: context, msg: 'Added $count photos to album', toastType: ToastType.success);
       }
-      // Nudge sync so the new assets appear in Drift without waiting for the
-      // next scheduled sync cycle.
-      await _triggerSync();
     } catch (_) {
       if (context.mounted) {
         ImmichToast.show(context: context, msg: 'Failed to add photos', toastType: ToastType.error);

--- a/mobile/lib/pages/library/spaces/space_album_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_album_detail.page.dart
@@ -11,6 +11,7 @@ import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
@@ -38,6 +39,25 @@ class SpaceAlbumDetailPage extends ConsumerStatefulWidget {
 }
 
 class _SpaceAlbumDetailPageState extends ConsumerState<SpaceAlbumDetailPage> {
+  String? _spaceName;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSpaceName();
+  }
+
+  Future<void> _loadSpaceName() async {
+    try {
+      final space = await ref.read(sharedSpaceApiRepositoryProvider).get(widget.spaceId);
+      if (mounted) {
+        setState(() => _spaceName = space.name);
+      }
+    } catch (_) {
+      // Best-effort — the subtitle simply won't render until the name loads.
+    }
+  }
+
   /// Add photos to this album by pushing the asset-selection timeline, then
   /// calling the server-only add path (D3 — server enforces space-editor
   /// permission), then nudging sync.
@@ -144,6 +164,7 @@ class _SpaceAlbumDetailPageState extends ConsumerState<SpaceAlbumDetailPage> {
         appBar: SpaceAlbumAppBar(
           canEdit: widget.canEdit,
           album: album,
+          spaceName: _spaceName,
           onAddPhotos: widget.canEdit ? _addPhotos : () {},
           onToggleTimeline: widget.canEdit ? _toggleTimeline : () {},
           onUnlink: widget.canEdit ? _unlink : () {},
@@ -172,6 +193,7 @@ class SpaceAlbumAppBar extends StatelessWidget {
     super.key,
     required this.canEdit,
     this.album,
+    this.spaceName,
     this.onAddPhotos,
     this.onToggleTimeline,
     this.onUnlink,
@@ -179,6 +201,10 @@ class SpaceAlbumAppBar extends StatelessWidget {
 
   final bool canEdit;
   final SpaceAlbum? album;
+
+  /// The name of the parent shared space, used for the app bar subtitle.
+  /// Null until the space metadata has loaded (subtitle is hidden until then).
+  final String? spaceName;
 
   /// Called when the editor taps "Add photos" in the kebab.
   final VoidCallback? onAddPhotos;
@@ -191,10 +217,24 @@ class SpaceAlbumAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final showSubtitle = album != null && spaceName != null;
     return SliverAppBar(
       floating: true,
       pinned: false,
-      title: album != null ? Text(album!.name) : null,
+      title: album != null
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(album!.name),
+                if (showSubtitle)
+                  Text(
+                    '${album!.assetCount} photos · in $spaceName',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+              ],
+            )
+          : null,
       actions: [
         SpaceAlbumKebab(
           canEdit: canEdit,

--- a/mobile/lib/pages/library/spaces/space_album_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_album_detail.page.dart
@@ -228,10 +228,7 @@ class SpaceAlbumAppBar extends StatelessWidget {
               children: [
                 Text(album!.name),
                 if (showSubtitle)
-                  Text(
-                    '${album!.assetCount} photos · in $spaceName',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  ),
+                  Text('${album!.assetCount} photos · in $spaceName', style: Theme.of(context).textTheme.bodySmall),
               ],
             )
           : null,

--- a/mobile/lib/pages/library/spaces/space_album_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_album_detail.page.dart
@@ -239,6 +239,7 @@ class SpaceAlbumAppBar extends StatelessWidget {
         SpaceAlbumKebab(
           canEdit: canEdit,
           showInTimeline: album?.showInTimeline ?? true,
+          toggleEnabled: album != null,
           onAddPhotos: onAddPhotos ?? () {},
           onToggleTimeline: onToggleTimeline ?? () {},
           onUnlink: onUnlink ?? () {},

--- a/mobile/lib/pages/library/spaces/space_albums.page.dart
+++ b/mobile/lib/pages/library/spaces/space_albums.page.dart
@@ -174,10 +174,7 @@ class _AlbumCard extends ConsumerWidget {
         if (snapshot.hasData && snapshot.data != null) {
           return ClipRRect(
             borderRadius: const BorderRadius.all(Radius.circular(16)),
-            child: Thumbnail.remote(
-              remoteId: thumbnailId,
-              thumbhash: snapshot.data!.thumbHash ?? '',
-            ),
+            child: Thumbnail.remote(remoteId: thumbnailId, thumbhash: snapshot.data!.thumbHash ?? ''),
           );
         }
         return _buildFallback(cs);
@@ -199,10 +196,7 @@ class _AlbumCard extends ConsumerWidget {
           Expanded(
             child: Stack(
               children: [
-                Opacity(
-                  opacity: isOffTimeline ? 0.6 : 1.0,
-                  child: _buildCoverArt(context, ref, cs),
-                ),
+                Opacity(opacity: isOffTimeline ? 0.6 : 1.0, child: _buildCoverArt(context, ref, cs)),
                 // Off-timeline badge
                 if (isOffTimeline)
                   Positioned.fill(

--- a/mobile/lib/pages/library/spaces/space_albums.page.dart
+++ b/mobile/lib/pages/library/spaces/space_albums.page.dart
@@ -1,8 +1,11 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
@@ -135,7 +138,7 @@ class _AlbumGrid extends StatelessWidget {
 // Album card
 // ---------------------------------------------------------------------------
 
-class _AlbumCard extends StatelessWidget {
+class _AlbumCard extends ConsumerWidget {
   const _AlbumCard({
     super.key,
     required this.album,
@@ -151,8 +154,39 @@ class _AlbumCard extends StatelessWidget {
   final void Function(String albumId) onUnlink;
   final void Function(String albumId) onTap;
 
+  Widget _buildFallback(ColorScheme cs) {
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHighest,
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
+        border: Border.all(color: cs.outline.withValues(alpha: 0.3), width: 1),
+      ),
+      child: const Center(child: Icon(Icons.photo_album_outlined, size: 40, color: Colors.grey)),
+    );
+  }
+
+  Widget _buildCoverArt(BuildContext context, WidgetRef ref, ColorScheme cs) {
+    final thumbnailId = album.thumbnailAssetId;
+    if (thumbnailId == null) return _buildFallback(cs);
+    return FutureBuilder<RemoteAsset?>(
+      future: ref.read(assetServiceProvider).getRemoteAsset(thumbnailId),
+      builder: (context, snapshot) {
+        if (snapshot.hasData && snapshot.data != null) {
+          return ClipRRect(
+            borderRadius: const BorderRadius.all(Radius.circular(16)),
+            child: Thumbnail.remote(
+              remoteId: thumbnailId,
+              thumbhash: snapshot.data!.thumbHash ?? '',
+            ),
+          );
+        }
+        return _buildFallback(cs);
+      },
+    );
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cs = context.colorScheme;
     final isOffTimeline = !album.showInTimeline;
 
@@ -167,14 +201,7 @@ class _AlbumCard extends StatelessWidget {
               children: [
                 Opacity(
                   opacity: isOffTimeline ? 0.6 : 1.0,
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: cs.surfaceContainerHighest,
-                      borderRadius: const BorderRadius.all(Radius.circular(16)),
-                      border: Border.all(color: cs.outline.withValues(alpha: 0.3), width: 1),
-                    ),
-                    child: const Center(child: Icon(Icons.photo_album_outlined, size: 40, color: Colors.grey)),
-                  ),
+                  child: _buildCoverArt(context, ref, cs),
                 ),
                 // Off-timeline badge
                 if (isOffTimeline)

--- a/mobile/lib/pages/library/spaces/space_link_album.page.dart
+++ b/mobile/lib/pages/library/spaces/space_link_album.page.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/utils/space_link_album_candidates.dart';
 
@@ -199,13 +202,11 @@ class _AlbumRow extends StatelessWidget {
 // Cover thumbnail
 // ---------------------------------------------------------------------------
 
-class _AlbumCover extends StatelessWidget {
+class _AlbumCover extends ConsumerWidget {
   const _AlbumCover({required this.album});
   final RemoteAlbum album;
 
-  @override
-  Widget build(BuildContext context) {
-    final cs = context.colorScheme;
+  Widget _buildFallback(ColorScheme cs) {
     return Container(
       width: 52,
       height: 52,
@@ -215,6 +216,32 @@ class _AlbumCover extends StatelessWidget {
         border: Border.all(color: cs.outline.withValues(alpha: 0.3), width: 1),
       ),
       child: const Center(child: Icon(Icons.photo_album_outlined, size: 24, color: Colors.grey)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cs = context.colorScheme;
+    final thumbnailId = album.thumbnailAssetId;
+    if (thumbnailId == null) return _buildFallback(cs);
+    return SizedBox(
+      width: 52,
+      height: 52,
+      child: FutureBuilder<RemoteAsset?>(
+        future: ref.read(assetServiceProvider).getRemoteAsset(thumbnailId),
+        builder: (context, snapshot) {
+          if (snapshot.hasData && snapshot.data != null) {
+            return ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(8)),
+              child: Thumbnail.remote(
+                remoteId: thumbnailId,
+                thumbhash: snapshot.data!.thumbHash ?? '',
+              ),
+            );
+          }
+          return _buildFallback(cs);
+        },
+      ),
     );
   }
 }

--- a/mobile/lib/pages/library/spaces/space_link_album.page.dart
+++ b/mobile/lib/pages/library/spaces/space_link_album.page.dart
@@ -233,10 +233,7 @@ class _AlbumCover extends ConsumerWidget {
           if (snapshot.hasData && snapshot.data != null) {
             return ClipRRect(
               borderRadius: const BorderRadius.all(Radius.circular(8)),
-              child: Thumbnail.remote(
-                remoteId: thumbnailId,
-                thumbhash: snapshot.data!.thumbHash ?? '',
-              ),
+              child: Thumbnail.remote(remoteId: thumbnailId, thumbhash: snapshot.data!.thumbHash ?? ''),
             );
           }
           return _buildFallback(cs);

--- a/mobile/lib/presentation/widgets/spaces/space_album_kebab.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_album_kebab.widget.dart
@@ -18,6 +18,7 @@ class SpaceAlbumKebab extends StatelessWidget {
     required this.onAddPhotos,
     required this.onToggleTimeline,
     required this.onUnlink,
+    this.toggleEnabled = true,
   });
 
   final bool canEdit;
@@ -25,6 +26,13 @@ class SpaceAlbumKebab extends StatelessWidget {
   final VoidCallback onAddPhotos;
   final VoidCallback onToggleTimeline;
   final VoidCallback onUnlink;
+
+  /// Whether the "Show/Hide in timeline" menu item is interactive.
+  ///
+  /// Set to [false] while the album stream is unresolved so an editor who
+  /// taps the item before metadata loads neither no-ops silently nor triggers
+  /// a premature mutation.
+  final bool toggleEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +58,7 @@ class SpaceAlbumKebab extends StatelessWidget {
         PopupMenuItem<_KebabAction>(
           key: const Key('space-album-kebab-toggle'),
           value: _KebabAction.toggle,
+          enabled: toggleEnabled,
           child: Text(showInTimeline ? 'Hide from timeline' : 'Show in timeline'),
         ),
         const PopupMenuItem<_KebabAction>(

--- a/mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart
@@ -188,10 +188,7 @@ class _SpaceAlbumCoverTile extends ConsumerWidget {
             child: SizedBox(
               width: _kTileSize,
               height: _kTileSize,
-              child: Thumbnail.remote(
-                remoteId: thumbnailId,
-                thumbhash: snapshot.data!.thumbHash ?? '',
-              ),
+              child: Thumbnail.remote(remoteId: thumbnailId, thumbhash: snapshot.data!.thumbHash ?? ''),
             ),
           );
         }
@@ -216,10 +213,7 @@ class _SpaceAlbumCoverTile extends ConsumerWidget {
             Stack(
               children: [
                 // Cover background / thumbnail
-                Opacity(
-                  opacity: isOffTimeline ? 0.6 : 1.0,
-                  child: _buildCoverArt(context, ref, cs),
-                ),
+                Opacity(opacity: isOffTimeline ? 0.6 : 1.0, child: _buildCoverArt(context, ref, cs)),
                 // Off-timeline badge
                 if (isOffTimeline)
                   Positioned.fill(

--- a/mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 
 /// Fixed height of the Albums shelf when it is visible (at least one album
@@ -144,29 +147,61 @@ class _HeaderRow extends StatelessWidget {
 
 /// A single cover tile.
 ///
-/// Cover strategy (D4 — album_tile.dart FutureBuilder fallback pattern):
+/// Cover strategy (album_tile.dart FutureBuilder pattern):
 ///   - If [album.thumbnailAssetId] is null → show [Icons.photo_album_outlined]
 ///     on [surfaceContainerHighest] immediately (cover is not yet synced).
-///   - Otherwise, show the same icon (B4 will wire the real thumbnail via an
-///     assetService lookup; for B2 the tile always shows the fallback icon
-///     when the cover is present — this keeps the test-harness stable and
-///     avoids async image loading in widget tests, per the plan RULES).
-///
-/// NOTE: replacing the unconditional fallback with a real thumbnail lookup
-/// is explicitly deferred to B4. The trade-off is documented here so the
-/// reviewer understands the placeholder is intentional.
+///   - Otherwise → look up the asset via [assetServiceProvider.getRemoteAsset]
+///     and render [Thumbnail.remote] when it resolves; falls back to the same
+///     placeholder icon while loading or when the asset is not found.
 ///
 /// Off-timeline dim: ~60 % opacity via [Color.withValues(alpha:)] on the
 /// tile + [Icons.visibility_off] badge. [withOpacity] is banned by `dart
 /// analyze --fatal-infos` (replaced by [withValues(alpha:)] in Material 3).
-class _SpaceAlbumCoverTile extends StatelessWidget {
+class _SpaceAlbumCoverTile extends ConsumerWidget {
   const _SpaceAlbumCoverTile({super.key, required this.album, required this.onTap});
 
   final SpaceAlbum album;
   final VoidCallback onTap;
 
+  Widget _buildFallback(ColorScheme cs) {
+    return Container(
+      width: _kTileSize,
+      height: _kTileSize,
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHighest,
+        borderRadius: const BorderRadius.all(Radius.circular(_kTileRadius)),
+        border: Border.all(color: cs.outline.withValues(alpha: 0.3), width: 1),
+      ),
+      child: const Icon(Icons.photo_album_outlined, size: 32, color: Colors.grey),
+    );
+  }
+
+  Widget _buildCoverArt(BuildContext context, WidgetRef ref, ColorScheme cs) {
+    final thumbnailId = album.thumbnailAssetId;
+    if (thumbnailId == null) return _buildFallback(cs);
+    return FutureBuilder<RemoteAsset?>(
+      future: ref.read(assetServiceProvider).getRemoteAsset(thumbnailId),
+      builder: (context, snapshot) {
+        if (snapshot.hasData && snapshot.data != null) {
+          return ClipRRect(
+            borderRadius: const BorderRadius.all(Radius.circular(_kTileRadius)),
+            child: SizedBox(
+              width: _kTileSize,
+              height: _kTileSize,
+              child: Thumbnail.remote(
+                remoteId: thumbnailId,
+                thumbhash: snapshot.data!.thumbHash ?? '',
+              ),
+            ),
+          );
+        }
+        return _buildFallback(cs);
+      },
+    );
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cs = context.colorScheme;
     final isOffTimeline = !album.showInTimeline;
 
@@ -180,23 +215,10 @@ class _SpaceAlbumCoverTile extends StatelessWidget {
             // Cover art (with optional dim + badge for off-timeline)
             Stack(
               children: [
-                // Cover background / fallback
+                // Cover background / thumbnail
                 Opacity(
                   opacity: isOffTimeline ? 0.6 : 1.0,
-                  child: Container(
-                    width: _kTileSize,
-                    height: _kTileSize,
-                    decoration: BoxDecoration(
-                      color: cs.surfaceContainerHighest,
-                      borderRadius: const BorderRadius.all(Radius.circular(_kTileRadius)),
-                      border: Border.all(
-                        // Use withValues(alpha:) — withOpacity is fatal-info in analyze
-                        color: cs.outline.withValues(alpha: 0.3),
-                        width: 1,
-                      ),
-                    ),
-                    child: const Icon(Icons.photo_album_outlined, size: 32, color: Colors.grey),
-                  ),
+                  child: _buildCoverArt(context, ref, cs),
                 ),
                 // Off-timeline badge
                 if (isOffTimeline)

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -53,7 +53,8 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
 
   Future<List<RemoteAlbum>> _getAll() async {
     try {
-      final albums = await _remoteAlbumService.getAll();
+      final currentUserId = ref.read(currentUserProvider)?.id;
+      final albums = await _remoteAlbumService.getAll(currentUserId: currentUserId);
       state = state.copyWith(albums: albums);
       return albums;
     } catch (error, stack) {
@@ -285,7 +286,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
   /// that views bound to the album list (counts, thumbnails) reflect the
   /// latest junction-table changes without a full `refresh()`.
   Future<void> _refreshAlbumInState(String albumId) async {
-    final updated = await _remoteAlbumService.get(albumId);
+    final updated = await _remoteAlbumService.get(albumId, currentUserId: ref.read(currentUserProvider)?.id);
     if (updated == null) {
       return;
     }

--- a/mobile/lib/providers/infrastructure/space_album_actions.dart
+++ b/mobile/lib/providers/infrastructure/space_album_actions.dart
@@ -1,12 +1,14 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/utils/background_sync.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
+import 'package:immich_mobile/repositories/drift_album_api_repository.dart';
 import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 
-/// Centralises the three space-album mutation operations:
+/// Centralises the space-album mutation operations:
 ///   - [link]           — PUT  /shared-spaces/{id}/albums/{albumId} (one or more)
 ///   - [unlink]         — DELETE /shared-spaces/{id}/albums/{albumId}
 ///   - [toggleTimeline] — PATCH  /shared-spaces/{id}/albums/{albumId}
+///   - [addAssets]      — PUT  /albums/{albumId}/assets (server-only)
 ///
 /// Each operation calls the API repo, fires the sync-nudge
 /// (`BackgroundSyncManager.syncRemote()`), then returns.
@@ -17,9 +19,10 @@ import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 /// album in a batch aborts the whole operation (fail-fast). The caller shows
 /// an error toast; the sync will catch up on the next regular cycle.
 class SpaceAlbumActions {
-  SpaceAlbumActions({required this._repo, required this._syncManager});
+  SpaceAlbumActions({required this._repo, required this._albumApiRepo, required this._syncManager});
 
   final SharedSpaceApiRepository _repo;
+  final DriftAlbumApiRepository _albumApiRepo;
   final BackgroundSyncManager _syncManager;
 
   /// Link one or more albums to a space.
@@ -48,6 +51,25 @@ class SpaceAlbumActions {
     await _repo.updateAlbumLink(spaceId, albumId, showInTimeline: !current);
     await _syncManager.syncRemote();
   }
+
+  /// Add assets to a linked album via the **server-only** REST path.
+  ///
+  /// A linked album may be "absorbed" — present only in `shared_space_album`
+  /// with no local `remote_album` row — so the personal-album add path (which
+  /// also writes the local `remote_album_asset` junction) would hit a foreign
+  /// key violation. This routes through [DriftAlbumApiRepository.addAssets]
+  /// (the REST add only) and then nudges sync; the server is the source of
+  /// truth and `spaceAlbum()`'s Drift watch surfaces the new assets.
+  ///
+  /// Returns the number of assets the server actually added. If [assetIds] is
+  /// empty, does nothing (no API call, no nudge). On API failure the exception
+  /// propagates and the nudge is skipped (fail-fast).
+  Future<int> addAssets(String albumId, List<String> assetIds) async {
+    if (assetIds.isEmpty) return 0;
+    final result = await _albumApiRepo.addAssets(albumId, assetIds);
+    await _syncManager.syncRemote();
+    return result.added.length;
+  }
 }
 
 /// Provider for [SpaceAlbumActions].
@@ -57,6 +79,7 @@ class SpaceAlbumActions {
 final spaceAlbumActionsProvider = Provider<SpaceAlbumActions>((ref) {
   return SpaceAlbumActions(
     repo: ref.watch(sharedSpaceApiRepositoryProvider),
+    albumApiRepo: ref.watch(driftAlbumApiRepositoryProvider),
     syncManager: ref.watch(backgroundSyncProvider),
   );
 });

--- a/mobile/test/domain/services/remote_album_service_test.dart
+++ b/mobile/test/domain/services/remote_album_service_test.dart
@@ -40,9 +40,7 @@ void main() {
 
   group('get', () {
     test('forwards currentUserId to the repository', () async {
-      when(
-        () => repository.get(any(), currentUserId: any(named: 'currentUserId')),
-      ).thenAnswer((_) async => null);
+      when(() => repository.get(any(), currentUserId: any(named: 'currentUserId'))).thenAnswer((_) async => null);
 
       await sut.get('a1', currentUserId: 'u1');
 

--- a/mobile/test/domain/services/remote_album_service_test.dart
+++ b/mobile/test/domain/services/remote_album_service_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/services/remote_album.service.dart';
+import 'package:immich_mobile/services/foreground_upload.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../infrastructure/repository.mock.dart';
+
+class MockForegroundUploadService extends Mock implements ForegroundUploadService {}
+
+void main() {
+  late RemoteAlbumService sut;
+  late MockRemoteAlbumRepository repository;
+  late MockDriftAlbumApiRepository albumApiRepository;
+  late MockForegroundUploadService uploadService;
+
+  setUp(() {
+    repository = MockRemoteAlbumRepository();
+    albumApiRepository = MockDriftAlbumApiRepository();
+    uploadService = MockForegroundUploadService();
+    sut = RemoteAlbumService(repository, albumApiRepository, uploadService);
+  });
+
+  group('getAll', () {
+    test('forwards currentUserId to the repository', () async {
+      when(() => repository.getAll(currentUserId: any(named: 'currentUserId'))).thenAnswer((_) async => []);
+
+      await sut.getAll(currentUserId: 'u1');
+
+      verify(() => repository.getAll(currentUserId: 'u1')).called(1);
+    });
+
+    test('defaults currentUserId to null when not provided', () async {
+      when(() => repository.getAll(currentUserId: any(named: 'currentUserId'))).thenAnswer((_) async => []);
+
+      await sut.getAll();
+
+      verify(() => repository.getAll(currentUserId: null)).called(1);
+    });
+  });
+
+  group('get', () {
+    test('forwards currentUserId to the repository', () async {
+      when(
+        () => repository.get(any(), currentUserId: any(named: 'currentUserId')),
+      ).thenAnswer((_) async => null);
+
+      await sut.get('a1', currentUserId: 'u1');
+
+      verify(() => repository.get('a1', currentUserId: 'u1')).called(1);
+    });
+  });
+}

--- a/mobile/test/medium/repositories/remote_album_repository_test.dart
+++ b/mobile/test/medium/repositories/remote_album_repository_test.dart
@@ -136,18 +136,9 @@ void main() {
   });
 
   group('currentUserRole', () {
-    Future<void> addAlbumUser(
-      String albumId,
-      String userId,
-      AlbumUserRole role,
-    ) =>
-        ctx.db.into(ctx.db.remoteAlbumUserEntity).insert(
-          RemoteAlbumUserEntityCompanion(
-            albumId: Value(albumId),
-            userId: Value(userId),
-            role: Value(role),
-          ),
-        );
+    Future<void> addAlbumUser(String albumId, String userId, AlbumUserRole role) => ctx.db
+        .into(ctx.db.remoteAlbumUserEntity)
+        .insert(RemoteAlbumUserEntityCompanion(albumId: Value(albumId), userId: Value(userId), role: Value(role)));
 
     test('getAll: populates editor role when current user is an editor', () async {
       final owner = await ctx.newUser();

--- a/mobile/test/medium/repositories/remote_album_repository_test.dart
+++ b/mobile/test/medium/repositories/remote_album_repository_test.dart
@@ -1,5 +1,8 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/infrastructure/entities/remote_album_user.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_album.repository.dart';
 
 import '../repository_context.dart';
@@ -129,6 +132,77 @@ void main() {
 
       expect(albums, hasLength(1));
       expect(albums.first.assetCount, 0);
+    });
+  });
+
+  group('currentUserRole', () {
+    Future<void> addAlbumUser(
+      String albumId,
+      String userId,
+      AlbumUserRole role,
+    ) =>
+        ctx.db.into(ctx.db.remoteAlbumUserEntity).insert(
+          RemoteAlbumUserEntityCompanion(
+            albumId: Value(albumId),
+            userId: Value(userId),
+            role: Value(role),
+          ),
+        );
+
+    test('getAll: populates editor role when current user is an editor', () async {
+      final owner = await ctx.newUser();
+      final currentUser = await ctx.newUser();
+      final album = await ctx.newRemoteAlbum(ownerId: owner.id);
+      await addAlbumUser(album.id, currentUser.id, AlbumUserRole.editor);
+
+      final albums = await sut.getAll(currentUserId: currentUser.id);
+
+      expect(albums, hasLength(1));
+      expect(albums.first.currentUserRole, AlbumUserRole.editor);
+    });
+
+    test('getAll: populates owner role when current user owns the album', () async {
+      final currentUser = await ctx.newUser();
+      await ctx.newRemoteAlbum(ownerId: currentUser.id);
+
+      final albums = await sut.getAll(currentUserId: currentUser.id);
+
+      expect(albums, hasLength(1));
+      expect(albums.first.currentUserRole, AlbumUserRole.owner);
+    });
+
+    test('getAll: populates viewer role when current user is a viewer', () async {
+      final owner = await ctx.newUser();
+      final currentUser = await ctx.newUser();
+      final album = await ctx.newRemoteAlbum(ownerId: owner.id);
+      await addAlbumUser(album.id, currentUser.id, AlbumUserRole.viewer);
+
+      final albums = await sut.getAll(currentUserId: currentUser.id);
+
+      expect(albums, hasLength(1));
+      expect(albums.first.currentUserRole, AlbumUserRole.viewer);
+    });
+
+    test('getAll: currentUserRole is null when currentUserId is not provided', () async {
+      final user = await ctx.newUser();
+      await ctx.newRemoteAlbum(ownerId: user.id);
+
+      final albums = await sut.getAll();
+
+      expect(albums, hasLength(1));
+      expect(albums.first.currentUserRole, isNull);
+    });
+
+    test('get: populates editor role when current user is an editor', () async {
+      final owner = await ctx.newUser();
+      final currentUser = await ctx.newUser();
+      final album = await ctx.newRemoteAlbum(ownerId: owner.id);
+      await addAlbumUser(album.id, currentUser.id, AlbumUserRole.editor);
+
+      final result = await sut.get(album.id, currentUserId: currentUser.id);
+
+      expect(result, isNotNull);
+      expect(result!.currentUserRole, AlbumUserRole.editor);
     });
   });
 

--- a/mobile/test/medium/repositories/space_album_repository_test.dart
+++ b/mobile/test/medium/repositories/space_album_repository_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/infrastructure/repositories/remote_album.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/space_album.repository.dart';
 
 import '../repository_context.dart';
@@ -89,5 +90,23 @@ void main() {
     expect(await ctx.db.select(ctx.db.sharedSpaceAlbumLinkEntity).get(), isEmpty);
     expect(await ctx.db.select(ctx.db.sharedSpaceAlbumEntity).get(), isNotEmpty);
     expect(await ctx.db.select(ctx.db.sharedSpaceAlbumAssetEntity).get(), isNotEmpty);
+  });
+
+  group('absorbed album add-photos (mobile F1 regression)', () {
+    test('local junction write throws on an absorbed album (no remote_album row), leaving no junction row', () async {
+      final user = await ctx.newUser();
+      final asset = await ctx.newRemoteAsset(ownerId: user.id);
+      final localRepo = DriftRemoteAlbumRepository(ctx.db);
+
+      // An absorbed linked album lives only in shared_space_album — it has no
+      // remote_album row. The personal-album add path batch-inserts into
+      // remote_album_asset, whose FK albumId -> remote_album is enforced, so the
+      // write fails (the empirical FK 787 bug the new server-only path avoids).
+      await expectLater(localRepo.addAssets('absorbed-album', [asset.id]), throwsA(anything));
+
+      // The failed transaction rolls back; the server-only fix never performs
+      // this local insert, so the junction table stays empty either way.
+      expect(await ctx.db.select(ctx.db.remoteAlbumAssetEntity).get(), isEmpty);
+    });
   });
 }

--- a/mobile/test/presentation/pages/space_album_detail_page_test.dart
+++ b/mobile/test/presentation/pages/space_album_detail_page_test.dart
@@ -17,10 +17,11 @@ Widget _wrapSliver(Widget sliverWidget) => MaterialApp(
   ),
 );
 
-SpaceAlbum _album({required String id, String? name, bool showInTimeline = true}) => SpaceAlbum(
+SpaceAlbum _album({required String id, String? name, bool showInTimeline = true, int assetCount = 0}) => SpaceAlbum(
   id: id,
   name: name ?? 'Album $id',
   showInTimeline: showInTimeline,
+  assetCount: assetCount,
 );
 
 // ---------------------------------------------------------------------------
@@ -65,5 +66,36 @@ void main() {
       find.byWidgetPredicate((w) => w is PopupMenuButton),
       findsNothing,
     );
+  });
+
+  testWidgets('subtitle "{count} photos · in {space}" renders when album and spaceName are provided', (tester) async {
+    await tester.pumpWidget(
+      _wrapSliver(
+        SpaceAlbumAppBar(
+          canEdit: false,
+          album: _album(id: 'a2', name: 'Summer', assetCount: 7),
+          spaceName: 'Trip 2024',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('7 photos · in Trip 2024'), findsOneWidget);
+  });
+
+  testWidgets('subtitle is absent when spaceName is null (metadata not yet loaded)', (tester) async {
+    await tester.pumpWidget(
+      _wrapSliver(
+        SpaceAlbumAppBar(
+          canEdit: false,
+          album: _album(id: 'a3', name: 'Summer', assetCount: 7),
+          // spaceName omitted / null
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // No subtitle should be rendered before the space name is loaded.
+    expect(find.textContaining('photos · in'), findsNothing);
   });
 }

--- a/mobile/test/presentation/pages/space_album_detail_page_test.dart
+++ b/mobile/test/presentation/pages/space_album_detail_page_test.dart
@@ -98,4 +98,66 @@ void main() {
     // No subtitle should be rendered before the space name is loaded.
     expect(find.textContaining('photos · in'), findsNothing);
   });
+
+  // ---------------------------------------------------------------------------
+  // Slice 14 — toggle disabled when album stream is unresolved
+  // ---------------------------------------------------------------------------
+
+  testWidgets('toggle menu item is DISABLED when album is null (stream unresolved)', (tester) async {
+    bool toggled = false;
+    await tester.pumpWidget(
+      _wrapSliver(
+        SpaceAlbumAppBar(
+          canEdit: true,
+          album: null, // stream not yet resolved
+          onToggleTimeline: () => toggled = true,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Open the popup menu
+    await tester.tap(find.byWidgetPredicate((w) => w is PopupMenuButton));
+    await tester.pumpAndSettle();
+
+    // The toggle item must exist and be disabled
+    final toggleItem = tester.widget<PopupMenuItem<dynamic>>(
+      find.byKey(const Key('space-album-kebab-toggle')),
+    );
+    expect(toggleItem.enabled, isFalse, reason: 'toggle item should be disabled when album is null');
+
+    // Tapping a disabled item must NOT fire the callback
+    await tester.tap(find.byKey(const Key('space-album-kebab-toggle')));
+    await tester.pumpAndSettle();
+    expect(toggled, isFalse, reason: 'onToggleTimeline must not be called when item is disabled');
+  });
+
+  testWidgets('toggle menu item is ENABLED when album is non-null and invokes callback', (tester) async {
+    bool toggled = false;
+    await tester.pumpWidget(
+      _wrapSliver(
+        SpaceAlbumAppBar(
+          canEdit: true,
+          album: _album(id: 'a4', name: 'Loaded Album'),
+          onToggleTimeline: () => toggled = true,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Open the popup menu
+    await tester.tap(find.byWidgetPredicate((w) => w is PopupMenuButton));
+    await tester.pumpAndSettle();
+
+    // The toggle item must exist and be enabled
+    final toggleItem = tester.widget<PopupMenuItem<dynamic>>(
+      find.byKey(const Key('space-album-kebab-toggle')),
+    );
+    expect(toggleItem.enabled, isTrue, reason: 'toggle item should be enabled when album is non-null');
+
+    // Tapping an enabled item MUST fire the callback
+    await tester.tap(find.byKey(const Key('space-album-kebab-toggle')));
+    await tester.pumpAndSettle();
+    expect(toggled, isTrue, reason: 'onToggleTimeline must be called when item is enabled and tapped');
+  });
 }

--- a/mobile/test/presentation/pages/space_album_detail_page_test.dart
+++ b/mobile/test/presentation/pages/space_album_detail_page_test.dart
@@ -12,17 +12,16 @@ import 'package:immich_mobile/presentation/widgets/spaces/space_album_kebab.widg
 Widget _wrapSliver(Widget sliverWidget) => MaterialApp(
   home: Scaffold(
     body: CustomScrollView(
-      slivers: [sliverWidget, const SliverToBoxAdapter(child: SizedBox(height: 800))],
+      slivers: [
+        sliverWidget,
+        const SliverToBoxAdapter(child: SizedBox(height: 800)),
+      ],
     ),
   ),
 );
 
-SpaceAlbum _album({required String id, String? name, bool showInTimeline = true, int assetCount = 0}) => SpaceAlbum(
-  id: id,
-  name: name ?? 'Album $id',
-  showInTimeline: showInTimeline,
-  assetCount: assetCount,
-);
+SpaceAlbum _album({required String id, String? name, bool showInTimeline = true, int assetCount = 0}) =>
+    SpaceAlbum(id: id, name: name ?? 'Album $id', showInTimeline: showInTimeline, assetCount: assetCount);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -43,10 +42,7 @@ void main() {
     expect(find.byType(SpaceAlbumKebab), findsOneWidget);
     // canEdit:true → SpaceAlbumKebab renders a PopupMenuButton (not SizedBox.shrink)
     // Use byWidgetPredicate since the type param is private (_KebabAction).
-    expect(
-      find.byWidgetPredicate((w) => w is PopupMenuButton),
-      findsOneWidget,
-    );
+    expect(find.byWidgetPredicate((w) => w is PopupMenuButton), findsOneWidget);
   });
 
   testWidgets('viewer role (canEdit:false) — SpaceAlbumKebab renders SizedBox.shrink', (tester) async {
@@ -62,10 +58,7 @@ void main() {
 
     expect(find.byType(SpaceAlbumKebab), findsOneWidget);
     // canEdit:false → the kebab renders SizedBox.shrink, so no PopupMenuButton
-    expect(
-      find.byWidgetPredicate((w) => w is PopupMenuButton),
-      findsNothing,
-    );
+    expect(find.byWidgetPredicate((w) => w is PopupMenuButton), findsNothing);
   });
 
   testWidgets('subtitle "{count} photos · in {space}" renders when album and spaceName are provided', (tester) async {
@@ -121,9 +114,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // The toggle item must exist and be disabled
-    final toggleItem = tester.widget<PopupMenuItem<dynamic>>(
-      find.byKey(const Key('space-album-kebab-toggle')),
-    );
+    final toggleItem = tester.widget<PopupMenuItem<dynamic>>(find.byKey(const Key('space-album-kebab-toggle')));
     expect(toggleItem.enabled, isFalse, reason: 'toggle item should be disabled when album is null');
 
     // Tapping a disabled item must NOT fire the callback
@@ -150,9 +141,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // The toggle item must exist and be enabled
-    final toggleItem = tester.widget<PopupMenuItem<dynamic>>(
-      find.byKey(const Key('space-album-kebab-toggle')),
-    );
+    final toggleItem = tester.widget<PopupMenuItem<dynamic>>(find.byKey(const Key('space-album-kebab-toggle')));
     expect(toggleItem.enabled, isTrue, reason: 'toggle item should be enabled when album is non-null');
 
     // Tapping an enabled item MUST fire the callback

--- a/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
@@ -34,30 +34,15 @@ Finder findByKeyPrefix(String prefix) => find.byWidgetPredicate(
 // Helpers
 // ---------------------------------------------------------------------------
 
-SpaceAlbum _album({
-  required String id,
-  String? name,
-  String? thumbnailAssetId,
-  bool showInTimeline = true,
-}) =>
-    SpaceAlbum(
-      id: id,
-      name: name ?? 'Album $id',
-      thumbnailAssetId: thumbnailAssetId,
-      showInTimeline: showInTimeline,
-    );
+SpaceAlbum _album({required String id, String? name, String? thumbnailAssetId, bool showInTimeline = true}) =>
+    SpaceAlbum(id: id, name: name ?? 'Album $id', thumbnailAssetId: thumbnailAssetId, showInTimeline: showInTimeline);
 
 /// Wraps [widget] in a [ProviderScope] that overrides [spaceAlbumsProvider]
 /// with a fixed list, and a minimal [MaterialApp] for theme/directionality.
 ///
 /// Pass [assetService] to also override [assetServiceProvider] — needed for
 /// cover-thumbnail tests that call [assetServiceProvider.getRemoteAsset].
-Widget _wrap(
-  Widget widget, {
-  required String spaceId,
-  required List<SpaceAlbum> albums,
-  AssetService? assetService,
-}) {
+Widget _wrap(Widget widget, {required String spaceId, required List<SpaceAlbum> albums, AssetService? assetService}) {
   return ProviderScope(
     overrides: [
       spaceAlbumsProvider(spaceId).overrideWith((_) => Stream.value(albums)),
@@ -81,19 +66,11 @@ void main() {
   const spaceId = 'space-1';
 
   testWidgets('count>0 + canEdit: shows cover tiles and Link tile', (tester) async {
-    final albums = [
-      _album(id: 'a1', name: 'Hawaii'),
-      _album(id: 'a2', name: 'Sunset'),
-    ];
+    final albums = [_album(id: 'a1', name: 'Hawaii'), _album(id: 'a2', name: 'Sunset')];
 
     await tester.pumpWidget(
       _wrap(
-        SpaceAlbumsShelf(
-          spaceId: spaceId,
-          canEdit: true,
-          onLinkTap: () {},
-          onAlbumTap: (_) {},
-        ),
+        SpaceAlbumsShelf(spaceId: spaceId, canEdit: true, onLinkTap: () {}, onAlbumTap: (_) {}),
         spaceId: spaceId,
         albums: albums,
       ),
@@ -114,12 +91,7 @@ void main() {
 
     await tester.pumpWidget(
       _wrap(
-        SpaceAlbumsShelf(
-          spaceId: spaceId,
-          canEdit: true,
-          onLinkTap: () {},
-          onAlbumTap: (_) {},
-        ),
+        SpaceAlbumsShelf(spaceId: spaceId, canEdit: true, onLinkTap: () {}, onAlbumTap: (_) {}),
         spaceId: spaceId,
         albums: albums,
       ),
@@ -133,12 +105,7 @@ void main() {
   testWidgets('count==0 + canEdit=true: shows only the Link tile', (tester) async {
     await tester.pumpWidget(
       _wrap(
-        SpaceAlbumsShelf(
-          spaceId: spaceId,
-          canEdit: true,
-          onLinkTap: () {},
-          onAlbumTap: (_) {},
-        ),
+        SpaceAlbumsShelf(spaceId: spaceId, canEdit: true, onLinkTap: () {}, onAlbumTap: (_) {}),
         spaceId: spaceId,
         albums: [],
       ),
@@ -153,12 +120,7 @@ void main() {
   testWidgets('count==0 + canEdit=false: renders nothing', (tester) async {
     await tester.pumpWidget(
       _wrap(
-        SpaceAlbumsShelf(
-          spaceId: spaceId,
-          canEdit: false,
-          onLinkTap: () {},
-          onAlbumTap: (_) {},
-        ),
+        SpaceAlbumsShelf(spaceId: spaceId, canEdit: false, onLinkTap: () {}, onAlbumTap: (_) {}),
         spaceId: spaceId,
         albums: [],
       ),
@@ -171,18 +133,11 @@ void main() {
   });
 
   testWidgets('album with null thumbnailAssetId uses photo_album_outlined fallback icon', (tester) async {
-    final albums = [
-      _album(id: 'a1', name: 'Unsynced', thumbnailAssetId: null),
-    ];
+    final albums = [_album(id: 'a1', name: 'Unsynced', thumbnailAssetId: null)];
 
     await tester.pumpWidget(
       _wrap(
-        SpaceAlbumsShelf(
-          spaceId: spaceId,
-          canEdit: false,
-          onLinkTap: () {},
-          onAlbumTap: (_) {},
-        ),
+        SpaceAlbumsShelf(spaceId: spaceId, canEdit: false, onLinkTap: () {}, onAlbumTap: (_) {}),
         spaceId: spaceId,
         albums: albums,
       ),
@@ -216,34 +171,27 @@ void main() {
     expect(called, isTrue);
   });
 
-  testWidgets(
-    'album WITH thumbnailAssetId resolving to asset shows Thumbnail cover (not placeholder icon)',
-    (tester) async {
-      final mockService = _MockAssetService();
-      final asset = _remoteAsset(id: 'thumb-1');
-      when(() => mockService.getRemoteAsset('thumb-1')).thenAnswer((_) async => asset);
+  testWidgets('album WITH thumbnailAssetId resolving to asset shows Thumbnail cover (not placeholder icon)', (
+    tester,
+  ) async {
+    final mockService = _MockAssetService();
+    final asset = _remoteAsset(id: 'thumb-1');
+    when(() => mockService.getRemoteAsset('thumb-1')).thenAnswer((_) async => asset);
 
-      final albums = [_album(id: 'a1', name: 'Hawaii', thumbnailAssetId: 'thumb-1')];
+    final albums = [_album(id: 'a1', name: 'Hawaii', thumbnailAssetId: 'thumb-1')];
 
-      await tester.pumpWidget(
-        _wrap(
-          SpaceAlbumsShelf(
-            spaceId: spaceId,
-            canEdit: false,
-            onLinkTap: () {},
-            onAlbumTap: (_) {},
-          ),
-          spaceId: spaceId,
-          albums: albums,
-          assetService: mockService,
-        ),
-      );
-      await tester.pump(); // StreamProvider emits albums
-      await tester.pump(); // FutureBuilder resolves (mock future is immediate)
+    await tester.pumpWidget(
+      _wrap(
+        SpaceAlbumsShelf(spaceId: spaceId, canEdit: false, onLinkTap: () {}, onAlbumTap: (_) {}),
+        spaceId: spaceId,
+        albums: albums,
+        assetService: mockService,
+      ),
+    );
+    await tester.pump(); // StreamProvider emits albums
+    await tester.pump(); // FutureBuilder resolves (mock future is immediate)
 
-      expect(find.byType(Thumbnail), findsOneWidget);
-      expect(find.byIcon(Icons.photo_album_outlined), findsNothing);
-    },
-  );
+    expect(find.byType(Thumbnail), findsOneWidget);
+    expect(find.byIcon(Icons.photo_album_outlined), findsNothing);
+  });
 }
-

--- a/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
@@ -1,9 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/domain/services/asset.service.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/presentation/widgets/spaces/space_albums_shelf.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../unit/presentation_context.dart';
+
+class _MockAssetService extends Mock implements AssetService {}
+
+RemoteAsset _remoteAsset({required String id}) => RemoteAsset(
+  id: id,
+  checksum: 'checksum1',
+  ownerId: 'owner1',
+  name: 'test.jpg',
+  type: AssetType.image,
+  createdAt: DateTime(2024, 1, 1),
+  updatedAt: DateTime(2024, 1, 1),
+  isEdited: false,
+);
 
 /// Finds widgets whose [ValueKey<String>] starts with [prefix].
 Finder findByKeyPrefix(String prefix) => find.byWidgetPredicate(
@@ -29,14 +49,19 @@ SpaceAlbum _album({
 
 /// Wraps [widget] in a [ProviderScope] that overrides [spaceAlbumsProvider]
 /// with a fixed list, and a minimal [MaterialApp] for theme/directionality.
+///
+/// Pass [assetService] to also override [assetServiceProvider] — needed for
+/// cover-thumbnail tests that call [assetServiceProvider.getRemoteAsset].
 Widget _wrap(
   Widget widget, {
   required String spaceId,
   required List<SpaceAlbum> albums,
+  AssetService? assetService,
 }) {
   return ProviderScope(
     overrides: [
       spaceAlbumsProvider(spaceId).overrideWith((_) => Stream.value(albums)),
+      if (assetService != null) assetServiceProvider.overrideWithValue(assetService),
     ],
     child: MaterialApp(home: Scaffold(body: widget)),
   );
@@ -47,6 +72,12 @@ Widget _wrap(
 // ---------------------------------------------------------------------------
 
 void main() {
+  setUpAll(() async {
+    // PresentationContext.create() calls TestUtils.init() + initializes
+    // StoreService (needed by Thumbnail.remote's RemoteImageProvider).
+    await PresentationContext.create();
+  });
+
   const spaceId = 'space-1';
 
   testWidgets('count>0 + canEdit: shows cover tiles and Link tile', (tester) async {
@@ -184,5 +215,35 @@ void main() {
     await tester.tap(find.text('See all ▸'));
     expect(called, isTrue);
   });
+
+  testWidgets(
+    'album WITH thumbnailAssetId resolving to asset shows Thumbnail cover (not placeholder icon)',
+    (tester) async {
+      final mockService = _MockAssetService();
+      final asset = _remoteAsset(id: 'thumb-1');
+      when(() => mockService.getRemoteAsset('thumb-1')).thenAnswer((_) async => asset);
+
+      final albums = [_album(id: 'a1', name: 'Hawaii', thumbnailAssetId: 'thumb-1')];
+
+      await tester.pumpWidget(
+        _wrap(
+          SpaceAlbumsShelf(
+            spaceId: spaceId,
+            canEdit: false,
+            onLinkTap: () {},
+            onAlbumTap: (_) {},
+          ),
+          spaceId: spaceId,
+          albums: albums,
+          assetService: mockService,
+        ),
+      );
+      await tester.pump(); // StreamProvider emits albums
+      await tester.pump(); // FutureBuilder resolves (mock future is immediate)
+
+      expect(find.byType(Thumbnail), findsOneWidget);
+      expect(find.byIcon(Icons.photo_album_outlined), findsNothing);
+    },
+  );
 }
 

--- a/mobile/test/providers/infrastructure/space_album_actions_test.dart
+++ b/mobile/test/providers/infrastructure/space_album_actions_test.dart
@@ -11,13 +11,11 @@ import 'package:mocktail/mocktail.dart';
 // Mocks
 // ---------------------------------------------------------------------------
 
-class MockSharedSpaceApiRepository extends Mock
-    implements SharedSpaceApiRepository {}
+class MockSharedSpaceApiRepository extends Mock implements SharedSpaceApiRepository {}
 
 class MockBackgroundSyncManager extends Mock implements BackgroundSyncManager {}
 
-class MockDriftAlbumApiRepository extends Mock
-    implements DriftAlbumApiRepository {}
+class MockDriftAlbumApiRepository extends Mock implements DriftAlbumApiRepository {}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,8 +59,9 @@ void main() {
     // Default stubs
     when(() => repo.linkAlbum(any(), any())).thenAnswer((_) async {});
     when(() => repo.unlinkAlbum(any(), any())).thenAnswer((_) async {});
-    when(() => repo.updateAlbumLink(any(), any(), showInTimeline: any(named: 'showInTimeline')))
-        .thenAnswer((_) async {});
+    when(
+      () => repo.updateAlbumLink(any(), any(), showInTimeline: any(named: 'showInTimeline')),
+    ).thenAnswer((_) async {});
     when(() => syncMgr.syncRemote()).thenAnswer((_) async => true);
 
     container = _makeContainer(repo: repo, syncMgr: syncMgr, albumApiRepo: albumApiRepo);
@@ -95,15 +94,11 @@ void main() {
     });
 
     test('on repo error: still fires syncRemote and rethrows', () async {
-      when(() => repo.linkAlbum(any(), any()))
-          .thenThrow(Exception('network error'));
+      when(() => repo.linkAlbum(any(), any())).thenThrow(Exception('network error'));
 
       final actions = container.read(spaceAlbumActionsProvider);
       // Expect an exception to be thrown
-      await expectLater(
-        () => actions.link(_spaceId, [_albumId]),
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(() => actions.link(_spaceId, [_albumId]), throwsA(isA<Exception>()));
 
       // syncRemote is NOT called when the first API call throws (fail-fast).
       // This is the chosen design: bubble the error, let the page catch it.
@@ -121,46 +116,28 @@ void main() {
     });
 
     test('on repo error: rethrows without calling syncRemote', () async {
-      when(() => repo.unlinkAlbum(any(), any()))
-          .thenThrow(Exception('network error'));
+      when(() => repo.unlinkAlbum(any(), any())).thenThrow(Exception('network error'));
 
       final actions = container.read(spaceAlbumActionsProvider);
-      await expectLater(
-        () => actions.unlink(_spaceId, _albumId),
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(() => actions.unlink(_spaceId, _albumId), throwsA(isA<Exception>()));
       verifyNever(() => syncMgr.syncRemote());
     });
   });
 
   group('SpaceAlbumActions.toggleTimeline', () {
-    test('toggleTimeline(current:true) calls updateAlbumLink(showInTimeline:false) then syncRemote',
-        () async {
+    test('toggleTimeline(current:true) calls updateAlbumLink(showInTimeline:false) then syncRemote', () async {
       final actions = container.read(spaceAlbumActionsProvider);
       await actions.toggleTimeline(_spaceId, _albumId, current: true);
 
-      verify(
-        () => repo.updateAlbumLink(
-          _spaceId,
-          _albumId,
-          showInTimeline: false,
-        ),
-      ).called(1);
+      verify(() => repo.updateAlbumLink(_spaceId, _albumId, showInTimeline: false)).called(1);
       verify(() => syncMgr.syncRemote()).called(1);
     });
 
-    test('toggleTimeline(current:false) calls updateAlbumLink(showInTimeline:true) then syncRemote',
-        () async {
+    test('toggleTimeline(current:false) calls updateAlbumLink(showInTimeline:true) then syncRemote', () async {
       final actions = container.read(spaceAlbumActionsProvider);
       await actions.toggleTimeline(_spaceId, _albumId, current: false);
 
-      verify(
-        () => repo.updateAlbumLink(
-          _spaceId,
-          _albumId,
-          showInTimeline: true,
-        ),
-      ).called(1);
+      verify(() => repo.updateAlbumLink(_spaceId, _albumId, showInTimeline: true)).called(1);
       verify(() => syncMgr.syncRemote()).called(1);
     });
 
@@ -170,18 +147,16 @@ void main() {
       ).thenThrow(Exception('network error'));
 
       final actions = container.read(spaceAlbumActionsProvider);
-      await expectLater(
-        () => actions.toggleTimeline(_spaceId, _albumId, current: true),
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(() => actions.toggleTimeline(_spaceId, _albumId, current: true), throwsA(isA<Exception>()));
       verifyNever(() => syncMgr.syncRemote());
     });
   });
 
   group('SpaceAlbumActions.addAssets', () {
     test('routes through the album API repo (server-only), nudges sync, returns added count', () async {
-      when(() => albumApiRepo.addAssets(any(), any()))
-          .thenAnswer((_) async => (added: ['a1', 'a2'], failed: <String>[]));
+      when(
+        () => albumApiRepo.addAssets(any(), any()),
+      ).thenAnswer((_) async => (added: ['a1', 'a2'], failed: <String>[]));
 
       final actions = container.read(spaceAlbumActionsProvider);
       final count = await actions.addAssets(_albumId, ['a1', 'a2']);
@@ -195,8 +170,7 @@ void main() {
     });
 
     test('returns only the count of successfully added assets', () async {
-      when(() => albumApiRepo.addAssets(any(), any()))
-          .thenAnswer((_) async => (added: ['a1'], failed: ['a2']));
+      when(() => albumApiRepo.addAssets(any(), any())).thenAnswer((_) async => (added: ['a1'], failed: ['a2']));
 
       final actions = container.read(spaceAlbumActionsProvider);
       final count = await actions.addAssets(_albumId, ['a1', 'a2']);
@@ -218,10 +192,7 @@ void main() {
       when(() => albumApiRepo.addAssets(any(), any())).thenThrow(Exception('network error'));
 
       final actions = container.read(spaceAlbumActionsProvider);
-      await expectLater(
-        () => actions.addAssets(_albumId, ['a1']),
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(() => actions.addAssets(_albumId, ['a1']), throwsA(isA<Exception>()));
       verifyNever(() => syncMgr.syncRemote());
     });
   });

--- a/mobile/test/providers/infrastructure/space_album_actions_test.dart
+++ b/mobile/test/providers/infrastructure/space_album_actions_test.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/utils/background_sync.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
+import 'package:immich_mobile/repositories/drift_album_api_repository.dart';
 import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -15,6 +16,9 @@ class MockSharedSpaceApiRepository extends Mock
 
 class MockBackgroundSyncManager extends Mock implements BackgroundSyncManager {}
 
+class MockDriftAlbumApiRepository extends Mock
+    implements DriftAlbumApiRepository {}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -26,11 +30,13 @@ const _album2 = 'album-2';
 ProviderContainer _makeContainer({
   required MockSharedSpaceApiRepository repo,
   required MockBackgroundSyncManager syncMgr,
+  required MockDriftAlbumApiRepository albumApiRepo,
 }) {
   final c = ProviderContainer(
     overrides: [
       sharedSpaceApiRepositoryProvider.overrideWithValue(repo),
       backgroundSyncProvider.overrideWithValue(syncMgr),
+      driftAlbumApiRepositoryProvider.overrideWithValue(albumApiRepo),
     ],
   );
   addTearDown(c.dispose);
@@ -44,11 +50,13 @@ ProviderContainer _makeContainer({
 void main() {
   late MockSharedSpaceApiRepository repo;
   late MockBackgroundSyncManager syncMgr;
+  late MockDriftAlbumApiRepository albumApiRepo;
   late ProviderContainer container;
 
   setUp(() {
     repo = MockSharedSpaceApiRepository();
     syncMgr = MockBackgroundSyncManager();
+    albumApiRepo = MockDriftAlbumApiRepository();
 
     // Default stubs
     when(() => repo.linkAlbum(any(), any())).thenAnswer((_) async {});
@@ -57,7 +65,7 @@ void main() {
         .thenAnswer((_) async {});
     when(() => syncMgr.syncRemote()).thenAnswer((_) async => true);
 
-    container = _makeContainer(repo: repo, syncMgr: syncMgr);
+    container = _makeContainer(repo: repo, syncMgr: syncMgr, albumApiRepo: albumApiRepo);
   });
 
   group('SpaceAlbumActions.link', () {
@@ -164,6 +172,54 @@ void main() {
       final actions = container.read(spaceAlbumActionsProvider);
       await expectLater(
         () => actions.toggleTimeline(_spaceId, _albumId, current: true),
+        throwsA(isA<Exception>()),
+      );
+      verifyNever(() => syncMgr.syncRemote());
+    });
+  });
+
+  group('SpaceAlbumActions.addAssets', () {
+    test('routes through the album API repo (server-only), nudges sync, returns added count', () async {
+      when(() => albumApiRepo.addAssets(any(), any()))
+          .thenAnswer((_) async => (added: ['a1', 'a2'], failed: <String>[]));
+
+      final actions = container.read(spaceAlbumActionsProvider);
+      final count = await actions.addAssets(_albumId, ['a1', 'a2']);
+
+      expect(count, 2);
+      verify(() => albumApiRepo.addAssets(_albumId, ['a1', 'a2'])).called(1);
+      verify(() => syncMgr.syncRemote()).called(1);
+      // The absorbed-album invariant: the server-only path never touches the
+      // local junction repository (no DriftRemoteAlbumRepository write).
+      verifyNoMoreInteractions(repo);
+    });
+
+    test('returns only the count of successfully added assets', () async {
+      when(() => albumApiRepo.addAssets(any(), any()))
+          .thenAnswer((_) async => (added: ['a1'], failed: ['a2']));
+
+      final actions = container.read(spaceAlbumActionsProvider);
+      final count = await actions.addAssets(_albumId, ['a1', 'a2']);
+
+      expect(count, 1);
+      verify(() => syncMgr.syncRemote()).called(1);
+    });
+
+    test('does nothing and no nudge when assetIds is empty', () async {
+      final actions = container.read(spaceAlbumActionsProvider);
+      final count = await actions.addAssets(_albumId, []);
+
+      expect(count, 0);
+      verifyNever(() => albumApiRepo.addAssets(any(), any()));
+      verifyNever(() => syncMgr.syncRemote());
+    });
+
+    test('on API error: rethrows without calling syncRemote', () async {
+      when(() => albumApiRepo.addAssets(any(), any())).thenThrow(Exception('network error'));
+
+      final actions = container.read(spaceAlbumActionsProvider);
+      await expectLater(
+        () => actions.addAssets(_albumId, ['a1']),
         throwsA(isA<Exception>()),
       );
       verifyNever(() => syncMgr.syncRemote());

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -14549,6 +14549,8 @@
             "required": true,
             "in": "path",
             "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
               "type": "string"
             }
           },
@@ -14604,6 +14606,8 @@
             "required": true,
             "in": "path",
             "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
               "type": "string"
             }
           },
@@ -14670,6 +14674,8 @@
             "required": true,
             "in": "path",
             "schema": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
               "type": "string"
             }
           },

--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -631,6 +631,7 @@ DELETE FROM "kysely_migrations"
    '1779000000000-AddSharedSpaceAlbumUserTables',
    '1779100000000-AddSharedSpaceAlbumCreateSideTriggers',
    '1779200000000-AddSharedSpaceAlbumDeleteSideTriggers',
+   '1779300000000-FixUserHasAlbumPathSoftDeleted',
 
    -- Post-v2.7.5 upstream migrations pulled in by rebase. Paired with the
    -- schema rollbacks in step 7 above.

--- a/server/src/controllers/shared-space.controller.ts
+++ b/server/src/controllers/shared-space.controller.ts
@@ -37,6 +37,7 @@ import {
   SharedSpaceActivityQueryDto,
   SharedSpaceActivityResponseDto,
   SharedSpaceAlbumLinkUpdateDto,
+  SharedSpaceAlbumParamDto,
   SharedSpaceAssetAddDto,
   SharedSpaceAssetRemoveDto,
   SharedSpaceCreateDto,
@@ -606,7 +607,7 @@ export class SharedSpaceController {
     description: 'Link an album so its photos appear in the space. Requires space editor/owner and album owner/editor.',
     history: new HistoryBuilder().added('v1').beta('v1'),
   })
-  linkAlbum(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto, @Param('albumId') albumId: string): Promise<void> {
+  linkAlbum(@Auth() auth: AuthDto, @Param() { id, albumId }: SharedSpaceAlbumParamDto): Promise<void> {
     return this.service.linkAlbum(auth, id, albumId);
   }
 
@@ -619,8 +620,7 @@ export class SharedSpaceController {
   })
   updateSharedSpaceAlbum(
     @Auth() auth: AuthDto,
-    @Param() { id }: UUIDParamDto,
-    @Param('albumId') albumId: string,
+    @Param() { id, albumId }: SharedSpaceAlbumParamDto,
     @Body() dto: SharedSpaceAlbumLinkUpdateDto,
   ): Promise<void> {
     return this.service.updateAlbumLink(auth, id, albumId, dto);
@@ -634,7 +634,7 @@ export class SharedSpaceController {
     description: 'Remove an album link. Album assets will no longer appear in the space.',
     history: new HistoryBuilder().added('v1').beta('v1'),
   })
-  unlinkAlbum(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto, @Param('albumId') albumId: string): Promise<void> {
+  unlinkAlbum(@Auth() auth: AuthDto, @Param() { id, albumId }: SharedSpaceAlbumParamDto): Promise<void> {
     return this.service.unlinkAlbum(auth, id, albumId);
   }
 }

--- a/server/src/dtos/shared-space.dto.ts
+++ b/server/src/dtos/shared-space.dto.ts
@@ -133,6 +133,11 @@ const SharedSpaceAlbumLinkUpdateSchema = z
   })
   .meta({ id: 'SharedSpaceAlbumLinkUpdateDto' });
 
+const SharedSpaceAlbumParamSchema = z.object({
+  id: z.uuidv4(),
+  albumId: z.uuidv4(),
+});
+
 const SharedSpaceLinkedAlbumSchema = z
   .object({
     albumId: z.string(),
@@ -194,6 +199,7 @@ export class SharedSpaceMemberMetadataContributionDto extends createZodDto(
 ) {}
 export class SharedSpaceLibraryLinkDto extends createZodDto(SharedSpaceLibraryLinkSchema) {}
 export class SharedSpaceAlbumLinkUpdateDto extends createZodDto(SharedSpaceAlbumLinkUpdateSchema) {}
+export class SharedSpaceAlbumParamDto extends createZodDto(SharedSpaceAlbumParamSchema) {}
 export class SharedSpaceLinkedAlbumDto extends createZodDto(SharedSpaceLinkedAlbumSchema) {}
 export class SharedSpaceAssetAddDto extends createZodDto(SharedSpaceAssetAddSchema) {}
 export class SharedSpaceAssetRemoveDto extends createZodDto(SharedSpaceAssetRemoveSchema) {}

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -583,6 +583,20 @@ WITH
       AND "asset"."deletedAt" IS NULL
       AND "asset"."isOffline" = false
       AND "asset"."visibility" IN ($5, $6)
+    UNION
+    SELECT
+      "asset"."id" AS "assetId"
+    FROM
+      "shared_space_album"
+      INNER JOIN "album" ON "album"."id" = "shared_space_album"."albumId"
+      AND "album"."deletedAt" IS NULL
+      INNER JOIN "album_asset" ON "album_asset"."albumId" = "shared_space_album"."albumId"
+      INNER JOIN "asset" ON "asset"."id" = "album_asset"."assetId"
+    WHERE
+      "shared_space_album"."spaceId" = $7
+      AND "asset"."deletedAt" IS NULL
+      AND "asset"."isOffline" = false
+      AND "asset"."visibility" IN ($8, $9)
   ),
   "person_rows" AS (
     SELECT
@@ -594,11 +608,11 @@ WITH
     FROM
       "shared_space_person"
     WHERE
-      "shared_space_person"."spaceId" = $7
-      AND "shared_space_person"."name" ILIKE $8 ESCAPE '\'
+      "shared_space_person"."spaceId" = $10
+      AND "shared_space_person"."name" ILIKE $11 ESCAPE '\'
       AND (
         "shared_space_person"."name" != ''
-        OR "shared_space_person"."assetCount" >= $9
+        OR "shared_space_person"."assetCount" >= $12
       )
   ),
   "person_keys" AS (
@@ -637,8 +651,8 @@ WITH
           INNER JOIN "shared_space_person" ON "shared_space_person"."id" = "shared_space_person_face"."personId"
         WHERE
           "shared_space_person_face"."assetFaceId" = "asset_face"."id"
-          AND "shared_space_person"."spaceId" = $10
-          AND "shared_space_person"."name" ILIKE $11 ESCAPE '\'
+          AND "shared_space_person"."spaceId" = $13
+          AND "shared_space_person"."name" ILIKE $14 ESCAPE '\'
       )
   )
 SELECT
@@ -673,6 +687,20 @@ WITH
       AND "asset"."deletedAt" IS NULL
       AND "asset"."isOffline" = false
       AND "asset"."visibility" IN ($5, $6)
+    UNION
+    SELECT
+      "asset"."id" AS "assetId"
+    FROM
+      "shared_space_album"
+      INNER JOIN "album" ON "album"."id" = "shared_space_album"."albumId"
+      AND "album"."deletedAt" IS NULL
+      INNER JOIN "album_asset" ON "album_asset"."albumId" = "shared_space_album"."albumId"
+      INNER JOIN "asset" ON "asset"."id" = "album_asset"."assetId"
+    WHERE
+      "shared_space_album"."spaceId" = $7
+      AND "asset"."deletedAt" IS NULL
+      AND "asset"."isOffline" = false
+      AND "asset"."visibility" IN ($8, $9)
   ),
   "detected_faces" AS (
     SELECT DISTINCT
@@ -694,10 +722,10 @@ WITH
       COALESCE(
         BOOL_OR(
           "shared_space_person"."id" IS NOT NULL
-          AND "shared_space_person"."name" ILIKE $7 ESCAPE '\'
+          AND "shared_space_person"."name" ILIKE $10 ESCAPE '\'
           AND (
             "shared_space_person"."name" != ''
-            OR "shared_space_person"."assetCount" >= $8
+            OR "shared_space_person"."assetCount" >= $11
           )
         ),
         false
@@ -705,10 +733,10 @@ WITH
       COALESCE(
         BOOL_OR(
           "shared_space_person"."isHidden" = false
-          AND "shared_space_person"."name" ILIKE $9 ESCAPE '\'
+          AND "shared_space_person"."name" ILIKE $12 ESCAPE '\'
           AND (
             "shared_space_person"."name" != ''
-            OR "shared_space_person"."assetCount" >= $10
+            OR "shared_space_person"."assetCount" >= $13
           )
         ),
         false
@@ -716,10 +744,10 @@ WITH
       COALESCE(
         BOOL_OR(
           "shared_space_person"."isHidden" = true
-          AND "shared_space_person"."name" ILIKE $11 ESCAPE '\'
+          AND "shared_space_person"."name" ILIKE $14 ESCAPE '\'
           AND (
             "shared_space_person"."name" != ''
-            OR "shared_space_person"."assetCount" >= $12
+            OR "shared_space_person"."assetCount" >= $15
           )
         ),
         false
@@ -728,7 +756,7 @@ WITH
       "detected_faces"
       LEFT JOIN "shared_space_person_face" ON "shared_space_person_face"."assetFaceId" = "detected_faces"."assetFaceId"
       LEFT JOIN "shared_space_person" ON "shared_space_person"."id" = "shared_space_person_face"."personId"
-      AND "shared_space_person"."spaceId" = $13
+      AND "shared_space_person"."spaceId" = $16
     GROUP BY
       "detected_faces"."assetFaceId"
   ),
@@ -752,10 +780,10 @@ WITH
       "detected_faces"
       INNER JOIN "shared_space_person_face" ON "shared_space_person_face"."assetFaceId" = "detected_faces"."assetFaceId"
       INNER JOIN "shared_space_person" ON "shared_space_person"."id" = "shared_space_person_face"."personId"
-      AND "shared_space_person"."spaceId" = $14
+      AND "shared_space_person"."spaceId" = $17
     WHERE
       true
-      AND "shared_space_person"."name" ILIKE $15 ESCAPE '\'
+      AND "shared_space_person"."name" ILIKE $18 ESCAPE '\'
   ),
   "matching_person_keys" AS (
     SELECT
@@ -829,6 +857,20 @@ WITH
       AND "asset"."deletedAt" IS NULL
       AND "asset"."isOffline" = false
       AND "asset"."visibility" IN ($7, $8)
+    UNION
+    SELECT
+      "asset"."id" AS "assetId"
+    FROM
+      "shared_space_album"
+      INNER JOIN "album" ON "album"."id" = "shared_space_album"."albumId"
+      AND "album"."deletedAt" IS NULL
+      INNER JOIN "album_asset" ON "album_asset"."albumId" = "shared_space_album"."albumId"
+      INNER JOIN "asset" ON "asset"."id" = "album_asset"."assetId"
+    WHERE
+      "shared_space_album"."spaceId" = $9
+      AND "asset"."deletedAt" IS NULL
+      AND "asset"."isOffline" = false
+      AND "asset"."visibility" IN ($10, $11)
   ),
   "selected_faces" AS (
     SELECT DISTINCT
@@ -894,6 +936,18 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
+    or exists (
+      select
+        "shared_space_album"."albumId"
+      from
+        "shared_space_album"
+        inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        and "album"."deletedAt" is null
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+      where
+        "album_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+    )
   )
 
 -- SharedSpaceRepository.getSpaceRepresentativeFaces
@@ -932,6 +986,18 @@ where
       where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
+    )
+    or exists (
+      select
+        "shared_space_album"."albumId"
+      from
+        "shared_space_album"
+        inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        and "album"."deletedAt" is null
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+      where
+        "album_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
     )
   )
 order by
@@ -1044,6 +1110,22 @@ where
   and "asset"."deletedAt" is null
   and "asset"."isOffline" = $3
   and "shared_space_library"."addedById" is not null
+select distinct
+  "shared_space_album"."addedById" as "userId"
+from
+  "shared_space_person_face"
+  inner join "asset_face" on "asset_face"."id" = "shared_space_person_face"."assetFaceId"
+  inner join "asset" on "asset"."id" = "asset_face"."assetId"
+  inner join "album_asset" on "album_asset"."assetId" = "asset"."id"
+  inner join "shared_space_album" on "shared_space_album"."albumId" = "album_asset"."albumId"
+  and "shared_space_album"."spaceId" = $1
+  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+  and "album"."deletedAt" is null
+where
+  "shared_space_person_face"."personId" = $2
+  and "asset"."deletedAt" is null
+  and "asset"."isOffline" = $3
+  and "shared_space_album"."addedById" is not null
 
 -- SharedSpaceRepository.getSpaceAssetAdder
 select
@@ -1119,6 +1201,18 @@ where
       where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = $3
+    )
+    or exists (
+      select
+        "shared_space_album"."albumId"
+      from
+        "shared_space_album"
+        inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        and "album"."deletedAt" is null
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+      where
+        "album_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_album"."spaceId" = $4
     )
   )
   and "person"."identityId" is not null
@@ -1217,6 +1311,18 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
+    or exists (
+      select
+        "shared_space_album"."albumId"
+      from
+        "shared_space_album"
+        inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        and "album"."deletedAt" is null
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+      where
+        "album_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+    )
   )
 
 -- SharedSpaceRepository.getFirstValidRepresentativeFaceForPerson
@@ -1252,6 +1358,18 @@ where
       where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
+    )
+    or exists (
+      select
+        "shared_space_album"."albumId"
+      from
+        "shared_space_album"
+        inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        and "album"."deletedAt" is null
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+      where
+        "album_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
     )
   )
 order by
@@ -1650,6 +1768,8 @@ from
       "asset"."id"
     from
       "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+      and "album"."deletedAt" is null
       inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       inner join "asset" on "asset"."id" = "album_asset"."assetId"
     where
@@ -1806,12 +1926,25 @@ from
       "shared_space_album"."spaceId"
     from
       "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+      and "album"."deletedAt" is null
       inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       inner join "shared_space" on "shared_space"."id" = "shared_space_album"."spaceId"
     where
       "album_asset"."assetId" = $5
       and "shared_space"."faceRecognitionEnabled" = $6
   ) as "combined"
+
+-- SharedSpaceRepository.getSpacePersonsForAsset
+select distinct
+  "shared_space_person"."spaceId",
+  "shared_space_person_face"."personId"
+from
+  "shared_space_person_face"
+  inner join "asset_face" on "asset_face"."id" = "shared_space_person_face"."assetFaceId"
+  inner join "shared_space_person" on "shared_space_person"."id" = "shared_space_person_face"."personId"
+where
+  "asset_face"."assetId" = $1
 
 -- SharedSpaceRepository.isPersonFaceAssigned
 select

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -2072,8 +2072,32 @@ from
   "shared_space_album_user"
 where
   "userId" = $1
-  and "createId" >= $2
-  and "createId" < $3
+  and "albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $2
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $3
+      )
+  )
+  and "createId" >= $4
+  and "createId" < $5
 order by
   "createId" asc
 
@@ -2276,6 +2300,30 @@ where
   "album_asset"."updateId" < $1
   and "album_asset"."updateId" > $2
   and "shared_space_album_user"."userId" = $3
+  and "album_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $4
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $5
+      )
+  )
 order by
   "album_asset"."updateId" asc
 
@@ -2308,11 +2356,13 @@ select
 from
   "album_asset" as "album_asset"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
+  inner join "album" on "album"."id" = "album_asset"."albumId"
 where
   "album_asset"."updateId" < $3
   and "album_asset"."updateId" <= $4
   and "album_asset"."updateId" >= $5
   and "album_asset"."albumId" = $6
+  and "album"."deletedAt" is null
 order by
   "album_asset"."updateId" asc
 
@@ -2351,6 +2401,30 @@ where
   and "asset"."updateId" > $4
   and "album_asset"."updateId" <= $5
   and "shared_space_album_user"."userId" = $6
+  and "album_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $7
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $8
+      )
+  )
 order by
   "asset"."updateId" asc
 
@@ -2388,6 +2462,30 @@ where
   "album_asset"."updateId" < $3
   and "album_asset"."updateId" > $4
   and "shared_space_album_user"."userId" = $5
+  and "album_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $6
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $7
+      )
+  )
 order by
   "album_asset"."updateId" asc
 
@@ -2422,11 +2520,13 @@ select
 from
   "album_asset" as "album_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "album_asset"."assetId"
+  inner join "album" on "album"."id" = "album_asset"."albumId"
 where
   "album_asset"."updateId" < $1
   and "album_asset"."updateId" <= $2
   and "album_asset"."updateId" >= $3
   and "album_asset"."albumId" = $4
+  and "album"."deletedAt" is null
 order by
   "album_asset"."updateId" asc
 
@@ -2467,6 +2567,30 @@ where
   and "asset_exif"."updateId" > $2
   and "album_asset"."updateId" <= $3
   and "shared_space_album_user"."userId" = $4
+  and "album_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $5
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $6
+      )
+  )
 order by
   "asset_exif"."updateId" asc
 
@@ -2506,5 +2630,29 @@ where
   "album_asset"."updateId" < $1
   and "album_asset"."updateId" > $2
   and "shared_space_album_user"."userId" = $3
+  and "album_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $4
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $5
+      )
+  )
 order by
   "album_asset"."updateId" asc

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -51,7 +51,7 @@ type EventMap = {
   AssetHide: [{ assetId: string; userId: string }];
   AssetShow: [{ assetId: string; userId: string }];
   AssetTrash: [{ assetId: string; userId: string }];
-  AssetDelete: [{ assetId: string; userId: string }];
+  AssetDelete: [{ assetId: string; userId: string; affectedSpacePersons?: { spaceId: string; personId: string }[] }];
   AssetMetadataExtracted: [{ assetId: string; userId: string; source?: JobSource }];
 
   // asset bulk events

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -856,6 +856,17 @@ export class SharedSpaceRepository {
                       .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
                       .where('shared_space_library.spaceId', '=', spaceId),
                   ),
+                  spaceEb.exists(
+                    spaceEb
+                      .selectFrom('shared_space_album')
+                      .innerJoin('album', (j) =>
+                        j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+                      )
+                      .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+                      .select('shared_space_album.albumId')
+                      .whereRef('album_asset.assetId', '=', 'asset.id')
+                      .where('shared_space_album.spaceId', '=', spaceId),
+                  ),
                 ]),
               )
               .$if(!!options.takenAfter, (qb2) => qb2.where('asset.fileCreatedAt', '>=', options.takenAfter!))
@@ -976,6 +987,20 @@ export class SharedSpaceRepository {
           AND ${visibilityFilter}
           ${takenAfterFilter}
           ${takenBeforeFilter}
+        UNION
+        SELECT "asset"."id" AS "assetId"
+        FROM "shared_space_album"
+        INNER JOIN "album"
+          ON "album"."id" = "shared_space_album"."albumId"
+          AND "album"."deletedAt" IS NULL
+        INNER JOIN "album_asset" ON "album_asset"."albumId" = "shared_space_album"."albumId"
+        INNER JOIN "asset" ON "asset"."id" = "album_asset"."assetId"
+        WHERE "shared_space_album"."spaceId" = ${spaceId}
+          AND "asset"."deletedAt" IS NULL
+          AND "asset"."isOffline" = false
+          AND ${visibilityFilter}
+          ${takenAfterFilter}
+          ${takenBeforeFilter}
       ),
       "person_rows" AS (
         SELECT
@@ -1076,6 +1101,20 @@ export class SharedSpaceRepository {
         FROM "shared_space_library"
         INNER JOIN "asset" ON "asset"."libraryId" = "shared_space_library"."libraryId"
         WHERE "shared_space_library"."spaceId" = ${spaceId}
+          AND "asset"."deletedAt" IS NULL
+          AND "asset"."isOffline" = false
+          AND ${visibilityFilter}
+          ${takenAfterFilter}
+          ${takenBeforeFilter}
+        UNION
+        SELECT "asset"."id" AS "assetId"
+        FROM "shared_space_album"
+        INNER JOIN "album"
+          ON "album"."id" = "shared_space_album"."albumId"
+          AND "album"."deletedAt" IS NULL
+        INNER JOIN "album_asset" ON "album_asset"."albumId" = "shared_space_album"."albumId"
+        INNER JOIN "asset" ON "asset"."id" = "album_asset"."assetId"
+        WHERE "shared_space_album"."spaceId" = ${spaceId}
           AND "asset"."deletedAt" IS NULL
           AND "asset"."isOffline" = false
           AND ${visibilityFilter}
@@ -1201,6 +1240,18 @@ export class SharedSpaceRepository {
           AND "asset"."deletedAt" IS NULL
           AND "asset"."isOffline" = false
           AND "asset"."visibility" IN (${sql.join(visibleSpaceAssetVisibilities)})
+        UNION
+        SELECT "asset"."id" AS "assetId"
+        FROM "shared_space_album"
+        INNER JOIN "album"
+          ON "album"."id" = "shared_space_album"."albumId"
+          AND "album"."deletedAt" IS NULL
+        INNER JOIN "album_asset" ON "album_asset"."albumId" = "shared_space_album"."albumId"
+        INNER JOIN "asset" ON "asset"."id" = "album_asset"."assetId"
+        WHERE "shared_space_album"."spaceId" = ${spaceId}
+          AND "asset"."deletedAt" IS NULL
+          AND "asset"."isOffline" = false
+          AND "asset"."visibility" IN (${sql.join(visibleSpaceAssetVisibilities)})
       ),
       "selected_faces" AS (
         SELECT DISTINCT
@@ -1269,6 +1320,17 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
           ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
+              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+              .select('shared_space_album.albumId')
+              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
+              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
+          ),
         ]),
       )
       .executeTakeFirst();
@@ -1305,6 +1367,17 @@ export class SharedSpaceRepository {
               .select('shared_space_library.libraryId')
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
+              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+              .select('shared_space_album.albumId')
+              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
+              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
           ),
         ]),
       )
@@ -1610,6 +1683,17 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .where('shared_space_library.spaceId', '=', spaceId),
           ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
+              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+              .select('shared_space_album.albumId')
+              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
+              .where('shared_space_album.spaceId', '=', spaceId),
+          ),
         ]),
       )
       .where('person.identityId', 'is not', null)
@@ -1806,6 +1890,17 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
           ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
+              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+              .select('shared_space_album.albumId')
+              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
+              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
+          ),
         ]),
       )
       .executeTakeFirst();
@@ -1844,6 +1939,17 @@ export class SharedSpaceRepository {
               .select('shared_space_library.libraryId')
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
+              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+              .select('shared_space_album.albumId')
+              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
+              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
           ),
         ]),
       )

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2427,6 +2427,9 @@ export class SharedSpaceRepository {
           .union(
             this.db
               .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
               .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
               .innerJoin('asset', 'asset.id', 'album_asset.assetId')
               .select('asset.id')
@@ -2582,6 +2585,9 @@ export class SharedSpaceRepository {
           .union(
             this.db
               .selectFrom('shared_space_album')
+              .innerJoin('album', (j) =>
+                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
               .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
               .innerJoin('shared_space', 'shared_space.id', 'shared_space_album.spaceId')
               .select('shared_space_album.spaceId')

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1596,7 +1596,24 @@ export class SharedSpaceRepository {
       .where('shared_space_library.addedById', 'is not', null)
       .execute();
 
-    return [...new Set([...directRows, ...libraryRows].flatMap((row) => (row.userId ? [row.userId] : [])))];
+    const albumRows = await this.db
+      .selectFrom('shared_space_person_face')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+      .innerJoin('album_asset', 'album_asset.assetId', 'asset.id')
+      .innerJoin('shared_space_album', (join) =>
+        join.onRef('shared_space_album.albumId', '=', 'album_asset.albumId').on('shared_space_album.spaceId', '=', spaceId),
+      )
+      .innerJoin('album', (j) => j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null))
+      .select('shared_space_album.addedById as userId')
+      .distinct()
+      .where('shared_space_person_face.personId', '=', personId)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.isOffline', '=', false)
+      .where('shared_space_album.addedById', 'is not', null)
+      .execute();
+
+    return [...new Set([...directRows, ...libraryRows, ...albumRows].flatMap((row) => (row.userId ? [row.userId] : [])))];
   }
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2617,6 +2617,23 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  /**
+   * Returns the (spaceId, personId) pairs for every shared-space person face that references
+   * an asset_face belonging to the given asset.  Must be called BEFORE the asset row is deleted
+   * (i.e. before the asset → asset_face → shared_space_person_face cascade runs).
+   */
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getSpacePersonsForAsset(assetId: string) {
+    return this.db
+      .selectFrom('shared_space_person_face')
+      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .innerJoin('shared_space_person', 'shared_space_person.id', 'shared_space_person_face.personId')
+      .select(['shared_space_person.spaceId', 'shared_space_person_face.personId'])
+      .distinct()
+      .where('asset_face.assetId', '=', assetId)
+      .execute();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   async isPersonFaceAssigned(assetFaceId: string, spaceId: string): Promise<boolean> {
     const result = await this.db

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1602,9 +1602,13 @@ export class SharedSpaceRepository {
       .innerJoin('asset', 'asset.id', 'asset_face.assetId')
       .innerJoin('album_asset', 'album_asset.assetId', 'asset.id')
       .innerJoin('shared_space_album', (join) =>
-        join.onRef('shared_space_album.albumId', '=', 'album_asset.albumId').on('shared_space_album.spaceId', '=', spaceId),
+        join
+          .onRef('shared_space_album.albumId', '=', 'album_asset.albumId')
+          .on('shared_space_album.spaceId', '=', spaceId),
       )
-      .innerJoin('album', (j) => j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null))
+      .innerJoin('album', (j) =>
+        j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+      )
       .select('shared_space_album.addedById as userId')
       .distinct()
       .where('shared_space_person_face.personId', '=', personId)
@@ -1613,7 +1617,9 @@ export class SharedSpaceRepository {
       .where('shared_space_album.addedById', 'is not', null)
       .execute();
 
-    return [...new Set([...directRows, ...libraryRows, ...albumRows].flatMap((row) => (row.userId ? [row.userId] : [])))];
+    return [
+      ...new Set([...directRows, ...libraryRows, ...albumRows].flatMap((row) => (row.userId ? [row.userId] : []))),
+    ];
   }
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1369,6 +1369,7 @@ export class SharedSpaceAlbumSync extends BaseSync {
       .selectFrom('shared_space_album_user')
       .select(['albumId as id', 'createId'])
       .where('userId', '=', userId)
+      .where('albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .$if(!!afterCreateId, (qb) => qb.where('createId', '>=', afterCreateId!))
       .where('createId', '<', nowId)
       .orderBy('createId', 'asc')
@@ -1492,6 +1493,7 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
       .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .stream();
   }
 }
@@ -1508,6 +1510,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
   getBackfill(options: SyncBackfillOptions, albumId: string, userId: string) {
     return this.backfillQuery('album_asset', options)
       .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .innerJoin('album', 'album.id', 'album_asset.albumId')
       .select(columns.syncAlbumAsset)
       .select((eb) =>
         eb
@@ -1520,6 +1523,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       )
       .select('album_asset.updateId')
       .where('album_asset.albumId', '=', albumId)
+      .where('album.deletedAt', 'is', null)
       .stream();
   }
 
@@ -1542,6 +1546,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .where('album_asset.updateId', '<=', albumToAssetAck.updateId) // Ensure we only send updates for assets that the client already knows about
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .stream();
   }
 
@@ -1563,6 +1568,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       )
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .stream();
   }
 }
@@ -1575,9 +1581,11 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
   getBackfill(options: SyncBackfillOptions, albumId: string) {
     return this.backfillQuery('album_asset', options)
       .innerJoin('asset_exif', 'asset_exif.assetId', 'album_asset.assetId')
+      .innerJoin('album', 'album.id', 'album_asset.albumId')
       .select(columns.syncAssetExif)
       .select('album_asset.updateId')
       .where('album_asset.albumId', '=', albumId)
+      .where('album.deletedAt', 'is', null)
       .stream();
   }
 
@@ -1591,6 +1599,7 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .where('album_asset.updateId', '<=', albumToAssetAck.updateId) // Ensure we only send exif updates for assets that the client already knows about
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .stream();
   }
 
@@ -1603,6 +1612,7 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .select(columns.syncAssetExif)
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .stream();
   }
 }

--- a/server/src/schema/functions.ts
+++ b/server/src/schema/functions.ts
@@ -536,17 +536,21 @@ export const user_has_album_path = registerFunction({
         SELECT 1
         FROM shared_space_album ssa2
         INNER JOIN shared_space_member ssm2 ON ssm2."spaceId" = ssa2."spaceId"
+        INNER JOIN album a2 ON a2."id" = ssa2."albumId"
         WHERE ssa2."albumId" = target_album_id
           AND ssm2."userId" = target_user_id
           AND ssa2."spaceId" <> exclude_space_id
+          AND a2."deletedAt" IS NULL
       )
       OR EXISTS (
         SELECT 1
         FROM shared_space_album ssa3
         INNER JOIN shared_space ss3 ON ss3."id" = ssa3."spaceId"
+        INNER JOIN album a3 ON a3."id" = ssa3."albumId"
         WHERE ssa3."albumId" = target_album_id
           AND ss3."createdById" = target_user_id
           AND ssa3."spaceId" <> exclude_space_id
+          AND a3."deletedAt" IS NULL
       );
 `,
 });

--- a/server/src/schema/migrations-gallery/1779300000000-FixUserHasAlbumPathSoftDeleted.ts
+++ b/server/src/schema/migrations-gallery/1779300000000-FixUserHasAlbumPathSoftDeleted.ts
@@ -1,0 +1,91 @@
+import { Kysely, sql } from 'kysely';
+
+// RBAC F2: fix user_has_album_path() to exclude soft-deleted albums from
+// branches 2 (member in another space) and 3 (creator of another space).
+//
+// Previously, branches 2 and 3 joined shared_space_album without checking
+// album.deletedAt, so a soft-deleted album still linked to another space was
+// treated as a valid access path. This caused under-revocation: grants were
+// retained even after the album was soft-deleted.
+//
+// Fix: add INNER JOIN album + AND a."deletedAt" IS NULL to branches 2 and 3,
+// matching the existing check already present in branch 1 (album_user).
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE OR REPLACE FUNCTION user_has_album_path(target_album_id uuid, target_user_id uuid, exclude_space_id uuid)
+  RETURNS boolean
+  STABLE LANGUAGE SQL
+  AS $$
+    SELECT
+      EXISTS (
+        SELECT 1 FROM album_user au
+        INNER JOIN album a ON a."id" = au."albumId"
+        WHERE au."albumId" = target_album_id
+          AND au."userId" = target_user_id
+          AND a."deletedAt" IS NULL
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM shared_space_album ssa2
+        INNER JOIN shared_space_member ssm2 ON ssm2."spaceId" = ssa2."spaceId"
+        INNER JOIN album a2 ON a2."id" = ssa2."albumId"
+        WHERE ssa2."albumId" = target_album_id
+          AND ssm2."userId" = target_user_id
+          AND ssa2."spaceId" <> exclude_space_id
+          AND a2."deletedAt" IS NULL
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM shared_space_album ssa3
+        INNER JOIN shared_space ss3 ON ss3."id" = ssa3."spaceId"
+        INNER JOIN album a3 ON a3."id" = ssa3."albumId"
+        WHERE ssa3."albumId" = target_album_id
+          AND ss3."createdById" = target_user_id
+          AND ssa3."spaceId" <> exclude_space_id
+          AND a3."deletedAt" IS NULL
+      );
+  $$;`.execute(db);
+
+  await sql`UPDATE "migration_overrides"
+  SET "value" = '{"type":"function","name":"user_has_album_path","sql":"CREATE OR REPLACE FUNCTION user_has_album_path(target_album_id uuid, target_user_id uuid, exclude_space_id uuid)\\n  RETURNS boolean\\n  STABLE LANGUAGE SQL\\n  AS $$\\n    SELECT\\n      EXISTS (\\n        SELECT 1 FROM album_user au\\n        INNER JOIN album a ON a.\\"id\\" = au.\\"albumId\\"\\n        WHERE au.\\"albumId\\" = target_album_id\\n          AND au.\\"userId\\" = target_user_id\\n          AND a.\\"deletedAt\\" IS NULL\\n      )\\n      OR EXISTS (\\n        SELECT 1\\n        FROM shared_space_album ssa2\\n        INNER JOIN shared_space_member ssm2 ON ssm2.\\"spaceId\\" = ssa2.\\"spaceId\\"\\n        INNER JOIN album a2 ON a2.\\"id\\" = ssa2.\\"albumId\\"\\n        WHERE ssa2.\\"albumId\\" = target_album_id\\n          AND ssm2.\\"userId\\" = target_user_id\\n          AND ssa2.\\"spaceId\\" <> exclude_space_id\\n          AND a2.\\"deletedAt\\" IS NULL\\n      )\\n      OR EXISTS (\\n        SELECT 1\\n        FROM shared_space_album ssa3\\n        INNER JOIN shared_space ss3 ON ss3.\\"id\\" = ssa3.\\"spaceId\\"\\n        INNER JOIN album a3 ON a3.\\"id\\" = ssa3.\\"albumId\\"\\n        WHERE ssa3.\\"albumId\\" = target_album_id\\n          AND ss3.\\"createdById\\" = target_user_id\\n          AND ssa3.\\"spaceId\\" <> exclude_space_id\\n          AND a3.\\"deletedAt\\" IS NULL\\n      );\\n  $$;"}'::jsonb
+  WHERE "name" = 'function_user_has_album_path';`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  // Restore the previous (buggy) definition that lacked the deletedAt checks on
+  // branches 2 and 3. Mirrors the body originally installed by migration
+  // 1779100000000-AddSharedSpaceAlbumCreateSideTriggers.ts.
+  await sql`CREATE OR REPLACE FUNCTION user_has_album_path(target_album_id uuid, target_user_id uuid, exclude_space_id uuid)
+  RETURNS boolean
+  STABLE LANGUAGE SQL
+  AS $$
+    SELECT
+      EXISTS (
+        SELECT 1 FROM album_user au
+        INNER JOIN album a ON a."id" = au."albumId"
+        WHERE au."albumId" = target_album_id
+          AND au."userId" = target_user_id
+          AND a."deletedAt" IS NULL
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM shared_space_album ssa2
+        INNER JOIN shared_space_member ssm2 ON ssm2."spaceId" = ssa2."spaceId"
+        WHERE ssa2."albumId" = target_album_id
+          AND ssm2."userId" = target_user_id
+          AND ssa2."spaceId" <> exclude_space_id
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM shared_space_album ssa3
+        INNER JOIN shared_space ss3 ON ss3."id" = ssa3."spaceId"
+        WHERE ssa3."albumId" = target_album_id
+          AND ss3."createdById" = target_user_id
+          AND ssa3."spaceId" <> exclude_space_id
+      );
+  $$;`.execute(db);
+
+  await sql`UPDATE "migration_overrides"
+  SET "value" = '{"type":"function","name":"user_has_album_path","sql":"CREATE OR REPLACE FUNCTION user_has_album_path(target_album_id uuid, target_user_id uuid, exclude_space_id uuid)\\n  RETURNS boolean\\n  STABLE LANGUAGE SQL\\n  AS $$\\n    SELECT\\n      EXISTS (\\n        SELECT 1 FROM album_user au\\n        INNER JOIN album a ON a.\\"id\\" = au.\\"albumId\\"\\n        WHERE au.\\"albumId\\" = target_album_id\\n          AND au.\\"userId\\" = target_user_id\\n          AND a.\\"deletedAt\\" IS NULL\\n      )\\n      OR EXISTS (\\n        SELECT 1\\n        FROM shared_space_album ssa2\\n        INNER JOIN shared_space_member ssm2 ON ssm2.\\"spaceId\\" = ssa2.\\"spaceId\\"\\n        WHERE ssa2.\\"albumId\\" = target_album_id\\n          AND ssm2.\\"userId\\" = target_user_id\\n          AND ssa2.\\"spaceId\\" <> exclude_space_id\\n      )\\n      OR EXISTS (\\n        SELECT 1\\n        FROM shared_space_album ssa3\\n        INNER JOIN shared_space ss3 ON ss3.\\"id\\" = ssa3.\\"spaceId\\"\\n        WHERE ssa3.\\"albumId\\" = target_album_id\\n          AND ss3.\\"createdById\\" = target_user_id\\n          AND ssa3.\\"spaceId\\" <> exclude_space_id\\n      );\\n  $$;"}'::jsonb
+  WHERE "name" = 'function_user_has_album_path';`.execute(db);
+}

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -37,6 +37,10 @@ describe(AssetService.name, () => {
 
   beforeEach(() => {
     ({ sut, mocks } = newTestService(AssetService));
+
+    // handleAssetDeletion now captures affected shared-space people before delete
+    // (faces F5); default to empty so unrelated deletion tests don't break.
+    mocks.sharedSpace.getSpacePersonsForAsset.mockResolvedValue([]);
   });
 
   describe('getStatistics', () => {
@@ -1315,6 +1319,7 @@ describe(AssetService.name, () => {
       expect(mocks.event.emit).toHaveBeenCalledWith('AssetDelete', {
         assetId: asset.id,
         userId: asset.ownerId,
+        affectedSpacePersons: [],
       });
     });
   });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -477,12 +477,17 @@ export class AssetService extends BaseService {
       }
     }
 
+    // Capture affected shared-space (spaceId, personId) pairs BEFORE the asset row and its
+    // DB cascade (asset_face → shared_space_person_face) are deleted.  The onAssetDelete
+    // handler in SharedSpaceService receives this data and recounts/cleans up after the delete.
+    const affectedSpacePersons = await this.sharedSpaceRepository.getSpacePersonsForAsset(id);
+
     await this.assetRepository.remove(asset);
     if (!asset.libraryId) {
       await this.userRepository.updateUsage(asset.ownerId, -(asset.exifInfo?.fileSizeInByte || 0));
     }
 
-    await this.eventRepository.emit('AssetDelete', { assetId: id, userId: asset.ownerId });
+    await this.eventRepository.emit('AssetDelete', { assetId: id, userId: asset.ownerId, affectedSpacePersons });
 
     // delete the motion if it is not used by another asset
     if (asset.livePhotoVideoId) {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -10171,6 +10171,44 @@ describe(SharedSpaceService.name, () => {
     });
   });
 
+  describe('onAssetDelete', () => {
+    it('recounts affected persons and deletes orphans for each impacted space', async () => {
+      const spaceA = newUuid();
+      const spaceB = newUuid();
+      const p1 = newUuid();
+      const p2 = newUuid();
+      mocks.sharedSpace.recountPersons.mockResolvedValue(void 0);
+      mocks.sharedSpace.deleteOrphanedPersons.mockResolvedValue();
+
+      await sut.onAssetDelete({
+        assetId: newUuid(),
+        userId: newUuid(),
+        affectedSpacePersons: [
+          { spaceId: spaceA, personId: p1 },
+          { spaceId: spaceA, personId: p2 },
+          { spaceId: spaceB, personId: p1 },
+        ],
+      });
+
+      expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([p1, p2]);
+      expect(mocks.sharedSpace.recountPersons).toHaveBeenCalledWith([p1]);
+      expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceA);
+      expect(mocks.sharedSpace.deleteOrphanedPersons).toHaveBeenCalledWith(spaceB);
+    });
+
+    it('does nothing when affectedSpacePersons is an empty array', async () => {
+      await sut.onAssetDelete({ assetId: newUuid(), userId: newUuid(), affectedSpacePersons: [] });
+      expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteOrphanedPersons).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when affectedSpacePersons is absent from the payload', async () => {
+      await sut.onAssetDelete({ assetId: newUuid(), userId: newUuid() });
+      expect(mocks.sharedSpace.recountPersons).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.deleteOrphanedPersons).not.toHaveBeenCalled();
+    });
+  });
+
   describe('activity logging', () => {
     it('linkAlbum logs an album_link activity for a new link', async () => {
       const auth = factory.auth({ user: { isAdmin: false } });

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -2801,6 +2801,36 @@ export class SharedSpaceService extends BaseService {
     }
   }
 
+  // Emit-timing note: AssetDelete fires AFTER the asset row and its DB cascade
+  // (asset → asset_face → shared_space_person_face) have already run.  By the time this
+  // handler executes, those rows are gone.  The affected (spaceId, personId) pairs are
+  // therefore captured at the emit site in asset.service.ts BEFORE deletion via
+  // sharedSpaceRepository.getSpacePersonsForAsset() and forwarded in the payload.
+  @OnEvent({ name: 'AssetDelete' })
+  async onAssetDelete({ assetId, affectedSpacePersons }: ArgOf<'AssetDelete'>): Promise<void> {
+    if (!affectedSpacePersons || affectedSpacePersons.length === 0) {
+      return;
+    }
+    try {
+      // Group personIds by spaceId: one recount + orphan-cleanup pass per space.
+      const spacePersonMap = new Map<string, string[]>();
+      for (const { spaceId, personId } of affectedSpacePersons) {
+        let ids = spacePersonMap.get(spaceId);
+        if (!ids) {
+          ids = [];
+          spacePersonMap.set(spaceId, ids);
+        }
+        ids.push(personId);
+      }
+      for (const [spaceId, personIds] of spacePersonMap) {
+        await this.sharedSpaceRepository.recountPersons(personIds);
+        await this.sharedSpaceRepository.deleteOrphanedPersons(spaceId);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to sync space people after deleting asset ${assetId}: ${error}`);
+    }
+  }
+
   @OnEvent({ name: 'AlbumDelete' })
   async onAlbumDelete({ albumId }: ArgOf<'AlbumDelete'>): Promise<void> {
     try {

--- a/server/src/services/user-admin.service.spec.ts
+++ b/server/src/services/user-admin.service.spec.ts
@@ -20,6 +20,11 @@ describe(UserAdminService.name, () => {
     mocks.user.get.mockImplementation((userId) =>
       Promise.resolve([userStub.admin, userStub.user1].find((user) => user.id === userId) ?? undefined),
     );
+
+    // delete()/restore() now enumerate the user's albums and re-project space
+    // faces (faces F3b); default these to empty so unrelated tests don't break.
+    mocks.album.getAllIds.mockResolvedValue([]);
+    mocks.sharedSpace.getSpacesLinkedToAlbum.mockResolvedValue([]);
   });
 
   describe('search', () => {

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -102,7 +102,21 @@ export class UserAdminService extends BaseService {
       throw new ForbiddenException('Cannot delete your own account');
     }
 
+    // Enumerate owned album ids BEFORE soft-deleting them: getAllIds filters out
+    // soft-deleted albums, so capturing them after softDeleteAll would return nothing.
+    const ownedAlbumIds = await this.albumRepository.getAllIds(id, { isOwned: true });
+
     await this.albumRepository.softDeleteAll(id);
+
+    // Eagerly clean the space-face projection for each soft-deleted owned album so
+    // album-sourced space people disappear immediately (and getSpacePersonThumbnail stops
+    // serving trashed crops). Reuses onAlbumDelete — the only AlbumDelete handler — which
+    // reads album_asset directly and so still works after the album row is soft-deleted.
+    // Runs for both force and non-force, since softDeleteAll always runs; on force the later
+    // UserDelete hard-delete is a harmless no-op because the faces are already cleaned.
+    for (const albumId of ownedAlbumIds) {
+      await this.eventRepository.emit('AlbumDelete', { albumId });
+    }
 
     const status = force ? UserStatus.Removing : UserStatus.Deleted;
     const user = await this.userRepository.update(id, { status, deletedAt: new Date() });
@@ -119,6 +133,26 @@ export class UserAdminService extends BaseService {
   async restore(auth: AuthDto, id: string): Promise<UserAdminResponseDto> {
     await this.findOrFail(id, { withDeleted: true });
     await this.albumRepository.restoreAll(id);
+
+    // Re-queue face matching for every face-enabled space linked to a restored album so the
+    // album-sourced space people re-converge (mirrors addMember). Albums are non-deleted again
+    // after restoreAll, so getAllIds now surfaces them.
+    const restoredAlbumIds = await this.albumRepository.getAllIds(id, { isOwned: true });
+    let anyFaceEnabledSpace = false;
+    for (const albumId of restoredAlbumIds) {
+      const spaces = await this.sharedSpaceRepository.getSpacesLinkedToAlbum(albumId);
+      for (const space of spaces) {
+        if (!space.faceRecognitionEnabled) {
+          continue;
+        }
+        await this.jobRepository.queue({ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: space.spaceId } });
+        anyFaceEnabledSpace = true;
+      }
+    }
+    if (anyFaceEnabledSpace) {
+      await this.jobRepository.queue({ name: JobName.SharedSpacePersonMetadataBackfill, data: {} });
+    }
+
     const user = await this.userRepository.restore(id);
     await this.eventRepository.emit('UserRestore', user);
     return mapUserAdmin(user);

--- a/server/src/services/user.service.spec.ts
+++ b/server/src/services/user.service.spec.ts
@@ -44,6 +44,9 @@ describe(UserService.name, () => {
     mocks.user.get.mockImplementation((userId) =>
       Promise.resolve([userStub.admin, userStub.user1].find((user) => user.id === userId) ?? undefined),
     );
+    // GREEN: handleUserDelete enumerates owned albums before deleteAll; default to empty so
+    // existing tests that don't mock getAllIds don't get a non-iterable undefined.
+    mocks.album.getAllIds.mockResolvedValue([]);
   });
 
   describe('getAll', () => {
@@ -896,6 +899,35 @@ describe(UserService.name, () => {
 
       expect(mocks.storage.unlinkDir).toHaveBeenCalledTimes(5);
       expect((StorageService as any).s3Backend).toBeUndefined();
+    });
+
+    it('should emit AlbumDelete for each owned album before albumRepository.deleteAll (faces F2)', async () => {
+      const user = { id: 'user-with-albums', deletedAt: makeDeletedAt(10) } as UserAdmin;
+      const ownedAlbumIds = ['album-f2-1', 'album-f2-2'];
+
+      mocks.user.get.mockResolvedValue(user);
+      mocks.album.getAllIds.mockResolvedValue(ownedAlbumIds);
+
+      const callOrder: string[] = [];
+      mocks.event.emit.mockImplementation(((event: string) => {
+        callOrder.push(`emit:${event}`);
+      }) as any);
+      mocks.album.deleteAll.mockImplementation(() => {
+        callOrder.push('deleteAll');
+        return Promise.resolve();
+      });
+
+      await sut.handleUserDelete({ id: user.id, force: true });
+
+      // AlbumDelete must be emitted once per owned album
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumDelete', { albumId: 'album-f2-1' });
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumDelete', { albumId: 'album-f2-2' });
+
+      // All AlbumDelete emits must precede deleteAll
+      const firstAlbumDeleteIndex = callOrder.indexOf('emit:AlbumDelete');
+      const deleteAllIndex = callOrder.indexOf('deleteAll');
+      expect(firstAlbumDeleteIndex).toBeGreaterThanOrEqual(0);
+      expect(deleteAllIndex).toBeGreaterThan(firstAlbumDeleteIndex);
     });
   });
 

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -323,6 +323,14 @@ export class UserService extends BaseService {
     }
 
     this.logger.warn(`Removing user from database: ${user.id}`);
+
+    // Clean up shared-space face projections for this user's albums before the
+    // albums (and their album_asset / shared_space_album links) are hard-deleted.
+    const ownedAlbumIds = await this.albumRepository.getAllIds(user.id, { isOwned: true });
+    for (const albumId of ownedAlbumIds) {
+      await this.eventRepository.emit('AlbumDelete', { albumId });
+    }
+
     await this.albumRepository.deleteAll(user.id);
     await this.userRepository.delete(user, true);
 

--- a/server/test/medium/specs/repositories/shared-space-album.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-album.repository.spec.ts
@@ -381,3 +381,45 @@ describe('isFaceInSpace — album leg', () => {
     expect(await sut.isFaceInSpace(space.id, faceId)).toBe(false);
   });
 });
+
+describe('face-pipeline gates honor album.deletedAt (faces F3a)', () => {
+  it('isAssetInSpace and getSpaceIdsForAsset exclude a soft-deleted album', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'GateAlbum' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await sut.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+
+    // Live album: the asset resolves as in-space and the face pipeline queues the space.
+    expect(await sut.isAssetInSpace(space.id, asset.id)).toBe(true);
+    const liveSpaceIds = await sut.getSpaceIdsForAsset(asset.id);
+    expect(liveSpaceIds.map((r) => r.spaceId)).toContain(space.id);
+
+    await ctx.softDeleteAlbum(album.id);
+
+    // Soft-deleted album: both gates must stop resolving its assets (A1 invariant).
+    expect(await sut.isAssetInSpace(space.id, asset.id)).toBe(false);
+    const deletedSpaceIds = await sut.getSpaceIdsForAsset(asset.id);
+    expect(deletedSpaceIds.map((r) => r.spaceId)).not.toContain(space.id);
+  });
+
+  it('keeps an asset in-space via a surviving direct path when its album is soft-deleted', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'GateDualAlbum' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await sut.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+
+    await ctx.softDeleteAlbum(album.id);
+
+    // Direct path survives the album soft-delete.
+    expect(await sut.isAssetInSpace(space.id, asset.id)).toBe(true);
+    const spaceIds = await sut.getSpaceIdsForAsset(asset.id);
+    expect(spaceIds.map((r) => r.spaceId)).toContain(space.id);
+  });
+});

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -112,6 +112,34 @@ const createSpaceIdentityPerson = async (
   });
 };
 
+// Seed a face-enabled space with an album-only person P whose only face is on a
+// linked-album asset (not direct-added, not in any linked library).
+const seedAlbumPerson = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  sut: SharedSpaceRepository,
+  opts: { fileCreatedAt?: Date; representative?: boolean } = {},
+) => {
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+  const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'AlbumPeople' });
+  const { asset } = await ctx.newAsset({
+    ownerId: user.id,
+    visibility: AssetVisibility.Timeline,
+    ...(opts.fileCreatedAt ? { fileCreatedAt: opts.fileCreatedAt } : {}),
+  });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+  await sut.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+  const person = await sut.createPerson({
+    spaceId: space.id,
+    name: 'Album Alice',
+    representativeFaceId: opts.representative ? assetFace.id : null,
+  });
+  await sut.addPersonFaces([{ personId: person.id, assetFaceId: assetFace.id }], { skipRecount: true });
+  return { user, space, album, asset, assetFace, person };
+};
+
 describe(SharedSpaceRepository.name, () => {
   // ==========================================
   // Space CRUD
@@ -3426,6 +3454,156 @@ describe(SharedSpaceRepository.name, () => {
       await sut.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
 
       await expect(sut.getAssetCount(space.id)).resolves.toBe(1);
+    });
+  });
+
+  describe('people projection — album-linked space', () => {
+    it('getSpaceRepresentativeFaces returns album-linked faces', async () => {
+      const { ctx, sut } = setup();
+      const { space, person, assetFace } = await seedAlbumPerson(ctx, sut);
+
+      const faces = await sut.getSpaceRepresentativeFaces({
+        spaceId: space.id,
+        personId: person.id,
+        take: 50,
+        skip: 0,
+      });
+
+      expect(faces.map((f) => f.id)).toContain(assetFace.id);
+    });
+
+    it('getSpacePersonStatistics counts album-linked assets and faces', async () => {
+      const { ctx, sut } = setup();
+      const { space, person } = await seedAlbumPerson(ctx, sut);
+
+      await expect(sut.getSpacePersonStatistics(space.id, person.id)).resolves.toEqual({ assets: 1, faces: 1 });
+    });
+
+    it('countPersonsBySpaceId includes album faces in detectedFaceCount and date-filtered totals', async () => {
+      const { ctx, sut } = setup();
+      const takenAt = new Date('2024-06-15T12:00:00.000Z');
+      const { space, person } = await seedAlbumPerson(ctx, sut, { fileCreatedAt: takenAt });
+
+      const base = await sut.countPersonsBySpaceId(space.id, {});
+      expect(base.total).toBeGreaterThanOrEqual(1);
+      expect(base.detectedFaceCount).toBe(1);
+
+      const inRange = await sut.countPersonsBySpaceId(space.id, {
+        takenAfter: new Date('2024-06-01T00:00:00.000Z'),
+        takenBefore: new Date('2024-07-01T00:00:00.000Z'),
+      });
+      expect(inRange.total).toBe(1);
+
+      const outOfRange = await sut.countPersonsBySpaceId(space.id, {
+        takenAfter: new Date('2025-01-01T00:00:00.000Z'),
+        takenBefore: new Date('2025-02-01T00:00:00.000Z'),
+      });
+      expect(outOfRange.total).toBe(0);
+      expect(person.id).toBeDefined();
+    });
+
+    it('getPeopleFaceStatisticsBySpaceId includes album-linked faces', async () => {
+      const { ctx, sut } = setup();
+      const { space } = await seedAlbumPerson(ctx, sut);
+
+      const stats = await sut.getPeopleFaceStatisticsBySpaceId(space.id, {});
+      expect(stats.detectedFaceCount).toBe(1);
+      expect(stats.assignedVisibleFaceCount).toBe(1);
+    });
+
+    it('getPersonsBySpaceId lists an album-only person, honoring date filters', async () => {
+      const { ctx, sut } = setup();
+      const takenAt = new Date('2024-06-15T12:00:00.000Z');
+      const { space, person } = await seedAlbumPerson(ctx, sut, { fileCreatedAt: takenAt });
+
+      const all = await sut.getPersonsBySpaceId(space.id, {});
+      expect(all.map((p) => p.id)).toContain(person.id);
+
+      const inRange = await sut.getPersonsBySpaceId(space.id, {
+        takenAfter: new Date('2024-06-01T00:00:00.000Z'),
+        takenBefore: new Date('2024-07-01T00:00:00.000Z'),
+      });
+      expect(inRange.map((p) => p.id)).toContain(person.id);
+
+      const outOfRange = await sut.getPersonsBySpaceId(space.id, {
+        takenAfter: new Date('2025-01-01T00:00:00.000Z'),
+        takenBefore: new Date('2025-02-01T00:00:00.000Z'),
+      });
+      expect(outOfRange.map((p) => p.id)).not.toContain(person.id);
+    });
+
+    it('getSpaceRepresentativeFaceForUpdate can select an album-linked face', async () => {
+      const { ctx, sut } = setup();
+      const { space, person, assetFace } = await seedAlbumPerson(ctx, sut);
+
+      const result = await sut.getSpaceRepresentativeFaceForUpdate({
+        spaceId: space.id,
+        personId: person.id,
+        assetFaceId: assetFace.id,
+      });
+
+      expect(result?.id).toBe(assetFace.id);
+    });
+
+    it('getIdentityEvidenceForSpacePerson includes album-linked faces', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+      const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'EvidenceAlbum' });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await sut.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+
+      const identity = await ctx.database
+        .insertInto('face_identity')
+        .values({ type: 'person' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      const { result: immichPerson } = await ctx.newPerson({ ownerId: user.id, identityId: identity.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: immichPerson.id });
+      const spacePerson = await sut.createPerson({ spaceId: space.id, name: 'Album Alice', representativeFaceId: null });
+      await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+      const evidence = await sut.getIdentityEvidenceForSpacePerson(space.id, spacePerson.id);
+      expect(evidence.map((e) => e.identityId)).toContain(identity.id);
+    });
+
+    it('does not double-count a person whose asset is both album-linked and direct-added', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+      const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'MultiPath' });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await sut.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+      const q = await sut.createPerson({ spaceId: space.id, name: 'Multi Q', representativeFaceId: null });
+      await sut.addPersonFaces([{ personId: q.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+      await expect(sut.getSpacePersonStatistics(space.id, q.id)).resolves.toEqual({ assets: 1, faces: 1 });
+      const people = await sut.getPersonsBySpaceId(space.id, {});
+      expect(people.filter((p) => p.id === q.id)).toHaveLength(1);
+    });
+
+    it('hides an album-only person when the linked album is soft-deleted', async () => {
+      const { ctx, sut } = setup();
+      const takenAt = new Date('2024-06-15T12:00:00.000Z');
+      const { space, person, album } = await seedAlbumPerson(ctx, sut, { fileCreatedAt: takenAt });
+
+      await ctx.softDeleteAlbum(album.id);
+
+      await expect(sut.getSpacePersonStatistics(space.id, person.id)).resolves.toEqual({ assets: 0, faces: 0 });
+      const dated = await sut.getPersonsBySpaceId(space.id, {
+        takenAfter: new Date('2024-06-01T00:00:00.000Z'),
+        takenBefore: new Date('2024-07-01T00:00:00.000Z'),
+      });
+      expect(dated.map((p) => p.id)).not.toContain(person.id);
+      await expect(
+        sut.getSpaceRepresentativeFaces({ spaceId: space.id, personId: person.id, take: 50, skip: 0 }),
+      ).resolves.toEqual([]);
     });
   });
 });

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -3562,7 +3562,11 @@ describe(SharedSpaceRepository.name, () => {
         .executeTakeFirstOrThrow();
       const { result: immichPerson } = await ctx.newPerson({ ownerId: user.id, identityId: identity.id });
       const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: immichPerson.id });
-      const spacePerson = await sut.createPerson({ spaceId: space.id, name: 'Album Alice', representativeFaceId: null });
+      const spacePerson = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Album Alice',
+        representativeFaceId: null,
+      });
       await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
 
       const evidence = await sut.getIdentityEvidenceForSpacePerson(space.id, spacePerson.id);

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -3606,4 +3606,34 @@ describe(SharedSpaceRepository.name, () => {
       ).resolves.toEqual([]);
     });
   });
+
+  // ==========================================
+  // getSpacePersonAssetAdderIds — faces F4
+  // ==========================================
+
+  describe('getSpacePersonAssetAdderIds — album adder (faces F4)', () => {
+    it('includes the album-linker as an asset adder for an album-only space person', async () => {
+      const { ctx, sut } = setup();
+      const { user, space, person } = await seedAlbumPerson(ctx, sut);
+
+      const result = await sut.getSpacePersonAssetAdderIds(space.id, person.id);
+
+      expect(result).toContain(user.id);
+    });
+
+    it('does not surface a different space album-linker for an unrelated space person', async () => {
+      const { ctx, sut } = setup();
+      // seed two independent album-linked spaces
+      const { user: user1, space: space1, person: person1 } = await seedAlbumPerson(ctx, sut);
+      const { user: user2, space: space2, person: person2 } = await seedAlbumPerson(ctx, sut);
+
+      const result1 = await sut.getSpacePersonAssetAdderIds(space1.id, person1.id);
+      const result2 = await sut.getSpacePersonAssetAdderIds(space2.id, person2.id);
+
+      expect(result1).toContain(user1.id);
+      expect(result1).not.toContain(user2.id);
+      expect(result2).toContain(user2.id);
+      expect(result2).not.toContain(user1.id);
+    });
+  });
 });

--- a/server/test/medium/specs/services/asset.service.spec.ts
+++ b/server/test/medium/specs/services/asset.service.spec.ts
@@ -14,6 +14,7 @@ import { MapRepository } from 'src/repositories/map.repository';
 import { OcrRepository } from 'src/repositories/ocr.repository';
 import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
 import { UserRepository } from 'src/repositories/user.repository';
@@ -35,6 +36,7 @@ const setup = (db?: Kysely<DB>) => {
       AlbumRepository,
       AccessRepository,
       SharedLinkAssetRepository,
+      SharedSpaceRepository,
       StackRepository,
       UserRepository,
     ],

--- a/server/test/medium/specs/services/shared-space-album.service.spec.ts
+++ b/server/test/medium/specs/services/shared-space-album.service.spec.ts
@@ -21,6 +21,7 @@ import { DB } from 'src/schema';
 import { AlbumService } from 'src/services/album.service';
 import { SharedSpaceService } from 'src/services/shared-space.service';
 import { TimelineService } from 'src/services/timeline.service';
+import { UserAdminService } from 'src/services/user-admin.service';
 import { UserService } from 'src/services/user.service';
 import { newMediumService } from 'test/medium.factory';
 import { factory, newEmbedding } from 'test/small.factory';
@@ -1227,5 +1228,185 @@ describe('UserService — handleUserDelete: space face cleanup (faces F2)', () =
       .where('id', '=', spacePersonCtrl.id)
       .execute();
     expect(spacePersonCtrlAfter).toHaveLength(1);
+  });
+});
+
+/**
+ * Wire SharedSpaceService + UserAdminService sharing a real EventRepository so that
+ * UserAdminService.delete() emits AlbumDelete and SharedSpaceService.onAlbumDelete fires
+ * synchronously while the album_asset / shared_space_album rows still exist (mirrors the
+ * setupWithUserDelete pattern above). The UserAdminService JobRepository is mocked so the
+ * restore() re-projection queue calls can be asserted.
+ *
+ * Assets are owned by Bob (not Alice) so soft-deleting/restoring Alice's account leaves the
+ * asset_face / shared_space_person_face rows intact for inspection.
+ */
+const setupWithUserAdminDelete = () => {
+  // SharedSpaceService context — supplies all real face/space repos and the onAlbumDelete handler
+  const spaceResult = newMediumService(SharedSpaceService, {
+    database: defaultDatabase,
+    real: [
+      AccessRepository,
+      AlbumRepository,
+      AlbumUserRepository,
+      AssetRepository,
+      SharedSpaceRepository,
+      UserRepository,
+    ],
+    mock: [EventRepository, LoggingRepository, JobRepository, StorageRepository],
+  });
+  spaceResult.ctx.getMock(JobRepository).queue.mockResolvedValue();
+  spaceResult.ctx.getMock(JobRepository).queueAll.mockResolvedValue();
+
+  // Real EventRepository wired with onAlbumDelete handler bound to the space sut.
+  // Only AlbumDelete is registered, so the UserTrash / UserRestore emits become harmless no-ops.
+  const realEventRepo = new EventRepository(null as any, new ConfigRepository(), LoggingRepository.create());
+  (realEventRepo as any).emitHandlers['AlbumDelete'] = [
+    {
+      event: 'AlbumDelete',
+      priority: 0,
+      server: false,
+      handler: spaceResult.sut.onAlbumDelete.bind(spaceResult.sut),
+      label: 'SharedSpaceService.onAlbumDelete',
+    },
+  ];
+
+  // UserAdminService context — real repos touched by delete()/restore()
+  const userAdminResult = newMediumService(UserAdminService, {
+    database: defaultDatabase,
+    real: [AlbumRepository, UserRepository, SharedSpaceRepository],
+    mock: [EventRepository, JobRepository, LoggingRepository],
+  });
+  const jobs = userAdminResult.ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+  jobs.queue.mockResolvedValue();
+
+  // Swap the mocked eventRepository on UserAdminService with the real wired one so that
+  // AlbumDelete actually runs onAlbumDelete (UserTrash / UserRestore hit no registered handler).
+  (userAdminResult.sut as any).eventRepository = realEventRepo;
+
+  return { userAdminSut: userAdminResult.sut, ctx: spaceResult.ctx, jobs };
+};
+
+describe('UserAdminService — delete (soft): space face cleanup (faces F3b)', () => {
+  it('removes album-only space faces / orphaned persons and retains direct-path faces when an album owner account is soft-deleted', async () => {
+    const { userAdminSut, ctx } = setupWithUserAdminDelete();
+
+    const { user: alice } = await ctx.newUser();
+    const { user: bob } = await ctx.newUser();
+
+    // Bob's face-enabled space S
+    const { space: spaceS } = await ctx.newSharedSpace({ createdById: bob.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: spaceS.id, userId: bob.id, role: 'owner' });
+
+    // Alice's album A linked to space S
+    const { result: album } = await ctx.newAlbum({ ownerId: alice.id, albumName: 'AliceSoftDeleteAlbum' });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: spaceS.id, albumId: album.id, addedById: bob.id });
+
+    // assetX: owned by Bob, in album A only — album-only path in space S → face removed
+    const { asset: assetX } = await ctx.newAsset({ ownerId: bob.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: assetX.id });
+
+    // assetZ: owned by Bob, in album A AND direct-added to S — second path → face retained
+    const { asset: assetZ } = await ctx.newAsset({ ownerId: bob.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: assetZ.id });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceS.id, assetId: assetZ.id });
+
+    const { result: faceXId } = await ctx.newAssetFace({ assetId: assetX.id });
+    const { result: faceZId } = await ctx.newAssetFace({ assetId: assetZ.id });
+
+    const spaceRepo = ctx.get(SharedSpaceRepository);
+
+    // spacePersonP: album-only person (only faceX) → must be DELETED after cleanup
+    const spacePersonP = await spaceRepo.createPerson({
+      spaceId: spaceS.id,
+      name: 'AlbumOnlyPerson',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: spacePersonP.id, assetFaceId: faceXId }]);
+
+    // spacePersonZ: direct-path person (only faceZ) → must SURVIVE cleanup
+    const spacePersonZ = await spaceRepo.createPerson({
+      spaceId: spaceS.id,
+      name: 'DirectPathPerson',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: spacePersonZ.id, assetFaceId: faceZId }]);
+
+    // Pre-condition: P surfaces in statistics and in the space person list
+    const statsBefore = await spaceRepo.getSpacePersonStatistics(spaceS.id, spacePersonP.id);
+    expect(statsBefore.assets).toBeGreaterThan(0);
+    const personsBefore = await spaceRepo.getPersonsBySpaceId(spaceS.id, {});
+    expect(personsBefore.map((p) => p.id)).toContain(spacePersonP.id);
+
+    // Soft-delete Alice's account (non-force) — GREEN: emits AlbumDelete for each owned album
+    const adminAuth = authFromUser(bob);
+    await userAdminSut.delete(adminAuth, alice.id, {});
+
+    // faceX (album-only) must be removed
+    const faceXAfter = await defaultDatabase
+      .selectFrom('shared_space_person_face')
+      .select('assetFaceId')
+      .where('assetFaceId', '=', faceXId)
+      .execute();
+    expect(faceXAfter).toHaveLength(0);
+
+    // orphaned person P must be gone
+    const personPAfter = await spaceRepo.getPersonById(spacePersonP.id);
+    expect(personPAfter).toBeUndefined();
+
+    // faceZ (direct path) must be retained, person Z must survive
+    const faceZAfter = await defaultDatabase
+      .selectFrom('shared_space_person_face')
+      .select('assetFaceId')
+      .where('assetFaceId', '=', faceZId)
+      .execute();
+    expect(faceZAfter).toHaveLength(1);
+    const personZAfter = await spaceRepo.getPersonById(spacePersonZ.id);
+    expect(personZAfter).toBeDefined();
+
+    // Slice 1 projection: P no longer surfaces via statistics or the space person list
+    const statsAfter = await spaceRepo.getSpacePersonStatistics(spaceS.id, spacePersonP.id);
+    expect(statsAfter.assets).toBe(0);
+    const personsAfter = await spaceRepo.getPersonsBySpaceId(spaceS.id, {});
+    expect(personsAfter.map((p) => p.id)).not.toContain(spacePersonP.id);
+  });
+});
+
+describe('UserAdminService — restore: space face re-projection (faces F3b)', () => {
+  it('re-queues face matching for each face-enabled linked space and a single metadata backfill when an album owner account is restored', async () => {
+    const { userAdminSut, ctx, jobs } = setupWithUserAdminDelete();
+
+    const { user: alice } = await ctx.newUser();
+    const { user: bob } = await ctx.newUser();
+
+    // Bob's face-enabled space S
+    const { space: spaceS } = await ctx.newSharedSpace({ createdById: bob.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: spaceS.id, userId: bob.id, role: 'owner' });
+
+    // Alice's album A linked to face-enabled space S
+    const { result: album } = await ctx.newAlbum({ ownerId: alice.id, albumName: 'AliceRestoreAlbum' });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: spaceS.id, albumId: album.id, addedById: bob.id });
+
+    const { asset: assetX } = await ctx.newAsset({ ownerId: bob.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: assetX.id });
+
+    const adminAuth = authFromUser(bob);
+
+    // Soft-delete then restore — only the restore re-projection should queue jobs
+    await userAdminSut.delete(adminAuth, alice.id, {});
+    jobs.queue.mockClear();
+
+    await userAdminSut.restore(adminAuth, alice.id);
+
+    // Per face-enabled linking space: a SharedSpaceFaceMatchAll job
+    expect(jobs.queue).toHaveBeenCalledWith(
+      expect.objectContaining({ name: JobName.SharedSpaceFaceMatchAll, data: { spaceId: spaceS.id } }),
+    );
+    // A single metadata backfill to re-converge people
+    expect(jobs.queue).toHaveBeenCalledWith(
+      expect.objectContaining({ name: JobName.SharedSpacePersonMetadataBackfill }),
+    );
   });
 });

--- a/server/test/medium/specs/services/shared-space-album.service.spec.ts
+++ b/server/test/medium/specs/services/shared-space-album.service.spec.ts
@@ -1,4 +1,5 @@
 import { Kysely } from 'kysely';
+import { StorageCore } from 'src/cores/storage.core';
 import { AssetVisibility, JobName, JobStatus, TimeBucketSize } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AlbumUserRepository } from 'src/repositories/album-user.repository';
@@ -20,6 +21,7 @@ import { DB } from 'src/schema';
 import { AlbumService } from 'src/services/album.service';
 import { SharedSpaceService } from 'src/services/shared-space.service';
 import { TimelineService } from 'src/services/timeline.service';
+import { UserService } from 'src/services/user.service';
 import { newMediumService } from 'test/medium.factory';
 import { factory, newEmbedding } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
@@ -1042,5 +1044,188 @@ describe('SharedSpaceService — onAlbumDelete face cleanup', () => {
       .execute();
     expect(facesAfter.map((f) => f.assetFaceId)).not.toContain(faceXId);
     expect(facesAfter.map((f) => f.assetFaceId)).toContain(faceZId);
+  });
+});
+
+/**
+ * Wire SharedSpaceService + UserService sharing a real EventRepository so that
+ * UserService.handleUserDelete emits AlbumDelete and SharedSpaceService.onAlbumDelete
+ * fires BEFORE albums are hard-deleted (same emit-then-delete ordering that the GREEN
+ * implementation must guarantee). Mirrors the setupWithAlbumDelete pattern above.
+ *
+ * Assets are owned by Bob (not Alice) so that when Alice's user row is hard-deleted
+ * the asset rows — and their associated asset_face / shared_space_person_face rows —
+ * are NOT cascade-deleted.  This gives us clean, inspectable state after the call.
+ */
+const setupWithUserDelete = () => {
+  // SharedSpaceService context — supplies all real face/space repos and the sut
+  const spaceResult = newMediumService(SharedSpaceService, {
+    database: defaultDatabase,
+    real: [
+      AccessRepository,
+      AlbumRepository,
+      AlbumUserRepository,
+      AssetRepository,
+      SharedSpaceRepository,
+      UserRepository,
+    ],
+    mock: [EventRepository, LoggingRepository, JobRepository, StorageRepository],
+  });
+  spaceResult.ctx.getMock(JobRepository).queue.mockResolvedValue();
+  spaceResult.ctx.getMock(JobRepository).queueAll.mockResolvedValue();
+
+  // Real EventRepository wired with onAlbumDelete handler
+  const realEventRepo = new EventRepository(null as any, new ConfigRepository(), LoggingRepository.create());
+  (realEventRepo as any).emitHandlers['AlbumDelete'] = [
+    {
+      event: 'AlbumDelete',
+      priority: 0,
+      server: false,
+      handler: spaceResult.sut.onAlbumDelete.bind(spaceResult.sut),
+      label: 'SharedSpaceService.onAlbumDelete',
+    },
+  ];
+
+  // UserService context — only needs the repos touched by handleUserDelete
+  const userResult = newMediumService(UserService, {
+    database: defaultDatabase,
+    real: [AlbumRepository, UserRepository, SystemMetadataRepository, ConfigRepository],
+    mock: [EventRepository, StorageRepository, LoggingRepository, JobRepository],
+  });
+
+  // handleUserDelete calls storageRepository.unlinkDir for each of five folder paths
+  // before proceeding to album/user deletion.  Provide a no-op mock so the storage
+  // call doesn't throw (the strict automock would fail without an implementation).
+  userResult.ctx.getMock(StorageRepository).unlinkDir.mockResolvedValue();
+
+  // Swap the mocked eventRepository on UserService with the real wired one
+  (userResult.sut as any).eventRepository = realEventRepo;
+
+  return { userSut: userResult.sut, ctx: spaceResult.ctx };
+};
+
+describe('UserService — handleUserDelete: space face cleanup (faces F2)', () => {
+  beforeAll(() => {
+    // handleUserDelete calls StorageCore.getFolderLocation to build filesystem paths
+    // before calling storageRepository.unlinkDir (which is mocked).  setMediaLocation
+    // must be called first or getMediaLocation() throws "Media location is not set."
+    StorageCore.setMediaLocation('/data');
+  });
+
+  it('removes orphaned space persons for album-only faces and retains faces that have another space path when album owner account is hard-deleted', async () => {
+    const { userSut, ctx } = setupWithUserDelete();
+
+    const { user: alice } = await ctx.newUser();
+    const { user: bob } = await ctx.newUser();
+
+    // Bob's face-enabled space S
+    const { space: spaceS } = await ctx.newSharedSpace({ createdById: bob.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: spaceS.id, userId: bob.id, role: 'owner' });
+
+    // Alice's album A — Alice is the owner (isAlbumOwned / getAllIds / deleteAll all key off this)
+    const { result: album } = await ctx.newAlbum({ ownerId: alice.id, albumName: 'AliceAlbum' });
+    // Link album A to space S
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: spaceS.id, albumId: album.id, addedById: bob.id });
+
+    // assetX: owned by Bob, in album A only — album-only path in space S
+    const { asset: assetX } = await ctx.newAsset({ ownerId: bob.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: assetX.id });
+
+    // assetZ: owned by Bob, in album A AND direct-added to space S — has a second path
+    const { asset: assetZ } = await ctx.newAsset({ ownerId: bob.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: assetZ.id });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceS.id, assetId: assetZ.id });
+
+    // Seed asset faces for assetX and assetZ
+    const { result: faceXId } = await ctx.newAssetFace({ assetId: assetX.id });
+    const { result: faceZId } = await ctx.newAssetFace({ assetId: assetZ.id });
+
+    const spaceRepo = ctx.get(SharedSpaceRepository);
+
+    // spacePersonX: linked only to faceX (album-only asset) → must be DELETED after cleanup
+    const spacePersonX = await spaceRepo.createPerson({
+      spaceId: spaceS.id,
+      name: 'AlbumOnlyPerson',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: spacePersonX.id, assetFaceId: faceXId }]);
+
+    // spacePersonZ: linked only to faceZ (direct-path asset) → must SURVIVE cleanup
+    const spacePersonZ = await spaceRepo.createPerson({
+      spaceId: spaceS.id,
+      name: 'DirectPathPerson',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: spacePersonZ.id, assetFaceId: faceZId }]);
+
+    // Control: Bob's second space — NOT linked to album A, must be entirely untouched
+    const { space: spaceControl } = await ctx.newSharedSpace({ createdById: bob.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: spaceControl.id, userId: bob.id, role: 'owner' });
+    const { asset: assetBob } = await ctx.newAsset({ ownerId: bob.id });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceControl.id, assetId: assetBob.id });
+    const { result: faceCtrlId } = await ctx.newAssetFace({ assetId: assetBob.id });
+    const spacePersonCtrl = await spaceRepo.createPerson({
+      spaceId: spaceControl.id,
+      name: 'ControlPerson',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: spacePersonCtrl.id, assetFaceId: faceCtrlId }]);
+
+    // Pre-condition: all three persons exist
+    const personsBefore = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', 'in', [spacePersonX.id, spacePersonZ.id, spacePersonCtrl.id])
+      .execute();
+    expect(personsBefore).toHaveLength(3);
+
+    // Hard-delete Alice — GREEN: emits AlbumDelete BEFORE deleteAll so onAlbumDelete
+    // cleanup runs while album_asset / shared_space_album rows still exist
+    await userSut.handleUserDelete({ id: alice.id, force: true });
+
+    // spacePersonX (album-only faces) must be DELETED by deleteOrphanedPersons via onAlbumDelete
+    // RED: this assertion FAILS because no AlbumDelete is emitted and the orphaned person survives
+    const spacePersonXAfter = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', '=', spacePersonX.id)
+      .execute();
+    expect(spacePersonXAfter).toHaveLength(0);
+
+    // shared_space_person_face for faceX must be REMOVED (album-only path, no other route)
+    // RED: this assertion FAILS because removePersonFacesByAssetIds never ran
+    const faceXAfter = await defaultDatabase
+      .selectFrom('shared_space_person_face')
+      .select('assetFaceId')
+      .where('assetFaceId', '=', faceXId)
+      .execute();
+    expect(faceXAfter).toHaveLength(0);
+
+    // shared_space_person_face for faceZ must be RETAINED (assetZ has a direct-add path)
+    const faceZAfter = await defaultDatabase
+      .selectFrom('shared_space_person_face')
+      .select('assetFaceId')
+      .where('assetFaceId', '=', faceZId)
+      .execute();
+    expect(faceZAfter).toHaveLength(1);
+
+    // spacePersonZ must survive (onAlbumDelete retains it because assetZ had a direct path)
+    const spacePersonZAfter = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', '=', spacePersonZ.id)
+      .execute();
+    expect(spacePersonZAfter).toHaveLength(1);
+
+    // Control: spacePersonCtrl (unrelated space) must be entirely untouched
+    const spacePersonCtrlAfter = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', '=', spacePersonCtrl.id)
+      .execute();
+    expect(spacePersonCtrlAfter).toHaveLength(1);
   });
 });

--- a/server/test/medium/specs/services/shared-space-album.service.spec.ts
+++ b/server/test/medium/specs/services/shared-space-album.service.spec.ts
@@ -1410,3 +1410,145 @@ describe('UserAdminService — restore: space face re-projection (faces F3b)', (
     );
   });
 });
+
+/**
+ * Emit-timing note: AssetDelete fires AFTER the asset row (and cascaded asset_face →
+ * shared_space_person_face rows) are already deleted.  The onAssetDelete handler therefore
+ * receives the affected (spaceId, personId) pairs pre-captured at the emit site in
+ * asset.service.ts BEFORE deletion.  These tests exercise the handler directly with
+ * the pre-captured payload and verify it correctly recounts surviving persons and removes orphans.
+ */
+describe('SharedSpaceService — onAssetDelete face cleanup', () => {
+  it('getSpacePersonsForAsset returns (spaceId, personId) pairs for faces on the asset', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id });
+
+    const spaceRepo = ctx.get(SharedSpaceRepository);
+    const spacePerson = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'FaceQueryPerson',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: spacePerson.id, assetFaceId: faceId }]);
+
+    const pairs = await spaceRepo.getSpacePersonsForAsset(asset.id);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0]).toMatchObject({ spaceId: space.id, personId: spacePerson.id });
+  });
+
+  it('recounts surviving person and removes orphan person after asset hard-delete', async () => {
+    const { sut, ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+
+    // Two assets: X will be deleted; Y will survive.
+    const { asset: assetX } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: assetY } = await ctx.newAsset({ ownerId: user.id });
+
+    const { result: faceXId } = await ctx.newAssetFace({ assetId: assetX.id });
+    const { result: faceYId } = await ctx.newAssetFace({ assetId: assetY.id });
+
+    const spaceRepo = ctx.get(SharedSpaceRepository);
+
+    // Person P has faces on both X and Y — survives with reduced count.
+    const personP = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'PersonP',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([
+      { personId: personP.id, assetFaceId: faceXId },
+      { personId: personP.id, assetFaceId: faceYId },
+    ]);
+
+    // Person Q has a face only on X — becomes orphan after deletion.
+    const personQ = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'PersonQ',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: personQ.id, assetFaceId: faceXId }]);
+
+    // Capture affected pairs BEFORE deletion (mirrors asset.service.ts behaviour).
+    const affectedSpacePersons = await spaceRepo.getSpacePersonsForAsset(assetX.id);
+
+    // Hard-delete asset X; the DB cascade removes asset_face and shared_space_person_face rows.
+    await defaultDatabase.deleteFrom('asset').where('id', '=', assetX.id).execute();
+
+    // Fire the handler with the pre-captured payload.
+    await sut.onAssetDelete({ assetId: assetX.id, userId: user.id, affectedSpacePersons });
+
+    // P survives with recounted faceCount/assetCount = 1 (only Y's face remains).
+    const personPAfter = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select(['faceCount', 'assetCount'])
+      .where('id', '=', personP.id)
+      .executeTakeFirst();
+    expect(personPAfter).toBeDefined();
+    expect(personPAfter!.faceCount).toBe(1);
+    expect(personPAfter!.assetCount).toBe(1);
+
+    // Q was an orphan (no remaining faces) and must be deleted.
+    const personQAfter = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', '=', personQ.id)
+      .execute();
+    expect(personQAfter).toHaveLength(0);
+  });
+
+  it('leaves persons in unaffected spaces untouched', async () => {
+    const { sut, ctx } = setup();
+    const { user } = await ctx.newUser();
+
+    // Space S contains assetX; space T has no relation to assetX.
+    const { space: spaceS } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: spaceT } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+
+    const { asset: assetX } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: assetT } = await ctx.newAsset({ ownerId: user.id });
+
+    const { result: faceXId } = await ctx.newAssetFace({ assetId: assetX.id });
+    const { result: faceTId } = await ctx.newAssetFace({ assetId: assetT.id });
+
+    const spaceRepo = ctx.get(SharedSpaceRepository);
+
+    const personS = await spaceRepo.createPerson({
+      spaceId: spaceS.id,
+      name: 'PersonS',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: personS.id, assetFaceId: faceXId }]);
+
+    const personT = await spaceRepo.createPerson({
+      spaceId: spaceT.id,
+      name: 'PersonT',
+      type: 'person',
+      representativeFaceId: null,
+    });
+    await spaceRepo.addPersonFaces([{ personId: personT.id, assetFaceId: faceTId }]);
+
+    // Only spaceS is affected by the delete of assetX.
+    const affectedSpacePersons = await spaceRepo.getSpacePersonsForAsset(assetX.id);
+    await defaultDatabase.deleteFrom('asset').where('id', '=', assetX.id).execute();
+
+    await sut.onAssetDelete({ assetId: assetX.id, userId: user.id, affectedSpacePersons });
+
+    // PersonT in spaceT must not have been deleted.
+    const personTAfter = await defaultDatabase
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', '=', personT.id)
+      .execute();
+    expect(personTAfter).toHaveLength(1);
+  });
+});

--- a/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
@@ -61,6 +61,33 @@ describe('SharedSpaceAlbumAssetExifSync.getBackfill', () => {
     }
     expect(result).toHaveLength(0);
   });
+
+  it('returns empty for a soft-deleted album', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
+
+    // Confirm exif appears before soft-delete
+    const streamBefore = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.map((r: any) => r.assetId)).toContain(asset.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result).toHaveLength(0);
+  });
 });
 
 describe('SharedSpaceAlbumAssetExifSync.getCreates', () => {
@@ -103,9 +130,78 @@ describe('SharedSpaceAlbumAssetExifSync.getCreates', () => {
     }
     expect(result.map((r: any) => r.assetId)).not.toContain(asset.id);
   });
+
+  it('excludes exif rows from soft-deleted albums', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    // Confirm exif is visible before soft-delete
+    const streamBefore = sut.getCreates({ nowId: NOW_ID, userId: member.id });
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.map((r: any) => r.assetId)).toContain(asset.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getCreates({ nowId: NOW_ID, userId: member.id });
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result.map((r: any) => r.assetId)).not.toContain(asset.id);
+  });
 });
 
 describe('SharedSpaceAlbumAssetExifSync.getUpdates', () => {
+  it('excludes exif updates for soft-deleted albums', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    // Confirm exif is visible in updates before soft-delete (with max ack)
+    const streamBefore = sut.getUpdates(
+      { nowId: NOW_ID, userId: member.id },
+      { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+    );
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.map((r: any) => r.assetId)).toContain(asset.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getUpdates(
+      { nowId: NOW_ID, userId: member.id },
+      { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+    );
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result.map((r: any) => r.assetId)).not.toContain(asset.id);
+  });
+
   it('honors albumToAssetAck coupling — only sends exif updates for assets the client already knows about', async () => {
     const { ctx, sut } = setup();
     const { user: owner } = await ctx.newUser();

--- a/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
@@ -45,6 +45,32 @@ describe('SharedSpaceAlbumAssetSync.getBackfill', () => {
     expect(result.map((r: any) => r.id)).toContain(asset.id);
   });
 
+  it('returns empty for a soft-deleted album', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    // Confirm asset appears before soft-delete
+    const streamBefore = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.map((r: any) => r.id)).toContain(asset.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result).toHaveLength(0);
+  });
+
   it('masks isFavorite to false for non-owners', async () => {
     const { ctx, db, sut } = setup();
     const { user: owner } = await ctx.newUser();
@@ -115,6 +141,37 @@ describe('SharedSpaceAlbumAssetSync.getCreates', () => {
     expect(result.map((r: any) => r.id)).not.toContain(asset.id);
   });
 
+  it('excludes assets from soft-deleted albums', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    // Confirm asset is visible before soft-delete
+    const streamBefore = sut.getCreates({ nowId: NOW_ID, userId: member.id });
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.map((r: any) => r.id)).toContain(asset.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getCreates({ nowId: NOW_ID, userId: member.id });
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result.map((r: any) => r.id)).not.toContain(asset.id);
+  });
+
   it('masks isFavorite to false for non-owner members in getCreates', async () => {
     const { ctx, db, sut } = setup();
     const { user: owner } = await ctx.newUser();
@@ -138,6 +195,42 @@ describe('SharedSpaceAlbumAssetSync.getCreates', () => {
 });
 
 describe('SharedSpaceAlbumAssetSync.getUpdates', () => {
+  it('excludes asset updates for soft-deleted albums', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    // Confirm asset is visible in updates before soft-delete (with max ack)
+    const streamBefore = sut.getUpdates(
+      { nowId: NOW_ID, userId: member.id },
+      { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+    );
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.map((r: any) => r.id)).toContain(asset.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getUpdates(
+      { nowId: NOW_ID, userId: member.id },
+      { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+    );
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result.map((r: any) => r.id)).not.toContain(asset.id);
+  });
+
   it('honors albumToAssetAck coupling — only sends updates for assets the client already knows about', async () => {
     const { ctx, sut } = setup();
     const { user: owner } = await ctx.newUser();

--- a/server/test/medium/specs/sync/shared-space-album-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-sync.spec.ts
@@ -78,6 +78,27 @@ describe('SharedSpaceAlbumSync.getCreatedAfter', () => {
     const rows = await sut.getCreatedAfter({ nowId: NOW_ID, userId: stranger.id, afterCreateId: undefined });
     expect(rows).toHaveLength(0);
   });
+
+  it('excludes soft-deleted albums', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    // Confirm grant is visible before soft-delete
+    const rowsBefore = await sut.getCreatedAfter({ nowId: NOW_ID, userId: member.id, afterCreateId: undefined });
+    expect(rowsBefore.map((r) => r.id)).toContain(album.id);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const rowsAfter = await sut.getCreatedAfter({ nowId: NOW_ID, userId: member.id, afterCreateId: undefined });
+    expect(rowsAfter.map((r) => r.id)).not.toContain(album.id);
+  });
 });
 
 describe('SharedSpaceAlbumSync.getUpserts', () => {

--- a/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
@@ -96,6 +96,37 @@ describe('SharedSpaceAlbumToAssetSync.getUpserts', () => {
     }
     expect(result.some((r: any) => r.albumId === album.id)).toBe(false);
   });
+
+  it('excludes membership rows for soft-deleted albums', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    // Confirm membership row is visible before soft-delete
+    const streamBefore = sut.getUpserts({ nowId: NOW_ID, userId: member.id });
+    const resultBefore: any[] = [];
+    for await (const row of streamBefore) {
+      resultBefore.push(row);
+    }
+    expect(resultBefore.some((r: any) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+
+    // Soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    const stream = sut.getUpserts({ nowId: NOW_ID, userId: member.id });
+    const result: any[] = [];
+    for await (const row of stream) {
+      result.push(row);
+    }
+    expect(result.some((r: any) => r.albumId === album.id)).toBe(false);
+  });
 });
 
 describe('SharedSpaceAlbumToAssetSync.getDeletes', () => {

--- a/server/test/medium/specs/sync/user-has-album-path.spec.ts
+++ b/server/test/medium/specs/sync/user-has-album-path.spec.ts
@@ -96,8 +96,14 @@ describe('user_has_album_path', () => {
     const { space: s1 } = await ctx.newSharedSpace({ createdById: owner.id });
     const { space: s2 } = await ctx.newSharedSpace({ createdById: owner.id });
     await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: member.id, role: SharedSpaceRole.Viewer });
-    await db.insertInto('shared_space_album').values({ spaceId: s1.id, albumId: album.id, addedById: owner.id }).execute();
-    await db.insertInto('shared_space_album').values({ spaceId: s2.id, albumId: album.id, addedById: owner.id }).execute();
+    await db
+      .insertInto('shared_space_album')
+      .values({ spaceId: s1.id, albumId: album.id, addedById: owner.id })
+      .execute();
+    await db
+      .insertInto('shared_space_album')
+      .values({ spaceId: s2.id, albumId: album.id, addedById: owner.id })
+      .execute();
 
     // member reaches album via s2; excluding s1 → branch 2 should be true
     expect(await hasPath(album.id, member.id, s1.id)).toBe(true);
@@ -116,8 +122,14 @@ describe('user_has_album_path', () => {
     const { album } = await ctx.newAlbum({ ownerId: albumOwner.id });
     const { space: s1 } = await ctx.newSharedSpace({ createdById: albumOwner.id });
     const { space: s2 } = await ctx.newSharedSpace({ createdById: creator.id });
-    await db.insertInto('shared_space_album').values({ spaceId: s1.id, albumId: album.id, addedById: albumOwner.id }).execute();
-    await db.insertInto('shared_space_album').values({ spaceId: s2.id, albumId: album.id, addedById: creator.id }).execute();
+    await db
+      .insertInto('shared_space_album')
+      .values({ spaceId: s1.id, albumId: album.id, addedById: albumOwner.id })
+      .execute();
+    await db
+      .insertInto('shared_space_album')
+      .values({ spaceId: s2.id, albumId: album.id, addedById: creator.id })
+      .execute();
 
     // creator of s2; excluding s1 → branch 3 should be true
     expect(await hasPath(album.id, creator.id, s1.id)).toBe(true);
@@ -134,7 +146,10 @@ describe('user_has_album_path', () => {
     const { user: owner } = await ctx.newUser();
     const { user: viewer } = await ctx.newUser();
     const { album } = await ctx.newAlbum({ ownerId: owner.id });
-    await db.insertInto('album_user').values({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer }).execute();
+    await db
+      .insertInto('album_user')
+      .values({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer })
+      .execute();
     expect(await hasPath(album.id, viewer.id, NIL)).toBe(true);
     await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
     expect(await hasPath(album.id, viewer.id, NIL)).toBe(false);

--- a/server/test/medium/specs/sync/user-has-album-path.spec.ts
+++ b/server/test/medium/specs/sync/user-has-album-path.spec.ts
@@ -85,4 +85,58 @@ describe('user_has_album_path', () => {
     const { album } = await ctx.newAlbum({ ownerId: owner.id });
     expect(await hasPath(album.id, stranger.id, NIL)).toBe(false);
   });
+
+  // --- RBAC F2: soft-deleted albums must NOT count as valid paths ---
+
+  it('false via branch 2 (member in another space) when the album is soft-deleted', async () => {
+    const ctx = new SyncTestContext(db);
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { space: s1 } = await ctx.newSharedSpace({ createdById: owner.id });
+    const { space: s2 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: member.id, role: SharedSpaceRole.Viewer });
+    await db.insertInto('shared_space_album').values({ spaceId: s1.id, albumId: album.id, addedById: owner.id }).execute();
+    await db.insertInto('shared_space_album').values({ spaceId: s2.id, albumId: album.id, addedById: owner.id }).execute();
+
+    // member reaches album via s2; excluding s1 → branch 2 should be true
+    expect(await hasPath(album.id, member.id, s1.id)).toBe(true);
+
+    // soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    // branch 2 must now return false (soft-deleted album is not a valid path)
+    expect(await hasPath(album.id, member.id, s1.id)).toBe(false);
+  });
+
+  it('false via branch 3 (creator of another space) when the album is soft-deleted', async () => {
+    const ctx = new SyncTestContext(db);
+    const { user: albumOwner } = await ctx.newUser();
+    const { user: creator } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: albumOwner.id });
+    const { space: s1 } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+    const { space: s2 } = await ctx.newSharedSpace({ createdById: creator.id });
+    await db.insertInto('shared_space_album').values({ spaceId: s1.id, albumId: album.id, addedById: albumOwner.id }).execute();
+    await db.insertInto('shared_space_album').values({ spaceId: s2.id, albumId: album.id, addedById: creator.id }).execute();
+
+    // creator of s2; excluding s1 → branch 3 should be true
+    expect(await hasPath(album.id, creator.id, s1.id)).toBe(true);
+
+    // soft-delete the album
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+
+    // branch 3 must now return false (soft-deleted album is not a valid path)
+    expect(await hasPath(album.id, creator.id, s1.id)).toBe(false);
+  });
+
+  it('regression: branch 1 (album_user) already returns false for soft-deleted album', async () => {
+    const ctx = new SyncTestContext(db);
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    await db.insertInto('album_user').values({ albumId: album.id, userId: viewer.id, role: AlbumUserRole.Viewer }).execute();
+    expect(await hasPath(album.id, viewer.id, NIL)).toBe(true);
+    await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
+    expect(await hasPath(album.id, viewer.id, NIL)).toBe(false);
+  });
 });


### PR DESCRIPTION
## What this is

Implements **every** finding from the three post-#726 reviews of `feat/space-albums` (@ `5f0076cd6e`) — access-control/RBAC, server correctness (people/faces), and mobile — built **test-first (TDD)** as 14 dependency-ordered slices via `/impl-loop`. The brainstormed spec that drove it is included in the PR:

- `docs/superpowers/specs/2026-06-29-space-albums-review-fixes-followup-design.md` — grouped problem set, intended behavior per fix, edge cases, rationale, product-vs-engineering split, Test Strategy.
- `docs/superpowers/plans/2026-06-29-space-albums-review-fixes-followup.md` — the 14 numbered slices, each: failing test(s) first (path + assertions) → minimal implementation → slice gate.

Base is **`feat/space-albums`** (not `main`). CI is green.

## Fixes (each a TDD slice: failing test → fix → slice gate)

**Server faces/people**
- **S1 — F1 (HIGH, ship-blocker):** album branch now propagated to all 7 space *people-projection* read/stat/face queries — album-linked faces appear in a space's people list, per-person stats, faces strip, and `detectedFaceCount`. Edge cases: album-only vs multi-path person (no double-count), trashed album, date filters, representative-face selection.
- **S2 — F3a:** `album.deletedAt` honored on the `isAssetInSpace` / `getSpaceIdsForAsset` face-pipeline gates.
- **S3 — F2:** owner-account **hard** delete cleans space faces (no stranded faces / zero-face orphan people).
- **S4 — F3b:** owner-account **soft** delete cleanup + restore re-projection (eager — see product note).
- **S5 — F4:** album-adder included in metadata inheritance.
- **S6 — F5:** asset-delete recounts affected space people + drops orphans.

**RBAC consistency**
- **S7 — F1:** album-asset sync streams exclude soft-deleted albums (`accessibleSpaceAlbums` parity).
- **S8 — F2:** `user_has_album_path` honors `album.deletedAt` on all branches (new fork migration + `functions.ts`).
- **S9 — F3:** `albumId` route param validated → **400**, not a 500.

**Mobile**
- **S10 — F1 (HIGH):** server-only add path for absorbed albums — kills the false "Failed to add photos" for a space editor who doesn't own the album.
- **S11 — F2:** `currentUserRole` populated so editable (not just owned) albums are linkable.
- **S12–S14 — F3/F4/F5:** detail-header subtitle, real album-cover thumbnails, toggle-before-load guard.

## Tests

Each slice ships its failing-test-first coverage, closing the gaps the reviews flagged as untested (server medium/unit, e2e, and mobile suites). All CI checks pass — the one earlier e2e red was a CI Docker-build flake (a GitHub API rate-limit hit while fetching a build dependency, before any test ran), cleared on re-run.

## Product decisions (reviewed and confirmed — keep current behavior)

The review surfaced four judgment calls; all were reviewed and confirmed to keep the current behavior, so the implementation above is final:
- faces **F6** — the headline count / recent strip keeps counting **all** linked-album photos (the count means "what's in the space"; `showInTimeline` stays a timeline-only control). No change.
- RBAC **F4** — the transitive-write model is **intended**: write follows space role, so an album-editor who is also a space editor can link the album, after which space editors get add/remove. No change.
- **F3b cleanup eagerness** — kept **eager** (S4 as implemented), closing the person-thumbnail exposure on owner-account soft-delete.
- RBAC **F5** — the space-creator sync path is **out of scope** for this PR: it is pre-existing shared-space infrastructure, not album-specific. Tracked separately.

## Lineage

Three-angle review of `feat/space-albums` → spec (this PR's two docs) → `/impl-loop` implementation. Mirrors the prior round's house format (`2026-06-25-space-albums-review-fixes` → PR #726, merged into `feat/space-albums`).
