### PR TITLE
fix(mobile): load a shared-space person's photos on the person-detail page (both entry points)

### DIFF
--- a/mobile/lib/domain/services/people.service.dart
+++ b/mobile/lib/domain/services/people.service.dart
@@ -40,6 +40,24 @@ class DriftPeopleService {
     return _repository.getAllPeople(sortBy: sortBy);
   }
 
+  /// Asset ids of the photos of a Space-shared [personId] in [spaceId], as resolved by the
+  /// server. The person detail timeline needs this because the local sync DB is owner-scoped:
+  /// a non-owned Space person's face→person links never sync, so the local person query is
+  /// empty ("0 items"). The Space assets themselves DO sync locally, so the timeline renders
+  /// them once the server says which ones contain the person — matching the web person detail
+  /// page. This is the person-detail sibling of issue #727.
+  ///
+  /// Best-effort like [getAssetPeople]: a network/server failure returns an empty list so the
+  /// detail page degrades to "no photos" rather than surfacing a visible error.
+  Future<List<String>> getSharedSpacePersonAssetIds(String spaceId, String personId) async {
+    try {
+      return await _sharedSpaceApiRepository.getSpacePersonAssets(spaceId, personId);
+    } catch (error, stackTrace) {
+      _log.warning("Failed to fetch assets for Space person $personId in space $spaceId", error, stackTrace);
+      return const [];
+    }
+  }
+
   /// People for the global People page: the viewer's own people AND people on assets shared
   /// with them through a Space, matching the web People page (which calls the server with
   /// withSharedSpaces:true). The local sync DB is owner-scoped and never receives

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -142,6 +142,18 @@ class TimelineFactory {
     _timelineRepository.person(userId, personId, groupBy ?? this.groupBy, temporalScope: temporalScope),
   );
 
+  /// Timeline for a Space-shared person, restricted to the [assetIds] the server resolved for
+  /// that person. Used instead of [person] when the viewer does not own the person: the local
+  /// sync DB is owner-scoped, so the person's face→person links never sync and [person] would
+  /// be empty. See [DriftTimelineRepository.sharedSpacePerson].
+  TimelineService sharedSpacePerson(
+    List<String> assetIds, {
+    GroupAssetsBy? groupBy,
+    TimelineTemporalScope temporalScope = const TimelineTemporalScope.none(),
+  }) => TimelineService(
+    _timelineRepository.sharedSpacePerson(assetIds, groupBy ?? this.groupBy, temporalScope: temporalScope),
+  );
+
   TimelineService fromAssets(List<BaseAsset> assets, TimelineOrigin type) =>
       TimelineService(_timelineRepository.fromAssets(assets, type));
 

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -786,6 +786,26 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
     origin: TimelineOrigin.person,
   );
 
+  /// Timeline for a Space-shared person, restricted to the [assetIds] the server resolved for
+  /// that person (GET /shared-spaces/{id}/people/{id}/assets). Unlike [person], this does NOT
+  /// filter by ownerId or join asset_face: a Space person's photos are owned by another user
+  /// and their face→person links are owner-scoped and never sync to the viewer, so the local
+  /// join would be empty ("0 items"). The Space assets themselves do sync locally, so once the
+  /// server tells us which ones contain the person we render them straight from remote_asset —
+  /// mirroring the web person detail page for a Space person. An empty [assetIds] yields an
+  /// empty timeline.
+  TimelineQuery sharedSpacePerson(
+    List<String> assetIds,
+    GroupAssetsBy groupBy, {
+    TimelineTemporalScope temporalScope = const TimelineTemporalScope.none(),
+  }) => _remoteQueryBuilder(
+    filter: (row) =>
+        row.deletedAt.isNull() & row.visibility.equalsValue(AssetVisibility.timeline) & row.id.isIn(assetIds),
+    groupBy: groupBy,
+    temporalScope: temporalScope,
+    origin: TimelineOrigin.person,
+  );
+
   Stream<List<Bucket>> _watchPlaceBucket(
     String place,
     List<String> userIds,

--- a/mobile/lib/presentation/pages/drift_person.page.dart
+++ b/mobile/lib/presentation/pages/drift_person.page.dart
@@ -7,8 +7,7 @@ import 'package:immich_mobile/presentation/widgets/people/person_option_sheet.wi
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_route_scope.dart';
 import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
-import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/person_timeline.provider.dart';
 import 'package:immich_mobile/utils/people.utils.dart';
 import 'package:immich_mobile/widgets/common/person_sliver_app_bar.dart';
 
@@ -83,14 +82,10 @@ class _DriftPersonPageState extends ConsumerState<DriftPersonPage> {
     final editable = spaceId == null ? true : ref.watch(driftSpaceEditableProvider(spaceId)).value ?? true;
 
     return TimelineRouteScope(
-      timelineServiceBuilder: (ref, scope, groupBy) {
-        final user = ref.watch(currentUserProvider);
-        if (user == null) {
-          throw Exception('User must be logged in to view person timeline');
-        }
-
-        return ref.watch(timelineFactoryProvider).person(user.id, _person.id, groupBy: groupBy, temporalScope: scope);
-      },
+      // A personal person reads the owner-scoped local timeline; a Space-shared person reads
+      // the server-resolved Space assets (the local owner-scoped join is empty for a person the
+      // viewer does not own). See buildPersonTimelineRouteService.
+      timelineServiceBuilder: (ref, scope, groupBy) => buildPersonTimelineRouteService(ref, _person, scope, groupBy),
       child: Timeline(
         withGroupingPill: true,
         appBar: PersonSliverAppBar(

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/people_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/people_details.widget.dart
@@ -134,7 +134,12 @@ class _Avatar extends StatelessWidget {
                   elevation: 3,
                   child: CircleAvatar(
                     maxRadius: imageSize / 2,
-                    backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
+                    // A Space-shared person's id is a shared_space_person id with no row in the
+                    // owner-only person table, so /people/{id}/thumbnail 404s — route it to the
+                    // membership-gated space endpoint, mirroring the #737 People grid.
+                    backgroundImage: RemoteImageProvider(
+                      url: getPersonThumbnailUrl(person.id, spaceId: person.spaceId),
+                    ),
                   ),
                 ),
               ),

--- a/mobile/lib/providers/infrastructure/person_timeline.provider.dart
+++ b/mobile/lib/providers/infrastructure/person_timeline.provider.dart
@@ -1,0 +1,53 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/person.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+
+/// Asset ids of the photos of a Space-shared person, resolved by the server. The person
+/// detail timeline needs this because the local sync DB is owner-scoped: a non-owned Space
+/// person's face→person links never sync, so the local person query is empty. See issue #727.
+final driftSharedSpacePersonAssetIdsProvider = FutureProvider.family<List<String>, ({String spaceId, String personId})>(
+  (ref, key) async {
+    final service = ref.watch(driftPeopleServiceProvider);
+    return service.getSharedSpacePersonAssetIds(key.spaceId, key.personId);
+  },
+);
+
+/// Builds the person detail timeline, routing on the person's profile exactly like the web
+/// person detail page:
+///
+///  - A personal/owned person (null spaceId) reads the owner-scoped local Drift timeline
+///    ([TimelineFactory.person]).
+///  - A Space-shared person (non-null spaceId) has photos owned by another user whose
+///    face→person links never sync to the viewer, so the owner-scoped query would be empty
+///    ("0 items"). Instead we ask the server which Space assets contain the person and render
+///    those locally-synced assets ([TimelineFactory.sharedSpacePerson]). While the fetch is in
+///    flight — or if it fails — the id list is empty (an empty timeline), then the timeline
+///    re-emits when the ids resolve. A Space person never falls through to the owner-scoped
+///    query, so it never dead-ends on the empty local join.
+TimelineService buildPersonTimelineRouteService(
+  Ref ref,
+  DriftPerson person,
+  TimelineTemporalScope temporalScope,
+  GroupAssetsBy groupBy,
+) {
+  final user = ref.watch(currentUserProvider);
+  if (user == null) {
+    throw Exception('User must be logged in to view person timeline');
+  }
+
+  final factory = ref.watch(timelineFactoryProvider);
+  final spaceId = person.spaceId;
+  if (spaceId != null) {
+    final assetIds =
+        ref.watch(driftSharedSpacePersonAssetIdsProvider((spaceId: spaceId, personId: person.id))).valueOrNull ??
+        const <String>[];
+    return factory.sharedSpacePerson(assetIds, groupBy: groupBy, temporalScope: temporalScope);
+  }
+
+  return factory.person(user.id, person.id, groupBy: groupBy, temporalScope: temporalScope);
+}

--- a/mobile/lib/repositories/person_api.repository.dart
+++ b/mobile/lib/repositories/person_api.repository.dart
@@ -122,16 +122,26 @@ class PersonApiRepository extends ApiRepository {
     final info = await checkNull(_apiService.assetsApi.getAssetInfo(assetId));
     return info.people
         .where((person) => !person.isHidden)
-        .map((person) => _toDriftPerson(person, info.ownerId))
+        .map((person) => _toDriftPerson(person, info.ownerId, info.resolvedSpaceId))
         .toList();
   }
 
-  static DriftPerson _toDriftPerson(PersonWithFacesResponseDto dto, String ownerId) {
+  static DriftPerson _toDriftPerson(PersonWithFacesResponseDto dto, String ownerId, String? resolvedSpaceId) {
     // The asset-info DTO does not carry created/faceAsset fields; the people strip does
     // not render them, so mirror updatedAt and leave the face-asset unset.
     final updatedAt = dto.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+    // Face-tap → person detail: for a Space-shared person the asset-info endpoint carries the
+    // space-person id (dto.spacePersonId) separately from the global identity id (dto.id), and
+    // the space id lives on the asset (resolvedSpaceId). Map such a person shape-identical to
+    // the People-page one — id = space-person id, spaceId set — so buildPersonTimelineRouteService
+    // takes the space branch and the detail page loads photos (and the thumbnail routes to the
+    // membership-gated space endpoint), mirroring web. Both ids must be present: the space assets
+    // endpoint needs the (spaceId, space-person id) pair. Personal/owned people keep the global id
+    // and null spaceId (owner-scoped local query + owner thumbnail). See issue #727.
+    final spacePersonId = dto.spacePersonId;
+    final isSpacePerson = spacePersonId != null && resolvedSpaceId != null;
     return DriftPerson(
-      id: dto.id,
+      id: isSpacePerson ? spacePersonId : dto.id,
       createdAt: updatedAt,
       updatedAt: updatedAt,
       ownerId: ownerId,
@@ -140,6 +150,7 @@ class PersonApiRepository extends ApiRepository {
       isHidden: dto.isHidden,
       color: dto.color,
       birthDate: dto.birthDate,
+      spaceId: isSpacePerson ? resolvedSpaceId : null,
     );
   }
 

--- a/mobile/lib/repositories/shared_space_api.repository.dart
+++ b/mobile/lib/repositories/shared_space_api.repository.dart
@@ -41,6 +41,15 @@ class SharedSpaceApiRepository extends ApiRepository {
     return response;
   }
 
+  /// Asset ids of the photos of a Space-scoped [personId] in [spaceId], from the
+  /// membership-gated `GET /shared-spaces/{id}/people/{personId}/assets` endpoint (the same
+  /// data the web person detail page reads for a Space person). Used by the person detail
+  /// timeline because the owner-scoped local sync DB never receives a non-owned person's
+  /// face→person links. Sibling of issue #727.
+  Future<List<String>> getSpacePersonAssets(String spaceId, String personId) async {
+    return await checkNull(_api.getSpacePersonAssets(spaceId, personId));
+  }
+
   /// Whether [userId] may edit Space-scoped people in [spaceId] (owner or editor role).
   /// Mirrors the web resolveSpaceEditable (person.service.ts): the server enforces the role
   /// on every write, so a membership-lookup failure fails open (returns true) rather than

--- a/mobile/test/domain/services/people_service_test.dart
+++ b/mobile/test/domain/services/people_service_test.dart
@@ -116,6 +116,31 @@ void main() {
     });
   });
 
+  // The person DETAIL page sibling of #727/#737: a Space-shared person's photos. The local sync
+  // DB never receives the face→person links for a person the viewer does not own, so the detail
+  // timeline must ask the server which Space assets contain the person (the Space assets
+  // themselves do sync). The web person detail page resolves exactly these photos.
+  group('getSharedSpacePersonAssetIds', () {
+    test('returns the asset ids the server resolved for the Space person', () async {
+      when(() => mockSharedSpace.getSpacePersonAssets(any(), any())).thenAnswer((_) async => ['asset-1', 'asset-2']);
+
+      final result = await sut.getSharedSpacePersonAssetIds('space-1', 'sp1');
+
+      expect(result, ['asset-1', 'asset-2']);
+      verify(() => mockSharedSpace.getSpacePersonAssets('space-1', 'sp1')).called(1);
+    });
+
+    // Best-effort like getAssetPeople: a network/server failure degrades the detail page to
+    // "no photos" rather than surfacing a visible error.
+    test('returns no asset ids when the server fetch fails', () async {
+      when(() => mockSharedSpace.getSpacePersonAssets(any(), any())).thenThrow(Exception('network down'));
+
+      final result = await sut.getSharedSpacePersonAssetIds('space-1', 'sp1');
+
+      expect(result, isEmpty);
+    });
+  });
+
   // Edits must route on the person's profile, exactly like the web People page: a personal/owned
   // person (null spaceId) goes to the owner-only person endpoint plus a local Drift write; a
   // Space-scoped person goes to the editor-gated shared-space endpoint with NO local write.

--- a/mobile/test/domain/services/timeline_factory_temporal_scope_test.dart
+++ b/mobile/test/domain/services/timeline_factory_temporal_scope_test.dart
@@ -73,6 +73,9 @@ void main() {
       () => repo.person('user-1', 'person-1', GroupAssetsBy.day, temporalScope: year),
     ).thenReturn(_query(TimelineOrigin.person));
     when(
+      () => repo.sharedSpacePerson(['a1', 'a2'], GroupAssetsBy.day, temporalScope: year),
+    ).thenReturn(_query(TimelineOrigin.person));
+    when(
       () => repo.map(['user-1'], 'user-1', mapOptions, GroupAssetsBy.day, temporalScope: year),
     ).thenReturn(_query(TimelineOrigin.map));
 
@@ -88,6 +91,7 @@ void main() {
     sut.video(['user-1'], 'user-1', temporalScope: year, groupBy: GroupAssetsBy.day);
     sut.place('Paris', ['user-1'], 'user-1', temporalScope: year, groupBy: GroupAssetsBy.day);
     sut.person('user-1', 'person-1', temporalScope: year, groupBy: GroupAssetsBy.day);
+    sut.sharedSpacePerson(['a1', 'a2'], temporalScope: year, groupBy: GroupAssetsBy.day);
     sut.map(['user-1'], 'user-1', mapOptions, temporalScope: year, groupBy: GroupAssetsBy.day);
 
     verify(() => repo.main(['user-1'], 'user-1', GroupAssetsBy.day, temporalScope: year)).called(1);
@@ -102,6 +106,7 @@ void main() {
     verify(() => repo.video(['user-1'], 'user-1', GroupAssetsBy.day, temporalScope: year)).called(1);
     verify(() => repo.place('Paris', ['user-1'], 'user-1', GroupAssetsBy.day, temporalScope: year)).called(1);
     verify(() => repo.person('user-1', 'person-1', GroupAssetsBy.day, temporalScope: year)).called(1);
+    verify(() => repo.sharedSpacePerson(['a1', 'a2'], GroupAssetsBy.day, temporalScope: year)).called(1);
     verify(() => repo.map(['user-1'], 'user-1', mapOptions, GroupAssetsBy.day, temporalScope: year)).called(1);
   });
 }

--- a/mobile/test/infrastructure/repositories/timeline_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/timeline_repository_test.dart
@@ -1126,4 +1126,60 @@ void main() {
       await controller.close();
     });
   });
+
+  group('DriftTimelineRepository.sharedSpacePerson()', () {
+    // Parity gap sibling of #727 (per-photo faces) and #737 (People page): a Space-shared
+    // person's DETAIL timeline.
+    //
+    // A Space-shared person's photos are owned by another user but sync into the viewer's
+    // local DB as Space assets. The face→person links, however, are owner-scoped and never
+    // sync to the viewer, so the owner-scoped person() timeline is empty for a person the
+    // viewer doesn't own — the "0 items" bug. The server resolves the person's asset ids
+    // (GET /shared-spaces/{id}/people/{id}/assets); sharedSpacePerson() renders a timeline
+    // restricted to those ids from the locally-synced Space assets, matching the web person
+    // detail page.
+
+    setUp(() async {
+      await insertUser('admin');
+      await insertUser('viewer');
+      // Two Space-shared photos owned by admin; only a1 contains the Space person.
+      await insertVideo('a1', 'admin', type: AssetType.image);
+      await insertVideo('a2', 'admin', type: AssetType.image);
+      await insertSpace('s1', 'admin');
+      await insertMember('s1', 'viewer', showInTimeline: true);
+      await linkAssetToSpace('s1', 'a1');
+      await linkAssetToSpace('s1', 'a2');
+    });
+
+    test('renders the resolved asset ids even though the viewer does not own them', () async {
+      final assets = await sut.sharedSpacePerson(['a1'], GroupAssetsBy.day).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id), ['a1']);
+
+      final buckets = await sut.sharedSpacePerson(['a1'], GroupAssetsBy.day).bucketSource().first;
+      final total = buckets.fold<int>(0, (sum, b) => sum + (b as TimeBucket).assetCount);
+      expect(total, 1);
+    });
+
+    test('restricts the timeline to the resolved ids, not the whole space', () async {
+      final assets = await sut.sharedSpacePerson(['a1'], GroupAssetsBy.day).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id), ['a1']);
+      expect(assets.map((a) => (a as RemoteAsset).id), isNot(contains('a2')));
+    });
+
+    test('empty resolved id list → no assets and no buckets', () async {
+      final assets = await sut.sharedSpacePerson(const [], GroupAssetsBy.day).assetSource(0, 100);
+      expect(assets, isEmpty);
+
+      final buckets = await sut.sharedSpacePerson(const [], GroupAssetsBy.day).bucketSource().first;
+      final total = buckets.fold<int>(0, (sum, b) => sum + (b as TimeBucket).assetCount);
+      expect(total, 0);
+    });
+
+    test('owner-scoped person() is empty for a non-owned Space person (the gap this closes)', () async {
+      // No face rows sync for the viewer and the assets are owned by admin, so the existing
+      // owner-scoped person timeline returns nothing — the "0 items" bug on the detail page.
+      final assets = await sut.person('viewer', 'space-person-1', GroupAssetsBy.day).assetSource(0, 100);
+      expect(assets, isEmpty);
+    });
+  });
 }

--- a/mobile/test/presentation/widgets/asset_viewer/people_details_widget_test.dart
+++ b/mobile/test/presentation/widgets/asset_viewer/people_details_widget_test.dart
@@ -1,0 +1,108 @@
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/person.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_details/people_details.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
+import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../test_utils.dart';
+import '../../../widget_tester_extensions.dart';
+
+class _MockUserService extends Mock implements UserService {}
+
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service, UserDto user) {
+    state = user;
+  }
+}
+
+DriftPerson _person(String id, String name, {String? spaceId}) => DriftPerson(
+  id: id,
+  createdAt: DateTime(2024, 1, 1),
+  updatedAt: DateTime(2024, 1, 1),
+  ownerId: 'admin',
+  name: name,
+  isFavorite: false,
+  isHidden: false,
+  color: null,
+  spaceId: spaceId,
+);
+
+void main() {
+  late Drift db;
+  late _MockUserService userService;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    TestUtils.init();
+    db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await StoreService.init(storeRepository: DriftStoreRepository(db), listenUpdates: false);
+  });
+
+  setUp(() async {
+    await Store.clear();
+    await Store.put(StoreKey.serverEndpoint, 'http://localhost:0');
+    userService = _MockUserService();
+    when(
+      () => userService.tryGetMyUser(),
+    ).thenReturn(UserDto(id: 'viewer', email: 'v@e', name: 'v', profileChangedAt: DateTime(2024)));
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream<UserDto?>.empty());
+  });
+
+  tearDownAll(() async {
+    await Store.clear();
+    await db.close();
+  });
+
+  // The strip avatar routes its thumbnail by person profile exactly like the #737 People grid:
+  // a Space-shared person's id is a shared_space_person id with no row in the owner-only person
+  // table, so /people/{id}/thumbnail 404s — it must resolve via the membership-gated space
+  // endpoint. This is the face-tap sibling of the People-page thumbnail routing.
+  String? avatarUrl(WidgetTester tester) {
+    final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
+    final provider = avatar.backgroundImage;
+    return provider is RemoteImageProvider ? provider.url : null;
+  }
+
+  Future<void> pumpStrip(WidgetTester tester, DriftPerson person) async {
+    final asset = TestUtils.createRemoteAsset(id: 'asset-1', ownerId: 'admin');
+    await tester.pumpConsumerWidget(
+      PeopleDetails(asset: asset),
+      overrides: [
+        driftPeopleAssetProvider.overrideWith((ref, key) async => [person]),
+        infra.userServiceProvider.overrideWithValue(userService),
+        currentUserProvider.overrideWith(
+          (ref) => _StubCurrentUserNotifier(
+            userService,
+            UserDto(id: 'viewer', email: 'v@e', name: 'v', profileChangedAt: DateTime(2024)),
+          ),
+        ),
+      ],
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a Space person\'s strip avatar resolves via the space thumbnail endpoint', (tester) async {
+    await pumpStrip(tester, _person('space-person-1', 'Alice', spaceId: 'space-1'));
+
+    expect(avatarUrl(tester), endsWith('/shared-spaces/space-1/people/space-person-1/thumbnail'));
+  });
+
+  testWidgets('a personal person\'s strip avatar resolves via the owner thumbnail endpoint', (tester) async {
+    await pumpStrip(tester, _person('global-1', 'Bob'));
+
+    expect(avatarUrl(tester), endsWith('/people/global-1/thumbnail'));
+  });
+}

--- a/mobile/test/providers/infrastructure/person_timeline_provider_test.dart
+++ b/mobile/test/providers/infrastructure/person_timeline_provider_test.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/person.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/people.service.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/person_timeline.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockFactory extends Mock implements TimelineFactory {}
+
+class _MockPeopleService extends Mock implements DriftPeopleService {}
+
+class _MockUserService extends Mock implements UserService {}
+
+class _FakeService extends Fake implements TimelineService {
+  @override
+  TimelineOrigin get origin => TimelineOrigin.person;
+  @override
+  Future<void> dispose() async {}
+}
+
+UserDto _user(String id) => UserDto(id: id, email: '$id@example.com', name: id, profileChangedAt: DateTime(2024, 1, 1));
+
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service, UserDto? initial) {
+    state = initial;
+  }
+}
+
+DriftPerson _person(String id, {String? spaceId}) => DriftPerson(
+  id: id,
+  createdAt: DateTime(2020),
+  updatedAt: DateTime(2020),
+  ownerId: 'owner',
+  name: 'Alice',
+  isFavorite: false,
+  isHidden: false,
+  color: null,
+  spaceId: spaceId,
+);
+
+ProviderContainer _container({
+  required TimelineFactory factory,
+  required DriftPeopleService peopleService,
+  UserDto? user,
+}) {
+  final mockUserSvc = _MockUserService();
+  when(() => mockUserSvc.tryGetMyUser()).thenReturn(user);
+  when(() => mockUserSvc.watchMyUser()).thenAnswer((_) => const Stream<UserDto?>.empty());
+
+  return ProviderContainer(
+    overrides: [
+      timelineFactoryProvider.overrideWithValue(factory),
+      driftPeopleServiceProvider.overrideWithValue(peopleService),
+      infra.userServiceProvider.overrideWithValue(mockUserSvc),
+      currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(mockUserSvc, user)),
+    ],
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(GroupAssetsBy.day);
+    registerFallbackValue(const TimelineTemporalScope.none());
+  });
+
+  const scope = TimelineTemporalScope.none();
+
+  group('buildPersonTimelineRouteService', () {
+    test('personal person (null spaceId) → owner-scoped factory.person', () {
+      final factory = _MockFactory();
+      final people = _MockPeopleService();
+      final fake = _FakeService();
+      when(
+        () => factory.person(
+          any(),
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      ).thenReturn(fake);
+
+      final container = _container(factory: factory, peopleService: people, user: _user('u1'));
+      addTearDown(container.dispose);
+      final route = ProviderContainer(
+        parent: container,
+        overrides: [
+          timelineServiceProvider.overrideWith(
+            (ref) => buildPersonTimelineRouteService(ref, _person('p1'), scope, GroupAssetsBy.day),
+          ),
+        ],
+      );
+      addTearDown(route.dispose);
+
+      final svc = route.read(timelineServiceProvider);
+      expect(svc, same(fake));
+      verify(() => factory.person('u1', 'p1', groupBy: GroupAssetsBy.day, temporalScope: scope)).called(1);
+      verifyNever(
+        () => factory.sharedSpacePerson(
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      );
+    });
+
+    test('Space person (non-null spaceId) → factory.sharedSpacePerson with the server-resolved asset ids', () async {
+      final factory = _MockFactory();
+      final people = _MockPeopleService();
+      final fake = _FakeService();
+      when(() => people.getSharedSpacePersonAssetIds('space-1', 'sp1')).thenAnswer((_) async => ['a1', 'a2']);
+      when(
+        () => factory.sharedSpacePerson(
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      ).thenReturn(fake);
+
+      final container = _container(factory: factory, peopleService: people, user: _user('u1'));
+      addTearDown(container.dispose);
+      // Resolve the server fetch before the timeline builder reads it.
+      await container.read(driftSharedSpacePersonAssetIdsProvider((spaceId: 'space-1', personId: 'sp1')).future);
+
+      final route = ProviderContainer(
+        parent: container,
+        overrides: [
+          timelineServiceProvider.overrideWith(
+            (ref) => buildPersonTimelineRouteService(ref, _person('sp1', spaceId: 'space-1'), scope, GroupAssetsBy.day),
+          ),
+        ],
+      );
+      addTearDown(route.dispose);
+
+      final svc = route.read(timelineServiceProvider);
+      expect(svc, same(fake));
+      verify(() => factory.sharedSpacePerson(['a1', 'a2'], groupBy: GroupAssetsBy.day, temporalScope: scope)).called(1);
+      // A Space person must never fall through to the owner-scoped query (the "0 items" bug).
+      verifyNever(
+        () => factory.person(
+          any(),
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      );
+    });
+
+    test('Space person still routes to sharedSpacePerson (empty) while the ids are loading', () {
+      final factory = _MockFactory();
+      final people = _MockPeopleService();
+      final fake = _FakeService();
+      // Never completes within the test: the builder must not block or fall back to person().
+      when(() => people.getSharedSpacePersonAssetIds(any(), any())).thenAnswer((_) => Completer<List<String>>().future);
+      when(
+        () => factory.sharedSpacePerson(
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      ).thenReturn(fake);
+
+      final container = _container(factory: factory, peopleService: people, user: _user('u1'));
+      addTearDown(container.dispose);
+      final route = ProviderContainer(
+        parent: container,
+        overrides: [
+          timelineServiceProvider.overrideWith(
+            (ref) => buildPersonTimelineRouteService(ref, _person('sp1', spaceId: 'space-1'), scope, GroupAssetsBy.day),
+          ),
+        ],
+      );
+      addTearDown(route.dispose);
+
+      final svc = route.read(timelineServiceProvider);
+      expect(svc, same(fake));
+      verify(() => factory.sharedSpacePerson(const [], groupBy: GroupAssetsBy.day, temporalScope: scope)).called(1);
+      verifyNever(
+        () => factory.person(
+          any(),
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      );
+    });
+  });
+}

--- a/mobile/test/repositories/person_api_repository_test.dart
+++ b/mobile/test/repositories/person_api_repository_test.dart
@@ -7,10 +7,15 @@ import 'package:openapi/api.dart' as api;
 
 class MockPeopleApi extends Mock implements api.PeopleApi {}
 
+class MockAssetsApi extends Mock implements api.AssetsApi {}
+
+class MockAssetInfo extends Mock implements api.AssetResponseDto {}
+
 class MockApiService extends Mock implements ApiService {}
 
 void main() {
   late MockPeopleApi mockApi;
+  late MockAssetsApi mockAssetsApi;
   late MockApiService mockApiService;
   late PersonApiRepository repository;
 
@@ -46,11 +51,103 @@ void main() {
     ).thenAnswer((_) => answer());
   }
 
+  api.PersonWithFacesResponseDto personWithFaces(
+    String id, {
+    String name = '',
+    bool isHidden = false,
+    String? spacePersonId,
+  }) => api.PersonWithFacesResponseDto(
+    id: id,
+    name: name,
+    thumbnailPath: '',
+    isHidden: isHidden,
+    birthDate: null,
+    spacePersonId: spacePersonId,
+  );
+
+  void stubAssetInfo({
+    required List<api.PersonWithFacesResponseDto> people,
+    required String ownerId,
+    String? resolvedSpaceId,
+  }) {
+    final info = MockAssetInfo();
+    when(() => info.people).thenReturn(people);
+    when(() => info.ownerId).thenReturn(ownerId);
+    when(() => info.resolvedSpaceId).thenReturn(resolvedSpaceId);
+    when(() => mockAssetsApi.getAssetInfo(any())).thenAnswer((_) async => info);
+  }
+
   setUp(() {
     mockApi = MockPeopleApi();
+    mockAssetsApi = MockAssetsApi();
     mockApiService = MockApiService();
     when(() => mockApiService.peopleApi).thenReturn(mockApi);
+    when(() => mockApiService.assetsApi).thenReturn(mockAssetsApi);
     repository = PersonApiRepository(mockApiService);
+  });
+
+  // Face-tap entry to the person detail page (open a photo → info → tap a face). The asset-info
+  // endpoint carries the space-person id separately (spacePersonId) from the global identity id
+  // (dto.id), and the space id on the asset (resolvedSpaceId). To make the face-tap DriftPerson
+  // shape-identical to the People-page one — so buildPersonTimelineRouteService takes the space
+  // branch and the detail page loads photos — a shared-space person must be mapped with
+  // id = spacePersonId and spaceId = resolvedSpaceId. This is the face-tap sibling of #727/#737.
+  group('getAssetPeople space-person mapping', () {
+    test('maps a shared-space person to id=spacePersonId and spaceId=resolvedSpaceId', () async {
+      stubAssetInfo(
+        people: [personWithFaces('global-1', name: 'Alice', spacePersonId: 'space-person-1')],
+        ownerId: 'admin',
+        resolvedSpaceId: 'space-1',
+      );
+
+      final result = await repository.getAssetPeople('asset-1');
+
+      expect(result.single.id, 'space-person-1');
+      expect(result.single.spaceId, 'space-1');
+      expect(result.single.name, 'Alice');
+    });
+
+    test('keeps the global id and null spaceId for a personal person (no spacePersonId)', () async {
+      stubAssetInfo(
+        people: [personWithFaces('global-2', name: 'Bob')],
+        ownerId: 'me',
+        resolvedSpaceId: null,
+      );
+
+      final result = await repository.getAssetPeople('asset-2');
+
+      expect(result.single.id, 'global-2');
+      expect(result.single.spaceId, isNull);
+    });
+
+    test('stays on the owner path when the asset has no resolvedSpaceId even if spacePersonId is set', () async {
+      // The space assets endpoint needs BOTH ids; without a resolved space id there is no space
+      // to query, so fall back to the owner-scoped shape rather than build an unroutable person.
+      stubAssetInfo(
+        people: [personWithFaces('global-3', name: 'Carol', spacePersonId: 'space-person-3')],
+        ownerId: 'me',
+        resolvedSpaceId: null,
+      );
+
+      final result = await repository.getAssetPeople('asset-3');
+
+      expect(result.single.id, 'global-3');
+      expect(result.single.spaceId, isNull);
+    });
+
+    test('excludes hidden people', () async {
+      stubAssetInfo(
+        people: [
+          personWithFaces('visible', name: 'Dan'),
+          personWithFaces('hidden', name: 'Eve', isHidden: true),
+        ],
+        ownerId: 'me',
+      );
+
+      final result = await repository.getAssetPeople('asset-4');
+
+      expect(result.map((p) => p.id), ['visible']);
+    });
   });
 
   group('getAllPeopleWithSharedSpaces', () {


### PR DESCRIPTION
## What & why

On mobile, opening a **shared-space person's detail page** showed an empty **"0 items"** page — their photos didn't load — while the web app showed them. This closes that mobile-vs-web parity gap so the person-detail page works from **both** entry points:

- **the People page grid** (sibling of #737), and
- **tapping a face** in a photo's info sheet (sibling of #727).

**Mobile-only. No server or RBAC change** — every endpoint used is already membership-gated and is already consumed by the #737 People-page fix and the web app.

## Root cause

The mobile person-detail timeline was built from **owner-scoped local Drift data** (`TimelineFactory.person` → `remote_asset.ownerId == viewer` joined to `asset_face.personId`). A shared-space person's photos are owned by another user, and their `face→person` links are owner-scoped and never sync to the viewer, so that local join is empty. The space **assets** themselves *do* sync locally; only the face links don't.

## The fix

**1. Person-detail routing (`a95290216d`).** Route the detail timeline on `DriftPerson.spaceId`, exactly like web (new `buildPersonTimelineRouteService`):

- **Personal/owned** person (null `spaceId`) → keeps the existing local owner-scoped timeline.
- **Shared-space** person → fetches its photo ids from the already membership-gated `GET /shared-spaces/{id}/people/{personId}/assets` (`getSpacePersonAssets` → `getSharedSpacePersonAssetIds` → `driftSharedSpacePersonAssetIdsProvider`) and renders them from the **locally-synced space assets** via a new `DriftTimelineRepository.sharedSpacePerson` (`_remoteQueryBuilder` filtered by `remote_asset.id IN assetIds`, **no** ownerId filter, **no** `asset_face` join). Best-effort: a fetch failure or in-flight load yields an empty timeline, never a fall-through to the owner-scoped query.

**2. Face-tap fold-in (`8f90e0bdec`).** The face-tap path built its `DriftPerson` via the asset-info mapper `PersonApiRepository._toDriftPerson`, which set `id` = the **global** person id and left `spaceId` null → the space branch never fired → 0 photos. The asset-info DTO carries the space-person id as a **separate** `spacePersonId` field from the global identity `id`, and the space id lives on the asset as `resolvedSpaceId`; both were discarded. Now, when `spacePersonId != null` **and** `resolvedSpaceId != null`, the person is mapped **shape-identical to the People-page one** — `id = spacePersonId`, `spaceId = resolvedSpaceId` (both required; the space endpoints need the pair). Personal/owned people keep the global id and null `spaceId`. Because the strip person's id is now the space-person id (no owner-only `person` row), the strip avatar thumbnail is switched from `getFaceThumbnailUrl(id)` to `getPersonThumbnailUrl(id, spaceId:)` so it routes to the membership-gated space thumbnail endpoint when `spaceId != null` — mirroring the #737 grid; identical to before for personal people.

## Testing

- Built with strict **TDD** (RED→GREEN) across the repository, service, factory, provider, mapper, and widget layers.
- **120 affected unit + widget tests green**; `flutter analyze` and `dart format` clean.
- **Captain-verified on the iOS simulator**: the person-detail page now loads photos from both the People page and the face-tap strip.

## Notes

- Sibling of #727 (per-photo faces) and #737 (People-page grid).
- `AGENTS.md`/`CLAUDE.md` mobile docs updated (both entry points documented; a stale note corrected).
