### PR TITLE
fix(mobile): populate filter/search facets for a shared-space viewer (#727 family)

### DIFF
--- a/mobile/lib/infrastructure/repositories/search_api.repository.dart
+++ b/mobile/lib/infrastructure/repositories/search_api.repository.dart
@@ -57,6 +57,10 @@ class SearchApiRepository extends ApiRepository {
         order: _order(filter) == null ? const Optional.absent() : Optional.present(_order(filter)!),
         page: Optional.present(page),
         size: const Optional.present(100),
+        // Include shared-space assets so a viewer's selected facet returns results (and a
+        // space-person token resolves). Gated on favourite — favourites are owner-only, mirroring
+        // web buildPhotosTimelineOptions (`includeSharedTimelineAssets = isFavorite === undefined`).
+        withSharedSpaces: filter.display.isFavorite ? const Optional.absent() : const Optional.present(true),
       );
       return _api.searchSmart(filter.display.isUntagged ? _ExplicitNullTagIdsSmartSearchDto(dto) : dto);
     }
@@ -88,6 +92,10 @@ class SearchApiRepository extends ApiRepository {
       order: _order(filter) == null ? const Optional.absent() : Optional.present(_order(filter)!),
       page: Optional.present(page),
       size: const Optional.present(1000),
+      // Include shared-space assets so a viewer's selected facet returns results (and a
+      // space-person token resolves). Gated on favourite — favourites are owner-only, mirroring
+      // web buildPhotosTimelineOptions (`includeSharedTimelineAssets = isFavorite === undefined`).
+      withSharedSpaces: filter.display.isFavorite ? const Optional.absent() : const Optional.present(true),
     );
     return _api.searchAssets(filter.display.isUntagged ? _ExplicitNullTagIdsMetadataSearchDto(dto) : dto);
   }

--- a/mobile/lib/presentation/widgets/filter_sheet/deep/people_section.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep/people_section.widget.dart
@@ -100,7 +100,7 @@ class _PeopleGridTile extends ConsumerWidget {
               ),
               child: CircleAvatar(
                 radius: 24,
-                backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
+                backgroundImage: RemoteImageProvider(url: photosFilterPersonThumbnailUrl(person)),
               ),
             ),
             const SizedBox(height: 6),

--- a/mobile/lib/presentation/widgets/filter_sheet/strips/people_strip.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/strips/people_strip.widget.dart
@@ -74,7 +74,7 @@ class _PersonTile extends ConsumerWidget {
               ),
               child: CircleAvatar(
                 radius: 24,
-                backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
+                backgroundImage: RemoteImageProvider(url: photosFilterPersonThumbnailUrl(person)),
               ),
             ),
             const SizedBox(height: 6),

--- a/mobile/lib/providers/photos_filter/city_suggestions.provider.dart
+++ b/mobile/lib/providers/photos_filter/city_suggestions.provider.dart
@@ -12,7 +12,9 @@ final citySuggestionsProvider = FutureProvider.autoDispose.family<List<String>, 
   final response = await api.getSearchSuggestionsWithHttpInfo(
     SearchSuggestionType.city,
     country: country,
-    withSharedSpaces: false,
+    // Include cities from shared-space assets so a non-owner viewer sees them, mirroring the
+    // web filter page (map-filter-config.ts `withSharedSpaces: true`). RBAC-projected server-side.
+    withSharedSpaces: true,
   );
 
   if (response.body.isEmpty) {

--- a/mobile/lib/providers/photos_filter/filter_suggestions.provider.dart
+++ b/mobile/lib/providers/photos_filter/filter_suggestions.provider.dart
@@ -27,6 +27,11 @@ final photosFilterSuggestionsProvider = FutureProvider.autoDispose.family<Filter
     tagIds: filter.tagIds,
     takenAfter: filter.date.takenAfter,
     takenBefore: filter.date.takenBefore,
+    // A non-owner viewer owns none of the shared-space assets they see, so an owner-scoped
+    // facet query comes up empty. Request shared-space content so the facets populate,
+    // mirroring the web filter page (map-filter-config.ts `withSharedSpaces: true`). The
+    // server RBAC-projects the result. See issue #727 family (#737 / #738).
+    withSharedSpaces: true,
   );
   return response ?? FilterSuggestionsResponseDto(hasUnnamedPeople: false);
 });

--- a/mobile/lib/utils/image_url_builder.dart
+++ b/mobile/lib/utils/image_url_builder.dart
@@ -38,3 +38,23 @@ String getSpacePersonThumbnailUrl(final String spaceId, final String personId) {
 String getPersonThumbnailUrl(final String personId, {final String? spaceId}) {
   return spaceId == null ? getFaceThumbnailUrl(personId) : getSpacePersonThumbnailUrl(spaceId, personId);
 }
+
+/// Thumbnail URL for a photos-filter suggestion person. When the filter requests shared spaces
+/// (`withSharedSpaces: true`) the server returns a tokenized [FilterSuggestionsPersonDto.id]
+/// (`person:<uuid>` / `space-person:<uuid>`) whose raw form 404s through [getFaceThumbnailUrl];
+/// route via [FilterSuggestionsPersonDto.primaryProfile] instead — a space person to the
+/// membership-gated space endpoint, otherwise the owner endpoint keyed on the raw profile id.
+/// Mirrors the web `getPhotosPersonFilterThumbnailUrl`.
+String photosFilterPersonThumbnailUrl(final FilterSuggestionsPersonDto person) {
+  final profile = person.primaryProfile.orElse(null);
+  if (profile != null) {
+    final spaceId = profile.spaceId.orElse(null);
+    if (profile.type == ScopedPrimaryProfileTypeEnum.spacePerson && spaceId != null) {
+      return getSpacePersonThumbnailUrl(spaceId, profile.id);
+    }
+    return getFaceThumbnailUrl(profile.id);
+  }
+  const personPrefix = 'person:';
+  final id = person.id.startsWith(personPrefix) ? person.id.substring(personPrefix.length) : person.id;
+  return getFaceThumbnailUrl(id);
+}

--- a/mobile/test/infrastructure/repositories/search_api_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/search_api_repository_test.dart
@@ -91,5 +91,42 @@ void main() {
       final dto = verify(() => searchApi.searchAssets(captureAny())).captured.single as MetadataSearchDto;
       expect(dto.order.value, AssetOrder.asc);
     });
+
+    // A viewer's selected facet only returns shared-space assets (and space-person tokens only
+    // resolve) when the search requests shared spaces — mirror web buildPhotosTimelineOptions,
+    // which gates shared content on `isFavorite === undefined` (favourites are owner-only).
+    test('metadata search requests shared spaces when not filtering by favourite', () async {
+      when(() => searchApi.searchAssets(any())).thenAnswer((_) async => null);
+      await sut.search(SearchFilter.empty(), 1);
+      final dto = verify(() => searchApi.searchAssets(captureAny())).captured.single as MetadataSearchDto;
+      expect(dto.withSharedSpaces.value, true);
+    });
+
+    test('metadata search omits shared spaces when filtering by favourite', () async {
+      when(() => searchApi.searchAssets(any())).thenAnswer((_) async => null);
+      final filter = SearchFilter.empty().copyWith(display: SearchFilter.empty().display.copyWith(isFavorite: true));
+      await sut.search(filter, 1);
+      final dto = verify(() => searchApi.searchAssets(captureAny())).captured.single as MetadataSearchDto;
+      expect(dto.withSharedSpaces.isPresent, isFalse);
+    });
+
+    test('smart search requests shared spaces when not filtering by favourite', () async {
+      when(() => searchApi.searchSmart(any())).thenAnswer((_) async => null);
+      final filter = SearchFilter.empty().copyWith(context: 'beach');
+      await sut.search(filter, 1);
+      final dto = verify(() => searchApi.searchSmart(captureAny())).captured.single as SmartSearchDto;
+      expect(dto.withSharedSpaces.value, true);
+    });
+
+    test('smart search omits shared spaces when filtering by favourite', () async {
+      when(() => searchApi.searchSmart(any())).thenAnswer((_) async => null);
+      final filter = SearchFilter.empty().copyWith(
+        context: 'beach',
+        display: SearchFilter.empty().display.copyWith(isFavorite: true),
+      );
+      await sut.search(filter, 1);
+      final dto = verify(() => searchApi.searchSmart(captureAny())).captured.single as SmartSearchDto;
+      expect(dto.withSharedSpaces.isPresent, isFalse);
+    });
   });
 }

--- a/mobile/test/presentation/widgets/filter_sheet/deep/people_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/people_section_test.dart
@@ -11,6 +11,7 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/deep/people_section.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:openapi/api.dart';
@@ -80,6 +81,41 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(container.read(photosFilterProvider).people.any((p) => p.id == 'p1'), isTrue);
+    });
+
+    // With withSharedSpaces the server returns a tokenized id + a space-person primaryProfile.
+    // The avatar must route off the profile to the membership-gated space endpoint, not the
+    // tokenized id (which would 404 through the owner /people/{id} endpoint). Mirrors #737.
+    testWidgets('space-person avatar routes to the membership-gated space thumbnail endpoint', (tester) async {
+      await tester.pumpConsumerWidget(
+        const Material(child: PeopleSectionDeep(onOpenPicker: null)),
+        overrides: [
+          photosFilterSuggestionsProvider.overrideWith(
+            (ref, filter) => Future.value(
+              _sugg(
+                people: [
+                  FilterSuggestionsPersonDto(
+                    id: 'space-person:profile-1',
+                    name: 'Alice',
+                    primaryProfile: Optional.present(
+                      ScopedPrimaryProfile(
+                        id: 'profile-1',
+                        spaceId: const Optional.present('space-1'),
+                        type: ScopedPrimaryProfileTypeEnum.spacePerson,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
+      final provider = avatar.backgroundImage! as RemoteImageProvider;
+      expect(provider.url, 'http://localhost:0/shared-spaces/space-1/people/profile-1/thumbnail');
     });
 
     testWidgets('empty list → empty state string and no "Search N" affordance', (tester) async {

--- a/mobile/test/providers/photos_filter/city_suggestions_provider_test.dart
+++ b/mobile/test/providers/photos_filter/city_suggestions_provider_test.dart
@@ -24,9 +24,7 @@ void main() {
     mockSearchApi = MockSearchApi();
     when(() => mockApiService.searchApi).thenReturn(mockSearchApi);
 
-    container = ProviderContainer(
-      overrides: [apiServiceProvider.overrideWithValue(mockApiService)],
-    );
+    container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(mockApiService)]);
     addTearDown(container.dispose);
   });
 
@@ -41,32 +39,25 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test(
-      'calls getSearchSuggestions(type=city, country) when country set',
-      () async {
-        when(
-          () => mockSearchApi.getSearchSuggestionsWithHttpInfo(
-            SearchSuggestionType.city,
-            country: 'France',
-            withSharedSpaces: false,
-          ),
-        ).thenAnswer(
-          (_) async => http.Response(jsonEncode(['Paris', 'Lyon']), 200),
-        );
+    test('calls getSearchSuggestions(type=city, country) with withSharedSpaces: true when country set', () async {
+      when(
+        () => mockSearchApi.getSearchSuggestionsWithHttpInfo(
+          SearchSuggestionType.city,
+          country: 'France',
+          withSharedSpaces: true,
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode(['Paris', 'Lyon']), 200));
 
-        final result = await container.read(
-          citySuggestionsProvider('France').future,
-        );
-        expect(result, ['Paris', 'Lyon']);
-        verify(
-          () => mockSearchApi.getSearchSuggestionsWithHttpInfo(
-            SearchSuggestionType.city,
-            country: 'France',
-            withSharedSpaces: false,
-          ),
-        ).called(1);
-      },
-    );
+      final result = await container.read(citySuggestionsProvider('France').future);
+      expect(result, ['Paris', 'Lyon']);
+      verify(
+        () => mockSearchApi.getSearchSuggestionsWithHttpInfo(
+          SearchSuggestionType.city,
+          country: 'France',
+          withSharedSpaces: true,
+        ),
+      ).called(1);
+    });
 
     test('null response from server → empty list', () async {
       when(
@@ -77,10 +68,7 @@ void main() {
         ),
       ).thenAnswer((_) async => http.Response('', 204));
 
-      expect(
-        await container.read(citySuggestionsProvider('France').future),
-        isEmpty,
-      );
+      expect(await container.read(citySuggestionsProvider('France').future), isEmpty);
     });
   });
 }

--- a/mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart
+++ b/mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart
@@ -29,6 +29,49 @@ void main() {
   });
 
   group('photosFilterSuggestionsProvider', () {
+    // A non-owner viewer whose visible photos are all shared-space owns no assets, so an
+    // owner-scoped facet query returns nothing. Request shared-space content so the facets
+    // populate — mirrors the web filter page (map-filter-config.ts withSharedSpaces: true).
+    test('requests shared-space facets so a viewer sees them (withSharedSpaces: true)', () async {
+      when(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).thenAnswer((_) async => FilterSuggestionsResponseDto(hasUnnamedPeople: false));
+
+      await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future);
+
+      verify(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: true,
+        ),
+      ).called(1);
+    });
+
     test('returns the FilterSuggestionsResponseDto returned by the API', () async {
       final dto = FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: ['France']);
       when(
@@ -123,6 +166,7 @@ void main() {
           tagIds: ['tag-1', 'tag-2'],
           takenAfter: after,
           takenBefore: before,
+          withSharedSpaces: true,
         ),
       ).called(1);
     });

--- a/mobile/test/unit/utils/image_url_builder_test.dart
+++ b/mobile/test/unit/utils/image_url_builder_test.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
+import 'package:openapi/api.dart' as api;
 
 void main() {
   late Drift db;
@@ -52,6 +53,50 @@ void main() {
         getPersonThumbnailUrl('space-person-1', spaceId: 'space-1'),
         'http://localhost:0/shared-spaces/space-1/people/space-person-1/thumbnail',
       );
+    });
+  });
+
+  // A photos-filter suggestion person carries a tokenized id (`person:<uuid>` / `space-person:<uuid>`)
+  // when withSharedSpaces resolves via the identity path — routing the avatar off that tokenized id
+  // 404s. Route via primaryProfile instead, mirroring web getPhotosPersonFilterThumbnailUrl.
+  group('photosFilterPersonThumbnailUrl', () {
+    test('routes a space-person profile to the membership-gated space endpoint', () {
+      final person = api.FilterSuggestionsPersonDto(
+        id: 'space-person:profile-1',
+        name: 'Alice',
+        primaryProfile: api.Optional.present(
+          api.ScopedPrimaryProfile(
+            id: 'profile-1',
+            spaceId: const api.Optional.present('space-1'),
+            type: api.ScopedPrimaryProfileTypeEnum.spacePerson,
+          ),
+        ),
+      );
+      expect(
+        photosFilterPersonThumbnailUrl(person),
+        'http://localhost:0/shared-spaces/space-1/people/profile-1/thumbnail',
+      );
+    });
+
+    test('routes a user-person profile to the owner endpoint using the raw profile id', () {
+      final person = api.FilterSuggestionsPersonDto(
+        id: 'person:profile-2',
+        name: 'Bob',
+        primaryProfile: api.Optional.present(
+          api.ScopedPrimaryProfile(id: 'profile-2', type: api.ScopedPrimaryProfileTypeEnum.userPerson),
+        ),
+      );
+      expect(photosFilterPersonThumbnailUrl(person), 'http://localhost:0/people/profile-2/thumbnail');
+    });
+
+    test('strips a person: prefix when no primaryProfile is present', () {
+      final person = api.FilterSuggestionsPersonDto(id: 'person:raw-uuid', name: 'Carol');
+      expect(photosFilterPersonThumbnailUrl(person), 'http://localhost:0/people/raw-uuid/thumbnail');
+    });
+
+    test('falls back to a bare id (owner endpoint) when there is no prefix or profile', () {
+      final person = api.FilterSuggestionsPersonDto(id: 'raw-uuid', name: 'Dave');
+      expect(photosFilterPersonThumbnailUrl(person), 'http://localhost:0/people/raw-uuid/thumbnail');
     });
   });
 }


### PR DESCRIPTION
## Problem

Logged in as a **non-owner viewer** whose visible photos are all shared-space (owned by someone else), the timeline renders fine but the **filter/search sheet is empty** — no people, places, tags or cities to filter on. This is the filter-panel sibling of the recently-merged #727 / #737 / #738 viewer-parity fixes.

## Root cause

The sheet's content facets are **server-sourced** (`getFilterSuggestions` / `getSearchSuggestions`), but the mobile calls **omitted the fork's `withSharedSpaces` flag** that the web filter page already passes (`web/src/lib/utils/map-filter-config.ts`). Without it the server scopes the facet queries to the viewer's *own* assets — of which a pure viewer owns none — so every content-derived facet (people, countries, cities, tags, cameras) returns empty. The static facets (when/rating/media/toggles) still render, matching the report.

## Fix — mobile-only

No server/RBAC change: the RBAC-projected `withSharedSpaces` path already exists and is consumed by the web filter page and the mobile People page (#737). This just consumes it.

- **`filter_suggestions.provider` / `city_suggestions.provider`** — request `withSharedSpaces: true` so People / Places / Tags / Cities populate for the viewer.
- **`search_api.repository`** — thread `withSharedSpaces` into the Smart/Metadata search DTOs so a *selected* facet actually returns shared-space results (and a `space-person:` token resolves). Gated on favourite, mirroring web `buildPhotosTimelineOptions` (`includeSharedTimelineAssets = isFavorite === undefined`; favourites are owner-only).
- **`image_url_builder` + People strip/section** — with shared spaces the server returns tokenized person ids (`person:` / `space-person:`); route the avatars via `primaryProfile` (new `photosFilterPersonThumbnailUrl`) so they don't 404 through the owner `/people/{id}` endpoint. Mirrors web `getPhotosPersonFilterThumbnailUrl` / the #737 thumbnail routing.

## Tests (TDD — failing first)

- `filter_suggestions_provider_test` — asserts `withSharedSpaces: true` on the wire.
- `city_suggestions_provider_test` — asserts `withSharedSpaces: true`.
- `search_api_repository_test` — asserts the Smart/Metadata DTOs request shared spaces when not filtering by favourite, and omit them when filtering by favourite.
- `image_url_builder_test` — unit-tests `photosFilterPersonThumbnailUrl` (space-person → space endpoint; user-person / tokenized / bare id → owner endpoint on the raw profile id).
- `people_section_test` — widget test: a space-person avatar routes to the membership-gated space thumbnail endpoint end-to-end.

All relevant suites green (`test/providers/photos_filter/`, `test/presentation/widgets/filter_sheet/`, `test/presentation/pages/photos_filter/`, the two repository/util tests): **381 passing**. `dart analyze` clean, `dart format` clean.

## Out of scope / notes

- The full-screen **"Search N people" picker page** stays owner-scoped/local by existing design (documented in `CLAUDE.md`); surfacing shared-space people there is a separate **product decision** and is deliberately not touched here.
- The new sheet has **no camera facet UI** at all — that's a separate feature gap, not this viewer bug.
- Issue **#732** (camera/lens filter zero-results for *non-admin*) is a distinct **server-side** bug (admin vs non-admin, not viewer vs owner) and is not addressed here.

> Base branch: **`rebase/upstream-rolling-20260509-active`** (the rolling rebase branch), not `main`.