### PR TITLE
ci(release): add pre-release server workflow

### DIFF
--- a/.github/workflows/gallery-prerelease-server.yml
+++ b/.github/workflows/gallery-prerelease-server.yml
@@ -1,0 +1,415 @@
+name: Pre-release Gallery Server
+
+# Publishes a Gallery PRE-RELEASE (release candidate), the way upstream Immich
+# shipped v3.0.0-rc.0. It builds + pushes the server and ML images under the RC
+# tag, creates a git tag, and creates a GitHub Release flagged as a pre-release.
+#
+# It deliberately does the SAFE subset of the GA release. Compared to
+# gallery-release-server-only.yml it:
+#   - does NOT move the floating `release` / `vN` / `latest` docker tags
+#   - does NOT mark the GitHub Release as `latest`
+#   - does NOT publish to the version endpoint that self-hosted instances poll
+#     (an RC version is semver-greater than the current GA, so flipping the
+#     endpoint would prompt every stable install to "upgrade" to a candidate)
+#   - does NOT restrict to `main` — RCs are cut from the rolling branch
+#
+# `apply-branding` IS given the RC version (a valid prerelease semver), so the
+# server reports its true version (e.g. 5.0.0-rc.0) rather than the nearest
+# fork tag that gallery-rc-build stamps.
+#
+# Dispatch it from the branch/ref you want to release (e.g. the rolling branch).
+# The workflow file must exist on that ref for workflow_dispatch to run it there.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Pre-release version tag (e.g. v5.0.0-rc.0). Must be v<N>.<N>.<N>-rc.<N>.'
+        required: true
+        type: string
+      commit:
+        description: 'Commit SHA to release up to (default: HEAD of the triggering ref). Must be an ancestor of the ref.'
+        required: false
+        type: string
+
+concurrency:
+  group: gallery-prerelease-${{ inputs.version }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  version:
+    name: Validate version & resolve commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.version.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Strict prerelease shape: v<major>.<minor>.<patch>-rc.<n> (Immich style).
+          # Rejects GA versions (would collide with the real release) and typos.
+          if [[ ! "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            echo "::error::Invalid version: '$INPUT_VERSION' (expected v<major>.<minor>.<patch>-rc.<n>, e.g. v5.0.0-rc.0)"
+            exit 1
+          fi
+
+          sha="$DEFAULT_SHA"
+          if [[ -n "$INPUT_COMMIT" ]]; then
+            # Resolve to a full SHA and require it to be an ancestor of the
+            # triggering ref, so we only ever release a commit already merged
+            # onto this branch — never an arbitrary or unmerged commit.
+            if ! sha=$(git rev-parse --verify --quiet "${INPUT_COMMIT}^{commit}"); then
+              echo "::error::commit '$INPUT_COMMIT' not found in history"
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$sha" "$DEFAULT_SHA"; then
+              echo "::error::commit '$sha' is not an ancestor of ${DEFAULT_SHA} — refusing to release a commit not merged on this ref"
+              exit 1
+            fi
+          fi
+
+          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Pre-releasing $INPUT_VERSION from $sha"
+
+  build-server:
+    name: Build Server (${{ matrix.platform }})
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.version.outputs.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply branding
+        # The RC version is a valid prerelease semver, so stamp it directly —
+        # the server then reports its true version instead of the nearest tag.
+        uses: ./.github/actions/apply-branding
+        with:
+          version: ${{ needs.version.outputs.version }}
+
+      - name: Prepare platform pair
+        id: prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "platform-pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: server/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            DEVICE=cpu
+            BUILD_ID=${{ github.run_id }}
+            BUILD_SOURCE_REF=${{ needs.version.outputs.version }}
+            BUILD_SOURCE_COMMIT=${{ needs.version.outputs.sha }}
+          outputs: type=image,"name=ghcr.io/open-noodle/gallery-server",push-by-digest=true,name-resolution=short,push=true
+          cache-from: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }}
+          cache-to: type=gha,scope=server-${{ steps.prepare.outputs.platform-pair }},mode=max
+
+      - name: Export digest
+        run: | # zizmor: ignore[template-injection]
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: prerelease-server-digests-${{ steps.prepare.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-server:
+    name: Merge Server Manifest
+    needs: [version, build-server]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: prerelease-server-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ghcr.io/open-noodle/gallery-server
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          # ONLY the RC tag — no release/vN/latest.
+          sources=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}" ${sources}
+
+  build-ml:
+    name: Build ML ${{ matrix.device }} (${{ matrix.platform }})
+    needs: version
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - device: cpu
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - device: cpu
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - device: cuda
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - device: openvino
+            platform: linux/amd64
+            runner: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.version.outputs.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply branding
+        uses: ./.github/actions/apply-branding
+        with:
+          version: ${{ needs.version.outputs.version }}
+
+      - name: Prepare platform pair
+        id: prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "platform-pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: machine-learning
+          file: machine-learning/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            DEVICE=${{ matrix.device }}
+          outputs: type=image,"name=ghcr.io/open-noodle/gallery-ml",push-by-digest=true,name-resolution=short,push=true
+          cache-from: type=gha,scope=ml-${{ matrix.device }}-${{ steps.prepare.outputs.platform-pair }}
+          cache-to: type=gha,scope=ml-${{ matrix.device }}-${{ steps.prepare.outputs.platform-pair }},mode=max
+
+      - name: Export digest
+        run: | # zizmor: ignore[template-injection]
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: prerelease-ml-${{ matrix.device }}-digests-${{ steps.prepare.outputs.platform-pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-ml:
+    name: Merge ML Manifest (${{ matrix.device }})
+    needs: [version, build-ml]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - device: cpu
+            suffix: ''
+          - device: cuda
+            suffix: '-cuda'
+          - device: openvino
+            suffix: '-openvino'
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: prerelease-ml-${{ matrix.device }}-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ghcr.io/open-noodle/gallery-ml
+          VERSION: ${{ needs.version.outputs.version }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          # ONLY the RC tag (+device suffix) — no release/vN/latest.
+          sources=$(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}${SUFFIX}" ${sources}
+
+  tag-and-release:
+    name: Create Git Tag and GitHub Pre-release
+    needs: [version, merge-server, merge-ml]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ needs.version.outputs.sha }}
+
+      - name: Create tag
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          SHA: ${{ needs.version.outputs.sha }}
+        run: |
+          # -f + --force makes re-runs idempotent if a prior attempt tagged
+          # before failing downstream. Only the RC tag is created/moved — the
+          # floating release/vN/latest tags are never touched.
+          git tag -f "$VERSION" "$SHA"
+          git push origin "$VERSION" --force
+
+      - name: Create GitHub Pre-release
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          SHA: ${{ needs.version.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          upstream_version=$(jq -r '.upstream.version' branding/config.json)
+
+          # Most recent GA tag (ancestor of the sorted list, excluding RCs) for
+          # the compare link. We intentionally do NOT inline the commit list: an
+          # RC across a major bump spans thousands of commits and would overflow
+          # the release-notes size limit. The compare link carries the detail.
+          prev_tag=$(git tag --list 'v*.*.*' --sort=-version:refname | grep -Ev -- '-rc\.' | grep -Fvx "$VERSION" | head -n1 || true)
+
+          {
+            echo "> ⚠️ **Release candidate — not for production.** Please back up your database before testing."
+            echo ""
+            echo "Based on [Immich v${upstream_version}](https://github.com/immich-app/immich/releases/tag/v${upstream_version})."
+            echo ""
+            echo "### Try it"
+            echo ""
+            echo "Set \`IMMICH_VERSION=${VERSION}\` in your \`.env\`, then:"
+            echo ""
+            echo '```bash'
+            echo "docker compose pull && docker compose up -d"
+            echo '```'
+            echo ""
+            echo "Report issues on [GitHub](https://github.com/${REPO}/issues)."
+            if [[ -n "$prev_tag" ]]; then
+              echo ""
+              echo "**Full changelog:** [\`${prev_tag}...${VERSION}\`](https://github.com/${REPO}/compare/${prev_tag}...${VERSION})"
+            fi
+          } > /tmp/prerelease-notes.md
+
+          # Idempotent on re-runs: edit the existing release, else create it.
+          # --prerelease (never --latest) keeps it off the "Latest" badge and
+          # out of the version-check path.
+          if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+            gh release edit "$VERSION" \
+              --repo "$REPO" \
+              --prerelease \
+              --target "$SHA" \
+              --title "$VERSION" \
+              --notes-file /tmp/prerelease-notes.md
+            gh release upload "$VERSION" \
+              --repo "$REPO" \
+              --clobber \
+              docker/docker-compose.yml \
+              docker/example.env
+          else
+            gh release create "$VERSION" \
+              --repo "$REPO" \
+              --target "$SHA" \
+              --title "$VERSION" \
+              --prerelease \
+              --notes-file /tmp/prerelease-notes.md \
+              docker/docker-compose.yml \
+              docker/example.env
+          fi
+
+          echo "Pre-released $VERSION from $SHA"

--- a/docs/plans/2026-07-02-prerelease-workflow-design.md
+++ b/docs/plans/2026-07-02-prerelease-workflow-design.md
@@ -1,0 +1,124 @@
+# Pre-release server workflow (`gallery-prerelease-server.yml`)
+
+**Date:** 2026-07-02
+**Status:** Design approved, pending implementation
+
+## Goal
+
+Publish a Gallery **pre-release** the way Immich shipped
+[`v3.0.0-rc.0`](https://github.com/immich-app/immich/releases/tag/v3.0.0-rc.0):
+multi-arch server + ML images under a semver RC tag, a git tag, and a GitHub
+Release flagged **pre-release** — without any of the "this is now the stable
+version" side effects.
+
+This fills the gap between the two existing workflows:
+
+- `gallery-rc-build.yml` — throwaway RC images under an arbitrary tag. No git
+  tag, no GitHub Release, no version endpoint. Stamps the _nearest fork tag_ as
+  the server version (e.g. `v4.56.7`), which mislabels the build.
+- `gallery-release-server-only.yml` — the GA release. Moves the
+  `release` / `vN` / `latest` docker tags, marks the GitHub Release `--latest`,
+  and **flips the version-poll endpoint** self-hosted instances check.
+
+The pre-release workflow wants the GitHub-Release object and reproducibility of
+the GA path, but the update-safety of the RC builder.
+
+## Why the version endpoint must not move (the core constraint)
+
+The server's update check (`VersionService.handleVersionCheck` →
+`ServerInfoRepository.getLatestRelease`) fetches the Bunny `/gallery` endpoint
+and broadcasts an "update available" notification when:
+
+```ts
+semver.gt(endpointVersion, serverVersion);
+```
+
+Because `5.0.0-rc.0 > 4.58.0`, publishing an RC to that endpoint would prompt
+**every stable install** to "upgrade" to a release candidate. Therefore the
+pre-release workflow **must not** run a `publish-version-endpoint` job. The
+endpoint stays on the current GA version (`v4.58.0`).
+
+Corollaries handled correctly by leaving the endpoint alone:
+
+- An RC tester running `5.0.0-rc.0` sees the endpoint still reporting `4.58.0`;
+  `semver.gt('4.58.0', '5.0.0-rc.0')` is `false`, so no downgrade prompt.
+- When GA `v5.0.0` later ships and flips the endpoint,
+  `semver.gt('5.0.0', '5.0.0-rc.0')` is `true`, so RC testers are correctly
+  prompted to move to GA.
+
+## Decisions
+
+| Decision         | Choice                                  | Rationale                                                                                                                                                                                  |
+| ---------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Architecture     | New standalone workflow                 | The GA workflow's tail (move `release`/`vN`/`latest`, `--latest`, flip endpoint) is exactly what an RC must not do. A separate workflow leaves the dangerous GA path untouched.            |
+| Tag format       | `v5.0.0-rc.0` (Immich dot-style)        | Numeric identifier sorts correctly in semver (`rc.10 > rc.9`). The dot-less `rcN` form makes `rc10` a single alphanumeric identifier that sorts _below_ `rc9` — a real footgun past rc9.   |
+| Version stamp    | Pass the RC version to `apply-branding` | `apply-branding.sh` strips the leading `v` and stamps `5.0.0-rc.0`, which is valid semver (`new SemVer('5.0.0-rc.0')` succeeds). The server reports its true version, not the nearest tag. |
+| Scope            | Server + ML only                        | Mobile releases independently (`gallery-build-mobile.yml`), matching the current decoupled split. RC testers get mobile via that separate pipeline.                                        |
+| ML matrix        | cpu + cuda + openvino                   | Mirrors the GA release matrix so RC testers on any inference backend can actually test.                                                                                                    |
+| Version endpoint | Never published                         | See constraint above.                                                                                                                                                                      |
+
+## Workflow shape
+
+`workflow_dispatch` inputs:
+
+- `version` (required) — validated against `^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$`
+  (e.g. `v5.0.0-rc.0`). Rejects GA versions and typos.
+- `commit` (optional) — SHA to release up to; defaults to HEAD of the dispatched
+  ref. Reuses the GA workflow's "must be an ancestor of the triggering ref"
+  check so only merged commits ship.
+
+Jobs:
+
+1. **`validate`** — check the `version` shape; resolve/verify `commit`.
+2. **`build-server`** (matrix: `linux/amd64`, `linux/arm64`) — `apply-branding`
+   **with `version`**, build + push-by-digest to
+   `ghcr.io/open-noodle/gallery-server`.
+3. **`merge-server`** — `docker buildx imagetools create -t gallery-server:<version>`
+   from the per-arch digests. **Only** the `<version>` tag — no `release`/`vN`/`latest`.
+4. **`build-ml`** (matrix: cpu/cuda/openvino × platforms per GA workflow) —
+   `apply-branding` with `version`, build + push-by-digest to `gallery-ml`.
+5. **`merge-ml`** (matrix: cpu → ``, cuda → `-cuda`, openvino → `-openvino`) —
+   `imagetools create -t gallery-ml:<version><suffix>`.
+6. **`tag-and-release`**:
+   - Create the annotated git tag `<version>` at the resolved SHA. **Does not**
+     move `release` / `vN` / `latest`.
+   - `gh release create <version> --prerelease` (never `--latest`) with
+     auto-generated notes and `docker/docker-compose.yml` + `docker/example.env`
+     attached.
+   - Notes header: testing instructions ("set `IMMICH_VERSION=<version>` in your
+     `.env`, then `docker compose pull && docker compose up -d`"), followed by
+     the commit list since the previous release/RC (reuse the GA workflow's
+     gallery-vs-upstream commit split).
+
+Explicitly **absent**: any `publish-version-endpoint` job, any floating-tag
+moves, any `--latest` marking, any branch guard restricting to `main`.
+
+## How it is dispatched (branch mechanics)
+
+`workflow_dispatch` runs the workflow file _as it exists on the selected ref_.
+The v5 work lives on the rolling branch
+(`rebase/upstream-rolling-20260509-active`), so to cut `v5.0.0-rc.0` the workflow
+file must be present on that branch. Plan:
+
+- Land the workflow on `main` (default branch → visible/dispatchable in the
+  Actions UI, carried into future rebases as a fork commit).
+- Ensure it is present on the current rolling branch (it is replayed as a fork
+  commit on the next rebase; for an immediate cut, add it to the rolling branch
+  directly).
+
+## Cleanup of ad-hoc RC images
+
+The earlier throwaway RC builds left `v5.0.0-rc1` and `v5.0.0-rc5` tagged in both
+`gallery-server` and `gallery-ml`. Since the series restarts clean at `rc.0`,
+these four tagged versions are deleted so the registry shows a single coherent
+`rc.N` series. (Requires `delete:packages` scope on the `gh` token.)
+
+## Verification plan
+
+- YAML/action lint (the repo pins action SHAs; keep the same pinned versions).
+- Dry-run reasoning: confirm `merge-*` jobs emit only the `<version>`(+suffix)
+  tags and that no job references the Bunny endpoint vars.
+- First real cut of `v5.0.0-rc.0` from the rolling branch: verify the pushed
+  image reports version `5.0.0-rc.0` at `/api/server/about`, the GitHub Release
+  is marked pre-release and **not** latest, and the `/gallery` endpoint is
+  unchanged.

--- a/docs/plans/2026-07-02-prerelease-workflow-design.md
+++ b/docs/plans/2026-07-02-prerelease-workflow-design.md
@@ -78,7 +78,7 @@ Jobs:
 4. **`build-ml`** (matrix: cpu/cuda/openvino × platforms per GA workflow) —
    `apply-branding` with `version`, build + push-by-digest to `gallery-ml`.
 5. **`merge-ml`** (matrix: cpu → ``, cuda → `-cuda`, openvino → `-openvino`) —
-   `imagetools create -t gallery-ml:<version><suffix>`.
+`imagetools create -t gallery-ml:<version><suffix>`.
 6. **`tag-and-release`**:
    - Create the annotated git tag `<version>` at the resolved SHA. **Does not**
      move `release` / `vN` / `latest`.


### PR DESCRIPTION
## What

Adds `.github/workflows/gallery-prerelease-server.yml` — a `workflow_dispatch` pipeline that publishes a Gallery **pre-release** (release candidate) the way upstream Immich shipped [`v3.0.0-rc.0`](https://github.com/immich-app/immich/releases/tag/v3.0.0-rc.0).

It builds + pushes multi-arch `gallery-server` and `gallery-ml` (cpu/cuda/openvino) under an RC tag, creates a git tag, and creates a GitHub Release flagged **pre-release** with `docker-compose.yml` + `example.env` attached. `apply-branding` is given the RC version (a valid prerelease semver), so the server reports its true version (e.g. `5.0.0-rc.0`) instead of the nearest fork tag that `gallery-rc-build` stamps.

## Why it's the *safe* subset of the GA release

Compared to `gallery-release-server-only.yml`, it deliberately does **not**:

- move the floating `release` / `vN` / `latest` docker tags
- mark the GitHub Release as `latest`
- publish to the version-poll endpoint

That last one is the load-bearing constraint: the server's update check fires when `semver.gt(endpointVersion, serverVersion)`, and `5.0.0-rc.0 > 4.58.0` — so flipping the endpoint to an RC would prompt **every stable install** to "upgrade" to a candidate. Leaving it alone also means RC testers aren't prompted to downgrade, and are correctly prompted to move to GA once `v5.0.0` ships.

## Version format

`version` input is validated against `^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$` (Immich dot-style, e.g. `v5.0.0-rc.0`). The dot keeps semver ordering correct (`rc.10 > rc.9`), unlike the dot-less `rcN` form.

## Notes

- Not yet triggered — no RC has been cut from this.
- To dispatch against the rolling branch, the file must exist on that ref too (it rides on as a fork commit on the next rebase).
- The ad-hoc `v5.0.0-rc1`/`rc5` GHCR images were deleted so the series starts clean at `rc.0`.

Design doc: `docs/plans/2026-07-02-prerelease-workflow-design.md`

## Verification

- `actionlint` → exit 0 (only info-level SC2086 on `${sources}`, identical intentional word-split as the existing release/rc workflows)
- All actions SHA-pinned identically to the existing workflows; inputs routed through `env:` (no template injection)