### PR TITLE
docs: base is Immich v3.0.1; version examples v4 → v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <br/>
 
 > [!NOTE]
-> This is a **community fork** of [Immich](https://github.com/immich-app/immich) with additional features and improvements. Currently based on **Immich v2.7.5**. We regularly sync with upstream to stay up to date. See [What's Different](#whats-different-from-upstream-immich) below.
+> This is a **community fork** of [Immich](https://github.com/immich-app/immich) with additional features and improvements. Currently based on **Immich v3.0.1**. We regularly sync with upstream to stay up to date. See [What's Different](#whats-different-from-upstream-immich) below.
 
 > [!TIP]
 > **Noodle Gallery mobile apps are out!** Back up your photos and browse your library on the go. [Download on the App Store](https://apps.apple.com/il/app/noodle-gallery/id6761776289) · [Get it on Google Play](https://play.google.com/store/apps/details?id=de.opennoodle.gallery)
@@ -254,8 +254,8 @@ Pre-built Docker images are published to GitHub Container Registry (GHCR) under 
 ### Tags
 
 - **`release`** / **`release-cuda`** — most recent published build (like upstream's `release` tag)
-- **`v4`** — floats to the latest v4.x.x release (set `IMMICH_VERSION=v4` to auto-update within major version)
-- **`v4.2.6`** — pinned version using [semantic versioning](https://semver.org/)
+- **`v5`** — floats to the latest v5.x.x release (set `IMMICH_VERSION=v5` to auto-update within major version)
+- **`v5.0.0`** — pinned version using [semantic versioning](https://semver.org/)
 
 ### Publishing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 > **Noodle Gallery mobile apps are out!** Back up your photos and browse your library on the go. [Download on the App Store](https://apps.apple.com/il/app/noodle-gallery/id6761776289) · [Get it on Google Play](https://play.google.com/store/apps/details?id=de.opennoodle.gallery)
 
 > [!TIP]
-> **Already running Immich?** Switching to Gallery is a three-line config change — two image names in your `docker-compose.yml` and `IMMICH_VERSION=v4` in your `.env`. Your library and database are fully compatible. See the [install guide](https://opennoodle.de/install/#migrate-from-immich).
+> **Already running Immich?** Switching to Gallery is a three-line config change — two image names in your `docker-compose.yml` and `IMMICH_VERSION=v5` in your `.env`. Your library and database are fully compatible. See the [install guide](https://opennoodle.de/install/#migrate-from-immich).
 >
 > **Not for you?** A one-command [switch-back script](https://docs.opennoodle.de/guides/switch-back-to-immich) cleans up Gallery-specific tables and columns and puts you back on upstream Immich. Your photos and videos never move.
 
@@ -117,7 +117,7 @@ docker exec -t immich_postgres pg_dumpall -c -U postgres | gzip > immich-db-back
 Set the version in your `.env` file:
 
 ```bash
-IMMICH_VERSION=v4
+IMMICH_VERSION=v5
 ```
 
 Change the image references in your `docker-compose.yml`:

--- a/docs/docs/developer/releases.md
+++ b/docs/docs/developer/releases.md
@@ -8,7 +8,7 @@ Both are manual (`Actions → Run workflow`, or `gh workflow run`) and must be t
 
 ### Release Mobile
 
-Workflow: `gallery-release-mobile.yml`. Input: a required `version` (e.g. `v4.56.6`).
+Workflow: `gallery-release-mobile.yml`. Input: a required `version` (e.g. `v5.0.0`).
 
 1. Builds + signs the Android AAB/APK and the iOS IPA at the commit that dispatched the run.
 2. Uploads the Android AAB to the Play Store **internal** track and the iOS IPA to **TestFlight**.
@@ -28,8 +28,8 @@ It builds and pushes multi-arch Docker images to `ghcr.io/open-noodle/`, moves t
 
 The three git tags:
 
-- `vX.Y.Z` — the specific version (e.g. `v4.56.6`)
-- `vX` — floats to the latest release in that major (e.g. `v4`)
+- `vX.Y.Z` — the specific version (e.g. `v5.0.0`)
+- `vX` — floats to the latest release in that major (e.g. `v5`)
 - `release` — always points to the latest server release
 
 ## Keeping mobile and server in sync (optional)
@@ -54,8 +54,8 @@ Users pin their deployments with the `IMMICH_VERSION` env var in `docker-compose
 
 | Tag              | Example   | Behavior                  |
 | ---------------- | --------- | ------------------------- |
-| Specific version | `v4.56.6` | Pinned to exact release   |
-| Major version    | `v4`      | Floats to latest `v4.x.x` |
+| Specific version | `v5.0.0`  | Pinned to exact release   |
+| Major version    | `v5`      | Floats to latest `v5.x.x` |
 | `release`        | `release` | Always latest build       |
 
 ## Upstream tracking


### PR DESCRIPTION
Post-v3-cutover doc refresh.

## Changes
- **README** — fork is now "Currently based on **Immich v3.0.1**" (was v2.7.5).
- **README + `docs/docs/developer/releases.md`** — illustrative version-tag examples updated from the `v4` series to `v5` (`v5.0.0`, `IMMICH_VERSION=v5`, `v5.x.x`), matching the v3-cutover fork release line (v5.0.0). Prettier reflowed the Docker-tag table.

## Deliberately left unchanged
- `docs/docs/overview/release-notes.md` — "Gallery 4.54.0 …" is a **historical** record, not a current-version reference.
- `docs/docs/install/requirements.md` — `x86-64-v1 … last version v2.7.5` is a factual CPU-support note.

## Related follow-ups (not in this PR — flagging for a decision)
- `docs/docs/guides/switch-back-to-immich.md` pins `ghcr.io/immich-app/immich-server:**v2.7.5**`. With the fork now on the v3.0.1 base (and `revert-to-immich.sql` reworked for v3.0.1), the switch-back image is likely now `v3.0.1` — worth confirming the exact target before changing a user recovery procedure.
- `CLAUDE.md` (→ symlink `AGENTS.md`) still says "based on **Immich v2.7.5**"; left out to keep this PR user-docs-only.

Not urgent to merge — opened per request, holding for review.