### PR TITLE
fix(revert): drop ChangeDurationToInteger pre-rename alias row so upstream v3.0.1 boots

### DIFF
--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -321,7 +321,19 @@ DELETE FROM "kysely_migrations"
    '1778600000000-SortSpacePeopleByNameIndex',
    '1778700000000-AddSharedSpaceFaceMatchBackfillTarget',
    '1778800000000-ReconcileFaceIdentityIndexOverrides',
-   '1778800000000-TrimSpacePersonNameIndex'
+   '1778800000000-TrimSpacePersonNameIndex',
+
+   -- Build-time compatibility alias (server/bin/sync-gallery-migrations.mjs).
+   -- Gallery's postbuild records ChangeDurationToInteger under BOTH its current
+   -- upstream name (1777667825574) and its pre-rename name (1776735180298), so
+   -- already-deployed DBs that ran the migration under the pre-rename name keep
+   -- booting. Upstream Immich v3.0.1 ships only 1777667825574, so on a reverted
+   -- DB the pre-rename alias row is an orphan and upstream's migrator aborts with
+   -- "corrupted migrations: previously executed migration
+   -- 1776735180298-ChangeDurationToInteger is missing". Drop the alias row here;
+   -- the real 1777667825574 row is always present by revert time and matches the
+   -- upstream file, so it stays.
+   '1776735180298-ChangeDurationToInteger'
 
    -- Post-v3.0.1 upstream migrations pulled in by rebase would be listed here,
    -- paired with the schema rollbacks in step 7. Currently none — the branch is


### PR DESCRIPTION
## Problem
The post-v3-cutover `gallery-revert-to-immich-validation` run on `main` failed. Phase 1 (Gallery `:main` v3.0.1 → apply `revert-to-immich.sql` → COMMIT) passed; **phase 2** (boot real `ghcr.io/immich-app/immich-server:v3.0.1` against the reverted DB) aborted:

```
corrupted migrations: previously executed migration 1776735180298-ChangeDurationToInteger is missing
```

## Root cause
Gallery's `postbuild` (`server/bin/sync-gallery-migrations.mjs`) writes a **compatibility alias**: `ChangeDurationToInteger` is recorded in `kysely_migrations` under both its current upstream name (`1777667825574`) and its pre-rename name (`1776735180298`). Upstream Immich v3.0.1 ships only `1777667825574`, so on a reverted DB the pre-rename row is an orphan and upstream's Kysely migrator hard-fails.

The migration-coverage grep can't catch this because the alias is synthesized at **build time**, not a source migration file.

## Fix
Add `1776735180298-ChangeDurationToInteger` to the `DELETE FROM "kysely_migrations"` list (step 8). The real `1777667825574` row is always present by revert time (you boot current Gallery to run the script) and matches the upstream file, so it stays → upstream boots clean.

## Validation
Dispatched `gallery-revert-to-immich-validation.yml` on this branch (reads the SQL from the ref, boots `:main` v3.0.1). Confirming phase-2 now passes before merge.