### PR TITLE
refactor(server): consolidate space-album scoping behind a shared helper (+ close soft-delete holes)

### DIFF
--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -397,33 +397,36 @@ where
       and (
         exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
             inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
           where
-            "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_member"."userId" = $3
+            "shared_space_member"."userId" = $3::uuid
+            and "shared_space_asset"."assetId" = "asset"."id"
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
             inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
           where
-            "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_member"."userId" = $4
+            "shared_space_member"."userId" = $4::uuid
+            and "shared_space_library"."libraryId" = "asset"."libraryId"
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
           where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_member"."userId" = $5
+            "shared_space_member"."userId" = $5::uuid
+            and "album_asset"."assetId" = "asset"."id"
         )
       )
   )

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -55,6 +55,7 @@ where
       and (
         exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
           where
@@ -63,6 +64,7 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
           where
@@ -71,11 +73,12 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
           where
             "album_asset"."assetId" = "asset"."id"
             and "shared_space_album"."spaceId" = any ($7::uuid[])
@@ -163,6 +166,7 @@ from
           and (
             exists (
               select
+                1 as "exists"
               from
                 "shared_space_asset"
               where
@@ -171,6 +175,7 @@ from
             )
             or exists (
               select
+                1 as "exists"
               from
                 "shared_space_library"
               where
@@ -179,11 +184,12 @@ from
             )
             or exists (
               select
+                1 as "exists"
               from
                 "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
                 inner join "album" on "album"."id" = "shared_space_album"."albumId"
                 and "album"."deletedAt" is null
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
               where
                 "album_asset"."assetId" = "asset"."id"
                 and "shared_space_album"."spaceId" = any ($5::uuid[])
@@ -243,6 +249,7 @@ drop as (
         and (
           exists (
             select
+              1 as "exists"
             from
               "shared_space_asset"
             where
@@ -251,6 +258,7 @@ drop as (
           )
           or exists (
             select
+              1 as "exists"
             from
               "shared_space_library"
             where
@@ -259,11 +267,12 @@ drop as (
           )
           or exists (
             select
+              1 as "exists"
             from
               "shared_space_album"
+              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
               inner join "album" on "album"."id" = "shared_space_album"."albumId"
               and "album"."deletedAt" is null
-              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             where
               "album_asset"."assetId" = "asset"."id"
               and "shared_space_album"."spaceId" = any ($5::uuid[])
@@ -1030,6 +1039,7 @@ where
         "asset"."ownerId" = any ($1::uuid[])
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
           where
@@ -1038,6 +1048,7 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
           where
@@ -1046,11 +1057,12 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
           where
             "album_asset"."assetId" = "asset"."id"
             and "shared_space_album"."spaceId" = any ($4::uuid[])
@@ -1089,6 +1101,7 @@ where
         "asset"."ownerId" = any ($1::uuid[])
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
           where
@@ -1097,6 +1110,7 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
           where
@@ -1105,11 +1119,12 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
           where
             "album_asset"."assetId" = "asset"."id"
             and "shared_space_album"."spaceId" = any ($4::uuid[])
@@ -1150,6 +1165,7 @@ where
         "asset"."ownerId" = any ($1::uuid[])
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
           where
@@ -1158,6 +1174,7 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
           where
@@ -1166,11 +1183,12 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
           where
             "album_asset"."assetId" = "asset"."id"
             and "shared_space_album"."spaceId" = any ($4::uuid[])
@@ -1204,6 +1222,7 @@ WITH
           "asset"."ownerId" = any ($1::uuid[])
           or exists (
             select
+              1 as "exists"
             from
               "shared_space_asset"
             where
@@ -1212,6 +1231,7 @@ WITH
           )
           or exists (
             select
+              1 as "exists"
             from
               "shared_space_library"
             where
@@ -1220,11 +1240,12 @@ WITH
           )
           or exists (
             select
+              1 as "exists"
             from
               "shared_space_album"
+              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
               inner join "album" on "album"."id" = "shared_space_album"."albumId"
               and "album"."deletedAt" is null
-              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             where
               "album_asset"."assetId" = "asset"."id"
               and "shared_space_album"."spaceId" = any ($4::uuid[])
@@ -1394,6 +1415,7 @@ where
         "asset"."ownerId" = any ($1::uuid[])
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
           where
@@ -1402,6 +1424,7 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
           where
@@ -1410,11 +1433,12 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
           where
             "album_asset"."assetId" = "asset"."id"
             and "shared_space_album"."spaceId" = any ($4::uuid[])
@@ -1453,6 +1477,7 @@ where
         "asset"."ownerId" = any ($1::uuid[])
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_asset"
           where
@@ -1461,6 +1486,7 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_library"
           where
@@ -1469,11 +1495,12 @@ where
         )
         or exists (
           select
+            1 as "exists"
           from
             "shared_space_album"
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
             inner join "album" on "album"."id" = "shared_space_album"."albumId"
             and "album"."deletedAt" is null
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
           where
             "album_asset"."assetId" = "asset"."id"
             and "shared_space_album"."spaceId" = any ($4::uuid[])

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -987,12 +987,12 @@ where
     )
     or exists (
       select
-        "shared_space_album"."albumId"
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       where
         "album_asset"."assetId" = "asset_face"."assetId"
         and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
@@ -1038,12 +1038,12 @@ where
     )
     or exists (
       select
-        "shared_space_album"."albumId"
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       where
         "album_asset"."assetId" = "asset_face"."assetId"
         and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
@@ -1198,6 +1198,8 @@ select
   "shared_space_album"."addedById"
 from
   "shared_space_album"
+  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+  and "album"."deletedAt" is null
   inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
 where
@@ -1253,15 +1255,15 @@ where
     )
     or exists (
       select
-        "shared_space_album"."albumId"
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       where
         "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = $4
+        and "shared_space_album"."spaceId" = $4::uuid
     )
   )
   and "person"."identityId" is not null
@@ -1362,12 +1364,12 @@ where
     )
     or exists (
       select
-        "shared_space_album"."albumId"
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       where
         "album_asset"."assetId" = "asset_face"."assetId"
         and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
@@ -1410,12 +1412,12 @@ where
     )
     or exists (
       select
-        "shared_space_album"."albumId"
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       where
         "album_asset"."assetId" = "asset_face"."assetId"
         and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
@@ -1554,6 +1556,8 @@ where
     select
     from
       "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+      and "album"."deletedAt" is null
       inner join "album_asset" as "other" on "other"."albumId" = "shared_space_album"."albumId"
     where
       "other"."assetId" = "album_asset"."assetId"
@@ -1589,6 +1593,8 @@ where
     select
     from
       "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+      and "album"."deletedAt" is null
       inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
     where
       "album_asset"."assetId" = "asset"."id"
@@ -1868,6 +1874,8 @@ from
       "asset_face"."id"
     from
       "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+      and "album"."deletedAt" is null
       inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
       inner join "asset" on "asset"."id" = "album_asset"."assetId"
       inner join "asset_face" on "asset_face"."assetId" = "asset"."id"

--- a/server/src/queries/view.repository.sql
+++ b/server/src/queries/view.repository.sql
@@ -10,33 +10,36 @@ where
     "asset"."ownerId" = $2::uuid
     or exists (
       select
+        1 as "exists"
       from
         "shared_space_asset"
         inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
       where
-        "shared_space_asset"."assetId" = "asset"."id"
-        and "shared_space_member"."userId" = $3::uuid
+        "shared_space_member"."userId" = $3::uuid
+        and "shared_space_asset"."assetId" = "asset"."id"
     )
     or exists (
       select
+        1 as "exists"
       from
         "shared_space_library"
         inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
       where
-        "shared_space_library"."libraryId" = "asset"."libraryId"
-        and "shared_space_member"."userId" = $4::uuid
+        "shared_space_member"."userId" = $4::uuid
+        and "shared_space_library"."libraryId" = "asset"."libraryId"
     )
     or exists (
       select
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
       where
-        "album_asset"."assetId" = "asset"."id"
-        and "shared_space_member"."userId" = $5::uuid
+        "shared_space_member"."userId" = $5::uuid
+        and "album_asset"."assetId" = "asset"."id"
     )
   )
   and "visibility" = $6
@@ -59,33 +62,36 @@ where
     "asset"."ownerId" = $1::uuid
     or exists (
       select
+        1 as "exists"
       from
         "shared_space_asset"
         inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_asset"."spaceId"
       where
-        "shared_space_asset"."assetId" = "asset"."id"
-        and "shared_space_member"."userId" = $2::uuid
+        "shared_space_member"."userId" = $2::uuid
+        and "shared_space_asset"."assetId" = "asset"."id"
     )
     or exists (
       select
+        1 as "exists"
       from
         "shared_space_library"
         inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
       where
-        "shared_space_library"."libraryId" = "asset"."libraryId"
-        and "shared_space_member"."userId" = $3::uuid
+        "shared_space_member"."userId" = $3::uuid
+        and "shared_space_library"."libraryId" = "asset"."libraryId"
     )
     or exists (
       select
+        1 as "exists"
       from
         "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "album" on "album"."id" = "shared_space_album"."albumId"
         and "album"."deletedAt" is null
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
         inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
       where
-        "album_asset"."assetId" = "asset"."id"
-        and "shared_space_member"."userId" = $4::uuid
+        "shared_space_member"."userId" = $4::uuid
+        and "album_asset"."assetId" = "asset"."id"
     )
   )
   and "visibility" = $5

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -5,6 +5,7 @@ import { ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
 import { AlbumUserRole, AssetVisibility, SharedSpaceRole } from 'src/enum';
 import { DB } from 'src/schema';
 import { asUuid } from 'src/utils/database';
+import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
 
 class ActivityAccess {
   constructor(private db: Kysely<DB>) {}
@@ -703,33 +704,13 @@ class PersonAccess {
             .where('asset_face.deletedAt', 'is', null)
             .where('asset_face.isVisible', 'is', true)
             .where((eb) =>
-              eb.or([
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_asset')
-                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
-                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_member.userId', '=', userId),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_library')
-                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
-                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                    .where('shared_space_member.userId', '=', userId),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_album')
-                    .innerJoin('album', (j) =>
-                      j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                    )
-                    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_album.spaceId')
-                    .whereRef('album_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_member.userId', '=', userId),
-                ),
-              ]),
+              eb.or(
+                spaceAssetPathBranches(eb, {
+                  correlateAssetId: 'asset.id',
+                  correlateLibraryId: 'asset.libraryId',
+                  scope: { memberUserId: userId },
+                }),
+              ),
             ),
         ),
       )

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -58,6 +58,7 @@ import {
   withTags,
 } from 'src/utils/database';
 import { globToSqlPattern } from 'src/utils/misc';
+import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
 
 export type AssetStats = Record<AssetType, number>;
 
@@ -308,31 +309,14 @@ export function withTimeBucketAssetFilters<O>(
     )
     .$if(!!options.spaceId, (qb) =>
       qb.where((eb) =>
-        eb.or([
-          eb.exists(
-            eb
-              .selectFrom('shared_space_asset')
-              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-              .where('shared_space_asset.spaceId', '=', asUuid(options.spaceId!)),
-          ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_library')
-              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-              .where('shared_space_library.spaceId', '=', asUuid(options.spaceId!)),
-          ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (join) =>
-                join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset.id')
-              .where('shared_space_album.spaceId', '=', asUuid(options.spaceId!))
-              .where('shared_space_album.showInTimeline', '=', true),
-          ),
-        ]),
+        eb.or(
+          spaceAssetPathBranches(eb, {
+            correlateAssetId: 'asset.id',
+            correlateLibraryId: 'asset.libraryId',
+            scope: { spaceId: options.spaceId! },
+            requireShowInTimeline: true,
+          }),
+        ),
       ),
     )
     .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
@@ -352,29 +336,12 @@ export function withTimeBucketAssetFilters<O>(
       qb.where((eb) =>
         eb.or([
           eb('asset.ownerId', '=', anyUuid(options.userIds!)),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_asset')
-              .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-              .where('shared_space_asset.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-          ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_library')
-              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-              .where('shared_space_library.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-          ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (join) =>
-                join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset.id')
-              .where('shared_space_album.spaceId', '=', anyUuid(options.timelineSpaceIds!))
-              .where('shared_space_album.showInTimeline', '=', true),
-          ),
+          ...spaceAssetPathBranches(eb, {
+            correlateAssetId: 'asset.id',
+            correlateLibraryId: 'asset.libraryId',
+            scope: { spaceIds: options.timelineSpaceIds! },
+            requireShowInTimeline: true,
+          }),
         ]),
       ),
     )
@@ -1384,31 +1351,14 @@ export class AssetRepository {
           )
           .$if(!!options.spaceId, (qb) =>
             qb.where((eb) =>
-              eb.or([
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_asset')
-                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_asset.spaceId', '=', asUuid(options.spaceId!)),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_library')
-                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                    .where('shared_space_library.spaceId', '=', asUuid(options.spaceId!)),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_album')
-                    .innerJoin('album', (join) =>
-                      join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                    )
-                    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                    .whereRef('album_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_album.spaceId', '=', asUuid(options.spaceId!))
-                    .where('shared_space_album.showInTimeline', '=', true),
-                ),
-              ]),
+              eb.or(
+                spaceAssetPathBranches(eb, {
+                  correlateAssetId: 'asset.id',
+                  correlateLibraryId: 'asset.libraryId',
+                  scope: { spaceId: options.spaceId! },
+                  requireShowInTimeline: true,
+                }),
+              ),
             ),
           )
           .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
@@ -1426,29 +1376,12 @@ export class AssetRepository {
             qb.where((eb) =>
               eb.or([
                 eb('asset.ownerId', '=', anyUuid(options.userIds!)),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_asset')
-                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_asset.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_library')
-                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                    .where('shared_space_library.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_album')
-                    .innerJoin('album', (join) =>
-                      join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                    )
-                    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                    .whereRef('album_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_album.spaceId', '=', anyUuid(options.timelineSpaceIds!))
-                    .where('shared_space_album.showInTimeline', '=', true),
-                ),
+                ...spaceAssetPathBranches(eb, {
+                  correlateAssetId: 'asset.id',
+                  correlateLibraryId: 'asset.libraryId',
+                  scope: { spaceIds: options.timelineSpaceIds! },
+                  requireShowInTimeline: true,
+                }),
               ]),
             ),
           )

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -16,6 +16,7 @@ import { FaceIdentityFaceSource, FaceIdentityFaceTable } from 'src/schema/tables
 import { FaceIdentityTable } from 'src/schema/tables/face-identity.table';
 import { anyUuid } from 'src/utils/database';
 import { asDateString, asDateTimeString } from 'src/utils/date';
+import { spaceAlbumAssetExistsSql } from 'src/utils/shared-space-album-scope';
 
 export type FaceIdentity = Selectable<FaceIdentityTable>;
 export type FaceIdentityFace = Selectable<FaceIdentityFaceTable>;
@@ -898,14 +899,10 @@ export class FaceIdentityRepository {
               INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
               WHERE shared_space_library."libraryId" = asset."libraryId"
             )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-              WHERE album_asset."assetId" = asset.id
-            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+            })}
           )
       ),
       accessible_faces AS (
@@ -1021,14 +1018,10 @@ export class FaceIdentityRepository {
               INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
               WHERE shared_space_library."libraryId" = asset."libraryId"
             )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-              WHERE album_asset."assetId" = asset.id
-            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+            })}
           )
       ),
       accessible_faces AS (
@@ -1166,14 +1159,10 @@ export class FaceIdentityRepository {
               INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
               WHERE shared_space_library."libraryId" = asset."libraryId"
             )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-              WHERE album_asset."assetId" = asset.id
-            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+            })}
           )
       )
       SELECT
@@ -1650,14 +1639,10 @@ export class FaceIdentityRepository {
               INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
               WHERE shared_space_library."libraryId" = asset."libraryId"
             )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-              WHERE album_asset."assetId" = asset.id
-            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+            })}
           )
       ),
       accessible_profiles AS (
@@ -1799,14 +1784,10 @@ export class FaceIdentityRepository {
               INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
               WHERE shared_space_library."libraryId" = asset."libraryId"
             )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-              WHERE album_asset."assetId" = asset.id
-            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+            })}
           )
       ),
       identity_counts AS (
@@ -1918,14 +1899,10 @@ export class FaceIdentityRepository {
               INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
               WHERE shared_space_library."libraryId" = asset."libraryId"
             )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-              WHERE album_asset."assetId" = asset.id
-            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+            })}
           )
       ),
       asset_counts AS (

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -14,6 +14,7 @@ import { SystemMetadataRepository } from 'src/repositories/system-metadata.repos
 import { DB } from 'src/schema';
 import { GeodataPlacesTable } from 'src/schema/tables/geodata-places.table';
 import { NaturalEarthCountriesTable } from 'src/schema/tables/natural-earth-countries.table';
+import { spaceAlbumAssetExists, spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
 
 export interface MapMarkerSearchOptions {
   isArchived?: boolean;
@@ -112,29 +113,12 @@ export class MapRepository {
           const albumScope: Expression<SqlBool>[] = [eb('ownerId', 'in', ownerIds)];
           if (timelineSpaceIds?.length) {
             albumScope.push(
-              eb.exists((eb) =>
-                eb
-                  .selectFrom('shared_space_asset')
-                  .whereRef('asset.id', '=', 'shared_space_asset.assetId')
-                  .where('shared_space_asset.spaceId', 'in', timelineSpaceIds),
-              ),
-              eb.exists((eb) =>
-                eb
-                  .selectFrom('shared_space_library')
-                  .whereRef('asset.libraryId', '=', 'shared_space_library.libraryId')
-                  .where('shared_space_library.spaceId', 'in', timelineSpaceIds),
-              ),
-              eb.exists((eb) =>
-                eb
-                  .selectFrom('shared_space_album')
-                  .innerJoin('album', (join) =>
-                    join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                  )
-                  .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                  .whereRef('asset.id', '=', 'album_asset.assetId')
-                  .where('shared_space_album.spaceId', 'in', timelineSpaceIds)
-                  .where('shared_space_album.showInTimeline', '=', true),
-              ),
+              ...spaceAssetPathBranches(eb, {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceIds: timelineSpaceIds },
+                requireShowInTimeline: true,
+              }),
             );
           }
 
@@ -173,17 +157,11 @@ export class MapRepository {
             ]),
             eb.and([
               eb('asset.visibility', '=', AssetVisibility.Timeline),
-              eb.exists((eb) =>
-                eb
-                  .selectFrom('shared_space_album')
-                  .innerJoin('album', (join) =>
-                    join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                  )
-                  .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                  .whereRef('asset.id', '=', 'album_asset.assetId')
-                  .where('shared_space_album.spaceId', 'in', timelineSpaceIds)
-                  .where('shared_space_album.showInTimeline', '=', true),
-              ),
+              spaceAlbumAssetExists(eb, {
+                correlateAssetId: 'asset.id',
+                scope: { spaceIds: timelineSpaceIds },
+                requireShowInTimeline: true,
+              }),
             ]),
           );
         }

--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -9,6 +9,7 @@ import { AssetOrderWithRandom, AssetVisibility, MemoryType } from 'src/enum';
 import { DB } from 'src/schema';
 import { MemoryTable } from 'src/schema/tables/memory.table';
 import { IBulkAsset } from 'src/types';
+import { spaceAlbumAssetExists } from 'src/utils/shared-space-album-scope';
 
 @Injectable()
 export class MemoryRepository implements IBulkAsset {
@@ -90,17 +91,10 @@ export class MemoryRepository implements IBulkAsset {
                     .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
                     .where('asset.isOffline', '=', false),
                 ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_album')
-                    .innerJoin('album', (j) =>
-                      j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                    )
-                    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                    .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_album.spaceId')
-                    .whereRef('album_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_member.userId', '=', userId),
-                ),
+                spaceAlbumAssetExists(eb, {
+                  correlateAssetId: 'asset.id',
+                  scope: { memberUserId: userId },
+                }),
               ]),
             ),
         ),

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/utils/database';
 import { without } from 'src/utils/filter-suggestions';
 import { paginationHelper } from 'src/utils/pagination';
+import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
 import z from 'zod';
 
 export interface SearchAssetIdOptions {
@@ -1115,58 +1116,24 @@ export class SearchRepository {
       .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) => qb.where('asset.ownerId', '=', anyUuid(userIds)))
       .$if(!!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
-          eb.or([
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_album')
-                .innerJoin('album', (j) =>
-                  j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                )
-                .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                .whereRef('album_asset.assetId', '=', 'asset.id')
-                .where('shared_space_album.spaceId', '=', asUuid(options!.spaceId!)),
-            ),
-          ]),
+          eb.or(
+            spaceAssetPathBranches(eb, {
+              correlateAssetId: 'asset.id',
+              correlateLibraryId: 'asset.libraryId',
+              scope: { spaceId: options!.spaceId! },
+            }),
+          ),
         ),
       )
       .$if(!!options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
           eb.or([
             eb('asset.ownerId', '=', anyUuid(userIds)),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_album')
-                .innerJoin('album', (j) =>
-                  j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                )
-                .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                .whereRef('album_asset.assetId', '=', 'asset.id')
-                .where('shared_space_album.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-            ),
+            ...spaceAssetPathBranches(eb, {
+              correlateAssetId: 'asset.id',
+              correlateLibraryId: 'asset.libraryId',
+              scope: { spaceIds: options!.timelineSpaceIds! },
+            }),
           ]),
         ),
       )
@@ -1252,30 +1219,11 @@ export class SearchRepository {
                     .where('album_user.albumId', '=', asUuid(options!.albumId!)),
                 ),
                 ...(options?.timelineSpaceIds?.length
-                  ? [
-                      eb.exists(
-                        eb
-                          .selectFrom('shared_space_asset')
-                          .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                          .where('shared_space_asset.spaceId', '=', anyUuid(options.timelineSpaceIds)),
-                      ),
-                      eb.exists(
-                        eb
-                          .selectFrom('shared_space_library')
-                          .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                          .where('shared_space_library.spaceId', '=', anyUuid(options.timelineSpaceIds)),
-                      ),
-                      eb.exists(
-                        eb
-                          .selectFrom('shared_space_album')
-                          .innerJoin('album', (j) =>
-                            j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                          )
-                          .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                          .whereRef('album_asset.assetId', '=', 'asset.id')
-                          .where('shared_space_album.spaceId', '=', anyUuid(options.timelineSpaceIds)),
-                      ),
-                    ]
+                  ? spaceAssetPathBranches(eb, {
+                      correlateAssetId: 'asset.id',
+                      correlateLibraryId: 'asset.libraryId',
+                      scope: { spaceIds: options.timelineSpaceIds },
+                    })
                   : []),
               ]),
             ]),
@@ -1286,58 +1234,24 @@ export class SearchRepository {
         )
         .$if(!!options?.spaceId && !options?.timelineSpaceIds && !options?.albumId, (qb) =>
           qb.where((eb) =>
-            eb.or([
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_asset')
-                  .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                  .where('shared_space_asset.spaceId', '=', asUuid(options!.spaceId!)),
-              ),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_library')
-                  .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                  .where('shared_space_library.spaceId', '=', asUuid(options!.spaceId!)),
-              ),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_album')
-                  .innerJoin('album', (j) =>
-                    j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                  )
-                  .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                  .whereRef('album_asset.assetId', '=', 'asset.id')
-                  .where('shared_space_album.spaceId', '=', asUuid(options!.spaceId!)),
-              ),
-            ]),
+            eb.or(
+              spaceAssetPathBranches(eb, {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceId: options!.spaceId! },
+              }),
+            ),
           ),
         )
         .$if(!!options?.timelineSpaceIds && !options?.albumId, (qb) =>
           qb.where((eb) =>
             eb.or([
               eb('asset.ownerId', '=', anyUuid(userIds)),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_asset')
-                  .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                  .where('shared_space_asset.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-              ),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_library')
-                  .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                  .where('shared_space_library.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-              ),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_album')
-                  .innerJoin('album', (j) =>
-                    j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                  )
-                  .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                  .whereRef('album_asset.assetId', '=', 'asset.id')
-                  .where('shared_space_album.spaceId', '=', anyUuid(options!.timelineSpaceIds!)),
-              ),
+              ...spaceAssetPathBranches(eb, {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceIds: options!.timelineSpaceIds! },
+              }),
             ]),
           ),
         )

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -18,6 +18,7 @@ import { SharedSpacePersonFaceTable } from 'src/schema/tables/shared-space-perso
 import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 import { anyUuid, dummy, searchAssetBuilder } from 'src/utils/database';
+import { spaceAlbumAssetExists } from 'src/utils/shared-space-album-scope';
 
 const withSpaceAlbumUsers = (eb: ExpressionBuilder<DB, 'album' | 'shared_space_album'>) =>
   jsonArrayFrom(
@@ -1342,17 +1343,10 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
           ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (j) =>
-                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .select('shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
-              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
-          ),
+          spaceAlbumAssetExists(eb, {
+            correlateAssetId: 'asset_face.assetId',
+            scope: { spaceIdRef: 'shared_space_person.spaceId' },
+          }),
         ]),
       )
       .executeTakeFirst();
@@ -1390,17 +1384,10 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
           ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (j) =>
-                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .select('shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
-              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
-          ),
+          spaceAlbumAssetExists(eb, {
+            correlateAssetId: 'asset_face.assetId',
+            scope: { spaceIdRef: 'shared_space_person.spaceId' },
+          }),
         ]),
       )
       .orderBy('asset.fileCreatedAt', 'desc')
@@ -1728,17 +1715,10 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .where('shared_space_library.spaceId', '=', spaceId),
           ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (j) =>
-                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .select('shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
-              .where('shared_space_album.spaceId', '=', spaceId),
-          ),
+          spaceAlbumAssetExists(eb, {
+            correlateAssetId: 'asset_face.assetId',
+            scope: { spaceId },
+          }),
         ]),
       )
       .where('person.identityId', 'is not', null)
@@ -1935,17 +1915,10 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
           ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (j) =>
-                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .select('shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
-              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
-          ),
+          spaceAlbumAssetExists(eb, {
+            correlateAssetId: 'asset_face.assetId',
+            scope: { spaceIdRef: 'shared_space_person.spaceId' },
+          }),
         ]),
       )
       .executeTakeFirst();
@@ -1985,17 +1958,10 @@ export class SharedSpaceRepository {
               .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
               .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
           ),
-          eb.exists(
-            eb
-              .selectFrom('shared_space_album')
-              .innerJoin('album', (j) =>
-                j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-              )
-              .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-              .select('shared_space_album.albumId')
-              .whereRef('album_asset.assetId', '=', 'asset_face.assetId')
-              .whereRef('shared_space_album.spaceId', '=', 'shared_space_person.spaceId'),
-          ),
+          spaceAlbumAssetExists(eb, {
+            correlateAssetId: 'asset_face.assetId',
+            scope: { spaceIdRef: 'shared_space_person.spaceId' },
+          }),
         ]),
       )
       .orderBy('asset.fileCreatedAt', 'desc')

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1660,6 +1660,9 @@ export class SharedSpaceRepository {
 
     const albumRow = await this.db
       .selectFrom('shared_space_album')
+      .innerJoin('album', (join) =>
+        join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+      )
       .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
       .innerJoin('asset', 'asset.id', 'album_asset.assetId')
       .select('shared_space_album.addedById')
@@ -2106,6 +2109,9 @@ export class SharedSpaceRepository {
           eb.exists(
             eb
               .selectFrom('shared_space_album')
+              .innerJoin('album', (join) =>
+                join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
               .innerJoin('album_asset as other', 'other.albumId', 'shared_space_album.albumId')
               .whereRef('other.assetId', '=', 'album_asset.assetId')
               .where('shared_space_album.spaceId', '=', spaceId)
@@ -2155,6 +2161,9 @@ export class SharedSpaceRepository {
           eb.exists(
             eb
               .selectFrom('shared_space_album')
+              .innerJoin('album', (join) =>
+                join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
               .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
               .whereRef('album_asset.assetId', '=', 'asset.id')
               .where('shared_space_album.spaceId', '=', spaceId),
@@ -2493,6 +2502,9 @@ export class SharedSpaceRepository {
           .union(
             this.db
               .selectFrom('shared_space_album')
+              .innerJoin('album', (join) =>
+                join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+              )
               .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
               .innerJoin('asset', 'asset.id', 'album_asset.assetId')
               .innerJoin('asset_face', 'asset_face.assetId', 'asset.id')

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -5,6 +5,11 @@ import { columns } from 'src/database';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { DB } from 'src/schema';
 import { SyncAck } from 'src/types';
+import { accessibleSpaceAlbums, accessibleSpaces } from 'src/utils/shared-space-album-scope';
+
+// Re-export the relocated scoping helpers so existing `sync.repository` importers
+// keep working after the definitions moved to the fork-owned scope module.
+
 
 export type SyncBackfillOptions = {
   nowId: string;
@@ -864,18 +869,8 @@ class AssetOcrSync extends BaseSync {
 // `SharedSpaceService.create`, so iterating via `shared_space_member` for backfill
 // enumeration is sufficient — the OR'd creator path here is for query filtering
 // only and protects against direct DB inserts that bypass the service.
-export function accessibleSpaces(eb: ExpressionBuilder<DB, keyof DB>, userId: string) {
-  return eb
-    .selectFrom('shared_space')
-    .select('shared_space.id')
-    .where('shared_space.createdById', '=', userId)
-    .union(
-      eb
-        .selectFrom('shared_space_member')
-        .select('shared_space_member.spaceId as id')
-        .where('shared_space_member.userId', '=', userId),
-    );
-}
+// `accessibleSpaces` is defined in the fork-owned scope module and re-exported at
+// the bottom of this file (see the re-export near the imports).
 
 const SHARED_SPACE_SYNC_COLUMNS = [
   'shared_space.id',
@@ -1140,20 +1135,9 @@ export class SharedSpaceToAssetSync extends BaseSync {
   }
 }
 
-// `accessibleSpaceAlbums` returns albums linked to spaces the user belongs to,
-// excluding soft-deleted albums. Used by SharedSpaceAlbumToAssetSync.getDeletes
-// and SharedSpaceAlbumAssetSync / SharedSpaceAlbumAssetExifSync for scoping.
-//
-// Usage:
-//   .where('album.id', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-export function accessibleSpaceAlbums(eb: ExpressionBuilder<DB, keyof DB>, userId: string) {
-  return eb
-    .selectFrom('shared_space_album')
-    .innerJoin('album', 'album.id', 'shared_space_album.albumId')
-    .select('shared_space_album.albumId as id')
-    .where('album.deletedAt', 'is', null)
-    .where('shared_space_album.spaceId', 'in', (e) => accessibleSpaces(e, userId));
-}
+// `accessibleSpaceAlbums` (album-id scope) and `accessibleSpaces` (space-id scope)
+// now live in the fork-owned scope module and are re-exported here for the sync
+// classes below and any other existing importers. See src/utils/shared-space-album-scope.ts.
 
 // `accessibleLibraries` is the source-of-truth scoping subquery used by every
 // library sync class. A user can access a library via direct ownership OR via
@@ -1653,3 +1637,5 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .stream();
   }
 }
+
+export {accessibleSpaceAlbums, accessibleSpaces} from 'src/utils/shared-space-album-scope';

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -10,7 +10,6 @@ import { accessibleSpaceAlbums, accessibleSpaces } from 'src/utils/shared-space-
 // Re-export the relocated scoping helpers so existing `sync.repository` importers
 // keep working after the definitions moved to the fork-owned scope module.
 
-
 export type SyncBackfillOptions = {
   nowId: string;
   afterUpdateId?: string;
@@ -1638,4 +1637,4 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
   }
 }
 
-export {accessibleSpaceAlbums, accessibleSpaces} from 'src/utils/shared-space-album-scope';
+export { accessibleSpaceAlbums, accessibleSpaces } from 'src/utils/shared-space-album-scope';

--- a/server/src/repositories/view-repository.ts
+++ b/server/src/repositories/view-repository.ts
@@ -4,6 +4,7 @@ import { DummyValue, GenerateSql } from 'src/decorators';
 import { AssetVisibility } from 'src/enum';
 import { DB } from 'src/schema';
 import { asUuid, withExif } from 'src/utils/database';
+import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
 
 export class ViewRepository {
   constructor(@InjectKysely() private db: Kysely<DB>) {}
@@ -57,31 +58,11 @@ export class ViewRepository {
   private ownedOrSpaceAccessible(eb: ExpressionBuilder<DB, 'asset'>, userId: string) {
     return eb.or([
       eb('asset.ownerId', '=', asUuid(userId)),
-      eb.exists(
-        eb
-          .selectFrom('shared_space_asset')
-          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
-          .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-          .where('shared_space_member.userId', '=', asUuid(userId)),
-      ),
-      eb.exists(
-        eb
-          .selectFrom('shared_space_library')
-          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
-          .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-          .where('shared_space_member.userId', '=', asUuid(userId)),
-      ),
-      eb.exists(
-        eb
-          .selectFrom('shared_space_album')
-          .innerJoin('album', (j) =>
-            j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-          )
-          .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_album.spaceId')
-          .whereRef('album_asset.assetId', '=', 'asset.id')
-          .where('shared_space_member.userId', '=', asUuid(userId)),
-      ),
+      ...spaceAssetPathBranches(eb, {
+        correlateAssetId: 'asset.id',
+        correlateLibraryId: 'asset.libraryId',
+        scope: { memberUserId: userId },
+      }),
     ]);
   }
 }

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -30,6 +30,7 @@ import { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
 import { DB } from 'src/schema';
 import { AssetExifTable } from 'src/schema/tables/asset-exif.table';
 import { AudioStreamInfo, VectorExtension, VideoFormat, VideoPacketInfo, VideoStreamInfo } from 'src/types';
+import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
 import { dateTruncUnitForTimeBucketSize } from 'src/utils/timeline-bucket';
 
 export const getKyselyConfig = (connection: DatabaseConnectionParams): KyselyConfig => {
@@ -655,31 +656,14 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(!!options.spaceId && !options.timelineSpaceIds, (qb) =>
       qb.where((eb) =>
         eb.and([
-          eb.or([
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', asUuid(options.spaceId!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', asUuid(options.spaceId!)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_album')
-                .innerJoin('album', (join) =>
-                  join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                )
-                .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                .whereRef('album_asset.assetId', '=', 'asset.id')
-                .where('shared_space_album.spaceId', '=', asUuid(options.spaceId!))
-                .where('shared_space_album.showInTimeline', '=', true),
-            ),
-          ]),
+          eb.or(
+            spaceAssetPathBranches(eb, {
+              correlateAssetId: 'asset.id',
+              correlateLibraryId: 'asset.libraryId',
+              scope: { spaceId: options.spaceId! },
+              requireShowInTimeline: true,
+            }),
+          ),
           // Fork RBAC (M3): elevation only unlocks the CALLER'S OWN locked/archived folder. The
           // caller's own (and partner) rows follow the resolved visibility applied above; every
           // OTHER space member's row is constrained to Timeline, so a space-scoped search can never
@@ -699,31 +683,14 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
           // Other space members' rows are always Timeline-only (elevation is per-owner, M3).
           eb.and([
             eb('asset.visibility', '=', AssetVisibility.Timeline),
-            eb.or([
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_asset')
-                  .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                  .where('shared_space_asset.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-              ),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_library')
-                  .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                  .where('shared_space_library.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-              ),
-              eb.exists(
-                eb
-                  .selectFrom('shared_space_album')
-                  .innerJoin('album', (join) =>
-                    join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                  )
-                  .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                  .whereRef('album_asset.assetId', '=', 'asset.id')
-                  .where('shared_space_album.spaceId', '=', anyUuid(options.timelineSpaceIds!))
-                  .where('shared_space_album.showInTimeline', '=', true),
-              ),
-            ]),
+            eb.or(
+              spaceAssetPathBranches(eb, {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceIds: options.timelineSpaceIds! },
+                requireShowInTimeline: true,
+              }),
+            ),
           ]),
         ]),
       ),

--- a/server/src/utils/shared-space-album-scope.guard.spec.ts
+++ b/server/src/utils/shared-space-album-scope.guard.spec.ts
@@ -13,7 +13,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const SERVER_ROOT = join(__dirname, '..', '..');
+// Server root — vitest runs with cwd at server/ (matches face-identity-query-shape.spec.ts).
+const SERVER_ROOT = process.cwd();
 
 const SCOPING_FILES = [
   'src/repositories/shared-space.repository.ts',
@@ -32,7 +33,8 @@ const SCOPING_FILES = [
 
 // A shared_space_library reference has "album coverage" if any of these appear
 // within +-WINDOW lines: the raw album table, or a fork album-scope helper call.
-const ALBUM_MARKER = /shared_space_album|spaceAlbumAssetExists|spaceAssetPathBranches|spaceAlbumAssetExistsSql|accessibleSpaceAlbums/;
+const ALBUM_MARKER =
+  /shared_space_album|spaceAlbumAssetExists|spaceAssetPathBranches|spaceAlbumAssetExistsSql|accessibleSpaceAlbums/;
 const LIBRARY_REF = /\bshared_space_library\b/;
 const WINDOW = 45;
 
@@ -60,12 +62,25 @@ const ALLOWLIST: Record<string, string> = {
   // album arm, so an album-only asset is invisible to them. Flagged for follow-up;
   // NOT fixed here (unplanned behavior change).
   findSpaceForAssetAndUser: 'GUARD-DISCOVERED gap: union(direct,library) omits album arm (pre-existing, follow-up)',
-  getPersonalThumbnailForSpacePerson: 'GUARD-DISCOVERED gap: or(direct,library) omits album arm (pre-existing, follow-up)',
+  getPersonalThumbnailForSpacePerson:
+    'GUARD-DISCOVERED gap: or(direct,library) omits album arm (pre-existing, follow-up)',
 };
 
 const DECL = /^\s*(?:export\s+)?(?:async\s+)?(?:function\s+)?([A-Za-z0-9_]+)\s*[(<]/;
 const NON_DECL = new Set([
-  'if', 'for', 'while', 'switch', 'catch', 'return', 'eb', 'qb', 'join', 'map', 'filter', 'forEach', 'then',
+  'if',
+  'for',
+  'while',
+  'switch',
+  'catch',
+  'return',
+  'eb',
+  'qb',
+  'join',
+  'map',
+  'filter',
+  'forEach',
+  'then',
 ]);
 
 const enclosingFn = (lines: string[], i: number): string => {

--- a/server/src/utils/shared-space-album-scope.guard.spec.ts
+++ b/server/src/utils/shared-space-album-scope.guard.spec.ts
@@ -1,0 +1,119 @@
+// Slice 4 — backstop guard (spec §2.5). The recurring space-album defect class is
+// "a 3-path access-scoping branch gains a shared_space_library arm but forgets the
+// shared_space_album arm" (the historical F1 bug). This test scans every scoping
+// file and asserts that each shared_space_library scoping reference has a nearby
+// linked-album marker — either raw `shared_space_album` OR a call to one of the
+// fork-owned album-scope helpers. It fires on any future clone (fork or upstream
+// rebase) that omits the album leg.
+//
+// Benign non-scope references (CRUD, column lists, library-only sync helpers) are
+// filtered by pattern; genuine non-3-path sites are named in ALLOWLIST with a
+// reason. Two ALLOWLIST entries are GAPS this very guard discovered — see below.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SERVER_ROOT = join(import.meta.dirname, '..', '..');
+
+const SCOPING_FILES = [
+  'src/repositories/shared-space.repository.ts',
+  'src/repositories/sync.repository.ts',
+  'src/repositories/face-identity.repository.ts',
+  'src/repositories/search.repository.ts',
+  'src/repositories/asset.repository.ts',
+  'src/repositories/access.repository.ts',
+  'src/utils/database.ts',
+  'src/repositories/map.repository.ts',
+  'src/repositories/view-repository.ts',
+  'src/repositories/memory.repository.ts',
+  'src/repositories/tag.repository.ts',
+  'src/repositories/download.repository.ts',
+];
+
+// A shared_space_library reference has "album coverage" if any of these appear
+// within +-WINDOW lines: the raw album table, or a fork album-scope helper call.
+const ALBUM_MARKER = /shared_space_album|spaceAlbumAssetExists|spaceAssetPathBranches|spaceAlbumAssetExistsSql|accessibleSpaceAlbums/;
+const LIBRARY_REF = /\bshared_space_library\b/;
+const WINDOW = 45;
+
+// Lines that reference shared_space_library but are NOT a 3-path access-scope arm.
+const BENIGN_LINE = [
+  /(insertInto|deleteFrom|updateTable|backfillQuery)\(\s*['"]shared_space_library/, // CRUD / sync backfill
+  /^'shared_space_library\.\w+',?$/, // column-list entry
+  /accessibleLibraries|library_user|library_asset|library_audit/, // library-only sync helpers
+];
+
+// Enclosing functions that legitimately reference shared_space_library WITHOUT an
+// album arm. Keyed by function name (robust to line drift). Every entry needs a reason.
+const ALLOWLIST: Record<string, string> = {
+  // Album-ABSENCE gate (keeps plain non-space album assets visible) — references
+  // asset/library absence by design, never an album access arm.
+  albumSharedSpaceScope: 'album-absence gate, not an album access arm',
+  // Pre-existing intentional RBAC gap: AssetUpdate/edit has no space-album arm
+  // (space editors can add/remove but not metadata-edit linked-album assets). Out
+  // of scope for this behavior-preserving consolidation; tracked separately.
+  checkSpaceEditAccess: 'known RBAC gap: AssetUpdate has no space-album arm (pre-existing)',
+  // Pre-existing coverage gap: this map-markers path never had an album leg.
+  getMapMarkers: 'known coverage gap: shared-space map markers omit the album path (pre-existing)',
+  // GUARD-DISCOVERED pre-existing missing-album gaps (not in the review's inventory,
+  // which only grepped shared_space_album). Both OR direct+library but omit the
+  // album arm, so an album-only asset is invisible to them. Flagged for follow-up;
+  // NOT fixed here (unplanned behavior change).
+  findSpaceForAssetAndUser: 'GUARD-DISCOVERED gap: union(direct,library) omits album arm (pre-existing, follow-up)',
+  getPersonalThumbnailForSpacePerson: 'GUARD-DISCOVERED gap: or(direct,library) omits album arm (pre-existing, follow-up)',
+};
+
+const DECL = /^\s*(?:export\s+)?(?:async\s+)?(?:function\s+)?([A-Za-z0-9_]+)\s*[(<]/;
+const NON_DECL = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'return', 'eb', 'qb', 'join', 'map', 'filter', 'forEach', 'then',
+]);
+
+const enclosingFn = (lines: string[], i: number): string => {
+  for (let j = i; j >= 0; j--) {
+    const m = DECL.exec(lines[j]);
+    if (m && !NON_DECL.has(m[1])) {
+      return m[1];
+    }
+  }
+  return '<module>';
+};
+
+describe('space-album scope guard: every library scoping arm has album coverage', () => {
+  it.each(SCOPING_FILES)('%s', (file) => {
+    const lines = readFileSync(join(SERVER_ROOT, file), 'utf8').split('\n');
+    const orphans: string[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const raw = lines[i];
+      const trimmed = raw.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+        continue;
+      }
+      if (!LIBRARY_REF.test(raw)) {
+        continue;
+      }
+      if (BENIGN_LINE.some((re) => re.test(trimmed))) {
+        continue;
+      }
+      const fn = enclosingFn(lines, i);
+      if (ALLOWLIST[fn]) {
+        continue;
+      }
+      const lo = Math.max(0, i - WINDOW);
+      const hi = Math.min(lines.length, i + WINDOW + 1);
+      const covered = lines.slice(lo, hi).some((l) => ALBUM_MARKER.test(l));
+      if (!covered) {
+        orphans.push(`${file}:${i + 1} (in ${fn}): ${trimmed.slice(0, 90)}`);
+      }
+    }
+
+    expect(
+      orphans,
+      `shared_space_library scoping arm(s) with no adjacent shared_space_album arm/helper.\n` +
+        `Add the album leg (route it through spaceAlbumAssetExists / spaceAssetPathBranches /\n` +
+        `spaceAlbumAssetExistsSql) or, if genuinely album-free, add the enclosing function to\n` +
+        `ALLOWLIST with a reason.\n` +
+        orphans.join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/server/src/utils/shared-space-album-scope.guard.spec.ts
+++ b/server/src/utils/shared-space-album-scope.guard.spec.ts
@@ -13,7 +13,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const SERVER_ROOT = join(import.meta.dirname, '..', '..');
+const SERVER_ROOT = join(__dirname, '..', '..');
 
 const SCOPING_FILES = [
   'src/repositories/shared-space.repository.ts',

--- a/server/src/utils/shared-space-album-scope.ts
+++ b/server/src/utils/shared-space-album-scope.ts
@@ -1,0 +1,182 @@
+// Fork-owned scope helpers for the shared-space "linked album" access path.
+//
+// Background: an asset is visible inside a shared space through one of three
+// paths — a directly-added asset (`shared_space_asset`), a linked library
+// (`shared_space_library`), or a LINKED ALBUM (`shared_space_album` ->
+// `album_asset`). Before this module the linked-album branch was hand-cloned
+// across ~30 upstream + ~19 fork call sites, each re-deriving the same
+// `shared_space_album ⋈ album ⋈ album_asset` join and each having to remember the
+// `album.deletedAt IS NULL` guard ("A1 invariant") and, on timeline surfaces, the
+// `shared_space_album.showInTimeline = true` gate.
+//
+// This module encodes that album path — and the A1 invariant — exactly ONCE.
+// Every call site routes its album leg through `spaceAlbumAssetExists` (used
+// positively for read/scope, or negated via `eb.not(...)` for "no other space
+// path" face cleanup). Because the module is fork-only, an upstream rebase never
+// touches it; each upstream call site shrinks to a single, stable helper call.
+//
+// See docs / data/sa-abstraction-spec-t8/report.md for the full design + slices.
+import { Expression, ExpressionBuilder, ReferenceExpression, SqlBool } from 'kysely';
+import { DB } from 'src/schema';
+import { anyUuid, asUuid } from 'src/utils/database';
+
+/**
+ * How a space-scoped branch is bound to the space(s) it applies to. Mirrors the
+ * exact predicates the hand-cloned branches used:
+ *  - `{ spaceId }`      -> `shared_space_album.spaceId = <uuid>`        (literal)
+ *  - `{ spaceIds }`     -> `shared_space_album.spaceId = any(<uuid[]>)` (timeline set)
+ *  - `{ memberUserId }` -> inner-join `shared_space_member` on the user  (membership)
+ *  - `{ spaceIdRef }`   -> `shared_space_album.spaceId = <outer column>` (correlated)
+ */
+export type SpaceScope =
+  | { spaceId: string }
+  | { spaceIds: string[] }
+  | { memberUserId: string }
+  | { spaceIdRef: ReferenceExpression<DB, keyof DB> };
+
+export interface SpaceAlbumAssetOptions {
+  /** Outer column the album's asset must match, e.g. 'asset.id' / 'asset_face.assetId'. */
+  correlateAssetId: ReferenceExpression<DB, keyof DB>;
+  scope: SpaceScope;
+  /** Timeline surfaces only: require `shared_space_album.showInTimeline = true`. Default false. */
+  requireShowInTimeline?: boolean;
+  /**
+   * The A1 invariant: require `album.deletedAt IS NULL`. Default true. Passing
+   * false reproduces the pre-fix soft-delete hole at the four legacy sites and is
+   * ONLY used to keep Slices 1-14 behavior-preserving; Slice 15 removes those.
+   */
+  requireAlbumNotDeleted?: boolean;
+  /** Exclude a specific linked album (the "other album" self-exclusion at getAlbumAssetIdsWithoutOtherSpacePath). */
+  excludeAlbumId?: string;
+}
+
+/**
+ * The single definition of the linked-album access path, as an `EXISTS (...)`
+ * predicate. Negate with `eb.not(spaceAlbumAssetExists(...))` for anti-join /
+ * "no other space path" uses.
+ */
+export function spaceAlbumAssetExists(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  options: SpaceAlbumAssetOptions,
+): Expression<SqlBool> {
+  const notDeleted = options.requireAlbumNotDeleted ?? true;
+  const { scope } = options;
+
+  return eb.exists(
+    eb
+      .selectFrom('shared_space_album')
+      .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+      // A1 invariant — the album must not be soft-deleted (unless explicitly opted out).
+      .$if(notDeleted, (qb) =>
+        qb.innerJoin('album', (join) =>
+          join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+        ),
+      )
+      // Membership scope joins the member table inside the subquery.
+      .$if('memberUserId' in scope, (qb) =>
+        qb
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_album.spaceId')
+          .where('shared_space_member.userId', '=', asUuid((scope as { memberUserId: string }).memberUserId)),
+      )
+      .select(eb.lit(1).as('exists'))
+      .whereRef('album_asset.assetId', '=', options.correlateAssetId)
+      .$if('spaceId' in scope, (qb) =>
+        qb.where('shared_space_album.spaceId', '=', asUuid((scope as { spaceId: string }).spaceId)),
+      )
+      .$if('spaceIds' in scope, (qb) =>
+        qb.where('shared_space_album.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
+      )
+      .$if('spaceIdRef' in scope, (qb) =>
+        qb.whereRef('shared_space_album.spaceId', '=', (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef),
+      )
+      .$if(!!options.requireShowInTimeline, (qb) => qb.where('shared_space_album.showInTimeline', '=', true))
+      .$if(!!options.excludeAlbumId, (qb) => qb.where('shared_space_album.albumId', '!=', options.excludeAlbumId!)),
+  );
+}
+
+export interface SpacePathBranchOptions {
+  /** Outer asset-id column for the direct + album arms, e.g. 'asset.id'. */
+  correlateAssetId: ReferenceExpression<DB, keyof DB>;
+  /** Outer library-id column for the library arm, e.g. 'asset.libraryId'. */
+  correlateLibraryId: ReferenceExpression<DB, keyof DB>;
+  scope: SpaceScope;
+  requireShowInTimeline?: boolean;
+}
+
+/** The directly-added-asset arm (`shared_space_asset`), matching the clean asset-outer sites. */
+export function spaceDirectAssetExists(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  options: { correlateAssetId: ReferenceExpression<DB, keyof DB>; scope: SpaceScope },
+): Expression<SqlBool> {
+  const { scope } = options;
+  return eb.exists(
+    eb
+      .selectFrom('shared_space_asset')
+      .$if('memberUserId' in scope, (qb) =>
+        qb
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
+          .where('shared_space_member.userId', '=', asUuid((scope as { memberUserId: string }).memberUserId)),
+      )
+      .select(eb.lit(1).as('exists'))
+      .whereRef('shared_space_asset.assetId', '=', options.correlateAssetId)
+      .$if('spaceId' in scope, (qb) =>
+        qb.where('shared_space_asset.spaceId', '=', asUuid((scope as { spaceId: string }).spaceId)),
+      )
+      .$if('spaceIds' in scope, (qb) =>
+        qb.where('shared_space_asset.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
+      )
+      .$if('spaceIdRef' in scope, (qb) =>
+        qb.whereRef('shared_space_asset.spaceId', '=', (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef),
+      ),
+  );
+}
+
+/** The linked-library arm (`shared_space_library`), correlating on the outer library id. */
+export function spaceLibraryAssetExists(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  options: { correlateLibraryId: ReferenceExpression<DB, keyof DB>; scope: SpaceScope },
+): Expression<SqlBool> {
+  const { scope } = options;
+  return eb.exists(
+    eb
+      .selectFrom('shared_space_library')
+      .$if('memberUserId' in scope, (qb) =>
+        qb
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
+          .where('shared_space_member.userId', '=', asUuid((scope as { memberUserId: string }).memberUserId)),
+      )
+      .select(eb.lit(1).as('exists'))
+      .whereRef('shared_space_library.libraryId', '=', options.correlateLibraryId)
+      .$if('spaceId' in scope, (qb) =>
+        qb.where('shared_space_library.spaceId', '=', asUuid((scope as { spaceId: string }).spaceId)),
+      )
+      .$if('spaceIds' in scope, (qb) =>
+        qb.where('shared_space_library.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
+      )
+      .$if('spaceIdRef' in scope, (qb) =>
+        qb.whereRef('shared_space_library.spaceId', '=', (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef),
+      ),
+  );
+}
+
+/**
+ * The three access-path arms `[direct, library, album]`, ready to spread into
+ * `eb.or([...ownExtras, ...spaceAssetPathBranches(eb, opts)])`. Only for the
+ * "clean" asset-outer sites (correlate on asset.id / asset.libraryId with no
+ * per-arm isOffline quirk); other sites route just the album arm through
+ * `spaceAlbumAssetExists` and keep their bespoke direct/library arms inline.
+ */
+export function spaceAssetPathBranches(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  options: SpacePathBranchOptions,
+): [Expression<SqlBool>, Expression<SqlBool>, Expression<SqlBool>] {
+  return [
+    spaceDirectAssetExists(eb, { correlateAssetId: options.correlateAssetId, scope: options.scope }),
+    spaceLibraryAssetExists(eb, { correlateLibraryId: options.correlateLibraryId, scope: options.scope }),
+    spaceAlbumAssetExists(eb, {
+      correlateAssetId: options.correlateAssetId,
+      scope: options.scope,
+      requireShowInTimeline: options.requireShowInTimeline,
+    }),
+  ];
+}

--- a/server/src/utils/shared-space-album-scope.ts
+++ b/server/src/utils/shared-space-album-scope.ts
@@ -51,6 +51,41 @@ export interface SpaceAlbumAssetOptions {
 }
 
 /**
+ * Spaces a user can access — created OR a member. Relocated here (from
+ * sync.repository.ts) so the whole "accessible*" scoping family lives in one
+ * fork-owned module; sync.repository.ts re-exports it for its existing callers.
+ *
+ * Usage: `.where('shared_space.id', 'in', (eb) => accessibleSpaces(eb, userId))`
+ */
+export function accessibleSpaces(eb: ExpressionBuilder<DB, keyof DB>, userId: string) {
+  return eb
+    .selectFrom('shared_space')
+    .select('shared_space.id')
+    .where('shared_space.createdById', '=', userId)
+    .union(
+      eb
+        .selectFrom('shared_space_member')
+        .select('shared_space_member.spaceId as id')
+        .where('shared_space_member.userId', '=', userId),
+    );
+}
+
+/**
+ * Album ids linked to spaces the user can access, excluding soft-deleted albums
+ * (A1). Relocated from sync.repository.ts; re-exported from there.
+ *
+ * Usage: `.where('album.id', 'in', (eb) => accessibleSpaceAlbums(eb, userId))`
+ */
+export function accessibleSpaceAlbums(eb: ExpressionBuilder<DB, keyof DB>, userId: string) {
+  return eb
+    .selectFrom('shared_space_album')
+    .innerJoin('album', 'album.id', 'shared_space_album.albumId')
+    .select('shared_space_album.albumId as id')
+    .where('album.deletedAt', 'is', null)
+    .where('shared_space_album.spaceId', 'in', (e) => accessibleSpaces(e, userId));
+}
+
+/**
  * The single definition of the linked-album access path, as an `EXISTS (...)`
  * predicate. Negate with `eb.not(spaceAlbumAssetExists(...))` for anti-join /
  * "no other space path" uses.
@@ -87,7 +122,11 @@ export function spaceAlbumAssetExists(
         qb.where('shared_space_album.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
       )
       .$if('spaceIdRef' in scope, (qb) =>
-        qb.whereRef('shared_space_album.spaceId', '=', (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef),
+        qb.whereRef(
+          'shared_space_album.spaceId',
+          '=',
+          (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef,
+        ),
       )
       .$if(!!options.requireShowInTimeline, (qb) => qb.where('shared_space_album.showInTimeline', '=', true))
       .$if(!!options.excludeAlbumId, (qb) => qb.where('shared_space_album.albumId', '!=', options.excludeAlbumId!)),
@@ -126,7 +165,11 @@ export function spaceDirectAssetExists(
         qb.where('shared_space_asset.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
       )
       .$if('spaceIdRef' in scope, (qb) =>
-        qb.whereRef('shared_space_asset.spaceId', '=', (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef),
+        qb.whereRef(
+          'shared_space_asset.spaceId',
+          '=',
+          (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef,
+        ),
       ),
   );
 }
@@ -154,7 +197,11 @@ export function spaceLibraryAssetExists(
         qb.where('shared_space_library.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
       )
       .$if('spaceIdRef' in scope, (qb) =>
-        qb.whereRef('shared_space_library.spaceId', '=', (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef),
+        qb.whereRef(
+          'shared_space_library.spaceId',
+          '=',
+          (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef,
+        ),
       ),
   );
 }

--- a/server/src/utils/shared-space-album-scope.ts
+++ b/server/src/utils/shared-space-album-scope.ts
@@ -16,7 +16,7 @@
 // touches it; each upstream call site shrinks to a single, stable helper call.
 //
 // See docs / data/sa-abstraction-spec-t8/report.md for the full design + slices.
-import { Expression, ExpressionBuilder, ReferenceExpression, SqlBool } from 'kysely';
+import { Expression, ExpressionBuilder, RawBuilder, ReferenceExpression, sql, SqlBool } from 'kysely';
 import { DB } from 'src/schema';
 import { anyUuid, asUuid } from 'src/utils/database';
 
@@ -179,4 +179,43 @@ export function spaceAssetPathBranches(
       requireShowInTimeline: options.requireShowInTimeline,
     }),
   ];
+}
+
+// ---------------------------------------------------------------------------
+// Raw-SQL family — for the sites that author queries with `sql``` tagged
+// templates (face-identity.repository.ts, shared-space.repository.ts stats).
+// These emit the SAME album path as the Kysely helpers above; the equivalence is
+// pinned by test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts.
+// ---------------------------------------------------------------------------
+
+export interface SpaceAlbumAssetSqlOptions {
+  /** Raw fragment for the outer asset id, e.g. sql`asset.id`. */
+  assetIdColumn: RawBuilder<unknown>;
+  /**
+   * Raw JOIN fragment that scopes `shared_space_album.spaceId` to the target
+   * space(s), placed directly after `FROM shared_space_album`, e.g.
+   * sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`.
+   */
+  spaceScopeJoin: RawBuilder<unknown>;
+  /** A1 invariant: require `album.deletedAt IS NULL`. Default true. */
+  requireAlbumNotDeleted?: boolean;
+}
+
+/**
+ * Raw-SQL analogue of `spaceAlbumAssetExists` — an `EXISTS (...)` fragment over
+ * the linked-album access path, for interpolation into `sql``` queries.
+ */
+export function spaceAlbumAssetExistsSql(options: SpaceAlbumAssetSqlOptions): RawBuilder<SqlBool> {
+  const albumJoin =
+    (options.requireAlbumNotDeleted ?? true)
+      ? sql`INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL`
+      : sql``;
+  return sql<SqlBool>`EXISTS (
+              SELECT 1
+              FROM shared_space_album
+              ${options.spaceScopeJoin}
+              ${albumJoin}
+              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
+              WHERE album_asset."assetId" = ${options.assetIdColumn}
+            )`;
 }

--- a/server/test/medium/specs/repositories/shared-space-album-scope.characterization.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-album-scope.characterization.spec.ts
@@ -121,8 +121,8 @@ describe('A. timeline album leg + showInTimeline gate (asset.repository.getTimeB
   });
 });
 
-describe('B. current (PRE-FIX) A1 soft-delete-hole behavior — Slice 15 flips these', () => {
-  it('PRE-FIX: isFaceInSpace returns true for a face whose only path is a SOFT-DELETED album', async () => {
+describe('B. A1 soft-delete-hole FIX (Slice 15) — a soft-deleted album is no longer a live path', () => {
+  it('isFaceInSpace returns false for a face whose only path is a SOFT-DELETED album', async () => {
     const { ctx, shared } = setup();
     const { user } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: user.id });
@@ -134,11 +134,11 @@ describe('B. current (PRE-FIX) A1 soft-delete-hole behavior — Slice 15 flips t
 
     await ctx.softDeleteAlbum(album.id);
 
-    // HOLE: album leg omits album.deletedAt, so the face still resolves. Slice 15 -> false.
-    expect(await shared.isFaceInSpace(space.id, faceId)).toBe(true);
+    // FIXED: album leg now guards album.deletedAt, so a soft-deleted album is not a path.
+    expect(await shared.isFaceInSpace(space.id, faceId)).toBe(false);
   });
 
-  it('PRE-FIX: getSpaceAssetAdder attributes via a SOFT-DELETED album', async () => {
+  it('getSpaceAssetAdder does not attribute via a SOFT-DELETED album', async () => {
     const { ctx, shared } = setup();
     const { user } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: user.id });
@@ -149,12 +149,12 @@ describe('B. current (PRE-FIX) A1 soft-delete-hole behavior — Slice 15 flips t
 
     await ctx.softDeleteAlbum(album.id);
 
-    // HOLE: album leg omits album.deletedAt, so the adder is still found. Slice 15 -> undefined.
+    // FIXED: album leg now guards album.deletedAt, so no adder is resolved via the trashed album.
     const adder = await shared.getSpaceAssetAdder(space.id, asset.id);
-    expect(adder?.addedById).toBe(user.id);
+    expect(adder).toBeUndefined();
   });
 
-  it('PRE-FIX: getAlbumAssetIdsWithoutOtherSpacePath treats a SOFT-DELETED other album as a live path (retains)', async () => {
+  it('getAlbumAssetIdsWithoutOtherSpacePath treats a SOFT-DELETED other album as no path (cleans up)', async () => {
     const { ctx, shared } = setup();
     const { user } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: user.id });
@@ -168,13 +168,13 @@ describe('B. current (PRE-FIX) A1 soft-delete-hole behavior — Slice 15 flips t
 
     await ctx.softDeleteAlbum(albumB.id);
 
-    // HOLE: branch 2 omits album.deletedAt, so soft-deleted albumB counts as another
-    // path and X is EXCLUDED (its space face is retained). Slice 15 -> [x.id].
+    // FIXED: branch 2 now guards album.deletedAt, so soft-deleted albumB is not a path and
+    // X (reachable only via trashed albums) is returned for face cleanup.
     const result = await shared.getAlbumAssetIdsWithoutOtherSpacePath(space.id, albumA.id);
-    expect(result).not.toContain(x.id);
+    expect(result).toContain(x.id);
   });
 
-  it('PRE-FIX: getAssetIdsWithoutOtherSpacePath treats a SOFT-DELETED album as a live path (retains)', async () => {
+  it('getAssetIdsWithoutOtherSpacePath treats a SOFT-DELETED album as no path (cleans up)', async () => {
     const { ctx, shared } = setup();
     const { user } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: user.id });
@@ -185,9 +185,9 @@ describe('B. current (PRE-FIX) A1 soft-delete-hole behavior — Slice 15 flips t
 
     await ctx.softDeleteAlbum(album.id);
 
-    // HOLE: branch 2 omits album.deletedAt, so soft-deleted album counts as a path and
-    // X is EXCLUDED (no cleanup). Slice 15 -> [x.id].
+    // FIXED: branch 2 now guards album.deletedAt, so the soft-deleted album is not a path and
+    // X is returned for face cleanup.
     const result = await shared.getAssetIdsWithoutOtherSpacePath(space.id, [x.id]);
-    expect(result).not.toContain(x.id);
+    expect(result).toContain(x.id);
   });
 });

--- a/server/test/medium/specs/repositories/shared-space-album-scope.characterization.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-album-scope.characterization.spec.ts
@@ -1,0 +1,193 @@
+// Characterization tests for the space-album scoping consolidation (spec:
+// data/sa-abstraction-spec-t8/report.md, Slice 1). These pin behaviors that the
+// consolidation (Slices 2-14) MUST preserve byte-for-byte, focusing on gaps the
+// existing suite leaves thin:
+//   A. the timeline album leg + showInTimeline gate (asset.repository, the
+//      highest-risk migration — the existing timeline spec only covers
+//      direct + library paths, never the album leg).
+//   B. the CURRENT (pre-fix) A1 soft-delete-hole behavior at the four sites that
+//      omit `album.deletedAt IS NULL` (isFaceInSpace, getSpaceAssetAdder,
+//      getAlbumAssetIdsWithoutOtherSpacePath, getAssetIdsWithoutOtherSpacePath).
+//      Slices 1-14 keep these EXACTLY as they are today; Slice 15 flips them and
+//      updates these assertions. The `PRE-FIX` markers below are the ones Slice 15
+//      rewrites.
+import { Kysely } from 'kysely';
+import { AssetVisibility, TimeBucketSize } from 'src/enum';
+import { AssetRepository } from 'src/repositories/asset.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: defaultDatabase,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, shared: ctx.get(SharedSpaceRepository), asset: ctx.get(AssetRepository) };
+};
+
+type Ctx = ReturnType<typeof setup>['ctx'];
+
+const timelineAsset = async (ctx: Ctx, ownerId: string, when: Date, options: Record<string, unknown> = {}) => {
+  const { asset } = await ctx.newAsset({
+    ownerId,
+    visibility: AssetVisibility.Timeline,
+    fileCreatedAt: when,
+    localDateTime: when,
+    width: 400,
+    height: 200,
+    thumbhash: Buffer.from('thumbhash'),
+    ...options,
+  });
+  await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+  return asset;
+};
+
+const yearBucketCount = async (asset: AssetRepository, spaceId: string): Promise<number> => {
+  const buckets = await asset.getTimeBuckets({
+    spaceId,
+    visibility: AssetVisibility.Timeline,
+    bucketSize: TimeBucketSize.Year,
+  });
+  return buckets.reduce((sum, b) => sum + Number(b.count), 0);
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('A. timeline album leg + showInTimeline gate (asset.repository.getTimeBuckets)', () => {
+  it('counts assets from a linked album with showInTimeline = true', async () => {
+    const { ctx, asset } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'ShownAlbum' });
+
+    const a1 = await timelineAsset(ctx, user.id, new Date('2024-01-01T12:00:00.000Z'));
+    const a2 = await timelineAsset(ctx, user.id, new Date('2024-01-02T12:00:00.000Z'));
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a2.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+
+    expect(await yearBucketCount(asset, space.id)).toBe(2);
+  });
+
+  it('does NOT count assets from a linked album with showInTimeline = false', async () => {
+    const { ctx, asset } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'HiddenAlbum' });
+
+    const a1 = await timelineAsset(ctx, user.id, new Date('2024-02-01T12:00:00.000Z'));
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+    expect(await yearBucketCount(asset, space.id)).toBe(0);
+  });
+
+  it('does NOT count assets from a soft-deleted linked album (A1 present in timeline)', async () => {
+    const { ctx, asset } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'SoftDeletedTimelineAlbum' });
+
+    const a1 = await timelineAsset(ctx, user.id, new Date('2024-03-01T12:00:00.000Z'));
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+
+    expect(await yearBucketCount(asset, space.id)).toBe(1);
+    await ctx.softDeleteAlbum(album.id);
+    expect(await yearBucketCount(asset, space.id)).toBe(0);
+  });
+
+  it('counts an asset reachable via BOTH a linked album and a direct add exactly once', async () => {
+    const { ctx, asset } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'DedupAlbum' });
+
+    const a1 = await timelineAsset(ctx, user.id, new Date('2024-04-01T12:00:00.000Z'));
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: a1.id, addedById: user.id });
+
+    expect(await yearBucketCount(asset, space.id)).toBe(1);
+  });
+});
+
+describe('B. current (PRE-FIX) A1 soft-delete-hole behavior — Slice 15 flips these', () => {
+  it('PRE-FIX: isFaceInSpace returns true for a face whose only path is a SOFT-DELETED album', async () => {
+    const { ctx, shared } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'FaceHoleAlbum' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id });
+
+    await ctx.softDeleteAlbum(album.id);
+
+    // HOLE: album leg omits album.deletedAt, so the face still resolves. Slice 15 -> false.
+    expect(await shared.isFaceInSpace(space.id, faceId)).toBe(true);
+  });
+
+  it('PRE-FIX: getSpaceAssetAdder attributes via a SOFT-DELETED album', async () => {
+    const { ctx, shared } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'AdderHoleAlbum' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+
+    await ctx.softDeleteAlbum(album.id);
+
+    // HOLE: album leg omits album.deletedAt, so the adder is still found. Slice 15 -> undefined.
+    const adder = await shared.getSpaceAssetAdder(space.id, asset.id);
+    expect(adder?.addedById).toBe(user.id);
+  });
+
+  it('PRE-FIX: getAlbumAssetIdsWithoutOtherSpacePath treats a SOFT-DELETED other album as a live path (retains)', async () => {
+    const { ctx, shared } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: albumA } = await ctx.newAlbum({ ownerId: user.id, albumName: 'HoleAlbumA' });
+    const { result: albumB } = await ctx.newAlbum({ ownerId: user.id, albumName: 'HoleAlbumB' });
+    const { asset: x } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: albumA.id, assetId: x.id });
+    await ctx.newAlbumAsset({ albumId: albumB.id, assetId: x.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: albumA.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: albumB.id });
+
+    await ctx.softDeleteAlbum(albumB.id);
+
+    // HOLE: branch 2 omits album.deletedAt, so soft-deleted albumB counts as another
+    // path and X is EXCLUDED (its space face is retained). Slice 15 -> [x.id].
+    const result = await shared.getAlbumAssetIdsWithoutOtherSpacePath(space.id, albumA.id);
+    expect(result).not.toContain(x.id);
+  });
+
+  it('PRE-FIX: getAssetIdsWithoutOtherSpacePath treats a SOFT-DELETED album as a live path (retains)', async () => {
+    const { ctx, shared } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'HoleAssetAlbum' });
+    const { asset: x } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: x.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    await ctx.softDeleteAlbum(album.id);
+
+    // HOLE: branch 2 omits album.deletedAt, so soft-deleted album counts as a path and
+    // X is EXCLUDED (no cleanup). Slice 15 -> [x.id].
+    const result = await shared.getAssetIdsWithoutOtherSpacePath(space.id, [x.id]);
+    expect(result).not.toContain(x.id);
+  });
+});

--- a/server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts
+++ b/server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts
@@ -27,7 +27,9 @@ const kyselyIds = async (spaceId: string, requireAlbumNotDeleted = true): Promis
   const rows = await db
     .selectFrom('asset')
     .select('asset.id')
-    .where((eb) => spaceAlbumAssetExists(eb, { correlateAssetId: 'asset.id', scope: { spaceId }, requireAlbumNotDeleted }))
+    .where((eb) =>
+      spaceAlbumAssetExists(eb, { correlateAssetId: 'asset.id', scope: { spaceId }, requireAlbumNotDeleted }),
+    )
     .execute();
   return new Set(rows.map((r) => r.id));
 };

--- a/server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts
+++ b/server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts
@@ -1,0 +1,103 @@
+// Slice 3 — cross-style equivalence: the raw-SQL album-arm fragment
+// (spaceAlbumAssetExistsSql) must return the SAME asset set as the Kysely
+// spaceAlbumAssetExists over identical data + scope (spec §3.4). This is the wire
+// that keeps the two authoring styles from drifting.
+import { Kysely, sql } from 'kysely';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { spaceAlbumAssetExists, spaceAlbumAssetExistsSql } from 'src/utils/shared-space-album-scope';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let db: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx };
+};
+
+type Ctx = ReturnType<typeof setup>['ctx'];
+
+const kyselyIds = async (spaceId: string, requireAlbumNotDeleted = true): Promise<Set<string>> => {
+  const rows = await db
+    .selectFrom('asset')
+    .select('asset.id')
+    .where((eb) => spaceAlbumAssetExists(eb, { correlateAssetId: 'asset.id', scope: { spaceId }, requireAlbumNotDeleted }))
+    .execute();
+  return new Set(rows.map((r) => r.id));
+};
+
+const rawIds = async (spaceId: string, requireAlbumNotDeleted = true): Promise<Set<string>> => {
+  const existsFragment = spaceAlbumAssetExistsSql({
+    assetIdColumn: sql`asset.id`,
+    spaceScopeJoin: sql`INNER JOIN shared_space ON shared_space.id = shared_space_album."spaceId" AND shared_space.id = ${spaceId}`,
+    requireAlbumNotDeleted,
+  });
+  const result = await sql<{ id: string }>`SELECT asset.id FROM asset WHERE ${existsFragment}`.execute(db);
+  return new Set(result.rows.map((r) => r.id));
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+const seedCombos = async (ctx: Ctx) => {
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+
+  const { result: shown } = await ctx.newAlbum({ ownerId: user.id, albumName: 'shown' });
+  const { result: hidden } = await ctx.newAlbum({ ownerId: user.id, albumName: 'hidden' });
+  const { result: deleted } = await ctx.newAlbum({ ownerId: user.id, albumName: 'deleted' });
+
+  const { asset: viaShown } = await ctx.newAsset({ ownerId: user.id });
+  const { asset: viaHidden } = await ctx.newAsset({ ownerId: user.id });
+  const { asset: viaDeleted } = await ctx.newAsset({ ownerId: user.id });
+  const { asset: viaDirect } = await ctx.newAsset({ ownerId: user.id });
+  await ctx.newAsset({ ownerId: user.id, libraryId: library.id }); // via library
+  await ctx.newAsset({ ownerId: user.id }); // none
+
+  await ctx.newAlbumAsset({ albumId: shown.id, assetId: viaShown.id });
+  await ctx.newAlbumAsset({ albumId: hidden.id, assetId: viaHidden.id });
+  await ctx.newAlbumAsset({ albumId: deleted.id, assetId: viaDeleted.id });
+  await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: shown.id, showInTimeline: true });
+  await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: hidden.id, showInTimeline: false });
+  await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: deleted.id });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: viaDirect.id, addedById: user.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+  await ctx.softDeleteAlbum(deleted.id);
+
+  return { space, viaShown, viaHidden };
+};
+
+describe('raw-SQL album arm ≡ Kysely album arm', () => {
+  it('returns the identical asset set (A1 on) across all path combinations', async () => {
+    const { ctx } = setup();
+    const { space, viaShown, viaHidden } = await seedCombos(ctx);
+
+    const kysely = await kyselyIds(space.id);
+    const raw = await rawIds(space.id);
+
+    expect(raw).toEqual(kysely);
+    // sanity: album assets present regardless of showInTimeline (arm has no timeline gate);
+    // soft-deleted album excluded (A1); direct/library assets absent from the album arm.
+    expect(kysely.has(viaShown.id)).toBe(true);
+    expect(kysely.has(viaHidden.id)).toBe(true);
+  });
+
+  it('returns the identical asset set with A1 off (soft-deleted album included by both)', async () => {
+    const { ctx } = setup();
+    const { space } = await seedCombos(ctx);
+
+    const kysely = await kyselyIds(space.id, false);
+    const raw = await rawIds(space.id, false);
+
+    expect(raw).toEqual(kysely);
+    expect(raw.size).toBe(kysely.size);
+  });
+});

--- a/server/test/medium/specs/utils/shared-space-album-scope.medium.spec.ts
+++ b/server/test/medium/specs/utils/shared-space-album-scope.medium.spec.ts
@@ -5,11 +5,7 @@ import { Kysely } from 'kysely';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
 import { BaseService } from 'src/services/base.service';
-import {
-  spaceAlbumAssetExists,
-  spaceAssetPathBranches,
-  type SpaceScope,
-} from 'src/utils/shared-space-album-scope';
+import { spaceAlbumAssetExists, spaceAssetPathBranches, type SpaceScope } from 'src/utils/shared-space-album-scope';
 import { newMediumService } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
@@ -178,7 +174,9 @@ describe('spaceAlbumAssetExists — album leg', () => {
       .selectFrom('asset_face')
       .select('asset_face.id')
       .where('asset_face.id', '=', faceId)
-      .where((eb) => spaceAlbumAssetExists(eb, { correlateAssetId: 'asset_face.assetId', scope: { spaceId: space.id } }))
+      .where((eb) =>
+        spaceAlbumAssetExists(eb, { correlateAssetId: 'asset_face.assetId', scope: { spaceId: space.id } }),
+      )
       .execute();
     expect(rows).toHaveLength(1);
   });

--- a/server/test/medium/specs/utils/shared-space-album-scope.medium.spec.ts
+++ b/server/test/medium/specs/utils/shared-space-album-scope.medium.spec.ts
@@ -1,0 +1,238 @@
+// Slice 2 — behavior tests for the fork-owned Kysely album-scope helpers.
+// Exercises spaceAlbumAssetExists / spaceAssetPathBranches against a real DB over
+// every access-path combination and edge case (spec §3.2).
+import { Kysely } from 'kysely';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import {
+  spaceAlbumAssetExists,
+  spaceAssetPathBranches,
+  type SpaceScope,
+} from 'src/utils/shared-space-album-scope';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let db: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx };
+};
+
+type Ctx = ReturnType<typeof setup>['ctx'];
+
+/** Assets whose album leg resolves for the given scope. */
+const albumAssetIds = async (
+  scope: SpaceScope,
+  flags?: { requireShowInTimeline?: boolean; requireAlbumNotDeleted?: boolean; excludeAlbumId?: string },
+): Promise<Set<string>> => {
+  const rows = await db
+    .selectFrom('asset')
+    .select('asset.id')
+    .where((eb) => spaceAlbumAssetExists(eb, { correlateAssetId: 'asset.id', scope, ...flags }))
+    .execute();
+  return new Set(rows.map((x) => x.id));
+};
+
+/** Assets visible via ANY of the three space paths for the given scope. */
+const anyPathAssetIds = (scope: SpaceScope, requireShowInTimeline?: boolean) =>
+  db
+    .selectFrom('asset')
+    .select('asset.id')
+    .where((eb) =>
+      eb.or(
+        spaceAssetPathBranches(eb, {
+          correlateAssetId: 'asset.id',
+          correlateLibraryId: 'asset.libraryId',
+          scope,
+          requireShowInTimeline,
+        }),
+      ),
+    )
+    .execute()
+    .then((r) => new Set(r.map((x) => x.id)));
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+describe('spaceAlbumAssetExists — album leg', () => {
+  it('selects assets in a linked, non-deleted album (album-only)', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'A' });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: other } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    const ids = await albumAssetIds({ spaceId: space.id });
+    expect(ids.has(a1.id)).toBe(true);
+    expect(ids.has(other.id)).toBe(false);
+  });
+
+  it('excludes a soft-deleted album by default (A1 on) but includes it when requireAlbumNotDeleted=false', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'SD' });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.softDeleteAlbum(album.id);
+
+    const a1On = await albumAssetIds({ spaceId: space.id });
+    const a1Off = await albumAssetIds({ spaceId: space.id }, { requireAlbumNotDeleted: false });
+    expect(a1On.has(a1.id)).toBe(false);
+    expect(a1Off.has(a1.id)).toBe(true);
+  });
+
+  it('honors showInTimeline only when requireShowInTimeline is set', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'Hidden' });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+    const withoutGate = await albumAssetIds({ spaceId: space.id });
+    const withGate = await albumAssetIds({ spaceId: space.id }, { requireShowInTimeline: true });
+    expect(withoutGate.has(a1.id)).toBe(true);
+    expect(withGate.has(a1.id)).toBe(false);
+  });
+
+  it('excludeAlbumId ignores the named album but keeps assets reachable via another linked album', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: albumA } = await ctx.newAlbum({ ownerId: user.id, albumName: 'A' });
+    const { result: albumB } = await ctx.newAlbum({ ownerId: user.id, albumName: 'B' });
+    const { asset: x } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: y } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: albumA.id, assetId: x.id });
+    await ctx.newAlbumAsset({ albumId: albumA.id, assetId: y.id });
+    await ctx.newAlbumAsset({ albumId: albumB.id, assetId: x.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: albumA.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: albumB.id });
+
+    const ids = await albumAssetIds({ spaceId: space.id }, { excludeAlbumId: albumA.id });
+    expect(ids.has(x.id)).toBe(true); // still reachable via B
+    expect(ids.has(y.id)).toBe(false); // only in A, which is excluded
+  });
+
+  it('member scope selects only for a member and not a non-member', async () => {
+    const { ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: stranger } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'M' });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    const asMember = await albumAssetIds({ memberUserId: member.id });
+    const asStranger = await albumAssetIds({ memberUserId: stranger.id });
+    expect(asMember.has(a1.id)).toBe(true);
+    expect(asStranger.has(a1.id)).toBe(false);
+  });
+
+  it('spaceIds scope selects across multiple linked spaces and dedups by asset id', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space: s1 } = await ctx.newSharedSpace({ createdById: user.id });
+    const { space: s2 } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'Multi' });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: s1.id, albumId: album.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: s2.id, albumId: album.id });
+
+    const rows = await db
+      .selectFrom('asset')
+      .select('asset.id')
+      .where((eb) => spaceAlbumAssetExists(eb, { correlateAssetId: 'asset.id', scope: { spaceIds: [s1.id, s2.id] } }))
+      .execute();
+    expect(rows.filter((r) => r.id === a1.id)).toHaveLength(1);
+  });
+
+  it('correlates on a non-asset outer column (asset_face.assetId)', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'F' });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    const { result: faceId } = await ctx.newAssetFace({ assetId: a1.id });
+
+    const rows = await db
+      .selectFrom('asset_face')
+      .select('asset_face.id')
+      .where('asset_face.id', '=', faceId)
+      .where((eb) => spaceAlbumAssetExists(eb, { correlateAssetId: 'asset_face.assetId', scope: { spaceId: space.id } }))
+      .execute();
+    expect(rows).toHaveLength(1);
+  });
+});
+
+const seedAllPaths = async (ctx: Ctx) => {
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+  const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'Paths' });
+
+  const { asset: viaAlbum } = await ctx.newAsset({ ownerId: user.id });
+  const { asset: viaDirect } = await ctx.newAsset({ ownerId: user.id });
+  const { asset: viaLibrary } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id });
+  const { asset: viaAll } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id });
+  const { asset: none } = await ctx.newAsset({ ownerId: user.id });
+
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: viaAlbum.id });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: viaAll.id });
+  await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: viaDirect.id, addedById: user.id });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: viaAll.id, addedById: user.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+  return { space, viaAlbum, viaDirect, viaLibrary, viaAll, none };
+};
+
+describe('spaceAssetPathBranches — the three-path OR', () => {
+  it('unions all three paths and excludes assets on none of them', async () => {
+    const { ctx } = setup();
+    const s = await seedAllPaths(ctx);
+    const ids = await anyPathAssetIds({ spaceId: s.space.id });
+    expect(ids.has(s.viaAlbum.id)).toBe(true);
+    expect(ids.has(s.viaDirect.id)).toBe(true);
+    expect(ids.has(s.viaLibrary.id)).toBe(true);
+    expect(ids.has(s.viaAll.id)).toBe(true);
+    expect(ids.has(s.none.id)).toBe(false);
+  });
+
+  it('counts an asset reachable via all three paths exactly once', async () => {
+    const { ctx } = setup();
+    const s = await seedAllPaths(ctx);
+    const rows = await db
+      .selectFrom('asset')
+      .select('asset.id')
+      .where((eb) =>
+        eb.or(
+          spaceAssetPathBranches(eb, {
+            correlateAssetId: 'asset.id',
+            correlateLibraryId: 'asset.libraryId',
+            scope: { spaceId: s.space.id },
+          }),
+        ),
+      )
+      .execute();
+    expect(rows.filter((r) => r.id === s.viaAll.id)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Consolidate shared-space-album scoping behind a helper (+ close soft-delete holes)

Recovers the server refactor originally in **#740** (now closed). That branch had diverged hopelessly — its head sat under ~1000 rolling-rebase commits that are now in `main`, so its diff had exploded past 300 files. The **actual work is 15 TDD-sliced commits**, cherry-picked here cleanly onto the current `space-albums-onto-main` base.

### What it does
- Introduces `server/src/utils/shared-space-album-scope.ts` — one place for shared-space asset/album scoping (`accessibleSpaces`, `accessibleSpaceAlbums`, `spaceAssetPathBranches`, `spaceAlbumAssetExists(Sql)`, …).
- Routes ~9 repositories through it (access, asset, search, timeline, map, memory, view, person-face, face-identity) — replacing duplicated inline `shared_space_*` SQL.
- **Closes 4 space-album soft-delete face-retention holes** (slice 15).
- Regenerated SQL query docs (access / search / shared.space / view).

### Reconciliation notes
Cherry-picked onto a base that diverged (v3 rebase + the space-albums feature + review-fixes). Only 2 files needed manual conflict resolution — `database.ts` (`searchAssetBuilder`) and `shared-space.repository.ts` — both resolved to **adopt the helper routing while preserving our RBAC‑M3 visibility constraints and the enriched `getLinkedAlbums`**. Slices 7–13/15 auto-merged.

### Verification (local)
- tsc clean; unit suite **4776 pass / 0 fail**.
- **Medium scope-equivalence gate PASS** — the 8-test `characterization` spec + `shared-space-album-scope.medium` (9) + `-sql` (2), which assert the consolidated scoping is **semantically identical** to the pre-refactor inline SQL (the security safety net for this merge). (Only unrelated EXIF/video medium specs fail locally — missing ffmpeg/exiftool binaries.)

Base is `space-albums-onto-main` so it stacks on #749. Replaces the closed #740.
