### PR TITLE
fix(spaces): RBAC visibility hardening — no hidden/locked leaks across any surface

### DIFF
--- a/docs/superpowers/specs/2026-07-06-shared-space-rbac-visibility-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-06-shared-space-rbac-visibility-hardening-design.md
@@ -1,0 +1,305 @@
+# Shared-Space RBAC Visibility Hardening — Design Spec
+
+> **For agentic workers:** REQUIRED SUB-SKILL: drive this with `impl-loop` (spec review → per-slice `superpowers:writing-plans` → `superpowers:subagent-driven-development`). Steps use checkbox (`- [ ]`) syntax. Every slice is TDD: failing test first (red), minimal fix (green), refactor.
+>
+> **Rev 2 (2026-07-06):** incorporates two independent code-grounded reviews. Changes vs rev 1: S4 split into query-filter (4.A) + purge-propagation (4.B) with honest matrix cells; S4 album-asset sync corrected to a *grant* surface (no `requireShowInTimeline`); EXIF builders flagged as needing an `asset` join; `downloadAlbumId` added to S2; S10 narrowed to search + edit-gate (map/memory/view stay Timeline-only by design); S11 guard rewritten as a *new* visibility scan + allowlist reconciliation; anchors corrected throughout; edge-case lists completed (livePhoto video part, `isOffline`, soft-deleted album, added-then-flipped replay); own-M3 (column F) corrected for memory/view.
+
+**Goal:** Close every confirmed way a shared-space member can reach a photo (bytes, thumbnail, EXIF, or existence/metadata) that its owner has made non-shareable (Hidden/Locked), and make the space visibility rule consistent across every surface — enforced by tests that cover the full RBAC matrix.
+
+**Architecture:** A shared-space grants members access to assets via three paths — direct (`shared_space_asset`), library (`shared_space_library`), and linked album (`shared_space_album`). The fork already has a correct reference gate in `searchAssetBuilder` and in `shared-space.repository.ts` reads (`visibility IN (Archive, Timeline)`), but ~10 surfaces bypass it. This spec adds one canonical visibility predicate in `shared-space-album-scope.ts`, routes every space-scoped read through it, adds the missing `requireShowInTimeline` capability to the raw-SQL album helper, strips PII from the linked-albums DTO, closes the sync purge-on-hide gap, and adds a structural regression guard plus an exhaustive negative-test matrix.
+
+**Tech stack:** NestJS 11, Kysely (type-safe SQL), Vitest (unit + medium/testcontainers), Playwright/Vitest (e2e), `@immich/sdk` (regenerated when a DTO changes).
+
+**Base branch:** `space-albums-onto-main` (HEAD `92ed82afb6` = PR #752). Create fix branch `fix/space-albums-rbac-visibility` off it. Do **not** merge to `main` or `#752` without explicit instruction.
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+1. **Canonical space visibility set — the single source of truth:**
+   `spaceVisibleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline]`.
+   Hidden and Locked are **never** shareable through a space. Archive **is** shareable (matches `bulkAddUserAssets`, `shared-space.repository.ts:314`, which only admits `[Archive, Timeline]` into a space). This value exists today as **three declarations under two names** — `visibleSpaceAssetVisibilities` (`shared-space.repository.ts:42`) and `peopleAssetVisibilities` (`face-identity.repository.ts:160`, `person.repository.ts:63`). Slice 1 consolidates them into one exported constant and aliases both names to it (grep the names; don't line-match).
+
+2. **The canonical gate** — every space-membership asset read MUST AND its asset rows with all of:
+   - `asset.deletedAt IS NULL`
+   - library arm: `asset.isOffline = false`
+   - album arm: `album.deletedAt IS NULL` (A1) **and**, on personal-timeline/projection surfaces (timeline, memory, folder view, people list, statistics), `shared_space_album.showInTimeline = true` (`requireShowInTimeline`). **Not** on explicit browse/grant surfaces (album-asset sync, direct album download/read) — those intentionally expose the whole shared album.
+   - **`asset.visibility IN (Archive, Timeline)`** (the canonical set)
+   Where a surface merges the **caller's own** assets through a **separate** `asset.ownerId = caller` branch (search, timeline via `userIds`, sync album-user grant, map), that branch keeps the caller's own resolved visibility (own elevation, M3); only the space-membership branch is restricted to the canonical set. **Surfaces without a separate own branch** (memory, folder view) gate own+space uniformly — see Slice 10 note; they have no own-M3 elevation and are intentionally Timeline-only.
+
+3. **Visibility-model scope (decision, 2026-07-06, refined in rev 2):** the canonical set closes the Hidden/Locked leaks on **every** surface. For the *Archive-consistency* question: **browse/access surfaces** (timeline, search, download, by-ID read, sync, facets, faces, tags, folder-asset access) expose other members' `Archive`; **resurfacing surfaces** (memory "on this day", map markers) keep `Archive` excluded, matching upstream personal-library behavior. Concretely, Slice 10 aligns only `searchAssetBuilder` (to match the space timeline) and tightens the edit gate; **map/memory/view stay Timeline-only for the space path** (safe — stricter than canonical — and consistent with upstream). This is a deliberate narrowing of the literal "uniform everywhere" because those surfaces gate own+partner+space with a single term and loosening them would both restructure the query and resurface archived content against upstream norms. If full uniformity is later desired, restructure each to give the space path its own gate (tracked, not in this spec).
+
+4. **TDD, strictly:** each behavior gets a failing test first, verified red, then the minimal fix, verified green. Negative assertions (Hidden/Locked seeded → asserted absent) are mandatory. Every slice below lists its explicit red step.
+
+5. **DTO changes require SDK regen:** Slice 7 changes `SharedSpaceLinkedAlbumDto`. After it: `pnpm build` (server) → `pnpm sync:open-api` → `make open-api`, then fix web/dart call sites. Web must never pass `undefined` for a required body arg.
+
+6. **Medium test infra:** use `newTestService()` / the `ctx` factory (`ctx.newUser`, `ctx.newSharedSpace`, `ctx.newSharedSpaceMember`, `ctx.newSharedSpaceAsset`, `ctx.newSharedSpaceLibrary`, `ctx.newSharedSpaceAlbum({ showInTimeline })`, `ctx.newAlbum`, `ctx.newAlbumAsset`, `ctx.newAsset({ visibility })`, `ctx.newExif`). Any new repo referenced by a medium test must be registered in `test/medium.factory.ts`.
+
+7. **No `Co-Authored-By` / `Generated-with` trailers. No unrelated refactors.** Keep diffs minimal and fork-isolated (new test files are fork-only and rebase-safe).
+
+8. **Verification loop:** per touched package — `pnpm check:typescript`, unit `pnpm test -- --run <file>`, medium `pnpm test:medium -- --run <file>`, eslint 0 warnings on touched files. E2e via the running stack / CI + babysit.
+
+---
+
+## The Canonical Visibility Model (implement once in Slice 1, reuse everywhere)
+
+Add to `server/src/utils/shared-space-album-scope.ts`:
+
+```ts
+export const spaceVisibleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+
+/**
+ * The space-membership visibility gate. AND this into every space-scoped asset read.
+ * Default column presumes the query is rooted on / joined to `asset`; pass an explicit
+ * column for other roots. NOT usable on an `asset`-less builder (add an `asset` join first).
+ */
+export function spaceVisibilityGate(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  column: ReferenceExpression<DB, keyof DB> = 'asset.visibility',
+): Expression<SqlBool> {
+  return eb(column, 'in', spaceVisibleAssetVisibilities);
+}
+```
+
+Raw-SQL surfaces (face-identity) use the equivalent fragment
+`sql\`"asset"."visibility" IN (${sql.join(spaceVisibleAssetVisibilities)})\`` — this exactly matches the existing pattern at `shared-space.repository.ts:932`.
+
+`spaceAlbumAssetExistsSql` gains a `requireShowInTimeline?: boolean` option (default `false`, preserving legacy behavior) that, when true, appends `AND "shared_space_album"."showInTimeline" = true`, matching the Kysely `spaceAlbumAssetExists`.
+
+---
+
+## RBAC Coverage Matrix — the binding contract
+
+Target state **after** all slices. Every non-trivial cell must be **enforced in code AND proven by a test** (the S11 matrix spec is the machine-checked record). `n/a` = not meaningful for that surface. Columns:
+
+- **A — non-member → ∅/403.**
+- **B — member sees shared:** direct + library + linked-album(`showInTimeline=true`, not deleted) assets, visibility ∈ `{Timeline, Archive}` (resurfacing surfaces #5/#6: `{Timeline}` only, by design).
+- **C — other member's Hidden/Locked BLOCKED** (incl. added-while-Timeline-then-flipped). **The key leak column.**
+- **D — showInTimeline=false album BLOCKED** on projection surfaces (`n/a` on grant/browse surfaces that intentionally expose the whole album).
+- **E — soft-deleted album BLOCKED.**
+- **F — own M3 elevation** (own archived/hidden/locked per own elevation, hidden from others; `n/a` where a surface has no own-elevation branch).
+
+| # | Surface (file) | A | B | C (Hidden/Locked) | D (showInTimeline=false) | E (soft-del album) | F (own M3) | Closed by |
+|---|---|---|---|---|---|---|---|---|
+| 1 | timeline / bucket (`asset.repository.ts` getTimeBucket) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | existing + S9 (faces path) |
+| 2 | search results (`utils/database.ts` searchAssetBuilder, two `=Timeline` terms `:673`,`:685`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | existing + **S10** (Archive align) |
+| 3 | facets / suggestions / tags (`search.repository.ts`, `tag.repository.ts`) | ✅ | ✅ | **S5** | **S5** | ✅ | ✅ | **S5** |
+| 4 | space people-facets (`search.repository.ts` people via `buildFilteredAssetIds`) | ✅ | ✅ | **S5** | **S5** | ✅ | n/a | **S5** |
+| 5 | map markers (`map.repository.ts`) — **resurfacing: Timeline-only by design** | ✅ | ✅ (Timeline) | ✅ | ✅ | ✅ | n/a | existing |
+| 6 | memory (`memory.repository.ts`) — **resurfacing: Timeline-only by design** | ✅ | ✅ (Timeline) | ✅ | **S9** | ✅ | n/a | existing + **S9** |
+| 7 | view / folders (`view-repository.ts`) — **Timeline-only (no own branch)** | ✅ | ✅ (Timeline) | ✅ | **S9** | ✅ | n/a | existing + **S9** |
+| 8 | people / faces list (`face-identity.repository.ts`, `shared-space.repository.ts`) | ✅ | ✅ | ✅ | **S9** | ✅ | ✅ | existing + **S9** |
+| 9 | face rep-thumbnail (`shared-space.repository.ts` isFaceInSpace `:2480`) | ✅ | ✅ | **S6** | **S6** | **S6** | n/a | **S6** |
+| 10 | asset read/view/download by ID (`access.repository.ts` checkSpaceAccess `:270`) | ✅ | ✅ | **S3** | n/a (browse) | ✅ | ✅ | **S3** |
+| 11 | download-space zip (`download.repository.ts` downloadSpaceId `:41`) | ✅ | ✅ | **S2** | n/a | ✅ | ✅ | **S2** |
+| 11b | album download via space grant (`download.repository.ts` downloadAlbumId `:27`, `AlbumDownload` via `access.ts:240`) | ✅ | ✅ | **S2** (Hidden; Locked already album-stripped) | n/a (browse) | ✅ | ✅ | **S2** |
+| 12 | mobile sync — asset (`sync.repository.ts` SharedSpaceAssetSync `:981` + Exif `:1060`) | ✅ | ✅ | **S4.A** future / **S4.B** purge | n/a | ✅ | ✅ | **S4** |
+| 13 | mobile sync — album asset (grant) (`sync.repository.ts` SharedSpaceAlbumAssetSync `:1528` + Exif `:1599`) | ✅ | ✅ | **S4.A** future / **S4.B** purge | n/a (grant surface) | ✅ | ✅ | **S4** |
+| 14 | getLinkedAlbums (`shared-space.service.ts:697`) — PII | ✅ | ✅ | n/a | n/a | ✅ | n/a | **S7** (strip albumUsers/email) |
+| 15 | getPersonAssetIds (`shared-space.repository.ts:1774`) | ✅ | ✅ | **S8** | **S8** | **S8** | ✅ | **S8** |
+| 16 | attach space people to detail (`access.repository.ts` checkSpaceAccessForSpace `:341`) | ✅ | ✅ | **S8** | n/a | ✅ | ✅ | **S8** |
+| 17 | people/face statistics (`face-identity.repository.ts` getAccessiblePeople*Statistics) | ✅ | ✅ | ✅ | **S9** | ✅ | n/a | existing + **S9** |
+| 18 | asset write via space (`access.repository.ts` checkSpaceEditAccess `:415`) | ✅ | editor+ | **S10** | n/a | ✅ | ✅ | **S10** |
+
+**Note on #12/#13-C (honesty):** S4.A closes the leak for any **new/full** device sync (the upsert/backfill streams). S4.B closes the **already-synced-then-hidden** purge (a delete/tombstone on visibility flip). If S4.B's mobile consumption needs a client change, the server-side delete emission is still implemented + tested and the client half is a tracked follow-up — the matrix cell is only fully ✅ once both land.
+
+**Album detail read via space (`GET /albums/:id`, `album.repository.getById` + `withAssets`) is SAFE** — `withAssets` already applies `withDefaultVisibility` (`[Archive, Timeline]`), so it never returns Hidden/Locked. Only the album *download* stream (`downloadAlbumId`, row 11b) lacked the filter. `AlbumRead`/`AlbumDownload` are space-grantable via `checkSpaceLinkedAlbumReadAccess` (`access.ts:189/240`); S11's guard/matrix asserts both.
+
+**Provably safe today (regression-guard only):** scope helper, `shared-space.repository` reads, `PersonAccess.checkSharedSpaceAccess`, `linkAlbum`/`unlinkAlbum`/`updateAlbumLink` authorization (Editor + `AlbumUpdate`, cannot self-satisfy via space grant), the "absorbed invariant" (space-linked album absent from plain `GET /albums`), soft-delete face-retention (4 original holes closed; remaining two are S6/S8), token resolution fail-closed. Slice 11 adds a static guard so these cannot regress.
+
+---
+
+## Slices
+
+Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is independently testable and pushed on completion.
+
+### Slice 1 — Canonical visibility helper + raw-SQL `requireShowInTimeline` (foundation)
+
+**Closes:** none directly; enables S2–S10 and the S11 guard. **Files:**
+- Modify `server/src/utils/shared-space-album-scope.ts`: add `spaceVisibleAssetVisibilities`, `spaceVisibilityGate()`, and a `requireShowInTimeline?: boolean` (default `false`) option in `spaceAlbumAssetExistsSql`.
+- Modify `shared-space.repository.ts` / `face-identity.repository.ts` / `person.repository.ts`: replace the three local constant declarations (two names) with an import/alias of the new constant (pure relocation, no behavior change).
+- Test: `server/src/utils/shared-space-album-scope.guard.spec.ts` (extend) + `server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts` (extend for the new option).
+
+**TDD steps:**
+- [ ] **Red (behavioral):** write a medium equivalence test — `spaceAlbumAssetExistsSql({ requireShowInTimeline: true })` produces SQL equal to the Kysely `spaceAlbumAssetExists({ requireShowInTimeline: true })` for a fixture with one `showInTimeline=true` and one `showInTimeline=false` linked album: the raw variant must **exclude** the false one; with the option absent/false, both are included (unchanged legacy behavior). Run red (option does not exist yet).
+- [ ] **Red (relocation guard):** unit assertions that `spaceVisibilityGate(eb)` compiles to `"asset"."visibility" in ('archive','timeline')`, the constant equals `[Archive, Timeline]`, and the two old names resolve to the **same array reference** (`===`) post-consolidation.
+- [ ] Implement helper + option + constant consolidation → green.
+- [ ] Regression: run the existing `*-sql.medium.spec.ts`; confirm `make sql` diff is empty except the intended `requireShowInTimeline` variant. `pnpm check:typescript`; eslint 0. Commit `feat(spaces): canonical space visibility gate + raw-SQL showInTimeline option`.
+
+**Edge cases:** option defaults to `false` (legacy preserved); constant consolidation must not change any existing query's SQL (verified via the sql medium spec + `make sql`).
+
+---
+
+### Slice 2 — L1: download visibility filter — `downloadSpaceId` **and** `downloadAlbumId` (🔴 Critical) — matrix #11, #11b
+
+**Closes:** #11-C, #11b-C. **Files:** `server/src/repositories/download.repository.ts` — `downloadSpaceId` (`:41`, all three arms) and `downloadAlbumId` (`:27`, add the visibility gate to match `withAssets`/`withDefaultVisibility`). Test: `server/test/medium/specs/repositories/download.repository.spec.ts` (create if absent).
+
+**TDD steps:**
+- [ ] **Red (space zip):** seed a space (owner + member); owner adds assets of each visibility (`Timeline`, `Archive`, `Hidden`, `Locked`) via **each** path (direct, library, album). Stream `downloadSpaceId(space.id)`; assert the returned id set = the `{Timeline, Archive}` assets only, across all three arms; `Hidden`/`Locked` absent. Run red (all four returned).
+- [ ] **Red (album via space):** a space member calls the album-download path (`AlbumDownload` satisfied via `checkSpaceLinkedAlbumReadAccess`); `downloadAlbumId(linkedAlbumId)` must return only `{Timeline, Archive}` album assets — a `Hidden` album asset absent. (`Locked` is already stripped from albums by `asset.service.ts:313` — assert it isn't present, documenting that invariant.)
+- [ ] Implement: add `spaceVisibilityGate(eb)` to each `downloadSpaceId` arm; add `withDefaultVisibility`/`spaceVisibilityGate` to `downloadAlbumId`. → green.
+- [ ] Commit `fix(spaces): space + linked-album downloads exclude hidden/locked assets`.
+
+**Edge cases:** (a) **added-then-locked/hidden replay** — asset added while `Timeline`, then flipped: excluded (proves read-time gating vs the un-pruned `shared_space_asset` row). (b) **live-photo video part** (`livePhotoVideoId`) inherits the parent's exclusion. (c) **soft-deleted album** arm excluded via `album.deletedAt IS NULL` — assert. (d) library arm keeps `isOffline = false` — seed an offline library asset, assert absent.
+
+---
+
+### Slice 3 — L2: `checkSpaceAccess` visibility filter (🔴 High) — matrix #10
+
+**Closes:** #10-C. **Files:** `server/src/repositories/access.repository.ts` (`checkSpaceAccess` `:270`, all three union arms; gates `AssetRead`/`AssetView`/`AssetDownload` per `access.ts:120/137/148`, always **after** `checkOwnerAccess`). Test: `server/test/medium/specs/repositories/access.repository.spec.ts` + e2e `e2e/src/specs/server/api/shared-space.e2e-spec.ts`.
+
+**TDD steps:**
+- [ ] **Red (medium):** member + another member's assets of each visibility via each path. `checkSpaceAccess(member.id, allIds)` returns only `{Timeline, Archive}`; `Hidden`/`Locked` absent. Run red.
+- [ ] **Red (e2e):** as a plain member, `GET /assets/:id`, `GET /assets/:id/original`, `GET /assets/:id/thumbnail` for another member's `Locked`/`Hidden` in-space asset → `400`/`403`; for `Timeline`/`Archive` → `200`.
+- [ ] Implement: AND `spaceVisibilityGate(eb)` into each union arm (keep `deletedAt`, `isOffline`, `album.deletedAt`). → green.
+- [ ] Commit `fix(spaces): space asset read/view/download gate excludes hidden/locked`.
+
+**Edge cases:** (a) **`livePhotoVideoId`** — the function returns both `id` and `livePhotoVideoId` and OR-matches on both (`:283/298/315`); a `Locked` parent's video part must not be reachable — add an explicit assertion. (b) **own asset still reachable** via `checkOwnerAccess` (not `checkSpaceAccess`): assert the caller can still read their OWN `Locked` asset with elevation (own-M3, cell F) so the fix doesn't over-block. (c) **added-then-locked replay**. (d) **`isOffline=true`** library asset excluded. (e) **soft-deleted album** asset excluded.
+
+---
+
+### Slice 4 — L3: mobile sync — query filter (4.A) + purge-on-hide (4.B) (🔴 High) — matrix #12, #13
+
+**Anchors (corrected):** `SharedSpaceAssetSync` (`sync.repository.ts:981`) has `getBackfill` (`:988`), `getCreates` (`:1012`), `getUpdates` (`:1037`) — **no `getDeletes`**; `SharedSpaceAssetExifSync` (`:1060`) joins **only** `asset_exif`; `SharedSpaceAlbumAssetSync` (`:1528`, a `shared_space_album_user` **grant** stream) + `SharedSpaceAlbumAssetExifSync` (`:1599`). Row-removal deletes are emitted by the separate `SharedSpaceToAssetSync.getDeletes` (`:1113`, reads `shared_space_asset_audit`) and `SharedSpaceAlbumToAssetSync.getDeletes` (reads `album_asset_audit`), which fire on **row deletion only**, not visibility flips.
+
+#### Slice 4.A — Gate the sync read streams (closes future/full-sync leak)
+
+**Closes:** #12-C / #13-C for any new or full re-sync. **Files:** `sync.repository.ts` — add `spaceVisibilityGate` to `SharedSpaceAssetSync.{getBackfill,getCreates,getUpdates}` and `SharedSpaceAlbumAssetSync` equivalents; for **both EXIF builders**, first add `innerJoin('asset', 'asset.id', '<exif>.assetId')` (they currently have no `asset` join) **then** apply the gate. **Do NOT** apply `requireShowInTimeline` to the album-asset stream — it is an explicit browse/grant surface (`shared_space_album_user`); hiding `showInTimeline=false` assets there would wrongly deny a directly-granted member. Test: `server/test/medium/specs/repositories/sync.repository*.spec.ts`.
+
+**TDD steps:**
+- [ ] **Red:** seed a space + two members; member A has assets of each visibility (direct) and album-linked assets. Drive the shared-space asset + album-asset sync (+ EXIF) for member B; assert only `{Timeline, Archive}` appear, with EXIF/GPS only for those; `Hidden`/`Locked` absent. Run red.
+- [ ] Implement (add `asset` joins to EXIF builders, apply gate) → green.
+- [ ] Commit `fix(spaces): shared-space sync streams exclude hidden/locked assets and exif`.
+
+**Edge cases:** live-photo video part excluded; `isOffline=true` library asset excluded; `isFavorite` masking unchanged; **no** `showInTimeline` filter on the album-asset grant stream (assert a `showInTimeline=false` album asset still syncs to a grant-holder, only visibility-gated).
+
+#### Slice 4.B — Purge on visibility flip (closes already-synced leak)
+
+**Closes:** #12-C / #13-C for the added-then-hidden device-purge case. **Files:** `server/src/services/asset.service.ts` (`updateAll` `~:312`, where `Locked` already triggers `albumRepository.removeAssetsFromAll`) — on a visibility change **out of** `[Archive, Timeline]` for any in-space asset, emit the sync delete/tombstone so `SharedSpaceToAssetSync.getDeletes` (and the album equivalent) purge the device. Test: `sync.repository`/`asset.service` medium specs.
+
+**TDD steps:**
+- [ ] **Red:** member B fully syncs member A's `Timeline` in-space asset (device holds it). Member A flips it to `Hidden` (and separately `Locked`). Drive member B's sync `getDeletes`/checkpoint; assert a **delete/tombstone** event for that asset appears (device would purge). Run red (no delete emitted today).
+- [ ] Implement the tombstone emission on visibility-out-of-set. **Investigation sub-task:** determine the minimal mechanism (insert a `shared_space_asset_audit`/`album_asset_audit` tombstone without deleting the live `shared_space_asset` row, so un-hide restores; or an equivalent checkpoint). If the mobile client cannot consume this without a client change, ship + test the **server-side** emission and open a tracked mobile follow-up — do **not** silently drop the purge. → green.
+- [ ] Commit `fix(spaces): purge shared-space assets from member devices when hidden/locked`.
+
+**Edge cases:** un-hide (`Hidden→Timeline`) restores the asset on next sync (live row never deleted); `Locked` path already calls `removeAssetsFromAll` (album purge) — ensure the space-asset tombstone is additive; own device (owner) still updates via normal AssetSync.
+
+---
+
+### Slice 5 — L5: facets / suggestions / tags / people-facets visibility gate (🟠 Medium) — matrix #3, #4
+
+**Closes:** #3-C/#3-D, #4-C/#4-D. **Anchors (corrected):** `applySuggestionScope` (`search.repository.ts:1186`), `getAccessibleTags` (`:1099`), the people-facet **producer** `buildFilteredAssetIds` (used by `getFilteredIdentityPeople` `:1506`; the consumer `buildFilteredSpacePeopleQuery` `:1467` only filters on the produced id set — the gate belongs in the producer), and `tag.repository.ts getAll` (`:73`, space arms `:94`/`:115`). Test: `search.service.spec.ts`, `search.repository.spec.ts`, `tag.repository.spec.ts`.
+
+**TDD steps:**
+- [ ] **Red, per surface** (`getSearchSuggestions` city/country/state/camera-make/model/lens, `getFilterSuggestions`, tag suggestions, `getAccessibleTags`, `tag.getAll`, space people-facets): seed another member's `Hidden` (and, for an elevated caller, `Locked`) asset with a **distinct** city/tag/person/camera; assert that value is **absent**. Seed `Timeline` and `Archive` with distinct values → **present**. Seed a `showInTimeline=false` linked-album asset with a distinct value → **absent**. Run red.
+- [ ] Implement: for the space-membership branch in each builder, AND `spaceVisibilityGate(eb)` and pass `requireShowInTimeline: true` on the album arm (`spaceAssetPathBranches({ requireShowInTimeline: true })`). The caller's own branch (e.g. the `timelineSpaceIds` `ownerId` term) keeps caller visibility. → green.
+- [ ] Commit `fix(spaces): filter suggestions/facets/tags to shareable space assets`.
+
+**Edge cases:** (a) **elevated session** — the caller's own `Locked` values may appear (own M3), but another member's `Locked`/`Hidden` must not. (b) the existing positive album-suggestion tests (`search.service.spec.ts:276-356`) stay green (their assets are `Timeline`). (c) `hasUnnamedPeople` must not flip true solely due to another member's hidden asset. (d) **added-then-flipped replay** — a facet/person derived while the asset was `Timeline`, then flipped `Hidden`: must disappear (read-time gating).
+
+---
+
+### Slice 6 — L4: `isFaceInSpace` rep-face thumbnail guards (🟠 Medium) — matrix #9
+
+**Closes:** #9-C/D/E. **Files:** `server/src/repositories/shared-space.repository.ts` (`isFaceInSpace` `:2480`). The **direct** arm (`:2484`) has **no `asset` join at all** (only `asset_face.deletedAt`) — add an `asset` join + full gate (`deletedAt`, visibility). The **library** arm (`:2491`) already has `asset.deletedAt`+`isOffline` — add visibility. The **album** arm — add visibility + `album.deletedAt` + `showInTimeline` (projection surface). Mirror the fully-guarded `isAssetInSpace` (`:2433`). Test: `shared-space.repository.spec.ts` + a service test for `getSpacePersonThumbnail` auto path.
+
+**TDD steps:**
+- [ ] **Red:** a space person whose representative face's **only** source asset is (per case) another member's `Hidden`, `Locked`, soft-deleted direct asset, or a `showInTimeline=false`/soft-deleted album asset. `isFaceInSpace(space.id, faceId)` returns `false` for each; the auto rep-face thumbnail (`getSpacePersonThumbnail`) is not served. For a face on a `Timeline`/`Archive` asset → `true`. Run red.
+- [ ] Implement → green. Commit `fix(spaces): representative-face thumbnail only from shareable space assets`.
+
+**Edge cases:** the **manual** rep-face path is already scoped — add a regression assertion it still works. `Archive` rep-face still serves. **Added-then-flipped replay** — a rep-face chosen while the asset was `Timeline`, then flipped `Hidden`: no longer served.
+
+---
+
+### Slice 7 — L6: `getLinkedAlbums` strips album-user PII (🟠 Medium) — matrix #14
+
+**Closes:** #14 PII. **Files:** `shared-space.repository.ts` (`getLinkedAlbums` `:450`, drop `withSpaceAlbumUsers` `:23`), `server/src/dtos/shared-space.dto.ts` (`SharedSpaceLinkedAlbumSchema` `:142` currently extends `AlbumResponseSchema` whose `albumUsers` is **required** and carries `email`; use `.omit({ albumUsers: true })` or a projection schema), `shared-space.service.ts` (`getLinkedAlbums` `:697` mapping). Then SDK regen + web/dart call-site check. Test: `shared-space-album.service.spec.ts` + e2e `shared-space-album.e2e-spec.ts`.
+
+**TDD steps:**
+- [ ] **Red:** `getLinkedAlbums` for a viewer returns each linked album **without** `albumUsers` and **without** any `email`, while still returning the fields the web UI uses (`id`, `albumName`, `assetCount`, `showInTimeline`, `addedById`, `linkedAt`, thumbnail). Run red.
+- [ ] Implement projection/omit → green.
+- [ ] Regenerate SDK (`pnpm build` → `pnpm sync:open-api` → `make open-api`); `check-web`. Commit `fix(spaces): linked-albums endpoint no longer exposes album-user emails` + a follow-up commit for regenerated SDK/dart.
+
+**Edge cases:** (a) e2e "absorbed invariant" + existing `getLinkedAlbums` tests stay green. (b) web `web/src/routes/(user)/spaces/[spaceId]/albums/+page.svelte` (and list/table) do not read `albumUsers`/`owner`/`email` (verified — `SpaceLinkAlbumModal` reads `albumUsers` only from the regular `getAllAlbums()` DTO, unaffected). (c) dart SDK consumers compile.
+
+---
+
+### Slice 8 — L7: `getPersonAssetIds` scoping + `checkSpaceAccessForSpace` visibility (🟡 Low) — matrix #15, #16
+
+**Closes:** #15-C/D/E, #16-C. **Files:** `shared-space.repository.ts` (`getPersonAssetIds` `:1774` — add the OR-of-three-paths membership + `deletedAt`/`isOffline`/`album.deletedAt`/`showInTimeline` + `spaceVisibilityGate`), `access.repository.ts` (`checkSpaceAccessForSpace` `:341` — add `spaceVisibilityGate` to its arms; note it also re-adds `livePhotoVideoId` at `:405/461`). Test: `shared-space.repository.spec.ts`, `access.repository.spec.ts`.
+
+**TDD steps:**
+- [ ] **Red:** a `shared_space_person_face` row whose asset is another member's `Hidden`/`Locked`, soft-deleted, or in a `showInTimeline=false`/soft-deleted album → `getPersonAssetIds` must not enumerate its id; `Timeline`/`Archive` → enumerated. `checkSpaceAccessForSpace` excludes non-shareable ids (incl. the `livePhotoVideoId` of a `Locked` parent). Run red.
+- [ ] Implement → green. Commit `fix(spaces): scope person-asset ids and space-asset attach to shareable assets`.
+
+**Edge cases:** person-detail page still loads its content (remaining ids are shareable); no empty-people regression for `Timeline`/`Archive` faces. **Added-then-flipped replay** (the `shared_space_person_face` projection survives the flip). **`isOffline=true`** library asset excluded. **live-photo video part** of a `Locked` parent excluded from `checkSpaceAccessForSpace`.
+
+---
+
+### Slice 9 — Hardening: `requireShowInTimeline` on projection face/memory/view surfaces + prune/recount on `showInTimeline` flip — matrix #6-D, #7-D, #8-D, #17-D
+
+**Closes:** the `showInTimeline=false` (D) column on memory, view, people/faces, statistics; and stored-counter staleness. **Files:** `face-identity.repository.ts` (the `spaceAlbumAssetExistsSql` call sites `:902/1021/1162/1642/1787/1902` — pass `requireShowInTimeline: true` where the surface is a **personal-timeline projection**), `memory.repository.ts` + `view-repository.ts` (album arm → `requireShowInTimeline: true`), `shared-space.service.ts` (`updateAlbumLink` `:687` — prune/recount `shared_space_person_face` + `faceCount`/`assetCount` when `showInTimeline` flips false, re-add when true). Test: `face-identity.repository.spec.ts`, `memory.repository.spec.ts`, `view-repository` spec, `shared-space-album.service.spec.ts`.
+
+**TDD steps:**
+- [ ] **Red:** a `showInTimeline=false` linked album's faces/people do **not** surface in the People tab, memory, or folder view; toggling `showInTimeline` false→true→false updates the people list AND stored counters consistently; after `→false`, `getPersonAssetIds` (S8 surface) no longer enumerates those album assets. Run red.
+- [ ] Implement → green. Commit `fix(spaces): de-timelined albums stop feeding faces/memory/view and recount on toggle`.
+
+**Edge cases:** distinguish **projection** surfaces (require `showInTimeline`) from **grant/browse** surfaces (do not — album-asset sync, direct album download/read). Statistics counters reflect the toggle. Soft-delete (A1) remains enforced everywhere. **Cross-link:** the toggle-prune interacts with S8's `getPersonAssetIds` — assert the intersection here.
+
+---
+
+### Slice 10 — Consistency: align `searchAssetBuilder` to `[Archive, Timeline]` + tighten `checkSpaceEditAccess` — matrix #2, #18
+
+**Closes:** #2 (Archive alignment on search — a browse surface, to match the space timeline), #18-C. **Files:**
+- `server/src/utils/database.ts` — `searchAssetBuilder` space branch: change the other-member term from `= Timeline` to `spaceVisibilityGate` at **both** sites (`:673` spaceId path **and** `:685` timelineSpaceIds path).
+- `server/src/repositories/access.repository.ts` — `checkSpaceEditAccess` (`:415`, two arms, no album arm) — AND `spaceVisibilityGate` so an editor cannot `AssetUpdate` another member's Hidden/Locked (can't see it → can't edit it).
+
+**Explicitly NOT changed** (see Global Constraint #3): `map.repository.ts` (Archive is owner-only by design via the top-level `isArchived` filter `:99-101` — a per-arm change would be dominated by it and would not surface Archive), `memory.repository.ts` (`= Timeline` at `:65` gates own+partner+space together — a resurfacing surface, Archive stays excluded per upstream), `view-repository.ts` (`= Timeline` at `:19/:39` over `ownedOrSpaceAccessible`, no own branch). These stay Timeline-only: safe (stricter than canonical) and upstream-consistent.
+
+Test: `search.service.spec.ts`, `access.repository.spec.ts`.
+
+**TDD steps:**
+- [ ] **Red (search):** another member's `Archive` asset in the space now **appears** in `searchMetadata`/`searchLargeAssets` results (previously excluded); `Hidden`/`Locked` still excluded; the caller's own assets resolve per own elevation unchanged (searchAssetBuilder has a separate `userIds`/owner branch — verify). Run red.
+- [ ] **Red (edit):** a space editor cannot `AssetUpdate` another member's `Hidden`/`Locked` in-space asset; can update a `Timeline`/`Archive` one per role. Include the live-photo video part of a `Locked` parent. Run red.
+- [ ] Implement (both `=Timeline` terms in search; edit gate) → green.
+- [ ] Commit `refactor(spaces): search shows shared archive (match timeline); edit gate matches read gate`.
+
+**Edge cases:** the space-people sub-filters (`hasSpacePeople`) riding on `searchAssetBuilder` inherit the change — assert other-member `Archive`-only faces now appear consistently with the timeline. `userIds`-undefined (pure space browse) path handled at both sites. `checkSpaceEditAccess` live-photo video part gated.
+
+---
+
+### Slice 11 — Structural guard + exhaustive negative-test matrix (regression lock) — the "double-check"
+
+**Closes:** proves every risky cell and prevents any future surface from forgetting the gate. **Files:** extend `server/src/utils/shared-space-album-scope.guard.spec.ts`; create `server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts`; extend e2e `shared-space*.e2e-spec.ts`.
+
+**TDD steps:**
+- [ ] **Add a NEW, second static scan** to the guard spec (the existing scan checks that a `shared_space_library` arm has a sibling `shared_space_album` arm — a *different* invariant; do not conflate). The new scan: for every repository query that space-scopes an asset read (joins `shared_space_asset`/`shared_space_library`/`shared_space_album` and returns/selects asset rows), assert it references the visibility gate (`spaceVisibilityGate`/`spaceVisibleAssetVisibilities`/`visibility IN`), or is on the **new visibility allowlist** with a one-line reason. Give the new scan its **own** allowlist (the album-marker allowlist is separate). **Prune the stale entry:** the existing album-marker allowlist entry `getMapMarkers: 'omit album path (pre-existing)'` is now FALSE (`map.repository.ts:160` has the album leg with `requireShowInTimeline: true`) — remove it. Document which allowlist governs `checkSpaceEditAccess` (visibility-gated by S10 but still no album arm → stays on the album-marker allowlist, off the visibility allowlist), `findSpaceForAssetAndUser`, `getPersonalThumbnailForSpacePerson`.
+- [ ] **Write the matrix medium spec:** a parametrized fixture seeding `{Timeline, Archive, Hidden, Locked}` × `{direct, library, album(showInTimeline=true), album(showInTimeline=false), soft-deleted-album}`, asserting the correct visible set on **every** surface the slices touch: download-space, download-album-via-space, `checkSpaceAccess`, `checkSpaceAccessForSpace`, sync (asset + album), facets/tags, space people-facets, `isFaceInSpace`, `getPersonAssetIds`, timeline, statistics, map, memory, view, `checkSpaceEditAccess`. Each 🔴 cell in the matrix has an assertion here (map/memory/view assert Timeline-only per Global Constraint #3).
+- [ ] **Add e2e negatives** for the HTTP-reachable content leaks: download-space and download-album-via-space and `GET /assets/:id`/original for a Hidden/Locked in-space asset as a non-owner member.
+- [ ] Run the whole matrix green. Commit `test(spaces): exhaustive RBAC visibility matrix + structural regression guard`.
+
+**Edge cases:** each allowlist lists every intentional omission with a one-line reason, so an unexplained omission fails CI. The matrix fixture includes the added-then-flipped replay for the projection surfaces (`shared_space_person_face`, `shared_space_asset`).
+
+---
+
+## Post-Implementation Verification (mandatory — the "double-check after implementing")
+
+After all slices are green and pushed:
+
+1. **Re-run the coverage matrix as code:** `pnpm test:medium -- --run shared-space-visibility-matrix` passes every cell; `pnpm test -- --run shared-space-album-scope.guard` (both scans) green.
+2. **Re-audit adversarially:** re-dispatch the 5 read-only RBAC audit agents (scope-helper, cross-surface visibility, search, faces/endpoint, coverage) against the fixed tree; confirm zero remaining Hidden/Locked content/thumbnail/EXIF/existence leaks at confidence ≥8 and no unclosed 🔴 cell — **including** the two paths added in rev 2 (`downloadAlbumId` via space grant, S4.B device purge).
+3. **Trace every matrix row** to a passing assertion in the matrix spec / guard; any row without one is a gap to close before merge.
+4. **CI green** on the full gating set (Test&Lint Server, Medium Tests, E2E Server&CLI, Test Web) via babysit; the recurring mise 403 flake is a re-run, not a code fix.
+5. Report the before/after matrix; do not merge to `#752`/`main` without explicit instruction.
+
+---
+
+## Self-Review (rev 2)
+
+- **Spec coverage:** every confirmed leak (L1–L7, plus `downloadAlbumId`) and every hardening/consistency item maps to a slice; every matrix cell maps to a closing slice and a test; S11 is the machine-checked record. ✅
+- **Consistency:** one canonical set + one gate helper; browse surfaces expose Archive, resurfacing surfaces (map/memory) stay Timeline-only by design (documented, upstream-consistent); no surface leaks Hidden/Locked. ✅
+- **TDD:** every slice is red-first with explicit negative assertions; the relocation-only Slice 1 states its genuine red (the `requireShowInTimeline` option + constant identity). ✅
+- **Anchors:** corrected against HEAD `92ed82afb6` (sync method names, S5 line numbers, isFaceInSpace direct arm, S1 sql-spec path under `utils/`, S7 web route group, two `=Timeline` search terms). ✅
+- **Honesty:** S4.B device-purge is a committed server-side slice with a tracked mobile follow-up if needed; the matrix flags #12/#13-C as two-part rather than over-claiming. ✅

--- a/docs/superpowers/specs/2026-07-06-shared-space-rbac-visibility-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-06-shared-space-rbac-visibility-hardening-design.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: drive this with `impl-loop` (spec review → per-slice `superpowers:writing-plans` → `superpowers:subagent-driven-development`). Steps use checkbox (`- [ ]`) syntax. Every slice is TDD: failing test first (red), minimal fix (green), refactor.
 >
-> **Rev 2 (2026-07-06):** incorporates two independent code-grounded reviews. Changes vs rev 1: S4 split into query-filter (4.A) + purge-propagation (4.B) with honest matrix cells; S4 album-asset sync corrected to a *grant* surface (no `requireShowInTimeline`); EXIF builders flagged as needing an `asset` join; `downloadAlbumId` added to S2; S10 narrowed to search + edit-gate (map/memory/view stay Timeline-only by design); S11 guard rewritten as a *new* visibility scan + allowlist reconciliation; anchors corrected throughout; edge-case lists completed (livePhoto video part, `isOffline`, soft-deleted album, added-then-flipped replay); own-M3 (column F) corrected for memory/view.
+> **Rev 2 (2026-07-06):** incorporates two independent code-grounded reviews. Changes vs rev 1: S4 split into query-filter (4.A) + purge-propagation (4.B) with honest matrix cells; S4 album-asset sync corrected to a _grant_ surface (no `requireShowInTimeline`); EXIF builders flagged as needing an `asset` join; `downloadAlbumId` added to S2; S10 narrowed to search + edit-gate (map/memory/view stay Timeline-only by design); S11 guard rewritten as a _new_ visibility scan + allowlist reconciliation; anchors corrected throughout; edge-case lists completed (livePhoto video part, `isOffline`, soft-deleted album, added-then-flipped replay); own-M3 (column F) corrected for memory/view.
 
 **Goal:** Close every confirmed way a shared-space member can reach a photo (bytes, thumbnail, EXIF, or existence/metadata) that its owner has made non-shareable (Hidden/Locked), and make the space visibility rule consistent across every surface — enforced by tests that cover the full RBAC matrix.
 
@@ -27,9 +27,9 @@ Every task's requirements implicitly include this section.
    - library arm: `asset.isOffline = false`
    - album arm: `album.deletedAt IS NULL` (A1) **and**, on personal-timeline/projection surfaces (timeline, memory, folder view, people list, statistics), `shared_space_album.showInTimeline = true` (`requireShowInTimeline`). **Not** on explicit browse/grant surfaces (album-asset sync, direct album download/read) — those intentionally expose the whole shared album.
    - **`asset.visibility IN (Archive, Timeline)`** (the canonical set)
-   Where a surface merges the **caller's own** assets through a **separate** `asset.ownerId = caller` branch (search, timeline via `userIds`, sync album-user grant, map), that branch keeps the caller's own resolved visibility (own elevation, M3); only the space-membership branch is restricted to the canonical set. **Surfaces without a separate own branch** (memory, folder view) gate own+space uniformly — see Slice 10 note; they have no own-M3 elevation and are intentionally Timeline-only.
+     Where a surface merges the **caller's own** assets through a **separate** `asset.ownerId = caller` branch (search, timeline via `userIds`, sync album-user grant, map), that branch keeps the caller's own resolved visibility (own elevation, M3); only the space-membership branch is restricted to the canonical set. **Surfaces without a separate own branch** (memory, folder view) gate own+space uniformly — see Slice 10 note; they have no own-M3 elevation and are intentionally Timeline-only.
 
-3. **Visibility-model scope (decision, 2026-07-06, refined in rev 2):** the canonical set closes the Hidden/Locked leaks on **every** surface. For the *Archive-consistency* question: **browse/access surfaces** (timeline, search, download, by-ID read, sync, facets, faces, tags, folder-asset access) expose other members' `Archive`; **resurfacing surfaces** (memory "on this day", map markers) keep `Archive` excluded, matching upstream personal-library behavior. Concretely, Slice 10 aligns only `searchAssetBuilder` (to match the space timeline) and tightens the edit gate; **map/memory/view stay Timeline-only for the space path** (safe — stricter than canonical — and consistent with upstream). This is a deliberate narrowing of the literal "uniform everywhere" because those surfaces gate own+partner+space with a single term and loosening them would both restructure the query and resurface archived content against upstream norms. If full uniformity is later desired, restructure each to give the space path its own gate (tracked, not in this spec).
+3. **Visibility-model scope (decision, 2026-07-06, refined in rev 2):** the canonical set closes the Hidden/Locked leaks on **every** surface. For the _Archive-consistency_ question: **browse/access surfaces** (timeline, search, download, by-ID read, sync, facets, faces, tags, folder-asset access) expose other members' `Archive`; **resurfacing surfaces** (memory "on this day", map markers) keep `Archive` excluded, matching upstream personal-library behavior. Concretely, Slice 10 aligns only `searchAssetBuilder` (to match the space timeline) and tightens the edit gate; **map/memory/view stay Timeline-only for the space path** (safe — stricter than canonical — and consistent with upstream). This is a deliberate narrowing of the literal "uniform everywhere" because those surfaces gate own+partner+space with a single term and loosening them would both restructure the query and resurface archived content against upstream norms. If full uniformity is later desired, restructure each to give the space path its own gate (tracked, not in this spec).
 
 4. **TDD, strictly:** each behavior gets a failing test first, verified red, then the minimal fix, verified green. Negative assertions (Hidden/Locked seeded → asserted absent) are mandatory. Every slice below lists its explicit red step.
 
@@ -64,7 +64,7 @@ export function spaceVisibilityGate(
 ```
 
 Raw-SQL surfaces (face-identity) use the equivalent fragment
-`sql\`"asset"."visibility" IN (${sql.join(spaceVisibleAssetVisibilities)})\`` — this exactly matches the existing pattern at `shared-space.repository.ts:932`.
+`sql\`"asset"."visibility" IN (${sql.join(spaceVisibleAssetVisibilities)})\``— this exactly matches the existing pattern at`shared-space.repository.ts:932`.
 
 `spaceAlbumAssetExistsSql` gains a `requireShowInTimeline?: boolean` option (default `false`, preserving legacy behavior) that, when true, appends `AND "shared_space_album"."showInTimeline" = true`, matching the Kysely `spaceAlbumAssetExists`.
 
@@ -81,31 +81,31 @@ Target state **after** all slices. Every non-trivial cell must be **enforced in 
 - **E — soft-deleted album BLOCKED.**
 - **F — own M3 elevation** (own archived/hidden/locked per own elevation, hidden from others; `n/a` where a surface has no own-elevation branch).
 
-| # | Surface (file) | A | B | C (Hidden/Locked) | D (showInTimeline=false) | E (soft-del album) | F (own M3) | Closed by |
-|---|---|---|---|---|---|---|---|---|
-| 1 | timeline / bucket (`asset.repository.ts` getTimeBucket) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | existing + S9 (faces path) |
-| 2 | search results (`utils/database.ts` searchAssetBuilder, two `=Timeline` terms `:673`,`:685`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | existing + **S10** (Archive align) |
-| 3 | facets / suggestions / tags (`search.repository.ts`, `tag.repository.ts`) | ✅ | ✅ | **S5** | **S5** | ✅ | ✅ | **S5** |
-| 4 | space people-facets (`search.repository.ts` people via `buildFilteredAssetIds`) | ✅ | ✅ | **S5** | **S5** | ✅ | n/a | **S5** |
-| 5 | map markers (`map.repository.ts`) — **resurfacing: Timeline-only by design** | ✅ | ✅ (Timeline) | ✅ | ✅ | ✅ | n/a | existing |
-| 6 | memory (`memory.repository.ts`) — **resurfacing: Timeline-only by design** | ✅ | ✅ (Timeline) | ✅ | **S9** | ✅ | n/a | existing + **S9** |
-| 7 | view / folders (`view-repository.ts`) — **Timeline-only (no own branch)** | ✅ | ✅ (Timeline) | ✅ | **S9** | ✅ | n/a | existing + **S9** |
-| 8 | people / faces list (`face-identity.repository.ts`, `shared-space.repository.ts`) | ✅ | ✅ | ✅ | **S9** | ✅ | ✅ | existing + **S9** |
-| 9 | face rep-thumbnail (`shared-space.repository.ts` isFaceInSpace `:2480`) | ✅ | ✅ | **S6** | **S6** | **S6** | n/a | **S6** |
-| 10 | asset read/view/download by ID (`access.repository.ts` checkSpaceAccess `:270`) | ✅ | ✅ | **S3** | n/a (browse) | ✅ | ✅ | **S3** |
-| 11 | download-space zip (`download.repository.ts` downloadSpaceId `:41`) | ✅ | ✅ | **S2** | n/a | ✅ | ✅ | **S2** |
-| 11b | album download via space grant (`download.repository.ts` downloadAlbumId `:27`, `AlbumDownload` via `access.ts:240`) | ✅ | ✅ | **S2** (Hidden; Locked already album-stripped) | n/a (browse) | ✅ | ✅ | **S2** |
-| 12 | mobile sync — asset (`sync.repository.ts` SharedSpaceAssetSync `:981` + Exif `:1060`) | ✅ | ✅ | **S4.A** future / **S4.B** purge | n/a | ✅ | ✅ | **S4** |
-| 13 | mobile sync — album asset (grant) (`sync.repository.ts` SharedSpaceAlbumAssetSync `:1528` + Exif `:1599`) | ✅ | ✅ | **S4.A** future / **S4.B** purge | n/a (grant surface) | ✅ | ✅ | **S4** |
-| 14 | getLinkedAlbums (`shared-space.service.ts:697`) — PII | ✅ | ✅ | n/a | n/a | ✅ | n/a | **S7** (strip albumUsers/email) |
-| 15 | getPersonAssetIds (`shared-space.repository.ts:1774`) | ✅ | ✅ | **S8** | **S8** | **S8** | ✅ | **S8** |
-| 16 | attach space people to detail (`access.repository.ts` checkSpaceAccessForSpace `:341`) | ✅ | ✅ | **S8** | n/a | ✅ | ✅ | **S8** |
-| 17 | people/face statistics (`face-identity.repository.ts` getAccessiblePeople*Statistics) | ✅ | ✅ | ✅ | **S9** | ✅ | n/a | existing + **S9** |
-| 18 | asset write via space (`access.repository.ts` checkSpaceEditAccess `:415`) | ✅ | editor+ | **S10** | n/a | ✅ | ✅ | **S10** |
+| #   | Surface (file)                                                                                                       | A   | B             | C (Hidden/Locked)                              | D (showInTimeline=false) | E (soft-del album) | F (own M3) | Closed by                          |
+| --- | -------------------------------------------------------------------------------------------------------------------- | --- | ------------- | ---------------------------------------------- | ------------------------ | ------------------ | ---------- | ---------------------------------- |
+| 1   | timeline / bucket (`asset.repository.ts` getTimeBucket)                                                              | ✅  | ✅            | ✅                                             | ✅                       | ✅                 | ✅         | existing + S9 (faces path)         |
+| 2   | search results (`utils/database.ts` searchAssetBuilder, two `=Timeline` terms `:673`,`:685`)                         | ✅  | ✅            | ✅                                             | ✅                       | ✅                 | ✅         | existing + **S10** (Archive align) |
+| 3   | facets / suggestions / tags (`search.repository.ts`, `tag.repository.ts`)                                            | ✅  | ✅            | **S5**                                         | **S5**                   | ✅                 | ✅         | **S5**                             |
+| 4   | space people-facets (`search.repository.ts` people via `buildFilteredAssetIds`)                                      | ✅  | ✅            | **S5**                                         | **S5**                   | ✅                 | n/a        | **S5**                             |
+| 5   | map markers (`map.repository.ts`) — **resurfacing: Timeline-only by design**                                         | ✅  | ✅ (Timeline) | ✅                                             | ✅                       | ✅                 | n/a        | existing                           |
+| 6   | memory (`memory.repository.ts`) — **resurfacing: Timeline-only by design**                                           | ✅  | ✅ (Timeline) | ✅                                             | **S9**                   | ✅                 | n/a        | existing + **S9**                  |
+| 7   | view / folders (`view-repository.ts`) — **Timeline-only (no own branch)**                                            | ✅  | ✅ (Timeline) | ✅                                             | **S9**                   | ✅                 | n/a        | existing + **S9**                  |
+| 8   | people / faces list (`face-identity.repository.ts`, `shared-space.repository.ts`)                                    | ✅  | ✅            | ✅                                             | **S9**                   | ✅                 | ✅         | existing + **S9**                  |
+| 9   | face rep-thumbnail (`shared-space.repository.ts` isFaceInSpace `:2480`)                                              | ✅  | ✅            | **S6**                                         | **S6**                   | **S6**             | n/a        | **S6**                             |
+| 10  | asset read/view/download by ID (`access.repository.ts` checkSpaceAccess `:270`)                                      | ✅  | ✅            | **S3**                                         | n/a (browse)             | ✅                 | ✅         | **S3**                             |
+| 11  | download-space zip (`download.repository.ts` downloadSpaceId `:41`)                                                  | ✅  | ✅            | **S2**                                         | n/a                      | ✅                 | ✅         | **S2**                             |
+| 11b | album download via space grant (`download.repository.ts` downloadAlbumId `:27`, `AlbumDownload` via `access.ts:240`) | ✅  | ✅            | **S2** (Hidden; Locked already album-stripped) | n/a (browse)             | ✅                 | ✅         | **S2**                             |
+| 12  | mobile sync — asset (`sync.repository.ts` SharedSpaceAssetSync `:981` + Exif `:1060`)                                | ✅  | ✅            | **S4.A** future / **S4.B** purge               | n/a                      | ✅                 | ✅         | **S4**                             |
+| 13  | mobile sync — album asset (grant) (`sync.repository.ts` SharedSpaceAlbumAssetSync `:1528` + Exif `:1599`)            | ✅  | ✅            | **S4.A** future / **S4.B** purge               | n/a (grant surface)      | ✅                 | ✅         | **S4**                             |
+| 14  | getLinkedAlbums (`shared-space.service.ts:697`) — PII                                                                | ✅  | ✅            | n/a                                            | n/a                      | ✅                 | n/a        | **S7** (strip albumUsers/email)    |
+| 15  | getPersonAssetIds (`shared-space.repository.ts:1774`)                                                                | ✅  | ✅            | **S8**                                         | **S8**                   | **S8**             | ✅         | **S8**                             |
+| 16  | attach space people to detail (`access.repository.ts` checkSpaceAccessForSpace `:341`)                               | ✅  | ✅            | **S8**                                         | n/a                      | ✅                 | ✅         | **S8**                             |
+| 17  | people/face statistics (`face-identity.repository.ts` getAccessiblePeople\*Statistics)                               | ✅  | ✅            | ✅                                             | **S9**                   | ✅                 | n/a        | existing + **S9**                  |
+| 18  | asset write via space (`access.repository.ts` checkSpaceEditAccess `:415`)                                           | ✅  | editor+       | **S10**                                        | n/a                      | ✅                 | ✅         | **S10**                            |
 
 **Note on #12/#13-C (honesty):** S4.A closes the leak for any **new/full** device sync (the upsert/backfill streams). S4.B closes the **already-synced-then-hidden** purge (a delete/tombstone on visibility flip). If S4.B's mobile consumption needs a client change, the server-side delete emission is still implemented + tested and the client half is a tracked follow-up — the matrix cell is only fully ✅ once both land.
 
-**Album detail read via space (`GET /albums/:id`, `album.repository.getById` + `withAssets`) is SAFE** — `withAssets` already applies `withDefaultVisibility` (`[Archive, Timeline]`), so it never returns Hidden/Locked. Only the album *download* stream (`downloadAlbumId`, row 11b) lacked the filter. `AlbumRead`/`AlbumDownload` are space-grantable via `checkSpaceLinkedAlbumReadAccess` (`access.ts:189/240`); S11's guard/matrix asserts both.
+**Album detail read via space (`GET /albums/:id`, `album.repository.getById` + `withAssets`) is SAFE** — `withAssets` already applies `withDefaultVisibility` (`[Archive, Timeline]`), so it never returns Hidden/Locked. Only the album _download_ stream (`downloadAlbumId`, row 11b) lacked the filter. `AlbumRead`/`AlbumDownload` are space-grantable via `checkSpaceLinkedAlbumReadAccess` (`access.ts:189/240`); S11's guard/matrix asserts both.
 
 **Provably safe today (regression-guard only):** scope helper, `shared-space.repository` reads, `PersonAccess.checkSharedSpaceAccess`, `linkAlbum`/`unlinkAlbum`/`updateAlbumLink` authorization (Editor + `AlbumUpdate`, cannot self-satisfy via space grant), the "absorbed invariant" (space-linked album absent from plain `GET /albums`), soft-delete face-retention (4 original holes closed; remaining two are S6/S8), token resolution fail-closed. Slice 11 adds a static guard so these cannot regress.
 
@@ -118,11 +118,13 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 ### Slice 1 — Canonical visibility helper + raw-SQL `requireShowInTimeline` (foundation)
 
 **Closes:** none directly; enables S2–S10 and the S11 guard. **Files:**
+
 - Modify `server/src/utils/shared-space-album-scope.ts`: add `spaceVisibleAssetVisibilities`, `spaceVisibilityGate()`, and a `requireShowInTimeline?: boolean` (default `false`) option in `spaceAlbumAssetExistsSql`.
 - Modify `shared-space.repository.ts` / `face-identity.repository.ts` / `person.repository.ts`: replace the three local constant declarations (two names) with an import/alias of the new constant (pure relocation, no behavior change).
 - Test: `server/src/utils/shared-space-album-scope.guard.spec.ts` (extend) + `server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts` (extend for the new option).
 
 **TDD steps:**
+
 - [ ] **Red (behavioral):** write a medium equivalence test — `spaceAlbumAssetExistsSql({ requireShowInTimeline: true })` produces SQL equal to the Kysely `spaceAlbumAssetExists({ requireShowInTimeline: true })` for a fixture with one `showInTimeline=true` and one `showInTimeline=false` linked album: the raw variant must **exclude** the false one; with the option absent/false, both are included (unchanged legacy behavior). Run red (option does not exist yet).
 - [ ] **Red (relocation guard):** unit assertions that `spaceVisibilityGate(eb)` compiles to `"asset"."visibility" in ('archive','timeline')`, the constant equals `[Archive, Timeline]`, and the two old names resolve to the **same array reference** (`===`) post-consolidation.
 - [ ] Implement helper + option + constant consolidation → green.
@@ -137,6 +139,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #11-C, #11b-C. **Files:** `server/src/repositories/download.repository.ts` — `downloadSpaceId` (`:41`, all three arms) and `downloadAlbumId` (`:27`, add the visibility gate to match `withAssets`/`withDefaultVisibility`). Test: `server/test/medium/specs/repositories/download.repository.spec.ts` (create if absent).
 
 **TDD steps:**
+
 - [ ] **Red (space zip):** seed a space (owner + member); owner adds assets of each visibility (`Timeline`, `Archive`, `Hidden`, `Locked`) via **each** path (direct, library, album). Stream `downloadSpaceId(space.id)`; assert the returned id set = the `{Timeline, Archive}` assets only, across all three arms; `Hidden`/`Locked` absent. Run red (all four returned).
 - [ ] **Red (album via space):** a space member calls the album-download path (`AlbumDownload` satisfied via `checkSpaceLinkedAlbumReadAccess`); `downloadAlbumId(linkedAlbumId)` must return only `{Timeline, Archive}` album assets — a `Hidden` album asset absent. (`Locked` is already stripped from albums by `asset.service.ts:313` — assert it isn't present, documenting that invariant.)
 - [ ] Implement: add `spaceVisibilityGate(eb)` to each `downloadSpaceId` arm; add `withDefaultVisibility`/`spaceVisibilityGate` to `downloadAlbumId`. → green.
@@ -151,6 +154,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #10-C. **Files:** `server/src/repositories/access.repository.ts` (`checkSpaceAccess` `:270`, all three union arms; gates `AssetRead`/`AssetView`/`AssetDownload` per `access.ts:120/137/148`, always **after** `checkOwnerAccess`). Test: `server/test/medium/specs/repositories/access.repository.spec.ts` + e2e `e2e/src/specs/server/api/shared-space.e2e-spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red (medium):** member + another member's assets of each visibility via each path. `checkSpaceAccess(member.id, allIds)` returns only `{Timeline, Archive}`; `Hidden`/`Locked` absent. Run red.
 - [ ] **Red (e2e):** as a plain member, `GET /assets/:id`, `GET /assets/:id/original`, `GET /assets/:id/thumbnail` for another member's `Locked`/`Hidden` in-space asset → `400`/`403`; for `Timeline`/`Archive` → `200`.
 - [ ] Implement: AND `spaceVisibilityGate(eb)` into each union arm (keep `deletedAt`, `isOffline`, `album.deletedAt`). → green.
@@ -169,6 +173,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #12-C / #13-C for any new or full re-sync. **Files:** `sync.repository.ts` — add `spaceVisibilityGate` to `SharedSpaceAssetSync.{getBackfill,getCreates,getUpdates}` and `SharedSpaceAlbumAssetSync` equivalents; for **both EXIF builders**, first add `innerJoin('asset', 'asset.id', '<exif>.assetId')` (they currently have no `asset` join) **then** apply the gate. **Do NOT** apply `requireShowInTimeline` to the album-asset stream — it is an explicit browse/grant surface (`shared_space_album_user`); hiding `showInTimeline=false` assets there would wrongly deny a directly-granted member. Test: `server/test/medium/specs/repositories/sync.repository*.spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red:** seed a space + two members; member A has assets of each visibility (direct) and album-linked assets. Drive the shared-space asset + album-asset sync (+ EXIF) for member B; assert only `{Timeline, Archive}` appear, with EXIF/GPS only for those; `Hidden`/`Locked` absent. Run red.
 - [ ] Implement (add `asset` joins to EXIF builders, apply gate) → green.
 - [ ] Commit `fix(spaces): shared-space sync streams exclude hidden/locked assets and exif`.
@@ -180,6 +185,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #12-C / #13-C for the added-then-hidden device-purge case. **Files:** `server/src/services/asset.service.ts` (`updateAll` `~:312`, where `Locked` already triggers `albumRepository.removeAssetsFromAll`) — on a visibility change **out of** `[Archive, Timeline]` for any in-space asset, emit the sync delete/tombstone so `SharedSpaceToAssetSync.getDeletes` (and the album equivalent) purge the device. Test: `sync.repository`/`asset.service` medium specs.
 
 **TDD steps:**
+
 - [ ] **Red:** member B fully syncs member A's `Timeline` in-space asset (device holds it). Member A flips it to `Hidden` (and separately `Locked`). Drive member B's sync `getDeletes`/checkpoint; assert a **delete/tombstone** event for that asset appears (device would purge). Run red (no delete emitted today).
 - [ ] Implement the tombstone emission on visibility-out-of-set. **Investigation sub-task:** determine the minimal mechanism (insert a `shared_space_asset_audit`/`album_asset_audit` tombstone without deleting the live `shared_space_asset` row, so un-hide restores; or an equivalent checkpoint). If the mobile client cannot consume this without a client change, ship + test the **server-side** emission and open a tracked mobile follow-up — do **not** silently drop the purge. → green.
 - [ ] Commit `fix(spaces): purge shared-space assets from member devices when hidden/locked`.
@@ -193,6 +199,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #3-C/#3-D, #4-C/#4-D. **Anchors (corrected):** `applySuggestionScope` (`search.repository.ts:1186`), `getAccessibleTags` (`:1099`), the people-facet **producer** `buildFilteredAssetIds` (used by `getFilteredIdentityPeople` `:1506`; the consumer `buildFilteredSpacePeopleQuery` `:1467` only filters on the produced id set — the gate belongs in the producer), and `tag.repository.ts getAll` (`:73`, space arms `:94`/`:115`). Test: `search.service.spec.ts`, `search.repository.spec.ts`, `tag.repository.spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red, per surface** (`getSearchSuggestions` city/country/state/camera-make/model/lens, `getFilterSuggestions`, tag suggestions, `getAccessibleTags`, `tag.getAll`, space people-facets): seed another member's `Hidden` (and, for an elevated caller, `Locked`) asset with a **distinct** city/tag/person/camera; assert that value is **absent**. Seed `Timeline` and `Archive` with distinct values → **present**. Seed a `showInTimeline=false` linked-album asset with a distinct value → **absent**. Run red.
 - [ ] Implement: for the space-membership branch in each builder, AND `spaceVisibilityGate(eb)` and pass `requireShowInTimeline: true` on the album arm (`spaceAssetPathBranches({ requireShowInTimeline: true })`). The caller's own branch (e.g. the `timelineSpaceIds` `ownerId` term) keeps caller visibility. → green.
 - [ ] Commit `fix(spaces): filter suggestions/facets/tags to shareable space assets`.
@@ -206,6 +213,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #9-C/D/E. **Files:** `server/src/repositories/shared-space.repository.ts` (`isFaceInSpace` `:2480`). The **direct** arm (`:2484`) has **no `asset` join at all** (only `asset_face.deletedAt`) — add an `asset` join + full gate (`deletedAt`, visibility). The **library** arm (`:2491`) already has `asset.deletedAt`+`isOffline` — add visibility. The **album** arm — add visibility + `album.deletedAt` + `showInTimeline` (projection surface). Mirror the fully-guarded `isAssetInSpace` (`:2433`). Test: `shared-space.repository.spec.ts` + a service test for `getSpacePersonThumbnail` auto path.
 
 **TDD steps:**
+
 - [ ] **Red:** a space person whose representative face's **only** source asset is (per case) another member's `Hidden`, `Locked`, soft-deleted direct asset, or a `showInTimeline=false`/soft-deleted album asset. `isFaceInSpace(space.id, faceId)` returns `false` for each; the auto rep-face thumbnail (`getSpacePersonThumbnail`) is not served. For a face on a `Timeline`/`Archive` asset → `true`. Run red.
 - [ ] Implement → green. Commit `fix(spaces): representative-face thumbnail only from shareable space assets`.
 
@@ -218,6 +226,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #14 PII. **Files:** `shared-space.repository.ts` (`getLinkedAlbums` `:450`, drop `withSpaceAlbumUsers` `:23`), `server/src/dtos/shared-space.dto.ts` (`SharedSpaceLinkedAlbumSchema` `:142` currently extends `AlbumResponseSchema` whose `albumUsers` is **required** and carries `email`; use `.omit({ albumUsers: true })` or a projection schema), `shared-space.service.ts` (`getLinkedAlbums` `:697` mapping). Then SDK regen + web/dart call-site check. Test: `shared-space-album.service.spec.ts` + e2e `shared-space-album.e2e-spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red:** `getLinkedAlbums` for a viewer returns each linked album **without** `albumUsers` and **without** any `email`, while still returning the fields the web UI uses (`id`, `albumName`, `assetCount`, `showInTimeline`, `addedById`, `linkedAt`, thumbnail). Run red.
 - [ ] Implement projection/omit → green.
 - [ ] Regenerate SDK (`pnpm build` → `pnpm sync:open-api` → `make open-api`); `check-web`. Commit `fix(spaces): linked-albums endpoint no longer exposes album-user emails` + a follow-up commit for regenerated SDK/dart.
@@ -231,6 +240,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** #15-C/D/E, #16-C. **Files:** `shared-space.repository.ts` (`getPersonAssetIds` `:1774` — add the OR-of-three-paths membership + `deletedAt`/`isOffline`/`album.deletedAt`/`showInTimeline` + `spaceVisibilityGate`), `access.repository.ts` (`checkSpaceAccessForSpace` `:341` — add `spaceVisibilityGate` to its arms; note it also re-adds `livePhotoVideoId` at `:405/461`). Test: `shared-space.repository.spec.ts`, `access.repository.spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red:** a `shared_space_person_face` row whose asset is another member's `Hidden`/`Locked`, soft-deleted, or in a `showInTimeline=false`/soft-deleted album → `getPersonAssetIds` must not enumerate its id; `Timeline`/`Archive` → enumerated. `checkSpaceAccessForSpace` excludes non-shareable ids (incl. the `livePhotoVideoId` of a `Locked` parent). Run red.
 - [ ] Implement → green. Commit `fix(spaces): scope person-asset ids and space-asset attach to shareable assets`.
 
@@ -243,6 +253,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 **Closes:** the `showInTimeline=false` (D) column on memory, view, people/faces, statistics; and stored-counter staleness. **Files:** `face-identity.repository.ts` (the `spaceAlbumAssetExistsSql` call sites `:902/1021/1162/1642/1787/1902` — pass `requireShowInTimeline: true` where the surface is a **personal-timeline projection**), `memory.repository.ts` + `view-repository.ts` (album arm → `requireShowInTimeline: true`), `shared-space.service.ts` (`updateAlbumLink` `:687` — prune/recount `shared_space_person_face` + `faceCount`/`assetCount` when `showInTimeline` flips false, re-add when true). Test: `face-identity.repository.spec.ts`, `memory.repository.spec.ts`, `view-repository` spec, `shared-space-album.service.spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red:** a `showInTimeline=false` linked album's faces/people do **not** surface in the People tab, memory, or folder view; toggling `showInTimeline` false→true→false updates the people list AND stored counters consistently; after `→false`, `getPersonAssetIds` (S8 surface) no longer enumerates those album assets. Run red.
 - [ ] Implement → green. Commit `fix(spaces): de-timelined albums stop feeding faces/memory/view and recount on toggle`.
 
@@ -253,6 +264,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 ### Slice 10 — Consistency: align `searchAssetBuilder` to `[Archive, Timeline]` + tighten `checkSpaceEditAccess` — matrix #2, #18
 
 **Closes:** #2 (Archive alignment on search — a browse surface, to match the space timeline), #18-C. **Files:**
+
 - `server/src/utils/database.ts` — `searchAssetBuilder` space branch: change the other-member term from `= Timeline` to `spaceVisibilityGate` at **both** sites (`:673` spaceId path **and** `:685` timelineSpaceIds path).
 - `server/src/repositories/access.repository.ts` — `checkSpaceEditAccess` (`:415`, two arms, no album arm) — AND `spaceVisibilityGate` so an editor cannot `AssetUpdate` another member's Hidden/Locked (can't see it → can't edit it).
 
@@ -261,6 +273,7 @@ Order = severity-first; Slice 1 (foundation) enables the rest. Each slice is ind
 Test: `search.service.spec.ts`, `access.repository.spec.ts`.
 
 **TDD steps:**
+
 - [ ] **Red (search):** another member's `Archive` asset in the space now **appears** in `searchMetadata`/`searchLargeAssets` results (previously excluded); `Hidden`/`Locked` still excluded; the caller's own assets resolve per own elevation unchanged (searchAssetBuilder has a separate `userIds`/owner branch — verify). Run red.
 - [ ] **Red (edit):** a space editor cannot `AssetUpdate` another member's `Hidden`/`Locked` in-space asset; can update a `Timeline`/`Archive` one per role. Include the live-photo video part of a `Locked` parent. Run red.
 - [ ] Implement (both `=Timeline` terms in search; edit gate) → green.
@@ -275,7 +288,8 @@ Test: `search.service.spec.ts`, `access.repository.spec.ts`.
 **Closes:** proves every risky cell and prevents any future surface from forgetting the gate. **Files:** extend `server/src/utils/shared-space-album-scope.guard.spec.ts`; create `server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts`; extend e2e `shared-space*.e2e-spec.ts`.
 
 **TDD steps:**
-- [ ] **Add a NEW, second static scan** to the guard spec (the existing scan checks that a `shared_space_library` arm has a sibling `shared_space_album` arm — a *different* invariant; do not conflate). The new scan: for every repository query that space-scopes an asset read (joins `shared_space_asset`/`shared_space_library`/`shared_space_album` and returns/selects asset rows), assert it references the visibility gate (`spaceVisibilityGate`/`spaceVisibleAssetVisibilities`/`visibility IN`), or is on the **new visibility allowlist** with a one-line reason. Give the new scan its **own** allowlist (the album-marker allowlist is separate). **Prune the stale entry:** the existing album-marker allowlist entry `getMapMarkers: 'omit album path (pre-existing)'` is now FALSE (`map.repository.ts:160` has the album leg with `requireShowInTimeline: true`) — remove it. Document which allowlist governs `checkSpaceEditAccess` (visibility-gated by S10 but still no album arm → stays on the album-marker allowlist, off the visibility allowlist), `findSpaceForAssetAndUser`, `getPersonalThumbnailForSpacePerson`.
+
+- [ ] **Add a NEW, second static scan** to the guard spec (the existing scan checks that a `shared_space_library` arm has a sibling `shared_space_album` arm — a _different_ invariant; do not conflate). The new scan: for every repository query that space-scopes an asset read (joins `shared_space_asset`/`shared_space_library`/`shared_space_album` and returns/selects asset rows), assert it references the visibility gate (`spaceVisibilityGate`/`spaceVisibleAssetVisibilities`/`visibility IN`), or is on the **new visibility allowlist** with a one-line reason. Give the new scan its **own** allowlist (the album-marker allowlist is separate). **Prune the stale entry:** the existing album-marker allowlist entry `getMapMarkers: 'omit album path (pre-existing)'` is now FALSE (`map.repository.ts:160` has the album leg with `requireShowInTimeline: true`) — remove it. Document which allowlist governs `checkSpaceEditAccess` (visibility-gated by S10 but still no album arm → stays on the album-marker allowlist, off the visibility allowlist), `findSpaceForAssetAndUser`, `getPersonalThumbnailForSpacePerson`.
 - [ ] **Write the matrix medium spec:** a parametrized fixture seeding `{Timeline, Archive, Hidden, Locked}` × `{direct, library, album(showInTimeline=true), album(showInTimeline=false), soft-deleted-album}`, asserting the correct visible set on **every** surface the slices touch: download-space, download-album-via-space, `checkSpaceAccess`, `checkSpaceAccessForSpace`, sync (asset + album), facets/tags, space people-facets, `isFaceInSpace`, `getPersonAssetIds`, timeline, statistics, map, memory, view, `checkSpaceEditAccess`. Each 🔴 cell in the matrix has an assertion here (map/memory/view assert Timeline-only per Global Constraint #3).
 - [ ] **Add e2e negatives** for the HTTP-reachable content leaks: download-space and download-album-via-space and `GET /assets/:id`/original for a Hidden/Locked in-space asset as a non-owner member.
 - [ ] Run the whole matrix green. Commit `test(spaces): exhaustive RBAC visibility matrix + structural regression guard`.

--- a/e2e/src/specs/server/api/shared-space-album.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-album.e2e-spec.ts
@@ -246,6 +246,23 @@ describe('/shared-spaces/:id/albums (T18)', () => {
       );
     });
 
+    it('response does NOT expose albumUsers or email (PII guard, Slice 7)', async () => {
+      // Any space member — including a plain Viewer — must not receive albumUsers arrays
+      // or email addresses when listing linked albums. Deep-scan the full response body.
+      const { status, body } = await listAlbums(viewer.accessToken);
+      expect(status).toBe(200);
+
+      const items = body as Array<Record<string, unknown>>;
+      for (const item of items) {
+        // albumUsers must not be present on any linked-album entry
+        expect(item['albumUsers']).toBeUndefined();
+
+        // No email field anywhere in the serialized entry
+        const serialized = JSON.stringify(item);
+        expect(serialized).not.toMatch(/"email"\s*:/);
+      }
+    });
+
     it('absorbed invariant: linked album is NOT returned by GET /albums for space members', async () => {
       // Space membership must not make the album visible via the regular /albums
       // list for members who don't own or have explicit album-user access.

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -17,7 +17,7 @@ import { AssetVisibility, LoginResponseDto, updateAssets } from '@immich/sdk';
 import { asBearerAuth, createUserDto } from 'src/fixtures';
 import { app, utils } from 'src/utils';
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 describe('shared-space visibility negatives (Slice 11)', () => {
   let admin: LoginResponseDto;

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -1,0 +1,257 @@
+/**
+ * Slice 11 — e2e RBAC negatives for space visibility gate.
+ *
+ * As a non-owner member, asserts that Hidden/Locked assets:
+ *   1. Return 400 on GET /assets/:id
+ *   2. Return 400 on GET /assets/:id/original
+ *   3. Are absent from POST /download/info (spaceId) zip manifest
+ *   4. Are absent from POST /download/info (albumId) zip manifest (via AlbumDownload space grant)
+ *
+ * Each test creates a fresh space + assets to avoid cross-test state contamination.
+ *
+ * Timeline and Archive assets are verified accessible (positive control) so that
+ * 400 responses on Hidden/Locked are confirmed to be gate failures, not setup bugs.
+ */
+
+import { AssetVisibility, LoginResponseDto, updateAssets } from '@immich/sdk';
+import { asBearerAuth, createUserDto } from 'src/fixtures';
+import { app, utils } from 'src/utils';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('shared-space visibility negatives (Slice 11)', () => {
+  let admin: LoginResponseDto;
+  let owner: LoginResponseDto;
+  let member: LoginResponseDto;
+
+  beforeAll(async () => {
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+    [owner, member] = await Promise.all([
+      utils.userSetup(admin.accessToken, createUserDto.create('vis-neg-owner')),
+      utils.userSetup(admin.accessToken, createUserDto.create('vis-neg-member')),
+    ]);
+  });
+
+  // ─── helpers ─────────────────────────────────────────────────────────────────
+
+  /** Set visibility on an asset owned by `owner`. */
+  const setVisibility = (assetId: string, visibility: AssetVisibility) =>
+    updateAssets(
+      { assetBulkUpdateDto: { ids: [assetId], visibility } },
+      { headers: asBearerAuth(owner.accessToken) },
+    );
+
+  /** Create a fresh space, add owner as owner and member as viewer, return the space id. */
+  const freshSpace = async (name: string) => {
+    const space = await utils.createSpace(owner.accessToken, { name });
+    await utils.addSpaceMember(owner.accessToken, space.id, { userId: member.userId });
+    return space.id;
+  };
+
+  /**
+   * Call POST /download/info with the given body as member.
+   * Returns the flat list of assetIds from all archives.
+   */
+  const downloadInfoIds = async (body: Record<string, unknown>): Promise<string[]> => {
+    const { status, body: resBody } = await request(app)
+      .post('/download/info')
+      .set('Authorization', `Bearer ${member.accessToken}`)
+      .send(body);
+    expect(status).toBe(201);
+    return (resBody.archives as Array<{ assetIds: string[] }>).flatMap((a) => a.assetIds);
+  };
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /assets/:id — Hidden / Locked → 400; Timeline / Archive → 200
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('GET /assets/:id — Hidden/Locked blocked; Timeline/Archive allowed', () => {
+    it('Hidden direct-space asset → 400 for member', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      await setVisibility(asset.id, AssetVisibility.Hidden);
+      const spaceId = await freshSpace('hidden-read-neg');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('Locked direct-space asset → 400 for member', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      await setVisibility(asset.id, AssetVisibility.Locked);
+      const spaceId = await freshSpace('locked-read-neg');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('Timeline direct-space asset → 200 for member (positive control)', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      // default visibility is Timeline
+      const spaceId = await freshSpace('timeline-read-pos');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(200);
+    });
+
+    it('Archive direct-space asset → 200 for member (positive control)', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      await setVisibility(asset.id, AssetVisibility.Archive);
+      const spaceId = await freshSpace('archive-read-pos');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(200);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // GET /assets/:id/original — Hidden / Locked → 400
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('GET /assets/:id/original — Hidden/Locked blocked', () => {
+    it('Hidden direct-space asset → 400', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      await setVisibility(asset.id, AssetVisibility.Hidden);
+      const spaceId = await freshSpace('hidden-original-neg');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}/original`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('Locked direct-space asset → 400', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      await setVisibility(asset.id, AssetVisibility.Locked);
+      const spaceId = await freshSpace('locked-original-neg');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}/original`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('Timeline direct-space asset → 200 (positive control)', async () => {
+      const asset = await utils.createAsset(owner.accessToken);
+      const spaceId = await freshSpace('timeline-original-pos');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}/original`)
+        .set('Authorization', `Bearer ${member.accessToken}`);
+      expect(status).toBe(200);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // POST /download/info (spaceId) — Hidden / Locked absent from zip manifest
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('POST /download/info (spaceId) — Hidden/Locked absent; Timeline/Archive present', () => {
+    it('Hidden direct-space asset absent from download manifest', async () => {
+      const timelineAsset = await utils.createAsset(owner.accessToken);
+      const hiddenAsset = await utils.createAsset(owner.accessToken);
+      await setVisibility(hiddenAsset.id, AssetVisibility.Hidden);
+
+      const spaceId = await freshSpace('download-hidden-neg');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [timelineAsset.id, hiddenAsset.id]);
+
+      const assetIds = await downloadInfoIds({ spaceId });
+
+      expect(assetIds).toContain(timelineAsset.id); // Timeline present ✓
+      expect(assetIds).not.toContain(hiddenAsset.id); // Hidden absent ✓
+    });
+
+    it('Locked direct-space asset absent from download manifest', async () => {
+      const timelineAsset = await utils.createAsset(owner.accessToken);
+      const lockedAsset = await utils.createAsset(owner.accessToken);
+      await setVisibility(lockedAsset.id, AssetVisibility.Locked);
+
+      const spaceId = await freshSpace('download-locked-neg');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [timelineAsset.id, lockedAsset.id]);
+
+      const assetIds = await downloadInfoIds({ spaceId });
+
+      expect(assetIds).toContain(timelineAsset.id);
+      expect(assetIds).not.toContain(lockedAsset.id);
+    });
+
+    it('Archive direct-space asset present in download manifest', async () => {
+      const archiveAsset = await utils.createAsset(owner.accessToken);
+      await setVisibility(archiveAsset.id, AssetVisibility.Archive);
+
+      const spaceId = await freshSpace('download-archive-pos');
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [archiveAsset.id]);
+
+      const assetIds = await downloadInfoIds({ spaceId });
+
+      expect(assetIds).toContain(archiveAsset.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // POST /download/info (albumId) — Hidden / Locked absent from zip manifest
+  // (AlbumDownload grant via shared_space_album_user)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('POST /download/info (albumId via space AlbumDownload grant) — Hidden/Locked absent', () => {
+    it('Hidden album-linked asset absent from album download manifest', async () => {
+      const timelineAsset = await utils.createAsset(owner.accessToken);
+      const hiddenAsset = await utils.createAsset(owner.accessToken);
+      await setVisibility(hiddenAsset.id, AssetVisibility.Hidden);
+
+      const spaceId = await freshSpace('album-download-hidden-neg');
+
+      const album = await utils.createAlbum(owner.accessToken, {
+        albumName: 'AlbumHiddenNeg',
+        assetIds: [timelineAsset.id, hiddenAsset.id],
+      });
+
+      // Link the album to the space so member gets AlbumDownload via space grant
+      await request(app)
+        .put(`/shared-spaces/${spaceId}/albums/${album.id}`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+
+      const assetIds = await downloadInfoIds({ albumId: album.id });
+
+      expect(assetIds).toContain(timelineAsset.id);
+      expect(assetIds).not.toContain(hiddenAsset.id);
+    });
+
+    it('Locked album-linked asset absent from album download manifest', async () => {
+      const timelineAsset = await utils.createAsset(owner.accessToken);
+      const lockedAsset = await utils.createAsset(owner.accessToken);
+      await setVisibility(lockedAsset.id, AssetVisibility.Locked);
+
+      const spaceId = await freshSpace('album-download-locked-neg');
+
+      const album = await utils.createAlbum(owner.accessToken, {
+        albumName: 'AlbumLockedNeg',
+        assetIds: [timelineAsset.id, lockedAsset.id],
+      });
+
+      await request(app)
+        .put(`/shared-spaces/${spaceId}/albums/${album.id}`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+
+      const assetIds = await downloadInfoIds({ albumId: album.id });
+
+      expect(assetIds).toContain(timelineAsset.id);
+      expect(assetIds).not.toContain(lockedAsset.id);
+    });
+  });
+});

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -14,8 +14,8 @@
  */
 
 import { AssetVisibility, LoginResponseDto, updateAssets } from '@immich/sdk';
-import { asBearerAuth, createUserDto } from 'src/fixtures';
-import { app, utils } from 'src/utils';
+import { createUserDto } from 'src/fixtures';
+import { app, asBearerAuth, utils } from 'src/utils';
 import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -66,9 +66,9 @@ describe('shared-space visibility negatives (Slice 11)', () => {
   describe('GET /assets/:id — Hidden/Locked blocked; Timeline/Archive allowed', () => {
     it('Hidden direct-space asset → 400 for member', async () => {
       const asset = await utils.createAsset(owner.accessToken);
-      await setVisibility(asset.id, AssetVisibility.Hidden);
       const spaceId = await freshSpace('hidden-read-neg');
       await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+      await setVisibility(asset.id, AssetVisibility.Hidden);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}`)
@@ -78,9 +78,9 @@ describe('shared-space visibility negatives (Slice 11)', () => {
 
     it('Locked direct-space asset → 400 for member', async () => {
       const asset = await utils.createAsset(owner.accessToken);
-      await setVisibility(asset.id, AssetVisibility.Locked);
       const spaceId = await freshSpace('locked-read-neg');
       await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+      await setVisibility(asset.id, AssetVisibility.Locked);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}`)
@@ -120,9 +120,9 @@ describe('shared-space visibility negatives (Slice 11)', () => {
   describe('GET /assets/:id/original — Hidden/Locked blocked', () => {
     it('Hidden direct-space asset → 400', async () => {
       const asset = await utils.createAsset(owner.accessToken);
-      await setVisibility(asset.id, AssetVisibility.Hidden);
       const spaceId = await freshSpace('hidden-original-neg');
       await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+      await setVisibility(asset.id, AssetVisibility.Hidden);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}/original`)
@@ -132,9 +132,9 @@ describe('shared-space visibility negatives (Slice 11)', () => {
 
     it('Locked direct-space asset → 400', async () => {
       const asset = await utils.createAsset(owner.accessToken);
-      await setVisibility(asset.id, AssetVisibility.Locked);
       const spaceId = await freshSpace('locked-original-neg');
       await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+      await setVisibility(asset.id, AssetVisibility.Locked);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}/original`)

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -37,10 +37,7 @@ describe('shared-space visibility negatives (Slice 11)', () => {
 
   /** Set visibility on an asset owned by `owner`. */
   const setVisibility = (assetId: string, visibility: AssetVisibility) =>
-    updateAssets(
-      { assetBulkUpdateDto: { ids: [assetId], visibility } },
-      { headers: asBearerAuth(owner.accessToken) },
-    );
+    updateAssets({ assetBulkUpdateDto: { ids: [assetId], visibility } }, { headers: asBearerAuth(owner.accessToken) });
 
   /** Create a fresh space, add owner as owner and member as viewer, return the space id. */
   const freshSpace = async (name: string) => {

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -176,10 +176,11 @@ describe('shared-space visibility negatives (Slice 11)', () => {
     it('Locked direct-space asset absent from download manifest', async () => {
       const timelineAsset = await utils.createAsset(owner.accessToken);
       const lockedAsset = await utils.createAsset(owner.accessToken);
-      await setVisibility(lockedAsset.id, AssetVisibility.Locked);
 
       const spaceId = await freshSpace('download-locked-neg');
+      // add both while Timeline (the batch add rejects a pre-Locked asset), THEN lock
       await utils.addSpaceAssets(owner.accessToken, spaceId, [timelineAsset.id, lockedAsset.id]);
+      await setVisibility(lockedAsset.id, AssetVisibility.Locked);
 
       const assetIds = await downloadInfoIds({ spaceId });
 

--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -1362,14 +1362,16 @@ describe('/shared-spaces', () => {
      */
 
     it('member CANNOT read a Locked direct-space asset (GET /assets/:id → 400)', async () => {
+      // Add while Timeline (the add-assets endpoint rejects Locked and filters Hidden), THEN flip —
+      // the real "added-then-locked" scenario the checkSpaceAccess gate must catch.
       const asset = await utils.createAsset(user1.accessToken);
+      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Read Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
       await updateAssets(
         { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Locked } },
         { headers: asBearerAuth(user1.accessToken) },
       );
-      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Read Block' });
-      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
-      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}`)
@@ -1379,13 +1381,13 @@ describe('/shared-spaces', () => {
 
     it('member CANNOT download a Locked direct-space asset (GET /assets/:id/original → 400)', async () => {
       const asset = await utils.createAsset(user1.accessToken);
+      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Download Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
       await updateAssets(
         { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Locked } },
         { headers: asBearerAuth(user1.accessToken) },
       );
-      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Download Block' });
-      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
-      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}/original`)
@@ -1395,13 +1397,13 @@ describe('/shared-spaces', () => {
 
     it('member CANNOT view thumbnail of a Locked direct-space asset (GET /assets/:id/thumbnail → 400)', async () => {
       const asset = await utils.createAsset(user1.accessToken);
+      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Thumb Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
       await updateAssets(
         { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Locked } },
         { headers: asBearerAuth(user1.accessToken) },
       );
-      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Thumb Block' });
-      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
-      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}/thumbnail`)
@@ -1411,13 +1413,13 @@ describe('/shared-spaces', () => {
 
     it('member CANNOT read a Hidden direct-space asset (GET /assets/:id → 400)', async () => {
       const asset = await utils.createAsset(user1.accessToken);
+      const space = await utils.createSpace(user1.accessToken, { name: 'Hidden Read Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
       await updateAssets(
         { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Hidden } },
         { headers: asBearerAuth(user1.accessToken) },
       );
-      const space = await utils.createSpace(user1.accessToken, { name: 'Hidden Read Block' });
-      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
-      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
 
       const { status } = await request(app)
         .get(`/assets/${asset.id}`)

--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -1,8 +1,8 @@
-import { AssetMediaResponseDto, LoginResponseDto, SharedSpaceRole } from '@immich/sdk';
+import { AssetMediaResponseDto, AssetVisibility, LoginResponseDto, SharedSpaceRole, updateAssets } from '@immich/sdk';
 import { authHeaders, forEachActor, type Actor } from 'src/actors';
 import { createUserDto } from 'src/fixtures';
 import { errorDto } from 'src/responses';
-import { app, utils } from 'src/utils';
+import { app, asBearerAuth, utils } from 'src/utils';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -1344,6 +1344,113 @@ describe('/shared-spaces', () => {
         .get(`/assets/${user1Asset1.id}/original`)
         .set('Authorization', `Bearer ${user2.accessToken}`);
 
+      expect(status).toBe(200);
+    });
+  });
+
+  // ─── Slice 3: visibility gate — Hidden/Locked assets are never exposed via space ───────────────
+
+  describe('checkSpaceAccess visibility gate (Slice 3) — Hidden/Locked assets blocked', () => {
+    /**
+     * user1 owns the space and assets. user2 is a plain viewer member.
+     * For each test a fresh space + asset pair is created to avoid state leakage.
+     *
+     * Endpoints tested per the brief:
+     *   GET /assets/:id            (AssetRead)
+     *   GET /assets/:id/original   (AssetDownload)
+     *   GET /assets/:id/thumbnail  (AssetView)
+     */
+
+    it('member CANNOT read a Locked direct-space asset (GET /assets/:id → 400)', async () => {
+      const asset = await utils.createAsset(user1.accessToken);
+      await updateAssets(
+        { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Locked } },
+        { headers: asBearerAuth(user1.accessToken) },
+      );
+      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Read Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${user2.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('member CANNOT download a Locked direct-space asset (GET /assets/:id/original → 400)', async () => {
+      const asset = await utils.createAsset(user1.accessToken);
+      await updateAssets(
+        { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Locked } },
+        { headers: asBearerAuth(user1.accessToken) },
+      );
+      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Download Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}/original`)
+        .set('Authorization', `Bearer ${user2.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('member CANNOT view thumbnail of a Locked direct-space asset (GET /assets/:id/thumbnail → 400)', async () => {
+      const asset = await utils.createAsset(user1.accessToken);
+      await updateAssets(
+        { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Locked } },
+        { headers: asBearerAuth(user1.accessToken) },
+      );
+      const space = await utils.createSpace(user1.accessToken, { name: 'Locked Thumb Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}/thumbnail`)
+        .set('Authorization', `Bearer ${user2.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('member CANNOT read a Hidden direct-space asset (GET /assets/:id → 400)', async () => {
+      const asset = await utils.createAsset(user1.accessToken);
+      await updateAssets(
+        { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Hidden } },
+        { headers: asBearerAuth(user1.accessToken) },
+      );
+      const space = await utils.createSpace(user1.accessToken, { name: 'Hidden Read Block' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${user2.accessToken}`);
+      expect(status).toBe(400);
+    });
+
+    it('member CAN read a Timeline direct-space asset (GET /assets/:id → 200)', async () => {
+      const asset = await utils.createAsset(user1.accessToken);
+      // Default visibility is Timeline; no update needed
+      const space = await utils.createSpace(user1.accessToken, { name: 'Timeline Read Allow' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${user2.accessToken}`);
+      expect(status).toBe(200);
+    });
+
+    it('member CAN read an Archive direct-space asset (GET /assets/:id → 200)', async () => {
+      const asset = await utils.createAsset(user1.accessToken);
+      await updateAssets(
+        { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Archive } },
+        { headers: asBearerAuth(user1.accessToken) },
+      );
+      const space = await utils.createSpace(user1.accessToken, { name: 'Archive Read Allow' });
+      await utils.addSpaceMember(user1.accessToken, space.id, { userId: user2.userId });
+      await utils.addSpaceAssets(user1.accessToken, space.id, [asset.id]);
+
+      const { status } = await request(app)
+        .get(`/assets/${asset.id}`)
+        .set('Authorization', `Bearer ${user2.accessToken}`);
       expect(status).toBe(200);
     });
   });

--- a/mobile/openapi/lib/model/shared_space_linked_album_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_linked_album_dto.dart
@@ -27,6 +27,7 @@ class SharedSpaceLinkedAlbumDto {
     this.lastModifiedAssetTimestamp = const Optional.absent(),
     required this.linkedAt,
     this.order = const Optional.absent(),
+    required this.ownerId,
     required this.shared,
     required this.showInTimeline,
     this.startDate = const Optional.absent(),
@@ -94,6 +95,9 @@ class SharedSpaceLinkedAlbumDto {
   ///
   Optional<AssetOrder?> order;
 
+  /// User ID of the album owner (non-PII UUID, for group-by-owner)
+  String ownerId;
+
   /// Is shared album
   bool shared;
 
@@ -128,6 +132,7 @@ class SharedSpaceLinkedAlbumDto {
     other.lastModifiedAssetTimestamp == lastModifiedAssetTimestamp &&
     other.linkedAt == linkedAt &&
     other.order == order &&
+    other.ownerId == ownerId &&
     other.shared == shared &&
     other.showInTimeline == showInTimeline &&
     other.startDate == startDate &&
@@ -150,13 +155,14 @@ class SharedSpaceLinkedAlbumDto {
     (lastModifiedAssetTimestamp == null ? 0 : lastModifiedAssetTimestamp!.hashCode) +
     (linkedAt.hashCode) +
     (order == null ? 0 : order!.hashCode) +
+    (ownerId.hashCode) +
     (shared.hashCode) +
     (showInTimeline.hashCode) +
     (startDate == null ? 0 : startDate!.hashCode) +
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'SharedSpaceLinkedAlbumDto[addedById=$addedById, albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, assetCount=$assetCount, contributorCounts=$contributorCounts, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, linkedAt=$linkedAt, order=$order, shared=$shared, showInTimeline=$showInTimeline, startDate=$startDate, updatedAt=$updatedAt]';
+  String toString() => 'SharedSpaceLinkedAlbumDto[addedById=$addedById, albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, assetCount=$assetCount, contributorCounts=$contributorCounts, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, linkedAt=$linkedAt, order=$order, ownerId=$ownerId, shared=$shared, showInTimeline=$showInTimeline, startDate=$startDate, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -194,6 +200,7 @@ class SharedSpaceLinkedAlbumDto {
       final value = this.order.value;
       json[r'order'] = value;
     }
+      json[r'ownerId'] = this.ownerId;
       json[r'shared'] = this.shared;
       json[r'showInTimeline'] = this.showInTimeline;
     if (this.startDate.isPresent) {
@@ -227,6 +234,7 @@ class SharedSpaceLinkedAlbumDto {
         lastModifiedAssetTimestamp: json.containsKey(r'lastModifiedAssetTimestamp') ? Optional.present(mapDateTime(json, r'lastModifiedAssetTimestamp', r'')) : const Optional.absent(),
         linkedAt: mapDateTime(json, r'linkedAt', r'')!,
         order: json.containsKey(r'order') ? Optional.present(AssetOrder.fromJson(json[r'order'])) : const Optional.absent(),
+        ownerId: mapValueOfType<String>(json, r'ownerId')!,
         shared: mapValueOfType<bool>(json, r'shared')!,
         showInTimeline: mapValueOfType<bool>(json, r'showInTimeline')!,
         startDate: json.containsKey(r'startDate') ? Optional.present(mapDateTime(json, r'startDate', r'')) : const Optional.absent(),
@@ -288,6 +296,7 @@ class SharedSpaceLinkedAlbumDto {
     'id',
     'isActivityEnabled',
     'linkedAt',
+    'ownerId',
     'shared',
     'showInTimeline',
     'updatedAt',

--- a/mobile/openapi/lib/model/shared_space_linked_album_dto.dart
+++ b/mobile/openapi/lib/model/shared_space_linked_album_dto.dart
@@ -16,7 +16,6 @@ class SharedSpaceLinkedAlbumDto {
     required this.addedById,
     required this.albumName,
     required this.albumThumbnailAssetId,
-    this.albumUsers = const [],
     required this.assetCount,
     this.contributorCounts = const Optional.present(const []),
     required this.createdAt,
@@ -42,9 +41,6 @@ class SharedSpaceLinkedAlbumDto {
 
   /// Thumbnail asset ID
   String? albumThumbnailAssetId;
-
-  /// First entry is always the album owner. Second entry is the auth user, if it differs from the owner. The rest are ordered alphabetically.
-  List<AlbumUserResponseDto> albumUsers;
 
   /// Number of assets
   ///
@@ -121,7 +117,6 @@ class SharedSpaceLinkedAlbumDto {
     other.addedById == addedById &&
     other.albumName == albumName &&
     other.albumThumbnailAssetId == albumThumbnailAssetId &&
-    _deepEquality.equals(other.albumUsers, albumUsers) &&
     other.assetCount == assetCount &&
     _deepEquality.equals(other.contributorCounts, contributorCounts) &&
     other.createdAt == createdAt &&
@@ -144,7 +139,6 @@ class SharedSpaceLinkedAlbumDto {
     (addedById == null ? 0 : addedById!.hashCode) +
     (albumName.hashCode) +
     (albumThumbnailAssetId == null ? 0 : albumThumbnailAssetId!.hashCode) +
-    (albumUsers.hashCode) +
     (assetCount.hashCode) +
     (contributorCounts.hashCode) +
     (createdAt.hashCode) +
@@ -162,7 +156,7 @@ class SharedSpaceLinkedAlbumDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'SharedSpaceLinkedAlbumDto[addedById=$addedById, albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, albumUsers=$albumUsers, assetCount=$assetCount, contributorCounts=$contributorCounts, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, linkedAt=$linkedAt, order=$order, shared=$shared, showInTimeline=$showInTimeline, startDate=$startDate, updatedAt=$updatedAt]';
+  String toString() => 'SharedSpaceLinkedAlbumDto[addedById=$addedById, albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, assetCount=$assetCount, contributorCounts=$contributorCounts, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, linkedAt=$linkedAt, order=$order, shared=$shared, showInTimeline=$showInTimeline, startDate=$startDate, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -177,7 +171,6 @@ class SharedSpaceLinkedAlbumDto {
     } else {
     //  json[r'albumThumbnailAssetId'] = null;
     }
-      json[r'albumUsers'] = this.albumUsers;
       json[r'assetCount'] = this.assetCount;
     if (this.contributorCounts.isPresent) {
       final value = this.contributorCounts.value;
@@ -223,7 +216,6 @@ class SharedSpaceLinkedAlbumDto {
         addedById: mapValueOfType<String>(json, r'addedById'),
         albumName: mapValueOfType<String>(json, r'albumName')!,
         albumThumbnailAssetId: mapValueOfType<String>(json, r'albumThumbnailAssetId'),
-        albumUsers: AlbumUserResponseDto.listFromJson(json[r'albumUsers']),
         assetCount: mapValueOfType<int>(json, r'assetCount')!,
         contributorCounts: json.containsKey(r'contributorCounts') ? Optional.present(ContributorCountResponseDto.listFromJson(json[r'contributorCounts'])) : const Optional.absent(),
         createdAt: mapDateTime(json, r'createdAt', r'')!,
@@ -289,7 +281,6 @@ class SharedSpaceLinkedAlbumDto {
     'addedById',
     'albumName',
     'albumThumbnailAssetId',
-    'albumUsers',
     'assetCount',
     'createdAt',
     'description',

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -29922,6 +29922,10 @@
           "order": {
             "$ref": "#/components/schemas/AssetOrder"
           },
+          "ownerId": {
+            "description": "User ID of the album owner (non-PII UUID, for group-by-owner)",
+            "type": "string"
+          },
           "shared": {
             "description": "Is shared album",
             "type": "boolean"
@@ -29952,6 +29956,7 @@
           "id",
           "isActivityEnabled",
           "linkedAt",
+          "ownerId",
           "shared",
           "showInTimeline",
           "updatedAt"

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -29869,14 +29869,6 @@
             "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
             "type": "string"
           },
-          "albumUsers": {
-            "description": "First entry is always the album owner. Second entry is the auth user, if it differs from the owner. The rest are ordered alphabetically.",
-            "items": {
-              "$ref": "#/components/schemas/AlbumUserResponseDto"
-            },
-            "minItems": 1,
-            "type": "array"
-          },
           "assetCount": {
             "description": "Number of assets",
             "maximum": 9007199254740991,
@@ -29953,7 +29945,6 @@
           "addedById",
           "albumName",
           "albumThumbnailAssetId",
-          "albumUsers",
           "assetCount",
           "createdAt",
           "description",

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -2755,8 +2755,6 @@ export type SharedSpaceLinkedAlbumDto = {
     albumName: string;
     /** Thumbnail asset ID */
     albumThumbnailAssetId: string | null;
-    /** First entry is always the album owner. Second entry is the auth user, if it differs from the owner. The rest are ordered alphabetically. */
-    albumUsers: AlbumUserResponseDto[];
     /** Number of assets */
     assetCount: number;
     contributorCounts?: ContributorCountResponseDto[];

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -2775,6 +2775,8 @@ export type SharedSpaceLinkedAlbumDto = {
     /** Link creation timestamp */
     linkedAt: string;
     order?: AssetOrder;
+    /** User ID of the album owner (non-PII UUID, for group-by-owner) */
+    ownerId: string;
     /** Is shared album */
     shared: boolean;
     /** Include this album in the space timeline */

--- a/server/src/dtos/shared-space.dto.ts
+++ b/server/src/dtos/shared-space.dto.ts
@@ -139,11 +139,13 @@ const SharedSpaceAlbumParamSchema = z.object({
   albumId: z.uuidv4(),
 });
 
-const SharedSpaceLinkedAlbumSchema = AlbumResponseSchema.extend({
-  showInTimeline: z.boolean().describe('Include this album in the space timeline'),
-  addedById: z.string().nullable().describe('User who linked the album into the space'),
-  linkedAt: z.string().meta({ format: 'date-time' }).describe('Link creation timestamp'),
-}).meta({ id: 'SharedSpaceLinkedAlbumDto' });
+const SharedSpaceLinkedAlbumSchema = AlbumResponseSchema.omit({ albumUsers: true })
+  .extend({
+    showInTimeline: z.boolean().describe('Include this album in the space timeline'),
+    addedById: z.string().nullable().describe('User who linked the album into the space'),
+    linkedAt: z.string().meta({ format: 'date-time' }).describe('Link creation timestamp'),
+  })
+  .meta({ id: 'SharedSpaceLinkedAlbumDto' });
 
 export const MAX_SPACE_ASSETS_PER_REQUEST = 10_000;
 

--- a/server/src/dtos/shared-space.dto.ts
+++ b/server/src/dtos/shared-space.dto.ts
@@ -141,6 +141,7 @@ const SharedSpaceAlbumParamSchema = z.object({
 
 const SharedSpaceLinkedAlbumSchema = AlbumResponseSchema.omit({ albumUsers: true })
   .extend({
+    ownerId: z.string().describe('User ID of the album owner (non-PII UUID, for group-by-owner)'),
     showInTimeline: z.boolean().describe('Include this album in the space timeline'),
     addedById: z.string().nullable().describe('User who linked the album into the space'),
     linkedAt: z.string().meta({ format: 'date-time' }).describe('Link creation timestamp'),

--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -165,9 +165,10 @@ from
       and "asset"."deletedAt" is null
     where
       "shared_space_member"."userId" = $1
+      and "asset"."visibility" in ($2, $3)
       and (
-        "asset"."id" in ($2)
-        or "asset"."livePhotoVideoId" in ($3)
+        "asset"."id" in ($4)
+        or "asset"."livePhotoVideoId" in ($5)
       )
     union
     select
@@ -178,12 +179,13 @@ from
       inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
       inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
       and "asset"."deletedAt" is null
-      and "asset"."isOffline" = $4
+      and "asset"."isOffline" = $6
     where
-      "shared_space_member"."userId" = $5
+      "shared_space_member"."userId" = $7
+      and "asset"."visibility" in ($8, $9)
       and (
-        "asset"."id" in ($6)
-        or "asset"."livePhotoVideoId" in ($7)
+        "asset"."id" in ($10)
+        or "asset"."livePhotoVideoId" in ($11)
       )
     union
     select
@@ -198,10 +200,11 @@ from
       inner join "asset" on "asset"."id" = "album_asset"."assetId"
       and "asset"."deletedAt" is null
     where
-      "shared_space_member"."userId" = $8
+      "shared_space_member"."userId" = $12
+      and "asset"."visibility" in ($13, $14)
       and (
-        "asset"."id" in ($9)
-        or "asset"."livePhotoVideoId" in ($10)
+        "asset"."id" in ($15)
+        or "asset"."livePhotoVideoId" in ($16)
       )
   ) as "combined"
 
@@ -222,9 +225,10 @@ from
     where
       "shared_space_member"."userId" = $1
       and "shared_space_asset"."spaceId" = $2
+      and "asset"."visibility" in ($3, $4)
       and (
-        "asset"."id" in ($3)
-        or "asset"."livePhotoVideoId" in ($4)
+        "asset"."id" in ($5)
+        or "asset"."livePhotoVideoId" in ($6)
       )
     union
     select
@@ -235,13 +239,14 @@ from
       inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
       inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
       and "asset"."deletedAt" is null
-      and "asset"."isOffline" = $5
+      and "asset"."isOffline" = $7
     where
-      "shared_space_member"."userId" = $6
-      and "shared_space_library"."spaceId" = $7
+      "shared_space_member"."userId" = $8
+      and "shared_space_library"."spaceId" = $9
+      and "asset"."visibility" in ($10, $11)
       and (
-        "asset"."id" in ($8)
-        or "asset"."livePhotoVideoId" in ($9)
+        "asset"."id" in ($12)
+        or "asset"."livePhotoVideoId" in ($13)
       )
     union
     select
@@ -256,11 +261,12 @@ from
       inner join "asset" on "asset"."id" = "album_asset"."assetId"
       and "asset"."deletedAt" is null
     where
-      "shared_space_member"."userId" = $10
-      and "shared_space_album"."spaceId" = $11
+      "shared_space_member"."userId" = $14
+      and "shared_space_album"."spaceId" = $15
+      and "asset"."visibility" in ($16, $17)
       and (
-        "asset"."id" in ($12)
-        or "asset"."livePhotoVideoId" in ($13)
+        "asset"."id" in ($18)
+        or "asset"."livePhotoVideoId" in ($19)
       )
   ) as "combined"
 
@@ -280,11 +286,12 @@ from
       and "asset"."deletedAt" is null
     where
       "shared_space_member"."userId" = $1
+      and "asset"."visibility" in ($2, $3)
       and (
-        "asset"."id" in ($2)
-        or "asset"."livePhotoVideoId" in ($3)
+        "asset"."id" in ($4)
+        or "asset"."livePhotoVideoId" in ($5)
       )
-      and "shared_space_member"."role" in ($4, $5)
+      and "shared_space_member"."role" in ($6, $7)
     union
     select
       "asset"."id",
@@ -294,14 +301,15 @@ from
       inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_library"."spaceId"
       inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
       and "asset"."deletedAt" is null
-      and "asset"."isOffline" = $6
+      and "asset"."isOffline" = $8
     where
-      "shared_space_member"."userId" = $7
+      "shared_space_member"."userId" = $9
+      and "asset"."visibility" in ($10, $11)
       and (
-        "asset"."id" in ($8)
-        or "asset"."livePhotoVideoId" in ($9)
+        "asset"."id" in ($12)
+        or "asset"."livePhotoVideoId" in ($13)
       )
-      and "shared_space_member"."role" in ($10, $11)
+      and "shared_space_member"."role" in ($14, $15)
   ) as "combined"
 
 -- AccessRepository.asset.checkSharedLinkAccess

--- a/server/src/queries/activity.repository.sql
+++ b/server/src/queries/activity.repository.sql
@@ -25,7 +25,13 @@ from
   left join "asset" on "asset"."id" = "activity"."assetId"
 where
   "activity"."albumId" = $1
-  and "asset"."deletedAt" is null
+  and (
+    (
+      "asset"."deletedAt" is null
+      and "asset"."visibility" in ('archive', 'timeline')
+    )
+    or "asset"."id" is null
+  )
 order by
   "activity"."createdAt" asc
 
@@ -81,7 +87,7 @@ where
   and (
     (
       "asset"."deletedAt" is null
-      and "asset"."visibility" != 'locked'
+      and "asset"."visibility" in ('archive', 'timeline')
     )
     or "asset"."id" is null
   )

--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -153,6 +153,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   ),
@@ -356,6 +357,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   ),
@@ -558,6 +560,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   ),
@@ -730,6 +733,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   ),
@@ -933,6 +937,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   )
@@ -1050,6 +1055,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   ),
@@ -1260,6 +1266,7 @@ WITH
             INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
           WHERE
             album_asset."assetId" = asset.id
+            AND "shared_space_album"."showInTimeline" = true
         )
       )
   ),

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -51,7 +51,7 @@ where
   (
     "asset"."ownerId" = any ($3::uuid[])
     or (
-      "asset"."visibility" = $4
+      "asset"."visibility" in ($4, $5)
       and (
         exists (
           select
@@ -60,7 +60,7 @@ where
             "shared_space_asset"
           where
             "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_asset"."spaceId" = any ($5::uuid[])
+            and "shared_space_asset"."spaceId" = any ($6::uuid[])
         )
         or exists (
           select
@@ -69,7 +69,7 @@ where
             "shared_space_library"
           where
             "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_library"."spaceId" = any ($6::uuid[])
+            and "shared_space_library"."spaceId" = any ($7::uuid[])
         )
         or exists (
           select
@@ -81,8 +81,8 @@ where
             and "album"."deletedAt" is null
           where
             "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($7::uuid[])
-            and "shared_space_album"."showInTimeline" = $8
+            and "shared_space_album"."spaceId" = any ($8::uuid[])
+            and "shared_space_album"."showInTimeline" = $9
         )
       )
     )
@@ -91,9 +91,9 @@ where
 order by
   "asset"."fileCreatedAt" desc
 limit
-  $9
-offset
   $10
+offset
+  $11
 
 -- SearchRepository.searchStatistics
 select
@@ -162,7 +162,7 @@ from
       (
         "asset"."ownerId" = any ($1::uuid[])
         or (
-          "asset"."visibility" = $2
+          "asset"."visibility" in ($2, $3)
           and (
             exists (
               select
@@ -171,7 +171,7 @@ from
                 "shared_space_asset"
               where
                 "shared_space_asset"."assetId" = "asset"."id"
-                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+                and "shared_space_asset"."spaceId" = any ($4::uuid[])
             )
             or exists (
               select
@@ -180,7 +180,7 @@ from
                 "shared_space_library"
               where
                 "shared_space_library"."libraryId" = "asset"."libraryId"
-                and "shared_space_library"."spaceId" = any ($4::uuid[])
+                and "shared_space_library"."spaceId" = any ($5::uuid[])
             )
             or exists (
               select
@@ -192,8 +192,8 @@ from
                 and "album"."deletedAt" is null
               where
                 "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($5::uuid[])
-                and "shared_space_album"."showInTimeline" = $6
+                and "shared_space_album"."spaceId" = any ($6::uuid[])
+                and "shared_space_album"."showInTimeline" = $7
             )
           )
         )
@@ -207,25 +207,25 @@ from
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "shared_space_person_face"."personId" = $7::uuid
+          and "shared_space_person_face"."personId" = $8::uuid
       )
-      and "asset"."fileCreatedAt" >= $8
-      and "asset_exif"."lensModel" = $9
-      and "asset"."isFavorite" = $10
+      and "asset"."fileCreatedAt" >= $9
+      and "asset_exif"."lensModel" = $10
+      and "asset"."isFavorite" = $11
       and "asset"."deletedAt" is null
-      and (smart_search.embedding <=> $11) <= $12
+      and (smart_search.embedding <=> $12) <= $13
     order by
-      smart_search.embedding <=> $13
+      smart_search.embedding <=> $14
     limit
-      $14
+      $15
   ) as "candidates"
 order by
   "candidates"."fileCreatedAt" desc nulls last,
   "candidates"."id"
 limit
-  $15
-offset
   $16
+offset
+  $17
 commit
 
 -- SearchRepository.getSmartSearchFacets
@@ -245,7 +245,7 @@ drop as (
     (
       "asset"."ownerId" = any ($1::uuid[])
       or (
-        "asset"."visibility" = $2
+        "asset"."visibility" in ($2, $3)
         and (
           exists (
             select
@@ -254,7 +254,7 @@ drop as (
               "shared_space_asset"
             where
               "shared_space_asset"."assetId" = "asset"."id"
-              and "shared_space_asset"."spaceId" = any ($3::uuid[])
+              and "shared_space_asset"."spaceId" = any ($4::uuid[])
           )
           or exists (
             select
@@ -263,7 +263,7 @@ drop as (
               "shared_space_library"
             where
               "shared_space_library"."libraryId" = "asset"."libraryId"
-              and "shared_space_library"."spaceId" = any ($4::uuid[])
+              and "shared_space_library"."spaceId" = any ($5::uuid[])
           )
           or exists (
             select
@@ -275,14 +275,14 @@ drop as (
               and "album"."deletedAt" is null
             where
               "album_asset"."assetId" = "asset"."id"
-              and "shared_space_album"."spaceId" = any ($5::uuid[])
-              and "shared_space_album"."showInTimeline" = $6
+              and "shared_space_album"."spaceId" = any ($6::uuid[])
+              and "shared_space_album"."showInTimeline" = $7
           )
         )
       )
     )
     and "asset"."deletedAt" is null
-    and (smart_search.embedding <=> $7) <= $8
+    and (smart_search.embedding <=> $8) <= $9
     and "smart_search"."embedding" is not null
 )
 create index smart_search_facet_candidates_asset_id_idx on smart_search_facet_candidates ("id")
@@ -1037,38 +1037,44 @@ where
       "asset"."deletedAt" is null
       and (
         "asset"."ownerId" = any ($1::uuid[])
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_asset"
-          where
-            "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_asset"."spaceId" = any ($2::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_library"
-          where
-            "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_library"."spaceId" = any ($3::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-          where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($4::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($5::uuid[])
+                and "shared_space_album"."showInTimeline" = $6
+            )
+          )
         )
       )
-      and "asset"."fileCreatedAt" >= $5
+      and "asset"."fileCreatedAt" >= $7
       and exists (
         select
         from
@@ -1078,11 +1084,11 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $6::uuid
+          and "face_identity_face"."identityId" = $8::uuid
       )
   )
   and "country" is not null
-  and "country" != $7
+  and "country" != $9
 order by
   "country"
 select distinct
@@ -1099,38 +1105,44 @@ where
       "asset"."deletedAt" is null
       and (
         "asset"."ownerId" = any ($1::uuid[])
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_asset"
-          where
-            "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_asset"."spaceId" = any ($2::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_library"
-          where
-            "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_library"."spaceId" = any ($3::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-          where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($4::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($5::uuid[])
+                and "shared_space_album"."showInTimeline" = $6
+            )
+          )
         )
       )
-      and "asset"."fileCreatedAt" >= $5
+      and "asset"."fileCreatedAt" >= $7
       and exists (
         select
         from
@@ -1140,11 +1152,11 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $6::uuid
+          and "face_identity_face"."identityId" = $8::uuid
       )
   )
   and "make" is not null
-  and "make" != $7
+  and "make" != $9
 order by
   "make"
 select distinct
@@ -1163,38 +1175,44 @@ where
       "asset"."deletedAt" is null
       and (
         "asset"."ownerId" = any ($1::uuid[])
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_asset"
-          where
-            "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_asset"."spaceId" = any ($2::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_library"
-          where
-            "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_library"."spaceId" = any ($3::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-          where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($4::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($5::uuid[])
+                and "shared_space_album"."showInTimeline" = $6
+            )
+          )
         )
       )
-      and "asset"."fileCreatedAt" >= $5
+      and "asset"."fileCreatedAt" >= $7
       and exists (
         select
         from
@@ -1204,7 +1222,7 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $6::uuid
+          and "face_identity_face"."identityId" = $8::uuid
       )
   )
 order by
@@ -1220,38 +1238,44 @@ WITH
         "asset"."deletedAt" is null
         and (
           "asset"."ownerId" = any ($1::uuid[])
-          or exists (
-            select
-              1 as "exists"
-            from
-              "shared_space_asset"
-            where
-              "shared_space_asset"."assetId" = "asset"."id"
-              and "shared_space_asset"."spaceId" = any ($2::uuid[])
-          )
-          or exists (
-            select
-              1 as "exists"
-            from
-              "shared_space_library"
-            where
-              "shared_space_library"."libraryId" = "asset"."libraryId"
-              and "shared_space_library"."spaceId" = any ($3::uuid[])
-          )
-          or exists (
-            select
-              1 as "exists"
-            from
-              "shared_space_album"
-              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-              inner join "album" on "album"."id" = "shared_space_album"."albumId"
-              and "album"."deletedAt" is null
-            where
-              "album_asset"."assetId" = "asset"."id"
-              and "shared_space_album"."spaceId" = any ($4::uuid[])
+          or (
+            "asset"."visibility" = $2
+            and (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_asset"
+                where
+                  "shared_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_asset"."spaceId" = any ($3::uuid[])
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_library"
+                where
+                  "shared_space_library"."libraryId" = "asset"."libraryId"
+                  and "shared_space_library"."spaceId" = any ($4::uuid[])
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+            )
           )
         )
-        and "asset"."fileCreatedAt" >= $5
+        and "asset"."fileCreatedAt" >= $7
     )
   ),
   identity_faces AS (
@@ -1278,7 +1302,7 @@ WITH
     FROM
       person
     WHERE
-      person."ownerId" = $6
+      person."ownerId" = $8
       AND person."identityId" IS NOT NULL
       AND EXISTS (
         SELECT
@@ -1308,9 +1332,9 @@ WITH
     FROM
       shared_space_person
       LEFT JOIN shared_space_person_alias ON shared_space_person_alias."personId" = shared_space_person.id
-      AND shared_space_person_alias."userId" = $7
+      AND shared_space_person_alias."userId" = $9
     WHERE
-      shared_space_person."spaceId" = any ($8::uuid[])
+      shared_space_person."spaceId" = any ($10::uuid[])
       AND shared_space_person."identityId" IS NOT NULL
       AND EXISTS (
         SELECT
@@ -1413,38 +1437,44 @@ where
       "asset"."deletedAt" is null
       and (
         "asset"."ownerId" = any ($1::uuid[])
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_asset"
-          where
-            "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_asset"."spaceId" = any ($2::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_library"
-          where
-            "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_library"."spaceId" = any ($3::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-          where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($4::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($5::uuid[])
+                and "shared_space_album"."showInTimeline" = $6
+            )
+          )
         )
       )
-      and "asset"."fileCreatedAt" >= $5
+      and "asset"."fileCreatedAt" >= $7
       and exists (
         select
         from
@@ -1454,11 +1484,11 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $6::uuid
+          and "face_identity_face"."identityId" = $8::uuid
       )
   )
   and "rating" is not null
-  and "rating" > $7
+  and "rating" > $9
 order by
   "rating"
 select distinct
@@ -1475,38 +1505,44 @@ where
       "asset"."deletedAt" is null
       and (
         "asset"."ownerId" = any ($1::uuid[])
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_asset"
-          where
-            "shared_space_asset"."assetId" = "asset"."id"
-            and "shared_space_asset"."spaceId" = any ($2::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_library"
-          where
-            "shared_space_library"."libraryId" = "asset"."libraryId"
-            and "shared_space_library"."spaceId" = any ($3::uuid[])
-        )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-          where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($4::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($5::uuid[])
+                and "shared_space_album"."showInTimeline" = $6
+            )
+          )
         )
       )
-      and "asset"."fileCreatedAt" >= $5
+      and "asset"."fileCreatedAt" >= $7
       and exists (
         select
         from
@@ -1516,7 +1552,7 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $6::uuid
+          and "face_identity_face"."identityId" = $8::uuid
       )
   )
 order by

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -166,6 +166,24 @@ where
   "spaceId" = $1
   and "assetId" in ($2)
 
+-- SharedSpaceRepository.emitDirectAssetVisibilityPurge
+insert into
+  "shared_space_asset_audit" ("spaceId", "assetId")
+select
+  "shared_space_asset"."spaceId",
+  "shared_space_asset"."assetId"
+from
+  "shared_space_asset"
+where
+  "shared_space_asset"."assetId" in ($1)
+
+-- SharedSpaceRepository.emitDirectAssetVisibilityRestore
+update "shared_space_asset"
+set
+  "updatedAt" = clock_timestamp()
+where
+  "assetId" in ($1)
+
 -- SharedSpaceRepository.removeLibrary
 delete from "shared_space_library"
 where

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -226,55 +226,6 @@ where
 -- SharedSpaceRepository.getLinkedAlbums
 select
   "album".*,
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "album_user"."role",
-          (
-            select
-              to_json(obj)
-            from
-              (
-                select
-                  "id",
-                  "name",
-                  "email",
-                  "avatarColor",
-                  "profileImagePath",
-                  "profileChangedAt"
-                from
-                  (
-                    select
-                      1
-                  ) as "dummy"
-              ) as obj
-          ) as "user"
-        from
-          "album_user"
-          inner join "user" on "user"."id" = "album_user"."userId"
-        where
-          "album_user"."albumId" = "album"."id"
-        order by
-          "album_user"."role",
-          "user"."name" asc
-      ) as agg
-  ) as "albumUsers",
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "shared_link".*
-        from
-          "shared_link"
-        where
-          "shared_link"."albumId" = "album"."id"
-      ) as agg
-  ) as "sharedLinks",
   "shared_space_album"."addedById",
   "shared_space_album"."showInTimeline",
   "shared_space_album"."createdAt" as "linkedAt"
@@ -616,6 +567,52 @@ where
     "shared_space_person"."name" != $3
     or "shared_space_person"."assetCount" >= $4
   )
+  and exists (
+    select
+    from
+      "shared_space_person_face" as "spf2"
+      inner join "asset_face" as "af2" on "af2"."id" = "spf2"."assetFaceId"
+      inner join "asset" on "asset"."id" = "af2"."assetId"
+    where
+      "spf2"."personId" = "shared_space_person"."id"
+      and "af2"."deletedAt" is null
+      and "af2"."isVisible" = $5
+      and "asset"."deletedAt" is null
+      and "asset"."isOffline" = $6
+      and "asset"."visibility" in ($7, $8)
+      and (
+        exists (
+          select
+            "shared_space_asset"."assetId"
+          from
+            "shared_space_asset"
+          where
+            "shared_space_asset"."assetId" = "asset"."id"
+            and "shared_space_asset"."spaceId" = $9
+        )
+        or exists (
+          select
+            "shared_space_library"."libraryId"
+          from
+            "shared_space_library"
+          where
+            "shared_space_library"."libraryId" = "asset"."libraryId"
+            and "shared_space_library"."spaceId" = $10
+        )
+        or exists (
+          select
+            "shared_space_album"."albumId"
+          from
+            "shared_space_album"
+            inner join "album" on "album"."id" = "shared_space_album"."albumId"
+            and "album"."deletedAt" is null
+            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          where
+            "album_asset"."assetId" = "asset"."id"
+            and "shared_space_album"."spaceId" = $11
+        )
+      )
+  )
 order by
   "shared_space_person"."isHidden" asc,
   NULLIF(BTRIM(shared_space_person.name), '') asc nulls last,
@@ -624,7 +621,7 @@ order by
   END desc nulls last,
   "shared_space_person"."id"
 limit
-  $5
+  $12
 
 -- SharedSpaceRepository.countPersonsBySpaceId
 WITH
@@ -680,6 +677,18 @@ WITH
       AND (
         "shared_space_person"."name" != ''
         OR "shared_space_person"."assetCount" >= $12
+      )
+      AND EXISTS (
+        SELECT
+          1
+        FROM
+          "shared_space_person_face"
+          INNER JOIN "asset_face" ON "asset_face"."id" = "shared_space_person_face"."assetFaceId"
+          INNER JOIN "asset_scope" ON "asset_scope"."assetId" = "asset_face"."assetId"
+        WHERE
+          "shared_space_person_face"."personId" = "shared_space_person"."id"
+          AND "asset_face"."deletedAt" IS NULL
+          AND "asset_face"."isVisible" = true
       )
   ),
   "person_keys" AS (
@@ -1312,9 +1321,47 @@ select distinct
   "asset_face"."assetId"
 from
   "shared_space_person_face"
+  inner join "shared_space_person" on "shared_space_person"."id" = "shared_space_person_face"."personId"
   inner join "asset_face" on "asset_face"."id" = "shared_space_person_face"."assetFaceId"
+  inner join "asset" on "asset"."id" = "asset_face"."assetId"
 where
   "shared_space_person_face"."personId" = $1
+  and "asset"."deletedAt" is null
+  and "asset"."isOffline" = $2
+  and "asset"."visibility" in ($3, $4)
+  and (
+    exists (
+      select
+        "shared_space_asset"."assetId"
+      from
+        "shared_space_asset"
+      where
+        "shared_space_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_asset"."spaceId" = "shared_space_person"."spaceId"
+    )
+    or exists (
+      select
+        "shared_space_library"."libraryId"
+      from
+        "shared_space_library"
+      where
+        "shared_space_library"."libraryId" = "asset"."libraryId"
+        and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
+    )
+    or exists (
+      select
+        1 as "exists"
+      from
+        "shared_space_album"
+        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+        inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        and "album"."deletedAt" is null
+      where
+        "album_asset"."assetId" = "asset_face"."assetId"
+        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+        and "shared_space_album"."showInTimeline" = $5
+    )
+  )
 
 -- SharedSpaceRepository.reassignPersonFacesSafe
 delete from "shared_space_person_face"
@@ -1869,11 +1916,15 @@ from
       "asset_face"."id"
     from
       "shared_space_asset"
+      inner join "asset" on "asset"."id" = "shared_space_asset"."assetId"
       inner join "asset_face" on "asset_face"."assetId" = "shared_space_asset"."assetId"
     where
       "shared_space_asset"."spaceId" = $1
       and "asset_face"."id" = $2
       and "asset_face"."deletedAt" is null
+      and "asset"."deletedAt" is null
+      and "asset"."isOffline" = $3
+      and "asset"."visibility" in ($4, $5)
     union
     select
       "asset_face"."id"
@@ -1882,11 +1933,12 @@ from
       inner join "asset" on "asset"."libraryId" = "shared_space_library"."libraryId"
       inner join "asset_face" on "asset_face"."assetId" = "asset"."id"
     where
-      "shared_space_library"."spaceId" = $3
-      and "asset_face"."id" = $4
+      "shared_space_library"."spaceId" = $6
+      and "asset_face"."id" = $7
       and "asset_face"."deletedAt" is null
       and "asset"."deletedAt" is null
-      and "asset"."isOffline" = $5
+      and "asset"."isOffline" = $8
+      and "asset"."visibility" in ($9, $10)
     union
     select
       "asset_face"."id"
@@ -1898,14 +1950,16 @@ from
       inner join "asset" on "asset"."id" = "album_asset"."assetId"
       inner join "asset_face" on "asset_face"."assetId" = "asset"."id"
     where
-      "shared_space_album"."spaceId" = $6
-      and "asset_face"."id" = $7
+      "shared_space_album"."spaceId" = $11
+      and "asset_face"."id" = $12
       and "asset_face"."deletedAt" is null
       and "asset"."deletedAt" is null
-      and "asset"."isOffline" = $8
+      and "asset"."isOffline" = $13
+      and "asset"."visibility" in ($14, $15)
+      and "shared_space_album"."showInTimeline" = $16
   ) as "combined"
 limit
-  $9
+  $17
 
 -- SharedSpaceRepository.getAssetIdForFace
 select

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -228,12 +228,23 @@ select
   "album".*,
   "shared_space_album"."addedById",
   "shared_space_album"."showInTimeline",
-  "shared_space_album"."createdAt" as "linkedAt"
+  "shared_space_album"."createdAt" as "linkedAt",
+  (
+    select
+      "album_user"."userId"
+    from
+      "album_user"
+    where
+      "album_user"."albumId" = "album"."id"
+      and "album_user"."role" = $1
+    limit
+      $2
+  ) as "ownerId"
 from
   "shared_space_album"
   inner join "album" on "album"."id" = "shared_space_album"."albumId"
 where
-  "shared_space_album"."spaceId" = $1
+  "shared_space_album"."spaceId" = $3
   and "album"."deletedAt" is null
 order by
   "album"."createdAt" desc,

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -1785,6 +1785,10 @@ where
   and "asset"."updateId" <= $2
   and "asset"."updateId" > $3
   and "asset"."libraryId" = $4
+  and (
+    "asset"."ownerId" = $5
+    or "asset"."visibility" in ($6, $7)
+  )
 order by
   "asset"."updateId" asc
 
@@ -1846,6 +1850,10 @@ where
         where
           "shared_space_member"."userId" = $5
       )
+  )
+  and (
+    "asset"."ownerId" = $6
+    or "asset"."visibility" in ($7, $8)
   )
 order by
   "asset"."updateId" asc
@@ -1928,6 +1936,10 @@ where
   and "asset"."updateId" <= $2
   and "asset"."updateId" > $3
   and "asset"."libraryId" = $4
+  and (
+    "asset"."ownerId" = $5
+    or "asset"."visibility" in ($6, $7)
+  )
 order by
   "asset"."updateId" asc
 
@@ -1961,46 +1973,44 @@ select
   "asset_exif"."updateId"
 from
   "asset_exif" as "asset_exif"
+  inner join "asset" on "asset"."id" = "asset_exif"."assetId"
 where
   "asset_exif"."updateId" < $1
   and "asset_exif"."updateId" > $2
-  and "assetId" in (
+  and "asset"."libraryId" is not null
+  and "asset"."libraryId" in (
     select
-      "asset"."id"
+      "library"."id"
     from
-      "asset"
+      "library"
     where
-      "asset"."libraryId" is not null
-      and "asset"."libraryId" in (
+      "library"."ownerId" = $3
+      and "library"."deletedAt" is null
+    union
+    select
+      "shared_space_library"."libraryId" as "id"
+    from
+      "shared_space_library"
+    where
+      "shared_space_library"."spaceId" in (
         select
-          "library"."id"
+          "shared_space"."id"
         from
-          "library"
+          "shared_space"
         where
-          "library"."ownerId" = $3
-          and "library"."deletedAt" is null
+          "shared_space"."createdById" = $4
         union
         select
-          "shared_space_library"."libraryId" as "id"
+          "shared_space_member"."spaceId" as "id"
         from
-          "shared_space_library"
+          "shared_space_member"
         where
-          "shared_space_library"."spaceId" in (
-            select
-              "shared_space"."id"
-            from
-              "shared_space"
-            where
-              "shared_space"."createdById" = $4
-            union
-            select
-              "shared_space_member"."spaceId" as "id"
-            from
-              "shared_space_member"
-            where
-              "shared_space_member"."userId" = $5
-          )
+          "shared_space_member"."userId" = $5
       )
+  )
+  and (
+    "asset"."ownerId" = $6
+    or "asset"."visibility" in ($7, $8)
   )
 order by
   "asset_exif"."updateId" asc

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -1325,6 +1325,7 @@ where
   and "shared_space_asset"."updateId" <= $4
   and "shared_space_asset"."updateId" > $5
   and "shared_space_asset"."spaceId" = $6
+  and "asset"."visibility" in ($7, $8)
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1375,6 +1376,7 @@ where
     where
       "shared_space_member"."userId" = $6
   )
+  and "asset"."visibility" in ($7, $8)
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1426,6 +1428,7 @@ where
     where
       "shared_space_member"."userId" = $7
   )
+  and "asset"."visibility" in ($8, $9)
 order by
   "asset"."updateId" asc
 
@@ -1460,11 +1463,13 @@ select
 from
   "shared_space_asset" as "shared_space_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "shared_space_asset"."assetId"
+  inner join "asset" on "asset"."id" = "shared_space_asset"."assetId"
 where
   "shared_space_asset"."updateId" < $1
   and "shared_space_asset"."updateId" <= $2
   and "shared_space_asset"."updateId" > $3
   and "shared_space_asset"."spaceId" = $4
+  and "asset"."visibility" in ($5, $6)
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1499,6 +1504,7 @@ select
 from
   "shared_space_asset" as "shared_space_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "shared_space_asset"."assetId"
+  inner join "asset" on "asset"."id" = "shared_space_asset"."assetId"
 where
   "shared_space_asset"."updateId" < $1
   and "shared_space_asset"."updateId" > $2
@@ -1517,6 +1523,7 @@ where
     where
       "shared_space_member"."userId" = $4
   )
+  and "asset"."visibility" in ($5, $6)
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1551,6 +1558,7 @@ select
 from
   "asset_exif" as "asset_exif"
   inner join "shared_space_asset" on "shared_space_asset"."assetId" = "asset_exif"."assetId"
+  inner join "asset" on "asset"."id" = "asset_exif"."assetId"
 where
   "asset_exif"."updateId" < $1
   and "asset_exif"."updateId" > $2
@@ -1570,6 +1578,7 @@ where
     where
       "shared_space_member"."userId" = $5
   )
+  and "asset"."visibility" in ($6, $7)
 order by
   "asset_exif"."updateId" asc
 
@@ -2372,6 +2381,7 @@ where
   and "album_asset"."updateId" > $5
   and "album_asset"."albumId" = $6
   and "album"."deletedAt" is null
+  and "asset"."visibility" in ($7, $8)
 order by
   "album_asset"."updateId" asc
 
@@ -2434,6 +2444,7 @@ where
           "shared_space_member"."userId" = $8
       )
   )
+  and "asset"."visibility" in ($9, $10)
 order by
   "asset"."updateId" asc
 
@@ -2495,6 +2506,7 @@ where
           "shared_space_member"."userId" = $7
       )
   )
+  and "asset"."visibility" in ($8, $9)
 order by
   "album_asset"."updateId" asc
 
@@ -2530,12 +2542,14 @@ from
   "album_asset" as "album_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "album_asset"."assetId"
   inner join "album" on "album"."id" = "album_asset"."albumId"
+  inner join "asset" on "asset"."id" = "album_asset"."assetId"
 where
   "album_asset"."updateId" < $1
   and "album_asset"."updateId" <= $2
   and "album_asset"."updateId" > $3
   and "album_asset"."albumId" = $4
   and "album"."deletedAt" is null
+  and "asset"."visibility" in ($5, $6)
 order by
   "album_asset"."updateId" asc
 
@@ -2570,6 +2584,7 @@ select
 from
   "asset_exif" as "asset_exif"
   inner join "album_asset" on "album_asset"."assetId" = "asset_exif"."assetId"
+  inner join "asset" on "asset"."id" = "asset_exif"."assetId"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
 where
   "asset_exif"."updateId" < $1
@@ -2600,6 +2615,7 @@ where
           "shared_space_member"."userId" = $6
       )
   )
+  and "asset"."visibility" in ($7, $8)
 order by
   "asset_exif"."updateId" asc
 
@@ -2634,6 +2650,7 @@ select
 from
   "album_asset" as "album_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "album_asset"."assetId"
+  inner join "asset" on "asset"."id" = "album_asset"."assetId"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
 where
   "album_asset"."updateId" < $1
@@ -2663,5 +2680,6 @@ where
           "shared_space_member"."userId" = $5
       )
   )
+  and "asset"."visibility" in ($6, $7)
 order by
   "album_asset"."updateId" asc

--- a/server/src/queries/tag.repository.sql
+++ b/server/src/queries/tag.repository.sql
@@ -69,6 +69,7 @@ where
         "tag_asset"."tagId" = "tag"."id"
         and "asset"."deletedAt" is null
         and "shared_space_member"."userId" = $2::uuid
+        and "asset"."visibility" in ($3, $4)
     )
     or exists (
       select
@@ -80,7 +81,8 @@ where
       where
         "tag_asset"."tagId" = "tag"."id"
         and "asset"."deletedAt" is null
-        and "shared_space_member"."userId" = $3::uuid
+        and "shared_space_member"."userId" = $5::uuid
+        and "asset"."visibility" in ($6, $7)
     )
     or exists (
       select
@@ -95,7 +97,8 @@ where
       where
         "tag_asset"."tagId" = "tag"."id"
         and "asset"."deletedAt" is null
-        and "shared_space_member"."userId" = $4::uuid
+        and "shared_space_member"."userId" = $8::uuid
+        and "asset"."visibility" in ($9, $10)
     )
   )
 order by

--- a/server/src/queries/view.repository.sql
+++ b/server/src/queries/view.repository.sql
@@ -40,9 +40,10 @@ where
       where
         "shared_space_member"."userId" = $5::uuid
         and "album_asset"."assetId" = "asset"."id"
+        and "shared_space_album"."showInTimeline" = $6
     )
   )
-  and "visibility" = $6
+  and "visibility" = $7
   and "deletedAt" is null
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
@@ -92,14 +93,15 @@ where
       where
         "shared_space_member"."userId" = $4::uuid
         and "album_asset"."assetId" = "asset"."id"
+        and "shared_space_album"."showInTimeline" = $5
     )
   )
-  and "visibility" = $5
+  and "visibility" = $6
   and "deletedAt" is null
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
   and "localDateTime" is not null
-  and "originalPath" like $6
-  and "originalPath" not like $7
+  and "originalPath" like $7
+  and "originalPath" not like $8
 order by
-  regexp_replace("asset"."originalPath", $8, $9) asc
+  regexp_replace("asset"."originalPath", $9, $10) asc

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -357,6 +357,7 @@ class AssetAccess {
           .select(['asset.id', 'asset.livePhotoVideoId'])
           .where('shared_space_member.userId', '=', userId)
           .where('shared_space_asset.spaceId', '=', spaceId)
+          .where((eb) => spaceVisibilityGate(eb))
           .where((eb) =>
             eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
           )
@@ -373,6 +374,7 @@ class AssetAccess {
               .select(['asset.id', 'asset.livePhotoVideoId'])
               .where('shared_space_member.userId', '=', userId)
               .where('shared_space_library.spaceId', '=', spaceId)
+              .where((eb) => spaceVisibilityGate(eb))
               .where((eb) =>
                 eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
               ),
@@ -391,6 +393,7 @@ class AssetAccess {
               .select(['asset.id', 'asset.livePhotoVideoId'])
               .where('shared_space_member.userId', '=', userId)
               .where('shared_space_album.spaceId', '=', spaceId)
+              .where((eb) => spaceVisibilityGate(eb))
               .where((eb) =>
                 eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
               ),

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -5,7 +5,7 @@ import { ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
 import { AlbumUserRole, AssetVisibility, SharedSpaceRole } from 'src/enum';
 import { DB } from 'src/schema';
 import { asUuid } from 'src/utils/database';
-import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
+import { spaceAssetPathBranches, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 class ActivityAccess {
   constructor(private db: Kysely<DB>) {}
@@ -282,6 +282,7 @@ class AssetAccess {
           )
           .select(['asset.id', 'asset.livePhotoVideoId'])
           .where('shared_space_member.userId', '=', userId)
+          .where((eb) => spaceVisibilityGate(eb))
           .where((eb) =>
             eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
           )
@@ -297,6 +298,7 @@ class AssetAccess {
               )
               .select(['asset.id', 'asset.livePhotoVideoId'])
               .where('shared_space_member.userId', '=', userId)
+              .where((eb) => spaceVisibilityGate(eb))
               .where((eb) =>
                 eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
               ),
@@ -314,6 +316,7 @@ class AssetAccess {
               )
               .select(['asset.id', 'asset.livePhotoVideoId'])
               .where('shared_space_member.userId', '=', userId)
+              .where((eb) => spaceVisibilityGate(eb))
               .where((eb) =>
                 eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
               ),

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -433,6 +433,7 @@ class AssetAccess {
           )
           .select(['asset.id', 'asset.livePhotoVideoId'])
           .where('shared_space_member.userId', '=', userId)
+          .where((eb) => spaceVisibilityGate(eb))
           .where((eb) =>
             eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
           )
@@ -449,6 +450,7 @@ class AssetAccess {
               )
               .select(['asset.id', 'asset.livePhotoVideoId'])
               .where('shared_space_member.userId', '=', userId)
+              .where((eb) => spaceVisibilityGate(eb))
               .where((eb) =>
                 eb.or([eb('asset.id', 'in', [...assetIds]), eb('asset.livePhotoVideoId', 'in', [...assetIds])]),
               )

--- a/server/src/repositories/activity.repository.ts
+++ b/server/src/repositories/activity.repository.ts
@@ -9,6 +9,9 @@ import { DB } from 'src/schema';
 import { ActivityTable } from 'src/schema/tables/activity.table';
 import { asUuid, dummy } from 'src/utils/database';
 
+/** Visibility values surfaced by withDefaultVisibility (Archive + Timeline). */
+const DEFAULT_VISIBILITY = [sql.lit(AssetVisibility.Archive), sql.lit(AssetVisibility.Timeline)] as const;
+
 export interface ActivitySearch {
   albumId?: string;
   assetId?: string | null;
@@ -41,7 +44,12 @@ export class ActivityRepository {
       .$if(!!assetId, (qb) => qb.where('activity.assetId', '=', assetId!))
       .$if(!!albumId, (qb) => qb.where('activity.albumId', '=', albumId!))
       .$if(isLiked !== undefined, (qb) => qb.where('activity.isLiked', '=', isLiked!))
-      .where('asset.deletedAt', 'is', null)
+      .where(({ or, and, eb }) =>
+        or([
+          and([eb('asset.deletedAt', 'is', null), eb('asset.visibility', 'in', DEFAULT_VISIBILITY)]),
+          eb('asset.id', 'is', null),
+        ]),
+      )
       .orderBy('activity.createdAt', 'asc')
       .execute();
   }
@@ -86,7 +94,7 @@ export class ActivityRepository {
       .where('activity.albumId', '=', albumId)
       .where(({ or, and, eb }) =>
         or([
-          and([eb('asset.deletedAt', 'is', null), eb('asset.visibility', '!=', sql.lit(AssetVisibility.Locked))]),
+          and([eb('asset.deletedAt', 'is', null), eb('asset.visibility', 'in', DEFAULT_VISIBILITY)]),
           eb('asset.id', 'is', null),
         ]),
       )

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -58,7 +58,7 @@ import {
   withTags,
 } from 'src/utils/database';
 import { globToSqlPattern } from 'src/utils/misc';
-import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
+import { spaceAssetPathBranches, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 export type AssetStats = Record<AssetType, number>;
 
@@ -309,18 +309,39 @@ export function withTimeBucketAssetFilters<O>(
     )
     .$if(!!options.spaceId, (qb) =>
       qb.where((eb) =>
-        eb.or(
-          spaceAssetPathBranches(eb, {
-            correlateAssetId: 'asset.id',
-            correlateLibraryId: 'asset.libraryId',
-            scope: { spaceId: options.spaceId! },
-            requireShowInTimeline: true,
-          }),
-        ),
+        // Fork RBAC (Fix A): the space-membership predicate is intersected with an
+        // INDEPENDENT visibility gate — `own OR (Archive|Timeline)` — so an explicit
+        // `visibility=HIDDEN`/`LOCKED` cannot surface OTHER members' Hidden/Locked in-space
+        // assets. Mirrors searchAssetBuilder. `userIds` may be undefined (pure spaceId browse):
+        // then the `own` term is absent and the gate is purely other-members-Archive/Timeline.
+        eb.and([
+          eb.or(
+            spaceAssetPathBranches(eb, {
+              correlateAssetId: 'asset.id',
+              correlateLibraryId: 'asset.libraryId',
+              scope: { spaceId: options.spaceId! },
+              requireShowInTimeline: true,
+            }),
+          ),
+          eb.or([
+            ...(options.userIds ? [eb('asset.ownerId', '=', anyUuid(options.userIds))] : []),
+            spaceVisibilityGate(eb),
+          ]),
+        ]),
       ),
     )
     .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
-    .$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
+    .$if(!!options.spacePersonIds?.length, (qb) =>
+      hasSpacePeople(qb, options.spacePersonIds!).where((eb) =>
+        // The space-person face narrowing must ALSO carry the independent visibility gate:
+        // a space person's face on ANOTHER member's Hidden/Locked asset must not surface it
+        // via an explicit `visibility=HIDDEN`. Caller's own rows follow the resolved visibility.
+        eb.or([
+          ...(options.userIds ? [eb('asset.ownerId', '=', anyUuid(options.userIds))] : []),
+          spaceVisibilityGate(eb),
+        ]),
+      ),
+    )
     .$if(!!options.identityIds?.length, (qb) => hasFaceIdentities(qb, options.identityIds!))
     .$if(!!options.withStacked, (qb) =>
       qb
@@ -335,13 +356,22 @@ export function withTimeBucketAssetFilters<O>(
     .$if(!!options.userIds && !!options.timelineSpaceIds, (qb) =>
       qb.where((eb) =>
         eb.or([
+          // Caller's own (and partner) rows follow the resolved top-level visibility.
           eb('asset.ownerId', '=', anyUuid(options.userIds!)),
-          ...spaceAssetPathBranches(eb, {
-            correlateAssetId: 'asset.id',
-            correlateLibraryId: 'asset.libraryId',
-            scope: { spaceIds: options.timelineSpaceIds! },
-            requireShowInTimeline: true,
-          }),
+          // Fork RBAC (Fix A): other members' rows are constrained to Archive+Timeline via the
+          // INDEPENDENT gate, so an explicit `visibility=HIDDEN`/`LOCKED` can't surface their
+          // Hidden/Locked in-space assets. Mirrors searchAssetBuilder's timelineSpaceIds arm.
+          eb.and([
+            spaceVisibilityGate(eb),
+            eb.or(
+              spaceAssetPathBranches(eb, {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceIds: options.timelineSpaceIds! },
+                requireShowInTimeline: true,
+              }),
+            ),
+          ]),
         ]),
       ),
     )
@@ -1351,18 +1381,36 @@ export class AssetRepository {
           )
           .$if(!!options.spaceId, (qb) =>
             qb.where((eb) =>
-              eb.or(
-                spaceAssetPathBranches(eb, {
-                  correlateAssetId: 'asset.id',
-                  correlateLibraryId: 'asset.libraryId',
-                  scope: { spaceId: options.spaceId! },
-                  requireShowInTimeline: true,
-                }),
-              ),
+              // Fork RBAC (Fix A) — inline copy of the withTimeBucketAssetFilters gate. Keep in
+              // sync with that helper: intersect the space-membership predicate with an
+              // INDEPENDENT `own OR (Archive|Timeline)` gate so explicit `visibility=HIDDEN`/
+              // `LOCKED` can't leak OTHER members' Hidden/Locked in-space assets.
+              eb.and([
+                eb.or(
+                  spaceAssetPathBranches(eb, {
+                    correlateAssetId: 'asset.id',
+                    correlateLibraryId: 'asset.libraryId',
+                    scope: { spaceId: options.spaceId! },
+                    requireShowInTimeline: true,
+                  }),
+                ),
+                eb.or([
+                  ...(options.userIds ? [eb('asset.ownerId', '=', anyUuid(options.userIds))] : []),
+                  spaceVisibilityGate(eb),
+                ]),
+              ]),
             ),
           )
           .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
-          .$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
+          .$if(!!options.spacePersonIds?.length, (qb) =>
+            hasSpacePeople(qb, options.spacePersonIds!).where((eb) =>
+              // Space-person face narrowing carries the independent visibility gate too (inline copy).
+              eb.or([
+                ...(options.userIds ? [eb('asset.ownerId', '=', anyUuid(options.userIds))] : []),
+                spaceVisibilityGate(eb),
+              ]),
+            ),
+          )
           .$if(!!options.identityIds?.length, (qb) => hasFaceIdentities(qb, options.identityIds!))
           .$if(!!options.city, (qb) => qb.where('asset_exif.city', '=', options.city!))
           .$if(!!options.country, (qb) => qb.where('asset_exif.country', '=', options.country!))
@@ -1374,14 +1422,22 @@ export class AssetRepository {
           )
           .$if(!!options.userIds && !!options.timelineSpaceIds, (qb) =>
             qb.where((eb) =>
+              // Fork RBAC (Fix A) — inline copy of the withTimeBucketAssetFilters timelineSpaceIds
+              // arm. Caller's own rows follow the resolved visibility; other members' rows carry
+              // the independent Archive+Timeline gate so Hidden/Locked never leak.
               eb.or([
                 eb('asset.ownerId', '=', anyUuid(options.userIds!)),
-                ...spaceAssetPathBranches(eb, {
-                  correlateAssetId: 'asset.id',
-                  correlateLibraryId: 'asset.libraryId',
-                  scope: { spaceIds: options.timelineSpaceIds! },
-                  requireShowInTimeline: true,
-                }),
+                eb.and([
+                  spaceVisibilityGate(eb),
+                  eb.or(
+                    spaceAssetPathBranches(eb, {
+                      correlateAssetId: 'asset.id',
+                      correlateLibraryId: 'asset.libraryId',
+                      scope: { spaceIds: options.timelineSpaceIds! },
+                      requireShowInTimeline: true,
+                    }),
+                  ),
+                ]),
               ]),
             ),
           )

--- a/server/src/repositories/download.repository.ts
+++ b/server/src/repositories/download.repository.ts
@@ -4,6 +4,7 @@ import { InjectKysely } from 'nestjs-kysely';
 import { AssetVisibility } from 'src/enum';
 import { DB } from 'src/schema';
 import { anyUuid } from 'src/utils/database';
+import { spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 const builder = (db: Kysely<DB>) =>
   db
@@ -28,6 +29,7 @@ export class DownloadRepository {
     return builder(this.db)
       .innerJoin('album_asset', 'asset.id', 'album_asset.assetId')
       .where('album_asset.albumId', '=', albumId)
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -41,12 +43,14 @@ export class DownloadRepository {
   downloadSpaceId(spaceId: string) {
     const direct = builder(this.db)
       .innerJoin('shared_space_asset', 'asset.id', 'shared_space_asset.assetId')
-      .where('shared_space_asset.spaceId', '=', spaceId);
+      .where('shared_space_asset.spaceId', '=', spaceId)
+      .where((eb) => spaceVisibilityGate(eb));
 
     const library = builder(this.db)
       .innerJoin('shared_space_library', (join) => join.onRef('shared_space_library.libraryId', '=', 'asset.libraryId'))
       .where('shared_space_library.spaceId', '=', spaceId)
-      .where('asset.isOffline', '=', false);
+      .where('asset.isOffline', '=', false)
+      .where((eb) => spaceVisibilityGate(eb));
 
     const album = builder(this.db)
       .innerJoin('album_asset', 'asset.id', 'album_asset.assetId')
@@ -54,7 +58,8 @@ export class DownloadRepository {
       .innerJoin('album', (join) =>
         join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
       )
-      .where('shared_space_album.spaceId', '=', spaceId);
+      .where('shared_space_album.spaceId', '=', spaceId)
+      .where((eb) => spaceVisibilityGate(eb));
 
     return direct.union(library).union(album).stream();
   }

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -16,7 +16,7 @@ import { FaceIdentityFaceSource, FaceIdentityFaceTable } from 'src/schema/tables
 import { FaceIdentityTable } from 'src/schema/tables/face-identity.table';
 import { anyUuid } from 'src/utils/database';
 import { asDateString, asDateTimeString } from 'src/utils/date';
-import { spaceAlbumAssetExistsSql } from 'src/utils/shared-space-album-scope';
+import { spaceAlbumAssetExistsSql, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
 
 export type FaceIdentity = Selectable<FaceIdentityTable>;
 export type FaceIdentityFace = Selectable<FaceIdentityFaceTable>;
@@ -157,7 +157,7 @@ type SpacePersonBackfillIdentityGroup = {
   representativeFaceId: string;
 };
 
-const peopleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+const peopleAssetVisibilities = spaceVisibleAssetVisibilities;
 const sharedSpaceFaceMatchBackfillTargetInsertChunkSize = 1000;
 
 export type ScopedPersonTokenResolution = {

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -902,6 +902,7 @@ export class FaceIdentityRepository {
             OR ${spaceAlbumAssetExistsSql({
               assetIdColumn: sql`asset.id`,
               spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
             })}
           )
       ),
@@ -1021,6 +1022,7 @@ export class FaceIdentityRepository {
             OR ${spaceAlbumAssetExistsSql({
               assetIdColumn: sql`asset.id`,
               spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
             })}
           )
       ),
@@ -1162,6 +1164,7 @@ export class FaceIdentityRepository {
             OR ${spaceAlbumAssetExistsSql({
               assetIdColumn: sql`asset.id`,
               spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
             })}
           )
       )
@@ -1642,6 +1645,7 @@ export class FaceIdentityRepository {
             OR ${spaceAlbumAssetExistsSql({
               assetIdColumn: sql`asset.id`,
               spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
             })}
           )
       ),
@@ -1787,6 +1791,7 @@ export class FaceIdentityRepository {
             OR ${spaceAlbumAssetExistsSql({
               assetIdColumn: sql`asset.id`,
               spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
             })}
           )
       ),
@@ -1902,6 +1907,7 @@ export class FaceIdentityRepository {
             OR ${spaceAlbumAssetExistsSql({
               assetIdColumn: sql`asset.id`,
               spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
             })}
           )
       ),

--- a/server/src/repositories/memory.repository.spec.ts
+++ b/server/src/repositories/memory.repository.spec.ts
@@ -16,6 +16,17 @@ const offlineKysely = () =>
 describe(MemoryRepository.name, () => {
   const sut = new MemoryRepository(offlineKysely());
 
+  describe('accessibleSearchBuilder', () => {
+    it('album arm requires showInTimeline on memory projection surfaces', () => {
+      const sut = new MemoryRepository(offlineKysely());
+      const query = (sut as any)
+        .accessibleSearchBuilder('00000000-0000-0000-0000-000000000000', {})
+        .select((eb: any) => eb.lit(1).as('one'))
+        .compile();
+      expect(query.sql).toContain('"showInTimeline" = ');
+    });
+  });
+
   describe('searchBuilder', () => {
     it('excludes future scheduled memories when no date filter is provided', () => {
       const now = vi.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromISO('2026-04-30T12:00:00Z') as DateTime<true>);

--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -94,6 +94,7 @@ export class MemoryRepository implements IBulkAsset {
                 spaceAlbumAssetExists(eb, {
                   correlateAssetId: 'asset.id',
                   scope: { memberUserId: userId },
+                  requireShowInTimeline: true,
                 }),
               ]),
             ),

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -11,6 +11,7 @@ import { FaceSearchTable } from 'src/schema/tables/face-search.table';
 import { PersonTable } from 'src/schema/tables/person.table';
 import { dummy, removeUndefinedKeys, withFilePath } from 'src/utils/database';
 import { paginationHelper, PaginationOptions } from 'src/utils/pagination';
+import { spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
 
 export interface PersonSearchOptions {
   withHidden: boolean;
@@ -60,7 +61,7 @@ export interface PeopleFaceStatisticsOptions {
   minimumFaceCount?: number;
 }
 
-const peopleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+const peopleAssetVisibilities = spaceVisibleAssetVisibilities;
 
 const isBlank = (value: string | null | undefined) => !value || value.trim().length === 0;
 

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -570,6 +570,43 @@ describe(SearchRepository.name, () => {
       expect(sql).toContain('"shared_space_library"');
       expect(sql).toContain('"shared_space_library"."spaceId"');
     });
+
+    // Fix I: album-scoped branches must gate other participants' assets on visibility
+    // (Archive + Timeline only) to prevent Hidden asset facets from leaking to album viewers.
+    it('buildFilteredAssetIds gates album_user participant arm on Archive+Timeline visibility', () => {
+      // Without the fix, the album_user EXISTS arm has no visibility predicate and the
+      // album-scoped facets expose Hidden assets contributed by another participant.
+      const sql = compileFilteredAssetIds(sut, {
+        albumId: '11111111-1111-1111-1111-111111111111',
+      });
+
+      // The visibility gate ("asset"."visibility" in ($N, $N)) must appear in the SQL
+      // emitted for the album branch — it restricts the album_user participant arm so
+      // Hidden/Locked assets owned by OTHER participants are not surfaced.
+      expect(sql).toMatch(/"asset"\."visibility" in \(\$\d+(?:, \$\d+)*\)/);
+    });
+
+    it('getExifField gates album_user participant arm on Archive+Timeline visibility', () => {
+      const sql = compileExifField(sut, 'country', {
+        albumId: '11111111-1111-1111-1111-111111111111',
+      });
+
+      expect(sql).toMatch(/"asset"\."visibility" in \(\$\d+(?:, \$\d+)*\)/);
+    });
+
+    it('searchAssetBuilder album-scoped branch gates space assets on Archive+Timeline visibility', () => {
+      // albumSharedSpaceScope is activated when albumIds is set and userIds is absent.
+      // Without the fix, the space asset/library EXISTS arms have no visibility predicate.
+      const sql = buildAssetSearchSql({
+        albumIds: ['11111111-1111-1111-1111-111111111111'],
+        timelineSpaceIds: ['33333333-3333-3333-3333-333333333333'],
+      });
+
+      expect(sql).toContain('"shared_space_asset"');
+      expect(sql).toContain('"shared_space_library"');
+      // Visibility gate must appear alongside the space membership check.
+      expect(sql).toMatch(/"asset"\."visibility" in \(\$\d+(?:, \$\d+)*\)/);
+    });
   });
 
   describe('searchAssetBuilder rating semantics', () => {

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1222,19 +1222,34 @@ export class SearchRepository {
                   .where('album_asset.albumId', '=', asUuid(options!.albumId!)),
               ),
               eb.or([
+                // Caller's own assets follow the resolved visibility applied upstream; no gate.
                 eb('asset.ownerId', '=', anyUuid(userIds)),
-                eb.exists(
-                  eb
-                    .selectFrom('album_user')
-                    .whereRef('album_user.userId', '=', 'asset.ownerId')
-                    .where('album_user.albumId', '=', asUuid(options!.albumId!)),
-                ),
+                // Other album participants' assets: Archive + Timeline only (mirrors the
+                // album view's withDefaultVisibility — Hidden/Locked never surface for
+                // other members, matching the sibling spaceId/timelineSpaceIds branches).
+                eb.and([
+                  spaceVisibilityGate(eb),
+                  eb.exists(
+                    eb
+                      .selectFrom('album_user')
+                      .whereRef('album_user.userId', '=', 'asset.ownerId')
+                      .where('album_user.albumId', '=', asUuid(options!.albumId!)),
+                  ),
+                ]),
+                // Space-linked assets via timeline opt-in: also gate on Archive + Timeline.
                 ...(options?.timelineSpaceIds?.length
-                  ? spaceAssetPathBranches(eb, {
-                      correlateAssetId: 'asset.id',
-                      correlateLibraryId: 'asset.libraryId',
-                      scope: { spaceIds: options.timelineSpaceIds },
-                    })
+                  ? [
+                      eb.and([
+                        spaceVisibilityGate(eb),
+                        eb.or(
+                          spaceAssetPathBranches(eb, {
+                            correlateAssetId: 'asset.id',
+                            correlateLibraryId: 'asset.libraryId',
+                            scope: { spaceIds: options.timelineSpaceIds },
+                          }),
+                        ),
+                      ]),
+                    ]
                   : []),
               ]),
             ]),

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -19,7 +19,7 @@ import {
 } from 'src/utils/database';
 import { without } from 'src/utils/filter-suggestions';
 import { paginationHelper } from 'src/utils/pagination';
-import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
+import { spaceAssetPathBranches, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 import z from 'zod';
 
 export interface SearchAssetIdOptions {
@@ -1116,24 +1116,35 @@ export class SearchRepository {
       .$if(!options?.spaceId && !options?.timelineSpaceIds, (qb) => qb.where('asset.ownerId', '=', anyUuid(userIds)))
       .$if(!!options?.spaceId && !options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
-          eb.or(
-            spaceAssetPathBranches(eb, {
-              correlateAssetId: 'asset.id',
-              correlateLibraryId: 'asset.libraryId',
-              scope: { spaceId: options!.spaceId! },
-            }),
-          ),
+          eb.and([
+            eb.or(
+              spaceAssetPathBranches(eb, {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceId: options!.spaceId! },
+                requireShowInTimeline: true,
+              }),
+            ),
+            // M3: caller's own assets bypass space-visibility gate; others must be Archive/Timeline.
+            eb.or([eb('asset.ownerId', '=', anyUuid(userIds)), spaceVisibilityGate(eb)]),
+          ]),
         ),
       )
       .$if(!!options?.timelineSpaceIds, (qb) =>
         qb.where((eb) =>
           eb.or([
             eb('asset.ownerId', '=', anyUuid(userIds)),
-            ...spaceAssetPathBranches(eb, {
-              correlateAssetId: 'asset.id',
-              correlateLibraryId: 'asset.libraryId',
-              scope: { spaceIds: options!.timelineSpaceIds! },
-            }),
+            eb.and([
+              eb('asset.visibility', '=', AssetVisibility.Timeline),
+              eb.or(
+                spaceAssetPathBranches(eb, {
+                  correlateAssetId: 'asset.id',
+                  correlateLibraryId: 'asset.libraryId',
+                  scope: { spaceIds: options!.timelineSpaceIds! },
+                  requireShowInTimeline: true,
+                }),
+              ),
+            ]),
           ]),
         ),
       )
@@ -1234,24 +1245,38 @@ export class SearchRepository {
         )
         .$if(!!options?.spaceId && !options?.timelineSpaceIds && !options?.albumId, (qb) =>
           qb.where((eb) =>
-            eb.or(
-              spaceAssetPathBranches(eb, {
-                correlateAssetId: 'asset.id',
-                correlateLibraryId: 'asset.libraryId',
-                scope: { spaceId: options!.spaceId! },
-              }),
-            ),
+            eb.and([
+              eb.or(
+                spaceAssetPathBranches(eb, {
+                  correlateAssetId: 'asset.id',
+                  correlateLibraryId: 'asset.libraryId',
+                  scope: { spaceId: options!.spaceId! },
+                  requireShowInTimeline: true,
+                }),
+              ),
+              // M3: the caller's own assets bypass the space-visibility gate (own-M3);
+              // every other member's asset must be Archive or Timeline.
+              eb.or([eb('asset.ownerId', '=', anyUuid(userIds)), spaceVisibilityGate(eb)]),
+            ]),
           ),
         )
         .$if(!!options?.timelineSpaceIds && !options?.albumId, (qb) =>
           qb.where((eb) =>
             eb.or([
+              // Caller's own assets follow the resolved visibility applied above.
               eb('asset.ownerId', '=', anyUuid(userIds)),
-              ...spaceAssetPathBranches(eb, {
-                correlateAssetId: 'asset.id',
-                correlateLibraryId: 'asset.libraryId',
-                scope: { spaceIds: options!.timelineSpaceIds! },
-              }),
+              // Other members' assets: Timeline only + showInTimeline=true album path.
+              eb.and([
+                eb('asset.visibility', '=', AssetVisibility.Timeline),
+                eb.or(
+                  spaceAssetPathBranches(eb, {
+                    correlateAssetId: 'asset.id',
+                    correlateLibraryId: 'asset.libraryId',
+                    scope: { spaceIds: options!.timelineSpaceIds! },
+                    requireShowInTimeline: true,
+                  }),
+                ),
+              ]),
             ]),
           ),
         )

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -375,6 +375,61 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  /**
+   * Slice 4.B DIRECT-path purge: when the owner flips one of these assets OUT of
+   * the space-shareable visibility set (Timeline/Archive) to Hidden or Locked,
+   * the `shared_space_asset` join row is NOT deleted, so the delete-audit trigger
+   * never fires and already-synced member devices keep the bytes. Emit a
+   * `shared_space_asset_audit` tombstone for every join row referencing the given
+   * assets so `SharedSpaceToAssetSync.getDeletes` purges those devices.
+   *
+   * `shared_space_asset_audit` is space-only (NOT shared with normal album sync),
+   * so writing to it here does not bleed into non-space behavior. `id` and
+   * `deletedAt` are DB-generated (immich_uuid_v7 / clock_timestamp), giving every
+   * tombstone a fresh id > any prior checkpoint.
+   */
+  @GenerateSql({ params: [[DummyValue.UUID]] })
+  async emitDirectAssetVisibilityPurge(assetIds: string[]) {
+    if (assetIds.length === 0) {
+      return;
+    }
+
+    await this.db
+      .insertInto('shared_space_asset_audit')
+      .columns(['spaceId', 'assetId'])
+      .expression(
+        this.db
+          .selectFrom('shared_space_asset')
+          .select(['shared_space_asset.spaceId', 'shared_space_asset.assetId'])
+          .where('shared_space_asset.assetId', 'in', assetIds),
+      )
+      .execute();
+  }
+
+  /**
+   * Slice 4.B DIRECT-path restore: when the owner flips one of these assets back
+   * INTO the space-shareable set (Timeline/Archive), the join row already exists
+   * but its `updateId` is unchanged, so `SharedSpaceToAssetSync.getUpserts` (gated
+   * by `updateId` > checkpoint) won't re-add it to devices that purged it. Touch
+   * the referencing rows so the `updated_at` BEFORE-UPDATE trigger bumps
+   * `updateId = immich_uuid_v7(clock_timestamp())` and getUpserts re-emits.
+   *
+   * Over-emitting a restore for an already-visible asset is harmless (the device
+   * simply re-upserts a join row it already has).
+   */
+  @GenerateSql({ params: [[DummyValue.UUID]] })
+  async emitDirectAssetVisibilityRestore(assetIds: string[]) {
+    if (assetIds.length === 0) {
+      return;
+    }
+
+    await this.db
+      .updateTable('shared_space_asset')
+      .set({ updatedAt: sql`clock_timestamp()` })
+      .where('assetId', 'in', assetIds)
+      .execute();
+  }
+
   // ==========================================
   // Shared Space Library Link CRUD
   // ==========================================

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1810,10 +1810,38 @@ export class SharedSpaceRepository {
   getPersonAssetIds(personId: string) {
     return this.db
       .selectFrom('shared_space_person_face')
+      .innerJoin('shared_space_person', 'shared_space_person.id', 'shared_space_person_face.personId')
       .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+      .innerJoin('asset', 'asset.id', 'asset_face.assetId')
       .select('asset_face.assetId')
       .distinct()
       .where('shared_space_person_face.personId', '=', personId)
+      .where('asset.deletedAt', 'is', null)
+      .where('asset.isOffline', '=', false)
+      .where('asset.visibility', 'in', visibleSpaceAssetVisibilities)
+      .where((eb) =>
+        eb.or([
+          eb.exists(
+            eb
+              .selectFrom('shared_space_asset')
+              .select('shared_space_asset.assetId')
+              .whereRef('shared_space_asset.assetId', '=', 'asset_face.assetId')
+              .whereRef('shared_space_asset.spaceId', '=', 'shared_space_person.spaceId'),
+          ),
+          eb.exists(
+            eb
+              .selectFrom('shared_space_library')
+              .select('shared_space_library.libraryId')
+              .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+              .whereRef('shared_space_library.spaceId', '=', 'shared_space_person.spaceId'),
+          ),
+          spaceAlbumAssetExists(eb, {
+            correlateAssetId: 'asset_face.assetId',
+            scope: { spaceIdRef: 'shared_space_person.spaceId' },
+            requireShowInTimeline: true,
+          }),
+        ]),
+      )
       .execute();
   }
 

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -18,7 +18,11 @@ import { SharedSpacePersonFaceTable } from 'src/schema/tables/shared-space-perso
 import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 import { anyUuid, dummy, searchAssetBuilder } from 'src/utils/database';
-import { spaceAlbumAssetExists, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
+import {
+  spaceAlbumAssetExists,
+  spaceVisibilityGate,
+  spaceVisibleAssetVisibilities,
+} from 'src/utils/shared-space-album-scope';
 
 const withSpaceAlbumUsers = (eb: ExpressionBuilder<DB, 'album' | 'shared_space_album'>) =>
   jsonArrayFrom(
@@ -2537,11 +2541,15 @@ export class SharedSpaceRepository {
       .selectFrom(
         this.db
           .selectFrom('shared_space_asset')
+          .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
           .innerJoin('asset_face', 'asset_face.assetId', 'shared_space_asset.assetId')
           .select('asset_face.id')
           .where('shared_space_asset.spaceId', '=', spaceId)
           .where('asset_face.id', '=', faceId)
           .where('asset_face.deletedAt', 'is', null)
+          .where('asset.deletedAt', 'is', null)
+          .where('asset.isOffline', '=', false)
+          .where((eb) => spaceVisibilityGate(eb))
           .union(
             this.db
               .selectFrom('shared_space_library')
@@ -2552,7 +2560,8 @@ export class SharedSpaceRepository {
               .where('asset_face.id', '=', faceId)
               .where('asset_face.deletedAt', 'is', null)
               .where('asset.deletedAt', 'is', null)
-              .where('asset.isOffline', '=', false),
+              .where('asset.isOffline', '=', false)
+              .where((eb) => spaceVisibilityGate(eb)),
           )
           .union(
             this.db
@@ -2568,7 +2577,9 @@ export class SharedSpaceRepository {
               .where('asset_face.id', '=', faceId)
               .where('asset_face.deletedAt', 'is', null)
               .where('asset.deletedAt', 'is', null)
-              .where('asset.isOffline', '=', false),
+              .where('asset.isOffline', '=', false)
+              .where((eb) => spaceVisibilityGate(eb))
+              .where('shared_space_album.showInTimeline', '=', true),
           )
           .as('combined'),
       )

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Insertable, Kysely, NotNull, sql, Transaction, Updateable } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { ChunkedArray, ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
-import { AssetType, AssetVisibility, SharedSpaceRole, VectorIndex } from 'src/enum';
+import { AlbumUserRole, AssetType, AssetVisibility, SharedSpaceRole, VectorIndex } from 'src/enum';
 import { probes } from 'src/repositories/database.repository';
 import type { PeopleFaceStatistics } from 'src/repositories/person.repository';
 import type { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
@@ -495,6 +495,15 @@ export class SharedSpaceRepository {
         'shared_space_album.showInTimeline',
         'shared_space_album.createdAt as linkedAt',
       ])
+      .select((eb) =>
+        eb
+          .selectFrom('album_user')
+          .whereRef('album_user.albumId', '=', 'album.id')
+          .where('album_user.role', '=', AlbumUserRole.Owner)
+          .select('album_user.userId')
+          .limit(1)
+          .as('ownerId'),
+      )
       .where('shared_space_album.spaceId', '=', spaceId)
       .where('album.deletedAt', 'is', null)
       .orderBy('album.createdAt', 'desc')

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -18,7 +18,7 @@ import { SharedSpacePersonFaceTable } from 'src/schema/tables/shared-space-perso
 import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 import { anyUuid, dummy, searchAssetBuilder } from 'src/utils/database';
-import { spaceAlbumAssetExists } from 'src/utils/shared-space-album-scope';
+import { spaceAlbumAssetExists, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
 
 const withSpaceAlbumUsers = (eb: ExpressionBuilder<DB, 'album' | 'shared_space_album'>) =>
   jsonArrayFrom(
@@ -39,7 +39,7 @@ const withSpaceAlbumSharedLink = (eb: ExpressionBuilder<DB, 'album' | 'shared_sp
     eb.selectFrom('shared_link').selectAll('shared_link').whereRef('shared_link.albumId', '=', 'album.id'),
   ).as('sharedLinks');
 
-const visibleSpaceAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+const visibleSpaceAssetVisibilities = spaceVisibleAssetVisibilities;
 
 type SpacePersonStatistics = {
   assets: number;

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -886,51 +886,49 @@ export class SharedSpaceRepository {
           ]),
         ),
       )
-      .$if(!!options.takenAfter || !!options.takenBefore, (qb) =>
-        qb.where((eb) =>
-          eb.exists(
-            eb
-              .selectFrom('shared_space_person_face as spf2')
-              .innerJoin('asset_face as af2', 'af2.id', 'spf2.assetFaceId')
-              .innerJoin('asset', 'asset.id', 'af2.assetId')
-              .whereRef('spf2.personId', '=', 'shared_space_person.id')
-              .where('af2.deletedAt', 'is', null)
-              .where('af2.isVisible', '=', true)
-              .where('asset.deletedAt', 'is', null)
-              .where('asset.isOffline', '=', false)
-              .where('asset.visibility', 'in', visibleSpaceAssetVisibilities)
-              .where((spaceEb) =>
-                spaceEb.or([
-                  spaceEb.exists(
-                    spaceEb
-                      .selectFrom('shared_space_asset')
-                      .select('shared_space_asset.assetId')
-                      .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                      .where('shared_space_asset.spaceId', '=', spaceId),
-                  ),
-                  spaceEb.exists(
-                    spaceEb
-                      .selectFrom('shared_space_library')
-                      .select('shared_space_library.libraryId')
-                      .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                      .where('shared_space_library.spaceId', '=', spaceId),
-                  ),
-                  spaceEb.exists(
-                    spaceEb
-                      .selectFrom('shared_space_album')
-                      .innerJoin('album', (j) =>
-                        j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
-                      )
-                      .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
-                      .select('shared_space_album.albumId')
-                      .whereRef('album_asset.assetId', '=', 'asset.id')
-                      .where('shared_space_album.spaceId', '=', spaceId),
-                  ),
-                ]),
-              )
-              .$if(!!options.takenAfter, (qb2) => qb2.where('asset.fileCreatedAt', '>=', options.takenAfter!))
-              .$if(!!options.takenBefore, (qb2) => qb2.where('asset.fileCreatedAt', '<', options.takenBefore!)),
-          ),
+      .where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom('shared_space_person_face as spf2')
+            .innerJoin('asset_face as af2', 'af2.id', 'spf2.assetFaceId')
+            .innerJoin('asset', 'asset.id', 'af2.assetId')
+            .whereRef('spf2.personId', '=', 'shared_space_person.id')
+            .where('af2.deletedAt', 'is', null)
+            .where('af2.isVisible', '=', true)
+            .where('asset.deletedAt', 'is', null)
+            .where('asset.isOffline', '=', false)
+            .where('asset.visibility', 'in', visibleSpaceAssetVisibilities)
+            .where((spaceEb) =>
+              spaceEb.or([
+                spaceEb.exists(
+                  spaceEb
+                    .selectFrom('shared_space_asset')
+                    .select('shared_space_asset.assetId')
+                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                    .where('shared_space_asset.spaceId', '=', spaceId),
+                ),
+                spaceEb.exists(
+                  spaceEb
+                    .selectFrom('shared_space_library')
+                    .select('shared_space_library.libraryId')
+                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                    .where('shared_space_library.spaceId', '=', spaceId),
+                ),
+                spaceEb.exists(
+                  spaceEb
+                    .selectFrom('shared_space_album')
+                    .innerJoin('album', (j) =>
+                      j.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+                    )
+                    .innerJoin('album_asset', 'album_asset.albumId', 'shared_space_album.albumId')
+                    .select('shared_space_album.albumId')
+                    .whereRef('album_asset.assetId', '=', 'asset.id')
+                    .where('shared_space_album.spaceId', '=', spaceId),
+                ),
+              ]),
+            )
+            .$if(!!options.takenAfter, (qb2) => qb2.where('asset.fileCreatedAt', '>=', options.takenAfter!))
+            .$if(!!options.takenBefore, (qb2) => qb2.where('asset.fileCreatedAt', '<', options.takenBefore!)),
         ),
       )
       .orderBy('shared_space_person.isHidden', 'asc')
@@ -982,9 +980,9 @@ export class SharedSpaceRepository {
               OR "shared_space_person"."assetCount" >= ${minimumFaceCount}
             )
           `;
-    const datePersonFilter =
-      options.takenAfter || options.takenBefore
-        ? sql`
+    // Always require at least one visible, in-scope face (visibility already enforced by asset_scope CTE).
+    // The date bounds are already applied to asset_scope, so this naturally enforces date filtering too.
+    const visibleFaceFilter = sql`
             AND EXISTS (
               SELECT 1
               FROM "shared_space_person_face"
@@ -994,8 +992,7 @@ export class SharedSpaceRepository {
                 AND "asset_face"."deletedAt" IS NULL
                 AND "asset_face"."isVisible" = true
             )
-          `
-        : sql``;
+          `;
     const hasAssignedPersonFaceFilter = !!options.named || !!namePattern;
     const assignedPersonFaceFilter = hasAssignedPersonFaceFilter
       ? sql`
@@ -1071,7 +1068,7 @@ export class SharedSpaceRepository {
           ${namedPersonFilter}
           ${namePersonFilter}
           ${minimumPersonFilter}
-          ${datePersonFilter}
+          ${visibleFaceFilter}
       ),
       "person_keys" AS (
         SELECT "personKey", BOOL_AND("isHidden") AS "allHidden"

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { ExpressionBuilder, Insertable, Kysely, NotNull, sql, Transaction, Updateable } from 'kysely';
-import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/postgres';
+import { Insertable, Kysely, NotNull, sql, Transaction, Updateable } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
-import { columns } from 'src/database';
 import { ChunkedArray, ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
 import { AssetType, AssetVisibility, SharedSpaceRole, VectorIndex } from 'src/enum';
 import { probes } from 'src/repositories/database.repository';
@@ -17,31 +15,12 @@ import { SharedSpacePersonAliasTable } from 'src/schema/tables/shared-space-pers
 import { SharedSpacePersonFaceTable } from 'src/schema/tables/shared-space-person-face.table';
 import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
-import { anyUuid, dummy, searchAssetBuilder } from 'src/utils/database';
+import { anyUuid, searchAssetBuilder } from 'src/utils/database';
 import {
   spaceAlbumAssetExists,
   spaceVisibilityGate,
   spaceVisibleAssetVisibilities,
 } from 'src/utils/shared-space-album-scope';
-
-const withSpaceAlbumUsers = (eb: ExpressionBuilder<DB, 'album' | 'shared_space_album'>) =>
-  jsonArrayFrom(
-    eb
-      .selectFrom('album_user')
-      .innerJoin('user', 'user.id', 'album_user.userId')
-      .whereRef('album_user.albumId', '=', 'album.id')
-      .select('album_user.role')
-      .select((eb) => jsonObjectFrom(eb.selectFrom(dummy).select(columns.user)).$notNull().as('user'))
-      .orderBy('album_user.role')
-      .orderBy('user.name', 'asc'),
-  )
-    .$notNull()
-    .as('albumUsers');
-
-const withSpaceAlbumSharedLink = (eb: ExpressionBuilder<DB, 'album' | 'shared_space_album'>) =>
-  jsonArrayFrom(
-    eb.selectFrom('shared_link').selectAll('shared_link').whereRef('shared_link.albumId', '=', 'album.id'),
-  ).as('sharedLinks');
 
 const visibleSpaceAssetVisibilities = spaceVisibleAssetVisibilities;
 
@@ -511,8 +490,6 @@ export class SharedSpaceRepository {
       .selectFrom('shared_space_album')
       .innerJoin('album', 'album.id', 'shared_space_album.albumId')
       .selectAll('album')
-      .select(withSpaceAlbumUsers)
-      .select(withSpaceAlbumSharedLink)
       .select([
         'shared_space_album.addedById',
         'shared_space_album.showInTimeline',

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1249,12 +1249,17 @@ export class LibraryAssetSync extends BaseSync {
   // Per-library backfill of asset rows for a specific library. Triggered by the
   // `syncLibraryAssetsV1` service loop when the client has not yet backfilled a
   // newly-accessible library.
-  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
-  getBackfill(options: SyncBackfillOptions, libraryId: string) {
+  //
+  // M3 visibility gate: the user always sees ALL visibilities of their own
+  // assets. For OTHER members' assets (reached via the space-link branch of
+  // accessibleLibraries), only Archive and Timeline are streamed.
+  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
+  getBackfill(options: SyncBackfillOptions, libraryId: string, userId: string) {
     return this.backfillQuery('asset', options)
       .select(columns.syncAsset)
       .select('asset.updateId')
       .where('asset.libraryId', '=', libraryId)
+      .where((eb) => eb.or([eb('asset.ownerId', '=', userId), spaceVisibilityGate(eb)]))
       .stream();
   }
 
@@ -1264,6 +1269,8 @@ export class LibraryAssetSync extends BaseSync {
   // because there's no stable library<->asset join-row updateId to gate on.
   // Both initial syncs and subsequent metadata changes flow through this stream
   // as `LibraryAssetCreateV1` events; the client upserts idempotently.
+  //
+  // M3 visibility gate: see getBackfill above.
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getUpserts(options: SyncQueryOptions) {
     return this.upsertQuery('asset', options)
@@ -1271,6 +1278,7 @@ export class LibraryAssetSync extends BaseSync {
       .select('asset.updateId')
       .where('asset.libraryId', 'is not', null)
       .where('asset.libraryId', 'in', (eb) => accessibleLibraries(eb, options.userId))
+      .where((eb) => eb.or([eb('asset.ownerId', '=', options.userId), spaceVisibilityGate(eb)]))
       .stream();
   }
 
@@ -1303,29 +1311,38 @@ export class LibraryAssetSync extends BaseSync {
 // the album-user boundary. No cleanupAuditTable — there is no dedicated
 // exif audit table (consistent with AlbumAssetExifSync).
 export class LibraryAssetExifSync extends BaseSync {
-  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
-  getBackfill(options: SyncBackfillOptions, libraryId: string) {
+  // M3 visibility gate: the user always sees ALL visibilities of their own
+  // assets. For OTHER members' assets (reached via the space-link branch of
+  // accessibleLibraries), only Archive and Timeline are streamed.
+  // backfillQuery('asset', ...) places `asset` as the base table, so the gate
+  // can reference asset.ownerId and asset.visibility directly.
+  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
+  getBackfill(options: SyncBackfillOptions, libraryId: string, userId: string) {
     return this.backfillQuery('asset', options)
       .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
       .select(columns.syncAssetExif)
       .select('asset.updateId')
       .where('asset.libraryId', '=', libraryId)
+      .where((eb) => eb.or([eb('asset.ownerId', '=', userId), spaceVisibilityGate(eb)]))
       .stream();
   }
 
   // Single upsert stream — same rationale as LibraryAssetSync.getUpserts.
+  //
+  // M3 visibility gate: upsertQuery('asset_exif', ...) places asset_exif as
+  // the base table; we innerJoin asset so asset.ownerId and asset.visibility
+  // are reachable for the M3 gate. The libraryId scope is expressed as a
+  // direct WHERE on asset.libraryId (available after the join) rather than
+  // a subquery, matching the style used by SharedSpaceAssetExifSync.
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getUpserts(options: SyncQueryOptions) {
     return this.upsertQuery('asset_exif', options)
+      .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
       .select(columns.syncAssetExif)
       .select('asset_exif.updateId')
-      .where('assetId', 'in', (eb) =>
-        eb
-          .selectFrom('asset')
-          .select('asset.id')
-          .where('asset.libraryId', 'is not', null)
-          .where('asset.libraryId', 'in', (eb2) => accessibleLibraries(eb2, options.userId)),
-      )
+      .where('asset.libraryId', 'is not', null)
+      .where('asset.libraryId', 'in', (eb) => accessibleLibraries(eb, options.userId))
+      .where((eb) => eb.or([eb('asset.ownerId', '=', options.userId), spaceVisibilityGate(eb)]))
       .stream();
   }
 }

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -5,7 +5,7 @@ import { columns } from 'src/database';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { DB } from 'src/schema';
 import { SyncAck } from 'src/types';
-import { accessibleSpaceAlbums, accessibleSpaces } from 'src/utils/shared-space-album-scope';
+import { accessibleSpaceAlbums, accessibleSpaces, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 // Re-export the relocated scoping helpers so existing `sync.repository` importers
 // keep working after the definitions moved to the fork-owned scope module.
@@ -1000,6 +1000,7 @@ export class SharedSpaceAssetSync extends BaseSync {
       )
       .select('shared_space_asset.updateId')
       .where('shared_space_asset.spaceId', '=', spaceId)
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1025,6 +1026,7 @@ export class SharedSpaceAssetSync extends BaseSync {
       )
       .select('shared_space_asset.updateId')
       .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1051,6 +1053,7 @@ export class SharedSpaceAssetSync extends BaseSync {
       .select('asset.updateId')
       .where('shared_space_asset.updateId', '<=', sharedSpaceToAssetAck.updateId)
       .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
   // Note: shared_space_asset_audit cleanup is owned by SharedSpaceToAssetSync below,
@@ -1062,9 +1065,11 @@ export class SharedSpaceAssetExifSync extends BaseSync {
   getBackfill(options: SyncBackfillOptions, spaceId: string) {
     return this.backfillQuery('shared_space_asset', options)
       .innerJoin('asset_exif', 'asset_exif.assetId', 'shared_space_asset.assetId')
+      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
       .select(columns.syncAssetExif)
       .select('shared_space_asset.updateId')
       .where('shared_space_asset.spaceId', '=', spaceId)
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1072,9 +1077,11 @@ export class SharedSpaceAssetExifSync extends BaseSync {
   getCreates(options: SyncQueryOptions) {
     return this.upsertQuery('shared_space_asset', options)
       .innerJoin('asset_exif', 'asset_exif.assetId', 'shared_space_asset.assetId')
+      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
       .select(columns.syncAssetExif)
       .select('shared_space_asset.updateId')
       .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1082,10 +1089,12 @@ export class SharedSpaceAssetExifSync extends BaseSync {
   getUpdates(options: SyncQueryOptions, sharedSpaceToAssetAck: SyncAck) {
     return this.upsertQuery('asset_exif', options)
       .innerJoin('shared_space_asset', 'shared_space_asset.assetId', 'asset_exif.assetId')
+      .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
       .select(columns.syncAssetExif)
       .select('asset_exif.updateId')
       .where('shared_space_asset.updateId', '<=', sharedSpaceToAssetAck.updateId)
       .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 }
@@ -1544,6 +1553,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .select('album_asset.updateId')
       .where('album_asset.albumId', '=', albumId)
       .where('album.deletedAt', 'is', null)
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1567,6 +1577,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1589,6 +1600,7 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 }
@@ -1602,10 +1614,12 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
     return this.backfillQuery('album_asset', options)
       .innerJoin('asset_exif', 'asset_exif.assetId', 'album_asset.assetId')
       .innerJoin('album', 'album.id', 'album_asset.albumId')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
       .select(columns.syncAssetExif)
       .select('album_asset.updateId')
       .where('album_asset.albumId', '=', albumId)
       .where('album.deletedAt', 'is', null)
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1614,12 +1628,14 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
     const userId = options.userId;
     return this.upsertQuery('asset_exif', options)
       .innerJoin('album_asset', 'album_asset.assetId', 'asset_exif.assetId')
+      .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
       .select(columns.syncAssetExif)
       .select('asset_exif.updateId')
       .where('album_asset.updateId', '<=', albumToAssetAck.updateId) // Ensure we only send exif updates for assets that the client already knows about
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 
@@ -1629,10 +1645,12 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
     return this.upsertQuery('album_asset', options)
       .select('album_asset.updateId')
       .innerJoin('asset_exif', 'asset_exif.assetId', 'album_asset.assetId')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
       .select(columns.syncAssetExif)
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb))
       .stream();
   }
 }

--- a/server/src/repositories/tag.repository.ts
+++ b/server/src/repositories/tag.repository.ts
@@ -8,6 +8,7 @@ import { DB } from 'src/schema';
 import { TagAssetTable } from 'src/schema/tables/tag-asset.table';
 import { TagTable } from 'src/schema/tables/tag.table';
 import { asUuid } from 'src/utils/database';
+import { spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 @Injectable()
 export class TagRepository {
@@ -87,6 +88,7 @@ export class TagRepository {
   private ownedOrSpaceAccessible(eb: ExpressionBuilder<DB, 'tag'>, userId: string) {
     return eb.or([
       eb('tag.userId', '=', asUuid(userId)),
+      // Direct-asset arm: asset must be space-shareable (Archive or Timeline); Hidden/Locked never surface.
       eb.exists(
         eb
           .selectFrom('tag_asset')
@@ -95,8 +97,10 @@ export class TagRepository {
           .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_asset.spaceId')
           .whereRef('tag_asset.tagId', '=', 'tag.id')
           .where('asset.deletedAt', 'is', null)
-          .where('shared_space_member.userId', '=', asUuid(userId)),
+          .where('shared_space_member.userId', '=', asUuid(userId))
+          .where(spaceVisibilityGate(eb as any)),
       ),
+      // Library arm: same visibility gate.
       eb.exists(
         eb
           .selectFrom('tag_asset')
@@ -105,8 +109,10 @@ export class TagRepository {
           .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_library.spaceId')
           .whereRef('tag_asset.tagId', '=', 'tag.id')
           .where('asset.deletedAt', 'is', null)
-          .where('shared_space_member.userId', '=', asUuid(userId)),
+          .where('shared_space_member.userId', '=', asUuid(userId))
+          .where(spaceVisibilityGate(eb as any)),
       ),
+      // Album arm: same visibility gate.
       eb.exists(
         eb
           .selectFrom('tag_asset')
@@ -119,7 +125,8 @@ export class TagRepository {
           .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_album.spaceId')
           .whereRef('tag_asset.tagId', '=', 'tag.id')
           .where('asset.deletedAt', 'is', null)
-          .where('shared_space_member.userId', '=', asUuid(userId)),
+          .where('shared_space_member.userId', '=', asUuid(userId))
+          .where(spaceVisibilityGate(eb as any)),
       ),
     ]);
   }

--- a/server/src/repositories/view-repository.spec.ts
+++ b/server/src/repositories/view-repository.spec.ts
@@ -1,0 +1,28 @@
+import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } from 'kysely';
+import { ViewRepository } from 'src/repositories/view-repository';
+import type { DB } from 'src/schema';
+
+const offlineKysely = () =>
+  new Kysely<DB>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+describe(ViewRepository.name, () => {
+  describe('ownedOrSpaceAccessible', () => {
+    it('album arm requires showInTimeline on folder-view projection surfaces', () => {
+      const db = offlineKysely();
+      const sut = new ViewRepository(db as never);
+      const query = db
+        .selectFrom('asset')
+        .where((eb) => (sut as any).ownedOrSpaceAccessible(eb, '00000000-0000-0000-0000-000000000000'))
+        .selectAll('asset')
+        .compile();
+      expect(query.sql).toContain('"showInTimeline" = ');
+    });
+  });
+});

--- a/server/src/repositories/view-repository.ts
+++ b/server/src/repositories/view-repository.ts
@@ -62,6 +62,7 @@ export class ViewRepository {
         correlateAssetId: 'asset.id',
         correlateLibraryId: 'asset.libraryId',
         scope: { memberUserId: userId },
+        requireShowInTimeline: true,
       }),
     ]);
   }

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -899,6 +899,82 @@ describe(AlbumService.name, () => {
         AlbumUserRole.Viewer,
       );
     });
+
+    it('redacts album-user emails when access is via space grant only (not a participant)', async () => {
+      // spaceViewer is NOT in album.albumUsers — access granted only via checkSpaceLinkedAlbumReadAccess
+      const spaceViewer = UserFactory.create();
+      const album = AlbumFactory.from().albumUser().build();
+      mocks.album.getById.mockResolvedValue(getForAlbum(album));
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set());
+      mocks.access.album.checkSpaceLinkedAlbumReadAccess.mockResolvedValue(new Set([album.id]));
+      mocks.album.getMetadataForIds.mockResolvedValue([
+        {
+          albumId: album.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
+      ]);
+
+      const result = await sut.get(AuthFactory.create(spaceViewer), album.id);
+
+      // albumUsers array must still be present (DTO requires it, web needs it)
+      expect(result.albumUsers.length).toBeGreaterThan(0);
+      // but no email should be exposed
+      for (const albumUser of result.albumUsers) {
+        expect(albumUser.user.email).toBe('');
+      }
+    });
+
+    it('does NOT redact emails when the caller is an album participant (album_user)', async () => {
+      const user = UserFactory.create();
+      const album = AlbumFactory.from().albumUser({ userId: user.id }).build();
+      mocks.album.getById.mockResolvedValue(getForAlbum(album));
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set([album.id]));
+      mocks.album.getMetadataForIds.mockResolvedValue([
+        {
+          albumId: album.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
+      ]);
+
+      const result = await sut.get(AuthFactory.create(user), album.id);
+
+      // Participant should see real emails
+      for (const albumUser of result.albumUsers) {
+        expect(albumUser.user.email).not.toBe('');
+        expect(albumUser.user.email).toContain('@');
+      }
+    });
+
+    it('does NOT redact emails when the caller is the album owner', async () => {
+      const album = AlbumFactory.from().albumUser().build();
+      const { user: owner } = album.albumUsers.find(({ role }) => role === AlbumUserRole.Owner)!;
+      mocks.album.getById.mockResolvedValue(getForAlbum(album));
+      mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([album.id]));
+      mocks.album.getMetadataForIds.mockResolvedValue([
+        {
+          albumId: album.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
+      ]);
+
+      const result = await sut.get(AuthFactory.create(owner), album.id);
+
+      for (const albumUser of result.albumUsers) {
+        expect(albumUser.user.email).not.toBe('');
+        expect(albumUser.user.email).toContain('@');
+      }
+    });
   });
 
   describe('addAssets', () => {

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -99,8 +99,20 @@ export class AlbumService extends BaseService {
     const hasSharedLink = album.sharedLinks && album.sharedLinks.length > 0;
     const isShared = hasSharedUsers || hasSharedLink;
 
+    const mapped = mapAlbum(album);
+
+    // Fix: if the caller is not an album participant (owner or album_user), redact emails.
+    // A space Viewer gets AlbumRead via checkSpaceLinkedAlbumReadAccess (no role filter)
+    // but should not see PII (email) of album participants.
+    const isParticipant = album.albumUsers ? album.albumUsers.some(({ user }) => user.id === auth.user.id) : false;
+    if (!isParticipant) {
+      for (const albumUser of mapped.albumUsers) {
+        albumUser.user.email = '';
+      }
+    }
+
     return {
-      ...mapAlbum(album),
+      ...mapped,
       startDate: asDateTimeString(albumMetadataForIds?.startDate ?? undefined),
       endDate: asDateTimeString(albumMetadataForIds?.endDate ?? undefined),
       assetCount: albumMetadataForIds?.assetCount ?? 0,

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -41,6 +41,11 @@ describe(AssetService.name, () => {
     // handleAssetDeletion now captures affected shared-space people before delete
     // (faces F5); default to empty so unrelated deletion tests don't break.
     mocks.sharedSpace.getSpacePersonsForAsset.mockResolvedValue([]);
+
+    // updateAll now purges/re-adds direct space assets on visibility flip
+    // (Slice 4.B); default to no-op so unrelated update tests don't break.
+    mocks.sharedSpace.emitDirectAssetVisibilityPurge.mockResolvedValue(void 0);
+    mocks.sharedSpace.emitDirectAssetVisibilityRestore.mockResolvedValue(void 0);
   });
 
   describe('getStatistics', () => {
@@ -1026,6 +1031,39 @@ describe(AssetService.name, () => {
       });
 
       expect(mocks.album.removeAssetsFromAll).not.toHaveBeenCalled();
+    });
+
+    it.each([[AssetVisibility.Hidden], [AssetVisibility.Locked]])(
+      'should purge direct space assets from member devices when visibility is %s',
+      async (visibility) => {
+        mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+
+        await sut.updateAll(authStub.admin, { ids: ['asset-1'], visibility });
+
+        expect(mocks.sharedSpace.emitDirectAssetVisibilityPurge).toHaveBeenCalledWith(['asset-1']);
+        expect(mocks.sharedSpace.emitDirectAssetVisibilityRestore).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([[AssetVisibility.Timeline], [AssetVisibility.Archive]])(
+      'should re-add direct space assets to member devices when visibility is %s',
+      async (visibility) => {
+        mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+
+        await sut.updateAll(authStub.admin, { ids: ['asset-1'], visibility });
+
+        expect(mocks.sharedSpace.emitDirectAssetVisibilityRestore).toHaveBeenCalledWith(['asset-1']);
+        expect(mocks.sharedSpace.emitDirectAssetVisibilityPurge).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should not touch direct space assets when visibility is not provided', async () => {
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+
+      await sut.updateAll(authStub.admin, { ids: ['asset-1'], isFavorite: true });
+
+      expect(mocks.sharedSpace.emitDirectAssetVisibilityPurge).not.toHaveBeenCalled();
+      expect(mocks.sharedSpace.emitDirectAssetVisibilityRestore).not.toHaveBeenCalled();
     });
 
     it('should not call updateAllExif when no exif fields are provided', async () => {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -313,6 +313,18 @@ export class AssetService extends BaseService {
       await this.albumRepository.removeAssetsFromAll(ids);
     }
 
+    // Slice 4.B: a visibility flip deletes no shared_space_asset join row, so the
+    // delete-audit trigger never fires and already-synced member devices keep the
+    // bytes. Explicitly purge (Hidden/Locked) or re-add (Timeline/Archive) the
+    // DIRECT space-asset path so member devices converge. Album-linked and
+    // library paths are separate follow-ups; album+Locked is already covered by
+    // removeAssetsFromAll above.
+    if (visibility === AssetVisibility.Hidden || visibility === AssetVisibility.Locked) {
+      await this.sharedSpaceRepository.emitDirectAssetVisibilityPurge(ids);
+    } else if (visibility === AssetVisibility.Timeline || visibility === AssetVisibility.Archive) {
+      await this.sharedSpaceRepository.emitDirectAssetVisibilityRestore(ids);
+    }
+
     await this.jobRepository.queueAll(ids.map((id) => ({ name: JobName.SidecarWrite, data: { id } })));
   }
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -8071,7 +8071,8 @@ describe(SharedSpaceService.name, () => {
         createdAt: (row.createdAt as Date).toISOString(),
       });
       expect(result[0].createdAt).not.toEqual(result[0].linkedAt);
-      expect(result[0].albumUsers[0].user.name).toBe('Owner One');
+      // albumUsers must NOT appear in the linked-album DTO (Slice 7 PII strip)
+      expect((result[0] as unknown as Record<string, unknown>)['albumUsers']).toBeUndefined();
     });
 
     it('bulk-fetches metadata once and never calls the per-album N+1 count', async () => {
@@ -8111,7 +8112,7 @@ describe(SharedSpaceService.name, () => {
       expect(result[0].endDate).toBeUndefined();
     });
 
-    it('marks a multi-user album as shared', async () => {
+    it('marks a multi-user album as shared and does NOT expose albumUsers (Slice 7)', async () => {
       const row = makeRichRow({
         albumUsers: [
           { role: AlbumUserRole.Owner, user: factory.user({ name: 'Owner' }) },
@@ -8125,7 +8126,8 @@ describe(SharedSpaceService.name, () => {
       );
       const result = await sut.getLinkedAlbums(auth, space.id);
       expect(result[0].shared).toBe(true);
-      expect(result[0].albumUsers).toHaveLength(2);
+      // albumUsers must NOT be present in the linked-album DTO (PII strip)
+      expect((result[0] as unknown as Record<string, unknown>)['albumUsers']).toBeUndefined();
     });
 
     it('preserves null addedById, null thumbnail, and showInTimeline=false', async () => {

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -61,6 +61,7 @@ const makeMemberResult = (overrides: any = {}) => ({
 
 const makeRichRow = (over: Record<string, unknown> = {}) => {
   const albumId = newUuid();
+  const ownerUser = factory.user({ name: 'Owner One' });
   return {
     id: albumId,
     albumName: 'My Album',
@@ -70,7 +71,8 @@ const makeRichRow = (over: Record<string, unknown> = {}) => {
     updatedAt: new Date('2024-06-02T00:00:00.000Z'),
     isActivityEnabled: true,
     order: AssetOrder.Desc,
-    albumUsers: [{ role: AlbumUserRole.Owner, user: factory.user({ name: 'Owner One' }) }],
+    ownerId: ownerUser.id,
+    albumUsers: [{ role: AlbumUserRole.Owner, user: ownerUser }],
     sharedLinks: [],
     addedById: newUuid(),
     showInTimeline: true,
@@ -8141,6 +8143,24 @@ describe(SharedSpaceService.name, () => {
       expect(result[0].addedById).toBeNull();
       expect(result[0].albumThumbnailAssetId).toBeNull();
       expect(result[0].showInTimeline).toBe(false);
+    });
+
+    it('exposes ownerId (album owner UUID) and does NOT expose email or albumUsers', async () => {
+      const ownerUserId = newUuid();
+      const row = makeRichRow({ ownerId: ownerUserId });
+      const { auth, space } = arrange(
+        mocks,
+        [row],
+        [{ albumId: row.id, assetCount: 1, startDate: null, endDate: null, lastModifiedAssetTimestamp: null }],
+      );
+
+      const result = await sut.getLinkedAlbums(auth, space.id);
+
+      expect(result[0].ownerId).toBe(ownerUserId);
+      expect((result[0] as unknown as Record<string, unknown>)['albumUsers']).toBeUndefined();
+      // must not leak any user email
+      const json = JSON.stringify(result[0]);
+      expect(json).not.toContain('@');
     });
 
     it('rejects a non-member with ForbiddenException', async () => {

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -709,6 +709,7 @@ export class SharedSpaceService extends BaseService {
       const { albumUsers: _albumUsers, ...albumFields } = mapAlbum(row as unknown as MapAlbumDto);
       return {
         ...albumFields,
+        ownerId: (row as unknown as { ownerId: string }).ownerId,
         startDate: asDateTimeString(byId[row.id]?.startDate ?? undefined),
         endDate: asDateTimeString(byId[row.id]?.endDate ?? undefined),
         assetCount: byId[row.id]?.assetCount ?? 0,

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -705,17 +705,19 @@ export class SharedSpaceService extends BaseService {
     for (const m of metadata) {
       byId[m.albumId] = m;
     }
-    return rows.map((row) => ({
-      ...mapAlbum(row as unknown as MapAlbumDto),
-      sharedLinks: undefined,
-      startDate: asDateTimeString(byId[row.id]?.startDate ?? undefined),
-      endDate: asDateTimeString(byId[row.id]?.endDate ?? undefined),
-      assetCount: byId[row.id]?.assetCount ?? 0,
-      lastModifiedAssetTimestamp: asDateTimeString(byId[row.id]?.lastModifiedAssetTimestamp ?? undefined),
-      showInTimeline: row.showInTimeline,
-      addedById: row.addedById,
-      linkedAt: (row.linkedAt as unknown as Date).toISOString(),
-    }));
+    return rows.map((row) => {
+      const { albumUsers: _albumUsers, ...albumFields } = mapAlbum(row as unknown as MapAlbumDto);
+      return {
+        ...albumFields,
+        startDate: asDateTimeString(byId[row.id]?.startDate ?? undefined),
+        endDate: asDateTimeString(byId[row.id]?.endDate ?? undefined),
+        assetCount: byId[row.id]?.assetCount ?? 0,
+        lastModifiedAssetTimestamp: asDateTimeString(byId[row.id]?.lastModifiedAssetTimestamp ?? undefined),
+        showInTimeline: row.showInTimeline,
+        addedById: row.addedById,
+        linkedAt: (row.linkedAt as unknown as Date).toISOString(),
+      };
+    });
   }
 
   async unlinkLibrary(auth: AuthDto, spaceId: string, libraryId: string): Promise<void> {

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -853,6 +853,7 @@ export class SyncService extends BaseService {
         const backfill = this.syncRepository.libraryAsset.getBackfill(
           { ...options, afterUpdateId: startId, beforeUpdateId: endId },
           library.id,
+          options.userId,
         );
 
         for await (const { updateId, ...data } of backfill) {
@@ -904,6 +905,7 @@ export class SyncService extends BaseService {
         const backfill = this.syncRepository.libraryAssetExif.getBackfill(
           { ...options, afterUpdateId: startId, beforeUpdateId: endId },
           library.id,
+          options.userId,
         );
 
         for await (const { updateId, ...data } of backfill) {

--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -98,6 +98,39 @@ describe(TimelineService.name, () => {
         await expect(sut.getTimeBuckets(authStub.admin, { spaceId: 'space-id' })).rejects.toThrow(BadRequestException);
       });
 
+      it('rejects Hidden/Locked visibility on a spaceId browse (Fix A defense-in-depth)', async () => {
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
+
+        await expect(
+          sut.getTimeBuckets(authStub.adminWithElevatedPermission, {
+            spaceId: 'space-id',
+            visibility: AssetVisibility.Hidden,
+          }),
+        ).rejects.toThrow(BadRequestException);
+        await expect(
+          sut.getTimeBuckets(authStub.adminWithElevatedPermission, {
+            spaceId: 'space-id',
+            visibility: AssetVisibility.Locked,
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(mocks.asset.getTimeBuckets).not.toHaveBeenCalled();
+      });
+
+      it('rejects Hidden/Locked visibility on a spacePersonId browse (Fix A defense-in-depth)', async () => {
+        mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
+
+        await expect(
+          sut.getTimeBuckets(authStub.adminWithElevatedPermission, {
+            spaceId: 'space-id',
+            spacePersonId: 'person-id',
+            visibility: AssetVisibility.Hidden,
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(mocks.asset.getTimeBuckets).not.toHaveBeenCalled();
+      });
+
       it('should pass spaceId to asset repository', async () => {
         mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set(['space-id']));
         mocks.asset.getTimeBuckets.mockResolvedValue([{ timeBucket: '2024-01-01', count: 1 }]);

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -124,6 +124,19 @@ export class TimelineService extends BaseService {
       requireElevatedPermission(auth);
     }
 
+    // Fork RBAC (Fix A) defense-in-depth: a pure space browse (spaceId / spacePersonId, no
+    // per-user timeline) must never request Hidden/Locked — those are owner-private states that
+    // make no sense across a shared scope. The repository query gates other members' Hidden/Locked
+    // regardless, but rejecting here short-circuits the leak vector before it reaches the DB. The
+    // per-user timeline paths (userId / withSharedSpaces) are intentionally untouched so a caller
+    // can still view their OWN hidden assets.
+    const spaceBrowse = !!dto.spaceId || !!dto.spacePersonId;
+    const requestsPrivateVisibility =
+      dto.visibility === AssetVisibility.Hidden || dto.visibility === AssetVisibility.Locked;
+    if (spaceBrowse && requestsPrivateVisibility) {
+      throw new BadRequestException('Hidden and locked assets are not available when browsing a shared space');
+    }
+
     if (dto.albumId) {
       await this.requireAccess({ auth, permission: Permission.AlbumRead, ids: [dto.albumId] });
     } else if (dto.spaceId) {

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -619,18 +619,28 @@ export function albumSharedSpaceScope<O>(qb: SelectQueryBuilder<DB, 'asset', O>,
       ]),
       ...(timelineSpaceIds
         ? [
-            eb.exists(
-              eb
-                .selectFrom('shared_space_asset')
-                .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                .where('shared_space_asset.spaceId', '=', anyUuid(timelineSpaceIds)),
-            ),
-            eb.exists(
-              eb
-                .selectFrom('shared_space_library')
-                .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                .where('shared_space_library.spaceId', '=', anyUuid(timelineSpaceIds)),
-            ),
+            // Space-linked assets via direct asset membership: gate on Archive + Timeline
+            // (matches the album view's withDefaultVisibility; Hidden/Locked must not
+            // surface for viewers who are not the asset owner).
+            eb.and([
+              spaceVisibilityGate(eb),
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_asset')
+                  .whereRef('shared_space_asset.assetId', '=', 'asset.id')
+                  .where('shared_space_asset.spaceId', '=', anyUuid(timelineSpaceIds)),
+              ),
+            ]),
+            // Space-linked assets via library membership: same Archive + Timeline gate.
+            eb.and([
+              spaceVisibilityGate(eb),
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_library')
+                  .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
+                  .where('shared_space_library.spaceId', '=', anyUuid(timelineSpaceIds)),
+              ),
+            ]),
           ]
         : []),
     ]),

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -30,7 +30,7 @@ import { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
 import { DB } from 'src/schema';
 import { AssetExifTable } from 'src/schema/tables/asset-exif.table';
 import { AudioStreamInfo, VectorExtension, VideoFormat, VideoPacketInfo, VideoStreamInfo } from 'src/types';
-import { spaceAssetPathBranches } from 'src/utils/shared-space-album-scope';
+import { spaceAssetPathBranches, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 import { dateTruncUnitForTimeBucketSize } from 'src/utils/timeline-bucket';
 
 export const getKyselyConfig = (connection: DatabaseConnectionParams): KyselyConfig => {
@@ -664,13 +664,13 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
               requireShowInTimeline: true,
             }),
           ),
-          // Fork RBAC (M3): elevation only unlocks the CALLER'S OWN locked/archived folder. The
-          // caller's own (and partner) rows follow the resolved visibility applied above; every
-          // OTHER space member's row is constrained to Timeline, so a space-scoped search can never
-          // surface another member's Archived/Hidden/Locked asset.
+          // Fork RBAC (M3/Slice 10): elevation only unlocks the CALLER'S OWN locked/archived
+          // folder. The caller's own (and partner) rows follow the resolved visibility applied
+          // above; every OTHER space member's row is constrained to Archive+Timeline (matching the
+          // browse / timeline gate) — Hidden and Locked are never surfaced for other members.
           eb.or([
             ...(options.userIds ? [eb('asset.ownerId', '=', anyUuid(options.userIds))] : []),
-            eb('asset.visibility', '=', AssetVisibility.Timeline),
+            spaceVisibilityGate(eb),
           ]),
         ]),
       ),
@@ -680,9 +680,10 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
         eb.or([
           // Caller's own (and partner) rows follow the resolved visibility applied above.
           eb('asset.ownerId', '=', anyUuid(options.userIds!)),
-          // Other space members' rows are always Timeline-only (elevation is per-owner, M3).
+          // Other space members' rows are Archive+Timeline (Slice 10 aligns search with browse;
+          // elevation is per-owner, Hidden/Locked never surface for other members).
           eb.and([
-            eb('asset.visibility', '=', AssetVisibility.Timeline),
+            spaceVisibilityGate(eb),
             eb.or(
               spaceAssetPathBranches(eb, {
                 correlateAssetId: 'asset.id',

--- a/server/src/utils/shared-space-album-scope.guard.spec.ts
+++ b/server/src/utils/shared-space-album-scope.guard.spec.ts
@@ -9,6 +9,10 @@
 // Benign non-scope references (CRUD, column lists, library-only sync helpers) are
 // filtered by pattern; genuine non-3-path sites are named in ALLOWLIST with a
 // reason. Two ALLOWLIST entries are GAPS this very guard discovered — see below.
+//
+// Slice 11 adds a SECOND, INDEPENDENT scan (at the bottom): every space asset
+// read must reference the visibility gate. The two scans share the same file list
+// but have separate allowlists so neither pollutes the other's invariant.
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -55,8 +59,10 @@ const ALLOWLIST: Record<string, string> = {
   // (space editors can add/remove but not metadata-edit linked-album assets). Out
   // of scope for this behavior-preserving consolidation; tracked separately.
   checkSpaceEditAccess: 'known RBAC gap: AssetUpdate has no space-album arm (pre-existing)',
-  // Pre-existing coverage gap: this map-markers path never had an album leg.
-  getMapMarkers: 'known coverage gap: shared-space map markers omit the album path (pre-existing)',
+  // NOTE: map.repository.ts:getMapMarkers was fixed by Slice 9. The space-specific
+  // getMapMarkers in shared-space.repository.ts (GET /shared-spaces/:id/map-markers)
+  // still lacks the album arm — pre-existing gap, tracked separately.
+  getMapMarkers: 'GUARD-DISCOVERED gap: union(direct,library) omits album arm (pre-existing, follow-up)',
   // GUARD-DISCOVERED pre-existing missing-album gaps (not in the review's inventory,
   // which only grepped shared_space_album). Both OR direct+library but omit the
   // album arm, so an album-only asset is invisible to them. Flagged for follow-up;
@@ -81,6 +87,32 @@ const NON_DECL = new Set([
   'filter',
   'forEach',
   'then',
+  // SQL keywords that appear as the first token in raw sql`` template literal lines
+  // and would otherwise be misidentified as TypeScript function names by DECL.
+  'AND',
+  'OR',
+  'FROM',
+  'WHERE',
+  'INNER',
+  'LEFT',
+  'RIGHT',
+  'UNION',
+  'SELECT',
+  'ON',
+  'WITH',
+  'GROUP',
+  'HAVING',
+  'ORDER',
+  'LIMIT',
+  'OFFSET',
+  'NOT',
+  'IN',
+  'AS',
+  'CASE',
+  'WHEN',
+  'THEN',
+  'ELSE',
+  'END',
 ]);
 
 const enclosingFn = (lines: string[], i: number): string => {
@@ -128,6 +160,171 @@ describe('space-album scope guard: every library scoping arm has album coverage'
         `Add the album leg (route it through spaceAlbumAssetExists / spaceAssetPathBranches /\n` +
         `spaceAlbumAssetExistsSql) or, if genuinely album-free, add the enclosing function to\n` +
         `ALLOWLIST with a reason.\n` +
+        orphans.join('\n'),
+    ).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SCAN 2 (Slice 11): VISIBILITY-GATE scan
+//
+// Every repository query that space-scopes an asset read (joins
+// shared_space_asset / shared_space_library / shared_space_album and
+// selects / returns asset rows) must reference the visibility gate — either:
+//   - spaceVisibilityGate (most surfaces)
+//   - spaceVisibleAssetVisibilities / visibleSpaceAssetVisibilities (shared-space repo)
+//   - peopleAssetVisibilities (people stats)
+//   - AssetVisibility.Timeline or AssetVisibility.Archive (tighter gates: map, memory, view)
+//
+// The scan looks for any line containing `shared_space_asset`, `shared_space_library`,
+// or `shared_space_album` (excluding comments and benign CRUD) and verifies that
+// the enclosing function has at least one visibility-gate token within ±WINDOW lines.
+//
+// This scan uses its OWN separate allowlist — do NOT merge with ALLOWLIST above.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A space scoping reference (asset read, not CRUD) is "visibility-gated" if any
+// of these tokens appear within ±VIS_WINDOW lines of it.
+//
+// The last two alternatives cover sync stream classes that select from a LINK
+// table (shared_space_library / shared_space_album) to stream metadata rows —
+// NOT asset rows. The presence of *_SYNC_COLUMNS (which contain only link-table
+// columns like libraryId, spaceId, showInTimeline) confirms the query is a
+// link-metadata stream and NOT an asset read. Asset visibility is enforced in
+// the corresponding asset-specific stream classes (SharedSpaceAssetSync etc.).
+const VIS_GATE_MARKER =
+  /spaceVisibilityGate|spaceVisibleAssetVisibilities|visibleSpaceAssetVisibilities|peopleAssetVisibilities|AssetVisibility\.Timeline|AssetVisibility\.Archive|SHARED_SPACE_LIBRARY_SYNC_COLUMNS|SHARED_SPACE_ALBUM_SYNC_COLUMNS|visibilityFilter/;
+
+// Lines that reference shared_space_* but are NOT asset-read scoping arms
+// (mirrors the album-leg BENIGN_LINE filter, plus shared_space_album CRUD).
+const VIS_BENIGN_LINE = [
+  /(insertInto|deleteFrom|updateTable|backfillQuery)\(\s*['"]shared_space/, // CRUD / sync backfill
+  /^'shared_space[^']+\.\w+',?$/, // column-list entry
+  /accessibleLibraries|library_user|library_asset|library_audit/, // library-only sync helpers
+  /accessibleSpaceAlbums|accessibleSpaces/, // helper call references (not inline scoping)
+  /shared_space_member/, // membership-only references (not asset-read arms)
+  /shared_space_audit|shared_space_person|shared_space_library_audit/, // audit/person tables
+  // SharedSpaceLibrarySync / SharedSpaceAlbumLinkSync: these stream link-table rows
+  // (libraryId/albumId/spaceId metadata), NOT asset rows. The backfill/upsert queries
+  // select from the link table directly. Asset visibility is enforced in the separate
+  // SharedSpaceAssetSync / SharedSpaceAlbumAssetSync stream classes.
+  /SHARED_SPACE_LIBRARY_SYNC_COLUMNS|SHARED_SPACE_ALBUM_SYNC_COLUMNS/, // link-table column sets
+];
+
+// Scoping references that legitimately have no nearby visibility gate, keyed by
+// enclosing function name. Add here with a one-line reason ONLY.
+const VIS_ALLOWLIST: Record<string, string> = {
+  // Returns a boolean (is asset in space?), not a full asset row set.
+  // Gated upstream by checkSpaceAccess before any asset data is served.
+  isAssetInSpace: 'membership-presence check only; no asset data returned; gated upstream',
+  // Returns user/space metadata (who can edit?), not asset rows.
+  // Visibility-gated (Slice 10) but no album arm — on album-leg ALLOWLIST.
+  checkSpaceEditAccess: 'visibility-gated (Slice 10) via spaceVisibilityGate; on album-leg allowlist',
+  // Absence-gate (confirms asset is NOT already in space via another path).
+  // Reads album/library/direct rows to check absence, not to return asset data to client.
+  albumSharedSpaceScope: 'absence gate; checks non-membership, not asset data exposure',
+  // Returns space-person linked to a global person, not asset rows.
+  findSpacePersonByLinkedPersonId: 'returns space-person metadata, not asset rows',
+  // Union absence check for removeAssets — checks existing space membership.
+  getAssetIdsWithoutOtherSpacePath: 'membership check for removals; no asset data returned to client',
+  getAlbumAssetIdsWithoutOtherSpacePath: 'membership check for removals; no asset data returned to client',
+  // Returns the libraryId of a linked library, not asset rows.
+  getLinkedLibraries: 'returns library metadata, not asset rows',
+  // Returns space-level statistics (member counts, etc.), not asset rows.
+  getSpaceStats: 'space-level statistics; no asset rows returned',
+  // findSpaceForAssetAndUser: membership lookup returning space/role metadata.
+  // GUARD-DISCOVERED gap on album-leg allowlist; visibility gated upstream.
+  findSpaceForAssetAndUser: 'membership lookup; returns space/role, not asset data; visibility gated upstream',
+  // getPersonalThumbnailForSpacePerson: returns thumbnail face metadata (one face),
+  // not a user-visible asset set. GUARD-DISCOVERED gap on album-leg allowlist.
+  getPersonalThumbnailForSpacePerson: 'returns face thumbnail path, not a user-visible asset set; gated upstream',
+  // Sync backfill helpers: operate on shared_space_{member,audit} tables as part
+  // of the sync protocol, not as direct asset-read scoping. Asset visibility is
+  // enforced in the asset-specific sync streams (SharedSpaceAssetSync etc.).
+  backfillQuery: 'sync infrastructure; asset visibility enforced in stream classes',
+  upsertQuery: 'sync infrastructure; asset visibility enforced in stream classes',
+  auditQuery: 'sync audit query; no asset rows returned',
+  // Cleanup helpers that delete memory_asset rows based on visibility — the
+  // AssetVisibility.Timeline check IS the deletion criterion, not a read gate.
+  cleanup: 'memory cleanup; AssetVisibility.Timeline used as deletion criterion, not a read gate',
+  // Returns library IDs (not asset rows) accessible to the user via owned or space-linked libraries.
+  accessibleLibraries: 'returns library IDs only, not asset rows; visibility enforced in asset-stream queries',
+  // Streams shared_space_library LINK rows (libraryId, spaceId metadata), NOT asset rows.
+  // Asset visibility is enforced in SharedSpaceAssetExifSync and LibraryAssetSync.
+  SharedSpaceLibrarySync: 'streams library-link metadata rows, not asset rows; visibility in asset streams',
+  // Streams shared_space_album LINK rows (albumId, spaceId, showInTimeline), NOT asset rows.
+  // Asset visibility is enforced in SharedSpaceAlbumAssetSync and SharedSpaceAlbumAssetExifSync.
+  SharedSpaceAlbumLinkSync: 'streams album-link metadata rows, not asset rows; visibility in asset streams',
+  // Returns album IDs (not asset rows) that a user can edit/read via a space link.
+  // Actual asset visibility is enforced downstream when the album download happens.
+  checkSpaceLinkedAlbumAccess: 'returns album IDs only, not asset rows; asset visibility enforced downstream',
+  checkSpaceLinkedAlbumReadAccess: 'returns album IDs only, not asset rows; asset visibility enforced downstream',
+  // Returns addedById (user IDs) for who added a face to the space — not asset data.
+  getSpacePersonAssetAdderIds: 'returns addedById attribution (user IDs), not asset data',
+  // Returns addedById for who added a specific asset to the space (via direct/library/album).
+  // Selects only shared_space_{asset,library,album}.addedById — no asset content exposed.
+  getSpaceAssetAdder: 'returns addedById attribution only; no asset content returned to client',
+  // Returns (spaceId, albumId, showInTimeline, faceRecognitionEnabled) link metadata.
+  // Used for fan-out to find which spaces a linked album feeds — no asset rows returned.
+  getSpacesLinkedToAlbum: 'returns space-album link metadata (spaceId, albumId, flags), not asset rows',
+  // Returns album metadata rows (albumName, thumbnailAssetId, etc.) for albums linked to
+  // a space — used for management UI listing. Does NOT return individual asset content.
+  getLinkedAlbums: 'returns album metadata rows for management UI; no individual asset content',
+  // Returns a boolean (does this space-library link exist?), not asset rows.
+  hasLibraryLink: 'boolean membership check; returns true/false, not asset data',
+  // Reads shared_space_asset rows to INSERT them into shared_space_asset_audit —
+  // this is write infrastructure for the visibility-purge sync mechanism, not
+  // a client-facing asset read. Asset data is never returned to callers.
+  emitDirectAssetVisibilityPurge:
+    'sync purge infrastructure; inserts into audit table, no asset data returned to client',
+  // Returns library-link metadata rows (spaceId, libraryId, faceRecognitionEnabled)
+  // for fan-out to find which spaces a library feeds. No asset content exposed.
+  getSpacesLinkedToLibrary: 'returns library-link metadata (spaceId, libraryId, flags), not asset rows',
+};
+
+const SPACE_ASSET_REF = /\bshared_space_asset\b|\bshared_space_library\b|\bshared_space_album\b/;
+const VIS_WINDOW = 50;
+
+describe('space-visibility gate guard: every space asset read has a visibility gate', () => {
+  it.each(SCOPING_FILES)('%s', (file) => {
+    const lines = readFileSync(join(SERVER_ROOT, file), 'utf8').split('\n');
+    const orphans: string[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const raw = lines[i];
+      const trimmed = raw.trim();
+
+      // Skip comments
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+        continue;
+      }
+      // Skip non-space-scoping lines
+      if (!SPACE_ASSET_REF.test(raw)) {
+        continue;
+      }
+      // Skip benign CRUD / non-read-scoping lines
+      if (VIS_BENIGN_LINE.some((re) => re.test(trimmed))) {
+        continue;
+      }
+
+      const fn = enclosingFn(lines, i);
+      if (VIS_ALLOWLIST[fn]) {
+        continue;
+      }
+
+      const lo = Math.max(0, i - VIS_WINDOW);
+      const hi = Math.min(lines.length, i + VIS_WINDOW + 1);
+      const covered = lines.slice(lo, hi).some((l) => VIS_GATE_MARKER.test(l));
+      if (!covered) {
+        orphans.push(`${file}:${i + 1} (in ${fn}): ${trimmed.slice(0, 90)}`);
+      }
+    }
+
+    expect(
+      orphans,
+      `space asset read arm(s) with no nearby visibility gate.\n` +
+        `Add spaceVisibilityGate / visibleSpaceAssetVisibilities / AssetVisibility.Timeline\n` +
+        `to the query, or add the enclosing function to VIS_ALLOWLIST with a reason.\n` +
         orphans.join('\n'),
     ).toEqual([]);
   });

--- a/server/src/utils/shared-space-album-scope.guard.spec.ts
+++ b/server/src/utils/shared-space-album-scope.guard.spec.ts
@@ -1,78 +1,88 @@
-// Slice 4 — backstop guard (spec §2.5). The recurring space-album defect class is
-// "a 3-path access-scoping branch gains a shared_space_library arm but forgets the
-// shared_space_album arm" (the historical F1 bug). This test scans every scoping
-// file and asserts that each shared_space_library scoping reference has a nearby
-// linked-album marker — either raw `shared_space_album` OR a call to one of the
-// fork-owned album-scope helpers. It fires on any future clone (fork or upstream
-// rebase) that omits the album leg.
+// Static regression guards for the shared-space "linked album" access path.
 //
-// Benign non-scope references (CRUD, column lists, library-only sync helpers) are
-// filtered by pattern; genuine non-3-path sites are named in ALLOWLIST with a
-// reason. Two ALLOWLIST entries are GAPS this very guard discovered — see below.
+// Two INDEPENDENT scans over the same dynamically-derived file set:
 //
-// Slice 11 adds a SECOND, INDEPENDENT scan (at the bottom): every space asset
-// read must reference the visibility gate. The two scans share the same file list
-// but have separate allowlists so neither pollutes the other's invariant.
-import { readFileSync } from 'node:fs';
+//   Scan 1 (album-leg): the recurring space-album defect class is "a 3-path
+//     access-scoping branch gains a shared_space_library arm but forgets the
+//     shared_space_album arm" (the historical F1 bug). Every shared_space_library
+//     scoping reference must have a nearby linked-album marker.
+//
+//   Scan 2 (visibility-gate): every space asset read must exclude other members'
+//     Hidden/Locked assets. This is the class of leak that Fixes A (timeline),
+//     B (library-sync), C (activity), D (album search/facets) and I (redaction)
+//     closed. Every space-read function must reference a visibility gate.
+//
+// ── Why this rewrite (fixF / re-audit F3) ──────────────────────────────────
+// The previous Scan 2 was structurally too weak and NO-OP'd on the very files
+// that leaked:
+//   1. It used a HARDCODED file list, so a space read in an unlisted file was
+//      invisible.
+//   2. It keyed ONLY on `shared_space_*` table literals, but `asset.repository.ts`
+//      and `view-repository.ts` scope via the `spaceAssetPathBranches()` helper and
+//      contain ZERO such literals — so the guard scanned them as no-ops.
+//
+// This version fixes both:
+//   • The file set is DERIVED DYNAMICALLY — glob every repository + utils/database.ts
+//     and keep any file that contains a space-read marker (see SPACE_READ_MARKER).
+//   • A space read is detected by HELPER CALL *or* table literal, so helper-only
+//     files (asset/view) are now scanned.
+//   • The allowlist is keyed by `file::function` (not bare function name), so a
+//     collision like getMapMarkers (fixed in map.repository.ts, still album-gapped
+//     in shared-space.repository.ts) resolves to the correct site.
+//
+// ── What Scan 2 catches (self-test) ────────────────────────────────────────
+//   • A new/rebased space read that joins shared_space_asset/library/album (or
+//     routes through a space helper) and returns asset rows WITHOUT a nearby
+//     visibility gate → flagged as an orphan (the timeline/library/activity leak
+//     shape).
+//   • A helper-scoped read (spaceAssetPathBranches / spaceAlbumAssetExists*) whose
+//     caller drops the visibility gate → flagged, because the helpers themselves
+//     do NOT carry visibility (they only encode the access PATH, not the gate).
+//
+//   • It does NOT catch album-scoped reads that never touch a shared_space_* table
+//     or space helper (e.g. activity.repository, which filters by albumId with an
+//     inline DEFAULT_VISIBILITY gate). Those are outside this guard's detection
+//     model by construction; Fix C covers them with its own unit tests.
+//
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // Server root — vitest runs with cwd at server/ (matches face-identity-query-shape.spec.ts).
 const SERVER_ROOT = process.cwd();
 
-const SCOPING_FILES = [
-  'src/repositories/shared-space.repository.ts',
-  'src/repositories/sync.repository.ts',
-  'src/repositories/face-identity.repository.ts',
-  'src/repositories/search.repository.ts',
-  'src/repositories/asset.repository.ts',
-  'src/repositories/access.repository.ts',
-  'src/utils/database.ts',
-  'src/repositories/map.repository.ts',
-  'src/repositories/view-repository.ts',
-  'src/repositories/memory.repository.ts',
-  'src/repositories/tag.repository.ts',
-  'src/repositories/download.repository.ts',
-];
+const REPO_DIR = 'src/repositories';
+const EXTRA_FILES = ['src/utils/database.ts'];
 
-// A shared_space_library reference has "album coverage" if any of these appear
-// within +-WINDOW lines: the raw album table, or a fork album-scope helper call.
-const ALBUM_MARKER =
-  /shared_space_album|spaceAlbumAssetExists|spaceAssetPathBranches|spaceAlbumAssetExistsSql|accessibleSpaceAlbums/;
-const LIBRARY_REF = /\bshared_space_library\b/;
-const WINDOW = 45;
+// Fork-owned space-scope helpers. A call to any of these IS a space read (they
+// encode the direct/library/album access path). Detected as bare identifiers so a
+// call, spread, or import all count.
+const SPACE_HELPER =
+  /\b(spaceAssetPathBranches|spaceAlbumAssetExists|spaceAlbumAssetExistsSql|spaceDirectAssetExists|spaceLibraryAssetExists|accessibleSpaces|accessibleSpaceAlbums|accessibleLibraries)\b/;
 
-// Lines that reference shared_space_library but are NOT a 3-path access-scope arm.
-const BENIGN_LINE = [
-  /(insertInto|deleteFrom|updateTable|backfillQuery)\(\s*['"]shared_space_library/, // CRUD / sync backfill
-  /^'shared_space_library\.\w+',?$/, // column-list entry
-  /accessibleLibraries|library_user|library_asset|library_audit/, // library-only sync helpers
-];
+// The raw join tables. A reference to any of these is also a space read.
+const SPACE_TABLE = /\bshared_space_(asset|library|album)\b/;
 
-// Enclosing functions that legitimately reference shared_space_library WITHOUT an
-// album arm. Keyed by function name (robust to line drift). Every entry needs a reason.
-const ALLOWLIST: Record<string, string> = {
-  // Album-ABSENCE gate (keeps plain non-space album assets visible) — references
-  // asset/library absence by design, never an album access arm.
-  albumSharedSpaceScope: 'album-absence gate, not an album access arm',
-  // Pre-existing intentional RBAC gap: AssetUpdate/edit has no space-album arm
-  // (space editors can add/remove but not metadata-edit linked-album assets). Out
-  // of scope for this behavior-preserving consolidation; tracked separately.
-  checkSpaceEditAccess: 'known RBAC gap: AssetUpdate has no space-album arm (pre-existing)',
-  // NOTE: map.repository.ts:getMapMarkers was fixed by Slice 9. The space-specific
-  // getMapMarkers in shared-space.repository.ts (GET /shared-spaces/:id/map-markers)
-  // still lacks the album arm — pre-existing gap, tracked separately.
-  getMapMarkers: 'GUARD-DISCOVERED gap: union(direct,library) omits album arm (pre-existing, follow-up)',
-  // GUARD-DISCOVERED pre-existing missing-album gaps (not in the review's inventory,
-  // which only grepped shared_space_album). Both OR direct+library but omit the
-  // album arm, so an album-only asset is invisible to them. Flagged for follow-up;
-  // NOT fixed here (unplanned behavior change).
-  findSpaceForAssetAndUser: 'GUARD-DISCOVERED gap: union(direct,library) omits album arm (pre-existing, follow-up)',
-  getPersonalThumbnailForSpacePerson:
-    'GUARD-DISCOVERED gap: or(direct,library) omits album arm (pre-existing, follow-up)',
+// Either signal means the line participates in a space-scoped read.
+const SPACE_READ_MARKER = new RegExp(`${SPACE_HELPER.source}|${SPACE_TABLE.source}`);
+
+// Derive the file set: every repository + utils/database.ts that contains a
+// space-read marker. Glob, do not hardcode — a new leaky file is auto-included.
+const deriveScopingFiles = (): string[] => {
+  const repoFiles = readdirSync(join(SERVER_ROOT, REPO_DIR))
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.spec.ts'))
+    .map((f) => `${REPO_DIR}/${f}`);
+  return [...repoFiles, ...EXTRA_FILES].filter((file) =>
+    SPACE_READ_MARKER.test(readFileSync(join(SERVER_ROOT, file), 'utf8')),
+  );
 };
 
-const DECL = /^\s*(?:export\s+)?(?:async\s+)?(?:function\s+)?([A-Za-z0-9_]+)\s*[(<]/;
+const SCOPING_FILES = deriveScopingFiles();
+
+// ── shared helpers ─────────────────────────────────────────────────────────
+
+const DECL =
+  /^\s*(?:export\s+)?(?:public\s+|private\s+|protected\s+)?(?:async\s+)?(?:function\s+)?([A-Za-z0-9_]+)\s*[(<]/;
 const NON_DECL = new Set([
   'if',
   'for',
@@ -113,6 +123,7 @@ const NON_DECL = new Set([
   'THEN',
   'ELSE',
   'END',
+  'SET',
 ]);
 
 const enclosingFn = (lines: string[], i: number): string => {
@@ -123,6 +134,53 @@ const enclosingFn = (lines: string[], i: number): string => {
     }
   }
   return '<module>';
+};
+
+const shortName = (file: string) => file.split('/').pop()!;
+const key = (file: string, fn: string) => `${shortName(file)}::${fn}`;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SCAN 1 — album-leg coverage
+//
+// Every `shared_space_library` scoping arm must have album coverage within
+// ±WINDOW lines: the raw `shared_space_album` table, or a fork album-scope helper.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALBUM_MARKER =
+  /shared_space_album|spaceAlbumAssetExists|spaceAssetPathBranches|spaceAlbumAssetExistsSql|accessibleSpaceAlbums/;
+const LIBRARY_REF = /\bshared_space_library\b/;
+const WINDOW = 45;
+
+// Lines that reference shared_space_library but are NOT a 3-path access-scope arm.
+const BENIGN_LINE = [
+  /(insertInto|deleteFrom|updateTable|backfillQuery|upsertQuery)\(\s*['"]shared_space_library/, // CRUD / sync backfill
+  /^'shared_space_library\.\w+',?$/, // column-list entry
+  /accessibleLibraries|library_user|library_asset|library_audit/, // library-only sync helpers
+];
+
+// Enclosing functions that legitimately reference shared_space_library WITHOUT an
+// album arm. Keyed by `<file>::<function>`. Every entry needs a real reason.
+const ALBUM_ALLOWLIST: Record<string, string> = {
+  // Album-ABSENCE gate (keeps plain non-space album assets visible) — references
+  // asset/library absence by design, never an album access arm.
+  'database.ts::albumSharedSpaceScope': 'album-absence gate, not an album access arm',
+  // Pre-existing intentional RBAC gap: AssetUpdate/edit has no space-album arm
+  // (space editors can add/remove but not metadata-edit linked-album assets).
+  'access.repository.ts::checkSpaceEditAccess': 'known RBAC gap: AssetUpdate has no space-album arm (pre-existing)',
+  // GET /shared-spaces/:id/map-markers unions direct+library only. Visibility-gated
+  // (visibleSpaceAssetVisibilities) so no leak — but album-linked markers are absent.
+  // Pre-existing album-completeness gap, tracked separately; NOT a visibility hole.
+  'shared-space.repository.ts::getMapMarkers':
+    'GUARD-DISCOVERED album gap: union(direct,library) omits album arm (pre-existing, follow-up)',
+  // Both OR direct+library but omit the album arm, so an album-only asset is
+  // invisible to them. Pre-existing; membership/thumbnail lookups (see Scan 2).
+  'shared-space.repository.ts::findSpaceForAssetAndUser':
+    'GUARD-DISCOVERED album gap: union(direct,library) omits album arm (pre-existing, follow-up)',
+  // Thumbnail-face lookup: or(direct,library) omits the album arm, so an album-only
+  // linked asset can't supply a fallback thumbnail. Visibility-gated (line 1486), so
+  // no visibility leak — a pre-existing album-completeness gap, tracked separately.
+  'shared-space.repository.ts::getPersonalThumbnailForSpacePerson':
+    'GUARD-DISCOVERED album gap: or(direct,library) omits album arm (pre-existing, follow-up)',
 };
 
 describe('space-album scope guard: every library scoping arm has album coverage', () => {
@@ -143,7 +201,7 @@ describe('space-album scope guard: every library scoping arm has album coverage'
         continue;
       }
       const fn = enclosingFn(lines, i);
-      if (ALLOWLIST[fn]) {
+      if (ALBUM_ALLOWLIST[key(file, fn)]) {
         continue;
       }
       const lo = Math.max(0, i - WINDOW);
@@ -158,131 +216,103 @@ describe('space-album scope guard: every library scoping arm has album coverage'
       orphans,
       `shared_space_library scoping arm(s) with no adjacent shared_space_album arm/helper.\n` +
         `Add the album leg (route it through spaceAlbumAssetExists / spaceAssetPathBranches /\n` +
-        `spaceAlbumAssetExistsSql) or, if genuinely album-free, add the enclosing function to\n` +
-        `ALLOWLIST with a reason.\n` +
+        `spaceAlbumAssetExistsSql) or, if genuinely album-free, add '<file>::<fn>' to\n` +
+        `ALBUM_ALLOWLIST with a reason.\n` +
         orphans.join('\n'),
     ).toEqual([]);
   });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// SCAN 2 (Slice 11): VISIBILITY-GATE scan
+// SCAN 2 — visibility-gate coverage
 //
-// Every repository query that space-scopes an asset read (joins
-// shared_space_asset / shared_space_library / shared_space_album and
-// selects / returns asset rows) must reference the visibility gate — either:
-//   - spaceVisibilityGate (most surfaces)
-//   - spaceVisibleAssetVisibilities / visibleSpaceAssetVisibilities (shared-space repo)
-//   - peopleAssetVisibilities (people stats)
-//   - AssetVisibility.Timeline or AssetVisibility.Archive (tighter gates: map, memory, view)
+// Every space-scoped ASSET read (joins shared_space_asset/library/album, or routes
+// through a space helper, and returns asset rows) must reference the visibility
+// gate within ±VIS_WINDOW lines. The gate excludes other members' Hidden/Locked.
 //
-// The scan looks for any line containing `shared_space_asset`, `shared_space_library`,
-// or `shared_space_album` (excluding comments and benign CRUD) and verifies that
-// the enclosing function has at least one visibility-gate token within ±WINDOW lines.
-//
-// This scan uses its OWN separate allowlist — do NOT merge with ALLOWLIST above.
+// A space read is detected by SPACE_READ_MARKER (helper call OR table literal), so
+// helper-only files (asset.repository.ts, view-repository.ts) are covered — the
+// gap that let Fixes A/C slip past the old table-literal-only scan.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// A space scoping reference (asset read, not CRUD) is "visibility-gated" if any
-// of these tokens appear within ±VIS_WINDOW lines of it.
-//
-// The last two alternatives cover sync stream classes that select from a LINK
-// table (shared_space_library / shared_space_album) to stream metadata rows —
-// NOT asset rows. The presence of *_SYNC_COLUMNS (which contain only link-table
-// columns like libraryId, spaceId, showInTimeline) confirms the query is a
-// link-metadata stream and NOT an asset read. Asset visibility is enforced in
-// the corresponding asset-specific stream classes (SharedSpaceAssetSync etc.).
+// A space read is "visibility-gated" if any of these appear within ±VIS_WINDOW.
+//   - spaceVisibilityGate / spaceVisibleAssetVisibilities / visibleSpaceAssetVisibilities:
+//     the Kysely `visibility IN (archive,timeline)` gate.
+//   - peopleAssetVisibilities: the raw-SQL alias of the same set (face/person stats).
+//   - visibilityFilter: the local raw-SQL const `visibility IN (visibleSpaceAssetVisibilities)`
+//     interpolated into the space-stats CTEs (countPersons / peopleFaceStatistics).
+//   - AssetVisibility.Timeline / AssetVisibility.Archive: an inline visibility '='
+//     predicate (map / memory / view use the tighter Timeline-only gate).
+//   - *_SYNC_COLUMNS: the query streams a LINK table (libraryId/albumId/spaceId
+//     metadata) not asset rows; asset visibility lives in the asset-stream classes.
 const VIS_GATE_MARKER =
-  /spaceVisibilityGate|spaceVisibleAssetVisibilities|visibleSpaceAssetVisibilities|peopleAssetVisibilities|AssetVisibility\.Timeline|AssetVisibility\.Archive|SHARED_SPACE_LIBRARY_SYNC_COLUMNS|SHARED_SPACE_ALBUM_SYNC_COLUMNS|visibilityFilter/;
+  /spaceVisibilityGate|spaceVisibleAssetVisibilities|visibleSpaceAssetVisibilities|peopleAssetVisibilities|visibilityFilter|AssetVisibility\.(Timeline|Archive)|SHARED_SPACE_LIBRARY_SYNC_COLUMNS|SHARED_SPACE_ALBUM_SYNC_COLUMNS/;
 
-// Lines that reference shared_space_* but are NOT asset-read scoping arms
-// (mirrors the album-leg BENIGN_LINE filter, plus shared_space_album CRUD).
+// Lines that reference a space marker but are NOT an asset-read scoping arm.
 const VIS_BENIGN_LINE = [
-  /(insertInto|deleteFrom|updateTable|backfillQuery)\(\s*['"]shared_space/, // CRUD / sync backfill
+  /(insertInto|deleteFrom|updateTable|backfillQuery|upsertQuery|auditQuery)\(\s*['"]shared_space/, // CRUD / sync
   /^'shared_space[^']+\.\w+',?$/, // column-list entry
-  /accessibleLibraries|library_user|library_asset|library_audit/, // library-only sync helpers
-  /accessibleSpaceAlbums|accessibleSpaces/, // helper call references (not inline scoping)
-  /shared_space_member/, // membership-only references (not asset-read arms)
-  /shared_space_audit|shared_space_person|shared_space_library_audit/, // audit/person tables
-  // SharedSpaceLibrarySync / SharedSpaceAlbumLinkSync: these stream link-table rows
-  // (libraryId/albumId/spaceId metadata), NOT asset rows. The backfill/upsert queries
-  // select from the link table directly. Asset visibility is enforced in the separate
-  // SharedSpaceAssetSync / SharedSpaceAlbumAssetSync stream classes.
-  /SHARED_SPACE_LIBRARY_SYNC_COLUMNS|SHARED_SPACE_ALBUM_SYNC_COLUMNS/, // link-table column sets
+  /shared_space_(asset|library|album)_audit/, // audit tables (tombstones, not reads)
 ];
 
-// Scoping references that legitimately have no nearby visibility gate, keyed by
-// enclosing function name. Add here with a one-line reason ONLY.
+// Space reads that legitimately have no nearby visibility gate. Keyed by
+// `<file>::<function>`. Every entry states WHY (not "enforced downstream" waves).
 const VIS_ALLOWLIST: Record<string, string> = {
-  // Returns a boolean (is asset in space?), not a full asset row set.
-  // Gated upstream by checkSpaceAccess before any asset data is served.
-  isAssetInSpace: 'membership-presence check only; no asset data returned; gated upstream',
-  // Returns user/space metadata (who can edit?), not asset rows.
-  // Visibility-gated (Slice 10) but no album arm — on album-leg ALLOWLIST.
-  checkSpaceEditAccess: 'visibility-gated (Slice 10) via spaceVisibilityGate; on album-leg allowlist',
-  // Absence-gate (confirms asset is NOT already in space via another path).
-  // Reads album/library/direct rows to check absence, not to return asset data to client.
-  albumSharedSpaceScope: 'absence gate; checks non-membership, not asset data exposure',
-  // Returns space-person linked to a global person, not asset rows.
-  findSpacePersonByLinkedPersonId: 'returns space-person metadata, not asset rows',
-  // Union absence check for removeAssets — checks existing space membership.
-  getAssetIdsWithoutOtherSpacePath: 'membership check for removals; no asset data returned to client',
-  getAlbumAssetIdsWithoutOtherSpacePath: 'membership check for removals; no asset data returned to client',
-  // Returns the libraryId of a linked library, not asset rows.
-  getLinkedLibraries: 'returns library metadata, not asset rows',
-  // Returns space-level statistics (member counts, etc.), not asset rows.
-  getSpaceStats: 'space-level statistics; no asset rows returned',
-  // findSpaceForAssetAndUser: membership lookup returning space/role metadata.
-  // GUARD-DISCOVERED gap on album-leg allowlist; visibility gated upstream.
-  findSpaceForAssetAndUser: 'membership lookup; returns space/role, not asset data; visibility gated upstream',
-  // getPersonalThumbnailForSpacePerson: returns thumbnail face metadata (one face),
-  // not a user-visible asset set. GUARD-DISCOVERED gap on album-leg allowlist.
-  getPersonalThumbnailForSpacePerson: 'returns face thumbnail path, not a user-visible asset set; gated upstream',
-  // Sync backfill helpers: operate on shared_space_{member,audit} tables as part
-  // of the sync protocol, not as direct asset-read scoping. Asset visibility is
-  // enforced in the asset-specific sync streams (SharedSpaceAssetSync etc.).
-  backfillQuery: 'sync infrastructure; asset visibility enforced in stream classes',
-  upsertQuery: 'sync infrastructure; asset visibility enforced in stream classes',
-  auditQuery: 'sync audit query; no asset rows returned',
-  // Cleanup helpers that delete memory_asset rows based on visibility — the
-  // AssetVisibility.Timeline check IS the deletion criterion, not a read gate.
-  cleanup: 'memory cleanup; AssetVisibility.Timeline used as deletion criterion, not a read gate',
-  // Returns library IDs (not asset rows) accessible to the user via owned or space-linked libraries.
-  accessibleLibraries: 'returns library IDs only, not asset rows; visibility enforced in asset-stream queries',
-  // Streams shared_space_library LINK rows (libraryId, spaceId metadata), NOT asset rows.
-  // Asset visibility is enforced in SharedSpaceAssetExifSync and LibraryAssetSync.
-  SharedSpaceLibrarySync: 'streams library-link metadata rows, not asset rows; visibility in asset streams',
-  // Streams shared_space_album LINK rows (albumId, spaceId, showInTimeline), NOT asset rows.
-  // Asset visibility is enforced in SharedSpaceAlbumAssetSync and SharedSpaceAlbumAssetExifSync.
-  SharedSpaceAlbumLinkSync: 'streams album-link metadata rows, not asset rows; visibility in asset streams',
-  // Returns album IDs (not asset rows) that a user can edit/read via a space link.
-  // Actual asset visibility is enforced downstream when the album download happens.
-  checkSpaceLinkedAlbumAccess: 'returns album IDs only, not asset rows; asset visibility enforced downstream',
-  checkSpaceLinkedAlbumReadAccess: 'returns album IDs only, not asset rows; asset visibility enforced downstream',
-  // Returns addedById (user IDs) for who added a face to the space — not asset data.
-  getSpacePersonAssetAdderIds: 'returns addedById attribution (user IDs), not asset data',
-  // Returns addedById for who added a specific asset to the space (via direct/library/album).
-  // Selects only shared_space_{asset,library,album}.addedById — no asset content exposed.
-  getSpaceAssetAdder: 'returns addedById attribution only; no asset content returned to client',
-  // Returns (spaceId, albumId, showInTimeline, faceRecognitionEnabled) link metadata.
-  // Used for fan-out to find which spaces a linked album feeds — no asset rows returned.
-  getSpacesLinkedToAlbum: 'returns space-album link metadata (spaceId, albumId, flags), not asset rows',
-  // Returns album metadata rows (albumName, thumbnailAssetId, etc.) for albums linked to
-  // a space — used for management UI listing. Does NOT return individual asset content.
-  getLinkedAlbums: 'returns album metadata rows for management UI; no individual asset content',
-  // Returns a boolean (does this space-library link exist?), not asset rows.
-  hasLibraryLink: 'boolean membership check; returns true/false, not asset data',
-  // Reads shared_space_asset rows to INSERT them into shared_space_asset_audit —
-  // this is write infrastructure for the visibility-purge sync mechanism, not
-  // a client-facing asset read. Asset data is never returned to callers.
-  emitDirectAssetVisibilityPurge:
-    'sync purge infrastructure; inserts into audit table, no asset data returned to client',
-  // Returns library-link metadata rows (spaceId, libraryId, faceRecognitionEnabled)
-  // for fan-out to find which spaces a library feeds. No asset content exposed.
-  getSpacesLinkedToLibrary: 'returns library-link metadata (spaceId, libraryId, flags), not asset rows',
+  // — Membership / link-metadata lookups: return a spaceId, library id, album id, or
+  //   metadata row — never asset rows. No asset content is served, so no gate applies.
+  'shared-space.repository.ts::findSpaceForAssetAndUser':
+    'membership lookup; returns spaceId, not asset data (on album-leg allowlist too)',
+  'shared-space.repository.ts::getLinkedLibraries': 'returns library metadata rows, not asset rows',
+  'shared-space.repository.ts::hasLibraryLink': 'boolean link-existence check; no asset data',
+  'shared-space.repository.ts::getLinkedAlbums': 'returns album metadata rows for management UI; no asset content',
+  'shared-space.repository.ts::getSpacesLinkedToAlbum': 'returns space-album link metadata (ids/flags), not asset rows',
+  'shared-space.repository.ts::getSpacesLinkedToLibrary': 'returns library-link metadata (ids/flags), not asset rows',
+
+  // — Anti-join membership gates: read direct/library/album rows to check that an
+  //   asset is NOT already reachable via another space path (removal / face cleanup).
+  //   The read decides membership, it does not return asset content to a client.
+  'shared-space.repository.ts::getAssetIdsWithoutOtherSpacePath':
+    'anti-join membership check for removals; no asset data',
+  'shared-space.repository.ts::getAlbumAssetIdsWithoutOtherSpacePath':
+    'anti-join membership check for removals; no asset data',
+
+  // — addedById attribution: select shared_space_*.addedById (who added the asset),
+  //   never asset content. No visibility gate needed.
+  'shared-space.repository.ts::getSpacePersonAssetAdderIds': 'returns addedById (user ids), not asset data',
+  'shared-space.repository.ts::getSpaceAssetAdder': 'returns addedById attribution only; no asset content',
+
+  // — Sync purge write-infra: INSERT ... SELECT that reads shared_space_asset JOIN
+  //   ids (spaceId, assetId) into the audit tombstone table. No asset content read,
+  //   and it fires precisely BECAUSE the asset left the visible set (purge event).
+  'shared-space.repository.ts::emitDirectAssetVisibilityPurge':
+    'reads join ids into audit tombstone (purge write-infra); no asset content returned',
+
+  // — Album-ACCESS grant checks: select ONLY album.id (which albums the user may
+  //   read/edit via a space link), never asset rows. Individual asset visibility is
+  //   enforced at each DOWNSTREAM asset read — album withAssets (withDefaultVisibility),
+  //   activity (Fix C), and album search/facets (Fix D) — all of which are now gated.
+  'access.repository.ts::checkSpaceLinkedAlbumAccess':
+    'selects album.id only, never asset rows; asset visibility gated at each downstream read (Fixes C/D)',
+  'access.repository.ts::checkSpaceLinkedAlbumReadAccess':
+    'selects album.id only, never asset rows; asset visibility gated at each downstream read (Fixes C/D)',
+
+  // — Sync scope helper: accessibleLibraries builds a UNION of library ids (owned +
+  //   space-linked) used as a subquery scope. It returns library ids, never asset rows;
+  //   the asset streams that USE it (LibraryAssetSync/ExifSync) carry the visibility gate.
+  'sync.repository.ts::accessibleLibraries': 'returns library ids only (UNION of owned + space-linked), not asset rows',
+
+  // — SharedSpaceSync.getUpserts streams SHARED_SPACE_SYNC_COLUMNS (space name/settings
+  //   metadata) scoped by accessibleSpaces — space rows, NOT asset rows. The per-asset
+  //   space streams (SharedSpaceAssetSync etc.) carry the visibility gate separately.
+  'sync.repository.ts::getUpserts':
+    'sync stream of shared_space metadata columns (accessibleSpaces-scoped), not asset rows',
+  // LibrarySync.getCreatedAfter streams library_user access-GRANT rows (libraryId,
+  // createId) scoped by accessibleLibraries — a per-user grant ledger, not asset
+  // rows. The library asset streams (LibraryAssetSync/ExifSync) carry the gate.
+  'sync.repository.ts::getCreatedAfter':
+    'streams library_user access-grant metadata (accessibleLibraries-scoped), not asset rows',
 };
 
-const SPACE_ASSET_REF = /\bshared_space_asset\b|\bshared_space_library\b|\bshared_space_album\b/;
 const VIS_WINDOW = 50;
 
 describe('space-visibility gate guard: every space asset read has a visibility gate', () => {
@@ -294,21 +324,22 @@ describe('space-visibility gate guard: every space asset read has a visibility g
       const raw = lines[i];
       const trimmed = raw.trim();
 
-      // Skip comments
       if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
         continue;
       }
-      // Skip non-space-scoping lines
-      if (!SPACE_ASSET_REF.test(raw)) {
+      if (!SPACE_READ_MARKER.test(raw)) {
         continue;
       }
-      // Skip benign CRUD / non-read-scoping lines
+      // The helper/scope module and its import lines are definitions, not reads.
+      if (/^import\b/.test(trimmed) || /from 'src\/utils\/shared-space-album-scope'/.test(trimmed)) {
+        continue;
+      }
       if (VIS_BENIGN_LINE.some((re) => re.test(trimmed))) {
         continue;
       }
 
       const fn = enclosingFn(lines, i);
-      if (VIS_ALLOWLIST[fn]) {
+      if (VIS_ALLOWLIST[key(file, fn)]) {
         continue;
       }
 
@@ -324,7 +355,7 @@ describe('space-visibility gate guard: every space asset read has a visibility g
       orphans,
       `space asset read arm(s) with no nearby visibility gate.\n` +
         `Add spaceVisibilityGate / visibleSpaceAssetVisibilities / AssetVisibility.Timeline\n` +
-        `to the query, or add the enclosing function to VIS_ALLOWLIST with a reason.\n` +
+        `to the query, or add '<file>::<fn>' to VIS_ALLOWLIST with a reason.\n` +
         orphans.join('\n'),
     ).toEqual([]);
   });

--- a/server/src/utils/shared-space-album-scope.ts
+++ b/server/src/utils/shared-space-album-scope.ts
@@ -17,8 +17,34 @@
 //
 // See docs / data/sa-abstraction-spec-t8/report.md for the full design + slices.
 import { Expression, ExpressionBuilder, RawBuilder, ReferenceExpression, sql, SqlBool } from 'kysely';
+import { AssetVisibility } from 'src/enum';
 import { DB } from 'src/schema';
 import { anyUuid, asUuid } from 'src/utils/database';
+
+/**
+ * The canonical set of asset visibilities that are shareable through a space.
+ * Hidden and Locked assets are never shareable; Archive and Timeline are.
+ * This is the single source of truth — previously declared as three local
+ * constants under two names across shared-space, face-identity, and person
+ * repositories.
+ */
+export const spaceVisibleAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+
+/**
+ * Returns an `eb.in` predicate restricting `column` to the two space-shareable
+ * visibility values (`archive`, `timeline`).
+ *
+ * Default column presumes an `asset`-rooted/joined query; not usable on an
+ * `asset`-less builder.
+ *
+ * Usage: `.where((eb) => spaceVisibilityGate(eb))`
+ */
+export function spaceVisibilityGate(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  column: ReferenceExpression<DB, keyof DB> = 'asset.visibility',
+): Expression<SqlBool> {
+  return eb(column, 'in', spaceVisibleAssetVisibilities);
+}
 
 /**
  * How a space-scoped branch is bound to the space(s) it applies to. Mirrors the
@@ -246,6 +272,8 @@ export interface SpaceAlbumAssetSqlOptions {
   spaceScopeJoin: RawBuilder<unknown>;
   /** A1 invariant: require `album.deletedAt IS NULL`. Default true. */
   requireAlbumNotDeleted?: boolean;
+  /** Timeline surfaces only: require `shared_space_album.showInTimeline = true`. Default false. */
+  requireShowInTimeline?: boolean;
 }
 
 /**
@@ -257,6 +285,7 @@ export function spaceAlbumAssetExistsSql(options: SpaceAlbumAssetSqlOptions): Ra
     (options.requireAlbumNotDeleted ?? true)
       ? sql`INNER JOIN album ON album.id = shared_space_album."albumId" AND album."deletedAt" IS NULL`
       : sql``;
+  const timelineGate = options.requireShowInTimeline ? sql`AND "shared_space_album"."showInTimeline" = true` : sql``;
   return sql<SqlBool>`EXISTS (
               SELECT 1
               FROM shared_space_album
@@ -264,5 +293,6 @@ export function spaceAlbumAssetExistsSql(options: SpaceAlbumAssetSqlOptions): Ra
               ${albumJoin}
               INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
               WHERE album_asset."assetId" = ${options.assetIdColumn}
+              ${timelineGate}
             )`;
 }

--- a/server/src/utils/shared-space-visibility.spec.ts
+++ b/server/src/utils/shared-space-visibility.spec.ts
@@ -1,0 +1,60 @@
+// Slice 1 — unit tests for the canonical visibility helper and related constants.
+// Tests:
+//   1. spaceVisibilityGate compiles to the expected SQL
+//   2. spaceVisibleAssetVisibilities equals [AssetVisibility.Archive, AssetVisibility.Timeline]
+//   3. The two old names are the SAME reference as the new constant (===)
+import { DummyDriver, Kysely, PostgresAdapter, PostgresIntrospector, PostgresQueryCompiler } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { DB } from 'src/schema';
+import { spaceVisibilityGate, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
+// Import the old names via the repositories that re-export them after consolidation.
+// These are module-level consts (not exported), so we verify via the shared reference test
+// by reading the same constant through the consolidated import.
+import { describe, expect, it } from 'vitest';
+
+// Offline Kysely — compiles SQL without executing it. No DB connection needed.
+const offlineKysely = () =>
+  new Kysely<DB>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  });
+
+describe('spaceVisibleAssetVisibilities', () => {
+  it('equals [AssetVisibility.Archive, AssetVisibility.Timeline]', () => {
+    expect(spaceVisibleAssetVisibilities).toEqual([AssetVisibility.Archive, AssetVisibility.Timeline]);
+  });
+});
+
+describe('spaceVisibilityGate', () => {
+  it('compiles to SQL with asset.visibility in (...) predicate and both values as parameters', () => {
+    const db = offlineKysely();
+    const compiled = db
+      .selectFrom('asset')
+      .selectAll()
+      .where((eb) => spaceVisibilityGate(eb))
+      .compile();
+
+    // Kysely uses parameterized queries; the column ref and IN operator appear in SQL
+    expect(compiled.sql).toContain('"asset"."visibility" in');
+    // Both visibility values are passed as bound parameters
+    expect(compiled.parameters).toContain('archive');
+    expect(compiled.parameters).toContain('timeline');
+  });
+
+  it('accepts a custom column reference', () => {
+    const db = offlineKysely();
+    const compiled = db
+      .selectFrom('asset')
+      .selectAll()
+      .where((eb) => spaceVisibilityGate(eb, 'asset.visibility'))
+      .compile();
+
+    expect(compiled.sql).toContain('"asset"."visibility" in');
+    expect(compiled.parameters).toContain('archive');
+    expect(compiled.parameters).toContain('timeline');
+  });
+});

--- a/server/test/medium/specs/repositories/access-space-visibility.repository.spec.ts
+++ b/server/test/medium/specs/repositories/access-space-visibility.repository.spec.ts
@@ -445,3 +445,148 @@ describe('checkSpaceAccessForSpace — visibility gate', () => {
     expect(after.has(asset.id)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// checkSpaceEditAccess — visibility gate (Slice 10)
+//
+// Security requirement: an editor role must NOT be able to edit another
+// member's Hidden or Locked asset via the space path. The edit gate must
+// mirror the read gate: only Timeline and Archive pass through.
+// ---------------------------------------------------------------------------
+
+describe('checkSpaceEditAccess — visibility gate (Slice 10)', () => {
+  // Path 1 — direct add (shared_space_asset)
+
+  it('grants Timeline and Archive to editor; blocks Hidden and Locked (direct path)', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: editor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: editor.id, role: 'editor' });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: archive } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [timeline.id, archive.id, hidden.id, locked.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    const result = await accessRepo.asset.checkSpaceEditAccess(
+      editor.id,
+      new Set([timeline.id, archive.id, hidden.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(archive.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('viewer role is NOT granted edit access regardless of visibility (direct path)', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: timeline.id });
+
+    const result = await accessRepo.asset.checkSpaceEditAccess(viewer.id, new Set([timeline.id]));
+
+    expect(result.has(timeline.id)).toBe(false);
+  });
+
+  it('livePhotoVideoId: Locked parent → video part NOT granted via edit gate (direct path)', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: editor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: editor.id, role: 'editor' });
+
+    const { asset: video } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: parent } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+      livePhotoVideoId: video.id,
+    });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: parent.id });
+
+    const result = await accessRepo.asset.checkSpaceEditAccess(editor.id, new Set([video.id]));
+    expect(result.has(video.id)).toBe(false);
+  });
+
+  // Path 2 — library (shared_space_library)
+
+  it('grants Timeline and Archive to editor; blocks Hidden and Locked (library path)', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: editor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: editor.id, role: 'editor' });
+
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const { asset: timeline } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archive } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hidden } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: locked } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    const result = await accessRepo.asset.checkSpaceEditAccess(
+      editor.id,
+      new Set([timeline.id, archive.id, hidden.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(archive.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('added-then-locked: asset added while Timeline, flipped to Locked → edit access revoked (direct path)', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: editor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: editor.id, role: 'editor' });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const before = await accessRepo.asset.checkSpaceEditAccess(editor.id, new Set([asset.id]));
+    expect(before.has(asset.id)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceEditAccess(editor.id, new Set([asset.id]));
+    expect(after.has(asset.id)).toBe(false);
+  });
+});

--- a/server/test/medium/specs/repositories/access-space-visibility.repository.spec.ts
+++ b/server/test/medium/specs/repositories/access-space-visibility.repository.spec.ts
@@ -306,3 +306,142 @@ describe('checkSpaceAccess — album path visibility gate', () => {
     expect(after.has(asset.id)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// checkSpaceAccessForSpace — visibility gate (Slice 8)
+// ---------------------------------------------------------------------------
+
+describe('checkSpaceAccessForSpace — visibility gate', () => {
+  it('grants Timeline and Archive; blocks Hidden and Locked (direct path)', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: archive } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [timeline.id, archive.id, hidden.id, locked.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    const result = await accessRepo.asset.checkSpaceAccessForSpace(
+      viewer.id,
+      space.id,
+      new Set([timeline.id, archive.id, hidden.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(archive.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('livePhotoVideoId of Locked parent is NOT granted via checkSpaceAccessForSpace', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset: video } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: parent } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+      livePhotoVideoId: video.id,
+    });
+
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: parent.id });
+
+    const result = await accessRepo.asset.checkSpaceAccessForSpace(viewer.id, space.id, new Set([video.id]));
+    expect(result.has(video.id)).toBe(false);
+  });
+
+  it('grants Timeline and Archive from a linked library; blocks Hidden and Locked', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const { asset: timeline } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: hidden } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+
+    const result = await accessRepo.asset.checkSpaceAccessForSpace(
+      viewer.id,
+      space.id,
+      new Set([timeline.id, hidden.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+  });
+
+  it('grants Timeline and Archive from a linked album; blocks Hidden and Locked', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'SpaceAccessAlbum' });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timeline.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: locked.id });
+
+    const result = await accessRepo.asset.checkSpaceAccessForSpace(
+      viewer.id,
+      space.id,
+      new Set([timeline.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('added-then-locked: asset added while Timeline, flipped to Locked → excluded', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const before = await accessRepo.asset.checkSpaceAccessForSpace(viewer.id, space.id, new Set([asset.id]));
+    expect(before.has(asset.id)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceAccessForSpace(viewer.id, space.id, new Set([asset.id]));
+    expect(after.has(asset.id)).toBe(false);
+  });
+});

--- a/server/test/medium/specs/repositories/access-space-visibility.repository.spec.ts
+++ b/server/test/medium/specs/repositories/access-space-visibility.repository.spec.ts
@@ -1,0 +1,308 @@
+/**
+ * Medium tests for `AccessRepository.asset.checkSpaceAccess` — visibility filter (Slice 3).
+ *
+ * Security requirement: space-membership asset access via any path (direct /
+ * library / album) must only expose assets whose visibility is `Timeline` or
+ * `Archive`. `Hidden` and `Locked` are NEVER exposed through the space gate.
+ *
+ * Each test seeds a clean context so there is no shared-state cross-contamination.
+ */
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { AccessRepository } from 'src/repositories/access.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: defaultDatabase,
+    real: [AccessRepository, SharedSpaceRepository],
+    mock: [LoggingRepository],
+  });
+  return { ctx, accessRepo: ctx.get(AccessRepository) };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+// ---------------------------------------------------------------------------
+// Path 1 — direct add (shared_space_asset)
+// ---------------------------------------------------------------------------
+
+describe('checkSpaceAccess — direct path visibility gate', () => {
+  it('grants Timeline and Archive assets; blocks Hidden and Locked', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: archive } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [timeline.id, archive.id, hidden.id, locked.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    const result = await accessRepo.asset.checkSpaceAccess(
+      viewer.id,
+      new Set([timeline.id, archive.id, hidden.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(archive.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('added-then-locked: asset added while Timeline, later flipped to Locked → excluded at read time', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // Asset starts as Timeline → shared_space_asset row created
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    // Before flip: readable
+    const before = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([asset.id]));
+    expect(before.has(asset.id)).toBe(true);
+
+    // Flip to Locked (the shared_space_asset row remains)
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', asset.id)
+      .execute();
+
+    // After flip: blocked despite the surviving space row
+    const after = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([asset.id]));
+    expect(after.has(asset.id)).toBe(false);
+  });
+
+  it('livePhotoVideoId: Locked parent → video part is NOT granted via livePhotoVideoId', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // Video asset (no visibility restriction itself — it's the *parent* that is Locked)
+    const { asset: video } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+
+    // Locked parent that references the video via livePhotoVideoId
+    const { asset: parent } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+      livePhotoVideoId: video.id,
+    });
+
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: parent.id });
+
+    // Ask for the video ID — the only route is via the Locked parent's livePhotoVideoId
+    const result = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([video.id]));
+    expect(result.has(video.id)).toBe(false);
+  });
+
+  it('own Locked asset is NOT over-blocked: checkOwnerAccess grants it; checkSpaceAccess is orthogonal', async () => {
+    // checkOwnerAccess runs BEFORE checkSpaceAccess in access.ts. This test confirms
+    // that checkSpaceAccess returning empty for a Locked asset does NOT "un-grant" what
+    // checkOwnerAccess already granted (the two paths are additive via setUnion).
+    // We verify the gate function itself is orthogonal: as an *owner* calling
+    // checkSpaceAccess (not checkOwnerAccess), the Locked asset is still excluded.
+    // The real over-block risk is that we might accidentally strip already-granted IDs —
+    // but since access.ts uses setDifference to feed checkSpaceAccess only the IDs not
+    // yet granted, there is no double-dip. We pin this explicitly.
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: locked.id });
+
+    // checkSpaceAccess excludes Locked even for the owner — the owner's OWN read
+    // comes from checkOwnerAccess (hasElevatedPermission), not from checkSpaceAccess.
+    const spaceResult = await accessRepo.asset.checkSpaceAccess(owner.id, new Set([locked.id]));
+    expect(spaceResult.has(locked.id)).toBe(false);
+
+    // checkOwnerAccess with elevation grants it (confirming the real path is untouched)
+    const ownerResult = await accessRepo.asset.checkOwnerAccess(owner.id, new Set([locked.id]), true);
+    expect(ownerResult.has(locked.id)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path 2 — library (shared_space_library)
+// ---------------------------------------------------------------------------
+
+describe('checkSpaceAccess — library path visibility gate', () => {
+  it('grants Timeline and Archive; blocks Hidden and Locked from a linked library', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const { asset: timeline } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archive } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hidden } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: locked } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    const result = await accessRepo.asset.checkSpaceAccess(
+      viewer.id,
+      new Set([timeline.id, archive.id, hidden.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(archive.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('isOffline=true library asset is excluded regardless of visibility', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const { asset: offlineTimeline } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+      isOffline: true,
+    });
+
+    const result = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([offlineTimeline.id]));
+    expect(result.has(offlineTimeline.id)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path 3 — album (shared_space_album)
+// ---------------------------------------------------------------------------
+
+describe('checkSpaceAccess — album path visibility gate', () => {
+  it('grants Timeline and Archive; blocks Hidden and Locked from a linked album', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'VisibilityTestAlbum' });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: archive } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [timeline.id, archive.id, hidden.id, locked.id]) {
+      await ctx.newAlbumAsset({ albumId: album.id, assetId });
+    }
+
+    const result = await accessRepo.asset.checkSpaceAccess(
+      viewer.id,
+      new Set([timeline.id, archive.id, hidden.id, locked.id]),
+    );
+
+    expect(result.has(timeline.id)).toBe(true);
+    expect(result.has(archive.id)).toBe(true);
+    expect(result.has(hidden.id)).toBe(false);
+    expect(result.has(locked.id)).toBe(false);
+  });
+
+  it('soft-deleted album assets are excluded', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'SoftDeletedAlbumVis' });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    // Before soft-delete: asset reachable
+    const before = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([asset.id]));
+    expect(before.has(asset.id)).toBe(true);
+
+    // Soft-delete the album
+    await ctx.softDeleteAlbum(album.id);
+
+    // After: excluded even though asset.visibility = Timeline
+    const after = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([asset.id]));
+    expect(after.has(asset.id)).toBe(false);
+  });
+
+  it('added-then-locked via album path: asset flipped to Locked → excluded', async () => {
+    const { ctx, accessRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'AlbumLockReplay' });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    const before = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([asset.id]));
+    expect(before.has(asset.id)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceAccess(viewer.id, new Set([asset.id]));
+    expect(after.has(asset.id)).toBe(false);
+  });
+});

--- a/server/test/medium/specs/repositories/activity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/activity.repository.spec.ts
@@ -1,0 +1,171 @@
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { ActivityRepository } from 'src/repositories/activity.repository';
+import { AlbumUserRepository } from 'src/repositories/album-user.repository';
+import { AlbumRepository } from 'src/repositories/album.repository';
+import { AssetRepository } from 'src/repositories/asset.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { UserRepository } from 'src/repositories/user.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: defaultDatabase,
+    real: [ActivityRepository, AlbumRepository, AlbumUserRepository, AssetRepository, UserRepository],
+    mock: [LoggingRepository],
+  });
+  return {
+    ctx,
+    activityRepo: ctx.get(ActivityRepository),
+  };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('ActivityRepository — visibility gate', () => {
+  /**
+   * TDD: Verifies that Hidden and Locked asset activity rows are filtered
+   * out from search() and getStatistics() so that album members cannot
+   * enumerate existence/content of non-visible assets.
+   *
+   * The check constraint on the activity table requires:
+   *   - comment IS NOT NULL  when isLiked = false (a comment row)
+   *   - comment IS NULL      when isLiked = true  (a like row)
+   */
+
+  it('search() excludes activity on Hidden assets', async () => {
+    const { ctx, activityRepo } = setup();
+    const { result: owner } = await ctx.newUser();
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Visibility Test' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiddenAsset.id });
+
+    // Create a like on each (likes: isLiked=true, comment=null)
+    await activityRepo.create({ albumId: album.id, assetId: timelineAsset.id, userId: owner.id, isLiked: true });
+    await activityRepo.create({ albumId: album.id, assetId: hiddenAsset.id, userId: owner.id, isLiked: true });
+
+    const results = await activityRepo.search({ albumId: album.id });
+
+    const assetIds = results.map((r) => r.assetId);
+    expect(assetIds).toContain(timelineAsset.id);
+    expect(assetIds).not.toContain(hiddenAsset.id);
+  });
+
+  it('search() excludes activity on Locked assets', async () => {
+    const { ctx, activityRepo } = setup();
+    const { result: owner } = await ctx.newUser();
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Locked Test' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: lockedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: lockedAsset.id });
+
+    await activityRepo.create({ albumId: album.id, assetId: timelineAsset.id, userId: owner.id, isLiked: true });
+    await activityRepo.create({ albumId: album.id, assetId: lockedAsset.id, userId: owner.id, isLiked: true });
+
+    const results = await activityRepo.search({ albumId: album.id });
+
+    const assetIds = results.map((r) => r.assetId);
+    expect(assetIds).toContain(timelineAsset.id);
+    expect(assetIds).not.toContain(lockedAsset.id);
+  });
+
+  it('search() includes activity on Archive assets', async () => {
+    const { ctx, activityRepo } = setup();
+    const { result: owner } = await ctx.newUser();
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Archive Test' });
+
+    const { asset: archiveAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: archiveAsset.id });
+    await activityRepo.create({ albumId: album.id, assetId: archiveAsset.id, userId: owner.id, isLiked: true });
+
+    const results = await activityRepo.search({ albumId: album.id });
+
+    const assetIds = results.map((r) => r.assetId);
+    expect(assetIds).toContain(archiveAsset.id);
+  });
+
+  it('search() still returns album-level activity (assetId is null)', async () => {
+    const { ctx, activityRepo } = setup();
+    const { result: owner } = await ctx.newUser();
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Album Like Test' });
+
+    // Album-level like (assetId = null) — no FK to album_asset, isLiked=true, comment=null
+    await activityRepo.create({ albumId: album.id, assetId: null, userId: owner.id, isLiked: true });
+
+    const results = await activityRepo.search({ albumId: album.id });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].assetId).toBeNull();
+  });
+
+  it('getStatistics() excludes Hidden asset activity from counts', async () => {
+    const { ctx, activityRepo } = setup();
+    const { result: owner } = await ctx.newUser();
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Stats Hidden Test' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiddenAsset.id });
+
+    // 1 comment on visible, 1 comment on hidden (isLiked=false requires comment IS NOT NULL)
+    await activityRepo.create({
+      albumId: album.id,
+      assetId: timelineAsset.id,
+      userId: owner.id,
+      isLiked: false,
+      comment: 'visible comment',
+    });
+    await activityRepo.create({
+      albumId: album.id,
+      assetId: hiddenAsset.id,
+      userId: owner.id,
+      isLiked: false,
+      comment: 'hidden comment',
+    });
+
+    const stats = await activityRepo.getStatistics({ albumId: album.id });
+
+    // Only the visible asset comment should count
+    expect(Number(stats.comments)).toBe(1);
+    expect(Number(stats.likes)).toBe(0);
+  });
+
+  it('getStatistics() excludes Locked asset activity from counts', async () => {
+    const { ctx, activityRepo } = setup();
+    const { result: owner } = await ctx.newUser();
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Stats Locked Test' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: lockedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: lockedAsset.id });
+
+    // 1 like on visible, 1 like on locked (isLiked=true, comment=null)
+    await activityRepo.create({ albumId: album.id, assetId: timelineAsset.id, userId: owner.id, isLiked: true });
+    await activityRepo.create({ albumId: album.id, assetId: lockedAsset.id, userId: owner.id, isLiked: true });
+
+    const stats = await activityRepo.getStatistics({ albumId: album.id });
+
+    // Only the visible asset like should count
+    expect(Number(stats.likes)).toBe(1);
+    expect(Number(stats.comments)).toBe(0);
+  });
+});

--- a/server/test/medium/specs/repositories/download.repository.spec.ts
+++ b/server/test/medium/specs/repositories/download.repository.spec.ts
@@ -1,4 +1,5 @@
 import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
 import { DownloadRepository } from 'src/repositories/download.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
@@ -121,5 +122,185 @@ describe('DownloadRepository.downloadSpaceId', () => {
 
     expect(ids.has(trashedAlbumAsset.id)).toBe(false);
     expect(ids.has(liveAlbumAsset.id)).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Visibility filtering — Slice 2 (space download must honour the canonical
+  // "space-visible" rule: only Timeline and Archive; Hidden and Locked never).
+  // ---------------------------------------------------------------------------
+
+  it('excludes Hidden and Locked assets from the direct-added arm, includes Timeline and Archive', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+
+    const seed = async (visibility: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility });
+      await ctx.newExif({ assetId: asset.id, fileSizeInByte: 1024 });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      return asset;
+    };
+
+    const timelineAsset = await seed(AssetVisibility.Timeline);
+    const archiveAsset = await seed(AssetVisibility.Archive);
+    const hiddenAsset = await seed(AssetVisibility.Hidden);
+    const lockedAsset = await seed(AssetVisibility.Locked);
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(timelineAsset.id)).toBe(true);
+    expect(ids.has(archiveAsset.id)).toBe(true);
+    expect(ids.has(hiddenAsset.id)).toBe(false);
+    expect(ids.has(lockedAsset.id)).toBe(false);
+  });
+
+  it('excludes Hidden and Locked assets from the library arm, includes Timeline and Archive', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const seed = async (visibility: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id, visibility });
+      await ctx.newExif({ assetId: asset.id, fileSizeInByte: 1024 });
+      return asset;
+    };
+
+    const timelineAsset = await seed(AssetVisibility.Timeline);
+    const archiveAsset = await seed(AssetVisibility.Archive);
+    const hiddenAsset = await seed(AssetVisibility.Hidden);
+    const lockedAsset = await seed(AssetVisibility.Locked);
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(timelineAsset.id)).toBe(true);
+    expect(ids.has(archiveAsset.id)).toBe(true);
+    expect(ids.has(hiddenAsset.id)).toBe(false);
+    expect(ids.has(lockedAsset.id)).toBe(false);
+  });
+
+  it('excludes Hidden assets from the album arm; Locked cannot be seeded into an album (auto-stripped invariant)', async () => {
+    // NOTE: asset.service.ts:313 (removeAssetsFromAll) strips Locked assets
+    // from all albums automatically. We therefore cannot reliably seed a Locked
+    // asset into an album via the normal album path. We assert Locked is absent
+    // and document this invariant here.
+    const { ctx, sut, spaceRepo } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+
+    const { asset: timelineAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: timelineAsset.id, fileSizeInByte: 1024 });
+
+    const { asset: archiveAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+    await ctx.newExif({ assetId: archiveAsset.id, fileSizeInByte: 1024 });
+
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+    await ctx.newExif({ assetId: hiddenAsset.id, fileSizeInByte: 1024 });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'Mixed Visibility' }, [
+      timelineAsset.id,
+      archiveAsset.id,
+      hiddenAsset.id,
+    ]);
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(timelineAsset.id)).toBe(true);
+    expect(ids.has(archiveAsset.id)).toBe(true);
+    expect(ids.has(hiddenAsset.id)).toBe(false);
+    // Locked cannot be placed in albums (see service-layer invariant above).
+  });
+
+  it('added-then-flipped replay: asset promoted to Hidden/Locked after row creation is excluded from downloadSpaceId', async () => {
+    // Edge case: a shared_space_asset row already exists (created when the asset
+    // was Timeline) but the asset's visibility was later changed to Hidden or
+    // Locked. The filter is applied at READ time, so the asset must be excluded.
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+
+    // Start as Timeline, add to space, then flip visibility.
+    const { asset: flippedToHidden } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: flippedToHidden.id, fileSizeInByte: 1024 });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: flippedToHidden.id });
+    await ctx.database
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', flippedToHidden.id)
+      .execute();
+
+    const { asset: flippedToLocked } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: flippedToLocked.id, fileSizeInByte: 1024 });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: flippedToLocked.id });
+    await ctx.database
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', flippedToLocked.id)
+      .execute();
+
+    // Control: a Timeline asset that was NOT flipped.
+    const { asset: stable } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: stable.id, fileSizeInByte: 1024 });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: stable.id });
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(flippedToHidden.id)).toBe(false);
+    expect(ids.has(flippedToLocked.id)).toBe(false);
+    expect(ids.has(stable.id)).toBe(true);
+  });
+
+  it('isOffline library asset is excluded from downloadSpaceId', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const { asset: offlineAsset } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id, isOffline: true });
+    await ctx.newExif({ assetId: offlineAsset.id, fileSizeInByte: 1024 });
+
+    const { asset: onlineAsset } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id, isOffline: false });
+    await ctx.newExif({ assetId: onlineAsset.id, fileSizeInByte: 1024 });
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(offlineAsset.id)).toBe(false);
+    expect(ids.has(onlineAsset.id)).toBe(true);
+  });
+});
+
+describe('DownloadRepository.downloadAlbumId', () => {
+  it('excludes Hidden assets from album download; Locked cannot be seeded into an album (auto-stripped invariant)', async () => {
+    // NOTE: asset.service.ts:313 (removeAssetsFromAll) strips Locked assets
+    // from all albums automatically. We therefore cannot reliably force a Locked
+    // asset into an album and test its exclusion. We assert Hidden is excluded
+    // and that Locked is absent (invariant documented).
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+
+    const { asset: timelineAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: timelineAsset.id, fileSizeInByte: 1024 });
+
+    const { asset: archiveAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+    await ctx.newExif({ assetId: archiveAsset.id, fileSizeInByte: 1024 });
+
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+    await ctx.newExif({ assetId: hiddenAsset.id, fileSizeInByte: 1024 });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'Download Album' }, [
+      timelineAsset.id,
+      archiveAsset.id,
+      hiddenAsset.id,
+    ]);
+
+    const ids = await collectIds(sut.downloadAlbumId(album.id));
+
+    expect(ids.has(timelineAsset.id)).toBe(true);
+    expect(ids.has(archiveAsset.id)).toBe(true);
+    expect(ids.has(hiddenAsset.id)).toBe(false);
+    // Locked cannot be placed in albums (see service-layer invariant above).
   });
 });

--- a/server/test/medium/specs/repositories/shared-space-face-matching.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-face-matching.spec.ts
@@ -454,6 +454,7 @@ describe('SharedSpaceRepository - face matching pipeline', () => {
       const faceIds: string[] = [];
       for (let i = 0; i < 3; i++) {
         const { asset } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
         const faceId = await createFaceWithEmbedding(ctx, { assetId: asset.id, personId: person.id });
         faceIds.push(faceId);
       }
@@ -540,7 +541,15 @@ describe('SharedSpaceRepository - face matching pipeline', () => {
       await ctx.database.deleteFrom('person').where('id', '=', person5.id).execute();
 
       const persons = await sut.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: true });
-      expect(persons).toHaveLength(5);
+      const personIds = persons.map((p) => p.id);
+      // SP1, SP2, SP3, SP5 have visible in-scope faces → listed (4 persons).
+      // SP4's only face is soft-deleted → excluded by the unconditional visibility gate.
+      expect(personIds).toContain(sp1.id);
+      expect(personIds).toContain(sp2.id);
+      expect(personIds).toContain(sp3.id);
+      expect(personIds).not.toContain(sp4.id); // all faces soft-deleted → no visible face
+      expect(personIds).toContain(sp5.id); // face is visible even though global person was deleted
+      expect(persons).toHaveLength(4);
     });
 
     it('should return correct results with takenAfter temporal filter', async () => {
@@ -595,6 +604,7 @@ describe('SharedSpaceRepository - face matching pipeline', () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
       const { result: person } = await ctx.newPerson({ ownerId: user.id, thumbnailPath: '' });
       const faceId = await createFaceWithEmbedding(ctx, { assetId: asset.id, personId: person.id });
 
@@ -616,6 +626,7 @@ describe('SharedSpaceRepository - face matching pipeline', () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
       const faceId = await createFaceWithEmbedding(ctx, { assetId: asset.id, personId: null });
 
       const sp = await sut.createPerson({
@@ -636,6 +647,7 @@ describe('SharedSpaceRepository - face matching pipeline', () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
       const { result: person } = await ctx.newPerson({
         ownerId: user.id,
         name: 'Soon Deleted',

--- a/server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts
@@ -19,8 +19,11 @@
  */
 
 import { Kysely } from 'kysely';
-import { AssetVisibility, TimeBucketSize } from 'src/enum';
+import { AlbumUserRole, AssetVisibility, TimeBucketSize } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
+import { ActivityRepository } from 'src/repositories/activity.repository';
+import { AlbumUserRepository } from 'src/repositories/album-user.repository';
+import { AlbumRepository } from 'src/repositories/album.repository';
 import { AssetRepository, TimeBucketOptions } from 'src/repositories/asset.repository';
 import { DownloadRepository } from 'src/repositories/download.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
@@ -28,14 +31,16 @@ import { MapRepository } from 'src/repositories/map.repository';
 import { MemoryRepository } from 'src/repositories/memory.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
-import { SyncRepository } from 'src/repositories/sync.repository';
+import { SyncBackfillOptions, SyncRepository } from 'src/repositories/sync.repository';
 import { TagRepository } from 'src/repositories/tag.repository';
+import { UserRepository } from 'src/repositories/user.repository';
 import { ViewRepository } from 'src/repositories/view-repository';
 import { DB } from 'src/schema';
+import { AlbumService } from 'src/services/album.service';
 import { BaseService } from 'src/services/base.service';
 import { upsertTags } from 'src/utils/tag';
 import { newMediumService } from 'test/medium.factory';
-import { newEmbedding } from 'test/small.factory';
+import { factory, newEmbedding } from 'test/small.factory';
 import { getKyselyDB } from 'test/utils';
 
 let defaultDatabase: Kysely<DB>;
@@ -48,6 +53,9 @@ const setup = () => {
     database: defaultDatabase,
     real: [
       AccessRepository,
+      ActivityRepository,
+      AlbumRepository,
+      AlbumUserRepository,
       AssetRepository,
       DownloadRepository,
       MapRepository,
@@ -56,6 +64,7 @@ const setup = () => {
       SharedSpaceRepository,
       SyncRepository,
       TagRepository,
+      UserRepository,
       ViewRepository,
     ],
     mock: [LoggingRepository],
@@ -63,6 +72,7 @@ const setup = () => {
   return {
     ctx,
     accessRepo: ctx.get(AccessRepository),
+    activityRepo: ctx.get(ActivityRepository),
     assetRepo: ctx.get(AssetRepository),
     downloadRepo: ctx.get(DownloadRepository),
     mapRepo: ctx.get(MapRepository),
@@ -87,6 +97,31 @@ async function collectDownloadIds(stream: AsyncIterable<{ id: string }>): Promis
   }
   return ids;
 }
+
+// Surface 18 helpers (timeline explicit-visibility)
+const BUCKET_WHEN = new Date('2024-07-10T12:00:00.000Z');
+
+const countTimeBuckets = (buckets: Array<{ count: number }>) => buckets.reduce((s, b) => s + Number(b.count), 0);
+
+const makeBucketReadyAsset = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  ownerId: string,
+  vis: AssetVisibility,
+  opts: { libraryId?: string } = {},
+) => {
+  const { asset } = await ctx.newAsset({
+    ownerId,
+    visibility: vis,
+    fileCreatedAt: BUCKET_WHEN,
+    localDateTime: BUCKET_WHEN,
+    width: 400,
+    height: 300,
+    thumbhash: Buffer.from('t'),
+    ...opts,
+  });
+  await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+  return asset.id;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // FIXTURE BUILDER
@@ -1429,5 +1464,539 @@ describe('matrix: view/folders (getUniqueOriginalPaths)', () => {
     expect(paths).not.toContain(arPath); // Archive excluded ✓
     expect(paths).not.toContain(hiPath); // Hidden blocked ✓
     expect(paths).not.toContain(noTlPath); // showInTimeline=false excluded ✓
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 18: timeline explicit visibility (spaceId + visibility=HIDDEN/LOCKED)
+// Fix A regression lock in the matrix.
+// Rule: another member's Hidden/Locked in-space assets ABSENT even with explicit
+//   visibility=HIDDEN or visibility=LOCKED passed to the timeline bucket queries;
+//   the owner's OWN Hidden is PRESENT (via timelineSpaceIds + userIds=[owner]).
+//
+// Full coverage lives in timeline-bucket-explicit-visibility.medium.spec.ts.
+// These assertions cross-lock the same guarantees using the matrix fixture.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: timeline explicit-visibility (spaceId + visibility=HIDDEN/LOCKED)', () => {
+  it("visibility=HIDDEN via spaceId does NOT surface another member's Hidden in-space asset", async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // Direct Hidden + album(shown) Hidden — both must be absent
+    const hiDirect = await makeBucketReadyAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiDirect });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenLeakMx' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+    const hiAlbum = await makeBucketReadyAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiAlbum });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+
+    // No other-member Hidden assets surface
+    expect(countTimeBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+
+    // getTimeBucketCovers likewise returns nothing
+    const covers = await assetRepo.getTimeBucketCovers({ ...opts, timeBuckets: ['2024-01-01'] });
+    const coverIds = new Set(covers.map((c) => c.representativeAssetId));
+    expect(coverIds.has(hiDirect)).toBe(false);
+    expect(coverIds.has(hiAlbum)).toBe(false);
+  });
+
+  it("visibility=LOCKED via spaceId does NOT surface another member's Locked in-space asset", async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const loId = await makeBucketReadyAsset(ctx, owner.id, AssetVisibility.Locked);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: loId });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Locked,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countTimeBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+  });
+
+  it("OWN Hidden via timelineSpaceIds IS present (owner's own hidden must not be over-blocked)", async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const ownHidden = await makeBucketReadyAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: ownHidden });
+
+    const opts: TimeBucketOptions = {
+      userIds: [owner.id],
+      timelineSpaceIds: [space.id],
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countTimeBuckets(await assetRepo.getTimeBuckets(opts))).toBe(1);
+
+    const covers = await assetRepo.getTimeBucketCovers({ ...opts, timeBuckets: ['2024-01-01'] });
+    const coverIds = new Set(covers.map((c) => c.representativeAssetId));
+    expect(coverIds.has(ownHidden)).toBe(true);
+  });
+
+  it("viewer's Hidden via timelineSpaceIds does NOT surface another member's Hidden album asset", async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenAlbumMxTS' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+    const hiAlbum = await makeBucketReadyAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiAlbum });
+
+    const opts: TimeBucketOptions = {
+      userIds: [viewer.id],
+      timelineSpaceIds: [space.id],
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countTimeBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+
+    const covers = await assetRepo.getTimeBucketCovers({ ...opts, timeBuckets: ['2024-01-01'] });
+    expect(covers.map((c) => c.representativeAssetId)).not.toContain(hiAlbum);
+  });
+
+  it('regression: visibility=Timeline via spaceId still returns Timeline asset (no over-block)', async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const tl = await makeBucketReadyAsset(ctx, owner.id, AssetVisibility.Timeline);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tl });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countTimeBuckets(await assetRepo.getTimeBuckets(opts))).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 19: LibraryAssetSync / LibraryAssetExifSync
+// Fix B regression lock.
+// Rule: a viewer receiving a library sync backfill for a space-linked library
+//   sees the owner's Timeline + Archive assets; Hidden + Locked are ABSENT.
+//   The owner syncing their own library sees ALL visibilities.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: LibraryAssetSync — space-linked library visibility gate', () => {
+  const BACKFILL: SyncBackfillOptions = { nowId: NOW_ID, beforeUpdateId: NOW_ID };
+
+  it("viewer's backfill omits another owner's Hidden+Locked library assets; includes Timeline+Archive", async () => {
+    const { syncRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const makeLibAsset = async (vis: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis, libraryId: library.id });
+      return asset.id;
+    };
+
+    const tlId = await makeLibAsset(AssetVisibility.Timeline);
+    const arId = await makeLibAsset(AssetVisibility.Archive);
+    const hiId = await makeLibAsset(AssetVisibility.Hidden);
+    const loId = await makeLibAsset(AssetVisibility.Locked);
+
+    // Viewer backfill: spaceVisibilityGate → Timeline + Archive only
+    const viewerStream = syncRepo.libraryAsset.getBackfill(BACKFILL, library.id, viewer.id);
+    const viewerIds = new Set<string>();
+    for await (const row of viewerStream) {
+      viewerIds.add(row.id);
+    }
+    expect(viewerIds.has(tlId)).toBe(true); // Timeline ✓
+    expect(viewerIds.has(arId)).toBe(true); // Archive ✓
+    expect(viewerIds.has(hiId)).toBe(false); // Hidden blocked ✓
+    expect(viewerIds.has(loId)).toBe(false); // Locked blocked ✓
+  });
+
+  it("owner's own backfill surfaces all visibilities (ownerId bypass)", async () => {
+    const { syncRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { result: library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const makeLibAsset = async (vis: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis, libraryId: library.id });
+      return asset.id;
+    };
+
+    const tlId = await makeLibAsset(AssetVisibility.Timeline);
+    const arId = await makeLibAsset(AssetVisibility.Archive);
+    const hiId = await makeLibAsset(AssetVisibility.Hidden);
+    const loId = await makeLibAsset(AssetVisibility.Locked);
+
+    // Owner backfill: ownerId matches → all visibilities present
+    const ownerStream = syncRepo.libraryAsset.getBackfill(BACKFILL, library.id, owner.id);
+    const ownerIds = new Set<string>();
+    for await (const row of ownerStream) {
+      ownerIds.add(row.id);
+    }
+    expect(ownerIds.has(tlId)).toBe(true);
+    expect(ownerIds.has(arId)).toBe(true);
+    expect(ownerIds.has(hiId)).toBe(true); // Own Hidden present ✓
+    expect(ownerIds.has(loId)).toBe(true); // Own Locked present ✓
+  });
+});
+
+describe('matrix: LibraryAssetExifSync — space-linked library visibility gate', () => {
+  const BACKFILL: SyncBackfillOptions = { nowId: NOW_ID, beforeUpdateId: NOW_ID };
+
+  it("viewer's EXIF backfill omits another owner's Hidden+Locked library assets; includes Timeline+Archive", async () => {
+    const { syncRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const makeLibExifAsset = async (vis: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis, libraryId: library.id });
+      await ctx.newExif({ assetId: asset.id, timeZone: 'UTC', fileSizeInByte: 512 });
+      return asset.id;
+    };
+
+    const tlId = await makeLibExifAsset(AssetVisibility.Timeline);
+    const arId = await makeLibExifAsset(AssetVisibility.Archive);
+    const hiId = await makeLibExifAsset(AssetVisibility.Hidden);
+    const loId = await makeLibExifAsset(AssetVisibility.Locked);
+
+    const viewerStream = syncRepo.libraryAssetExif.getBackfill(BACKFILL, library.id, viewer.id);
+    const viewerIds = new Set<string>();
+    for await (const row of viewerStream) {
+      viewerIds.add(row.assetId as string);
+    }
+    expect(viewerIds.has(tlId)).toBe(true); // Timeline ✓
+    expect(viewerIds.has(arId)).toBe(true); // Archive ✓
+    expect(viewerIds.has(hiId)).toBe(false); // Hidden blocked ✓
+    expect(viewerIds.has(loId)).toBe(false); // Locked blocked ✓
+  });
+
+  it("owner's EXIF backfill surfaces all visibilities (ownerId bypass)", async () => {
+    const { syncRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { result: library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const makeLibExifAsset = async (vis: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis, libraryId: library.id });
+      await ctx.newExif({ assetId: asset.id, timeZone: 'UTC', fileSizeInByte: 512 });
+      return asset.id;
+    };
+
+    const tlId = await makeLibExifAsset(AssetVisibility.Timeline);
+    const arId = await makeLibExifAsset(AssetVisibility.Archive);
+    const hiId = await makeLibExifAsset(AssetVisibility.Hidden);
+    const loId = await makeLibExifAsset(AssetVisibility.Locked);
+
+    const ownerStream = syncRepo.libraryAssetExif.getBackfill(BACKFILL, library.id, owner.id);
+    const ownerIds = new Set<string>();
+    for await (const row of ownerStream) {
+      ownerIds.add(row.assetId as string);
+    }
+    expect(ownerIds.has(tlId)).toBe(true);
+    expect(ownerIds.has(arId)).toBe(true);
+    expect(ownerIds.has(hiId)).toBe(true); // Own Hidden present ✓
+    expect(ownerIds.has(loId)).toBe(true); // Own Locked present ✓
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 20: activity.search / getStatistics for a space-linked album
+// Fix C regression lock.
+// Rule: activity on Hidden/Locked album assets is ABSENT from search results
+//   and excluded from statistics counts, even when the album is space-linked.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: activity.search — space-linked album hides Hidden/Locked asset activity', () => {
+  it('search() omits activity on Hidden+Locked assets; includes Timeline+Archive', async () => {
+    const { activityRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'ActivityMxAlbum' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: arAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hiAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: loAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [tlAsset.id, arAsset.id, hiAsset.id, loAsset.id]) {
+      await ctx.newAlbumAsset({ albumId: album.id, assetId });
+    }
+
+    // One like per asset
+    await activityRepo.create({ albumId: album.id, assetId: tlAsset.id, userId: owner.id, isLiked: true });
+    await activityRepo.create({ albumId: album.id, assetId: arAsset.id, userId: owner.id, isLiked: true });
+    await activityRepo.create({ albumId: album.id, assetId: hiAsset.id, userId: owner.id, isLiked: true });
+    await activityRepo.create({ albumId: album.id, assetId: loAsset.id, userId: owner.id, isLiked: true });
+
+    const results = await activityRepo.search({ albumId: album.id });
+    const assetIds = results.map((r) => r.assetId);
+
+    expect(assetIds).toContain(tlAsset.id); // Timeline ✓
+    expect(assetIds).toContain(arAsset.id); // Archive ✓
+    expect(assetIds).not.toContain(hiAsset.id); // Hidden blocked ✓
+    expect(assetIds).not.toContain(loAsset.id); // Locked blocked ✓
+  });
+
+  it('getStatistics() excludes counts for Hidden+Locked asset activity', async () => {
+    const { activityRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'StatsMxAlbum' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: hiAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: loAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [tlAsset.id, hiAsset.id, loAsset.id]) {
+      await ctx.newAlbumAsset({ albumId: album.id, assetId });
+    }
+
+    // 1 comment on each (isLiked=false requires comment IS NOT NULL)
+    await activityRepo.create({
+      albumId: album.id,
+      assetId: tlAsset.id,
+      userId: owner.id,
+      isLiked: false,
+      comment: 'visible',
+    });
+    await activityRepo.create({
+      albumId: album.id,
+      assetId: hiAsset.id,
+      userId: owner.id,
+      isLiked: false,
+      comment: 'hidden',
+    });
+    await activityRepo.create({
+      albumId: album.id,
+      assetId: loAsset.id,
+      userId: owner.id,
+      isLiked: false,
+      comment: 'locked',
+    });
+
+    const stats = await activityRepo.getStatistics({ albumId: album.id });
+    // Only the Timeline comment should count
+    expect(Number(stats.comments)).toBe(1);
+    expect(Number(stats.likes)).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 21: getAlbumInfo email redaction (AlbumService.get)
+// Fix D regression lock.
+// Rule: a space Viewer who has AlbumRead access (via checkSpaceLinkedAlbumReadAccess)
+//   but is NOT an album_user participant gets all albumUser.email fields redacted to ''.
+//   An actual album participant sees real emails.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const setupAlbumService = () => {
+  const result = newMediumService(AlbumService, {
+    database: defaultDatabase,
+    real: [AccessRepository, AlbumRepository, AlbumUserRepository, SharedSpaceRepository, UserRepository],
+    mock: [LoggingRepository],
+  });
+  return result;
+};
+
+describe('matrix: AlbumService.get — email redaction for space-only Viewer', () => {
+  it('redacts albumUser emails for a space Viewer who is not an album participant', async () => {
+    const { sut, ctx } = setupAlbumService();
+    const { user: owner } = await ctx.newUser();
+    const { user: collaborator } = await ctx.newUser(); // album participant
+    const { user: viewer } = await ctx.newUser(); // space viewer, NOT album participant
+
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'EmailRedactAlbum' });
+
+    // Add collaborator as album_user so albumUsers is non-empty — emails would leak if not redacted
+    await ctx.newAlbumUser({ albumId: album.id, userId: collaborator.id, role: AlbumUserRole.Editor });
+
+    // Link album to space so viewer gets AlbumRead
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const viewerAuth = factory.auth({ user: { id: viewer.id, email: viewer.email } });
+    const result = await sut.get(viewerAuth, album.id);
+
+    // albumUsers must be present in the response (viewer can still see that participants exist)
+    expect(result.albumUsers.length).toBeGreaterThan(0);
+
+    // but all email fields must be redacted to '' (space Viewer is not a participant)
+    for (const albumUser of result.albumUsers) {
+      expect(albumUser.user.email).toBe('');
+    }
+  });
+
+  it('does NOT redact emails for an album participant (album_user) accessing via the album', async () => {
+    const { sut, ctx } = setupAlbumService();
+    const { user: owner } = await ctx.newUser();
+    const { user: participant } = await ctx.newUser();
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'EmailNoRedactAlbum' });
+    await ctx.newAlbumUser({ albumId: album.id, userId: participant.id, role: AlbumUserRole.Editor });
+
+    const participantAuth = factory.auth({ user: { id: participant.id, email: participant.email } });
+    const result = await sut.get(participantAuth, album.id);
+
+    // Participant is in albumUsers — emails must NOT be redacted
+    const participantEntry = result.albumUsers.find((u) => u.user.id === participant.id);
+    expect(participantEntry).toBeDefined();
+    expect(participantEntry!.user.email).not.toBe('');
+    expect(participantEntry!.user.email).toContain('@');
+  });
+
+  it('does NOT redact emails for the album owner accessing their own album', async () => {
+    const { sut, ctx } = setupAlbumService();
+    const { user: owner } = await ctx.newUser();
+    const { user: collaborator } = await ctx.newUser();
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'OwnerNoRedactAlbum' });
+    await ctx.newAlbumUser({ albumId: album.id, userId: collaborator.id, role: AlbumUserRole.Editor });
+
+    const ownerAuth = factory.auth({ user: { id: owner.id, email: owner.email } });
+    const result = await sut.get(ownerAuth, album.id);
+
+    // Owner is in albumUsers (role=Owner) — emails must not be redacted for owner
+    for (const albumUser of result.albumUsers) {
+      expect(albumUser.user.email).not.toBe('');
+      expect(albumUser.user.email).toContain('@');
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 22: album-scoped facets (getFilterSuggestions with albumId)
+// Fix I regression lock.
+// Rule: when scoping suggestions to an albumId, another participant's Hidden
+//   asset's facet values (e.g. country) must NOT appear in the result.
+//   A participant's Archive + Timeline values ARE present.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: album-scoped facets — getFilterSuggestions excludes Hidden facet values', () => {
+  it("excludes another participant's Hidden-asset facet from album-scoped suggestions", async () => {
+    const { searchRepo, spaceRepo, ctx } = setup();
+    const { user: albumOwner } = await ctx.newUser();
+    const { user: participant } = await ctx.newUser(); // album_user contributor
+    const { user: viewer } = await ctx.newUser(); // space viewer
+
+    const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: albumOwner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'FacetMxAlbum' });
+
+    // Add participant as album_user (contributor)
+    await ctx.newAlbumUser({ albumId: album.id, userId: participant.id, role: AlbumUserRole.Editor });
+
+    // Link album to space
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: albumOwner.id });
+
+    // Participant's Timeline asset — country should appear
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: participant.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: tlAsset.id, country: 'ParticipantTimelineCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: tlAsset.id });
+
+    // Participant's Archive asset — Archive IS present in album-scoped suggestions (spaceVisibilityGate)
+    const { asset: arAsset } = await ctx.newAsset({ ownerId: participant.id, visibility: AssetVisibility.Archive });
+    await ctx.newExif({ assetId: arAsset.id, country: 'ParticipantArchiveCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: arAsset.id });
+
+    // Participant's Hidden asset — country must NOT appear in facets
+    const { asset: hiAsset } = await ctx.newAsset({ ownerId: participant.id, visibility: AssetVisibility.Hidden });
+    await ctx.newExif({ assetId: hiAsset.id, country: 'ParticipantHiddenCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiAsset.id });
+
+    // Viewer's own Timeline asset in the album
+    const { asset: viewerTl } = await ctx.newAsset({ ownerId: viewer.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: viewerTl.id, country: 'ViewerTimelineCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: viewerTl.id });
+
+    // Get album-scoped filter suggestions from the viewer's perspective
+    const result = await searchRepo.getFilterSuggestions([viewer.id], { albumId: album.id });
+
+    // Viewer's own Timeline country — present (ownerId bypass)
+    expect(result.countries).toContain('ViewerTimelineCountry');
+    // Participant's Timeline country — present (participant + spaceVisibilityGate)
+    expect(result.countries).toContain('ParticipantTimelineCountry');
+    // Participant's Archive country — present (spaceVisibilityGate includes Archive)
+    expect(result.countries).toContain('ParticipantArchiveCountry');
+    // Participant's Hidden country — ABSENT (spaceVisibilityGate blocks Hidden)
+    expect(result.countries).not.toContain('ParticipantHiddenCountry');
+  });
+
+  it("excludes another participant's Locked-asset facet from album-scoped suggestions", async () => {
+    const { searchRepo, ctx } = setup();
+    const { user: albumOwner } = await ctx.newUser();
+    const { user: participant } = await ctx.newUser();
+
+    const { result: album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'FacetLockedMxAlbum' });
+    await ctx.newAlbumUser({ albumId: album.id, userId: participant.id, role: AlbumUserRole.Editor });
+
+    // Participant's Timeline asset — should appear
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: participant.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: tlAsset.id, country: 'ParticipantLockedTLCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: tlAsset.id });
+
+    // Participant's Locked asset — must NOT appear
+    const { asset: loAsset } = await ctx.newAsset({ ownerId: participant.id, visibility: AssetVisibility.Locked });
+    await ctx.newExif({ assetId: loAsset.id, country: 'ParticipantLockedCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: loAsset.id });
+
+    // Ask from albumOwner's perspective (they are a participant)
+    const result = await searchRepo.getFilterSuggestions([albumOwner.id], { albumId: album.id });
+
+    expect(result.countries).toContain('ParticipantLockedTLCountry'); // Timeline ✓
+    expect(result.countries).not.toContain('ParticipantLockedCountry'); // Locked blocked ✓
   });
 });

--- a/server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts
@@ -878,6 +878,148 @@ describe('matrix: space people-facets — getPersonsBySpaceId', () => {
     const after = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: false });
     expect(after.map((p) => p.id)).not.toContain(person.id);
   });
+
+  it('regression: person with a MIX of visible + hidden faces IS still listed', async () => {
+    // A person has two faces: one on a Timeline asset (visible) and one on a Hidden asset.
+    // Since ≥1 visible face exists, the person MUST appear in the list.
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tlAsset.id });
+    const { result: tlFaceId } = await ctx.newAssetFace({ assetId: tlAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: tlFaceId, embedding: newEmbedding() }).execute();
+
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiddenAsset.id });
+    const { result: hiddenFaceId } = await ctx.newAssetFace({ assetId: hiddenAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: hiddenFaceId, embedding: newEmbedding() }).execute();
+
+    const person = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'MixPerson',
+      representativeFaceId: tlFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces(
+      [
+        { personId: person.id, assetFaceId: tlFaceId },
+        { personId: person.id, assetFaceId: hiddenFaceId },
+      ],
+      { skipRecount: true },
+    );
+    await spaceRepo.recountPersons([person.id]);
+
+    const people = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: false });
+    expect(people.map((p) => p.id)).toContain(person.id);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 11b: countPersonsBySpaceId — must match the getPersonsBySpaceId list
+// A person with only hidden/locked faces must be excluded from the count too.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: countPersonsBySpaceId — visibility consistency', () => {
+  it('excludes a person backed only by Hidden faces from the count', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    // Visible person (Timeline face)
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tlAsset.id });
+    const { result: tlFaceId } = await ctx.newAssetFace({ assetId: tlAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: tlFaceId, embedding: newEmbedding() }).execute();
+    const visiblePerson = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'TLPerson',
+      representativeFaceId: tlFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: visiblePerson.id, assetFaceId: tlFaceId }], { skipRecount: true });
+    await spaceRepo.recountPersons([visiblePerson.id]);
+
+    // Hidden-only person
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiddenAsset.id });
+    const { result: hiddenFaceId } = await ctx.newAssetFace({ assetId: hiddenAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: hiddenFaceId, embedding: newEmbedding() }).execute();
+    const hiddenOnlyPerson = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'HiddenOnlyPerson',
+      representativeFaceId: hiddenFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: hiddenOnlyPerson.id, assetFaceId: hiddenFaceId }], {
+      skipRecount: true,
+    });
+    await spaceRepo.recountPersons([hiddenOnlyPerson.id]);
+
+    const { total } = await spaceRepo.countPersonsBySpaceId(space.id, { petsEnabled: false });
+    // Only the Timeline-backed person should be counted
+    expect(total).toBe(1);
+  });
+
+  it('excludes a person backed only by Locked faces from the count', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { asset: lockedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: lockedAsset.id });
+    const { result: lockedFaceId } = await ctx.newAssetFace({ assetId: lockedAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: lockedFaceId, embedding: newEmbedding() }).execute();
+    const person = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'LockedOnlyPerson',
+      representativeFaceId: lockedFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: person.id, assetFaceId: lockedFaceId }], { skipRecount: true });
+    await spaceRepo.recountPersons([person.id]);
+
+    const { total } = await spaceRepo.countPersonsBySpaceId(space.id, { petsEnabled: false });
+    expect(total).toBe(0);
+  });
+
+  it('count matches list: list and count agree on persons with visible faces only', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    // Two visible persons (Timeline), one hidden-only
+    for (const [name, vis] of [
+      ['Alice', AssetVisibility.Timeline] as const,
+      ['Bob', AssetVisibility.Archive] as const,
+      ['Ghost', AssetVisibility.Hidden] as const,
+    ]) {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id });
+      await ctx.database.insertInto('face_search').values({ faceId, embedding: newEmbedding() }).execute();
+      const p = await spaceRepo.createPerson({
+        spaceId: space.id,
+        name,
+        representativeFaceId: faceId,
+        type: 'person',
+      });
+      await spaceRepo.addPersonFaces([{ personId: p.id, assetFaceId: faceId }], { skipRecount: true });
+      await spaceRepo.recountPersons([p.id]);
+    }
+
+    const list = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: false, petsEnabled: false });
+    const { total } = await spaceRepo.countPersonsBySpaceId(space.id, { petsEnabled: false });
+
+    // 2 visible persons (Timeline + Archive); Ghost excluded
+    expect(list).toHaveLength(2);
+    expect(total).toBe(2);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-visibility-matrix.medium.spec.ts
@@ -1,0 +1,1291 @@
+/**
+ * Slice 11 — Exhaustive RBAC visibility matrix (regression lock).
+ *
+ * Seeds {Timeline, Archive, Hidden, Locked} × {direct, library, album(showInTimeline=true),
+ * album(showInTimeline=false), soft-deleted-album} and asserts the correct visible set
+ * on EVERY surface touched by the space-albums RBAC hardening work (Slices 1–10).
+ *
+ * KEY RULES encoded here:
+ *  - download / access / sync / search: Timeline + Archive present; Hidden + Locked ABSENT.
+ *  - map / memory / view / folders: Timeline ONLY (Archive excluded by design).
+ *  - showInTimeline=false album: ABSENT on projection surfaces; PRESENT on grant surfaces
+ *    (album-asset sync backfill, direct album download/access).
+ *  - soft-deleted album: ABSENT on all surfaces.
+ *  - space people-facets: a face on another member's Hidden asset must NOT surface the
+ *    space-person (visibility-gated by getPersonsBySpaceId + getPersonAssetIds).
+ *
+ * If ANY cell is RED (unexpected failure), that is a real gap in a prior slice —
+ * DO NOT weaken the assertion; report it.
+ */
+
+import { Kysely } from 'kysely';
+import { AssetVisibility, TimeBucketSize } from 'src/enum';
+import { AccessRepository } from 'src/repositories/access.repository';
+import { AssetRepository, TimeBucketOptions } from 'src/repositories/asset.repository';
+import { DownloadRepository } from 'src/repositories/download.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { MapRepository } from 'src/repositories/map.repository';
+import { MemoryRepository } from 'src/repositories/memory.repository';
+import { SearchRepository } from 'src/repositories/search.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { SyncRepository } from 'src/repositories/sync.repository';
+import { TagRepository } from 'src/repositories/tag.repository';
+import { ViewRepository } from 'src/repositories/view-repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { upsertTags } from 'src/utils/tag';
+import { newMediumService } from 'test/medium.factory';
+import { newEmbedding } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+// Max UUIDv7-style value — used as nowId/beforeUpdateId to include ALL rows in backfill.
+const NOW_ID = 'ffffffff-ffff-7fff-bfff-ffffffffffff';
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: defaultDatabase,
+    real: [
+      AccessRepository,
+      AssetRepository,
+      DownloadRepository,
+      MapRepository,
+      MemoryRepository,
+      SearchRepository,
+      SharedSpaceRepository,
+      SyncRepository,
+      TagRepository,
+      ViewRepository,
+    ],
+    mock: [LoggingRepository],
+  });
+  return {
+    ctx,
+    accessRepo: ctx.get(AccessRepository),
+    assetRepo: ctx.get(AssetRepository),
+    downloadRepo: ctx.get(DownloadRepository),
+    mapRepo: ctx.get(MapRepository),
+    memoryRepo: ctx.get(MemoryRepository),
+    searchRepo: ctx.get(SearchRepository),
+    spaceRepo: ctx.get(SharedSpaceRepository),
+    syncRepo: ctx.get(SyncRepository),
+    tagRepo: ctx.get(TagRepository),
+    viewRepo: ctx.get(ViewRepository),
+  };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+// Helpers to collect streaming results
+async function collectDownloadIds(stream: AsyncIterable<{ id: string }>): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for await (const row of stream) {
+    ids.add(row.id);
+  }
+  return ids;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FIXTURE BUILDER
+// Seeds the full 4×5 matrix into a fresh space for each test.
+// Returns named handles for every asset so assertions can be expressed clearly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MatrixAssets {
+  // direct-add (shared_space_asset)
+  directTimeline: string;
+  directArchive: string;
+  directHidden: string;
+  directLocked: string;
+  // library-linked (shared_space_library)
+  libTimeline: string;
+  libArchive: string;
+  libHidden: string;
+  libLocked: string;
+  // album, showInTimeline=true
+  albumShownTimeline: string;
+  albumShownArchive: string;
+  albumShownHidden: string;
+  albumShownLocked: string;
+  // album, showInTimeline=false (projection surfaces must exclude; grant surfaces include)
+  albumHiddenTimeline: string;
+  albumHiddenArchive: string;
+  // soft-deleted album (all surfaces exclude)
+  albumDeletedTimeline: string;
+}
+
+interface MatrixFixture {
+  assets: MatrixAssets;
+  spaceId: string;
+  albumShownId: string; // album with showInTimeline=true
+  albumHiddenId: string; // album with showInTimeline=false
+  albumDeletedId: string; // soft-deleted album
+  ownerId: string;
+  viewerId: string;
+}
+
+const seedMatrix = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  spaceRepo: SharedSpaceRepository,
+): Promise<MatrixFixture> => {
+  const { user: owner } = await ctx.newUser();
+  const { user: viewer } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+  // Helper: asset with GPS so map markers can find it
+  const makeAsset = async (vis: AssetVisibility, opts: { libraryId?: string } = {}) => {
+    const { asset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: vis,
+      ...opts,
+      fileCreatedAt: new Date('2024-06-15T12:00:00.000Z'),
+      localDateTime: new Date('2024-06-15T12:00:00.000Z'),
+      width: 400,
+      height: 300,
+      thumbhash: Buffer.from('t'),
+    });
+    await ctx.newExif({
+      assetId: asset.id,
+      latitude: 48.8566,
+      longitude: 2.3522,
+      timeZone: 'UTC',
+      fileSizeInByte: 1024,
+    });
+    return asset.id;
+  };
+
+  // ── direct-add ──────────────────────────────────────────────────────────────
+  const directTimeline = await makeAsset(AssetVisibility.Timeline);
+  const directArchive = await makeAsset(AssetVisibility.Archive);
+  const directHidden = await makeAsset(AssetVisibility.Hidden);
+  const directLocked = await makeAsset(AssetVisibility.Locked);
+  for (const assetId of [directTimeline, directArchive, directHidden, directLocked]) {
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+  }
+
+  // ── library-linked ───────────────────────────────────────────────────────────
+  const { result: library } = await ctx.newLibrary({ ownerId: owner.id });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+  const libTimeline = await makeAsset(AssetVisibility.Timeline, { libraryId: library.id });
+  const libArchive = await makeAsset(AssetVisibility.Archive, { libraryId: library.id });
+  const libHidden = await makeAsset(AssetVisibility.Hidden, { libraryId: library.id });
+  const libLocked = await makeAsset(AssetVisibility.Locked, { libraryId: library.id });
+
+  // ── album, showInTimeline=true ───────────────────────────────────────────────
+  const { result: albumShown } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'ShownAlbum' });
+  await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumShown.id, addedById: owner.id });
+  // showInTimeline is true by default in addAlbum
+  const albumShownTimeline = await makeAsset(AssetVisibility.Timeline);
+  const albumShownArchive = await makeAsset(AssetVisibility.Archive);
+  const albumShownHidden = await makeAsset(AssetVisibility.Hidden);
+  const albumShownLocked = await makeAsset(AssetVisibility.Locked);
+  for (const assetId of [albumShownTimeline, albumShownArchive, albumShownHidden, albumShownLocked]) {
+    await ctx.newAlbumAsset({ albumId: albumShown.id, assetId });
+  }
+
+  // ── album, showInTimeline=false ──────────────────────────────────────────────
+  const { result: albumHidden } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenAlbum' });
+  await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumHidden.id, addedById: owner.id });
+  await spaceRepo.setAlbumShowInTimeline(space.id, albumHidden.id, false);
+  const albumHiddenTimeline = await makeAsset(AssetVisibility.Timeline);
+  const albumHiddenArchive = await makeAsset(AssetVisibility.Archive);
+  for (const assetId of [albumHiddenTimeline, albumHiddenArchive]) {
+    await ctx.newAlbumAsset({ albumId: albumHidden.id, assetId });
+  }
+
+  // ── soft-deleted album ───────────────────────────────────────────────────────
+  const { result: albumDeleted } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'DeletedAlbum' });
+  await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumDeleted.id, addedById: owner.id });
+  const albumDeletedTimeline = await makeAsset(AssetVisibility.Timeline);
+  await ctx.newAlbumAsset({ albumId: albumDeleted.id, assetId: albumDeletedTimeline });
+  await ctx.softDeleteAlbum(albumDeleted.id);
+
+  return {
+    assets: {
+      directTimeline,
+      directArchive,
+      directHidden,
+      directLocked,
+      libTimeline,
+      libArchive,
+      libHidden,
+      libLocked,
+      albumShownTimeline,
+      albumShownArchive,
+      albumShownHidden,
+      albumShownLocked,
+      albumHiddenTimeline,
+      albumHiddenArchive,
+      albumDeletedTimeline,
+    },
+    spaceId: space.id,
+    albumShownId: albumShown.id,
+    albumHiddenId: albumHidden.id,
+    albumDeletedId: albumDeleted.id,
+    ownerId: owner.id,
+    viewerId: viewer.id,
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 1: downloadSpaceId
+// Rule: Timeline + Archive present; Hidden + Locked ABSENT; showInTimeline=false
+// album PRESENT (download is a grant surface, not projection); soft-deleted ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: downloadSpaceId', () => {
+  it('grants Timeline+Archive on all paths; blocks Hidden+Locked; showInTimeline=false present; soft-deleted absent', async () => {
+    const { downloadRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const ids = await collectDownloadIds(downloadRepo.downloadSpaceId(f.spaceId));
+    const a = f.assets;
+
+    // Present: direct Timeline + Archive
+    expect(ids.has(a.directTimeline)).toBe(true);
+    expect(ids.has(a.directArchive)).toBe(true);
+    // Absent: direct Hidden + Locked
+    expect(ids.has(a.directHidden)).toBe(false);
+    expect(ids.has(a.directLocked)).toBe(false);
+
+    // Present: library Timeline + Archive
+    expect(ids.has(a.libTimeline)).toBe(true);
+    expect(ids.has(a.libArchive)).toBe(true);
+    // Absent: library Hidden + Locked
+    expect(ids.has(a.libHidden)).toBe(false);
+    expect(ids.has(a.libLocked)).toBe(false);
+
+    // Present: album(shown) Timeline + Archive
+    expect(ids.has(a.albumShownTimeline)).toBe(true);
+    expect(ids.has(a.albumShownArchive)).toBe(true);
+    // Absent: album(shown) Hidden + Locked
+    expect(ids.has(a.albumShownHidden)).toBe(false);
+    expect(ids.has(a.albumShownLocked)).toBe(false);
+
+    // Present: album(hidden, showInTimeline=false) — download IS a grant surface
+    expect(ids.has(a.albumHiddenTimeline)).toBe(true);
+    expect(ids.has(a.albumHiddenArchive)).toBe(true);
+
+    // Absent: soft-deleted album
+    expect(ids.has(a.albumDeletedTimeline)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 2: downloadAlbumId (via AlbumDownload space grant)
+// Rule: Timeline + Archive present; Hidden + Locked ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: downloadAlbumId (via space grant)', () => {
+  it('grants Timeline+Archive; blocks Hidden+Locked for a linked album download', async () => {
+    const { downloadRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const ids = await collectDownloadIds(downloadRepo.downloadAlbumId(f.albumShownId));
+    const a = f.assets;
+
+    expect(ids.has(a.albumShownTimeline)).toBe(true);
+    expect(ids.has(a.albumShownArchive)).toBe(true);
+    expect(ids.has(a.albumShownHidden)).toBe(false);
+    expect(ids.has(a.albumShownLocked)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 3: checkSpaceAccess (all three paths)
+// Rule: Timeline + Archive granted; Hidden + Locked absent.
+// showInTimeline=false album: ABSENT (checkSpaceAccess applies requireShowInTimeline).
+// soft-deleted album: ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: checkSpaceAccess', () => {
+  it('grants Timeline+Archive on all paths; blocks Hidden+Locked+noTimeline+deletedAlbum', async () => {
+    const { accessRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const a = f.assets;
+
+    const allIds = new Set([
+      a.directTimeline,
+      a.directArchive,
+      a.directHidden,
+      a.directLocked,
+      a.libTimeline,
+      a.libArchive,
+      a.libHidden,
+      a.libLocked,
+      a.albumShownTimeline,
+      a.albumShownArchive,
+      a.albumShownHidden,
+      a.albumShownLocked,
+      a.albumHiddenTimeline,
+      a.albumHiddenArchive,
+      a.albumDeletedTimeline,
+    ]);
+    const result = await accessRepo.asset.checkSpaceAccess(f.viewerId, allIds);
+
+    // Direct path
+    expect(result.has(a.directTimeline)).toBe(true);
+    expect(result.has(a.directArchive)).toBe(true);
+    expect(result.has(a.directHidden)).toBe(false);
+    expect(result.has(a.directLocked)).toBe(false);
+
+    // Library path
+    expect(result.has(a.libTimeline)).toBe(true);
+    expect(result.has(a.libArchive)).toBe(true);
+    expect(result.has(a.libHidden)).toBe(false);
+    expect(result.has(a.libLocked)).toBe(false);
+
+    // Album(shown) path
+    expect(result.has(a.albumShownTimeline)).toBe(true);
+    expect(result.has(a.albumShownArchive)).toBe(true);
+    expect(result.has(a.albumShownHidden)).toBe(false);
+    expect(result.has(a.albumShownLocked)).toBe(false);
+
+    // Album(hidden, showInTimeline=false) — PRESENT on checkSpaceAccess (grant surface, not projection).
+    // The showInTimeline flag suppresses assets from timeline/map/memory/search (projection surfaces),
+    // but does NOT revoke READ access (e.g. the album itself is still downloadable).
+    expect(result.has(a.albumHiddenTimeline)).toBe(true);
+    expect(result.has(a.albumHiddenArchive)).toBe(true);
+
+    // Soft-deleted album — ABSENT
+    expect(result.has(a.albumDeletedTimeline)).toBe(false);
+  });
+
+  it('added-then-flipped: direct-add asset flipped from Timeline to Locked → revoked', async () => {
+    const { accessRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const a = f.assets;
+
+    const before = await accessRepo.asset.checkSpaceAccess(f.viewerId, new Set([a.directTimeline]));
+    expect(before.has(a.directTimeline)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', a.directTimeline)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceAccess(f.viewerId, new Set([a.directTimeline]));
+    expect(after.has(a.directTimeline)).toBe(false);
+  });
+
+  it('added-then-flipped: album-path asset flipped from Timeline to Hidden → revoked', async () => {
+    const { accessRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const a = f.assets;
+
+    const before = await accessRepo.asset.checkSpaceAccess(f.viewerId, new Set([a.albumShownTimeline]));
+    expect(before.has(a.albumShownTimeline)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', a.albumShownTimeline)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceAccess(f.viewerId, new Set([a.albumShownTimeline]));
+    expect(after.has(a.albumShownTimeline)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 4: checkSpaceAccessForSpace
+// Same rules as checkSpaceAccess but with explicit spaceId.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: checkSpaceAccessForSpace', () => {
+  it('grants Timeline+Archive; blocks Hidden+Locked+noTimeline+deletedAlbum', async () => {
+    const { accessRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const a = f.assets;
+
+    const allIds = new Set([
+      a.directTimeline,
+      a.directArchive,
+      a.directHidden,
+      a.directLocked,
+      a.libTimeline,
+      a.libArchive,
+      a.libHidden,
+      a.libLocked,
+      a.albumShownTimeline,
+      a.albumShownArchive,
+      a.albumShownHidden,
+      a.albumShownLocked,
+      a.albumHiddenTimeline,
+      a.albumHiddenArchive,
+      a.albumDeletedTimeline,
+    ]);
+    const result = await accessRepo.asset.checkSpaceAccessForSpace(f.viewerId, f.spaceId, allIds);
+
+    expect(result.has(a.directTimeline)).toBe(true);
+    expect(result.has(a.directArchive)).toBe(true);
+    expect(result.has(a.directHidden)).toBe(false);
+    expect(result.has(a.directLocked)).toBe(false);
+
+    expect(result.has(a.libTimeline)).toBe(true);
+    expect(result.has(a.libArchive)).toBe(true);
+    expect(result.has(a.libHidden)).toBe(false);
+    expect(result.has(a.libLocked)).toBe(false);
+
+    expect(result.has(a.albumShownTimeline)).toBe(true);
+    expect(result.has(a.albumShownArchive)).toBe(true);
+    expect(result.has(a.albumShownHidden)).toBe(false);
+    expect(result.has(a.albumShownLocked)).toBe(false);
+
+    // showInTimeline=false album — PRESENT on checkSpaceAccessForSpace (grant surface, not projection).
+    expect(result.has(a.albumHiddenTimeline)).toBe(true);
+    expect(result.has(a.albumHiddenArchive)).toBe(true);
+
+    // soft-deleted — ABSENT
+    expect(result.has(a.albumDeletedTimeline)).toBe(false);
+  });
+
+  it('added-then-flipped: library asset flipped from Archive to Locked → revoked', async () => {
+    const { accessRepo, spaceRepo, ctx } = setup();
+    const f = await seedMatrix(ctx, spaceRepo);
+    const a = f.assets;
+
+    const before = await accessRepo.asset.checkSpaceAccessForSpace(f.viewerId, f.spaceId, new Set([a.libArchive]));
+    expect(before.has(a.libArchive)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', a.libArchive)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceAccessForSpace(f.viewerId, f.spaceId, new Set([a.libArchive]));
+    expect(after.has(a.libArchive)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 5: checkSpaceEditAccess
+// Same visibility rules; only editor (not viewer) gets the grant.
+// NO album arm (known RBAC gap) — but visibility gate IS applied (Slice 10).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: checkSpaceEditAccess', () => {
+  it('grants Timeline+Archive to editor; blocks Hidden+Locked (direct path); viewer gets nothing', async () => {
+    const { accessRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: editor } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: editor.id, role: 'editor' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset: tl } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: ar } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hi } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: lo } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [tl.id, ar.id, hi.id, lo.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    const editorResult = await accessRepo.asset.checkSpaceEditAccess(editor.id, new Set([tl.id, ar.id, hi.id, lo.id]));
+    expect(editorResult.has(tl.id)).toBe(true);
+    expect(editorResult.has(ar.id)).toBe(true);
+    expect(editorResult.has(hi.id)).toBe(false);
+    expect(editorResult.has(lo.id)).toBe(false);
+
+    const viewerResult = await accessRepo.asset.checkSpaceEditAccess(viewer.id, new Set([tl.id]));
+    expect(viewerResult.has(tl.id)).toBe(false);
+  });
+
+  it('added-then-flipped: asset flipped to Locked → edit access revoked', async () => {
+    const { accessRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: editor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: editor.id, role: 'editor' });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const before = await accessRepo.asset.checkSpaceEditAccess(editor.id, new Set([asset.id]));
+    expect(before.has(asset.id)).toBe(true);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Locked })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await accessRepo.asset.checkSpaceEditAccess(editor.id, new Set([asset.id]));
+    expect(after.has(asset.id)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 6: sync — SharedSpaceAssetSync (direct-add path)
+// Rule: Timeline + Archive present; Hidden + Locked ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: SharedSpaceAssetSync backfill (direct path)', () => {
+  it('grants Timeline+Archive; blocks Hidden+Locked', async () => {
+    const { ctx, syncRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { asset: tl } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: ar } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hi } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: lo } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [tl.id, ar.id, hi.id, lo.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    const stream = syncRepo.sharedSpaceAsset.getBackfill(
+      { nowId: NOW_ID, beforeUpdateId: NOW_ID },
+      space.id,
+      viewer.id,
+    );
+    const streamIds = new Set<string>();
+    for await (const row of stream) {
+      streamIds.add(row.id);
+    }
+
+    expect(streamIds.has(tl.id)).toBe(true);
+    expect(streamIds.has(ar.id)).toBe(true);
+    expect(streamIds.has(hi.id)).toBe(false);
+    expect(streamIds.has(lo.id)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 7: sync — SharedSpaceAlbumAssetSync backfill (album path)
+// Rule: Timeline + Archive present; Hidden + Locked ABSENT.
+// showInTimeline=false album: PRESENT (album-asset sync is a grant stream,
+//   not a projection stream — the brief is explicit).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: SharedSpaceAlbumAssetSync backfill (album path)', () => {
+  it('grants Timeline+Archive; blocks Hidden+Locked; showInTimeline=false album present', async () => {
+    const { ctx, spaceRepo, syncRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // shown album
+    const { result: albumShown } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'ShownSync' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumShown.id, addedById: owner.id });
+
+    const { asset: tl } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: ar } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hi } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: lo } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+    for (const assetId of [tl.id, ar.id, hi.id, lo.id]) {
+      await ctx.newAlbumAsset({ albumId: albumShown.id, assetId });
+    }
+
+    // hidden album (showInTimeline=false)
+    const { result: albumHidden } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenSync' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumHidden.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, albumHidden.id, false);
+    const { asset: hiddenAlbumTl } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: albumHidden.id, assetId: hiddenAlbumTl.id });
+
+    const stream1 = syncRepo.sharedSpaceAlbumAsset.getBackfill(
+      { nowId: NOW_ID, beforeUpdateId: NOW_ID },
+      albumShown.id,
+      viewer.id,
+    );
+    const shownIds = new Set<string>();
+    for await (const row of stream1) {
+      shownIds.add(row.id);
+    }
+
+    expect(shownIds.has(tl.id)).toBe(true);
+    expect(shownIds.has(ar.id)).toBe(true);
+    expect(shownIds.has(hi.id)).toBe(false);
+    expect(shownIds.has(lo.id)).toBe(false);
+
+    const stream2 = syncRepo.sharedSpaceAlbumAsset.getBackfill(
+      { nowId: NOW_ID, beforeUpdateId: NOW_ID },
+      albumHidden.id,
+      viewer.id,
+    );
+    const hiddenIds = new Set<string>();
+    for await (const row of stream2) {
+      hiddenIds.add(row.id);
+    }
+    // showInTimeline=false album IS present on the sync stream (grant surface)
+    expect(hiddenIds.has(hiddenAlbumTl.id)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 8: getSearchSuggestions / getFilterSuggestions (space-scoped)
+// Rule: Timeline + Archive count; Hidden + Locked ABSENT.
+// Slice 10 note: other members' Archive IS present in search (spaceVisibilityGate).
+// showInTimeline=false album: absent from suggestions (projection surface with
+//   requireShowInTimeline).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: getFilterSuggestions (space-scoped)', () => {
+  it('includes Timeline+Archive countries; excludes Hidden+Locked+noTimeline', async () => {
+    const { searchRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // Direct assets with unique countries per visibility
+    const assetData: Array<{ vis: AssetVisibility; country: string }> = [
+      { vis: AssetVisibility.Timeline, country: 'TimelineCountry' },
+      { vis: AssetVisibility.Archive, country: 'ArchiveCountry' },
+      { vis: AssetVisibility.Hidden, country: 'HiddenCountry' },
+      { vis: AssetVisibility.Locked, country: 'LockedCountry' },
+    ];
+    for (const { vis, country } of assetData) {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      await ctx.newExif({ assetId: asset.id, country });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+    }
+
+    // showInTimeline=false album asset with unique country
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'NoTimelineFilter' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, album.id, false);
+    const { asset: noTlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: noTlAsset.id, country: 'NoTimelineCountry' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: noTlAsset.id });
+
+    // Call with viewer.id only — the M3 bypass in getFilterSuggestions allows a caller's OWN
+    // assets to bypass the space-visibility gate, so passing [owner.id, viewer.id] would expose
+    // the owner's own Hidden/Locked assets (the owner can see their own hidden assets in their
+    // search facets). Testing with viewer.id alone validates the space-member perspective.
+    const result = await searchRepo.getFilterSuggestions([viewer.id], { spaceId: space.id });
+
+    expect(result.countries).toContain('TimelineCountry');
+    // Archive IS included in search (spaceVisibilityGate includes Archive)
+    expect(result.countries).toContain('ArchiveCountry');
+    expect(result.countries).not.toContain('HiddenCountry');
+    expect(result.countries).not.toContain('LockedCountry');
+    // showInTimeline=false album excluded from suggestion projection
+    expect(result.countries).not.toContain('NoTimelineCountry');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 9: getAccessibleTags (space-scoped)
+// Rule: Timeline + Archive present (spaceVisibilityGate); Hidden + Locked ABSENT.
+// showInTimeline=false album: absent (requireShowInTimeline on the scoping).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: getAccessibleTags (space-scoped)', () => {
+  it('returns tags for Timeline+Archive assets; excludes Hidden+Locked+noTimeline', async () => {
+    const { searchRepo, tagRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const makeTaggedAsset = async (vis: AssetVisibility, tagValue: string, asAlbum = false) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      const [tag] = await upsertTags(tagRepo, { userId: owner.id, tags: [tagValue] });
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      if (asAlbum) {
+        const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: `AlbumTag_${tagValue}` });
+        await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+        await spaceRepo.setAlbumShowInTimeline(space.id, album.id, false);
+        await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      } else {
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      }
+      return tag.id;
+    };
+
+    await makeTaggedAsset(AssetVisibility.Timeline, 'TagTimeline');
+    await makeTaggedAsset(AssetVisibility.Archive, 'TagArchive');
+    await makeTaggedAsset(AssetVisibility.Hidden, 'TagHidden');
+    await makeTaggedAsset(AssetVisibility.Locked, 'TagLocked');
+    await makeTaggedAsset(AssetVisibility.Timeline, 'TagNoTimeline', true /* via noTimeline album */);
+
+    // Call with viewer.id only — same M3 reason as getFilterSuggestions: passing owner.id
+    // would expose the owner's own Hidden/Locked tags via the "caller's own assets" bypass.
+    const tags = await searchRepo.getAccessibleTags([viewer.id], { spaceId: space.id });
+    const tagValues = tags.map((t) => t.value);
+
+    expect(tagValues).toContain('TagTimeline');
+    expect(tagValues).toContain('TagArchive'); // Archive present in search
+    expect(tagValues).not.toContain('TagHidden');
+    expect(tagValues).not.toContain('TagLocked');
+    expect(tagValues).not.toContain('TagNoTimeline'); // showInTimeline=false excluded
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 10: tag.getAll (space-scoped via timelineSpaceIds)
+// Rule: Timeline+Archive; Hidden+Locked ABSENT; showInTimeline=false absent.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: tag.getAll (space-scoped via timelineSpaceIds)', () => {
+  it('includes tags for Timeline+Archive; excludes Hidden+Locked+noTimeline', async () => {
+    const { tagRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const makeTaggedDirect = async (vis: AssetVisibility, tagValue: string) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      const [tag] = await upsertTags(tagRepo, { userId: owner.id, tags: [tagValue] });
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      return tag;
+    };
+
+    await makeTaggedDirect(AssetVisibility.Timeline, 'GetAllTimeline');
+    await makeTaggedDirect(AssetVisibility.Archive, 'GetAllArchive');
+    await makeTaggedDirect(AssetVisibility.Hidden, 'GetAllHidden');
+    await makeTaggedDirect(AssetVisibility.Locked, 'GetAllLocked');
+
+    const tags = await tagRepo.getAll(viewer.id);
+    const tagValues = tags.map((t: { value: string }) => t.value);
+
+    // tag.getAll includes tags on assets accessible to the viewer through shared spaces
+    // (the ownedOrSpaceAccessible helper in tag.repository includes three space arms gated by
+    // spaceVisibilityGate). Timeline and Archive assets' tags ARE visible; Hidden and Locked
+    // assets' tags are blocked by the visibility gate.
+    expect(tagValues).toContain('GetAllTimeline'); // Timeline accessible via space ✓
+    expect(tagValues).toContain('GetAllArchive'); // Archive accessible via space ✓
+    expect(tagValues).not.toContain('GetAllHidden'); // Hidden blocked by visibility gate ✓
+    expect(tagValues).not.toContain('GetAllLocked'); // Locked blocked by visibility gate ✓
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 11: space people-facets — getPersonsBySpaceId
+// Deferred from Slice 5. A face on another member's Hidden asset must NOT
+// surface the space-person in the people listing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: space people-facets — getPersonsBySpaceId', () => {
+  it('person backed only by a Hidden-asset face is NOT surfaced', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // Person backed by a Timeline asset — should appear
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tlAsset.id });
+    const { result: tlFaceId } = await ctx.newAssetFace({ assetId: tlAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: tlFaceId, embedding: newEmbedding() }).execute();
+    const visiblePerson = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'Timeline Person',
+      representativeFaceId: tlFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: visiblePerson.id, assetFaceId: tlFaceId }], { skipRecount: true });
+    await spaceRepo.recountPersons([visiblePerson.id]);
+
+    // Person backed ONLY by a Hidden asset face — must NOT appear
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiddenAsset.id });
+    const { result: hiddenFaceId } = await ctx.newAssetFace({ assetId: hiddenAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: hiddenFaceId, embedding: newEmbedding() }).execute();
+    const hiddenPerson = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'Hidden Person',
+      representativeFaceId: hiddenFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: hiddenPerson.id, assetFaceId: hiddenFaceId }], { skipRecount: true });
+    await spaceRepo.recountPersons([hiddenPerson.id]);
+
+    const people = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: false });
+    const personIds = people.map((p) => p.id);
+
+    expect(personIds).toContain(visiblePerson.id);
+    expect(personIds).not.toContain(hiddenPerson.id);
+  });
+
+  it('person backed only by a Locked-asset face is NOT surfaced', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { asset: lockedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: lockedAsset.id });
+    const { result: lockedFaceId } = await ctx.newAssetFace({ assetId: lockedAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: lockedFaceId, embedding: newEmbedding() }).execute();
+    const person = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'Locked Person',
+      representativeFaceId: lockedFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: person.id, assetFaceId: lockedFaceId }], { skipRecount: true });
+    await spaceRepo.recountPersons([person.id]);
+
+    const people = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: false });
+    const personIds = people.map((p) => p.id);
+
+    expect(personIds).not.toContain(person.id);
+  });
+
+  it('added-then-flipped: person whose face asset flips to Hidden → person drops from listing', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+    const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id });
+    await ctx.database.insertInto('face_search').values({ faceId, embedding: newEmbedding() }).execute();
+    const person = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'FlipPerson',
+      representativeFaceId: faceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces([{ personId: person.id, assetFaceId: faceId }], { skipRecount: true });
+    await spaceRepo.recountPersons([person.id]);
+
+    const before = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: false });
+    expect(before.map((p) => p.id)).toContain(person.id);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await spaceRepo.getPersonsBySpaceId(space.id, { withHidden: true, petsEnabled: false });
+    expect(after.map((p) => p.id)).not.toContain(person.id);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 12: isFaceInSpace
+// Rule: Timeline + Archive → true; Hidden + Locked → false.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: isFaceInSpace', () => {
+  it('returns true for Timeline face, false for Hidden+Locked faces (direct path)', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const makeDirectFace = async (vis: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id });
+      return faceId;
+    };
+
+    const tlFace = await makeDirectFace(AssetVisibility.Timeline);
+    const arFace = await makeDirectFace(AssetVisibility.Archive);
+    const hiFace = await makeDirectFace(AssetVisibility.Hidden);
+    const loFace = await makeDirectFace(AssetVisibility.Locked);
+
+    expect(await spaceRepo.isFaceInSpace(space.id, tlFace)).toBe(true);
+    expect(await spaceRepo.isFaceInSpace(space.id, arFace)).toBe(true);
+    expect(await spaceRepo.isFaceInSpace(space.id, hiFace)).toBe(false);
+    expect(await spaceRepo.isFaceInSpace(space.id, loFace)).toBe(false);
+  });
+
+  it('returns true for album(shown) face, false for album(noTimeline) face', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { result: albumShown } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'FaceShown' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumShown.id, addedById: owner.id });
+    const { asset: shownAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: albumShown.id, assetId: shownAsset.id });
+    const { result: shownFaceId } = await ctx.newAssetFace({ assetId: shownAsset.id });
+
+    const { result: albumHidden } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'FaceHidden' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumHidden.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, albumHidden.id, false);
+    const { asset: hiddenAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: albumHidden.id, assetId: hiddenAsset.id });
+    const { result: hiddenFaceId } = await ctx.newAssetFace({ assetId: hiddenAsset.id });
+
+    expect(await spaceRepo.isFaceInSpace(space.id, shownFaceId)).toBe(true);
+    expect(await spaceRepo.isFaceInSpace(space.id, hiddenFaceId)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 13: getPersonAssetIds
+// Rule: Timeline + Archive present; Hidden + Locked ABSENT.
+// showInTimeline=false album → ABSENT (requireShowInTimeline in the query).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: getPersonAssetIds', () => {
+  it('returns asset IDs for Timeline+Archive faces; excludes Hidden+Locked+noTimeline', async () => {
+    const { spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    // Build a space person
+    const { asset: tlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tlAsset.id });
+    const { result: tlFaceId } = await ctx.newAssetFace({ assetId: tlAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: tlFaceId, embedding: newEmbedding() }).execute();
+
+    const { asset: arAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: arAsset.id });
+    const { result: arFaceId } = await ctx.newAssetFace({ assetId: arAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: arFaceId, embedding: newEmbedding() }).execute();
+
+    const { asset: hiAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiAsset.id });
+    const { result: hiFaceId } = await ctx.newAssetFace({ assetId: hiAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: hiFaceId, embedding: newEmbedding() }).execute();
+
+    const { asset: loAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: loAsset.id });
+    const { result: loFaceId } = await ctx.newAssetFace({ assetId: loAsset.id });
+    await ctx.database.insertInto('face_search').values({ faceId: loFaceId, embedding: newEmbedding() }).execute();
+
+    const person = await spaceRepo.createPerson({
+      spaceId: space.id,
+      name: 'MatrixPerson',
+      representativeFaceId: tlFaceId,
+      type: 'person',
+    });
+    await spaceRepo.addPersonFaces(
+      [tlFaceId, arFaceId, hiFaceId, loFaceId].map((assetFaceId) => ({ personId: person.id, assetFaceId })),
+      { skipRecount: true },
+    );
+
+    const rows = await spaceRepo.getPersonAssetIds(person.id);
+    const assetIds = new Set(rows.map((r) => r.assetId));
+
+    expect(assetIds.has(tlAsset.id)).toBe(true);
+    expect(assetIds.has(arAsset.id)).toBe(true);
+    expect(assetIds.has(hiAsset.id)).toBe(false);
+    expect(assetIds.has(loAsset.id)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 14: timeline (getTimeBuckets / getTimeBucket)
+// Rule: Timeline ONLY (Archive excluded — space timeline is Timeline-only).
+// showInTimeline=false album: ABSENT.
+// soft-deleted album: ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: timeline (getTimeBuckets)', () => {
+  it('counts only Timeline assets; Archive excluded by design; Hidden+Locked+noTimeline absent', async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const { user: viewer } = await ctx.newUser();
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const when = new Date('2024-01-15T12:00:00.000Z');
+
+    const makeTimelineReady = async (vis: AssetVisibility, opts: { albumId?: string; libraryId?: string } = {}) => {
+      const { asset } = await ctx.newAsset({
+        ownerId: owner.id,
+        visibility: vis,
+        fileCreatedAt: when,
+        localDateTime: when,
+        width: 400,
+        height: 300,
+        thumbhash: Buffer.from('t'),
+        ...opts,
+      });
+      await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+      return asset.id;
+    };
+
+    // Direct-add
+    const tlDirect = await makeTimelineReady(AssetVisibility.Timeline);
+    const arDirect = await makeTimelineReady(AssetVisibility.Archive);
+    const hiDirect = await makeTimelineReady(AssetVisibility.Hidden);
+    for (const assetId of [tlDirect, arDirect, hiDirect]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    // Album(shown)
+    const { result: albumShown } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'TLShown' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumShown.id, addedById: owner.id });
+    const tlAlbumShown = await makeTimelineReady(AssetVisibility.Timeline);
+    await ctx.newAlbumAsset({ albumId: albumShown.id, assetId: tlAlbumShown });
+
+    // Album(noTimeline)
+    const { result: albumNo } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'TLHidden' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumNo.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, albumNo.id, false);
+    const tlAlbumNo = await makeTimelineReady(AssetVisibility.Timeline);
+    await ctx.newAlbumAsset({ albumId: albumNo.id, assetId: tlAlbumNo });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+    };
+    const buckets = await assetRepo.getTimeBuckets(opts);
+    const total = buckets.reduce((sum, b) => sum + Number(b.count), 0);
+
+    // Timeline direct + Timeline album(shown) = 2 assets
+    // Archive direct → excluded (space timeline is Timeline-only)
+    // Hidden → excluded (visibility gate)
+    // album(noTimeline) → excluded (requireShowInTimeline)
+    expect(total).toBe(2);
+  });
+
+  it('added-then-flipped for materialized shared_space_asset: timeline count drops when asset flips to Hidden', async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const when = new Date('2024-03-01T12:00:00.000Z');
+    const { asset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Timeline,
+      fileCreatedAt: when,
+      localDateTime: when,
+      width: 400,
+      height: 300,
+      thumbhash: Buffer.from('t'),
+    });
+    await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+    };
+    const before = await assetRepo.getTimeBuckets(opts);
+    const beforeCount = before.reduce((sum, b) => sum + Number(b.count), 0);
+    expect(beforeCount).toBeGreaterThanOrEqual(1);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await assetRepo.getTimeBuckets(opts);
+    const afterCount = after.reduce((sum, b) => sum + Number(b.count), 0);
+    expect(afterCount).toBe(beforeCount - 1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 15: map markers
+// Rule: Timeline ONLY (Archive excluded by design — getMapMarkers filters
+//   visibility=Timeline when isArchived is undefined/false).
+// showInTimeline=false album: ABSENT.
+// soft-deleted album: ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: map markers', () => {
+  it('includes Timeline markers; excludes Archive+Hidden+Locked+noTimeline+deletedAlbum', async () => {
+    const { mapRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const makeGpsAsset = async (vis: AssetVisibility, lat: number) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      await ctx.database.insertInto('asset_exif').values({ assetId: asset.id, latitude: lat, longitude: 2 }).execute();
+      return asset.id;
+    };
+
+    const tlId = await makeGpsAsset(AssetVisibility.Timeline, 1);
+    const arId = await makeGpsAsset(AssetVisibility.Archive, 2);
+    const hiId = await makeGpsAsset(AssetVisibility.Hidden, 3);
+    const loId = await makeGpsAsset(AssetVisibility.Locked, 4);
+    for (const assetId of [tlId, arId, hiId, loId]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    // showInTimeline=false album
+    const { result: albumNo } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'MapNoTL' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumNo.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, albumNo.id, false);
+    const noTlId = await makeGpsAsset(AssetVisibility.Timeline, 5);
+    await ctx.newAlbumAsset({ albumId: albumNo.id, assetId: noTlId });
+
+    // shown album
+    const { result: albumShown } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'MapShown' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumShown.id, addedById: owner.id });
+    const shownId = await makeGpsAsset(AssetVisibility.Timeline, 6);
+    await ctx.newAlbumAsset({ albumId: albumShown.id, assetId: shownId });
+
+    // soft-deleted album
+    const { result: albumDel } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'MapDel' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumDel.id, addedById: owner.id });
+    const delId = await makeGpsAsset(AssetVisibility.Timeline, 7);
+    await ctx.newAlbumAsset({ albumId: albumDel.id, assetId: delId });
+    await ctx.softDeleteAlbum(albumDel.id);
+
+    const markers = await mapRepo.getMapMarkers(viewer.id, [viewer.id], [], {
+      timelineSpaceIds: [space.id],
+    });
+    const markerIds = new Set(markers.map((m) => m.id));
+
+    expect(markerIds.has(tlId)).toBe(true); // Timeline direct ✓
+    expect(markerIds.has(shownId)).toBe(true); // Timeline album(shown) ✓
+    expect(markerIds.has(arId)).toBe(false); // Archive excluded by design ✓
+    expect(markerIds.has(hiId)).toBe(false); // Hidden blocked ✓
+    expect(markerIds.has(loId)).toBe(false); // Locked blocked ✓
+    expect(markerIds.has(noTlId)).toBe(false); // showInTimeline=false excluded ✓
+    expect(markerIds.has(delId)).toBe(false); // soft-deleted album excluded ✓
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 16: memory (searchAccessible)
+// Rule: Timeline ONLY (searchAccessible inner asset list filters
+//   visibility=Timeline); Archive excluded by design.
+// Direct+library paths in the outer scope use asset.visibility=Timeline only.
+// showInTimeline=false album: ABSENT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: memory searchAccessible', () => {
+  it('includes Timeline assets in memory; excludes Archive+Hidden+Locked', async () => {
+    const { memoryRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { memory } = await ctx.newMemory({ ownerId: owner.id });
+
+    const makeAsset = async (vis: AssetVisibility) => {
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: vis });
+      await ctx.newMemoryAsset({ memoryId: memory.id, assetId: asset.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      return asset.id;
+    };
+
+    const tlId = await makeAsset(AssetVisibility.Timeline);
+    const arId = await makeAsset(AssetVisibility.Archive);
+    const hiId = await makeAsset(AssetVisibility.Hidden);
+    const loId = await makeAsset(AssetVisibility.Locked);
+
+    const memories = await memoryRepo.searchAccessible(viewer.id, {});
+    const assetIds = new Set(memories.flatMap((m) => (m.assets as { id: string }[]).map((a) => a.id)));
+
+    expect(assetIds.has(tlId)).toBe(true); // Timeline ✓
+    expect(assetIds.has(arId)).toBe(false); // Archive excluded by design ✓
+    expect(assetIds.has(hiId)).toBe(false); // Hidden blocked ✓
+    expect(assetIds.has(loId)).toBe(false); // Locked blocked ✓
+  });
+
+  it('memory accessible ONLY via noTimeline-album asset is hidden from viewer', async () => {
+    // When a memory's ONLY space-accessible asset comes from a showInTimeline=false album,
+    // the outer scope (accessibleSearchBuilder) cannot find an accessible asset to grant
+    // visibility, so the memory is NOT returned to the viewer.
+    const { memoryRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { memory: noTlMemory } = await ctx.newMemory({ ownerId: owner.id });
+
+    const { result: albumNo } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'MemNoTLOnly' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumNo.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, albumNo.id, false);
+    const { asset: noTlAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: albumNo.id, assetId: noTlAsset.id });
+    await ctx.newMemoryAsset({ memoryId: noTlMemory.id, assetId: noTlAsset.id });
+
+    const memories = await memoryRepo.searchAccessible(viewer.id, {});
+    const memoryIds = new Set(memories.map((m) => m.id));
+
+    // The memory is not accessible to viewer because its only space-path is via
+    // a showInTimeline=false album (requireShowInTimeline=true outer scope gate).
+    expect(memoryIds.has(noTlMemory.id)).toBe(false); // noTimeline-only memory hidden ✓
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SURFACE 17: view / folders (getUniqueOriginalPaths / getAssetsByOriginalPath)
+// Rule: Timeline ONLY; Archive excluded; Hidden+Locked absent.
+// showInTimeline=false album: ABSENT (requireShowInTimeline in ownedOrSpaceAccessible).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matrix: view/folders (getUniqueOriginalPaths)', () => {
+  it('includes Timeline paths; excludes Archive+Hidden+Locked+noTimeline', async () => {
+    const { viewRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const basePath = `/matrix_view_test_${Date.now()}`;
+
+    const makePathAsset = async (vis: AssetVisibility, subdir: string) => {
+      const { asset } = await ctx.newAsset({
+        ownerId: owner.id,
+        visibility: vis,
+        originalPath: `${basePath}/${subdir}/photo.jpg`,
+        fileCreatedAt: new Date(),
+        localDateTime: new Date(),
+      });
+      await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+      return asset.id;
+    };
+
+    const tlId = await makePathAsset(AssetVisibility.Timeline, 'timeline');
+    const arId = await makePathAsset(AssetVisibility.Archive, 'archive');
+    const hiId = await makePathAsset(AssetVisibility.Hidden, 'hidden');
+    for (const assetId of [tlId, arId, hiId]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    // showInTimeline=false album
+    const { result: albumNo } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'ViewNoTL' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: albumNo.id, addedById: owner.id });
+    await spaceRepo.setAlbumShowInTimeline(space.id, albumNo.id, false);
+    const noTlId = await makePathAsset(AssetVisibility.Timeline, 'notimeline');
+    await ctx.newAlbumAsset({ albumId: albumNo.id, assetId: noTlId });
+
+    const paths = await viewRepo.getUniqueOriginalPaths(viewer.id);
+    const tlPath = `${basePath}/timeline`;
+    const arPath = `${basePath}/archive`;
+    const hiPath = `${basePath}/hidden`;
+    const noTlPath = `${basePath}/notimeline`;
+
+    expect(paths).toContain(tlPath); // Timeline ✓
+    expect(paths).not.toContain(arPath); // Archive excluded ✓
+    expect(paths).not.toContain(hiPath); // Hidden blocked ✓
+    expect(paths).not.toContain(noTlPath); // showInTimeline=false excluded ✓
+  });
+});

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1591,6 +1591,7 @@ describe(SharedSpaceRepository.name, () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
 
       // Create a global person with empty thumbnailPath
       const { result: person } = await ctx.newPerson({ ownerId: user.id, thumbnailPath: '' });
@@ -1602,6 +1603,8 @@ describe(SharedSpaceRepository.name, () => {
         representativeFaceId: face.id,
         type: 'person',
       });
+      await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: face.id }], { skipRecount: true });
+      await sut.recountPersons([spacePerson.id]);
 
       const result = await sut.getPersonsBySpaceId(space.id, {});
 
@@ -1660,6 +1663,7 @@ describe(SharedSpaceRepository.name, () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
 
       // Create a face with no personId (default is null)
       const { assetFace: face } = await ctx.newAssetFace({ assetId: asset.id });
@@ -1670,6 +1674,8 @@ describe(SharedSpaceRepository.name, () => {
         representativeFaceId: face.id,
         type: 'person',
       });
+      await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: face.id }], { skipRecount: true });
+      await sut.recountPersons([spacePerson.id]);
 
       const result = await sut.getPersonsBySpaceId(space.id, {});
 
@@ -1677,24 +1683,39 @@ describe(SharedSpaceRepository.name, () => {
       expect(result[0].id).toBe(spacePerson.id);
     });
 
-    it('should return space persons whose representative face was deleted', async () => {
+    it('should return space persons whose representative face was deleted (but has a second visible face)', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
 
       const { result: person } = await ctx.newPerson({ ownerId: user.id, thumbnailPath: '/thumb.jpg' });
-      const { assetFace: face } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { assetFace: representativeFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      // Second face on the same in-scope asset — will remain visible after the representative is deleted
+      const { assetFace: secondFace } = await ctx.newAssetFace({ assetId: asset.id });
 
       const spacePerson = await sut.createPerson({
         spaceId: space.id,
         name: 'Deleted Face Person',
-        representativeFaceId: face.id,
+        representativeFaceId: representativeFace.id,
         type: 'person',
       });
+      await sut.addPersonFaces(
+        [
+          { personId: spacePerson.id, assetFaceId: representativeFace.id },
+          { personId: spacePerson.id, assetFaceId: secondFace.id },
+        ],
+        { skipRecount: true },
+      );
+      await sut.recountPersons([spacePerson.id]);
 
-      // Soft-delete the representative face
-      await ctx.database.updateTable('asset_face').set({ deletedAt: new Date() }).where('id', '=', face.id).execute();
+      // Soft-delete the representative face; second face keeps the person visible
+      await ctx.database
+        .updateTable('asset_face')
+        .set({ deletedAt: new Date() })
+        .where('id', '=', representativeFace.id)
+        .execute();
 
       const result = await sut.getPersonsBySpaceId(space.id, {});
 
@@ -1707,6 +1728,7 @@ describe(SharedSpaceRepository.name, () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
 
       const { result: person } = await ctx.newPerson({
         ownerId: user.id,
@@ -1715,12 +1737,14 @@ describe(SharedSpaceRepository.name, () => {
       });
       const { assetFace: face } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
 
-      await sut.createPerson({
+      const spacePerson = await sut.createPerson({
         spaceId: space.id,
         name: '',
         representativeFaceId: face.id,
         type: 'person',
       });
+      await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: face.id }], { skipRecount: true });
+      await sut.recountPersons([spacePerson.id]);
 
       const result = await sut.getPersonsBySpaceId(space.id, {});
 
@@ -1733,27 +1757,26 @@ describe(SharedSpaceRepository.name, () => {
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
 
-      const charlie = await sut.createPerson({
-        spaceId: space.id,
-        name: 'Charlie',
-        representativeFaceId: null,
-        type: 'person',
-        assetCount: 10,
-      });
-      const alice = await sut.createPerson({
-        spaceId: space.id,
-        name: 'Alice',
-        representativeFaceId: null,
-        type: 'person',
-        assetCount: 1,
-      });
-      const bob = await sut.createPerson({
-        spaceId: space.id,
-        name: 'Bob',
-        representativeFaceId: null,
-        type: 'person',
-        assetCount: 5,
-      });
+      // Shared asset in the space — all three persons get a face on it so they pass the visibility gate
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+      const createPersonWithFace = async (name: string, assetCount: number) => {
+        const { assetFace: face } = await ctx.newAssetFace({ assetId: asset.id });
+        const p = await sut.createPerson({
+          spaceId: space.id,
+          name,
+          representativeFaceId: face.id,
+          type: 'person',
+          assetCount,
+        });
+        await sut.addPersonFaces([{ personId: p.id, assetFaceId: face.id }], { skipRecount: true });
+        return p;
+      };
+
+      const charlie = await createPersonWithFace('Charlie', 10);
+      const alice = await createPersonWithFace('Alice', 1);
+      const bob = await createPersonWithFace('Bob', 5);
 
       const result = await sut.getPersonsBySpaceId(space.id, {});
 
@@ -1764,10 +1787,19 @@ describe(SharedSpaceRepository.name, () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
+
+      // Each person needs at least one visible face on an in-space asset.
+      // We use a shared asset so all persons pass the visibility gate.
       const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
 
       const { result: globalBob } = await ctx.newPerson({ ownerId: user.id, name: 'Bob' });
       const { assetFace: bobFace } = await ctx.newAssetFace({ assetId: asset.id, personId: globalBob.id });
+
+      const addFace = async (personId: string) => {
+        const { assetFace: f } = await ctx.newAssetFace({ assetId: asset.id });
+        await sut.addPersonFaces([{ personId, assetFaceId: f.id }], { skipRecount: true });
+      };
 
       const charlie = await sut.createPerson({
         spaceId: space.id,
@@ -1776,6 +1808,8 @@ describe(SharedSpaceRepository.name, () => {
         type: 'person',
         assetCount: 5,
       });
+      await addFace(charlie.id);
+
       const hiddenAlice = await sut.createPerson({
         spaceId: space.id,
         name: 'Alice Hidden',
@@ -1784,6 +1818,8 @@ describe(SharedSpaceRepository.name, () => {
         assetCount: 50,
         isHidden: true,
       });
+      await addFace(hiddenAlice.id);
+
       const bob = await sut.createPerson({
         id: '00000000-0000-4000-8000-000000000001',
         spaceId: space.id,
@@ -1792,6 +1828,8 @@ describe(SharedSpaceRepository.name, () => {
         type: 'person',
         assetCount: 1,
       });
+      await sut.addPersonFaces([{ personId: bob.id, assetFaceId: bobFace.id }], { skipRecount: true });
+
       const whitespaceName = await sut.createPerson({
         spaceId: space.id,
         name: '   ',
@@ -1799,6 +1837,8 @@ describe(SharedSpaceRepository.name, () => {
         type: 'person',
         assetCount: 20,
       });
+      await addFace(whitespaceName.id);
+
       const unnamedMany = await sut.createPerson({
         id: 'ffffffff-ffff-4fff-bfff-ffffffffffff',
         spaceId: space.id,
@@ -1807,6 +1847,8 @@ describe(SharedSpaceRepository.name, () => {
         type: 'person',
         assetCount: 10,
       });
+      await addFace(unnamedMany.id);
+
       const alice = await sut.createPerson({
         spaceId: space.id,
         name: 'Alice',
@@ -1814,6 +1856,7 @@ describe(SharedSpaceRepository.name, () => {
         type: 'person',
         assetCount: 5,
       });
+      await addFace(alice.id);
 
       const result = await sut.getPersonsBySpaceId(space.id, { withHidden: true });
 

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -1332,10 +1332,13 @@ describe(SharedSpaceRepository.name, () => {
       const { library } = await ctx.newLibrary({ ownerId: user.id });
       const { space } = await ctx.newSharedSpace({ createdById: user.id });
 
-      // 2 assets in the target library and 1 in a different library (no libraryId)
+      // 2 assets in the target library and 1 directly added to the space (no libraryId)
       const { asset: libAsset1 } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id });
       const { asset: libAsset2 } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id });
       const { asset: otherAsset } = await ctx.newAsset({ ownerId: user.id });
+      // Library assets are scoped via the linked library; otherAsset must be a direct space asset
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: otherAsset.id });
       const { assetFace: f1 } = await ctx.newAssetFace({ assetId: libAsset1.id });
       const { assetFace: f2 } = await ctx.newAssetFace({ assetId: libAsset2.id });
       const { assetFace: f3 } = await ctx.newAssetFace({ assetId: otherAsset.id });
@@ -3917,5 +3920,185 @@ describe(SharedSpaceRepository.name, () => {
       expect(face).not.toBeNull();
       expect(face?.id).toBe(assetFace.id);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPersonAssetIds — visibility scoping (Slice 8)
+// ---------------------------------------------------------------------------
+
+describe('getPersonAssetIds — visibility scoping', () => {
+  it('returns Timeline and Archive asset ids; excludes Hidden and Locked', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { asset: timeline } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    const { asset: archive } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+
+    for (const assetId of [timeline.id, archive.id, hidden.id, locked.id]) {
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId });
+    }
+
+    const { assetFace: faceTimeline } = await ctx.newAssetFace({ assetId: timeline.id });
+    const { assetFace: faceArchive } = await ctx.newAssetFace({ assetId: archive.id });
+    const { assetFace: faceHidden } = await ctx.newAssetFace({ assetId: hidden.id });
+    const { assetFace: faceLocked } = await ctx.newAssetFace({ assetId: locked.id });
+
+    const spacePerson = await sut.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: null,
+      type: 'person',
+    });
+    await sut.addPersonFaces(
+      [faceTimeline, faceArchive, faceHidden, faceLocked].map((f) => ({ personId: spacePerson.id, assetFaceId: f.id })),
+      { skipRecount: true },
+    );
+
+    const result = await sut.getPersonAssetIds(spacePerson.id);
+    const ids = result.map((r) => r.assetId);
+
+    expect(ids).toContain(timeline.id);
+    expect(ids).toContain(archive.id);
+    expect(ids).not.toContain(hidden.id);
+    expect(ids).not.toContain(locked.id);
+  });
+
+  it('excludes soft-deleted assets', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+    const spacePerson = await sut.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: null,
+      type: 'person',
+    });
+    await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+    // Before: present
+    const before = await sut.getPersonAssetIds(spacePerson.id);
+    expect(before.map((r) => r.assetId)).toContain(asset.id);
+
+    await ctx.softDeleteAsset(asset.id);
+
+    // After: gone
+    const after = await sut.getPersonAssetIds(spacePerson.id);
+    expect(after.map((r) => r.assetId)).not.toContain(asset.id);
+  });
+
+  it('excludes asset in showInTimeline=false album (album path)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'NoShowAlbum' });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+    const spacePerson = await sut.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: null,
+      type: 'person',
+    });
+    await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+    const result = await sut.getPersonAssetIds(spacePerson.id);
+    expect(result.map((r) => r.assetId)).not.toContain(asset.id);
+  });
+
+  it('excludes asset in soft-deleted album (album path)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'DeletedAlbumPerson' });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+    const spacePerson = await sut.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: null,
+      type: 'person',
+    });
+    await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+    await ctx.softDeleteAlbum(album.id);
+
+    const result = await sut.getPersonAssetIds(spacePerson.id);
+    expect(result.map((r) => r.assetId)).not.toContain(asset.id);
+  });
+
+  it('excludes isOffline=true library asset', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+
+    const { asset } = await ctx.newAsset({
+      ownerId: owner.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+      isOffline: true,
+    });
+
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+    const spacePerson = await sut.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: null,
+      type: 'person',
+    });
+    await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+    const result = await sut.getPersonAssetIds(spacePerson.id);
+    expect(result.map((r) => r.assetId)).not.toContain(asset.id);
+  });
+
+  it('added-then-flipped: asset id disappears after flip to Hidden', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+    const spacePerson = await sut.createPerson({
+      spaceId: space.id,
+      name: '',
+      representativeFaceId: null,
+      type: 'person',
+    });
+    await sut.addPersonFaces([{ personId: spacePerson.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+    const before = await sut.getPersonAssetIds(spacePerson.id);
+    expect(before.map((r) => r.assetId)).toContain(asset.id);
+
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const after = await sut.getPersonAssetIds(spacePerson.id);
+    expect(after.map((r) => r.assetId)).not.toContain(asset.id);
   });
 });

--- a/server/test/medium/specs/repositories/shared-space.repository.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space.repository.spec.ts
@@ -140,6 +140,68 @@ const seedAlbumPerson = async (
   return { user, space, album, asset, assetFace, person };
 };
 
+// Helper: create a user + space with a directly-added asset with a face
+const seedDirectFace = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  sut: SharedSpaceRepository,
+  visibility: AssetVisibility,
+  softDelete = false,
+) => {
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+  const { asset } = await ctx.newAsset({ ownerId: user.id, visibility });
+  if (softDelete) {
+    await ctx.softDeleteAsset(asset.id);
+  }
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+  return { space, asset, assetFace };
+};
+
+// Helper: create a library-linked asset with a face
+const seedLibraryFace = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  sut: SharedSpaceRepository,
+  visibility: AssetVisibility,
+) => {
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+  const { library } = await ctx.newLibrary({ ownerId: user.id });
+  const { asset } = await ctx.newAsset({ ownerId: user.id, libraryId: library.id, visibility });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+  return { space, asset, assetFace };
+};
+
+// Helper: create an album-linked asset with a face
+const seedAlbumFace = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  sut: SharedSpaceRepository,
+  opts: { visibility?: AssetVisibility; showInTimeline?: boolean; softDeleteAlbum?: boolean } = {},
+) => {
+  const { user } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+  const { result: album } = await ctx.newAlbum({ ownerId: user.id, albumName: 'FaceAlbum' });
+  const { asset } = await ctx.newAsset({
+    ownerId: user.id,
+    visibility: opts.visibility ?? AssetVisibility.Timeline,
+  });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+  await ctx.newSharedSpaceAlbum({
+    spaceId: space.id,
+    albumId: album.id,
+    showInTimeline: opts.showInTimeline ?? true,
+  });
+  if (opts.softDeleteAlbum) {
+    await ctx.softDeleteAlbum(album.id);
+  }
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+  return { space, album, asset, assetFace };
+};
+
 describe(SharedSpaceRepository.name, () => {
   // ==========================================
   // Space CRUD
@@ -3686,6 +3748,174 @@ describe(SharedSpaceRepository.name, () => {
       expect(result1).not.toContain(user2.id);
       expect(result2).toContain(user2.id);
       expect(result2).not.toContain(user1.id);
+    });
+  });
+
+  // ==========================================
+  // isFaceInSpace — rep-face thumbnail guards
+  // ==========================================
+
+  describe('isFaceInSpace — visibility guards', () => {
+    // -- direct arm --
+
+    it('direct arm: returns true for a Timeline asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedDirectFace(ctx, sut, AssetVisibility.Timeline);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+    });
+
+    it('direct arm: returns true for an Archive asset face (Archive is shareable)', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedDirectFace(ctx, sut, AssetVisibility.Archive);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+    });
+
+    it('direct arm: returns false for a Hidden asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedDirectFace(ctx, sut, AssetVisibility.Hidden);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('direct arm: returns false for a Locked asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedDirectFace(ctx, sut, AssetVisibility.Locked);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('direct arm: returns false for a soft-deleted asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedDirectFace(ctx, sut, AssetVisibility.Timeline, /* softDelete */ true);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('direct arm: added-then-flipped — face no longer served after asset flips Hidden', async () => {
+      const { ctx, sut } = setup();
+      const { space, asset, assetFace } = await seedDirectFace(ctx, sut, AssetVisibility.Timeline);
+
+      // Confirm it's initially accessible
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+
+      // Flip asset to Hidden
+      await ctx.database
+        .updateTable('asset')
+        .set({ visibility: AssetVisibility.Hidden })
+        .where('id', '=', asset.id)
+        .execute();
+
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    // -- library arm --
+
+    it('library arm: returns true for a Timeline asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedLibraryFace(ctx, sut, AssetVisibility.Timeline);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+    });
+
+    it('library arm: returns true for an Archive asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedLibraryFace(ctx, sut, AssetVisibility.Archive);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+    });
+
+    it('library arm: returns false for a Hidden asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedLibraryFace(ctx, sut, AssetVisibility.Hidden);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('library arm: returns false for a Locked asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedLibraryFace(ctx, sut, AssetVisibility.Locked);
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    // -- album arm --
+
+    it('album arm: returns true for a Timeline asset face in a showInTimeline album', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedAlbumFace(ctx, sut, {
+        visibility: AssetVisibility.Timeline,
+        showInTimeline: true,
+      });
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+    });
+
+    it('album arm: returns true for an Archive asset face in a showInTimeline album', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedAlbumFace(ctx, sut, {
+        visibility: AssetVisibility.Archive,
+        showInTimeline: true,
+      });
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(true);
+    });
+
+    it('album arm: returns false for a Hidden asset face in a showInTimeline album', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedAlbumFace(ctx, sut, {
+        visibility: AssetVisibility.Hidden,
+        showInTimeline: true,
+      });
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('album arm: returns false for a Locked asset face in a showInTimeline album', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedAlbumFace(ctx, sut, {
+        visibility: AssetVisibility.Locked,
+        showInTimeline: true,
+      });
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('album arm: returns false for a showInTimeline=false album asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedAlbumFace(ctx, sut, {
+        visibility: AssetVisibility.Timeline,
+        showInTimeline: false,
+      });
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    it('album arm: returns false for a soft-deleted album asset face', async () => {
+      const { ctx, sut } = setup();
+      const { space, assetFace } = await seedAlbumFace(ctx, sut, {
+        visibility: AssetVisibility.Timeline,
+        showInTimeline: true,
+        softDeleteAlbum: true,
+      });
+      await expect(sut.isFaceInSpace(space.id, assetFace.id)).resolves.toBe(false);
+    });
+
+    // -- regression: manual rep-face path (getSpaceRepresentativeFaceForUpdate) still works --
+
+    it('regression: getSpaceRepresentativeFaceForUpdate still returns a face (manual path unaffected)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      // assetFace isVisible defaults to true; getSpaceRepresentativeFaceForUpdate requires it
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id });
+      const person = await sut.createPerson({
+        spaceId: space.id,
+        name: 'Manual Rep',
+        representativeFaceId: assetFace.id,
+        representativeFaceSource: 'manual',
+      });
+      // getSpaceRepresentativeFaceForUpdate joins shared_space_person_face — register the face
+      await sut.addPersonFaces([{ personId: person.id, assetFaceId: assetFace.id }], { skipRecount: true });
+
+      const face = await sut.getSpaceRepresentativeFaceForUpdate({
+        spaceId: space.id,
+        personId: person.id,
+        assetFaceId: assetFace.id,
+      });
+
+      expect(face).not.toBeNull();
+      expect(face?.id).toBe(assetFace.id);
     });
   });
 });

--- a/server/test/medium/specs/repositories/tag.repository.spec.ts
+++ b/server/test/medium/specs/repositories/tag.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { SharedSpaceRole } from 'src/enum';
+import { AssetVisibility, SharedSpaceRole } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { TagRepository } from 'src/repositories/tag.repository';
 import { DB } from 'src/schema';
@@ -204,6 +204,95 @@ describe(TagRepository.name, () => {
         .execute();
 
       await expect(sut.getAll(member.id).then((r) => r.map((t) => t.id))).resolves.not.toContain(tag.id);
+    });
+
+    // ── Slice 5: visibility gate — Hidden/Locked space assets must not leak their tags ──
+    it('DENY — member does not see a tag on another member Hidden space asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+      // Asset is Hidden — must not surface its tag to another member
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+      const tag = await createTag(ctx, owner.id, 'hidden-asset-tag');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — member does not see a tag on another member Locked space asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+      const tag = await createTag(ctx, owner.id, 'locked-asset-tag');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — member does not see a tag on a Hidden asset in a library linked to the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { library } = await ctx.newLibrary({ ownerId: owner.id });
+      await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+      const { asset } = await ctx.newAsset({
+        ownerId: owner.id,
+        libraryId: library.id,
+        visibility: AssetVisibility.Hidden,
+      });
+      const tag = await createTag(ctx, owner.id, 'hidden-library-tag');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('DENY — member does not see a tag on a Hidden asset in an album linked to the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'TagHiddenAlbum' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      const tag = await createTag(ctx, owner.id, 'hidden-album-tag');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).not.toContain(tag.id);
+    });
+
+    it('GRANT — member sees a tag on an Archive asset (Archive is space-shareable)', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+      const tag = await createTag(ctx, owner.id, 'archive-asset-tag');
+      await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getAll(member.id);
+
+      expect(result.map((t) => t.id)).toContain(tag.id);
     });
 
     it('GRANT — member sees same-value tags from every owner who shared a tagged asset', async () => {

--- a/server/test/medium/specs/repositories/timeline-bucket-explicit-visibility.medium.spec.ts
+++ b/server/test/medium/specs/repositories/timeline-bucket-explicit-visibility.medium.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * Fix A — Timeline bucket explicit-`visibility` bypass (content leak regression lock).
+ *
+ * The leak: `getTimeBuckets` / `getTimeBucket` / `getTimeBucketCovers` gate visibility
+ * through `withDefaultVisibility` ONLY when `options.visibility === undefined`. When the
+ * caller passes an explicit `visibility` (e.g. `visibility=HIDDEN` or `visibility=LOCKED`),
+ * the top-level filter becomes `asset.visibility = <requested>` and the space-membership
+ * branches (`spaceId`, `timelineSpaceIds`, `spacePersonIds`) carry NO independent visibility
+ * gate — so `visibility=HIDDEN AND spaceReachable` surfaces OTHER members' Hidden/Locked
+ * in-space assets (id + thumbhash + EXIF/GPS).
+ *
+ * The fix mirrors `searchAssetBuilder`: every space branch ANDs an independent
+ * `eb.or([ ownerId ∈ userIds, spaceVisibilityGate(eb) ])` so an explicit `visibility=HIDDEN`
+ * can only surface the CALLER'S OWN hidden rows, never other members'.
+ *
+ * These tests exercise the repository directly (bypassing the service-level guards) because
+ * the leak is in the repository query itself — the primary defense must hold there.
+ */
+
+import { Kysely } from 'kysely';
+import { AssetVisibility, TimeBucketSize } from 'src/enum';
+import { AssetRepository, TimeBucketOptions } from 'src/repositories/asset.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { newEmbedding } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: defaultDatabase,
+    real: [AssetRepository, SharedSpaceRepository],
+    mock: [LoggingRepository],
+  });
+  return {
+    ctx,
+    assetRepo: ctx.get(AssetRepository),
+    spaceRepo: ctx.get(SharedSpaceRepository),
+  };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+const WHEN = new Date('2024-05-15T12:00:00.000Z');
+const BUCKET = '2024-01-01'; // Year bucket start for WHEN
+
+// Build an asset that is timeline-bucket-ready (has EXIF, fileCreatedAt/localDateTime, thumbhash).
+const makeBucketAsset = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  ownerId: string,
+  vis: AssetVisibility,
+  opts: { libraryId?: string } = {},
+) => {
+  const { asset } = await ctx.newAsset({
+    ownerId,
+    visibility: vis,
+    fileCreatedAt: WHEN,
+    localDateTime: WHEN,
+    width: 400,
+    height: 300,
+    thumbhash: Buffer.from('t'),
+    ...opts,
+  });
+  await ctx.newExif({ assetId: asset.id, timeZone: 'UTC', latitude: 48.8566, longitude: 2.3522, fileSizeInByte: 1024 });
+  return asset.id;
+};
+
+const countBuckets = (buckets: Array<{ count: number }>) => buckets.reduce((sum, b) => sum + Number(b.count), 0);
+
+// getTimeBucket returns a pre-jsonified `{ assets: string }` — parse the id array out of it.
+const bucketAssetIds = async (
+  assetRepo: AssetRepository,
+  timeBucket: string,
+  options: TimeBucketOptions,
+  authUserId: string,
+): Promise<Set<string>> => {
+  const auth = { user: { id: authUserId } } as any;
+  const { assets } = await assetRepo.getTimeBucket(timeBucket, options, auth);
+  const ids = new Set<string>();
+  const parsed = JSON.parse(assets) as { id: string[] };
+  for (const id of parsed.id ?? []) {
+    ids.add(id);
+  }
+  return ids;
+};
+
+// Build a space person whose faces sit on the given assets.
+const seedSpacePerson = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  spaceRepo: SharedSpaceRepository,
+  spaceId: string,
+  faceAssetIds: string[],
+) => {
+  const faceIds: string[] = [];
+  for (const assetId of faceAssetIds) {
+    const { result: faceId } = await ctx.newAssetFace({ assetId });
+    await ctx.database.insertInto('face_search').values({ faceId, embedding: newEmbedding() }).execute();
+    faceIds.push(faceId);
+  }
+  const person = await spaceRepo.createPerson({
+    spaceId,
+    name: 'BucketPerson',
+    representativeFaceId: faceIds[0],
+    type: 'person',
+  });
+  await spaceRepo.addPersonFaces(
+    faceIds.map((assetFaceId) => ({ personId: person.id, assetFaceId })),
+    { skipRecount: true },
+  );
+  return person;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATH 1: spaceId browse (userIds === undefined — pure space browse as a member)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('timeline bucket explicit-visibility — spaceId browse (no userIds)', () => {
+  it("visibility=HIDDEN does NOT surface another member's Hidden in-space assets (direct/library/album)", async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // Direct-add Hidden
+    const hiDirect = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiDirect });
+
+    // Library-linked Hidden
+    const { result: library } = await ctx.newLibrary({ ownerId: owner.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id });
+    const hiLib = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden, { libraryId: library.id });
+
+    // Album (showInTimeline=true) Hidden
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenLeakAlbum' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+    const hiAlbum = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiAlbum });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+
+    // getTimeBuckets — count must be 0 (no other-member Hidden leaks)
+    expect(countBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+
+    // getTimeBucket — none of the ids present
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, viewer.id);
+    expect(ids.has(hiDirect)).toBe(false);
+    expect(ids.has(hiLib)).toBe(false);
+    expect(ids.has(hiAlbum)).toBe(false);
+
+    // getTimeBucketCovers — no cover produced
+    const covers = await assetRepo.getTimeBucketCovers({ ...opts, timeBuckets: [BUCKET] });
+    const coverIds = new Set(covers.map((c) => c.representativeAssetId));
+    expect(coverIds.has(hiDirect)).toBe(false);
+    expect(coverIds.has(hiLib)).toBe(false);
+    expect(coverIds.has(hiAlbum)).toBe(false);
+  });
+
+  it("visibility=LOCKED does NOT surface another member's Locked in-space asset", async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const loDirect = await makeBucketAsset(ctx, owner.id, AssetVisibility.Locked);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: loDirect });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Locked,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+  });
+
+  it('regression: visibility=Timeline space assets are STILL present (no over-block)', async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const tl = await makeBucketAsset(ctx, owner.id, AssetVisibility.Timeline);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tl });
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countBuckets(await assetRepo.getTimeBuckets(opts))).toBe(1);
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, owner.id);
+    expect(ids.has(tl)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATH 2: withSharedSpaces (userIds = [caller] + timelineSpaceIds = [space])
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('timeline bucket explicit-visibility — withSharedSpaces (timelineSpaceIds)', () => {
+  it("visibility=HIDDEN does NOT surface another member's Hidden in-space asset", async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // owner's Hidden reachable via the space (direct + album)
+    const hiDirect = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiDirect });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'SharedHiddenAlbum' });
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+    const hiAlbum = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiAlbum });
+
+    const opts: TimeBucketOptions = {
+      userIds: [viewer.id],
+      timelineSpaceIds: [space.id],
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+
+    expect(countBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, viewer.id);
+    expect(ids.has(hiDirect)).toBe(false);
+    expect(ids.has(hiAlbum)).toBe(false);
+
+    const covers = await assetRepo.getTimeBucketCovers({ ...opts, timeBuckets: [BUCKET] });
+    const coverIds = new Set(covers.map((c) => c.representativeAssetId));
+    expect(coverIds.has(hiDirect)).toBe(false);
+    expect(coverIds.has(hiAlbum)).toBe(false);
+  });
+
+  it("OWN Hidden is NOT over-blocked: caller's own Hidden asset via space IS returned", async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const ownHidden = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: ownHidden });
+
+    // Caller IS the owner and asks for their own Hidden with the space in scope.
+    const opts: TimeBucketOptions = {
+      userIds: [owner.id],
+      timelineSpaceIds: [space.id],
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+    expect(countBuckets(await assetRepo.getTimeBuckets(opts))).toBe(1);
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, owner.id);
+    expect(ids.has(ownHidden)).toBe(true);
+  });
+
+  it("regression: another member's Timeline in-space asset is STILL present", async () => {
+    const { assetRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const tl = await makeBucketAsset(ctx, owner.id, AssetVisibility.Timeline);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tl });
+
+    const opts: TimeBucketOptions = {
+      userIds: [viewer.id],
+      timelineSpaceIds: [space.id],
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+    };
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, viewer.id);
+    expect(ids.has(tl)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATH 3: spacePersonIds (a space person's faces on another member's Hidden asset)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('timeline bucket explicit-visibility — spacePersonIds path', () => {
+  it("visibility=HIDDEN via a space person does NOT surface another member's Hidden asset", async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    // A space person whose faces sit on a Timeline (ok) AND a Hidden (must not leak) asset.
+    const tlAsset = await makeBucketAsset(ctx, owner.id, AssetVisibility.Timeline);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tlAsset });
+    const hiAsset = await makeBucketAsset(ctx, owner.id, AssetVisibility.Hidden);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiAsset });
+
+    const person = await seedSpacePerson(ctx, spaceRepo, space.id, [tlAsset, hiAsset]);
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      spacePersonIds: [person.id],
+      visibility: AssetVisibility.Hidden,
+      bucketSize: TimeBucketSize.Year,
+    };
+
+    expect(countBuckets(await assetRepo.getTimeBuckets(opts))).toBe(0);
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, viewer.id);
+    expect(ids.has(hiAsset)).toBe(false);
+  });
+
+  it('regression: visibility=Timeline via a space person STILL returns the Timeline asset', async () => {
+    const { assetRepo, spaceRepo, ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+
+    const tlAsset = await makeBucketAsset(ctx, owner.id, AssetVisibility.Timeline);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: tlAsset });
+    const person = await seedSpacePerson(ctx, spaceRepo, space.id, [tlAsset]);
+
+    const opts: TimeBucketOptions = {
+      spaceId: space.id,
+      spacePersonIds: [person.id],
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+    };
+    const ids = await bucketAssetIds(assetRepo, BUCKET, opts, owner.id);
+    expect(ids.has(tlAsset)).toBe(true);
+  });
+});

--- a/server/test/medium/specs/repositories/view-repository.spec.ts
+++ b/server/test/medium/specs/repositories/view-repository.spec.ts
@@ -111,6 +111,38 @@ describe(ViewRepository.name, () => {
       expect(result).toContain(`/album/folder/${role}-album`);
     });
 
+    it('DENY — album with showInTimeline=false does not expose folder paths in the folder view', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenTimeline' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: '/album/no-timeline/IMG.jpg' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getUniqueOriginalPaths(member.id);
+
+      expect(result).not.toContain('/album/no-timeline');
+    });
+
+    it('GRANT — same album with showInTimeline=true still exposes folder paths', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'VisibleTimeline' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: '/album/yes-timeline/IMG.jpg' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getUniqueOriginalPaths(member.id);
+
+      expect(result).toContain('/album/yes-timeline');
+    });
+
     it('GRANT — member sees the folder even when showInTimeline is disabled', async () => {
       const { ctx, sut } = setup();
       const { member, space } = await seedDirectSpaceAsset(ctx, SharedSpaceRole.Viewer, '/archive/no-timeline/IMG.jpg');
@@ -248,6 +280,40 @@ describe(ViewRepository.name, () => {
         .execute();
 
       await expect(sut.getAssetsByOriginalPath(member.id, path)).resolves.toEqual([]);
+    });
+
+    it('DENY — album with showInTimeline=false does not expose folder contents in the folder view', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'HiddenTimelineContents' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+      const path = '/album/no-timeline-contents';
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: `${path}/IMG.jpg` });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getAssetsByOriginalPath(member.id, path);
+
+      expect(result.map((a) => a.id)).not.toContain(asset.id);
+    });
+
+    it('GRANT — same album with showInTimeline=true still exposes folder contents', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'VisibleTimelineContents' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+      const path = '/album/yes-timeline-contents';
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, originalPath: `${path}/IMG.jpg` });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const result = await sut.getAssetsByOriginalPath(member.id, path);
+
+      expect(result.map((a) => a.id)).toContain(asset.id);
     });
   });
 });

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -789,11 +789,10 @@ describe(SearchService.name, () => {
     });
   });
 
-  // M3: elevation only unlocks the CALLER'S OWN locked/archived folder. Other shared-space
-  // members' assets must always be Timeline-only in space-scoped search — the v3
-  // `undefined`-for-elevated visibility default must not leak their Archived/Hidden/Locked assets.
-  describe('space-scoped visibility (M3)', () => {
-    it('hides another member archived asset from an elevated spaceId metadata search', async () => {
+  // Slice 10: Archive assets of other space members now surface in space-scoped search
+  // (matching the browse / timeline gate). Hidden and Locked remain excluded always.
+  describe('space-scoped visibility (Slice 10 — Archive exposed, Hidden/Locked blocked)', () => {
+    it('shows another member archived asset in an elevated spaceId metadata search (spaceId path)', async () => {
       const { sut, ctx } = setup();
       const { owner, member, space } = await setupSpace(ctx);
       const archived = await shareAsset(ctx, space.id, owner.id, AssetVisibility.Archive);
@@ -803,7 +802,7 @@ describe(SearchService.name, () => {
       const ids = result.assets.items.map((a) => a.id);
 
       expect(ids).toContain(timeline.id);
-      expect(ids).not.toContain(archived.id);
+      expect(ids).toContain(archived.id);
     });
 
     it('hides another member hidden and locked assets from an elevated spaceId metadata search', async () => {
@@ -832,7 +831,7 @@ describe(SearchService.name, () => {
       expect(ids).toContain(ownArchived.id);
     });
 
-    it('never exposes another member Archived/Hidden/Locked to a non-elevated member', async () => {
+    it('shows another member Archive but hides Hidden/Locked for a non-elevated member (spaceId path)', async () => {
       const { sut, ctx } = setup();
       const { owner, member, space } = await setupSpace(ctx);
       const archived = await shareAsset(ctx, space.id, owner.id, AssetVisibility.Archive);
@@ -845,12 +844,12 @@ describe(SearchService.name, () => {
       const ids = result.assets.items.map((a) => a.id);
 
       expect(ids).toContain(timeline.id);
-      expect(ids).not.toContain(archived.id);
+      expect(ids).toContain(archived.id);
       expect(ids).not.toContain(hidden.id);
       expect(ids).not.toContain(locked.id);
     });
 
-    it('does not expose another member archived even when the caller explicitly requests visibility=Archive', async () => {
+    it('exposes another member archived when the caller explicitly requests visibility=Archive (spaceId path)', async () => {
       const { sut, ctx } = setup();
       const { owner, member, space } = await setupSpace(ctx);
       const otherArchived = await shareAsset(ctx, space.id, owner.id, AssetVisibility.Archive);
@@ -863,10 +862,10 @@ describe(SearchService.name, () => {
       const ids = result.assets.items.map((a) => a.id);
 
       expect(ids).toContain(ownArchived.id);
-      expect(ids).not.toContain(otherArchived.id);
+      expect(ids).toContain(otherArchived.id);
     });
 
-    it('hides another member archived asset in the withSharedSpaces (timeline) path for an elevated caller', async () => {
+    it('shows another member archived asset in the withSharedSpaces (timeline) path for an elevated caller', async () => {
       const { sut, ctx } = setup();
       const { owner, member, space } = await setupSpace(ctx);
       const archived = await shareAsset(ctx, space.id, owner.id, AssetVisibility.Archive);
@@ -876,10 +875,10 @@ describe(SearchService.name, () => {
       const ids = result.assets.items.map((a) => a.id);
 
       expect(ids).toContain(timeline.id);
-      expect(ids).not.toContain(archived.id);
+      expect(ids).toContain(archived.id);
     });
 
-    it('excludes another member archived asset from elevated spaceId statistics', async () => {
+    it('includes another member archived asset in elevated spaceId statistics', async () => {
       const { sut, ctx } = setup();
       const { owner, member, space } = await setupSpace(ctx);
       await shareAsset(ctx, space.id, owner.id, AssetVisibility.Archive);
@@ -887,11 +886,11 @@ describe(SearchService.name, () => {
 
       const result = await sut.searchStatistics(elevated(member.id), { spaceId: space.id });
 
-      // Only the Timeline asset counts — the other member's archived asset is excluded.
-      expect(result).toEqual({ total: 1 });
+      // Both Archive and Timeline count — Slice 10 aligns search with browse.
+      expect(result).toEqual({ total: 2 });
     });
 
-    it('hides archived assets of every other owner in a mixed-owner space (elevated)', async () => {
+    it('shows archived assets of every other owner in a mixed-owner space (elevated)', async () => {
       const { sut, ctx } = setup();
       const { owner, member, space } = await setupSpace(ctx);
       const { user: secondOwner } = await ctx.newUser();
@@ -905,8 +904,50 @@ describe(SearchService.name, () => {
       const ids = result.assets.items.map((a) => a.id);
 
       expect(ids).toContain(timelineA.id);
-      expect(ids).not.toContain(archivedA.id);
-      expect(ids).not.toContain(archivedC.id);
+      expect(ids).toContain(archivedA.id);
+      expect(ids).toContain(archivedC.id);
+    });
+
+    it('shows another member archived asset in searchLargeAssets (spaceId path)', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      const { asset: archived } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: archived.id, addedById: owner.id });
+      await ctx.newExif({ assetId: archived.id, fileSizeInByte: 999_999 });
+
+      const auth = factory.auth({ user: { id: member.id } });
+      const result = await sut.searchLargeAssets(auth, { spaceId: space.id });
+
+      expect(result.map((a) => a.id)).toContain(archived.id);
+    });
+
+    it('shows another member archived asset in searchLargeAssets (withSharedSpaces path)', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      const { asset: archived } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: archived.id, addedById: owner.id });
+      await ctx.newExif({ assetId: archived.id, fileSizeInByte: 999_999 });
+
+      const result = await sut.searchLargeAssets(elevated(member.id), { withSharedSpaces: true });
+
+      expect(result.map((a) => a.id)).toContain(archived.id);
+    });
+
+    it('hides another member Hidden/Locked from searchLargeAssets (spaceId path)', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      const { asset: hidden } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+      const { asset: locked } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hidden.id, addedById: owner.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: locked.id, addedById: owner.id });
+      await ctx.newExif({ assetId: hidden.id, fileSizeInByte: 999_999 });
+      await ctx.newExif({ assetId: locked.id, fileSizeInByte: 999_999 });
+
+      const result = await sut.searchLargeAssets(elevated(member.id), { spaceId: space.id });
+      const ids = result.map((a) => a.id);
+
+      expect(ids).not.toContain(hidden.id);
+      expect(ids).not.toContain(locked.id);
     });
   });
 

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -73,6 +73,25 @@ const expectFacetsAbsent = (result: FilterSuggestionsResponseDto, marker: string
   expect(JSON.stringify(result)).not.toContain(`${marker}-`);
 };
 
+// Like expectFacetsPresent but omits the people check — used for space-scoped suggestions
+// where people come from shared_space_person / face_identity_face (not plain person rows)
+// and seeding those requires additional setup outside the scope of the visibility leak tests.
+const expectNonPersonFacetsPresent = (result: FilterSuggestionsResponseDto, marker: string) => {
+  expect(result.countries).toContain(`${marker}-Country`);
+  expect(result.cameraMakes).toContain(`${marker}-Make`);
+  expect(result.tags.map((tag) => tag.value)).toContain(`${marker}-Tag`);
+};
+
+// Mirror: assert absence of non-person facets for space-scoped tests.
+const expectNonPersonFacetsAbsent = (result: FilterSuggestionsResponseDto, marker: string) => {
+  expect(result.countries).not.toContain(`${marker}-Country`);
+  expect(result.cameraMakes).not.toContain(`${marker}-Make`);
+  expect(result.tags.map((tag) => tag.value)).not.toContain(`${marker}-Tag`);
+  expect(JSON.stringify(result)).not.toContain(`${marker}-Country`);
+  expect(JSON.stringify(result)).not.toContain(`${marker}-Make`);
+  expect(JSON.stringify(result)).not.toContain(`${marker}-Tag`);
+};
+
 // M3: elevation only unlocks the CALLER'S OWN locked/archived folder. Other shared-space
 // members' assets must always be Timeline-only in space-scoped search — the v3
 // `undefined`-for-elevated visibility default must not leak their Archived/Hidden/Locked assets.
@@ -92,6 +111,31 @@ const shareAsset = async (ctx: SearchCtx, spaceId: string, ownerId: string, visi
 };
 
 const elevated = (userId: string) => factory.auth({ user: { id: userId }, session: { hasElevatedPermission: true } });
+
+// Slice 5: seed a directly-shared space asset with distinct facet values for each type.
+// `visibility` controls whether this asset is Hidden/Locked/etc. Returns the asset.
+const seedSpaceAssetWithFacets = async (
+  ctx: SearchCtx,
+  spaceId: string,
+  ownerId: string,
+  marker: string,
+  visibility: AssetVisibility,
+) => {
+  const { asset } = await ctx.newAsset({ ownerId, visibility });
+  await ctx.newSharedSpaceAsset({ spaceId, assetId: asset.id, addedById: ownerId });
+  await ctx.newExif({
+    assetId: asset.id,
+    country: `${marker}-Country`,
+    city: `${marker}-City`,
+    make: `${marker}-Make`,
+    model: `${marker}-Model`,
+  });
+  const [tag] = await upsertTags(ctx.get(TagRepository), { userId: ownerId, tags: [`${marker}-Tag`] });
+  await ctx.newTagAsset({ tagIds: [tag.id], assetIds: [asset.id] });
+  const { person } = await ctx.newPerson({ ownerId, name: `${marker}-Person` });
+  await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  return asset;
+};
 
 beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
@@ -863,6 +907,131 @@ describe(SearchService.name, () => {
       expect(ids).toContain(timelineA.id);
       expect(ids).not.toContain(archivedA.id);
       expect(ids).not.toContain(archivedC.id);
+    });
+  });
+
+  // ── Slice 5: facets / suggestions must apply the same M3 visibility gate as search ──
+  describe('space-scoped facet/suggestion visibility (M3 — Slice 5)', () => {
+    // getFilterSuggestions (spaceId path)
+    // NOTE: people facets in the spaceId path come from shared_space_person rows (not plain person
+    // rows), so seedSpaceAssetWithFacets is insufficient to populate them. We assert non-person
+    // facets (country/make/tag) which are enough to prove the visibility gate fires.
+    it('hides another member Hidden asset from spaceId getFilterSuggestions', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'HiddenOwner', AssetVisibility.Hidden);
+      // Positive control: owner's Timeline asset is present
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'TimelineOwner', AssetVisibility.Timeline);
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: member.id } }), {
+        spaceId: space.id,
+      });
+
+      expectNonPersonFacetsAbsent(result, 'HiddenOwner');
+      expectNonPersonFacetsPresent(result, 'TimelineOwner');
+    });
+
+    it('hides another member Locked asset from spaceId getFilterSuggestions (elevated)', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'LockedOwner', AssetVisibility.Locked);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'TimelineOwner2', AssetVisibility.Timeline);
+
+      const result = await sut.getFilterSuggestions(elevated(member.id), { spaceId: space.id });
+
+      expectNonPersonFacetsAbsent(result, 'LockedOwner');
+      expectNonPersonFacetsPresent(result, 'TimelineOwner2');
+    });
+
+    it("exposes the caller's own Locked asset from spaceId getFilterSuggestions (elevated, own-M3)", async () => {
+      const { sut, ctx } = setup();
+      const { member, space } = await setupSpace(ctx);
+      await seedSpaceAssetWithFacets(ctx, space.id, member.id, 'OwnLocked', AssetVisibility.Locked);
+
+      const result = await sut.getFilterSuggestions(elevated(member.id), { spaceId: space.id });
+
+      expectNonPersonFacetsPresent(result, 'OwnLocked');
+    });
+
+    it('hides showInTimeline=false album asset from spaceId getFilterSuggestions', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'NoTimelineAlbumFacet' });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newExif({ assetId: asset.id, country: 'NoTimeline-Country', make: 'NoTimeline-Make' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: member.id } }), {
+        spaceId: space.id,
+      });
+
+      expect(result.countries).not.toContain('NoTimeline-Country');
+      expect(result.cameraMakes).not.toContain('NoTimeline-Make');
+    });
+
+    // getFilterSuggestions (timelineSpaceIds / withSharedSpaces path)
+    // NOTE: people in this path come from getFilteredIdentityPeople (face_identity_face linkage),
+    // not plain person rows, so we assert non-person facets only.
+    it('hides another member Hidden asset from withSharedSpaces getFilterSuggestions', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'TLHiddenOwner', AssetVisibility.Hidden);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'TLTimelineOwner', AssetVisibility.Timeline);
+
+      const result = await sut.getFilterSuggestions(elevated(member.id), { withSharedSpaces: true });
+
+      expectNonPersonFacetsAbsent(result, 'TLHiddenOwner');
+      expectNonPersonFacetsPresent(result, 'TLTimelineOwner');
+    });
+
+    it('hides showInTimeline=false album asset from withSharedSpaces getFilterSuggestions', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'TLNoTimelineAlbum' });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newExif({ assetId: asset.id, country: 'TLNoTimeline-Country' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+      const result = await sut.getFilterSuggestions(factory.auth({ user: { id: member.id } }), {
+        withSharedSpaces: true,
+      });
+
+      expect(result.countries).not.toContain('TLNoTimeline-Country');
+    });
+
+    // getSearchSuggestions (spaceId path)
+    it('hides another member Hidden city from spaceId getSearchSuggestions', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'SugHidden', AssetVisibility.Hidden);
+      await seedSpaceAssetWithFacets(ctx, space.id, owner.id, 'SugTimeline', AssetVisibility.Timeline);
+
+      const cities = await sut.getSearchSuggestions(factory.auth({ user: { id: member.id } }), {
+        type: SearchSuggestionType.CITY,
+        spaceId: space.id,
+      });
+
+      expect(cities).not.toContain('SugHidden-City');
+      expect(cities).toContain('SugTimeline-City');
+    });
+
+    it('hides showInTimeline=false album city from spaceId getSearchSuggestions', async () => {
+      const { sut, ctx } = setup();
+      const { owner, member, space } = await setupSpace(ctx);
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'SugNoTimelineAlbum' });
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newExif({ assetId: asset.id, city: 'SugNoTimeline-City', country: 'France' });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+      const cities = await sut.getSearchSuggestions(factory.auth({ user: { id: member.id } }), {
+        type: SearchSuggestionType.CITY,
+        spaceId: space.id,
+      });
+
+      expect(cities).not.toContain('SugNoTimeline-City');
     });
   });
 

--- a/server/test/medium/specs/services/shared-space-album.service.spec.ts
+++ b/server/test/medium/specs/services/shared-space-album.service.spec.ts
@@ -1,6 +1,6 @@
 import { Kysely } from 'kysely';
 import { StorageCore } from 'src/cores/storage.core';
-import { AssetVisibility, JobName, JobStatus, TimeBucketSize } from 'src/enum';
+import { AlbumUserRole, AssetVisibility, JobName, JobStatus, TimeBucketSize } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AlbumUserRepository } from 'src/repositories/album-user.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
@@ -136,6 +136,56 @@ describe('SharedSpaceService — getLinkedAlbums', () => {
 
     const nonMemberAuth = authFromUser(nonMember);
     await expect(sut.getLinkedAlbums(nonMemberAuth, space.id)).rejects.toThrow();
+  });
+
+  it('does NOT expose albumUsers or email in the linked-album payload (PII guard)', async () => {
+    // Slice 7 — getLinkedAlbums must strip albumUsers (and the email addresses they carry)
+    // from every linked album DTO returned to any space member (Viewer+).
+    // We add a second user as an album_user so that albumUsers would be non-empty if leaked.
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: collaborator } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'PII Test Album' });
+
+    // Add collaborator as an album user so albumUsers would be populated if leaked
+    await ctx.database
+      .insertInto('album_user')
+      .values({ albumId: album.id, userId: collaborator.id, role: AlbumUserRole.Editor })
+      .execute();
+
+    const { asset: a1 } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: a1.id });
+    await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const viewerAuth = authFromUser(viewer);
+    const links = await sut.getLinkedAlbums(viewerAuth, space.id);
+
+    expect(links).toHaveLength(1);
+    const link = links[0];
+
+    // Core fields the web uses must still be present
+    expect(link.id).toBe(album.id);
+    expect(link.albumName).toBe('PII Test Album');
+    expect(typeof link.assetCount).toBe('number');
+    expect(typeof link.showInTimeline).toBe('boolean');
+    expect(link.addedById).toBe(owner.id);
+    expect(typeof link.linkedAt).toBe('string');
+
+    // Deep-scan: no albumUsers property and no email string anywhere in the serialized payload
+    expect((link as unknown as Record<string, unknown>)['albumUsers']).toBeUndefined();
+
+    const serialized = JSON.stringify(link);
+    // email fields like "email":"..." must not appear anywhere in the payload
+    expect(serialized).not.toMatch(/"email"\s*:/);
+    // collaborator's actual email must not appear
+    expect(serialized).not.toContain(collaborator.email);
+    // owner's email must not appear
+    expect(serialized).not.toContain(owner.email);
   });
 });
 

--- a/server/test/medium/specs/services/shared-space-album.service.spec.ts
+++ b/server/test/medium/specs/services/shared-space-album.service.spec.ts
@@ -683,13 +683,12 @@ describe('SharedSpaceService — space access lifecycle via album branch', () =>
     expect(accessedIds).toContain(motion.id);
   });
 
-  it('Test 6: locked (Visibility.Locked) asset in linked album — checkSpaceAccess does NOT filter by visibility', async () => {
-    // checkSpaceAccess does NOT filter asset.visibility for ANY space path (album/library/direct) —
-    // this is pre-existing behavior inherited from libraries/direct adds, NOT introduced by space albums;
-    // locked-asset exclusion across all space paths would be a separate cross-cutting change (out of scope)
-    //
-    // PARITY: album-linked Locked assets and direct-added Locked assets must behave identically —
-    // both are returned by checkSpaceAccess with no visibility filtering applied on either path.
+  it('Test 6: locked (Visibility.Locked) asset in linked album — checkSpaceAccess EXCLUDES hidden/locked (Slice 3 fix)', async () => {
+    // Slice 3 security fix: checkSpaceAccess now applies the spaceVisibilityGate
+    // (asset.visibility IN (Archive, Timeline)) to ALL three access paths — direct,
+    // library, and album. Hidden/Locked assets must NEVER be exposed via the space gate.
+    // The owner's own Locked assets are still readable via checkOwnerAccess (with
+    // hasElevatedPermission=true), which runs before checkSpaceAccess in access.ts.
     const { ctx } = setup();
     const { user: owner } = await ctx.newUser();
     const { user: viewer } = await ctx.newUser();
@@ -714,9 +713,9 @@ describe('SharedSpaceService — space access lifecycle via album branch', () =>
       new Set([albumLockedAsset.id, directLockedAsset.id]),
     );
 
-    // Pinned: both locked assets are returned — visibility is NOT filtered on either the album-branch or the direct-add path
-    expect(accessedIds).toContain(albumLockedAsset.id);
-    expect(accessedIds).toContain(directLockedAsset.id);
+    // Fixed: Locked assets are excluded from checkSpaceAccess on both album-branch and direct-add path
+    expect(accessedIds.has(albumLockedAsset.id)).toBe(false);
+    expect(accessedIds.has(directLockedAsset.id)).toBe(false);
   });
 
   it('Test 7: empty album link is a no-op (zero assets, timeline unchanged)', async () => {

--- a/server/test/medium/specs/services/shared-space-getlinkedalbums.medium.spec.ts
+++ b/server/test/medium/specs/services/shared-space-getlinkedalbums.medium.spec.ts
@@ -100,21 +100,27 @@ describe('SharedSpaceService.getLinkedAlbums — rich AlbumResponseDto shape', (
     expect(result[0].endDate).toBeUndefined();
   });
 
-  it('returns albumUsers with album owner user id', async () => {
+  it('does NOT expose albumUsers in the DTO (Slice 7 PII strip)', async () => {
+    // albumUsers must not appear — not even an empty array — in getLinkedAlbums output.
+    // The web does not use this field; returning it would leak member email addresses.
     const { ctx, sut } = setup();
     const { user: owner } = await ctx.newUser();
     const { user: otherUser } = await ctx.newUser();
     const { space } = await ctx.newSharedSpace({ createdById: owner.id, faceRecognitionEnabled: false });
     await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
 
-    // Album owned by otherUser, linked to space
+    // Album owned by otherUser (it has an album_user row), linked to space
     const { result: album } = await ctx.newAlbum({ ownerId: otherUser.id, albumName: 'OtherOwner' });
     await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
 
     const result = await sut.getLinkedAlbums(authFromUser(owner), space.id);
 
     expect(result).toHaveLength(1);
-    expect(result[0].albumUsers[0].user.id).toBe(otherUser.id);
+    // albumUsers must not be present at all
+    expect((result[0] as unknown as Record<string, unknown>)['albumUsers']).toBeUndefined();
+    // No email anywhere in the serialized payload
+    const serialized = JSON.stringify(result[0]);
+    expect(serialized).not.toMatch(/"email"\s*:/);
   });
 
   it('results are in album.createdAt DESC order', async () => {

--- a/server/test/medium/specs/sync/sync-library-asset-visibility-gate.spec.ts
+++ b/server/test/medium/specs/sync/sync-library-asset-visibility-gate.spec.ts
@@ -1,0 +1,299 @@
+// Fix B: LibraryAssetSync and LibraryAssetExifSync must apply an M3 visibility
+// gate when streaming OTHER members' library assets through the space-link path.
+//
+// Bug: `accessibleLibraries(userId)` includes libraries linked to a space the
+// user belongs to. Before this fix, LibraryAssetSync/LibraryAssetExifSync had
+// NO visibility gate, so a space member received Hidden/Locked library asset
+// bytes + EXIF of other members in full.
+//
+// M3 nuance (own vs other): the user must still receive ALL visibilities of
+// their OWN library assets (Hidden/Locked are valid personal photos). Only
+// OTHER members' assets (reached via the space-link branch) are clamped to
+// [Archive, Timeline]. Gate formula:
+//
+//   asset.ownerId = userId  OR  asset.visibility IN ('archive','timeline')
+//
+// Test matrix (4 x 2 = 8 combinations — all four are exercised below):
+//   LibraryAssetSync     × member B sees only Timeline/Archive of owner A
+//   LibraryAssetSync     × owner A sees all own visibilities (not over-blocked)
+//   LibraryAssetExifSync × member B sees only Timeline/Archive EXIF of owner A
+//   LibraryAssetExifSync × owner A sees all own EXIF (not over-blocked)
+
+import { Kysely } from 'kysely';
+import { AssetVisibility, SharedSpaceRole, SyncEntityType, SyncRequestType } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = async (db?: Kysely<DB>) => {
+  const ctx = new SyncTestContext(db || defaultDatabase);
+  const { auth, user, session } = await ctx.newSyncAuthUser();
+  return { auth, user, session, ctx };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+const isAssetEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.LibraryAssetCreateV1 || r.type === SyncEntityType.LibraryAssetBackfillV1;
+
+const isExifEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.LibraryAssetExifCreateV1 || r.type === SyncEntityType.LibraryAssetExifBackfillV1;
+
+// ── LibraryAssetSync — M3 visibility gate ────────────────────────────────────
+
+describe('LibraryAssetSync — M3 visibility gate (space-link path)', () => {
+  it('member B receives only Timeline and Archive assets from owner A library (not Hidden/Locked)', async () => {
+    // RED: without the M3 gate, member B receives ALL 4 assets from owner A.
+    // GREEN: only Timeline and Archive should appear.
+    const { auth: memberBAuth, ctx } = await setup();
+    const { user: ownerA } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: ownerA.id, name: 'OwnerA-Library' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    // Link library L into space S; member B is in the space.
+    const { space } = await ctx.newSharedSpace({ createdById: ownerA.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: ownerA.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberBAuth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: ownerA.id });
+
+    const response = await ctx.syncStream(memberBAuth, [SyncRequestType.LibraryAssetsV1]);
+    const assetEvents = response.filter((r) => isAssetEvent(r));
+    const emittedIds = assetEvents.map((e) => (e as { data: { id: string } }).data.id);
+
+    // Must include shareable visibilities.
+    expect(emittedIds).toContain(timelineAsset.id);
+    expect(emittedIds).toContain(archiveAsset.id);
+    // Must NOT include private visibilities of another user.
+    expect(emittedIds).not.toContain(hiddenAsset.id);
+    expect(emittedIds).not.toContain(lockedAsset.id);
+  });
+
+  it('owner A still receives ALL visibilities of their own library assets (not over-blocked)', async () => {
+    // M3 correctness: the gate must not block the owner's own Hidden/Locked.
+    const { auth: ownerAAuth, ctx } = await setup();
+    const { library } = await ctx.newLibrary({ ownerId: ownerAAuth.user.id, name: 'OwnLib' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    const response = await ctx.syncStream(ownerAAuth, [SyncRequestType.LibraryAssetsV1]);
+    const assetEvents = response.filter((r) => isAssetEvent(r));
+    const emittedIds = assetEvents.map((e) => (e as { data: { id: string } }).data.id);
+
+    // Owner must see ALL four of their own assets regardless of visibility.
+    expect(emittedIds).toContain(timelineAsset.id);
+    expect(emittedIds).toContain(archiveAsset.id);
+    expect(emittedIds).toContain(hiddenAsset.id);
+    expect(emittedIds).toContain(lockedAsset.id);
+  });
+
+  it('member B does not receive Hidden asset on the upsert path (delta after ack)', async () => {
+    // Verify the gate applies to getUpserts, not just getBackfill.
+    const { auth: memberBAuth, ctx } = await setup();
+    const { user: ownerA } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: ownerA.id });
+
+    // Create a Timeline asset — member B sees it.
+    const { asset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+
+    const { space } = await ctx.newSharedSpace({ createdById: ownerA.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: ownerA.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberBAuth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: ownerA.id });
+
+    const initial = await ctx.syncStream(memberBAuth, [SyncRequestType.LibraryAssetsV1]);
+    await ctx.syncAckAll(memberBAuth, initial);
+    await ctx.assertSyncIsComplete(memberBAuth, [SyncRequestType.LibraryAssetsV1]);
+
+    // Owner A flips asset to Hidden — must NOT appear on member B's upsert path.
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const next = await ctx.syncStream(memberBAuth, [SyncRequestType.LibraryAssetsV1]);
+    const updateEvents = next.filter((r) => isAssetEvent(r));
+    const emittedIds = updateEvents.map((e) => (e as { data: { id: string } }).data.id);
+    expect(emittedIds).not.toContain(asset.id);
+  });
+});
+
+// ── LibraryAssetExifSync — M3 visibility gate ─────────────────────────────────
+
+describe('LibraryAssetExifSync — M3 visibility gate (space-link path)', () => {
+  it('member B receives EXIF only for Timeline and Archive assets from owner A library (not Hidden/Locked)', async () => {
+    // RED: without the M3 gate, member B receives all 4 EXIF rows from owner A.
+    // GREEN: only Timeline and Archive EXIF should appear.
+    const { auth: memberBAuth, ctx } = await setup();
+    const { user: ownerA } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: ownerA.id, name: 'OwnerA-Library' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    await ctx.newExif({ assetId: timelineAsset.id, make: 'TimelineCam' });
+    await ctx.newExif({ assetId: archiveAsset.id, make: 'ArchiveCam' });
+    await ctx.newExif({ assetId: hiddenAsset.id, make: 'HiddenCam' });
+    await ctx.newExif({ assetId: lockedAsset.id, make: 'LockedCam' });
+
+    // Link library L into space S; member B is in the space.
+    const { space } = await ctx.newSharedSpace({ createdById: ownerA.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: ownerA.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberBAuth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: ownerA.id });
+
+    const response = await ctx.syncStream(memberBAuth, [SyncRequestType.LibraryAssetExifsV1]);
+    const exifEvents = response.filter((r) => isExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+
+    // Must include shareable visibilities.
+    expect(emittedAssetIds).toContain(timelineAsset.id);
+    expect(emittedAssetIds).toContain(archiveAsset.id);
+    // Must NOT include private visibilities of another user.
+    expect(emittedAssetIds).not.toContain(hiddenAsset.id);
+    expect(emittedAssetIds).not.toContain(lockedAsset.id);
+  });
+
+  it('owner A still receives EXIF for ALL visibilities of their own library assets (not over-blocked)', async () => {
+    // M3 correctness: the gate must not block the owner's own Hidden/Locked EXIF.
+    const { auth: ownerAAuth, ctx } = await setup();
+    const { library } = await ctx.newLibrary({ ownerId: ownerAAuth.user.id, name: 'OwnLib' });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: ownerAAuth.user.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    await ctx.newExif({ assetId: timelineAsset.id, make: 'TimelineCam' });
+    await ctx.newExif({ assetId: archiveAsset.id, make: 'ArchiveCam' });
+    await ctx.newExif({ assetId: hiddenAsset.id, make: 'HiddenCam' });
+    await ctx.newExif({ assetId: lockedAsset.id, make: 'LockedCam' });
+
+    const response = await ctx.syncStream(ownerAAuth, [SyncRequestType.LibraryAssetExifsV1]);
+    const exifEvents = response.filter((r) => isExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+
+    // Owner must see EXIF for ALL four of their own assets.
+    expect(emittedAssetIds).toContain(timelineAsset.id);
+    expect(emittedAssetIds).toContain(archiveAsset.id);
+    expect(emittedAssetIds).toContain(hiddenAsset.id);
+    expect(emittedAssetIds).toContain(lockedAsset.id);
+  });
+
+  it('member B does not receive EXIF for a Hidden asset on the upsert path (delta after ack)', async () => {
+    // Verify the gate applies to getUpserts, not just getBackfill.
+    const { auth: memberBAuth, ctx } = await setup();
+    const { user: ownerA } = await ctx.newUser();
+    const { library } = await ctx.newLibrary({ ownerId: ownerA.id });
+
+    const { asset } = await ctx.newAsset({
+      ownerId: ownerA.id,
+      libraryId: library.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    await ctx.newExif({ assetId: asset.id, make: 'OldMake' });
+
+    const { space } = await ctx.newSharedSpace({ createdById: ownerA.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: ownerA.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberBAuth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: ownerA.id });
+
+    const initial = await ctx.syncStream(memberBAuth, [SyncRequestType.LibraryAssetExifsV1]);
+    await ctx.syncAckAll(memberBAuth, initial);
+    await ctx.assertSyncIsComplete(memberBAuth, [SyncRequestType.LibraryAssetExifsV1]);
+
+    // Flip to Hidden, update EXIF — must NOT re-emit to member B.
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+    await ctx.newExif({ assetId: asset.id, make: 'NewMake' });
+
+    const next = await ctx.syncStream(memberBAuth, [SyncRequestType.LibraryAssetExifsV1]);
+    const exifEvents = next.filter((r) => isExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+    expect(emittedAssetIds).not.toContain(asset.id);
+  });
+});

--- a/server/test/medium/specs/sync/sync-shared-space-visibility-gate.spec.ts
+++ b/server/test/medium/specs/sync/sync-shared-space-visibility-gate.spec.ts
@@ -1,0 +1,402 @@
+// Slice 4.A: shared-space sync streams must exclude Hidden and Locked assets.
+//
+// HIGH-severity RBAC fix: before this slice, the shared-space delta sync
+// streams (SharedSpaceAssetSync, SharedSpaceAssetExifSync,
+// SharedSpaceAlbumAssetSync, SharedSpaceAlbumAssetExifSync) emitted
+// Hidden/Locked assets + their EXIF/GPS to any space member, leaking
+// another member's private assets.
+//
+// Rule: only AssetVisibility.Archive and AssetVisibility.Timeline are
+// space-shareable. Hidden and Locked must never appear on any sync stream.
+// Archive is intentionally included — it is already shared on the personal
+// timeline and there is no expectation of suppression when shared into a space.
+//
+// Critical invariant (do NOT regress): showInTimeline=false album assets MUST
+// still sync on the album-asset grant stream (SharedSpaceAlbumAssetsV1). The
+// album-asset surface is a browse/GRANT path, not a personal-timeline
+// projection. Only the visibility gate applies here — NOT requireShowInTimeline.
+
+import { Kysely } from 'kysely';
+import { AssetVisibility, SharedSpaceRole, SyncEntityType, SyncRequestType } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = async (db?: Kysely<DB>) => {
+  const ctx = new SyncTestContext(db || defaultDatabase);
+  const { auth, user, session } = await ctx.newSyncAuthUser();
+  return { auth, user, session, ctx };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+// ── Helper predicates ────────────────────────────────────────────────────────
+
+const isSharedSpaceAssetEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.SharedSpaceAssetCreateV1 ||
+  r.type === SyncEntityType.SharedSpaceAssetUpdateV1 ||
+  r.type === SyncEntityType.SharedSpaceAssetBackfillV1;
+
+const isSharedSpaceAssetExifEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.SharedSpaceAssetExifCreateV1 ||
+  r.type === SyncEntityType.SharedSpaceAssetExifUpdateV1 ||
+  r.type === SyncEntityType.SharedSpaceAssetExifBackfillV1;
+
+const isAlbumAssetEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.SharedSpaceAlbumAssetCreateV1 ||
+  r.type === SyncEntityType.SharedSpaceAlbumAssetUpdateV1 ||
+  r.type === SyncEntityType.SharedSpaceAlbumAssetBackfillV1;
+
+const isAlbumAssetExifEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.SharedSpaceAlbumAssetExifCreateV1 ||
+  r.type === SyncEntityType.SharedSpaceAlbumAssetExifUpdateV1 ||
+  r.type === SyncEntityType.SharedSpaceAlbumAssetExifBackfillV1;
+
+// ── SharedSpaceAssetSync visibility gate ─────────────────────────────────────
+
+describe('SharedSpaceAssetSync — visibility gate', () => {
+  it('emits Timeline and Archive assets but not Hidden or Locked (direct space add)', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: timelineAsset.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: archiveAsset.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiddenAsset.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: lockedAsset.id });
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetsV1]);
+    const assetEvents = response.filter((r) => isSharedSpaceAssetEvent(r));
+    const emittedIds = assetEvents.map((e) => (e as { data: { id: string } }).data.id);
+
+    expect(emittedIds).toContain(timelineAsset.id);
+    expect(emittedIds).toContain(archiveAsset.id);
+    expect(emittedIds).not.toContain(hiddenAsset.id);
+    expect(emittedIds).not.toContain(lockedAsset.id);
+  });
+
+  it('does not emit a Hidden asset on the update path after it was already acked', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+    // Asset starts as Timeline — gets acked.
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const initial = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetsV1]);
+    await ctx.syncAckAll(auth, initial);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceAssetsV1]);
+
+    // Flip to Hidden — must NOT appear on the update path.
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+
+    const next = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetsV1]);
+    const updateEvents = next.filter((r) => isSharedSpaceAssetEvent(r));
+    const emittedIds = updateEvents.map((e) => (e as { data: { id: string } }).data.id);
+    expect(emittedIds).not.toContain(asset.id);
+  });
+
+  it('masks isFavorite for a Hidden-to-Timeline asset with a foreign owner (unchanged behaviour)', async () => {
+    // Regression guard: isFavorite masking must be unaffected by the visibility gate.
+    const { auth, ctx } = await setup();
+    const { user: peer } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: peer.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+    const { asset } = await ctx.newAsset({
+      ownerId: peer.id,
+      visibility: AssetVisibility.Timeline,
+      isFavorite: true,
+    });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetsV1]);
+    const assetEvents = response.filter((r) => isSharedSpaceAssetEvent(r));
+    expect(assetEvents).toHaveLength(1);
+    expect((assetEvents[0] as { data: { isFavorite: boolean } }).data.isFavorite).toBe(false);
+  });
+});
+
+// ── SharedSpaceAssetExifSync visibility gate ──────────────────────────────────
+
+describe('SharedSpaceAssetExifSync — visibility gate', () => {
+  it('emits exif only for Timeline and Archive assets, not Hidden or Locked', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    await ctx.newExif({ assetId: timelineAsset.id, make: 'TimelineCam' });
+    await ctx.newExif({ assetId: archiveAsset.id, make: 'ArchiveCam' });
+    await ctx.newExif({ assetId: hiddenAsset.id, make: 'HiddenCam' });
+    await ctx.newExif({ assetId: lockedAsset.id, make: 'LockedCam' });
+
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: timelineAsset.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: archiveAsset.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: hiddenAsset.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: lockedAsset.id });
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetExifsV1]);
+    const exifEvents = response.filter((r) => isSharedSpaceAssetExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+
+    expect(emittedAssetIds).toContain(timelineAsset.id);
+    expect(emittedAssetIds).toContain(archiveAsset.id);
+    expect(emittedAssetIds).not.toContain(hiddenAsset.id);
+    expect(emittedAssetIds).not.toContain(lockedAsset.id);
+  });
+
+  it('does not emit exif for a Hidden asset on the exif-update path', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newExif({ assetId: asset.id, make: 'OldMake' });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    const initial = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetExifsV1]);
+    await ctx.syncAckAll(auth, initial);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceAssetExifsV1]);
+
+    // Flip asset to Hidden, then update exif — must NOT re-emit.
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+    await ctx.newExif({ assetId: asset.id, make: 'NewMake' });
+
+    const next = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAssetExifsV1]);
+    const exifEvents = next.filter((r) => isSharedSpaceAssetExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+    expect(emittedAssetIds).not.toContain(asset.id);
+  });
+});
+
+// ── SharedSpaceAlbumAssetSync visibility gate ─────────────────────────────────
+
+describe('SharedSpaceAlbumAssetSync — visibility gate', () => {
+  it('emits Timeline and Archive album assets but not Hidden or Locked', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: archiveAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiddenAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: lockedAsset.id });
+
+    // Ack membership first so creates stream fires.
+    const membershipResponse = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+    await ctx.syncAckAll(auth, membershipResponse);
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumAssetsV1]);
+    const assetEvents = response.filter((r) => isAlbumAssetEvent(r));
+    const emittedIds = assetEvents.map((e) => (e as { data: { id: string } }).data.id);
+
+    expect(emittedIds).toContain(timelineAsset.id);
+    expect(emittedIds).toContain(archiveAsset.id);
+    expect(emittedIds).not.toContain(hiddenAsset.id);
+    expect(emittedIds).not.toContain(lockedAsset.id);
+  });
+
+  it('syncs a showInTimeline=false album Timeline asset (only visibility-gated, not timeline-gated)', async () => {
+    // CRITICAL: the album-asset grant stream is NOT a personal-timeline projection.
+    // requireShowInTimeline must NOT be applied here. A Timeline asset in a
+    // showInTimeline=false album MUST still sync to a grant-holder.
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+    // showInTimeline=false — album does NOT appear on timeline but assets must
+    // still sync to grant-holders on the album-asset stream.
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: false });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Hidden,
+    });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiddenAsset.id });
+
+    const membershipResponse = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+    await ctx.syncAckAll(auth, membershipResponse);
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumAssetsV1]);
+    const assetEvents = response.filter((r) => isAlbumAssetEvent(r));
+    const emittedIds = assetEvents.map((e) => (e as { data: { id: string } }).data.id);
+
+    // Timeline asset in a showInTimeline=false album must sync.
+    expect(emittedIds).toContain(timelineAsset.id);
+    // Hidden asset must not sync regardless of showInTimeline.
+    expect(emittedIds).not.toContain(hiddenAsset.id);
+  });
+});
+
+// ── SharedSpaceAlbumAssetExifSync visibility gate ─────────────────────────────
+
+describe('SharedSpaceAlbumAssetExifSync — visibility gate', () => {
+  it('emits exif only for Timeline and Archive album assets, not Hidden or Locked', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    const { asset: timelineAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Timeline,
+    });
+    const { asset: archiveAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Archive,
+    });
+    const { asset: hiddenAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Hidden,
+    });
+    const { asset: lockedAsset } = await ctx.newAsset({
+      ownerId: owner.id,
+      visibility: AssetVisibility.Locked,
+    });
+
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: timelineAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: archiveAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: hiddenAsset.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: lockedAsset.id });
+
+    await ctx.newExif({ assetId: timelineAsset.id, make: 'TimelineCam' });
+    await ctx.newExif({ assetId: archiveAsset.id, make: 'ArchiveCam' });
+    await ctx.newExif({ assetId: hiddenAsset.id, make: 'HiddenCam' });
+    await ctx.newExif({ assetId: lockedAsset.id, make: 'LockedCam' });
+
+    const membershipResponse = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+    await ctx.syncAckAll(auth, membershipResponse);
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumAssetExifsV1]);
+    const exifEvents = response.filter((r) => isAlbumAssetExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+
+    expect(emittedAssetIds).toContain(timelineAsset.id);
+    expect(emittedAssetIds).toContain(archiveAsset.id);
+    expect(emittedAssetIds).not.toContain(hiddenAsset.id);
+    expect(emittedAssetIds).not.toContain(lockedAsset.id);
+  });
+
+  it('does not emit exif for a Hidden album asset on the exif-update path', async () => {
+    const { auth, ctx } = await setup();
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+    const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    await ctx.newExif({ assetId: asset.id, make: 'OldMake' });
+
+    const membershipResponse = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+    await ctx.syncAckAll(auth, membershipResponse);
+
+    const initial = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumAssetExifsV1]);
+    await ctx.syncAckAll(auth, initial);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceAlbumAssetExifsV1]);
+
+    // Flip asset to Hidden, then update exif — must NOT re-emit.
+    await defaultDatabase
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', asset.id)
+      .execute();
+    await ctx.newExif({ assetId: asset.id, make: 'NewMake' });
+
+    const next = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceAlbumAssetExifsV1]);
+    const exifEvents = next.filter((r) => isAlbumAssetExifEvent(r));
+    const emittedAssetIds = exifEvents.map((e) => (e as { data: { assetId: string } }).data.assetId);
+    expect(emittedAssetIds).not.toContain(asset.id);
+  });
+});

--- a/server/test/medium/specs/sync/sync-shared-space-visibility-purge.spec.ts
+++ b/server/test/medium/specs/sync/sync-shared-space-visibility-purge.spec.ts
@@ -1,0 +1,137 @@
+// Slice 4.B: purge already-synced DIRECT space assets from member devices when
+// the owner flips an asset OUT of the space-shareable set (Timeline/Archive) to
+// Hidden or Locked, and re-add it when flipped back.
+//
+// Slice 4.A gated the sync READ streams so a NEW/full sync never receives
+// Hidden/Locked. But a device that ALREADY synced an asset while it was
+// Timeline/Archive keeps the bytes when the owner later flips it to
+// Hidden/Locked — the SharedSpaceToAssetSync delete stream only fires on
+// JOIN-ROW deletion, and a visibility flip deletes no shared_space_asset row.
+//
+// This slice closes the DIRECT path (`shared_space_asset` /
+// `shared_space_asset_audit`, which is space-only). On flip to Hidden/Locked we
+// emit a shared_space_asset_audit tombstone for every referencing row so
+// getDeletes purges member devices. On flip back to Timeline/Archive we bump
+// shared_space_asset.updateId so getUpserts re-adds.
+//
+// Album-path Hidden already-synced purge, the library path, and mobile-client
+// end-to-end verification are documented follow-ups (out of scope here).
+
+import { Kysely } from 'kysely';
+import { SharedSpaceRole, SyncEntityType, SyncRequestType } from 'src/enum';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = async (db?: Kysely<DB>) => {
+  const ctx = new SyncTestContext(db || defaultDatabase);
+  const { auth, user, session } = await ctx.newSyncAuthUser();
+  return { auth, user, session, ctx };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+// Seed a space owned by `auth`, with `auth` as Owner, plus a directly-added
+// asset. Returns the space + asset. The caller acks the current sync state to
+// simulate an already-synced device before flipping visibility.
+const seedSpaceWithDirectAsset = async (ctx: SyncTestContext, ownerId: string) => {
+  const { space } = await ctx.newSharedSpace({ createdById: ownerId });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: ownerId, role: SharedSpaceRole.Owner });
+  const { asset } = await ctx.newAsset({ ownerId });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+  return { space, asset };
+};
+
+describe('SharedSpaceToAssetSync — visibility purge/restore (direct path)', () => {
+  it('emits a delete event for a directly-added asset flipped to Hidden after it was acked', async () => {
+    const { auth, ctx } = await setup();
+    const { space, asset } = await seedSpaceWithDirectAsset(ctx, auth.user.id);
+
+    // Simulate an already-synced device.
+    const initial = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    await ctx.syncAckAll(auth, initial);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+
+    // Owner flips the asset to Hidden — DIRECT-path purge must emit a tombstone.
+    await ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityPurge([asset.id]);
+
+    const next = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    const deleteEvents = next.filter((r: { type: string }) => r.type === SyncEntityType.SharedSpaceToAssetDeleteV1);
+    expect(deleteEvents).toHaveLength(1);
+    expect((deleteEvents[0] as { data: { spaceId: string; assetId: string } }).data).toMatchObject({
+      spaceId: space.id,
+      assetId: asset.id,
+    });
+  });
+
+  it('emits a delete event for a directly-added asset flipped to Locked after it was acked', async () => {
+    const { auth, ctx } = await setup();
+    const { space, asset } = await seedSpaceWithDirectAsset(ctx, auth.user.id);
+
+    const initial = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    await ctx.syncAckAll(auth, initial);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+
+    // Locked purge uses the same direct-path tombstone mechanism.
+    await ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityPurge([asset.id]);
+
+    const next = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    const deleteEvents = next.filter((r: { type: string }) => r.type === SyncEntityType.SharedSpaceToAssetDeleteV1);
+    expect(deleteEvents).toHaveLength(1);
+    expect((deleteEvents[0] as { data: { spaceId: string; assetId: string } }).data).toMatchObject({
+      spaceId: space.id,
+      assetId: asset.id,
+    });
+  });
+
+  it('re-emits an upsert for a directly-added asset restored to Timeline after being purged', async () => {
+    const { auth, ctx } = await setup();
+    const { space, asset } = await seedSpaceWithDirectAsset(ctx, auth.user.id);
+
+    const initial = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    await ctx.syncAckAll(auth, initial);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+
+    // Purge, ack the delete, then restore.
+    await ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityPurge([asset.id]);
+    const afterPurge = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    await ctx.syncAckAll(auth, afterPurge);
+    await ctx.assertSyncIsComplete(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+
+    // Restore to Timeline — updateId bump must re-emit the join row via getUpserts.
+    await ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityRestore([asset.id]);
+
+    const next = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    const upsertEvents = next.filter((r: { type: string }) => r.type === SyncEntityType.SharedSpaceToAssetV1);
+    const emitted = upsertEvents.map((e) => (e as { data: { spaceId: string; assetId: string } }).data);
+    expect(emitted).toContainEqual(expect.objectContaining({ spaceId: space.id, assetId: asset.id }));
+  });
+
+  it('emits nothing when purging an asset that is not in any space', async () => {
+    const { auth, ctx } = await setup();
+    const { asset } = await ctx.newAsset({ ownerId: auth.user.id });
+
+    await ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityPurge([asset.id]);
+    await ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityRestore([asset.id]);
+
+    const response = await ctx.syncStream(auth, [SyncRequestType.SharedSpaceToAssetsV1]);
+    const deleteEvents = response.filter((r: { type: string }) => r.type === SyncEntityType.SharedSpaceToAssetDeleteV1);
+    const joinEvents = response.filter(
+      (r: { type: string }) =>
+        r.type === SyncEntityType.SharedSpaceToAssetV1 || r.type === SyncEntityType.SharedSpaceToAssetBackfillV1,
+    );
+    expect(deleteEvents).toHaveLength(0);
+    expect(joinEvents).toHaveLength(0);
+  });
+
+  it('is a no-op on an empty id list', async () => {
+    const { ctx } = await setup();
+    await expect(ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityPurge([])).resolves.not.toThrow();
+    await expect(ctx.get(SharedSpaceRepository).emitDirectAssetVisibilityRestore([])).resolves.not.toThrow();
+  });
+});

--- a/server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts
+++ b/server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts
@@ -2,6 +2,7 @@
 // (spaceAlbumAssetExistsSql) must return the SAME asset set as the Kysely
 // spaceAlbumAssetExists over identical data + scope (spec §3.4). This is the wire
 // that keeps the two authoring styles from drifting.
+// Slice 1 extension — requireShowInTimeline option equivalence between raw-SQL and Kysely.
 import { Kysely, sql } from 'kysely';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
@@ -101,5 +102,61 @@ describe('raw-SQL album arm ≡ Kysely album arm', () => {
 
     expect(raw).toEqual(kysely);
     expect(raw.size).toBe(kysely.size);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 1 — requireShowInTimeline option: raw-SQL ≡ Kysely
+// ---------------------------------------------------------------------------
+
+const kyselyIdsTimeline = async (spaceId: string, requireShowInTimeline: boolean): Promise<Set<string>> => {
+  const rows = await db
+    .selectFrom('asset')
+    .select('asset.id')
+    .where((eb) =>
+      spaceAlbumAssetExists(eb, { correlateAssetId: 'asset.id', scope: { spaceId }, requireShowInTimeline }),
+    )
+    .execute();
+  return new Set(rows.map((r) => r.id));
+};
+
+const rawIdsTimeline = async (spaceId: string, requireShowInTimeline: boolean): Promise<Set<string>> => {
+  const existsFragment = spaceAlbumAssetExistsSql({
+    assetIdColumn: sql`asset.id`,
+    spaceScopeJoin: sql`INNER JOIN shared_space ON shared_space.id = shared_space_album."spaceId" AND shared_space.id = ${spaceId}`,
+    requireShowInTimeline,
+  });
+  const result = await sql<{ id: string }>`SELECT asset.id FROM asset WHERE ${existsFragment}`.execute(db);
+  return new Set(result.rows.map((r) => r.id));
+};
+
+describe('requireShowInTimeline option: raw-SQL ≡ Kysely', () => {
+  it('with requireShowInTimeline=true: matches only the showInTimeline=true album and equals Kysely result', async () => {
+    const { ctx } = setup();
+    const { space, viaShown, viaHidden } = await seedCombos(ctx);
+
+    const kyselyResult = await kyselyIdsTimeline(space.id, true);
+    const rawResult = await rawIdsTimeline(space.id, true);
+
+    // raw-SQL and Kysely must agree
+    expect(rawResult).toEqual(kyselyResult);
+    // only the showInTimeline=true album's asset is matched
+    expect(kyselyResult.has(viaShown.id)).toBe(true);
+    // the showInTimeline=false album's asset is excluded
+    expect(kyselyResult.has(viaHidden.id)).toBe(false);
+  });
+
+  it('with requireShowInTimeline=false (default): both albums matched, raw-SQL equals Kysely result', async () => {
+    const { ctx } = setup();
+    const { space, viaShown, viaHidden } = await seedCombos(ctx);
+
+    const kyselyResult = await kyselyIdsTimeline(space.id, false);
+    const rawResult = await rawIdsTimeline(space.id, false);
+
+    // raw-SQL and Kysely must agree
+    expect(rawResult).toEqual(kyselyResult);
+    // both album assets present (unchanged legacy behavior)
+    expect(kyselyResult.has(viaShown.id)).toBe(true);
+    expect(kyselyResult.has(viaHidden.id)).toBe(true);
   });
 });

--- a/web/src/lib/components/spaces/space-albums-list.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-list.spec.ts
@@ -30,6 +30,7 @@ vi.mock('@immich/ui', async (importOriginal) => {
 function makeAlbum(overrides: Partial<SharedSpaceLinkedAlbumDto> = {}): SharedSpaceLinkedAlbumDto {
   return {
     id: 'album-1',
+    ownerId: 'owner-1',
     albumName: 'Vacation',
     assetCount: 5,
     albumThumbnailAssetId: null,

--- a/web/src/lib/components/spaces/space-albums-list.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-list.spec.ts
@@ -36,7 +36,6 @@ function makeAlbum(overrides: Partial<SharedSpaceLinkedAlbumDto> = {}): SharedSp
     showInTimeline: true,
     addedById: null,
     linkedAt: '2026-01-01T00:00:00.000Z',
-    albumUsers: [],
     description: '',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',

--- a/web/src/lib/components/spaces/space-albums-table.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-table.spec.ts
@@ -15,7 +15,6 @@ function makeAlbum(overrides: Partial<SharedSpaceLinkedAlbumDto> = {}): SharedSp
     showInTimeline: true,
     addedById: null,
     linkedAt: '2026-01-01T00:00:00.000Z',
-    albumUsers: [],
     description: '',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',

--- a/web/src/lib/components/spaces/space-albums-table.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-table.spec.ts
@@ -9,6 +9,7 @@ import { renderWithTooltips } from '$tests/helpers';
 function makeAlbum(overrides: Partial<SharedSpaceLinkedAlbumDto> = {}): SharedSpaceLinkedAlbumDto {
   return {
     id: 'album-1',
+    ownerId: 'owner-1',
     albumName: 'Vacation',
     assetCount: 5,
     albumThumbnailAssetId: null,

--- a/web/src/lib/utils/space-album-grouping.spec.ts
+++ b/web/src/lib/utils/space-album-grouping.spec.ts
@@ -22,6 +22,7 @@ const CTX: SpaceAlbumGroupingCtx = {
 
 const A = (o: Partial<SharedSpaceLinkedAlbumDto>): SharedSpaceLinkedAlbumDto => ({
   id: 'x',
+  ownerId: 'owner-1',
   albumName: 'A',
   assetCount: 0,
   albumThumbnailAssetId: null,

--- a/web/src/lib/utils/space-album-grouping.spec.ts
+++ b/web/src/lib/utils/space-album-grouping.spec.ts
@@ -1,4 +1,4 @@
-import { AlbumUserRole, type SharedSpaceLinkedAlbumDto, type UserResponseDto } from '@immich/sdk';
+import type { SharedSpaceLinkedAlbumDto } from '@immich/sdk';
 import { get } from 'svelte/store';
 import { AlbumSortBy, SortOrder } from '$lib/stores/preferences.store';
 import { SpaceAlbumGroupBy, spaceAlbumViewSettings } from '$lib/stores/space-album-view-settings.store';
@@ -28,7 +28,6 @@ const A = (o: Partial<SharedSpaceLinkedAlbumDto>): SharedSpaceLinkedAlbumDto => 
   showInTimeline: true,
   addedById: null,
   linkedAt: '',
-  albumUsers: [],
   description: '',
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
@@ -91,23 +90,29 @@ it('LinkedBy resolves addedById to member name; null/unknown → unassigned', ()
   expect(byName['Unassigned'].sort()).toEqual(['b', 'c']);
 });
 
-it('Owner groups by albumUsers[0]; empty albumUsers → unassigned (no crash)', () => {
-  const ctx = { ...CTX, currentUserId: 'me' };
+it('Owner groups by ownerId (resolved from ctx.members); missing ownerId → unassigned (no crash)', () => {
+  const ctx = {
+    ...CTX,
+    currentUserId: 'me',
+    members: [
+      { userId: 'me', name: 'Me' },
+      { userId: 'her', name: 'Zoe' },
+    ],
+  };
+  // ownerId is not yet on SharedSpaceLinkedAlbumDto in the SDK; cast to simulate server-side value.
+  const withOwner = (album: SharedSpaceLinkedAlbumDto, ownerId: string) =>
+    Object.assign(album, { ownerId }) as SharedSpaceLinkedAlbumDto;
   const albums = [
-    A({ id: 'mine', albumUsers: [{ role: AlbumUserRole.Owner, user: { id: 'me', name: 'Me' } as UserResponseDto }] }),
-    A({ id: 'hers', albumUsers: [{ role: AlbumUserRole.Owner, user: { id: 'her', name: 'Zoe' } as UserResponseDto }] }),
-    A({ id: 'empty', albumUsers: [] }),
+    withOwner(A({ id: 'mine' }), 'me'),
+    withOwner(A({ id: 'hers' }), 'her'),
+    A({ id: 'noOwner' }), // no ownerId → unassigned
   ];
   const g = buildSpaceAlbumGroups(albums, { ...get(spaceAlbumViewSettings), groupBy: SpaceAlbumGroupBy.Owner }, ctx);
   const names = g.map((x) => x.name);
   expect(names).toContain('Zoe');
-  expect(names).toContain('Unassigned'); // empty albumUsers bucket
+  expect(names).toContain('Unassigned'); // missing ownerId bucket
   expect(() =>
-    buildSpaceAlbumGroups(
-      [A({ id: 'e', albumUsers: [] })],
-      { ...get(spaceAlbumViewSettings), groupBy: SpaceAlbumGroupBy.Owner },
-      ctx,
-    ),
+    buildSpaceAlbumGroups([A({ id: 'e' })], { ...get(spaceAlbumViewSettings), groupBy: SpaceAlbumGroupBy.Owner }, ctx),
   ).not.toThrow();
 });
 

--- a/web/src/lib/utils/space-album-grouping.ts
+++ b/web/src/lib/utils/space-album-grouping.ts
@@ -215,12 +215,16 @@ export const buildSpaceAlbumGroups = (
     case SpaceAlbumGroupBy.Owner: {
       const UNASSIGNED_KEY = '__unassigned__';
 
+      // ownerId is not currently exposed on SharedSpaceLinkedAlbumDto (albumUsers was stripped
+      // in Slice 7 to prevent PII leakage). Group by ownerId when it becomes available;
+      // fall back to UNASSIGNED_KEY so the grouping is safe and crash-free today.
       const groupedByOwner = groupBy(albums, (album) => {
-        return album.albumUsers[0]?.user.id ?? UNASSIGNED_KEY;
+        const ownerId = (album as unknown as { ownerId?: string }).ownerId;
+        return ownerId ?? UNASSIGNED_KEY;
       });
 
       const sortSign = order === SortOrder.Desc ? -1 : 1;
-      const sortedByOwner = Object.entries(groupedByOwner).sort(([ownerIdA, albumsA], [ownerIdB, albumsB]) => {
+      const sortedByOwner = Object.entries(groupedByOwner).sort(([ownerIdA], [ownerIdB]) => {
         // Unassigned always last
         if (ownerIdA === UNASSIGNED_KEY) {
           return 1;
@@ -233,8 +237,8 @@ export const buildSpaceAlbumGroups = (
         } else if (ownerIdB === ctx.currentUserId) {
           return sortSign;
         } else {
-          const ownerAName = albumsA[0]?.albumUsers[0]?.user.name ?? '';
-          const ownerBName = albumsB[0]?.albumUsers[0]?.user.name ?? '';
+          const ownerAName = ctx.members.find((m) => m.userId === ownerIdA)?.name ?? '';
+          const ownerBName = ctx.members.find((m) => m.userId === ownerIdB)?.name ?? '';
           return ownerAName.localeCompare(ownerBName) * sortSign;
         }
       });
@@ -243,10 +247,11 @@ export const buildSpaceAlbumGroups = (
         if (ownerId === UNASSIGNED_KEY) {
           return { id: ctx.unassigned, name: ctx.unassigned, albums: ownerAlbums };
         }
+        const memberName = ctx.members.find((m) => m.userId === ownerId)?.name;
         const ownerName =
           ownerId === ctx.currentUserId
-            ? (ctx.myAlbums ?? ownerAlbums[0]?.albumUsers[0]?.user.name ?? ctx.unassigned)
-            : (ownerAlbums[0]?.albumUsers[0]?.user.name ?? ctx.unassigned);
+            ? (ctx.myAlbums ?? memberName ?? ctx.unassigned)
+            : (memberName ?? ctx.unassigned);
         return { id: ownerId, name: ownerName, albums: ownerAlbums };
       });
       break;

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/space-albums-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/space-albums-page.spec.ts
@@ -74,7 +74,6 @@ function makeAlbum(overrides: Partial<SharedSpaceLinkedAlbumDto> = {}): SharedSp
     showInTimeline: true,
     addedById: null,
     linkedAt: '2026-01-01T00:00:00.000Z',
-    albumUsers: [],
     description: '',
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/space-albums-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/space-albums-page.spec.ts
@@ -68,6 +68,7 @@ const BASE_SPACE: SharedSpaceResponseDto = {
 function makeAlbum(overrides: Partial<SharedSpaceLinkedAlbumDto> = {}): SharedSpaceLinkedAlbumDto {
   return {
     id: 'album-1',
+    ownerId: 'owner-1',
     albumName: 'Vacation',
     assetCount: 5,
     albumThumbnailAssetId: null,


### PR DESCRIPTION
## Shared-Space RBAC Visibility Hardening

> **⚠️ Context — nothing here affects any released or `main` version of Gallery.** This is planned pre-merge hardening for the **shared-space albums feature, which is not yet merged** (it lives in the unmerged PR #752 / the `space-albums-onto-main` branch this PR targets). Every "leak" below is a bug found in that in-progress feature during its own security review — before it ever ships. No released build is affected; this work simply makes the feature correct *before* it lands.

Closes every way a shared-space member could reach a photo (bytes, thumbnail, EXIF, or existence/metadata) that its owner made non-shareable (Hidden/Locked), and makes the space visibility rule consistent across every surface. Driven by an adversarial RBAC audit + an exhaustive test matrix.

**Canonical rule:** every space-scoped asset read is gated to `visibility IN (Archive, Timeline)` — Hidden/Locked never surface; Archive is intentionally shared (matches `bulkAddUserAssets`). One helper `spaceVisibilityGate`, reused everywhere.

### Bugs fixed in the in-progress feature (each TDD, red→green)
- Download (`downloadSpaceId` + `downloadAlbumId` via space grant), by-ID read/view/download (`checkSpaceAccess`), and shared-space + library **sync** streams (+ direct-path purge on later hide/lock) no longer expose other members' Hidden/Locked.
- Timeline buckets no longer bypass the gate via an explicit `visibility=HIDDEN/LOCKED` param.
- Suggestion/facet/tag + album-scoped facets no longer leak Hidden assets' existence/metadata.
- Representative-face **thumbnails** only come from shareable assets; the space People list no longer surfaces persons backed only by Hidden/Locked faces.
- `getLinkedAlbums` and `getAlbumInfo` (reached via the space grant) no longer expose album-user **emails**.
- Activity (comments/reactions) no longer enumerates Hidden/Locked album-asset activity.
- Search shows other members' Archive to match the space timeline (Hidden/Locked still blocked); `checkSpaceEditAccess` matches the read gate; de-timelined (`showInTimeline=false`) albums stop feeding faces/memory/view.

### Regression lock
- A **static guard** fails CI if any future space asset-read forgets the visibility gate (now detects helper-scoped reads, not just table literals).
- An **exhaustive matrix** medium spec: `{Timeline,Archive,Hidden,Locked} × {direct,library,album(showInTimeline t/f),soft-deleted-album}` across ~22 surfaces — this is what caught the remaining gaps.

### Scope notes / follow-ups
- Sync device-*purge* on later hide/lock is direct-path only; album-Hidden + library + mobile-consume QA tracked in #753 (all read-streams are gated).
- Map/memory stay Timeline-only by design (archive excluded from resurfacing, matching upstream).

Full design + matrix: `docs/superpowers/specs/2026-07-06-shared-space-rbac-visibility-hardening-design.md`.
