### PR TITLE
feat(spaces): stacked photos in Spaces — whole-stack add/remove + mobile collapse (#751)

### DIFF
--- a/docs/docs/features/shared-spaces.md
+++ b/docs/docs/features/shared-spaces.md
@@ -149,6 +149,20 @@ If you're a server admin, you can [link an external library](#connected-librarie
 2. Long-press to select photos.
 3. Tap **Remove from Space** in the bottom sheet.
 
+## Stacked Photos
+
+Stacks (RAW+JPEG pairs, bursts, or manually grouped photos) are treated as a unit in a space:
+
+- **Adding** any photo of a stack adds the **entire stack** to the space. In the space timeline the stack appears collapsed to its cover photo — exactly like your main timeline — with a badge showing how many frames it holds. Open the cover to page through every frame.
+- **Removing** any photo of a stack removes the **whole stack** from the space.
+- Changing which photo is the stack's cover keeps the stack in the space — the new cover simply takes its place.
+
+Hidden and locked photos are never added to a shared space, even when they belong to a stack.
+
+:::note
+Stacks that were added to a space before this feature shipped — or stacks you re-group after adding them — may still show only their cover. Re-add the stack to bring in every frame.
+:::
+
 ## Timeline Integration
 
 Each member can choose whether a space's photos appear in their personal timeline. Tap or click the **eye icon** in the space header to toggle between **Show on timeline** and **Hide from timeline**.

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-1.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-1.md
@@ -24,11 +24,13 @@ Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice
 ### Task 1: Repository query `getOwnedStackSiblingIds`
 
 **Files:**
+
 - Modify: `server/src/repositories/shared-space.repository.ts` (add method near `addAssets`, ~line 333)
 - Create: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
 - Regenerate: `server/src/queries/shared.space.repository.sql`
 
 **Interfaces:**
+
 - Produces: `getOwnedStackSiblingIds(userId: string, assetIds: string[]): Promise<string[]>` — asset ids of all non-deleted, space-eligible-visibility, `ownerId = userId` assets sharing a non-null `stackId` with any of `assetIds`. Returns `[]` for empty input.
 
 - [ ] **Step 1: Write the failing medium tests**
@@ -245,10 +247,12 @@ git commit -m "feat(spaces): add getOwnedStackSiblingIds repo query for stack ex
 ### Task 2: `addAssets` expands to the stack closure
 
 **Files:**
+
 - Modify: `server/src/services/shared-space.service.ts:571-596` (`addAssets`)
 - Modify: `server/src/services/shared-space.service.spec.ts` (add default mock in `beforeEach`; add expansion tests to the `describe('addAssets', …)` block near line 2139)
 
 **Interfaces:**
+
 - Consumes: `SharedSpaceRepository.getOwnedStackSiblingIds(userId, assetIds) → Promise<string[]>` (Task 1).
 
 - [ ] **Step 1: Add the default mock so existing tests keep passing**
@@ -256,7 +260,7 @@ git commit -m "feat(spaces): add getOwnedStackSiblingIds repo query for stack ex
 In `server/src/services/shared-space.service.spec.ts`, inside `beforeEach` (after `({ sut, mocks } = newTestService(SharedSpaceService));`, near line 243), add:
 
 ```ts
-    mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
+mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
 ```
 
 - [ ] **Step 2: Write the failing unit tests**
@@ -264,102 +268,102 @@ In `server/src/services/shared-space.service.spec.ts`, inside `beforeEach` (afte
 Add these tests inside `describe('addAssets', …)` in `server/src/services/shared-space.service.spec.ts`:
 
 ```ts
-    it('should expand a stack to its siblings and insert the whole stack (E1/E2)', async () => {
-      const auth = factory.auth();
-      const spaceId = newUuid();
-      const cover = newUuid();
-      const sibling1 = newUuid();
-      const sibling2 = newUuid();
-      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+it('should expand a stack to its siblings and insert the whole stack (E1/E2)', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const cover = newUuid();
+  const sibling1 = newUuid();
+  const sibling2 = newUuid();
+  const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
 
-      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
-      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1, sibling2]);
-      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.update.mockResolvedValue(space);
-      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+  mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
+  mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1, sibling2]);
+  mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.update.mockResolvedValue(space);
+  mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
 
-      await sut.addAssets(auth, spaceId, { assetIds: [cover] });
+  await sut.addAssets(auth, spaceId, { assetIds: [cover] });
 
-      expect(mocks.sharedSpace.getOwnedStackSiblingIds).toHaveBeenCalledWith(auth.user.id, [cover]);
-      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
-        { spaceId, assetId: cover, addedById: auth.user.id },
-        { spaceId, assetId: sibling1, addedById: auth.user.id },
-        { spaceId, assetId: sibling2, addedById: auth.user.id },
-      ]);
-    });
+  expect(mocks.sharedSpace.getOwnedStackSiblingIds).toHaveBeenCalledWith(auth.user.id, [cover]);
+  expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+    { spaceId, assetId: cover, addedById: auth.user.id },
+    { spaceId, assetId: sibling1, addedById: auth.user.id },
+    { spaceId, assetId: sibling2, addedById: auth.user.id },
+  ]);
+});
 
-    it('should dedupe seeds and returned siblings (E8)', async () => {
-      const auth = factory.auth();
-      const spaceId = newUuid();
-      const a = newUuid();
-      const b = newUuid();
-      const c = newUuid();
-      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+it('should dedupe seeds and returned siblings (E8)', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const a = newUuid();
+  const b = newUuid();
+  const c = newUuid();
+  const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
 
-      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([a, b]));
-      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([b, c]);
-      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.update.mockResolvedValue(space);
-      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+  mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([a, b]));
+  mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([b, c]);
+  mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.update.mockResolvedValue(space);
+  mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
 
-      await sut.addAssets(auth, spaceId, { assetIds: [a, b] });
+  await sut.addAssets(auth, spaceId, { assetIds: [a, b] });
 
-      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
-        { spaceId, assetId: a, addedById: auth.user.id },
-        { spaceId, assetId: b, addedById: auth.user.id },
-        { spaceId, assetId: c, addedById: auth.user.id },
-      ]);
-    });
+  expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+    { spaceId, assetId: a, addedById: auth.user.id },
+    { spaceId, assetId: b, addedById: auth.user.id },
+    { spaceId, assetId: c, addedById: auth.user.id },
+  ]);
+});
 
-    it('should retain an explicitly-added seed that is not a returned sibling (E7)', async () => {
-      const auth = factory.auth();
-      const spaceId = newUuid();
-      const seed = newUuid();
-      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+it('should retain an explicitly-added seed that is not a returned sibling (E7)', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const seed = newUuid();
+  const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
 
-      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([seed]));
-      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
-      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.update.mockResolvedValue(space);
-      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+  mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([seed]));
+  mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
+  mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.update.mockResolvedValue(space);
+  mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
 
-      await sut.addAssets(auth, spaceId, { assetIds: [seed] });
+  await sut.addAssets(auth, spaceId, { assetIds: [seed] });
 
-      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([{ spaceId, assetId: seed, addedById: auth.user.id }]);
-    });
+  expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([{ spaceId, assetId: seed, addedById: auth.user.id }]);
+});
 
-    it('should queue SharedSpaceFaceMatch jobs for the expanded set (E12)', async () => {
-      const auth = factory.auth();
-      const spaceId = newUuid();
-      const cover = newUuid();
-      const sibling1 = newUuid();
-      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
-      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+it('should queue SharedSpaceFaceMatch jobs for the expanded set (E12)', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const cover = newUuid();
+  const sibling1 = newUuid();
+  const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+  const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
 
-      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
-      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1]);
-      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.update.mockResolvedValue(space);
-      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+  mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
+  mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1]);
+  mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.update.mockResolvedValue(space);
+  mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
 
-      await sut.addAssets(auth, spaceId, { assetIds: [cover] });
+  await sut.addAssets(auth, spaceId, { assetIds: [cover] });
 
-      expect(mocks.job.queueAll).toHaveBeenCalledWith([
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: cover } },
-        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: sibling1 } },
-      ]);
-    });
+  expect(mocks.job.queueAll).toHaveBeenCalledWith([
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: cover } },
+    { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: sibling1 } },
+  ]);
+});
 ```
 
 - [ ] **Step 3: Run to verify failure**
@@ -424,9 +428,11 @@ git commit -m "feat(spaces): expand add-to-space to the whole stack (#751)"
 ### Task 3: Composition E2E medium tests (timeline collapse, promote-primary, idempotency)
 
 **Files:**
+
 - Modify: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` (add a second `describe`)
 
 **Interfaces:**
+
 - Consumes: `SharedSpaceRepository.getOwnedStackSiblingIds` + `addAssets`; `AssetRepository.getTimeBuckets`; `StackRepository.update`; `ctx.newStack`, `ctx.newSharedSpace`, `ctx.newSharedSpaceMember`.
 
 - [ ] **Step 1: Write the failing composition tests**
@@ -443,7 +449,13 @@ Then the describe block:
 
 ```ts
 describe('stack-in-space composition (E10/E13)', () => {
-  const addWholeStack = async (ctx: any, sut: SharedSpaceRepository, spaceId: string, userId: string, seedId: string) => {
+  const addWholeStack = async (
+    ctx: any,
+    sut: SharedSpaceRepository,
+    spaceId: string,
+    userId: string,
+    seedId: string,
+  ) => {
     const siblings = await sut.getOwnedStackSiblingIds(userId, [seedId]);
     const expanded = [...new Set([seedId, ...siblings])];
     return sut.addAssets(expanded.map((assetId) => ({ spaceId, assetId, addedById: userId })));
@@ -531,6 +543,7 @@ git commit -m "test(spaces): composition E2E for stack-in-space add + collapse (
 `node ./dist/bin/sync-sql.js` reads the `@GenerateSql` decorators from the built `dist/` and writes `server/src/queries/*.sql`. It needs a reachable Postgres.
 
 Procedure:
+
 1. `cd server && pnpm build` (produces `dist/bin/sync-sql.js`).
 2. Ensure a Postgres is reachable with the immich dev env (`DB_HOSTNAME`, `DB_USERNAME`, `DB_PASSWORD`, `DB_DATABASE_NAME`, `DB_PORT`). If the dev stack DB is not up, start just Postgres, or export the same connection the medium tests would use.
 3. `mise sql` (or `node ./dist/bin/sync-sql.js`).

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-1.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-1.md
@@ -1,0 +1,547 @@
+# Stacked Photos in Spaces — Slice S1 Implementation Plan (Server: add expands the whole stack)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adding any frame of a stack to a Space (`SharedSpaceService.addAssets`) brings in all of the adder's space-eligible frames of that stack, so the Space timeline collapses to the cover exactly like the main timeline and any primary change "just works."
+
+**Architecture:** A new owner-scoped repository query `getOwnedStackSiblingIds` returns the stack siblings of the given assets; `addAssets` unions those with the passed ids and inserts/face-matches the expanded set. No schema change. Read-time stack collapse is unchanged and does the rest.
+
+**Tech Stack:** NestJS 11, Kysely, Vitest (unit + medium via testcontainers Postgres), `@GenerateSql` SQL-doc generation.
+
+Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice S1; edge cases E1–E13).
+
+## Global Constraints
+
+- No relative imports in `server/` — use the `src/` path alias.
+- Prettier: 120 cols, single quotes, trailing commas, semicolons. ESLint zero-warnings.
+- Reuse the existing constant `visibleSpaceAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline]` (`server/src/repositories/shared-space.repository.ts:42`) — do NOT invent a new visibility set. It excludes Hidden and Locked (the RBAC-sensitive tiers).
+- Expansion is **owner-scoped**: only siblings with `ownerId = auth.user.id` (stacks are single-owner, so the adder already has `AssetRead` — no extra permission check).
+- New `@GenerateSql` method ⇒ regenerate `server/src/queries/shared.space.repository.sql` (built server + Postgres) and commit it.
+- Adding a repository **method** (not a new repository) ⇒ no `BaseService` / `BaseService.create()` / medium-factory `newRealRepository` changes.
+
+---
+
+### Task 1: Repository query `getOwnedStackSiblingIds`
+
+**Files:**
+- Modify: `server/src/repositories/shared-space.repository.ts` (add method near `addAssets`, ~line 333)
+- Create: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
+- Regenerate: `server/src/queries/shared.space.repository.sql`
+
+**Interfaces:**
+- Produces: `getOwnedStackSiblingIds(userId: string, assetIds: string[]): Promise<string[]>` — asset ids of all non-deleted, space-eligible-visibility, `ownerId = userId` assets sharing a non-null `stackId` with any of `assetIds`. Returns `[]` for empty input.
+
+- [ ] **Step 1: Write the failing medium tests**
+
+Create `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`:
+
+```ts
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db || defaultDatabase,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(SharedSpaceRepository) };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('SharedSpaceRepository.getOwnedStackSiblingIds', () => {
+  it('returns all siblings when the seed is the stack cover (E1)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id, child2.id]));
+  });
+
+  it('returns all siblings incl. the primary when the seed is a non-primary frame (E2)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [child1.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id]));
+  });
+
+  it('returns nothing for an asset with no stack (E3)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [asset.id]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not expand a stack owned by another user (E4)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: other } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newStack({ ownerId: owner.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(other.id, [primary.id]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('excludes Hidden and Locked siblings (E5)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, hidden.id, locked.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('includes Archived siblings — archive is space-eligible (E5b)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: archived } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, archived.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, archived.id]));
+  });
+
+  it('excludes soft-deleted siblings (E6)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: deleted } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, deleted.id]);
+    await ctx.softDeleteAsset(deleted.id);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('dedupes when two seeds share a stack (E8)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id, child1.id]);
+
+    expect(result.length).toBe(new Set(result).size);
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id]));
+  });
+
+  it('handles a mixed batch of stacked and unstacked seeds (E9)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: standalone } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id, standalone.id]);
+
+    // standalone has no stack → contributes no siblings; the stack expands fully
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id]));
+  });
+
+  it('returns [] for empty input (E11)', async () => {
+    const { sut } = setup();
+    const result = await sut.getOwnedStackSiblingIds('00000000-0000-0000-0000-000000000000', []);
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
+Expected: FAIL — `sut.getOwnedStackSiblingIds is not a function` (method does not exist yet).
+
+- [ ] **Step 3: Implement the query**
+
+In `server/src/repositories/shared-space.repository.ts`, add immediately after the `addAssets` method (after line 333):
+
+```ts
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  async getOwnedStackSiblingIds(userId: string, assetIds: string[]): Promise<string[]> {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .selectFrom('asset as seed')
+      .innerJoin('asset as sibling', 'sibling.stackId', 'seed.stackId')
+      .select('sibling.id as assetId')
+      .distinct()
+      .where('seed.id', 'in', assetIds)
+      .where('seed.stackId', 'is not', null)
+      .where('sibling.ownerId', '=', userId)
+      .where('sibling.deletedAt', 'is', null)
+      .where('sibling.visibility', 'in', visibleSpaceAssetVisibilities)
+      .execute();
+
+    return rows.map((row) => row.assetId);
+  }
+```
+
+(`GenerateSql`, `DummyValue` are already imported at the top of the file; `visibleSpaceAssetVisibilities` is the module constant at line 42.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
+Expected: PASS (all 10 tests).
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd server && pnpm check`
+Expected: no errors.
+
+- [ ] **Step 6: Regenerate SQL docs and commit**
+
+Regenerate the query doc for the new `@GenerateSql` method (needs a built server + Postgres — see "SQL regeneration" note at the end of this plan):
+
+Run: `cd server && pnpm build && (mise sql || node ./dist/bin/sync-sql.js)`
+Expected: `server/src/queries/shared.space.repository.sql` gains a `getOwnedStackSiblingIds` entry; no other query files change.
+
+```bash
+git add server/src/repositories/shared-space.repository.ts \
+        server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts \
+        server/src/queries/shared.space.repository.sql
+git commit -m "feat(spaces): add getOwnedStackSiblingIds repo query for stack expansion (#751)"
+```
+
+---
+
+### Task 2: `addAssets` expands to the stack closure
+
+**Files:**
+- Modify: `server/src/services/shared-space.service.ts:571-596` (`addAssets`)
+- Modify: `server/src/services/shared-space.service.spec.ts` (add default mock in `beforeEach`; add expansion tests to the `describe('addAssets', …)` block near line 2139)
+
+**Interfaces:**
+- Consumes: `SharedSpaceRepository.getOwnedStackSiblingIds(userId, assetIds) → Promise<string[]>` (Task 1).
+
+- [ ] **Step 1: Add the default mock so existing tests keep passing**
+
+In `server/src/services/shared-space.service.spec.ts`, inside `beforeEach` (after `({ sut, mocks } = newTestService(SharedSpaceService));`, near line 243), add:
+
+```ts
+    mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
+```
+
+- [ ] **Step 2: Write the failing unit tests**
+
+Add these tests inside `describe('addAssets', …)` in `server/src/services/shared-space.service.spec.ts`:
+
+```ts
+    it('should expand a stack to its siblings and insert the whole stack (E1/E2)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const sibling2 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1, sibling2]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.sharedSpace.getOwnedStackSiblingIds).toHaveBeenCalledWith(auth.user.id, [cover]);
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+        { spaceId, assetId: cover, addedById: auth.user.id },
+        { spaceId, assetId: sibling1, addedById: auth.user.id },
+        { spaceId, assetId: sibling2, addedById: auth.user.id },
+      ]);
+    });
+
+    it('should dedupe seeds and returned siblings (E8)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const a = newUuid();
+      const b = newUuid();
+      const c = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([a, b]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([b, c]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [a, b] });
+
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+        { spaceId, assetId: a, addedById: auth.user.id },
+        { spaceId, assetId: b, addedById: auth.user.id },
+        { spaceId, assetId: c, addedById: auth.user.id },
+      ]);
+    });
+
+    it('should retain an explicitly-added seed that is not a returned sibling (E7)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const seed = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([seed]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [seed] });
+
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([{ spaceId, assetId: seed, addedById: auth.user.id }]);
+    });
+
+    it('should queue SharedSpaceFaceMatch jobs for the expanded set (E12)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: cover } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: sibling1 } },
+      ]);
+    });
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts -t addAssets`
+Expected: the 4 new tests FAIL (siblings not expanded); existing `addAssets` tests still PASS (default mock returns `[]`).
+
+- [ ] **Step 4: Implement the expansion in `addAssets`**
+
+Replace the body of `addAssets` (`server/src/services/shared-space.service.ts:571-596`) with:
+
+```ts
+  async addAssets(auth: AuthDto, spaceId: string, dto: SharedSpaceAssetAddDto): Promise<void> {
+    await this.requireRole(auth, spaceId, SharedSpaceRole.Editor);
+    await this.requireAccess({ auth, permission: Permission.AssetRead, ids: dto.assetIds });
+
+    const siblingIds = await this.sharedSpaceRepository.getOwnedStackSiblingIds(auth.user.id, dto.assetIds);
+    const expandedAssetIds = [...new Set([...dto.assetIds, ...siblingIds])];
+
+    const inserted = await this.sharedSpaceRepository.addAssets(
+      expandedAssetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),
+    );
+
+    await this.sharedSpaceRepository.update(spaceId, { lastActivityAt: new Date() });
+
+    await this.sharedSpaceRepository.logActivity({
+      spaceId,
+      userId: auth.user.id,
+      type: SharedSpaceActivityType.AssetAdd,
+      data: { count: inserted.length, assetIds: dto.assetIds.slice(0, 4) },
+    });
+
+    const space = await this.sharedSpaceRepository.getById(spaceId);
+    if (space?.faceRecognitionEnabled) {
+      await this.jobRepository.queueAll(
+        expandedAssetIds.map((assetId) => ({
+          name: JobName.SharedSpaceFaceMatch as const,
+          data: { spaceId, assetId },
+        })),
+      );
+    }
+  }
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts`
+Expected: PASS (all `addAssets` tests, new and existing).
+
+- [ ] **Step 6: Type-check + commit**
+
+Run: `cd server && pnpm check`
+Expected: no errors.
+
+```bash
+git add server/src/services/shared-space.service.ts server/src/services/shared-space.service.spec.ts
+git commit -m "feat(spaces): expand add-to-space to the whole stack (#751)"
+```
+
+---
+
+### Task 3: Composition E2E medium tests (timeline collapse, promote-primary, idempotency)
+
+**Files:**
+- Modify: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` (add a second `describe`)
+
+**Interfaces:**
+- Consumes: `SharedSpaceRepository.getOwnedStackSiblingIds` + `addAssets`; `AssetRepository.getTimeBuckets`; `StackRepository.update`; `ctx.newStack`, `ctx.newSharedSpace`, `ctx.newSharedSpaceMember`.
+
+- [ ] **Step 1: Write the failing composition tests**
+
+Append to `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`. Add imports at the top:
+
+```ts
+import { AssetRepository } from 'src/repositories/asset.repository';
+import { StackRepository } from 'src/repositories/stack.repository';
+import { TimeBucketSize } from 'src/enum';
+```
+
+Then the describe block:
+
+```ts
+describe('stack-in-space composition (E10/E13)', () => {
+  const addWholeStack = async (ctx: any, sut: SharedSpaceRepository, spaceId: string, userId: string, seedId: string) => {
+    const siblings = await sut.getOwnedStackSiblingIds(userId, [seedId]);
+    const expanded = [...new Set([seedId, ...siblings])];
+    return sut.addAssets(expanded.map((assetId) => ({ spaceId, assetId, addedById: userId })));
+  };
+
+  const bucketCount = async (ctx: any, spaceId: string) => {
+    const buckets = await ctx.get(AssetRepository).getTimeBuckets({
+      spaceId,
+      visibility: AssetVisibility.Timeline,
+      bucketSize: TimeBucketSize.Year,
+      withStacked: true,
+    });
+    return buckets.reduce((sum: number, b: { count: number }) => sum + b.count, 0);
+  };
+
+  it('collapses to one cover after the whole stack is added (E1/E13)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
+
+    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+
+    expect(await sut.getAssetCount(space.id)).toBe(3);
+    await expect(bucketCount(ctx, space.id)).resolves.toBe(1);
+  });
+
+  it('keeps the stack visible after promoting a different primary (E13)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { stack } = await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    await ctx.get(StackRepository).update(stack.id, { id: stack.id, primaryAssetId: child1.id });
+
+    await expect(bucketCount(ctx, space.id)).resolves.toBe(1);
+  });
+
+  it('is idempotent on re-add (E10)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    const secondInsert = await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+
+    expect(secondInsert).toHaveLength(0);
+    expect(await sut.getAssetCount(space.id)).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify pass**
+
+These exercise already-implemented code (Tasks 1–2 + existing collapse), so they should PASS on first run. If any fails, fix the implementation, not the test.
+
+Run: `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
+Expected: PASS (all describes).
+
+> Note: these are composition tests over already-shipped behavior; a first-run green is acceptable here (they assert the integrated outcome, not a new unit). If `TimeBucketSize` import path differs, confirm against `server/src/enum.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+git commit -m "test(spaces): composition E2E for stack-in-space add + collapse (#751)"
+```
+
+---
+
+## SQL regeneration (for Task 1, Step 6)
+
+`node ./dist/bin/sync-sql.js` reads the `@GenerateSql` decorators from the built `dist/` and writes `server/src/queries/*.sql`. It needs a reachable Postgres.
+
+Procedure:
+1. `cd server && pnpm build` (produces `dist/bin/sync-sql.js`).
+2. Ensure a Postgres is reachable with the immich dev env (`DB_HOSTNAME`, `DB_USERNAME`, `DB_PASSWORD`, `DB_DATABASE_NAME`, `DB_PORT`). If the dev stack DB is not up, start just Postgres, or export the same connection the medium tests would use.
+3. `mise sql` (or `node ./dist/bin/sync-sql.js`).
+4. `git diff --stat server/src/queries/` should show **only** `shared.space.repository.sql` changed (a new `getOwnedStackSiblingIds` block). Commit it with Task 1.
+
+If SQL regeneration is environmentally blocked, do NOT skip silently — report it as a blocker; the CI SQL-docs check will fail without it.
+
+## Slice S1 Verification Gate (run before pushing)
+
+- [ ] `cd server && pnpm check` — no type errors
+- [ ] `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts` — green
+- [ ] `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` — green
+- [ ] `server/src/queries/shared.space.repository.sql` regenerated and committed
+- [ ] `cd server && pnpm lint` (deferred to end is fine) — zero warnings on touched files

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-2.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-2.md
@@ -24,10 +24,12 @@ Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice
 ### Task 1: Repository query `getStackSiblingIdsInSpace`
 
 **Files:**
+
 - Modify: `server/src/repositories/shared-space.repository.ts` — add after `removeAssets` (the method around line 392).
 - Modify: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` — add a `describe` block.
 
 **Interfaces:**
+
 - Produces: `getStackSiblingIdsInSpace(spaceId: string, assetIds: string[]): Promise<string[]>` — asset ids of assets that (a) share a non-null `stackId` with any of `assetIds` AND (b) are direct members of `spaceId`. Returns `[]` for empty input.
 
 - [ ] **Step 1: Write the failing medium tests** — append this `describe` to `shared-space-stack-expansion.medium.spec.ts` (the file already imports `setup`, `ctx` helpers, `SharedSpaceRepository`):
@@ -141,68 +143,67 @@ git commit -m "feat(spaces): add getStackSiblingIdsInSpace repo query for remove
 ### Task 2: `removeAssets` expands to the stack closure
 
 **Files:**
+
 - Modify: `server/src/services/shared-space.service.ts` — the `removeAssets` method.
 - Modify: `server/src/services/shared-space.service.spec.ts` — add default mock in `beforeEach`; add tests to the `describe('removeAssets', …)` block.
 
 **Interfaces:**
+
 - Consumes: `SharedSpaceRepository.getStackSiblingIdsInSpace(spaceId, assetIds) → Promise<string[]>` (Task 1).
 
 - [ ] **Step 1: Add the default mock** — in `beforeEach` (next to the existing `mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([])` added in S1):
 
 ```ts
-    mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([]);
+mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([]);
 ```
 
 - [ ] **Step 2: Write the failing unit tests** — add to `describe('removeAssets', …)` in `shared-space.service.spec.ts`. (Mirror the setup style already used in that block: mock `getMember` with an Editor member, `getById` with a space, `getLastAssetAddedAt`, `getAssetIdsWithoutOtherSpacePath` → `[]` unless asserting orphans.)
 
 ```ts
-    it('should expand removal to same-stack space members (E14/E15)', async () => {
-      const auth = factory.auth();
-      const spaceId = newUuid();
-      const cover = newUuid();
-      const sibling1 = newUuid();
-      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
-      const space = factory.sharedSpace({ id: spaceId });
+it('should expand removal to same-stack space members (E14/E15)', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const cover = newUuid();
+  const sibling1 = newUuid();
+  const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+  const space = factory.sharedSpace({ id: spaceId });
 
-      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
-      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
-      mocks.sharedSpace.update.mockResolvedValue(space);
-      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
-      mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
+  mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
+  mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+  mocks.sharedSpace.update.mockResolvedValue(space);
+  mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+  mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
 
-      await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
+  await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
 
-      expect(mocks.sharedSpace.getStackSiblingIdsInSpace).toHaveBeenCalledWith(spaceId, [cover]);
-      expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
-      expect(mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
-    });
+  expect(mocks.sharedSpace.getStackSiblingIdsInSpace).toHaveBeenCalledWith(spaceId, [cover]);
+  expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
+  expect(mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
+});
 
-    it('should reset the thumbnail when it is an expanded (sibling) frame (E17)', async () => {
-      const auth = factory.auth();
-      const spaceId = newUuid();
-      const cover = newUuid();
-      const sibling1 = newUuid();
-      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
-      const space = factory.sharedSpace({ id: spaceId, thumbnailAssetId: sibling1 });
+it('should reset the thumbnail when it is an expanded (sibling) frame (E17)', async () => {
+  const auth = factory.auth();
+  const spaceId = newUuid();
+  const cover = newUuid();
+  const sibling1 = newUuid();
+  const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+  const space = factory.sharedSpace({ id: spaceId, thumbnailAssetId: sibling1 });
 
-      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
-      mocks.sharedSpace.getById.mockResolvedValue(space);
-      mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
-      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
-      mocks.sharedSpace.update.mockResolvedValue(space);
-      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
-      mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
+  mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+  mocks.sharedSpace.getById.mockResolvedValue(space);
+  mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
+  mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+  mocks.sharedSpace.update.mockResolvedValue(space);
+  mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+  mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
 
-      // thumbnail (sibling1) is NOT in the caller's dto.assetIds — only reachable via expansion
-      await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
+  // thumbnail (sibling1) is NOT in the caller's dto.assetIds — only reachable via expansion
+  await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
 
-      expect(mocks.sharedSpace.update).toHaveBeenCalledWith(
-        spaceId,
-        expect.objectContaining({ thumbnailAssetId: null }),
-      );
-    });
+  expect(mocks.sharedSpace.update).toHaveBeenCalledWith(spaceId, expect.objectContaining({ thumbnailAssetId: null }));
+});
 ```
 
 - [ ] **Step 3: Run to verify failure**
@@ -275,9 +276,11 @@ git commit -m "feat(spaces): expand remove-from-space to the whole stack (#751)"
 ### Task 3: Composition E2E medium tests (remove whole stack, album survival)
 
 **Files:**
+
 - Modify: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` — add a `describe`.
 
 **Interfaces:**
+
 - Consumes: `getStackSiblingIdsInSpace`, `removeAssets`, `getAssetCount`, `getAssetIdsWithoutOtherSpacePath`; `ctx.newAlbum`, `ctx.newSharedSpaceAlbum`, `ctx.newSharedSpaceAsset`.
 
 - [ ] **Step 1: Write the tests** — append:

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-2.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-2.md
@@ -1,0 +1,373 @@
+# Stacked Photos in Spaces — Slice S2 Implementation Plan (Server: remove expands the whole stack)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Removing any frame of a stack from a Space (`SharedSpaceService.removeAssets`) removes all of that stack's direct members from the Space, with correct thumbnail-reset and face-orphan handling; frames still reachable via a linked album stay members.
+
+**Architecture:** A new space-scoped repository query `getStackSiblingIdsInSpace` returns the same-stack direct members of a Space; `removeAssets` unions those with the passed ids and deletes/cleans up the expanded set. No schema change.
+
+**Tech Stack:** NestJS 11, Kysely, Vitest (unit + medium testcontainers), `@GenerateSql`.
+
+Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice S2; edge cases E14–E19). Baseline: S1 is complete (commits through `3adecfa66d`) — `getOwnedStackSiblingIds`, `addAssets` expansion, and the medium file `shared-space-stack-expansion.medium.spec.ts` already exist.
+
+## Global Constraints
+
+- No relative imports in `server/`; Prettier 120 cols/single quotes/trailing commas; ESLint zero-warnings.
+- Remove expansion is **space-scoped, not owner-scoped**: a stack sibling qualifies iff it is a current direct member (`shared_space_asset`) of THIS `spaceId`. No visibility/owner/offline filter (members are members).
+- `expandedAssetIds` (= `dto.assetIds` ∪ member-siblings) must feed the delete, the thumbnail-reset check, AND the `getAssetIdsWithoutOtherSpacePath` face-orphan computation.
+- Preserve all existing `removeAssets` behavior: role check, `NotFoundException` when space missing, `getLastAssetAddedAt` → `lastActivityAt`, activity log, orphan face/person cleanup.
+- New `@GenerateSql` method ⇒ regenerate `server/src/queries/shared.space.repository.sql` (controller handles it).
+- Adding a repository method ⇒ no `BaseService`/`create()`/medium-factory changes.
+
+---
+
+### Task 1: Repository query `getStackSiblingIdsInSpace`
+
+**Files:**
+- Modify: `server/src/repositories/shared-space.repository.ts` — add after `removeAssets` (the method around line 392).
+- Modify: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` — add a `describe` block.
+
+**Interfaces:**
+- Produces: `getStackSiblingIdsInSpace(spaceId: string, assetIds: string[]): Promise<string[]>` — asset ids of assets that (a) share a non-null `stackId` with any of `assetIds` AND (b) are direct members of `spaceId`. Returns `[]` for empty input.
+
+- [ ] **Step 1: Write the failing medium tests** — append this `describe` to `shared-space-stack-expansion.medium.spec.ts` (the file already imports `setup`, `ctx` helpers, `SharedSpaceRepository`):
+
+```ts
+describe('SharedSpaceRepository.getStackSiblingIdsInSpace', () => {
+  it('returns same-stack direct members of the space (E18)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child2.id, addedById: user.id });
+
+    const result = await sut.getStackSiblingIdsInSpace(space.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id, child2.id]));
+  });
+
+  it('excludes same-stack assets that are NOT members of the space (E18)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    // only the primary is a direct member; child1 is not
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+
+    const result = await sut.getStackSiblingIdsInSpace(space.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('does not cross space boundaries (E18)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: child1.id, addedById: user.id });
+
+    const result = await sut.getStackSiblingIdsInSpace(spaceA.id, [primary.id]);
+
+    // child1 is a member of space B, not A → excluded from space A's expansion
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('returns [] for empty input', async () => {
+    const { ctx, sut } = setup();
+    const { space } = await ctx.newSharedSpace({ createdById: (await ctx.newUser()).user.id });
+    const result = await sut.getStackSiblingIdsInSpace(space.id, []);
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts -t getStackSiblingIdsInSpace`
+Expected: FAIL — `sut.getStackSiblingIdsInSpace is not a function`.
+
+- [ ] **Step 3: Implement the query** — in `shared-space.repository.ts`, after `removeAssets`:
+
+```ts
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  async getStackSiblingIdsInSpace(spaceId: string, assetIds: string[]): Promise<string[]> {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .selectFrom('asset as seed')
+      .innerJoin('asset as sibling', 'sibling.stackId', 'seed.stackId')
+      .innerJoin('shared_space_asset', 'shared_space_asset.assetId', 'sibling.id')
+      .select('sibling.id as assetId')
+      .distinct()
+      .where('seed.id', 'in', assetIds)
+      .where('seed.stackId', 'is not', null)
+      .where('shared_space_asset.spaceId', '=', spaceId)
+      .execute();
+
+    return rows.map((row) => row.assetId);
+  }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
+Expected: PASS (all describes, including the new one).
+
+- [ ] **Step 5: Type-check + commit** (omit the `.sql` — controller regenerates it)
+
+Run: `cd server && pnpm check` → no errors.
+
+```bash
+git add server/src/repositories/shared-space.repository.ts \
+        server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+git commit -m "feat(spaces): add getStackSiblingIdsInSpace repo query for remove expansion (#751)"
+```
+
+---
+
+### Task 2: `removeAssets` expands to the stack closure
+
+**Files:**
+- Modify: `server/src/services/shared-space.service.ts` — the `removeAssets` method.
+- Modify: `server/src/services/shared-space.service.spec.ts` — add default mock in `beforeEach`; add tests to the `describe('removeAssets', …)` block.
+
+**Interfaces:**
+- Consumes: `SharedSpaceRepository.getStackSiblingIdsInSpace(spaceId, assetIds) → Promise<string[]>` (Task 1).
+
+- [ ] **Step 1: Add the default mock** — in `beforeEach` (next to the existing `mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([])` added in S1):
+
+```ts
+    mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([]);
+```
+
+- [ ] **Step 2: Write the failing unit tests** — add to `describe('removeAssets', …)` in `shared-space.service.spec.ts`. (Mirror the setup style already used in that block: mock `getMember` with an Editor member, `getById` with a space, `getLastAssetAddedAt`, `getAssetIdsWithoutOtherSpacePath` → `[]` unless asserting orphans.)
+
+```ts
+    it('should expand removal to same-stack space members (E14/E15)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+      mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
+
+      await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.sharedSpace.getStackSiblingIdsInSpace).toHaveBeenCalledWith(spaceId, [cover]);
+      expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
+      expect(mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
+    });
+
+    it('should reset the thumbnail when it is an expanded (sibling) frame (E17)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, thumbnailAssetId: sibling1 });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+      mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
+
+      // thumbnail (sibling1) is NOT in the caller's dto.assetIds — only reachable via expansion
+      await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.sharedSpace.update).toHaveBeenCalledWith(
+        spaceId,
+        expect.objectContaining({ thumbnailAssetId: null }),
+      );
+    });
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts -t removeAssets`
+Expected: the 2 new tests FAIL (no expansion yet — `removeAssets` called with `[cover]`, thumbnail not reset); existing `removeAssets` tests PASS (default mock `[]`).
+
+- [ ] **Step 4: Implement expansion in `removeAssets`** — replace the method body so it reads exactly:
+
+```ts
+  async removeAssets(auth: AuthDto, spaceId: string, dto: SharedSpaceAssetRemoveDto): Promise<void> {
+    await this.requireRole(auth, spaceId, SharedSpaceRole.Editor);
+
+    const space = await this.sharedSpaceRepository.getById(spaceId);
+    if (!space) {
+      throw new NotFoundException('Space not found');
+    }
+
+    const siblingIds = await this.sharedSpaceRepository.getStackSiblingIdsInSpace(spaceId, dto.assetIds);
+    const expandedAssetIds = [...new Set([...dto.assetIds, ...siblingIds])];
+
+    await this.sharedSpaceRepository.removeAssets(spaceId, expandedAssetIds);
+
+    const lastAddedAt = await this.sharedSpaceRepository.getLastAssetAddedAt(spaceId);
+    const updateData: { lastActivityAt: Date | null; thumbnailAssetId?: null } = {
+      lastActivityAt: lastAddedAt ?? null,
+    };
+
+    if (space?.thumbnailAssetId && expandedAssetIds.includes(space.thumbnailAssetId)) {
+      updateData.thumbnailAssetId = null;
+    }
+
+    await this.sharedSpaceRepository.update(spaceId, updateData);
+
+    await this.sharedSpaceRepository.logActivity({
+      spaceId,
+      userId: auth.user.id,
+      type: SharedSpaceActivityType.AssetRemove,
+      data: { count: expandedAssetIds.length },
+    });
+
+    const orphanedAssetIds = await this.sharedSpaceRepository.getAssetIdsWithoutOtherSpacePath(
+      spaceId,
+      expandedAssetIds,
+    );
+    if (orphanedAssetIds.length > 0) {
+      await this.sharedSpaceRepository.removePersonFacesByAssetIds(spaceId, orphanedAssetIds);
+      await this.sharedSpaceRepository.deleteOrphanedPersons(spaceId);
+      await this.queueSpacePersonMetadataBackfill();
+    }
+  }
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts`
+Expected: PASS (all `removeAssets` tests, new and existing).
+
+- [ ] **Step 6: Type-check + commit**
+
+Run: `cd server && pnpm check` → no errors.
+
+```bash
+git add server/src/services/shared-space.service.ts server/src/services/shared-space.service.spec.ts
+git commit -m "feat(spaces): expand remove-from-space to the whole stack (#751)"
+```
+
+---
+
+### Task 3: Composition E2E medium tests (remove whole stack, album survival)
+
+**Files:**
+- Modify: `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` — add a `describe`.
+
+**Interfaces:**
+- Consumes: `getStackSiblingIdsInSpace`, `removeAssets`, `getAssetCount`, `getAssetIdsWithoutOtherSpacePath`; `ctx.newAlbum`, `ctx.newSharedSpaceAlbum`, `ctx.newSharedSpaceAsset`.
+
+- [ ] **Step 1: Write the tests** — append:
+
+```ts
+describe('stack-in-space removal composition (E14/E15/E16)', () => {
+  const removeWholeStack = async (sut: SharedSpaceRepository, spaceId: string, seedId: string) => {
+    const siblings = await sut.getStackSiblingIdsInSpace(spaceId, [seedId]);
+    const expanded = [...new Set([seedId, ...siblings])];
+    await sut.removeAssets(spaceId, expanded);
+    return expanded;
+  };
+
+  it('removing the cover removes the whole stack (E14)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+
+    await removeWholeStack(sut, space.id, primary.id);
+
+    expect(await sut.getAssetCount(space.id)).toBe(0);
+  });
+
+  it('removing a non-cover frame removes the whole stack (E15)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+
+    await removeWholeStack(sut, space.id, child1.id);
+
+    expect(await sut.getAssetCount(space.id)).toBe(0);
+  });
+
+  it('a frame still reachable via a linked album is not flagged as a face-orphan (E16)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+    // child1 is ALSO in an album that is linked to the space
+    const { album } = await ctx.newAlbum({ ownerId: user.id }, [child1.id]);
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+
+    const expanded = await removeWholeStack(sut, space.id, primary.id);
+    const orphans = await sut.getAssetIdsWithoutOtherSpacePath(space.id, expanded);
+
+    // primary has no remaining path → orphan; child1 remains via the album → NOT an orphan
+    expect(orphans).toContain(primary.id);
+    expect(orphans).not.toContain(child1.id);
+  });
+});
+```
+
+> `ctx.newAlbum` returns `{ album }`; confirm the returned album shape has `.id` (medium.factory.ts:228). If `newAlbum`'s asset-adding overload isn't wired for `album_asset`, add the asset via `ctx.newAlbumAsset({ albumId: album.id, assetId: child1.id })` instead.
+
+- [ ] **Step 2: Run to verify pass** (exercises implemented code; first-run green acceptable)
+
+Run: `cd server && ./node_modules/.bin/vitest --config test/vitest.config.medium.mjs --run test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+git commit -m "test(spaces): composition E2E for stack-in-space removal + album survival (#751)"
+```
+
+---
+
+## SQL regeneration (controller, after Task 1)
+
+Same procedure as S1: `cd server && pnpm build`; start `ghcr.io/immich-app/postgres:14-vectorchord0.4.3` on :5432 (POSTGRES_USER/PASSWORD=postgres, DB=immich); `DB_URL=postgres://postgres:postgres@localhost:5432/immich pnpm --filter immich migrations:run`; `DB_URL=… mise //:sql`; confirm only `server/src/queries/shared.space.repository.sql` changed (adds a `getStackSiblingIdsInSpace` block); commit it.
+
+## Slice S2 Verification Gate
+
+- [ ] `cd server && pnpm check` — clean
+- [ ] `cd server && pnpm test -- --run src/services/shared-space.service.spec.ts` — green
+- [ ] medium spec green (query + both composition describes)
+- [ ] `server/src/queries/shared.space.repository.sql` regenerated + committed
+- [ ] `cd server && pnpm lint` — zero warnings on touched files

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-3.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-3.md
@@ -1,0 +1,208 @@
+# Stacked Photos in Spaces — Slice S3 Implementation Plan (Mobile: collapse the aggregated-Space timeline)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The mobile aggregated-Space timeline collapses a stack to its cover (one tile, correct count), exactly like the main timeline. The space-**album** detail timeline is intentionally left uncollapsed (parity with web/albums).
+
+**Architecture:** Add a `LEFT OUTER JOIN stack_entity` + the collapse predicate `(stack_id IS NULL OR remote_asset.id = stack.primary_asset_id)` to the three Drift query builders that serve the aggregated-Space timeline. Mirrors the raw-SQL collapse in `merged_asset.drift`. No schema change, no codegen.
+
+**Tech Stack:** Flutter 3.44.1 (pinned), Drift (in-memory Postgres-less SQLite for tests), `flutter_test`.
+
+Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice S3; edge cases E20–E23).
+
+## Global Constraints
+
+- Flutter **3.44.1** via mise. Run mobile commands from `mobile/` as `mise exec -- flutter <...>`.
+- These DB-layer tests need only `flutter pub get` + `flutter test <path>` — NO `easy_localization:generate` / `generate_keys.dart` (the timeline/DB import graph never touches `lib/generated/`). Drift generated code is committed.
+- Modify ONLY the two aggregated-Space builders (`_watchSharedSpaceBucket` — both its `groupBy == none` count query AND its grouped query — and `_getSharedSpaceBucketAssets`). Do NOT touch `_watchSpaceAlbumBucket` / `_getSpaceAlbumBucketAssets` (the album-detail path must stay uncollapsed).
+- Collapse semantics (from `merged_asset.drift:74-77`): keep an asset iff `stack_id IS NULL OR remote_asset.id = stack_entity.primary_asset_id`.
+- Drift column accessors: `_db.remoteAssetEntity.stackId` (SQL `stack_id`, nullable), `_db.stackEntity.id`, `_db.stackEntity.primaryAssetId`.
+
+---
+
+### Task 1: Add stack-collapse to the aggregated-Space builders (test-first)
+
+**Files:**
+- Modify: `mobile/lib/infrastructure/repositories/timeline.repository.dart` (three query builders inside `_watchSharedSpaceBucket` and `_getSharedSpaceBucketAssets`).
+- Modify: `mobile/test/medium/repositories/timeline_repository_test.dart` (add a `group` of tests).
+
+**Interfaces:** none new — behavior change to existing `sut.sharedSpace(...)` queries.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these imports at the top of `mobile/test/medium/repositories/timeline_repository_test.dart` (alongside the existing imports):
+
+```dart
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/infrastructure/entities/stack.entity.drift.dart';
+```
+
+Add this `group` inside `main()` (after the existing tests). It uses the existing `MediumRepositoryContext` helpers `ctx.newUser()`, `ctx.newSharedSpace(createdById:)`, `ctx.newRemoteAsset(ownerId:, stackId:, createdAt:)`, `ctx.insertSharedSpaceAsset(spaceId:, assetId:)`, and (for E21) `ctx.newSharedSpaceAlbum()`, `ctx.insertSharedSpaceAlbumLink(spaceId:, albumId:, showInTimeline:)`, `ctx.insertSharedSpaceAlbumAsset(albumId:, assetId:)`. There is no stack-row helper, so the `stack_entity` row is inserted directly.
+
+```dart
+  group('aggregated-space stack collapse (S3)', () {
+    const stackId = 'stack-1';
+    final createdAt = DateTime(2024, 1, 1, 12);
+
+    Future<void> insertStack(String id, String ownerId, String primaryAssetId) => ctx.db
+        .into(ctx.db.stackEntity)
+        .insert(StackEntityCompanion.insert(id: id, ownerId: ownerId, primaryAssetId: primaryAssetId));
+
+    test('collapses a 3-frame stack to its cover in assetSource + bucket count (E20/E23)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      await insertStack(stackId, user.id, primary.id);
+      for (final a in [primary, child1, child2]) {
+        await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: a.id);
+      }
+
+      // asset query: only the cover survives
+      final assets = await sut.sharedSpace(space.id, GroupAssetsBy.none).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id).toList(), [primary.id]);
+
+      // bucket-count query agrees: one day bucket with count 1
+      final buckets = await sut.sharedSpace(space.id, GroupAssetsBy.day).bucketSource().first;
+      expect(buckets, hasLength(1));
+      expect((buckets.single as TimeBucket).assetCount, 1);
+    });
+
+    test('does NOT collapse the space-album detail timeline (E21)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum();
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      await insertStack(stackId, user.id, primary.id);
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id, showInTimeline: true);
+      for (final a in [primary, child1, child2]) {
+        await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: a.id);
+      }
+
+      final assets = await sut.spaceAlbum(space.id, album.id, GroupAssetsBy.none).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id).toSet(), {primary.id, child1.id, child2.id});
+    });
+
+    test('legacy partial stack (only non-primary frames are members) yields zero (E22)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      await insertStack(stackId, user.id, primary.id);
+      // Only the NON-primary frames are direct members; the primary is absent.
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child1.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child2.id);
+
+      final assets = await sut.sharedSpace(space.id, GroupAssetsBy.none).assetSource(0, 100);
+      // non-primary frames are collapsed out; the primary isn't a member → nothing shows
+      // (consistent with server/web timeline; documented limitation).
+      expect(assets, isEmpty);
+    });
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run (from `mobile/`): `mise exec -- flutter test test/medium/repositories/timeline_repository_test.dart`
+(If deps aren't fetched: `mise exec -- flutter pub get` first.)
+Expected: the E20/E23 test FAILS (assetSource returns all 3 → `[primary, child1, child2]` ≠ `[primary]`; bucket count is 3 not 1) and the E22 test FAILS (returns child1/child2 → not empty). The E21 test PASSES already (album path untouched). This is the correct red — the collapse isn't implemented yet.
+
+- [ ] **Step 3: Implement collapse — three query builders in `timeline.repository.dart`**
+
+**(a) `_watchSharedSpaceBucket`, the `groupBy == GroupAssetsBy.none` count query** — in its `..join([ ... ])` list (currently ending with the `sharedSpaceAlbumLinkEntity` leftOuterJoin), add a fifth join as the last element:
+
+```dart
+          leftOuterJoin(
+            _db.stackEntity,
+            _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+            useColumns: false,
+          ),
+```
+
+and extend that query's `..where( ... )` by ANDing the collapse predicate as the final conjunct:
+
+```dart
+        ..where(
+          _db.remoteAssetEntity.deletedAt.isNull() &
+              _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
+              _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
+              (_db.sharedSpaceAssetEntity.assetId.isNotNull() |
+                  _db.sharedSpaceLibraryEntity.libraryId.isNotNull() |
+                  _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()) &
+              (_db.remoteAssetEntity.stackId.isNull() |
+                  _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
+        );
+```
+
+**(b) `_watchSharedSpaceBucket`, the grouped query** (the `final query = _db.remoteAssetEntity.selectOnly()...` block) — add the same fifth `leftOuterJoin(_db.stackEntity, ...)` to its `..join([ ... ])` list, and AND the same collapse predicate onto its `..where( ... )` (which ends with the same three-way membership OR):
+
+```dart
+      ..where(
+        _db.remoteAssetEntity.deletedAt.isNull() &
+            _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
+            _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
+            (_db.sharedSpaceAssetEntity.assetId.isNotNull() |
+                _db.sharedSpaceLibraryEntity.libraryId.isNotNull() |
+                _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()) &
+            (_db.remoteAssetEntity.stackId.isNull() |
+                _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
+      )
+      ..groupBy([dateExp])
+      ..orderBy([OrderingTerm.desc(dateExp)]);
+```
+
+**(c) `_getSharedSpaceBucketAssets`** — its `.join([ ... ])` currently contains only the `localAssetEntity` leftOuterJoin. Add the stack join to that list:
+
+```dart
+        _db.remoteAssetEntity.select().addColumns([_db.localAssetEntity.id]).join([
+            leftOuterJoin(
+              _db.localAssetEntity,
+              _db.remoteAssetEntity.checksum.equalsExp(_db.localAssetEntity.checksum),
+              useColumns: false,
+            ),
+            leftOuterJoin(
+              _db.stackEntity,
+              _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+              useColumns: false,
+            ),
+          ])
+```
+
+and AND the collapse predicate onto its `..where( ... )` (which currently ends with `membership`):
+
+```dart
+          ..where(
+            _db.remoteAssetEntity.deletedAt.isNull() &
+                _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
+                _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
+                membership &
+                (_db.remoteAssetEntity.stackId.isNull() |
+                    _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
+          )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run (from `mobile/`): `mise exec -- flutter test test/medium/repositories/timeline_repository_test.dart`
+Expected: PASS — all tests in the file, including the new group (E20/E23, E21, E22) and the pre-existing shared-space tests.
+
+- [ ] **Step 5: Analyze / lint / commit**
+
+Run (from `mobile/`): `mise exec -- dart analyze lib/infrastructure/repositories/timeline.repository.dart test/medium/repositories/timeline_repository_test.dart`
+Expected: no errors/warnings on the touched files. (CI runs `dart analyze --fatal-infos` over the whole package; keep the touched files clean.)
+
+```bash
+git add mobile/lib/infrastructure/repositories/timeline.repository.dart \
+        mobile/test/medium/repositories/timeline_repository_test.dart
+git commit -m "feat(spaces): collapse stacks in the mobile aggregated-space timeline (#751)"
+```
+
+## Slice S3 Verification Gate
+
+- [ ] `mise exec -- flutter test test/medium/repositories/timeline_repository_test.dart` — all green (new group + pre-existing)
+- [ ] `mise exec -- dart analyze lib test` clean on touched files (CI uses `--fatal-infos` over the package)
+- [ ] Confirmed `_watchSpaceAlbumBucket` / `_getSpaceAlbumBucketAssets` are unchanged (E21 test guards this)

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-3.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-3.md
@@ -23,6 +23,7 @@ Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice
 ### Task 1: Add stack-collapse to the aggregated-Space builders (test-first)
 
 **Files:**
+
 - Modify: `mobile/lib/infrastructure/repositories/timeline.repository.dart` (three query builders inside `_watchSharedSpaceBucket` and `_getSharedSpaceBucketAssets`).
 - Modify: `mobile/test/medium/repositories/timeline_repository_test.dart` (add a `group` of tests).
 

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-4.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-4.md
@@ -1,0 +1,102 @@
+# Stacked Photos in Spaces — Slice S4 Implementation Plan (Web guard test + user docs)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox syntax.
+
+**Goal:** Lock in web's correct-by-default behavior (space timeline requests stack collapse; space-album detail does not) with a guard test, and document the whole-stack add/remove behavior + the re-add workaround for users. No web app code change.
+
+**Tech Stack:** SvelteKit + Vitest (web unit), Docusaurus markdown.
+
+Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice S4; edge cases E24, E25).
+
+## Global Constraints
+
+- No web app source change expected — this slice is a guard test + docs only.
+- `buildSpaceTimelineOptions(spaceId, filters)` returns `{ spaceId, withStacked: true, ... }` (`web/src/lib/utils/space-filter-options.ts:5`). `buildAlbumTimelineOptions(albumId, order, filters)` returns options WITHOUT `withStacked` (`web/src/lib/utils/album-filter-options.ts:42`).
+- Empty filters via `createFilterState()` (`web/src/lib/components/filter-panel/filter-panel.ts:78`). `AssetOrder` from `@immich/sdk` (requires the SDK build; run `make build-sdk` if the import fails to resolve at test time).
+- Prettier on any touched markdown under `docs/` (CI Docs Build is strict).
+
+---
+
+### Task 1: Web guard test (E24/E25)
+
+**Files:**
+- Create: `web/src/lib/utils/space-filter-options.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { AssetOrder } from '@immich/sdk';
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildAlbumTimelineOptions } from '$lib/utils/album-filter-options';
+import { buildSpaceTimelineOptions } from '$lib/utils/space-filter-options';
+import { describe, expect, it } from 'vitest';
+
+describe('space vs album timeline options — stack collapse (#751)', () => {
+  it('space timeline requests stack collapse (withStacked: true) (E24)', () => {
+    const options = buildSpaceTimelineOptions('space-1', createFilterState());
+
+    expect(options.spaceId).toBe('space-1');
+    expect(options.withStacked).toBe(true);
+  });
+
+  it('space-album detail does NOT collapse stacks (no withStacked) (E25)', () => {
+    const options = buildAlbumTimelineOptions('album-1', AssetOrder.Desc, createFilterState());
+
+    expect(options.withStacked).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd web && pnpm test -- --run src/lib/utils/space-filter-options.spec.ts`
+Expected: PASS (guards existing correct behavior). If `@immich/sdk` import fails, run `make build-sdk` from repo root first, then re-run. This test passes on unchanged web code — it is a regression guard, so a first-run green is correct here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/lib/utils/space-filter-options.spec.ts
+git commit -m "test(spaces): guard space timeline collapses stacks, album detail does not (#751)"
+```
+
+---
+
+### Task 2: User documentation
+
+**Files:**
+- Modify: `docs/docs/features/shared-spaces.md` — insert a new `## Stacked Photos` section between `## Removing Photos from a Space` (ends line 150) and `## Timeline Integration` (line 152).
+
+- [ ] **Step 1: Insert the section** (verbatim, after the Removing section's last line and its blank line, before `## Timeline Integration`):
+
+```markdown
+## Stacked Photos
+
+Stacks (RAW+JPEG pairs, bursts, or manually grouped photos) are treated as a unit in a space:
+
+- **Adding** any photo of a stack adds the **entire stack** to the space. In the space timeline the stack appears collapsed to its cover photo — exactly like your main timeline — with a badge showing how many frames it holds. Open the cover to page through every frame.
+- **Removing** any photo of a stack removes the **whole stack** from the space.
+- Changing which photo is the stack's cover keeps the stack in the space — the new cover simply takes its place.
+
+Hidden and locked photos are never added to a shared space, even when they belong to a stack.
+
+:::note
+Stacks that were added to a space before this feature shipped — or stacks you re-group after adding them — may still show only their cover. Re-add the stack to bring in every frame.
+:::
+```
+
+- [ ] **Step 2: Prettier**
+
+Run: `cd docs && pnpm exec prettier --write docs/features/shared-spaces.md` (or the repo's markdown prettier command). Confirm no formatting diff remains.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/docs/features/shared-spaces.md
+git commit -m "docs(spaces): document whole-stack add/remove in shared spaces (#751)"
+```
+
+## Slice S4 Verification Gate
+
+- [ ] `cd web && pnpm test -- --run src/lib/utils/space-filter-options.spec.ts` — green (build SDK first if needed)
+- [ ] `cd web && pnpm check:typescript` — clean (new spec typechecks)
+- [ ] Prettier clean on `docs/docs/features/shared-spaces.md`

--- a/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-4.md
+++ b/docs/superpowers/plans/2026-07-06-spaces-stacked-photos-slice-4.md
@@ -20,6 +20,7 @@ Spec: `docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md` (Slice
 ### Task 1: Web guard test (E24/E25)
 
 **Files:**
+
 - Create: `web/src/lib/utils/space-filter-options.spec.ts`
 
 - [ ] **Step 1: Write the test**
@@ -64,6 +65,7 @@ git commit -m "test(spaces): guard space timeline collapses stacks, album detail
 ### Task 2: User documentation
 
 **Files:**
+
 - Modify: `docs/docs/features/shared-spaces.md` — insert a new `## Stacked Photos` section between `## Removing Photos from a Space` (ends line 150) and `## Timeline Integration` (line 152).
 
 - [ ] **Step 1: Insert the section** (verbatim, after the Removing section's last line and its blank line, before `## Timeline Integration`):

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -224,9 +224,18 @@ With every frame a direct member:
 - **Legacy partial stacks.** Stacks added to Spaces _before_ this change keep only their cover
   as a member until re-added. No backfill migration ships.
 - **Album-linked partial stacks** are not completed (see Non-goals).
+- **Mobile collapse is best-effort for non-owned stacks.** The mobile stack-collapse reads the
+  local `stack_entity` table, which only syncs for the viewer's own and partners' stacks — there
+  is no shared-space stack sync. So when a viewer opens a Space containing **another member's**
+  stack, the client can't know which frame is the cover and shows the stack's frames **flat**
+  (all of them) rather than collapsed. This is strictly better than pre-feature behavior (the
+  frames are all present via S1's membership fix) and never hides them; full mobile collapse for
+  non-owned stacks would require a new shared-space stack sync stream (out of scope). Owned
+  stacks collapse normally. The collapse predicate therefore keeps any asset whose `stack_entity`
+  row is absent locally.
 
-Both limitations follow directly from the locked decisions (add/remove-only sync depth; no
-backfill).
+These limitations follow from the locked decisions (add/remove-only sync depth; no backfill) and
+the mobile owner-scoped sync model.
 
 ## Edge-case coverage matrix
 

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -237,6 +237,19 @@ With every frame a direct member:
 These limitations follow from the locked decisions (add/remove-only sync depth; no backfill) and
 the mobile owner-scoped sync model.
 
+## Follow-ups (out of scope for this change)
+
+- **Main-timeline sibling of the mobile collapse guard.** The viewer's **main** timeline
+  (`mobile/lib/infrastructure/entities/merged_asset.drift`) also merges in a Space's assets when
+  the viewer enables space-timeline integration, and applies the same
+  `stack_id IS NULL OR rae.id = se.primary_asset_id` collapse **without** the `se.id IS NULL`
+  fallback this change added to the aggregated-Space builders. So a non-owned Space stack can
+  still vanish from the *main* timeline for a viewer who integrated the Space. This is
+  **pre-existing** (that file is untouched here; on the base branch only the cover was a member
+  and it was already filtered the same way) and out of scope for #751, but the same one-line
+  `se.id IS NULL` guard (plus a regression test of the same shape) should be applied there as a
+  follow-up so the "no non-owned stack vanishes on mobile" guarantee is uniform.
+
 ## Edge-case coverage matrix
 
 Every row below has a dedicated test in the slice noted. This is the definition of "full

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -130,13 +130,18 @@ stack siblings, and wire it into the direct add/remove paths. No schema change.
 - After the existing role/permission checks, expand `dto.assetIds` to the stack closure via a
   new repository query, producing `expandedAssetIds`.
 - **RBAC filter on the auto-pulled siblings:** only expand to siblings that are
-  **`ownerId = auth.user.id`**, **`visibility = Timeline`**, and **`deletedAt IS NULL`**. The
-  owner restriction guarantees the adder already has `AssetRead` on every expanded id (stacks
-  are single-owner), so no additional permission check is needed and there is no throw risk;
-  the visibility/deleted filters prevent pulling Archived/Hidden/Locked/trashed frames into a
-  shared Space (aligned with the in-flight #753/#754 RBAC hardening). Explicitly-selected seed
-  ids are always retained even if they are not timeline-visible — only the _auto-pulled
-  siblings_ are filtered.
+  **`ownerId = auth.user.id`**, **`visibility IN visibleSpaceAssetVisibilities`**, and
+  **`deletedAt IS NULL`**. `visibleSpaceAssetVisibilities` is the existing repo constant
+  `[AssetVisibility.Archive, AssetVisibility.Timeline]` (`shared-space.repository.ts:42`) already
+  used by `bulkAddUserAssets` and `getAssetCount` as the canonical "space-eligible" set —
+  reusing it keeps stack expansion consistent with existing direct membership (archived frames
+  are legitimately space-eligible; the view-time `visibility = Timeline` scope hides them from
+  the aggregated Space timeline). The set **excludes Hidden and Locked** — the RBAC-sensitive
+  tiers we must never pull into a shared Space (aligned with the in-flight #753/#754 hardening).
+  The owner restriction guarantees the adder already has `AssetRead` on every expanded id (stacks
+  are single-owner), so no additional permission check is needed and there is no throw risk.
+  Explicitly-selected seed ids are always retained even if they are not space-eligible — only the
+  _auto-pulled siblings_ are filtered.
 - Use `expandedAssetIds` for **both** the `shared_space_asset` insert **and** the
   `SharedSpaceFaceMatch` job fan-out (`:590`), so faces are matched on all added frames. The
   activity-log `count` continues to reflect `inserted.length` (newly-inserted rows only).
@@ -156,10 +161,10 @@ stack siblings, and wire it into the direct add/remove paths. No schema change.
 **Repository queries** — both live in `server/src/repositories/shared-space.repository.ts` next
 to their only callers (`addAssets` / `removeAssets`), each `@GenerateSql`-decorated:
 
-- Add path: `getOwnedTimelineStackSiblingIds(userId, assetIds) → assetId[]` — sibling ids
+- Add path: `getOwnedStackSiblingIds(userId, assetIds) → assetId[]` — sibling ids
   sharing a non-null `stackId` with any seed, filtered to `ownerId = userId`,
-  `visibility = Timeline`, `deletedAt IS NULL`. The service unions the result with the original
-  seed ids.
+  `visibility IN visibleSpaceAssetVisibilities`, `deletedAt IS NULL`. The service unions the
+  result with the original seed ids.
 - Remove path: `getStackSiblingIdsInSpace(spaceId, assetIds) → assetId[]` — sibling ids sharing a
   stack with any seed that are current direct members (`shared_space_asset`) of `spaceId`.
 
@@ -234,7 +239,8 @@ coverage" for this feature.
 | E2 | Add a **non-primary** frame owned by the adder | All siblings **incl. the primary** become members | S1 |
 | E3 | Add an asset **with no stack** | Only that asset is added (expansion is a no-op) | S1 |
 | E4 | Add an asset **not owned** by the adder (shared to them) | No expansion — only that asset is added (owner-scoped guard) | S1 |
-| E5 | A sibling is **Archived / Hidden / Locked** (`visibility != Timeline`) | Excluded from expansion — never pulled into the Space | S1 |
+| E5 | A sibling is **Hidden or Locked** | Excluded from expansion — never pulled into a shared Space | S1 |
+| E5b | A sibling is **Archived** | **Included** — archived is space-eligible (`visibleSpaceAssetVisibilities`); it is a member but stays hidden from the Timeline-scoped Space view | S1 |
 | E6 | A sibling is **soft-deleted** (`deletedAt` set / trashed) | Excluded from expansion | S1 |
 | E7 | The **seed itself** is non-timeline-visible but explicitly selected | Retained (only auto-pulled siblings are filtered) | S1 |
 | E8 | **Two seeds from the same stack** in one request | Expansion dedupes → each frame inserted once | S1 |
@@ -272,20 +278,23 @@ produces in production).
 - **Goal:** adding any frame of a stack via add-to-space brings in all the adder's
   timeline-visible frames of that stack.
 - **Code:**
-  - `server/src/repositories/shared-space.repository.ts` — add `getOwnedTimelineStackSiblingIds(userId, assetIds)` (`@GenerateSql`).
+  - `server/src/repositories/shared-space.repository.ts` — add `getOwnedStackSiblingIds(userId, assetIds)` (`@GenerateSql`).
   - `server/src/services/shared-space.service.ts` — in `addAssets` (`:571`), expand `dto.assetIds`
-    → `expandedAssetIds` (union of seeds + owned/timeline/non-deleted siblings); feed it to the
-    `shared_space_asset` insert **and** the `SharedSpaceFaceMatch` fan-out (`:590`).
+    → `expandedAssetIds` (union of seeds + owned/space-eligible/non-deleted siblings); feed it to
+    the `shared_space_asset` insert **and** the `SharedSpaceFaceMatch` fan-out (`:590`). Add a
+    default `mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([])` to the service
+    spec's `beforeEach` so existing `addAssets` tests keep passing.
 - **Tests (write first):**
   - Unit — `server/src/services/shared-space.service.spec.ts`: `addAssets` expands and inserts the
     expanded set; face-match jobs cover the expanded set; empty input short-circuits. Covers
     E4, E11, E12 (behavioral), E13 wiring.
-  - Medium — `server/test/medium/specs/repositories/shared-space.repository.spec.ts`: the sibling
-    query filters (owner, visibility, deleted), seed retention, dedupe. Covers E1–E9.
-  - Medium — new `server/test/medium/specs/services/shared-space-stacks.service.spec.ts`:
-    end-to-end add → all frames members → Space timeline (`withStacked`) returns one collapsed
-    cover with the right count; re-add idempotency (E10); promote-a-different-primary keeps the
-    stack visible (E13).
+  - Medium — new `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts`:
+    the `getOwnedStackSiblingIds` filters (owner E4, Hidden/Locked E5, Archived-included E5b,
+    deleted E6, seed retention E7, dedupe E8, mixed E9, no-stack E3, cover E1, non-primary E2,
+    empty E11). Composition E2E: seed a stack, expand + `addAssets` via the repo, then
+    `ctx.get(AssetRepository).getTimeBuckets({ spaceId, visibility: Timeline, withStacked: true })`
+    returns one collapsed cover; re-add idempotency (E10); promote-a-different-primary via
+    `StackRepository.update` keeps the stack visible (E13).
 - **Verification gate:** `cd server && pnpm check` (tsc) · `pnpm test -- --run src/services/shared-space.service.spec.ts` · `pnpm test:medium` for the two specs · `make sql` (running DB) to refresh docs for the new `@GenerateSql` method.
 - **Acceptance:** E1–E13 green; adding a stack cover in a real Space makes every frame a member and the Space timeline shows one cover with the correct badge count.
 
@@ -301,11 +310,11 @@ produces in production).
 - **Tests (write first):**
   - Unit — `shared-space.service.spec.ts`: `removeAssets` expands and feeds delete + thumbnail +
     orphan computation the expanded set.
-  - Medium — `shared-space.repository.spec.ts`: `getStackSiblingIdsInSpace` returns only
-    same-stack **direct members** of the given Space (E18).
-  - Medium — `shared-space-stacks.service.spec.ts`: remove cover → all gone (E14); remove
-    non-cover → all gone (E15); frame kept alive by a linked album stays visible & is not a
-    face-orphan (E16, E19); thumbnail reset when an expanded frame was the thumbnail (E17).
+  - Medium — `shared-space-stack-expansion.medium.spec.ts`: `getStackSiblingIdsInSpace` returns
+    only same-stack **direct members** of the given Space (E18). Composition E2E: remove cover →
+    all gone (E14); remove non-cover → all gone (E15); frame kept alive by a linked album stays
+    visible & is not a face-orphan (E16, E19); thumbnail reset when an expanded frame was the
+    thumbnail (E17).
 - **Verification gate:** same shape as S1 (tsc · unit · the two medium specs · `make sql`).
 - **Acceptance:** E14–E19 green; removing one frame of an in-Space stack clears the whole stack,
   except frames still reachable via a linked album.
@@ -351,7 +360,7 @@ produces in production).
 | `server/src/services/shared-space.service.ts` | expand in `addAssets` / `removeAssets` | S1, S2 |
 | `server/src/services/shared-space.service.spec.ts` | unit tests | S1, S2 |
 | `server/test/medium/specs/repositories/shared-space.repository.spec.ts` | query medium tests | S1, S2 |
-| `server/test/medium/specs/services/shared-space-stacks.service.spec.ts` (new) | end-to-end medium tests | S1, S2 |
+| `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` (new) | query + composition E2E medium tests | S1, S2 |
 | `mobile/lib/infrastructure/repositories/timeline.repository.dart` | collapse two aggregated-Space builders | S3 |
 | `mobile/test/infrastructure/repositories/timeline_repository_test.dart` | Drift collapse tests | S3 |
 | `web/src/routes/(user)/spaces/[spaceId]/.../spaces-page.spec.ts` | guard tests | S4 |

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -32,9 +32,9 @@ Two facts in the code are **independent of each other**, and their mismatch is t
 Promoting a new primary only writes `stack.primaryAssetId` (`stack.service.ts` →
 `stack.repository.ts`); it touches **no** `shared_space_asset` rows. So:
 
-| Step | Old primary | New primary |
-|------|-------------|-------------|
-| Stack added to Space | ✅ member, ✅ is global primary → **shows** | ❌ not a member |
+| Step                      | Old primary                                                           | New primary                                                              |
+| ------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Stack added to Space      | ✅ member, ✅ is global primary → **shows**                           | ❌ not a member                                                          |
 | User promotes new primary | ✅ still member, but now ❌ non-primary → **dropped by stack filter** | ✅ now global primary, but ❌ not a member → **dropped by Space filter** |
 
 → neither shows. This reproduces the discussion word-for-word.
@@ -82,14 +82,14 @@ albums work; only line numbers moved.
 
 ## Design decisions (locked)
 
-| Decision | Choice |
-|---|---|
-| Target behavior | Whole stack lives in the Space (the discussion's "Better" ask; subsumes "Minimum") |
-| Where expansion happens | **Server-side only** — single source of truth for web, mobile, and CLI |
-| Sync depth | Expand on **add and remove only** (MVP) |
-| Platforms | Server + web + mobile |
-| Legacy data | **No backfill migration** |
-| Remove semantics | Removing any frame of a stack removes the **whole stack** from the Space |
+| Decision                | Choice                                                                             |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| Target behavior         | Whole stack lives in the Space (the discussion's "Better" ask; subsumes "Minimum") |
+| Where expansion happens | **Server-side only** — single source of truth for web, mobile, and CLI             |
+| Sync depth              | Expand on **add and remove only** (MVP)                                            |
+| Platforms               | Server + web + mobile                                                              |
+| Legacy data             | **No backfill migration**                                                          |
+| Remove semantics        | Removing any frame of a stack removes the **whole stack** from the Space           |
 
 ## Development approach — TDD (mandatory)
 
@@ -192,12 +192,12 @@ Add the same collapse the main timeline uses (`mobile/lib/infrastructure/entitie
 `stack_id IS NULL OR remote_asset.id = primary_asset_id`) — `LEFT JOIN stack_entity ON stack_id = id`
 plus that predicate — to **both** the aggregated-Space asset query and its count query:
 
-| Mobile method | Collapse? |
-|---|---|
+| Mobile method                                                       | Collapse?              |
+| ------------------------------------------------------------------- | ---------------------- |
 | `_watchSharedSpaceBucket` (`:452`) — aggregated Space bucket counts | **Yes — add collapse** |
-| `_getSharedSpaceBucketAssets` (`:570`) — aggregated Space assets | **Yes — add collapse** |
-| `_watchSpaceAlbumBucket` (`:638`) — space-album detail counts | No — leave as-is |
-| `_getSpaceAlbumBucketAssets` (`:698`) — space-album detail assets | No — leave as-is |
+| `_getSharedSpaceBucketAssets` (`:570`) — aggregated Space assets    | **Yes — add collapse** |
+| `_watchSpaceAlbumBucket` (`:638`) — space-album detail counts       | No — leave as-is       |
+| `_getSpaceAlbumBucketAssets` (`:698`) — space-album detail assets   | No — leave as-is       |
 
 This keeps parity with web (aggregated Space collapses via `withStacked: true`; album-detail
 does not) and with normal album behavior. Tap-to-expand (`asset_stack.provider.dart`) already
@@ -209,12 +209,12 @@ device.
 
 With every frame a direct member:
 
-| Step | Behavior |
-|------|----------|
-| Add stack to Space | All frames inserted; timeline collapses to global primary (a member) → **cover shows**, badge count accurate |
-| Promote a new primary | New primary already a member → **shows instantly**; old primary collapsed under it |
-| Tap the cover | All frames shown — all are members |
-| Remove the stack | All frames removed (unless still visible via a linked album) |
+| Step                  | Behavior                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Add stack to Space    | All frames inserted; timeline collapses to global primary (a member) → **cover shows**, badge count accurate |
+| Promote a new primary | New primary already a member → **shows instantly**; old primary collapsed under it                           |
+| Tap the cover         | All frames shown — all are members                                                                           |
+| Remove the stack      | All frames removed (unless still visible via a linked album)                                                 |
 
 ## Accepted limitations (MVP — documented, not silently dropped)
 
@@ -244,7 +244,7 @@ the mobile owner-scoped sync model.
   the viewer enables space-timeline integration, and applies the same
   `stack_id IS NULL OR rae.id = se.primary_asset_id` collapse **without** the `se.id IS NULL`
   fallback this change added to the aggregated-Space builders. So a non-owned Space stack can
-  still vanish from the *main* timeline for a viewer who integrated the Space. This is
+  still vanish from the _main_ timeline for a viewer who integrated the Space. This is
   **pre-existing** (that file is untouched here; on the base branch only the cover was a member
   and it was already filtered the same way) and out of scope for #751, but the same one-line
   `se.id IS NULL` guard (plus a regression test of the same shape) should be applied there as a
@@ -255,34 +255,34 @@ the mobile owner-scoped sync model.
 Every row below has a dedicated test in the slice noted. This is the definition of "full
 coverage" for this feature.
 
-| # | Case | Expected behavior | Slice |
-|---|------|-------------------|-------|
-| E1 | Add a stack **cover** owned by the adder | All timeline-visible siblings of the stack become direct members | S1 |
-| E2 | Add a **non-primary** frame owned by the adder | All siblings **incl. the primary** become members | S1 |
-| E3 | Add an asset **with no stack** | Only that asset is added (expansion is a no-op) | S1 |
-| E4 | Add an asset **not owned** by the adder (shared to them) | No expansion — only that asset is added (owner-scoped guard) | S1 |
-| E5 | A sibling is **Hidden or Locked** | Excluded from expansion — never pulled into a shared Space | S1 |
-| E5b | A sibling is **Archived** | **Included** — archived is space-eligible (`visibleSpaceAssetVisibilities`); it is a member but stays hidden from the Timeline-scoped Space view | S1 |
-| E6 | A sibling is **soft-deleted** (`deletedAt` set / trashed) | Excluded from expansion | S1 |
-| E7 | The **seed itself** is non-timeline-visible but explicitly selected | Retained (only auto-pulled siblings are filtered) | S1 |
-| E8 | **Two seeds from the same stack** in one request | Expansion dedupes → each frame inserted once | S1 |
-| E9 | **Mixed batch** (some stacked, some standalone) | Correct union: standalone kept as-is, stacks expanded | S1 |
-| E10 | **Re-add** a stack already partly in the Space | `onConflict doNothing`; idempotent; `inserted.length` counts only new rows | S1 |
-| E11 | Empty `assetIds` | No-op; no sibling query issued | S1 |
-| E12 | `faceRecognitionEnabled` on the Space | `SharedSpaceFaceMatch` queued for **every** expanded frame; disabled → none | S1 |
-| E13 | Add cover, then **promote a different frame to primary** | Space timeline still shows the stack (new primary already a member) | S1 (medium) |
-| E14 | Remove the **cover** | All direct-member frames of the stack are removed | S2 |
-| E15 | Remove a **non-cover** frame | The whole stack's direct members are removed | S2 |
-| E16 | A removed frame is **also a member via a linked album** | Its direct row is deleted, but it **remains a space member** via the album path, so `getAssetIdsWithoutOtherSpacePath` does **not** flag it as a face-orphan (its faces are preserved). NB: whether it still renders in the aggregated timeline is subject to the album-partial-stack non-goal — E16 asserts the face-orphan correctness, not timeline visibility | S2 |
-| E17 | The Space **thumbnail** was an expanded (not directly-passed) frame | Thumbnail reset to `null` | S2 |
-| E18 | Passed siblings that are **not members** of the Space | Delete is a harmless no-op | S2 |
-| E19 | Face-orphan cleanup after remove | Runs over the **expanded** set; persons/faces removed only when no other Space path remains | S2 |
-| E20 | Mobile: Space with a 3-frame stack (all members) | **One** collapsed cover tile; bucket count == 1 | S3 |
-| E21 | Mobile: **space-album detail** view | Unchanged — shows all 3 frames (parity with albums) | S3 |
-| E22 | Mobile: **legacy partial stack** (only non-primary frames are members, primary absent) | Collapse yields **0** tiles — consistent with server/web timeline; documented limitation | S3 |
-| E23 | Mobile: bucket-count query and asset query agree after collapse | Same collapsed cardinality | S3 |
-| E24 | Web: Space view after all frames are members | Renders the collapsed cover with the **correct** count | S4 |
-| E25 | Web: space-album detail view | Still uncollapsed (asserts `withStacked` is **not** sent — guards the non-goal) | S4 |
+| #   | Case                                                                                   | Expected behavior                                                                                                                                                                                                                                                                                                                                                 | Slice       |
+| --- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| E1  | Add a stack **cover** owned by the adder                                               | All timeline-visible siblings of the stack become direct members                                                                                                                                                                                                                                                                                                  | S1          |
+| E2  | Add a **non-primary** frame owned by the adder                                         | All siblings **incl. the primary** become members                                                                                                                                                                                                                                                                                                                 | S1          |
+| E3  | Add an asset **with no stack**                                                         | Only that asset is added (expansion is a no-op)                                                                                                                                                                                                                                                                                                                   | S1          |
+| E4  | Add an asset **not owned** by the adder (shared to them)                               | No expansion — only that asset is added (owner-scoped guard)                                                                                                                                                                                                                                                                                                      | S1          |
+| E5  | A sibling is **Hidden or Locked**                                                      | Excluded from expansion — never pulled into a shared Space                                                                                                                                                                                                                                                                                                        | S1          |
+| E5b | A sibling is **Archived**                                                              | **Included** — archived is space-eligible (`visibleSpaceAssetVisibilities`); it is a member but stays hidden from the Timeline-scoped Space view                                                                                                                                                                                                                  | S1          |
+| E6  | A sibling is **soft-deleted** (`deletedAt` set / trashed)                              | Excluded from expansion                                                                                                                                                                                                                                                                                                                                           | S1          |
+| E7  | The **seed itself** is non-timeline-visible but explicitly selected                    | Retained (only auto-pulled siblings are filtered)                                                                                                                                                                                                                                                                                                                 | S1          |
+| E8  | **Two seeds from the same stack** in one request                                       | Expansion dedupes → each frame inserted once                                                                                                                                                                                                                                                                                                                      | S1          |
+| E9  | **Mixed batch** (some stacked, some standalone)                                        | Correct union: standalone kept as-is, stacks expanded                                                                                                                                                                                                                                                                                                             | S1          |
+| E10 | **Re-add** a stack already partly in the Space                                         | `onConflict doNothing`; idempotent; `inserted.length` counts only new rows                                                                                                                                                                                                                                                                                        | S1          |
+| E11 | Empty `assetIds`                                                                       | No-op; no sibling query issued                                                                                                                                                                                                                                                                                                                                    | S1          |
+| E12 | `faceRecognitionEnabled` on the Space                                                  | `SharedSpaceFaceMatch` queued for **every** expanded frame; disabled → none                                                                                                                                                                                                                                                                                       | S1          |
+| E13 | Add cover, then **promote a different frame to primary**                               | Space timeline still shows the stack (new primary already a member)                                                                                                                                                                                                                                                                                               | S1 (medium) |
+| E14 | Remove the **cover**                                                                   | All direct-member frames of the stack are removed                                                                                                                                                                                                                                                                                                                 | S2          |
+| E15 | Remove a **non-cover** frame                                                           | The whole stack's direct members are removed                                                                                                                                                                                                                                                                                                                      | S2          |
+| E16 | A removed frame is **also a member via a linked album**                                | Its direct row is deleted, but it **remains a space member** via the album path, so `getAssetIdsWithoutOtherSpacePath` does **not** flag it as a face-orphan (its faces are preserved). NB: whether it still renders in the aggregated timeline is subject to the album-partial-stack non-goal — E16 asserts the face-orphan correctness, not timeline visibility | S2          |
+| E17 | The Space **thumbnail** was an expanded (not directly-passed) frame                    | Thumbnail reset to `null`                                                                                                                                                                                                                                                                                                                                         | S2          |
+| E18 | Passed siblings that are **not members** of the Space                                  | Delete is a harmless no-op                                                                                                                                                                                                                                                                                                                                        | S2          |
+| E19 | Face-orphan cleanup after remove                                                       | Runs over the **expanded** set; persons/faces removed only when no other Space path remains                                                                                                                                                                                                                                                                       | S2          |
+| E20 | Mobile: Space with a 3-frame stack (all members)                                       | **One** collapsed cover tile; bucket count == 1                                                                                                                                                                                                                                                                                                                   | S3          |
+| E21 | Mobile: **space-album detail** view                                                    | Unchanged — shows all 3 frames (parity with albums)                                                                                                                                                                                                                                                                                                               | S3          |
+| E22 | Mobile: **legacy partial stack** (only non-primary frames are members, primary absent) | Collapse yields **0** tiles — consistent with server/web timeline; documented limitation                                                                                                                                                                                                                                                                          | S3          |
+| E23 | Mobile: bucket-count query and asset query agree after collapse                        | Same collapsed cardinality                                                                                                                                                                                                                                                                                                                                        | S3          |
+| E24 | Web: Space view after all frames are members                                           | Renders the collapsed cover with the **correct** count                                                                                                                                                                                                                                                                                                            | S4          |
+| E25 | Web: space-album detail view                                                           | Still uncollapsed (asserts `withStacked` is **not** sent — guards the non-goal)                                                                                                                                                                                                                                                                                   | S4          |
 
 **Known consistent edge (not a bug, not fixed):** a stack whose **primary is non-timeline**
 (e.g. archived) vanishes from the Space timeline entirely (non-primaries collapsed out, primary
@@ -376,14 +376,14 @@ produces in production).
 
 ## Files touched (summary)
 
-| File | Change | Slice |
-|------|--------|-------|
-| `server/src/repositories/shared-space.repository.ts` | two `@GenerateSql` stack-closure queries | S1, S2 |
-| `server/src/services/shared-space.service.ts` | expand in `addAssets` / `removeAssets` | S1, S2 |
-| `server/src/services/shared-space.service.spec.ts` | unit tests | S1, S2 |
-| `server/test/medium/specs/repositories/shared-space.repository.spec.ts` | query medium tests | S1, S2 |
-| `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` (new) | query + composition E2E medium tests | S1, S2 |
-| `mobile/lib/infrastructure/repositories/timeline.repository.dart` | collapse two aggregated-Space builders | S3 |
-| `mobile/test/infrastructure/repositories/timeline_repository_test.dart` | Drift collapse tests | S3 |
-| `web/src/routes/(user)/spaces/[spaceId]/.../spaces-page.spec.ts` | guard tests | S4 |
-| `docs/docs/…` (Spaces user doc) | re-add-workaround note | S4 |
+| File                                                                                      | Change                                   | Slice  |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------- | ------ |
+| `server/src/repositories/shared-space.repository.ts`                                      | two `@GenerateSql` stack-closure queries | S1, S2 |
+| `server/src/services/shared-space.service.ts`                                             | expand in `addAssets` / `removeAssets`   | S1, S2 |
+| `server/src/services/shared-space.service.spec.ts`                                        | unit tests                               | S1, S2 |
+| `server/test/medium/specs/repositories/shared-space.repository.spec.ts`                   | query medium tests                       | S1, S2 |
+| `server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts` (new) | query + composition E2E medium tests     | S1, S2 |
+| `mobile/lib/infrastructure/repositories/timeline.repository.dart`                         | collapse two aggregated-Space builders   | S3     |
+| `mobile/test/infrastructure/repositories/timeline_repository_test.dart`                   | Drift collapse tests                     | S3     |
+| `web/src/routes/(user)/spaces/[spaceId]/.../spaces-page.spec.ts`                          | guard tests                              | S4     |
+| `docs/docs/…` (Spaces user doc)                                                           | re-add-workaround note                   | S4     |

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -1,0 +1,222 @@
+# Support of stacked photos in Spaces — Design
+
+- **Discussion:** [open-noodle/gallery #751 — "Support of stacked photos in Spaces"](https://github.com/open-noodle/gallery/discussions/751)
+- **Date:** 2026-07-06
+- **Base branch:** `space-albums-onto-main` (HEAD `92ed82afb6`)
+- **Status:** Approved design, ready for implementation plan
+
+## Problem
+
+When a photo **stack** (RAW+JPEG, burst) is added to a shared **Space**, only the stack's
+primary (cover) frame becomes a member. Worse, if the user later promotes a different frame
+to primary, the stack disappears from the Space entirely — neither the old nor the new
+primary is shown.
+
+### Root cause
+
+Two facts in the code are **independent of each other**, and their mismatch is the bug:
+
+1. **Direct Space membership is per-asset-id.** `SharedSpaceService.addAssets`
+   (`server/src/services/shared-space.service.ts:571`) inserts exactly the asset ids passed
+   into `shared_space_asset` — no stack expansion
+   (`SharedSpaceRepository.addAssets`, `server/src/repositories/shared-space.repository.ts:322`).
+   Because the timeline UI collapses stacks, a user adding a stack only ever sends the **cover
+   id**, so only the cover becomes a member.
+
+2. **The Space timeline collapses stacks by the _global_ primary**, not by what's in the Space.
+   The Space timeline query filters to `visibility = Timeline` and drops any asset where
+   `stack.primaryAssetId != asset.id` (`server/src/repositories/asset.repository.ts:1389`, and
+   the count builder at `:325`). This is keyed on **global** stack membership and is a separate,
+   ANDed `.$if(...)` clause — completely independent of the Space-membership filter.
+
+Promoting a new primary only writes `stack.primaryAssetId` (`stack.service.ts` →
+`stack.repository.ts`); it touches **no** `shared_space_asset` rows. So:
+
+| Step | Old primary | New primary |
+|------|-------------|-------------|
+| Stack added to Space | ✅ member, ✅ is global primary → **shows** | ❌ not a member |
+| User promotes new primary | ✅ still member, but now ❌ non-primary → **dropped by stack filter** | ✅ now global primary, but ❌ not a member → **dropped by Space filter** |
+
+→ neither shows. This reproduces the discussion word-for-word.
+
+### Membership model on this base (`space-albums-onto-main`)
+
+An asset is visible in a Space via a **3-way union**, centralized in
+`server/src/utils/shared-space-album-scope.ts` → `spaceAssetPathBranches(eb, …)`:
+
+1. **Direct** — `shared_space_asset` (asset id). _This is the path #751 is about._
+2. **Library** — `shared_space_library` (by `asset.libraryId`).
+3. **Album (new)** — `shared_space_album` (`spaceId`, `albumId`, `showInTimeline`) → assets
+   by-reference via `album_asset`. No copy into `shared_space_asset`.
+
+Critically, the direct path is **structurally identical to `main`** (still per-asset-id, still
+zero stack awareness), and the Space filter and the `withStacked` stack-collapse filter are
+still separate, ANDed `.$if` calls. The core bug and its fix are therefore unchanged by the
+albums work; only line numbers moved.
+
+## Goals
+
+- Adding a stack to a Space (via the direct add-to-space action) puts **all of the stack's
+  frames** into the Space, so it collapses to its cover exactly like the main timeline: correct
+  stack-count badge, tap-in shows every frame, and promoting any frame to primary "just works"
+  because every frame is already a member.
+- Removing a stack from a Space removes **all** of its frames.
+- The Space timeline renders the stack **collapsed to its cover** on every surface — server,
+  web, and mobile.
+
+## Non-goals (explicitly out of scope)
+
+- **Album-path stack completeness.** If a user _links an album_ that itself contains only a
+  stack's cover (because adding a stack to an album adds only the cover — longstanding upstream
+  album behavior), the Space shows a partial stack via the album path. Fixing that means
+  changing upstream album-stacking semantics, far outside #751. We fix the **direct
+  add-to-space path** only. (The _display_ collapse fix still benefits album-linked stacks for
+  free, since the timeline unions all paths before collapsing.)
+- **Space-album _detail_ view collapse.** The per-album detail view inside a Space intentionally
+  does **not** collapse stacks — it mirrors normal album behavior (web `album-filter-options.ts`
+  never sets `withStacked`; the space-album detail page shows every frame). We keep it that way
+  on all platforms.
+- **Reconciling membership when a stack's composition changes _after_ it's in a Space**
+  (re-stacking, adding a frame to an in-Space stack). MVP scope — see Accepted Limitations.
+- **Backfilling existing partial stacks** already in Spaces. MVP scope — see Accepted Limitations.
+
+## Design decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Target behavior | Whole stack lives in the Space (the discussion's "Better" ask; subsumes "Minimum") |
+| Where expansion happens | **Server-side only** — single source of truth for web, mobile, and CLI |
+| Sync depth | Expand on **add and remove only** (MVP) |
+| Platforms | Server + web + mobile |
+| Legacy data | **No backfill migration** |
+| Remove semantics | Removing any frame of a stack removes the **whole stack** from the Space |
+
+## Detailed design
+
+### 1. Server — stack-closure expansion (the load-bearing change)
+
+Introduce a small, isolated, testable unit that expands a set of asset ids to include their
+stack siblings, and wire it into the direct add/remove paths. No schema change.
+
+**Add-time expansion (`SharedSpaceService.addAssets`, `shared-space.service.ts:571`)**
+
+- After the existing role/permission checks, expand `dto.assetIds` to the stack closure via a
+  new repository query, producing `expandedAssetIds`.
+- **RBAC filter on the auto-pulled siblings:** only expand to siblings that are
+  **`ownerId = auth.user.id`**, **`visibility = Timeline`**, and **`deletedAt IS NULL`**. The
+  owner restriction guarantees the adder already has `AssetRead` on every expanded id (stacks
+  are single-owner), so no additional permission check is needed and there is no throw risk;
+  the visibility/deleted filters prevent pulling Archived/Hidden/Locked/trashed frames into a
+  shared Space (aligned with the in-flight #753/#754 RBAC hardening). Explicitly-selected seed
+  ids are always retained even if they are not timeline-visible — only the _auto-pulled
+  siblings_ are filtered.
+- Use `expandedAssetIds` for **both** the `shared_space_asset` insert **and** the
+  `SharedSpaceFaceMatch` job fan-out (`:590`), so faces are matched on all added frames. The
+  activity-log `count` continues to reflect `inserted.length` (newly-inserted rows only).
+
+**Remove-time expansion (`SharedSpaceService.removeAssets`, `shared-space.service.ts:761`)**
+
+- Expand `dto.assetIds` to the sibling frames of the same stack(s) that are **direct members of
+  this Space**, producing `expandedAssetIds`. (Space-scoped rather than owner-scoped: any editor
+  curating the Space should be able to remove the whole stack; the existing delete is already
+  `spaceId`-scoped so passing extra non-member ids is a harmless no-op.)
+- Use `expandedAssetIds` for the delete (`:768`), the thumbnail-reset check (`:775`), and the
+  face-orphan computation `getAssetIdsWithoutOtherSpacePath` (`:788`). Because the three
+  membership paths are independent, a frame still visible via a linked album correctly **stays**
+  visible after its direct row is removed — `getAssetIdsWithoutOtherSpacePath` already accounts
+  for this.
+
+**Repository queries** (`shared-space.repository.ts` or `stack.repository.ts` — placement TBD in
+the plan, following the existing helper-module pattern):
+
+- Add path: `getOwnedTimelineStackSiblingIds(userId, assetIds) → assetId[]` — sibling ids
+  sharing a non-null `stackId` with any seed, filtered to `ownerId = userId`,
+  `visibility = Timeline`, `deletedAt IS NULL`. The service unions the result with the original
+  seed ids.
+- Remove path: `getStackSiblingIdsInSpace(spaceId, assetIds) → assetId[]` — sibling ids sharing a
+  stack with any seed that are current direct members (`shared_space_asset`) of `spaceId`.
+
+**No change needed** to `queueBulkAdd` / `bulkAddUserAssets` (`:598` / repo `:303`): it already
+inserts _all_ of a user's timeline-visible assets, so stacks are naturally whole there.
+
+### 2. Web — no code change expected (verify only)
+
+The Space timeline already sends `withStacked: true`
+(`web/src/lib/utils/space-filter-options.ts:6`) and collapses on the server query. Once all
+frames are members, the cover shows, the badge count becomes **correct** (it was over-counting
+before), and tap-to-expand shows every frame. The direct add-to-space action
+(`web/src/lib/services/space.service.ts` → `addAssets`) passes the selected cover ids; the
+server expands. **Verify** there is no client-side spot that assumed only-the-cover-is-a-member;
+none is expected. The space-album _detail_ view stays uncollapsed by design (see Non-goals).
+
+### 3. Mobile — collapse the aggregated-Space timeline (two Drift builders)
+
+The mobile Space timeline is a local Drift query that omits stack-collapse
+(`mobile/lib/infrastructure/repositories/timeline.repository.dart`). After the server fix, all
+frames sync into local `shared_space_asset`, so without this change mobile would show N flat
+tiles.
+
+Add the same collapse the main timeline uses (`mobile/lib/infrastructure/entities/merged_asset.drift`
+`stack_id IS NULL OR remote_asset.id = primary_asset_id`) — `LEFT JOIN stack_entity ON stack_id = id`
+plus that predicate — to **both** the aggregated-Space asset query and its count query:
+
+| Mobile method | Collapse? |
+|---|---|
+| `_watchSharedSpaceBucket` (`:452`) — aggregated Space bucket counts | **Yes — add collapse** |
+| `_getSharedSpaceBucketAssets` (`:570`) — aggregated Space assets | **Yes — add collapse** |
+| `_watchSpaceAlbumBucket` (`:638`) — space-album detail counts | No — leave as-is |
+| `_getSpaceAlbumBucketAssets` (`:698`) — space-album detail assets | No — leave as-is |
+
+This keeps parity with web (aggregated Space collapses via `withStacked: true`; album-detail
+does not) and with normal album behavior. Tap-to-expand (`asset_stack.provider.dart`) already
+fetches stack children by `stackId` globally, so it works unchanged once frames are members.
+**Verify** the `shared_space_asset` sync stream propagates the newly-inserted member rows to the
+device.
+
+## After-fix behavior walkthrough
+
+With every frame a direct member:
+
+| Step | Behavior |
+|------|----------|
+| Add stack to Space | All frames inserted; timeline collapses to global primary (a member) → **cover shows**, badge count accurate |
+| Promote a new primary | New primary already a member → **shows instantly**; old primary collapsed under it |
+| Tap the cover | All frames shown — all are members |
+| Remove the stack | All frames removed (unless still visible via a linked album) |
+
+## Accepted limitations (MVP — documented, not silently dropped)
+
+- **Composition drift after add.** If a stack's members change _after_ it's in a Space
+  (re-stacking, adding a frame to an in-Space stack), the Space is not auto-reconciled.
+  Workaround: re-add the stack.
+- **Legacy partial stacks.** Stacks added to Spaces _before_ this change keep only their cover
+  as a member until re-added. No backfill migration ships.
+- **Album-linked partial stacks** are not completed (see Non-goals).
+
+Both limitations follow directly from the locked decisions (add/remove-only sync depth; no
+backfill).
+
+## Testing plan
+
+- **Server unit** — the expansion helper: stack closure correctness; owner + `visibility=Timeline`
+  + non-deleted filtering on the add path; space-scoped sibling resolution on the remove path;
+  seeds retained. `addAssets`/`removeAssets` call it and feed the expanded set to inserts/deletes,
+  face-match jobs, thumbnail-reset, and orphan computation.
+- **Server medium (real DB)** — the end-to-end proof: add a stack's cover → all frames become
+  `shared_space_asset` members; query the Space timeline → one collapsed cover with correct
+  count; promote a different frame to primary → Space still shows the stack; remove one frame →
+  all frames gone (but a frame kept alive by a linked album stays).
+- **Mobile** — Drift query test for aggregated-Space collapse (mirror the existing main-timeline
+  stack test); assert the space-album detail query is unchanged.
+- **Web** — light: assert the Space view renders the collapsed cover with the correct count once
+  all frames are members.
+
+## Files touched (summary)
+
+- `server/src/services/shared-space.service.ts` — expand in `addAssets` / `removeAssets`.
+- `server/src/repositories/shared-space.repository.ts` (and/or `stack.repository.ts`) — new
+  stack-closure queries.
+- `mobile/lib/infrastructure/repositories/timeline.repository.dart` — collapse in
+  `_watchSharedSpaceBucket` and `_getSharedSpaceBucketAssets`.
+- Tests: server unit + medium, mobile Drift, web component.
+- Docs: user-facing note on the re-add workaround for legacy/drift cases.

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -251,7 +251,7 @@ coverage" for this feature.
 | E13 | Add cover, then **promote a different frame to primary** | Space timeline still shows the stack (new primary already a member) | S1 (medium) |
 | E14 | Remove the **cover** | All direct-member frames of the stack are removed | S2 |
 | E15 | Remove a **non-cover** frame | The whole stack's direct members are removed | S2 |
-| E16 | A removed frame is **also visible via a linked album** | Its direct row is deleted, but it **stays visible** via the album path; not counted as a face-orphan | S2 |
+| E16 | A removed frame is **also a member via a linked album** | Its direct row is deleted, but it **remains a space member** via the album path, so `getAssetIdsWithoutOtherSpacePath` does **not** flag it as a face-orphan (its faces are preserved). NB: whether it still renders in the aggregated timeline is subject to the album-partial-stack non-goal — E16 asserts the face-orphan correctness, not timeline visibility | S2 |
 | E17 | The Space **thumbnail** was an expanded (not directly-passed) frame | Thumbnail reset to `null` | S2 |
 | E18 | Passed siblings that are **not members** of the Space | Delete is a harmless no-op | S2 |
 | E19 | Face-orphan cleanup after remove | Runs over the **expanded** set; persons/faces removed only when no other Space path remains | S2 |

--- a/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
+++ b/docs/superpowers/specs/2026-07-06-spaces-stacked-photos-design.md
@@ -91,6 +91,33 @@ albums work; only line numbers moved.
 | Legacy data | **No backfill migration** |
 | Remove semantics | Removing any frame of a stack removes the **whole stack** from the Space |
 
+## Development approach — TDD (mandatory)
+
+Every slice is implemented **test-first**, red → green → refactor:
+
+1. **Red** — write the unit / medium / widget test(s) for the slice's behavior and edge cases
+   first, and run them to confirm they **fail for the right reason** (asserting the missing
+   behavior, not a compile error or a missing fixture).
+2. **Green** — write the minimum implementation to make those tests pass.
+3. **Refactor** — clean up with tests green.
+
+No implementation code is written before a failing test exists for it. A slice is "done" only
+when its **full verification gate** (listed per slice) passes when _you_ run it — a subagent
+reporting "green" is not sufficient; run the real gate (server `tsc` + unit + the slice's medium
+spec; mobile `flutter test`; web `check` + unit) yourself. Notes that bite in this repo:
+
+- New `@GenerateSql`-decorated repository methods require `make sql` **with a running DB** to
+  refresh query docs, or CI's SQL-docs check fails. **Never** run `make sql` without a DB — it
+  deletes all query files.
+- We add **methods to existing repositories** (no new injected repository), so there is **no**
+  `BaseService` constructor / `BaseService.create()` positional-list / medium-factory
+  `newRealRepository` change to make. If a medium test throws "Unable to create repository
+  instance," that is a signal something was mis-wired — not expected here.
+- Mobile tests run on the pinned **Flutter 3.44.1** (`mobile/pubspec.yaml`); bootstrap once with
+  `flutter pub get`, generate localization + keys
+  (`dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart`), then
+  `flutter test <path>`. Drift generated code is committed, so no `build_runner` is needed.
+
 ## Detailed design
 
 ### 1. Server — stack-closure expansion (the load-bearing change)
@@ -126,8 +153,8 @@ stack siblings, and wire it into the direct add/remove paths. No schema change.
   visible after its direct row is removed — `getAssetIdsWithoutOtherSpacePath` already accounts
   for this.
 
-**Repository queries** (`shared-space.repository.ts` or `stack.repository.ts` — placement TBD in
-the plan, following the existing helper-module pattern):
+**Repository queries** — both live in `server/src/repositories/shared-space.repository.ts` next
+to their only callers (`addAssets` / `removeAssets`), each `@GenerateSql`-decorated:
 
 - Add path: `getOwnedTimelineStackSiblingIds(userId, assetIds) → assetId[]` — sibling ids
   sharing a non-null `stackId` with any seed, filtered to `ownerId = userId`,
@@ -196,27 +223,136 @@ With every frame a direct member:
 Both limitations follow directly from the locked decisions (add/remove-only sync depth; no
 backfill).
 
-## Testing plan
+## Edge-case coverage matrix
 
-- **Server unit** — the expansion helper: stack closure correctness; owner + `visibility=Timeline`
-  + non-deleted filtering on the add path; space-scoped sibling resolution on the remove path;
-  seeds retained. `addAssets`/`removeAssets` call it and feed the expanded set to inserts/deletes,
-  face-match jobs, thumbnail-reset, and orphan computation.
-- **Server medium (real DB)** — the end-to-end proof: add a stack's cover → all frames become
-  `shared_space_asset` members; query the Space timeline → one collapsed cover with correct
-  count; promote a different frame to primary → Space still shows the stack; remove one frame →
-  all frames gone (but a frame kept alive by a linked album stays).
-- **Mobile** — Drift query test for aggregated-Space collapse (mirror the existing main-timeline
-  stack test); assert the space-album detail query is unchanged.
-- **Web** — light: assert the Space view renders the collapsed cover with the correct count once
-  all frames are members.
+Every row below has a dedicated test in the slice noted. This is the definition of "full
+coverage" for this feature.
+
+| # | Case | Expected behavior | Slice |
+|---|------|-------------------|-------|
+| E1 | Add a stack **cover** owned by the adder | All timeline-visible siblings of the stack become direct members | S1 |
+| E2 | Add a **non-primary** frame owned by the adder | All siblings **incl. the primary** become members | S1 |
+| E3 | Add an asset **with no stack** | Only that asset is added (expansion is a no-op) | S1 |
+| E4 | Add an asset **not owned** by the adder (shared to them) | No expansion — only that asset is added (owner-scoped guard) | S1 |
+| E5 | A sibling is **Archived / Hidden / Locked** (`visibility != Timeline`) | Excluded from expansion — never pulled into the Space | S1 |
+| E6 | A sibling is **soft-deleted** (`deletedAt` set / trashed) | Excluded from expansion | S1 |
+| E7 | The **seed itself** is non-timeline-visible but explicitly selected | Retained (only auto-pulled siblings are filtered) | S1 |
+| E8 | **Two seeds from the same stack** in one request | Expansion dedupes → each frame inserted once | S1 |
+| E9 | **Mixed batch** (some stacked, some standalone) | Correct union: standalone kept as-is, stacks expanded | S1 |
+| E10 | **Re-add** a stack already partly in the Space | `onConflict doNothing`; idempotent; `inserted.length` counts only new rows | S1 |
+| E11 | Empty `assetIds` | No-op; no sibling query issued | S1 |
+| E12 | `faceRecognitionEnabled` on the Space | `SharedSpaceFaceMatch` queued for **every** expanded frame; disabled → none | S1 |
+| E13 | Add cover, then **promote a different frame to primary** | Space timeline still shows the stack (new primary already a member) | S1 (medium) |
+| E14 | Remove the **cover** | All direct-member frames of the stack are removed | S2 |
+| E15 | Remove a **non-cover** frame | The whole stack's direct members are removed | S2 |
+| E16 | A removed frame is **also visible via a linked album** | Its direct row is deleted, but it **stays visible** via the album path; not counted as a face-orphan | S2 |
+| E17 | The Space **thumbnail** was an expanded (not directly-passed) frame | Thumbnail reset to `null` | S2 |
+| E18 | Passed siblings that are **not members** of the Space | Delete is a harmless no-op | S2 |
+| E19 | Face-orphan cleanup after remove | Runs over the **expanded** set; persons/faces removed only when no other Space path remains | S2 |
+| E20 | Mobile: Space with a 3-frame stack (all members) | **One** collapsed cover tile; bucket count == 1 | S3 |
+| E21 | Mobile: **space-album detail** view | Unchanged — shows all 3 frames (parity with albums) | S3 |
+| E22 | Mobile: **legacy partial stack** (only non-primary frames are members, primary absent) | Collapse yields **0** tiles — consistent with server/web timeline; documented limitation | S3 |
+| E23 | Mobile: bucket-count query and asset query agree after collapse | Same collapsed cardinality | S3 |
+| E24 | Web: Space view after all frames are members | Renders the collapsed cover with the **correct** count | S4 |
+| E25 | Web: space-album detail view | Still uncollapsed (asserts `withStacked` is **not** sent — guards the non-goal) | S4 |
+
+**Known consistent edge (not a bug, not fixed):** a stack whose **primary is non-timeline**
+(e.g. archived) vanishes from the Space timeline entirely (non-primaries collapsed out, primary
+filtered by visibility) — this is identical to how the **main** timeline already behaves. No
+special handling.
+
+## Implementation slices (for `/impl-loop`)
+
+Four vertical slices, each independently implementable, test-first, and shippable. Order:
+S1 → S2 → S3 → S4 (S3/S4 are independently testable via fixtures but describe behavior that S1
+produces in production).
+
+### Slice S1 — Server: adding a stack adds the whole stack
+
+- **Goal:** adding any frame of a stack via add-to-space brings in all the adder's
+  timeline-visible frames of that stack.
+- **Code:**
+  - `server/src/repositories/shared-space.repository.ts` — add `getOwnedTimelineStackSiblingIds(userId, assetIds)` (`@GenerateSql`).
+  - `server/src/services/shared-space.service.ts` — in `addAssets` (`:571`), expand `dto.assetIds`
+    → `expandedAssetIds` (union of seeds + owned/timeline/non-deleted siblings); feed it to the
+    `shared_space_asset` insert **and** the `SharedSpaceFaceMatch` fan-out (`:590`).
+- **Tests (write first):**
+  - Unit — `server/src/services/shared-space.service.spec.ts`: `addAssets` expands and inserts the
+    expanded set; face-match jobs cover the expanded set; empty input short-circuits. Covers
+    E4, E11, E12 (behavioral), E13 wiring.
+  - Medium — `server/test/medium/specs/repositories/shared-space.repository.spec.ts`: the sibling
+    query filters (owner, visibility, deleted), seed retention, dedupe. Covers E1–E9.
+  - Medium — new `server/test/medium/specs/services/shared-space-stacks.service.spec.ts`:
+    end-to-end add → all frames members → Space timeline (`withStacked`) returns one collapsed
+    cover with the right count; re-add idempotency (E10); promote-a-different-primary keeps the
+    stack visible (E13).
+- **Verification gate:** `cd server && pnpm check` (tsc) · `pnpm test -- --run src/services/shared-space.service.spec.ts` · `pnpm test:medium` for the two specs · `make sql` (running DB) to refresh docs for the new `@GenerateSql` method.
+- **Acceptance:** E1–E13 green; adding a stack cover in a real Space makes every frame a member and the Space timeline shows one cover with the correct badge count.
+
+### Slice S2 — Server: removing a stack removes the whole stack
+
+- **Goal:** removing any frame removes all of that stack's direct members from the Space, with
+  correct face-orphan and thumbnail handling, while album-visible frames survive.
+- **Code:**
+  - `server/src/repositories/shared-space.repository.ts` — add `getStackSiblingIdsInSpace(spaceId, assetIds)` (`@GenerateSql`).
+  - `server/src/services/shared-space.service.ts` — in `removeAssets` (`:761`), expand
+    `dto.assetIds` → `expandedAssetIds`; feed it to the delete (`:768`), the thumbnail-reset
+    check (`:775`), and `getAssetIdsWithoutOtherSpacePath` (`:788`).
+- **Tests (write first):**
+  - Unit — `shared-space.service.spec.ts`: `removeAssets` expands and feeds delete + thumbnail +
+    orphan computation the expanded set.
+  - Medium — `shared-space.repository.spec.ts`: `getStackSiblingIdsInSpace` returns only
+    same-stack **direct members** of the given Space (E18).
+  - Medium — `shared-space-stacks.service.spec.ts`: remove cover → all gone (E14); remove
+    non-cover → all gone (E15); frame kept alive by a linked album stays visible & is not a
+    face-orphan (E16, E19); thumbnail reset when an expanded frame was the thumbnail (E17).
+- **Verification gate:** same shape as S1 (tsc · unit · the two medium specs · `make sql`).
+- **Acceptance:** E14–E19 green; removing one frame of an in-Space stack clears the whole stack,
+  except frames still reachable via a linked album.
+
+### Slice S3 — Mobile: collapse the aggregated-Space timeline
+
+- **Goal:** the mobile Space timeline renders a stack as one cover-with-badge; the space-album
+  detail view stays uncollapsed.
+- **Code:** `mobile/lib/infrastructure/repositories/timeline.repository.dart` — add
+  `LEFT JOIN stack_entity ON stack_id = id` + `(stack_id IS NULL OR remote_asset.id = primary_asset_id)`
+  to `_watchSharedSpaceBucket` (`:452`) and `_getSharedSpaceBucketAssets` (`:570`). **Do not**
+  touch `_watchSpaceAlbumBucket` / `_getSpaceAlbumBucketAssets`.
+- **Tests (write first):** `mobile/test/infrastructure/repositories/timeline_repository_test.dart`
+  (and/or `mobile/test/medium/repositories/timeline_repository_test.dart`) — seed a Space with a
+  3-frame stack: aggregated-Space query returns one cover and count == 1 (E20, E23); space-album
+  detail query still returns all 3 (E21); a Space with only non-primary frames returns 0 (E22);
+  non-stacked assets unaffected.
+- **Verification gate:** Flutter 3.44.1 bootstrap (pub get + gen l10n/keys), then
+  `flutter test test/infrastructure/repositories/timeline_repository_test.dart`.
+- **Acceptance:** E20–E23 green.
+
+### Slice S4 — Web guard test + user docs
+
+- **Goal:** lock in web's correct behavior (no production code change expected) and document the
+  MVP workarounds.
+- **Code:** none expected in web app code. Docs: add a short note to the Spaces user doc
+  (`docs/docs/` — run prettier; Docs Build is strict) that (a) stacks are added/removed as a
+  whole, and (b) stacks added before this release, or re-stacked afterward, may need re-adding.
+- **Tests (write first):** `web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts`
+  (or the timeline-manager spec) — Space view passes `withStacked: true` and renders the
+  collapsed cover with the correct count once all frames are members (E24); space-album detail
+  builds options **without** `withStacked` (E25). If no web app change is truly needed, S4 is
+  test + docs only.
+- **Verification gate:** `cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint` ·
+  `pnpm test -- --run <spec>` · prettier on any touched markdown.
+- **Acceptance:** E24–E25 green; docs note merged.
 
 ## Files touched (summary)
 
-- `server/src/services/shared-space.service.ts` — expand in `addAssets` / `removeAssets`.
-- `server/src/repositories/shared-space.repository.ts` (and/or `stack.repository.ts`) — new
-  stack-closure queries.
-- `mobile/lib/infrastructure/repositories/timeline.repository.dart` — collapse in
-  `_watchSharedSpaceBucket` and `_getSharedSpaceBucketAssets`.
-- Tests: server unit + medium, mobile Drift, web component.
-- Docs: user-facing note on the re-add workaround for legacy/drift cases.
+| File | Change | Slice |
+|------|--------|-------|
+| `server/src/repositories/shared-space.repository.ts` | two `@GenerateSql` stack-closure queries | S1, S2 |
+| `server/src/services/shared-space.service.ts` | expand in `addAssets` / `removeAssets` | S1, S2 |
+| `server/src/services/shared-space.service.spec.ts` | unit tests | S1, S2 |
+| `server/test/medium/specs/repositories/shared-space.repository.spec.ts` | query medium tests | S1, S2 |
+| `server/test/medium/specs/services/shared-space-stacks.service.spec.ts` (new) | end-to-end medium tests | S1, S2 |
+| `mobile/lib/infrastructure/repositories/timeline.repository.dart` | collapse two aggregated-Space builders | S3 |
+| `mobile/test/infrastructure/repositories/timeline_repository_test.dart` | Drift collapse tests | S3 |
+| `web/src/routes/(user)/spaces/[spaceId]/.../spaces-page.spec.ts` | guard tests | S4 |
+| `docs/docs/…` (Spaces user doc) | re-add-workaround note | S4 |

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -562,11 +562,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               _db.sharedSpaceAlbumLinkEntity.showInTimeline.equals(true),
           useColumns: false,
         ),
-        leftOuterJoin(
-          _db.stackEntity,
-          _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
-          useColumns: false,
-        ),
+        leftOuterJoin(_db.stackEntity, _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId), useColumns: false),
       ])
       ..where(
         _db.remoteAssetEntity.deletedAt.isNull() &

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -499,6 +499,11 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
                 _db.sharedSpaceAlbumLinkEntity.showInTimeline.equals(true),
             useColumns: false,
           ),
+          leftOuterJoin(
+            _db.stackEntity,
+            _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+            useColumns: false,
+          ),
         ])
         ..where(
           _db.remoteAssetEntity.deletedAt.isNull() &
@@ -506,7 +511,9 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
               (_db.sharedSpaceAssetEntity.assetId.isNotNull() |
                   _db.sharedSpaceLibraryEntity.libraryId.isNotNull() |
-                  _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()),
+                  _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()) &
+              (_db.remoteAssetEntity.stackId.isNull() |
+                  _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
         );
       return countQuery
           .map((row) => row.read(countExp) ?? 0)
@@ -545,6 +552,11 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               _db.sharedSpaceAlbumLinkEntity.showInTimeline.equals(true),
           useColumns: false,
         ),
+        leftOuterJoin(
+          _db.stackEntity,
+          _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+          useColumns: false,
+        ),
       ])
       ..where(
         _db.remoteAssetEntity.deletedAt.isNull() &
@@ -552,7 +564,9 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
             _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
             (_db.sharedSpaceAssetEntity.assetId.isNotNull() |
                 _db.sharedSpaceLibraryEntity.libraryId.isNotNull() |
-                _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()),
+                _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()) &
+            (_db.remoteAssetEntity.stackId.isNull() |
+                _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
       )
       ..groupBy([dateExp])
       ..orderBy([OrderingTerm.desc(dateExp)]);
@@ -605,12 +619,19 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               _db.remoteAssetEntity.checksum.equalsExp(_db.localAssetEntity.checksum),
               useColumns: false,
             ),
+            leftOuterJoin(
+              _db.stackEntity,
+              _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+              useColumns: false,
+            ),
           ])
           ..where(
             _db.remoteAssetEntity.deletedAt.isNull() &
                 _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
                 _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
-                membership,
+                membership &
+                (_db.remoteAssetEntity.stackId.isNull() |
+                    _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
           )
           ..orderBy([OrderingTerm.desc(_db.remoteAssetEntity.createdAt)])
           ..limit(count, offset: offset);

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -469,6 +469,15 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
     //
     // An asset matching both branches is counted once because we COUNT
     // DISTINCT remote_asset.id.
+    //
+    // Stack collapse: we LEFT JOIN stack_entity and keep an asset when it has
+    // no stack, when it IS the stack's primary (cover), OR when the stack row
+    // is not present locally (stack_entity.id IS NULL). That last arm matters
+    // for shared spaces: stack_entity only syncs for the viewer's own and
+    // partners' stacks (there is no shared-space stack sync), yet a non-owned
+    // space asset still carries its stack_id. Without the `IS NULL` fallback
+    // such a stack would collapse against a missing primary and vanish
+    // entirely; instead we show its frames flat (as before collapse existed).
 
     if (groupBy == GroupAssetsBy.none) {
       final countExp = _db.remoteAssetEntity.id.count(distinct: true);
@@ -513,6 +522,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
                   _db.sharedSpaceLibraryEntity.libraryId.isNotNull() |
                   _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()) &
               (_db.remoteAssetEntity.stackId.isNull() |
+                  _db.stackEntity.id.isNull() |
                   _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
         );
       return countQuery
@@ -566,6 +576,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
                 _db.sharedSpaceLibraryEntity.libraryId.isNotNull() |
                 _db.sharedSpaceAlbumLinkEntity.albumId.isNotNull()) &
             (_db.remoteAssetEntity.stackId.isNull() |
+                _db.stackEntity.id.isNull() |
                 _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
       )
       ..groupBy([dateExp])
@@ -631,6 +642,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
                 _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
                 membership &
                 (_db.remoteAssetEntity.stackId.isNull() |
+                    _db.stackEntity.id.isNull() |
                     _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
           )
           ..orderBy([OrderingTerm.desc(_db.remoteAssetEntity.createdAt)])

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -226,6 +226,10 @@ void main() {
       final buckets = await sut.sharedSpace(space.id, GroupAssetsBy.day).bucketSource().first;
       expect(buckets, hasLength(1));
       expect((buckets.single as TimeBucket).assetCount, 1);
+
+      // the flat (none) count builder also collapses (sum of segment counts == 1)
+      final noneBuckets = await sut.sharedSpace(space.id, GroupAssetsBy.none).bucketSource().first;
+      expect(noneBuckets.fold<int>(0, (sum, b) => sum + b.assetCount), 1);
     });
 
     test('does NOT collapse the space-album detail timeline (E21)', () async {
@@ -243,6 +247,10 @@ void main() {
 
       final assets = await sut.spaceAlbum(space.id, album.id, GroupAssetsBy.none).assetSource(0, 100);
       expect(assets.map((a) => (a as RemoteAsset).id).toSet(), {primary.id, child1.id, child2.id});
+
+      // the album count builder likewise stays uncollapsed (all 3 counted)
+      final albumBuckets = await sut.spaceAlbum(space.id, album.id, GroupAssetsBy.none).bucketSource().first;
+      expect(albumBuckets.fold<int>(0, (sum, b) => sum + b.assetCount), 3);
     });
 
     test('legacy partial stack (only non-primary frames are members) yields zero (E22)', () async {

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -1,7 +1,9 @@
 import 'package:drift/drift.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/infrastructure/entities/shared_space_album_link.entity.drift.dart';
+import 'package:immich_mobile/infrastructure/entities/stack.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/timeline.repository.dart';
 import 'package:intl/date_symbol_data_local.dart';
 
@@ -194,6 +196,70 @@ void main() {
 
       final restored = await sut.sharedSpace(space.id, .none).assetSource(0, 100);
       expect(restored.map((a) => (a as RemoteAsset).id), contains(asset.id));
+    });
+  });
+
+  group('aggregated-space stack collapse (S3)', () {
+    const stackId = 'stack-1';
+    final createdAt = DateTime(2024, 1, 1, 12);
+
+    Future<void> insertStack(String id, String ownerId, String primaryAssetId) => ctx.db
+        .into(ctx.db.stackEntity)
+        .insert(StackEntityCompanion.insert(id: id, ownerId: ownerId, primaryAssetId: primaryAssetId));
+
+    test('collapses a 3-frame stack to its cover in assetSource + bucket count (E20/E23)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      await insertStack(stackId, user.id, primary.id);
+      for (final a in [primary, child1, child2]) {
+        await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: a.id);
+      }
+
+      // asset query: only the cover survives
+      final assets = await sut.sharedSpace(space.id, GroupAssetsBy.none).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id).toList(), [primary.id]);
+
+      // bucket-count query agrees: one day bucket with count 1
+      final buckets = await sut.sharedSpace(space.id, GroupAssetsBy.day).bucketSource().first;
+      expect(buckets, hasLength(1));
+      expect((buckets.single as TimeBucket).assetCount, 1);
+    });
+
+    test('does NOT collapse the space-album detail timeline (E21)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum();
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      await insertStack(stackId, user.id, primary.id);
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id, showInTimeline: true);
+      for (final a in [primary, child1, child2]) {
+        await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: a.id);
+      }
+
+      final assets = await sut.spaceAlbum(space.id, album.id, GroupAssetsBy.none).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id).toSet(), {primary.id, child1.id, child2.id});
+    });
+
+    test('legacy partial stack (only non-primary frames are members) yields zero (E22)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      final child2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId, createdAt: createdAt);
+      await insertStack(stackId, user.id, primary.id);
+      // Only the NON-primary frames are direct members; the primary is absent.
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child1.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child2.id);
+
+      final assets = await sut.sharedSpace(space.id, GroupAssetsBy.none).assetSource(0, 100);
+      // non-primary frames are collapsed out; the primary isn't a member → nothing shows
+      // (consistent with server/web timeline; documented limitation).
+      expect(assets, isEmpty);
     });
   });
 }

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -157,8 +157,7 @@ void main() {
     // honours the showInTimeline filter). It is pinned here as an explicit
     // regression guard so that future query refactors can't silently break this
     // data contract.
-    test('toggle-flip regression: updating showInTimeline flips asset in/out of space timeline',
-        () async {
+    test('toggle-flip regression: updating showInTimeline flips asset in/out of space timeline', () async {
       final user = await ctx.newUser();
       final space = await ctx.newSharedSpace(createdById: user.id);
       final album = await ctx.newSharedSpaceAlbum();
@@ -174,11 +173,7 @@ void main() {
       // Simulate the sync-nudge delivering the toggled PATCH result:
       // update the link row to showInTimeline = false.
       await (ctx.db.update(ctx.db.sharedSpaceAlbumLinkEntity)
-            ..where(
-              (t) =>
-                  t.spaceId.equals(space.id) &
-                  t.albumId.equals(album.id),
-            ))
+            ..where((t) => t.spaceId.equals(space.id) & t.albumId.equals(album.id)))
           .write(const SharedSpaceAlbumLinkEntityCompanion(showInTimeline: Value(false)));
 
       // After toggle: asset must be excluded from the space timeline.
@@ -187,11 +182,7 @@ void main() {
 
       // Re-enable: asset returns.
       await (ctx.db.update(ctx.db.sharedSpaceAlbumLinkEntity)
-            ..where(
-              (t) =>
-                  t.spaceId.equals(space.id) &
-                  t.albumId.equals(album.id),
-            ))
+            ..where((t) => t.spaceId.equals(space.id) & t.albumId.equals(album.id)))
           .write(const SharedSpaceAlbumLinkEntityCompanion(showInTimeline: Value(true)));
 
       final restored = await sut.sharedSpace(space.id, .none).assetSource(0, 100);

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -269,5 +269,25 @@ void main() {
       // (consistent with server/web timeline; documented limitation).
       expect(assets, isEmpty);
     });
+
+    test('shows a stack flat (not vanished) when its stack row is not synced locally', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      // A viewer sees another member's stacked frames with stack_id set, but no
+      // stack_entity row (stack_entity only syncs for own/partner stacks). The
+      // collapse must degrade to a flat view, never hide the frames.
+      final frame1 = await ctx.newRemoteAsset(ownerId: user.id, stackId: 'unsynced-stack', createdAt: createdAt);
+      final frame2 = await ctx.newRemoteAsset(ownerId: user.id, stackId: 'unsynced-stack', createdAt: createdAt);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: frame1.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: frame2.id);
+      // Deliberately NO insertStack(...) — the stack_entity row is absent.
+
+      final assets = await sut.sharedSpace(space.id, GroupAssetsBy.none).assetSource(0, 100);
+      expect(assets.map((a) => (a as RemoteAsset).id).toSet(), {frame1.id, frame2.id});
+
+      // count builder agrees: both frames counted, none dropped
+      final buckets = await sut.sharedSpace(space.id, GroupAssetsBy.none).bucketSource().first;
+      expect(buckets.fold<int>(0, (sum, b) => sum + b.assetCount), 2);
+    });
   });
 }

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -180,6 +180,18 @@ where
   "spaceId" = $1
   and "assetId" in ($2)
 
+-- SharedSpaceRepository.getStackSiblingIdsInSpace
+select distinct
+  "sibling"."id" as "assetId"
+from
+  "asset" as "seed"
+  inner join "asset" as "sibling" on "sibling"."stackId" = "seed"."stackId"
+  inner join "shared_space_asset" on "shared_space_asset"."assetId" = "sibling"."id"
+where
+  "seed"."id" in ($1)
+  and "seed"."stackId" is not null
+  and "shared_space_asset"."spaceId" = $2
+
 -- SharedSpaceRepository.removeLibrary
 delete from "shared_space_library"
 where

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -149,6 +149,19 @@ from
       and "asset"."visibility" in ($11, $12)
   ) as "combined"
 
+-- SharedSpaceRepository.getOwnedStackSiblingIds
+select distinct
+  "sibling"."id" as "assetId"
+from
+  "asset" as "seed"
+  inner join "asset" as "sibling" on "sibling"."stackId" = "seed"."stackId"
+where
+  "seed"."id" in ($1)
+  and "seed"."stackId" is not null
+  and "sibling"."ownerId" = $2
+  and "sibling"."deletedAt" is null
+  and "sibling"."visibility" in ($3, $4)
+
 -- SharedSpaceRepository.getEditableByAssetIds
 select distinct
   "shared_space_asset"."spaceId"

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -160,7 +160,8 @@ where
   and "seed"."stackId" is not null
   and "sibling"."ownerId" = $2
   and "sibling"."deletedAt" is null
-  and "sibling"."visibility" in ($3, $4)
+  and "sibling"."isOffline" = $3
+  and "sibling"."visibility" in ($4, $5)
 
 -- SharedSpaceRepository.getEditableByAssetIds
 select distinct

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -347,6 +347,7 @@ export class SharedSpaceRepository {
       .where('seed.stackId', 'is not', null)
       .where('sibling.ownerId', '=', userId)
       .where('sibling.deletedAt', 'is', null)
+      .where('sibling.isOffline', '=', false)
       .where('sibling.visibility', 'in', visibleSpaceAssetVisibilities)
       .execute();
 

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -332,6 +332,27 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  async getOwnedStackSiblingIds(userId: string, assetIds: string[]): Promise<string[]> {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .selectFrom('asset as seed')
+      .innerJoin('asset as sibling', 'sibling.stackId', 'seed.stackId')
+      .select('sibling.id as assetId')
+      .distinct()
+      .where('seed.id', 'in', assetIds)
+      .where('seed.stackId', 'is not', null)
+      .where('sibling.ownerId', '=', userId)
+      .where('sibling.deletedAt', 'is', null)
+      .where('sibling.visibility', 'in', visibleSpaceAssetVisibilities)
+      .execute();
+
+    return rows.map((row) => row.assetId);
+  }
+
   /**
    * Returns the set of space IDs that contain ANY of the given asset IDs
    * via direct membership (`shared_space_asset`) AND in which the user has

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -397,6 +397,26 @@ export class SharedSpaceRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  async getStackSiblingIdsInSpace(spaceId: string, assetIds: string[]): Promise<string[]> {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .selectFrom('asset as seed')
+      .innerJoin('asset as sibling', 'sibling.stackId', 'seed.stackId')
+      .innerJoin('shared_space_asset', 'shared_space_asset.assetId', 'sibling.id')
+      .select('sibling.id as assetId')
+      .distinct()
+      .where('seed.id', 'in', assetIds)
+      .where('seed.stackId', 'is not', null)
+      .where('shared_space_asset.spaceId', '=', spaceId)
+      .execute();
+
+    return rows.map((row) => row.assetId);
+  }
+
   // ==========================================
   // Shared Space Library Link CRUD
   // ==========================================

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -2716,7 +2716,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
       mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
-      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(void 0);
       mocks.sharedSpace.update.mockResolvedValue(space);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
       mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
@@ -2740,7 +2740,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.getById.mockResolvedValue(space);
       mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
       mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
-      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(void 0);
       mocks.sharedSpace.update.mockResolvedValue(space);
       mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
       mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -239,6 +239,7 @@ describe(SharedSpaceService.name, () => {
 
   beforeEach(() => {
     ({ sut, mocks } = newTestService(SharedSpaceService));
+    mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
     mocks.sharedSpace.hasPetsBySpaceId.mockResolvedValue(false);
     mocks.sharedSpace.recountPersons.mockResolvedValue(void 0);
     mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
@@ -2330,6 +2331,103 @@ describe(SharedSpaceService.name, () => {
         expect.arrayContaining([expect.objectContaining({ name: JobName.SharedSpaceFaceMatch })]),
       );
       expectNoSharedSpaceFaceIdentityRootJobs(mocks);
+    });
+
+    it('should expand a stack to its siblings and insert the whole stack (E1/E2)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const sibling2 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1, sibling2]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.sharedSpace.getOwnedStackSiblingIds).toHaveBeenCalledWith(auth.user.id, [cover]);
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+        { spaceId, assetId: cover, addedById: auth.user.id },
+        { spaceId, assetId: sibling1, addedById: auth.user.id },
+        { spaceId, assetId: sibling2, addedById: auth.user.id },
+      ]);
+    });
+
+    it('should dedupe seeds and returned siblings (E8)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const a = newUuid();
+      const b = newUuid();
+      const c = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([a, b]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([b, c]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [a, b] });
+
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+        { spaceId, assetId: a, addedById: auth.user.id },
+        { spaceId, assetId: b, addedById: auth.user.id },
+        { spaceId, assetId: c, addedById: auth.user.id },
+      ]);
+    });
+
+    it('should retain an explicitly-added seed that is not a returned sibling (E7)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const seed = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([seed]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [seed] });
+
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([{ spaceId, assetId: seed, addedById: auth.user.id }]);
+    });
+
+    it('should queue SharedSpaceFaceMatch jobs for the expanded set (E12)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([cover]));
+      mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([cover, sibling1]);
+      mocks.sharedSpace.addAssets.mockResolvedValue([] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: cover } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: sibling1 } },
+      ]);
     });
   });
 

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -240,6 +240,7 @@ describe(SharedSpaceService.name, () => {
   beforeEach(() => {
     ({ sut, mocks } = newTestService(SharedSpaceService));
     mocks.sharedSpace.getOwnedStackSiblingIds.mockResolvedValue([]);
+    mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([]);
     mocks.sharedSpace.hasPetsBySpaceId.mockResolvedValue(false);
     mocks.sharedSpace.recountPersons.mockResolvedValue(void 0);
     mocks.sharedSpace.isAssetInSpace.mockResolvedValue(true);
@@ -2700,6 +2701,56 @@ describe(SharedSpaceService.name, () => {
       );
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
+      );
+    });
+
+    it('should expand removal to same-stack space members (E14/E15)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
+      mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+      mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
+
+      await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.sharedSpace.getStackSiblingIdsInSpace).toHaveBeenCalledWith(spaceId, [cover]);
+      expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
+      expect(mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath).toHaveBeenCalledWith(spaceId, [cover, sibling1]);
+    });
+
+    it('should reset the thumbnail when it is an expanded (sibling) frame (E17)', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const cover = newUuid();
+      const sibling1 = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, thumbnailAssetId: sibling1 });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.getStackSiblingIdsInSpace.mockResolvedValue([cover, sibling1]);
+      mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(undefined);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+      mocks.sharedSpace.getAssetIdsWithoutOtherSpacePath.mockResolvedValue([]);
+
+      // thumbnail (sibling1) is NOT in the caller's dto.assetIds — only reachable via expansion
+      await sut.removeAssets(auth, spaceId, { assetIds: [cover] });
+
+      expect(mocks.sharedSpace.update).toHaveBeenCalledWith(
+        spaceId,
+        expect.objectContaining({ thumbnailAssetId: null }),
       );
     });
   });

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -571,8 +571,12 @@ export class SharedSpaceService extends BaseService {
   async addAssets(auth: AuthDto, spaceId: string, dto: SharedSpaceAssetAddDto): Promise<void> {
     await this.requireRole(auth, spaceId, SharedSpaceRole.Editor);
     await this.requireAccess({ auth, permission: Permission.AssetRead, ids: dto.assetIds });
+
+    const siblingIds = await this.sharedSpaceRepository.getOwnedStackSiblingIds(auth.user.id, dto.assetIds);
+    const expandedAssetIds = [...new Set([...dto.assetIds, ...siblingIds])];
+
     const inserted = await this.sharedSpaceRepository.addAssets(
-      dto.assetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),
+      expandedAssetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),
     );
 
     await this.sharedSpaceRepository.update(spaceId, { lastActivityAt: new Date() });
@@ -587,7 +591,7 @@ export class SharedSpaceService extends BaseService {
     const space = await this.sharedSpaceRepository.getById(spaceId);
     if (space?.faceRecognitionEnabled) {
       await this.jobRepository.queueAll(
-        dto.assetIds.map((assetId) => ({
+        expandedAssetIds.map((assetId) => ({
           name: JobName.SharedSpaceFaceMatch as const,
           data: { spaceId, assetId },
         })),

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -769,14 +769,18 @@ export class SharedSpaceService extends BaseService {
     if (!space) {
       throw new NotFoundException('Space not found');
     }
-    await this.sharedSpaceRepository.removeAssets(spaceId, dto.assetIds);
+
+    const siblingIds = await this.sharedSpaceRepository.getStackSiblingIdsInSpace(spaceId, dto.assetIds);
+    const expandedAssetIds = [...new Set([...dto.assetIds, ...siblingIds])];
+
+    await this.sharedSpaceRepository.removeAssets(spaceId, expandedAssetIds);
 
     const lastAddedAt = await this.sharedSpaceRepository.getLastAssetAddedAt(spaceId);
     const updateData: { lastActivityAt: Date | null; thumbnailAssetId?: null } = {
       lastActivityAt: lastAddedAt ?? null,
     };
 
-    if (space?.thumbnailAssetId && dto.assetIds.includes(space.thumbnailAssetId)) {
+    if (space?.thumbnailAssetId && expandedAssetIds.includes(space.thumbnailAssetId)) {
       updateData.thumbnailAssetId = null;
     }
 
@@ -786,10 +790,13 @@ export class SharedSpaceService extends BaseService {
       spaceId,
       userId: auth.user.id,
       type: SharedSpaceActivityType.AssetRemove,
-      data: { count: dto.assetIds.length },
+      data: { count: expandedAssetIds.length },
     });
 
-    const orphanedAssetIds = await this.sharedSpaceRepository.getAssetIdsWithoutOtherSpacePath(spaceId, dto.assetIds);
+    const orphanedAssetIds = await this.sharedSpaceRepository.getAssetIdsWithoutOtherSpacePath(
+      spaceId,
+      expandedAssetIds,
+    );
     if (orphanedAssetIds.length > 0) {
       await this.sharedSpaceRepository.removePersonFacesByAssetIds(spaceId, orphanedAssetIds);
       await this.sharedSpaceRepository.deleteOrphanedPersons(spaceId);

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -274,19 +274,21 @@ describe('SharedSpaceRepository.getStackSiblingIdsInSpace', () => {
 
   it('returns [] for empty input', async () => {
     const { ctx, sut } = setup();
-    const { space } = await ctx.newSharedSpace({ createdById: (await ctx.newUser()).user.id });
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
     const result = await sut.getStackSiblingIdsInSpace(space.id, []);
     expect(result).toEqual([]);
   });
 });
 
+const removeWholeStack = async (sut: SharedSpaceRepository, spaceId: string, seedId: string) => {
+  const siblings = await sut.getStackSiblingIdsInSpace(spaceId, [seedId]);
+  const expanded = [...new Set([seedId, ...siblings])];
+  await sut.removeAssets(spaceId, expanded);
+  return expanded;
+};
+
 describe('stack-in-space removal composition (E14/E15/E16)', () => {
-  const removeWholeStack = async (sut: SharedSpaceRepository, spaceId: string, seedId: string) => {
-    const siblings = await sut.getStackSiblingIdsInSpace(spaceId, [seedId]);
-    const expanded = [...new Set([seedId, ...siblings])];
-    await sut.removeAssets(spaceId, expanded);
-    return expanded;
-  };
 
   it('removing the cover removes the whole stack (E14)', async () => {
     const { ctx, sut } = setup();

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -1,7 +1,9 @@
 import { Kysely } from 'kysely';
-import { AssetVisibility } from 'src/enum';
+import { AssetVisibility, TimeBucketSize } from 'src/enum';
+import { AssetRepository } from 'src/repositories/asset.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { StackRepository } from 'src/repositories/stack.repository';
 import { DB } from 'src/schema';
 import { BaseService } from 'src/services/base.service';
 import { newMediumService } from 'test/medium.factory';
@@ -140,5 +142,70 @@ describe('SharedSpaceRepository.getOwnedStackSiblingIds', () => {
     const { sut } = setup();
     const result = await sut.getOwnedStackSiblingIds('00000000-0000-0000-0000-000000000000', []);
     expect(result).toEqual([]);
+  });
+});
+
+const addWholeStack = async (ctx: any, sut: SharedSpaceRepository, spaceId: string, userId: string, seedId: string) => {
+  const siblings = await sut.getOwnedStackSiblingIds(userId, [seedId]);
+  const expanded = [...new Set([seedId, ...siblings])];
+  return sut.addAssets(expanded.map((assetId) => ({ spaceId, assetId, addedById: userId })));
+};
+
+const bucketCount = async (ctx: any, spaceId: string) => {
+  const buckets = await ctx.get(AssetRepository).getTimeBuckets({
+    spaceId,
+    visibility: AssetVisibility.Timeline,
+    bucketSize: TimeBucketSize.Year,
+    withStacked: true,
+  });
+  return buckets.reduce((sum: number, b: { count: number }) => sum + b.count, 0);
+};
+
+describe('stack-in-space composition (E10/E13)', () => {
+  it('collapses to one cover after the whole stack is added (E1/E13)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
+
+    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+
+    expect(await sut.getAssetCount(space.id)).toBe(3);
+    await expect(bucketCount(ctx, space.id)).resolves.toBe(1);
+  });
+
+  it('keeps the stack visible after promoting a different primary (E13)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { stack } = await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    await ctx.get(StackRepository).update(stack.id, { id: stack.id, primaryAssetId: child1.id });
+
+    await expect(bucketCount(ctx, space.id)).resolves.toBe(1);
+  });
+
+  it('is idempotent on re-add (E10)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: 'owner' });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    const secondInsert = await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+
+    expect(secondInsert).toHaveLength(0);
+    expect(await sut.getAssetCount(space.id)).toBe(2);
   });
 });

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -279,3 +279,63 @@ describe('SharedSpaceRepository.getStackSiblingIdsInSpace', () => {
     expect(result).toEqual([]);
   });
 });
+
+describe('stack-in-space removal composition (E14/E15/E16)', () => {
+  const removeWholeStack = async (sut: SharedSpaceRepository, spaceId: string, seedId: string) => {
+    const siblings = await sut.getStackSiblingIdsInSpace(spaceId, [seedId]);
+    const expanded = [...new Set([seedId, ...siblings])];
+    await sut.removeAssets(spaceId, expanded);
+    return expanded;
+  };
+
+  it('removing the cover removes the whole stack (E14)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+
+    await removeWholeStack(sut, space.id, primary.id);
+
+    expect(await sut.getAssetCount(space.id)).toBe(0);
+  });
+
+  it('removing a non-cover frame removes the whole stack (E15)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+
+    await removeWholeStack(sut, space.id, child1.id);
+
+    expect(await sut.getAssetCount(space.id)).toBe(0);
+  });
+
+  it('a frame still reachable via a linked album is not flagged as a face-orphan (E16)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+    // child1 is ALSO in an album that is linked to the space
+    const { album } = await ctx.newAlbum({ ownerId: user.id }, [child1.id]);
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, addedById: user.id });
+
+    const expanded = await removeWholeStack(sut, space.id, primary.id);
+    const orphans = await sut.getAssetIdsWithoutOtherSpacePath(space.id, expanded);
+
+    // primary has no remaining path → orphan; child1 remains via the album → NOT an orphan
+    expect(orphans).toContain(primary.id);
+    expect(orphans).not.toContain(child1.id);
+  });
+});

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -1,0 +1,144 @@
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db || defaultDatabase,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(SharedSpaceRepository) };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('SharedSpaceRepository.getOwnedStackSiblingIds', () => {
+  it('returns all siblings when the seed is the stack cover (E1)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id, child2.id]));
+  });
+
+  it('returns all siblings incl. the primary when the seed is a non-primary frame (E2)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [child1.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id]));
+  });
+
+  it('returns nothing for an asset with no stack (E3)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [asset.id]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not expand a stack owned by another user (E4)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: other } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newStack({ ownerId: owner.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(other.id, [primary.id]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('excludes Hidden and Locked siblings (E5)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: hidden } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+    const { asset: locked } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, hidden.id, locked.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('includes Archived siblings — archive is space-eligible (E5b)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: archived } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, archived.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, archived.id]));
+  });
+
+  it('excludes soft-deleted siblings (E6)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: deleted } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, deleted.id]);
+    await ctx.softDeleteAsset(deleted.id);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('dedupes when two seeds share a stack (E8)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id, child1.id]);
+
+    expect(result.length).toBe(new Set(result).size);
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id]));
+  });
+
+  it('handles a mixed batch of stacked and unstacked seeds (E9)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: standalone } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id, standalone.id]);
+
+    // standalone has no stack → contributes no siblings; the stack expands fully
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id]));
+  });
+
+  it('returns [] for empty input (E11)', async () => {
+    const { sut } = setup();
+    const result = await sut.getOwnedStackSiblingIds('00000000-0000-0000-0000-000000000000', []);
+    expect(result).toEqual([]);
+  });
+});

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -221,3 +221,61 @@ describe('stack-in-space composition (E10/E13)', () => {
     expect(await sut.getAssetCount(space.id)).toBe(2);
   });
 });
+
+describe('SharedSpaceRepository.getStackSiblingIdsInSpace', () => {
+  it('returns same-stack direct members of the space (E18)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child1.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child2.id, addedById: user.id });
+
+    const result = await sut.getStackSiblingIdsInSpace(space.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id, child1.id, child2.id]));
+  });
+
+  it('excludes same-stack assets that are NOT members of the space (E18)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    // only the primary is a direct member; child1 is not
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: primary.id, addedById: user.id });
+
+    const result = await sut.getStackSiblingIdsInSpace(space.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('does not cross space boundaries (E18)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space: spaceA } = await ctx.newSharedSpace({ createdById: user.id });
+    const { space: spaceB } = await ctx.newSharedSpace({ createdById: user.id });
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
+    await ctx.newSharedSpaceAsset({ spaceId: spaceA.id, assetId: primary.id, addedById: user.id });
+    await ctx.newSharedSpaceAsset({ spaceId: spaceB.id, assetId: child1.id, addedById: user.id });
+
+    const result = await sut.getStackSiblingIdsInSpace(spaceA.id, [primary.id]);
+
+    // child1 is a member of space B, not A → excluded from space A's expansion
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
+  it('returns [] for empty input', async () => {
+    const { ctx, sut } = setup();
+    const { space } = await ctx.newSharedSpace({ createdById: (await ctx.newUser()).user.id });
+    const result = await sut.getStackSiblingIdsInSpace(space.id, []);
+    expect(result).toEqual([]);
+  });
+});

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -289,7 +289,6 @@ const removeWholeStack = async (sut: SharedSpaceRepository, spaceId: string, see
 };
 
 describe('stack-in-space removal composition (E14/E15/E16)', () => {
-
   it('removing the cover removes the whole stack (E14)', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-stack-expansion.medium.spec.ts
@@ -111,6 +111,18 @@ describe('SharedSpaceRepository.getOwnedStackSiblingIds', () => {
     expect(new Set(result)).toEqual(new Set([primary.id]));
   });
 
+  it('excludes offline siblings, matching the canonical space-eligible filter (E6b)', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+    const { asset: offline } = await ctx.newAsset({ ownerId: user.id, isOffline: true });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, offline.id]);
+
+    const result = await sut.getOwnedStackSiblingIds(user.id, [primary.id]);
+
+    expect(new Set(result)).toEqual(new Set([primary.id]));
+  });
+
   it('dedupes when two seeds share a stack (E8)', async () => {
     const { ctx, sut } = setup();
     const { user } = await ctx.newUser();
@@ -145,7 +157,7 @@ describe('SharedSpaceRepository.getOwnedStackSiblingIds', () => {
   });
 });
 
-const addWholeStack = async (ctx: any, sut: SharedSpaceRepository, spaceId: string, userId: string, seedId: string) => {
+const addWholeStack = async (sut: SharedSpaceRepository, spaceId: string, userId: string, seedId: string) => {
   const siblings = await sut.getOwnedStackSiblingIds(userId, [seedId]);
   const expanded = [...new Set([seedId, ...siblings])];
   return sut.addAssets(expanded.map((assetId) => ({ spaceId, assetId, addedById: userId })));
@@ -172,7 +184,7 @@ describe('stack-in-space composition (E10/E13)', () => {
     const { asset: child2 } = await ctx.newAsset({ ownerId: user.id });
     await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id, child2.id]);
 
-    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    await addWholeStack(sut, space.id, user.id, primary.id);
 
     expect(await sut.getAssetCount(space.id)).toBe(3);
     await expect(bucketCount(ctx, space.id)).resolves.toBe(1);
@@ -187,7 +199,7 @@ describe('stack-in-space composition (E10/E13)', () => {
     const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
     const { stack } = await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
 
-    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    await addWholeStack(sut, space.id, user.id, primary.id);
     await ctx.get(StackRepository).update(stack.id, { id: stack.id, primaryAssetId: child1.id });
 
     await expect(bucketCount(ctx, space.id)).resolves.toBe(1);
@@ -202,8 +214,8 @@ describe('stack-in-space composition (E10/E13)', () => {
     const { asset: child1 } = await ctx.newAsset({ ownerId: user.id });
     await ctx.newStack({ ownerId: user.id }, [primary.id, child1.id]);
 
-    await addWholeStack(ctx, sut, space.id, user.id, primary.id);
-    const secondInsert = await addWholeStack(ctx, sut, space.id, user.id, primary.id);
+    await addWholeStack(sut, space.id, user.id, primary.id);
+    const secondInsert = await addWholeStack(sut, space.id, user.id, primary.id);
 
     expect(secondInsert).toHaveLength(0);
     expect(await sut.getAssetCount(space.id)).toBe(2);

--- a/web/src/lib/utils/space-filter-options.spec.ts
+++ b/web/src/lib/utils/space-filter-options.spec.ts
@@ -1,8 +1,8 @@
 import { AssetOrder } from '@immich/sdk';
+import { describe, expect, it } from 'vitest';
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import { buildAlbumTimelineOptions } from '$lib/utils/album-filter-options';
 import { buildSpaceTimelineOptions } from '$lib/utils/space-filter-options';
-import { describe, expect, it } from 'vitest';
 
 describe('space vs album timeline options — stack collapse (#751)', () => {
   it('space timeline requests stack collapse (withStacked: true) (E24)', () => {

--- a/web/src/lib/utils/space-filter-options.spec.ts
+++ b/web/src/lib/utils/space-filter-options.spec.ts
@@ -1,0 +1,20 @@
+import { AssetOrder } from '@immich/sdk';
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildAlbumTimelineOptions } from '$lib/utils/album-filter-options';
+import { buildSpaceTimelineOptions } from '$lib/utils/space-filter-options';
+import { describe, expect, it } from 'vitest';
+
+describe('space vs album timeline options — stack collapse (#751)', () => {
+  it('space timeline requests stack collapse (withStacked: true) (E24)', () => {
+    const options = buildSpaceTimelineOptions('space-1', createFilterState());
+
+    expect(options.spaceId).toBe('space-1');
+    expect(options.withStacked).toBe(true);
+  });
+
+  it('space-album detail does NOT collapse stacks (no withStacked) (E25)', () => {
+    const options = buildAlbumTimelineOptions('album-1', AssetOrder.Desc, createFilterState());
+
+    expect(options.withStacked).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements [discussion #751 — Support of stacked photos in Spaces](https://github.com/open-noodle/gallery/discussions/751).

## Problem

Adding a stack (RAW+JPEG, burst) to a Space only added its **primary** frame. Changing the primary afterward made the **whole stack disappear** — the old primary got collapsed out of the timeline while the new primary was never a member. Root cause: Space membership was per-asset-id, but the timeline collapses stacks by the **global** primary, independent of what's actually in the Space.

## Fix

Make Space membership **stack-complete at the write boundary**, so the existing stack-collapse does the rest.

| Slice | Change |
|---|---|
| **Server — add** | `addAssets` expands passed ids to the whole owner-owned stack (`getOwnedStackSiblingIds`: `ownerId` + space-eligible visibility `[Archive, Timeline]` + not-deleted/offline). Feeds the expanded set to the insert **and** the face-match jobs. |
| **Server — remove** | `removeAssets` expands to the same-stack **direct members** of the Space (`getStackSiblingIdsInSpace`). Feeds the expanded set to the delete, the thumbnail-reset check, and the face-orphan computation. Album-reachable frames correctly survive. |
| **Mobile** | Collapses stacks in the 3 aggregated-Space Drift builders (space-album detail left uncollapsed, matching web/albums). Degrades gracefully: a non-owned stack whose `stack_entity` row isn't synced locally shows **flat** rather than vanishing. |
| **Web + docs** | Guard test that the Space timeline sends `withStacked: true` and album detail does not; a "Stacked Photos" section in the user docs. |

Result: adding a stack brings in every frame, it collapses to its cover with the correct badge, tapping in shows all frames, and promoting any frame to primary "just works."

## Accepted limitations (MVP, documented in the spec)

- No auto-reconcile if a stack's composition changes *after* it's in a Space (re-add to fix).
- No backfill of stacks added before this change (re-add to fix).
- Album-path partial stacks unchanged (upstream album behavior; explicit non-goal).
- Mobile collapse is best-effort for **non-owned** stacks (no shared-space stack sync) — they show flat, never hidden. A follow-up for the `merged_asset.drift` main-timeline sibling is noted in the spec.

## Testing

- **Server:** unit (`shared-space.service.spec.ts`) + medium (`shared-space-stack-expansion.medium.spec.ts`, real Postgres) covering edge cases E1–E19; full unit suite green, tsc clean, SQL docs regenerated.
- **Mobile:** Drift tests for collapse / album-not-collapsed / legacy-zero / non-owned-flat; `dart analyze` clean.
- **Web:** guard spec (E24/E25); full web unit suite green.

Built on `space-albums-onto-main` (needs the album-within-space model), with #754 (RBAC visibility hardening) merged in. Design spec + per-slice plans under `docs/superpowers/`.
