### PR TITLE
fix(release): pin example.env to v5 and auto-sync it to release major

### DIFF
--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -363,6 +363,18 @@ jobs:
 
           git push origin "$VERSION" "v${major}" "release" --force
 
+      - name: Sync example.env to release major
+        env:
+          MAJOR: ${{ needs.version.outputs.major }}
+        run: |
+          # example.env is attached to the release below and is what the install
+          # docs' releases/latest/download/example.env link serves. It pins
+          # IMMICH_VERSION to the major rolling tag (e.g. v5). Rewrite it to this
+          # release's major so the attached asset never lags a major bump, even
+          # if the committed docker/example.env wasn't bumped for this release.
+          sed -i "s/^IMMICH_VERSION=.*/IMMICH_VERSION=${MAJOR}/" docker/example.env
+          grep '^IMMICH_VERSION=' docker/example.env
+
       - name: Create GitHub Release
         env:
           VERSION: ${{ needs.version.outputs.version }}

--- a/docker/example.env
+++ b/docker/example.env
@@ -9,8 +9,8 @@ DB_DATA_LOCATION=./postgres
 # To set a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # TZ=Etc/UTC
 
-# The Gallery version to use. You can pin this to a specific version like "v4.50.0"
-IMMICH_VERSION=v4
+# The Gallery version to use. You can pin this to a specific version like "v5.0.0"
+IMMICH_VERSION=v5
 
 # Connection secret for postgres. You should change it to a random password
 # Please use only the characters `A-Za-z0-9`, without special characters or spaces


### PR DESCRIPTION
## Problem

The v5.0.0 release page attaches an `example.env` that still pins `IMMICH_VERSION=v4`. This isn't cosmetic: the install docs (`docs/install/script.md`, `synology.md`) point users at `https://github.com/open-noodle/gallery/releases/latest/download/example.env`, so **everyone setting up v5 right now gets a v4 pin**.

Root cause: the `tag` job attaches `docker/example.env` verbatim, and that committed file was never bumped past `v4`.

## Fix

1. **Bump the committed file** `docker/example.env` → `IMMICH_VERSION=v5` (and the comment example → `v5.0.0`). Pinning the *major* rolling tag mirrors upstream immich's own convention (upstream pins `v3`).
2. **Auto-sync going forward**: a new `Sync example.env to release major` step in `gallery-release-server-only.yml` rewrites `IMMICH_VERSION` to the release's major (already computed as `needs.version.outputs.major`) in the attached copy, right before `gh release create`. The released asset can now never lag a major bump, even if the committed file wasn't bumped for that release. Idempotent when the committed file is already correct.

## Also done outside this PR

Re-uploaded the corrected `example.env` to the already-published **v5.0.0** release (`--clobber`) so `releases/latest/download/example.env` serves the v5 pin immediately.

## Verified

- Substitution logic tested against a stale `v4` file → correctly rewrites to `v5`/`v6`/`v10` per release major; no-op when already correct.
- `docker-compose.yml` defaults to `${IMMICH_VERSION:-release}`, so unset stays on `release` — unchanged.