### PR TITLE
fix(timeline): apply description/filename/OCR filters to the asset list

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -608,13 +608,29 @@ order by
 
 -- AssetRepository.getTimeBucket
 with
+  "filtered" as (
+    select
+      "asset"."id"
+    from
+      "asset"
+      left join "stack" on "stack"."id" = "asset"."stackId"
+      and "stack"."primaryAssetId" = "asset"."id"
+    where
+      date_trunc('MONTH', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $1
+      and "asset"."deletedAt" is null
+      and "asset"."visibility" in ('archive', 'timeline')
+      and (
+        "asset"."stackId" is null
+        or "stack" is not null
+      )
+  ),
   "cte" as (
     select
       "asset"."duration",
       "asset"."id",
       "asset"."visibility",
       asset."isFavorite"
-      and asset."ownerId" = $1 as "isFavorite",
+      and asset."ownerId" = $2 as "isFavorite",
       asset.type = 'IMAGE' as "isImage",
       asset."deletedAt" is not null as "isTrashed",
       "asset"."livePhotoVideoId",
@@ -646,7 +662,8 @@ with
       "asset_exif"."country",
       "stack"
     from
-      "asset"
+      "filtered"
+      inner join "asset" on "asset"."id" = "filtered"."id"
       inner join "asset_exif" on "asset"."id" = "asset_exif"."assetId"
       left join lateral (
         select
@@ -656,22 +673,10 @@ with
         where
           "stacked"."stackId" = "asset"."stackId"
           and "stacked"."deletedAt" is null
-          and "stacked"."visibility" = $2
+          and "stacked"."visibility" = $3
         group by
           "stacked"."stackId"
       ) as "stacked_assets" on true
-    where
-      "asset"."deletedAt" is null
-      and "asset"."visibility" in ('archive', 'timeline')
-      and date_trunc('MONTH', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $3
-      and not exists (
-        select
-        from
-          "stack"
-        where
-          "stack"."id" = "asset"."stackId"
-          and "stack"."primaryAssetId" != "asset"."id"
-      )
     order by
       (asset."localDateTime" AT TIME ZONE 'UTC')::date desc,
       "asset"."fileCreatedAt" desc
@@ -706,13 +711,23 @@ from
 
 -- AssetRepository.getTimeBucket
 with
+  "filtered" as (
+    select
+      "asset"."id"
+    from
+      "asset"
+    where
+      date_trunc('YEAR', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $1
+      and "asset"."deletedAt" is null
+      and "asset"."visibility" in ('archive', 'timeline')
+  ),
   "cte" as (
     select
       "asset"."duration",
       "asset"."id",
       "asset"."visibility",
       asset."isFavorite"
-      and asset."ownerId" = $1 as "isFavorite",
+      and asset."ownerId" = $2 as "isFavorite",
       asset.type = 'IMAGE' as "isImage",
       asset."deletedAt" is not null as "isTrashed",
       "asset"."livePhotoVideoId",
@@ -743,12 +758,9 @@ with
       "asset_exif"."city",
       "asset_exif"."country"
     from
-      "asset"
+      "filtered"
+      inner join "asset" on "asset"."id" = "filtered"."id"
       inner join "asset_exif" on "asset"."id" = "asset_exif"."assetId"
-    where
-      "asset"."deletedAt" is null
-      and "asset"."visibility" in ('archive', 'timeline')
-      and date_trunc('YEAR', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $2
     order by
       (asset."localDateTime" AT TIME ZONE 'UTC')::date desc,
       "asset"."fileCreatedAt" desc
@@ -782,13 +794,23 @@ from
 
 -- AssetRepository.getTimeBucket
 with
+  "filtered" as (
+    select
+      "asset"."id"
+    from
+      "asset"
+    where
+      date_trunc('DAY', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $1
+      and "asset"."deletedAt" is null
+      and "asset"."visibility" in ('archive', 'timeline')
+  ),
   "cte" as (
     select
       "asset"."duration",
       "asset"."id",
       "asset"."visibility",
       asset."isFavorite"
-      and asset."ownerId" = $1 as "isFavorite",
+      and asset."ownerId" = $2 as "isFavorite",
       asset.type = 'IMAGE' as "isImage",
       asset."deletedAt" is not null as "isTrashed",
       "asset"."livePhotoVideoId",
@@ -819,12 +841,9 @@ with
       "asset_exif"."city",
       "asset_exif"."country"
     from
-      "asset"
+      "filtered"
+      inner join "asset" on "asset"."id" = "filtered"."id"
       inner join "asset_exif" on "asset"."id" = "asset_exif"."assetId"
-    where
-      "asset"."deletedAt" is null
-      and "asset"."visibility" in ('archive', 'timeline')
-      and date_trunc('DAY', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $2
     order by
       (asset."localDateTime" AT TIME ZONE 'UTC')::date desc,
       "asset"."fileCreatedAt" desc

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -1303,9 +1303,24 @@ export class AssetRepository {
     const order = options.order === AssetOrder.Asc ? AssetOrder.Asc : AssetOrder.Desc;
     const bucketSize = options.bucketSize ?? TimeBucketSize.Month;
     const query = this.db
+      // Stage 1 — FILTER: reuse the shared timeline filter chain (the same one
+      // getTimeBuckets/getTimeBucketCovers use) so the asset list can never drift
+      // out of sync with the scrubber counts. Selects ids only; asset_exif is
+      // joined by the helper only when an exif filter is active.
+      .with('filtered', (qb) =>
+        withTimeBucketAssetFilters(
+          qb
+            .selectFrom('asset')
+            .select('asset.id')
+            .where(truncatedDate(options.orderBy, bucketSize), '=', timeBucket.replace(/^[+-]/, '')),
+          options,
+        ),
+      )
+      // Stage 2 — PROJECT: build the columnar row shape for the matched ids.
       .with('cte', (qb) =>
         qb
-          .selectFrom('asset')
+          .selectFrom('filtered')
+          .innerJoin('asset', 'asset.id', 'filtered.id')
           .innerJoin('asset_exif', 'asset.id', 'asset_exif.assetId')
           .select((eb) => [
             'asset.duration',
@@ -1340,104 +1355,10 @@ export class AssetRepository {
             qb.select(['asset_exif.city', 'asset_exif.country']),
           )
           .$if(!!options.withCoordinates, (qb) => qb.select(['asset_exif.latitude', 'asset_exif.longitude']))
-          .$if(!!options.forceEmptyResult, (qb) => qb.where(sql<SqlBool>`false`))
-          .where('asset.deletedAt', options.isTrashed ? 'is not' : 'is', null)
-          .$if(options.visibility == undefined, withDefaultVisibility)
-          .$if(!!options.visibility, (qb) => qb.where('asset.visibility', '=', options.visibility!))
-          .$if(!!options.bbox, (qb) => {
-            const bbox = options.bbox!;
-            const circle = getBoundingCircle(bbox);
-
-            const withBoundingCircle = qb.where(
-              sql`earth_box(ll_to_earth_public(${circle.centerLatitude}, ${circle.centerLongitude}), ${circle.radius})`,
-              '@>',
-              sql`ll_to_earth_public(asset_exif.latitude, asset_exif.longitude)`,
-            );
-
-            return withBoundingBox(withBoundingCircle, bbox);
-          })
-          .where(truncatedDate(options.orderBy, bucketSize), '=', timeBucket.replace(/^[+-]/, ''))
-          .$if(!!options.albumId, (qb) =>
-            qb.where((eb) =>
-              eb.exists(
-                eb
-                  .selectFrom('album_asset')
-                  .whereRef('album_asset.assetId', '=', 'asset.id')
-                  .where('album_asset.albumId', '=', asUuid(options.albumId!)),
-              ),
-            ),
-          )
-          .$if(!!options.isNotInAlbum && !options.albumId, (qb) =>
-            qb.where((eb) =>
-              eb.not(eb.exists((eb) => eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
-            ),
-          )
-          .$if(!!options.isInAlbum && !options.albumId, (qb) =>
-            qb.where((eb) =>
-              eb.exists((eb) => eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id')),
-            ),
-          )
-          .$if(!!options.spaceId, (qb) =>
-            qb.where((eb) =>
-              eb.or([
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_asset')
-                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_asset.spaceId', '=', asUuid(options.spaceId!)),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_library')
-                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                    .where('shared_space_library.spaceId', '=', asUuid(options.spaceId!)),
-                ),
-              ]),
-            ),
-          )
-          .$if(!!options.personIds?.length, (qb) => hasPeople(qb, options.personIds!))
-          .$if(!!options.spacePersonIds?.length, (qb) => hasSpacePeople(qb, options.spacePersonIds!))
-          .$if(!!options.identityIds?.length, (qb) => hasFaceIdentities(qb, options.identityIds!))
-          .$if(!!options.city, (qb) => qb.where('asset_exif.city', '=', options.city!))
-          .$if(!!options.country, (qb) => qb.where('asset_exif.country', '=', options.country!))
-          .$if(!!options.make, (qb) => qb.where('asset_exif.make', '=', options.make!))
-          .$if(!!options.model, (qb) => qb.where('asset_exif.model', '=', options.model!))
-          .$if(options.rating !== undefined, (qb) => qb.where('asset_exif.rating', '>=', options.rating!))
-          .$if(!!options.userIds && !options.timelineSpaceIds, (qb) =>
-            qb.where('asset.ownerId', '=', anyUuid(options.userIds!)),
-          )
-          .$if(!!options.userIds && !!options.timelineSpaceIds, (qb) =>
-            qb.where((eb) =>
-              eb.or([
-                eb('asset.ownerId', '=', anyUuid(options.userIds!)),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_asset')
-                    .whereRef('shared_space_asset.assetId', '=', 'asset.id')
-                    .where('shared_space_asset.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-                ),
-                eb.exists(
-                  eb
-                    .selectFrom('shared_space_library')
-                    .whereRef('shared_space_library.libraryId', '=', 'asset.libraryId')
-                    .where('shared_space_library.spaceId', '=', anyUuid(options.timelineSpaceIds!)),
-                ),
-              ]),
-            ),
-          )
-          .$if(options.isFavorite !== undefined, (qb) => qb.where('asset.isFavorite', '=', options.isFavorite!))
+          // withStacked collapses a stack to its primary asset (filtered in Stage 1)
+          // and projects the [stackId, count] array for the columnar output.
           .$if(!!options.withStacked, (qb) =>
             qb
-              .where((eb) =>
-                eb.not(
-                  eb.exists(
-                    eb
-                      .selectFrom('stack')
-                      .whereRef('stack.id', '=', 'asset.stackId')
-                      .whereRef('stack.primaryAssetId', '!=', 'asset.id'),
-                  ),
-                ),
-              )
               .leftJoinLateral(
                 (eb) =>
                   eb
@@ -1452,14 +1373,6 @@ export class AssetRepository {
               )
               .select('stack'),
           )
-          .$if(!!options.assetType, (qb) => qb.where('asset.type', '=', options.assetType!))
-          .$if(options.isDuplicate !== undefined, (qb) =>
-            qb.where('asset.duplicateId', options.isDuplicate ? 'is not' : 'is', null),
-          )
-          .$if(!!options.isTrashed, (qb) => qb.where('asset.status', '!=', AssetStatus.Deleted))
-          .$if(!!options.tagIds?.length, (qb) => withAnyTagId(qb, options.tagIds!))
-          .$if(!!options.takenAfter, (qb) => qb.where('asset.localDateTime', '>=', new Date(options.takenAfter!)))
-          .$if(!!options.takenBefore, (qb) => qb.where('asset.localDateTime', '<=', new Date(options.takenBefore!)))
           .orderBy(
             options.orderBy == AssetOrderBy.CreatedAt
               ? sql`"createdAt"`

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -903,6 +903,127 @@ describe(AssetRepository.name, () => {
         }),
       );
     });
+
+    it('filters bucket assets by description (accent/case-insensitive substring)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+
+      const [{ asset: match }, { asset: other }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          fileCreatedAt: new Date('2026-03-08T12:00:00.000Z'),
+          localDateTime: new Date('2026-03-08T12:00:00.000Z'),
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          fileCreatedAt: new Date('2026-03-08T13:00:00.000Z'),
+          localDateTime: new Date('2026-03-08T13:00:00.000Z'),
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: match.id, description: 'A lovely beach sunset', timeZone: 'UTC' }),
+        ctx.newExif({ assetId: other.id, description: 'Mountain hike', timeZone: 'UTC' }),
+      ]);
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        { userIds: [user.id], visibility: AssetVisibility.Timeline, description: 'BEACH' },
+        auth,
+      );
+      expect(JSON.parse(bucket.assets).id).toEqual([match.id]);
+    });
+
+    it('filters bucket assets by originalFileName (accent/case-insensitive substring)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+
+      const [{ asset: match }, { asset: other }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_beach_0001.jpg',
+          fileCreatedAt: new Date('2026-03-08T12:00:00.000Z'),
+          localDateTime: new Date('2026-03-08T12:00:00.000Z'),
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          originalFileName: 'IMG_forest_0002.jpg',
+          fileCreatedAt: new Date('2026-03-08T13:00:00.000Z'),
+          localDateTime: new Date('2026-03-08T13:00:00.000Z'),
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: match.id, timeZone: 'UTC' }),
+        ctx.newExif({ assetId: other.id, timeZone: 'UTC' }),
+      ]);
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        { userIds: [user.id], visibility: AssetVisibility.Timeline, originalFileName: 'BEACH' },
+        auth,
+      );
+      expect(JSON.parse(bucket.assets).id).toEqual([match.id]);
+    });
+
+    it('filters bucket assets by ocr text', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+
+      const [{ asset: match }, { asset: other }] = await Promise.all([
+        ctx.newAsset({
+          ownerId: user.id,
+          fileCreatedAt: new Date('2026-03-08T12:00:00.000Z'),
+          localDateTime: new Date('2026-03-08T12:00:00.000Z'),
+        }),
+        ctx.newAsset({
+          ownerId: user.id,
+          fileCreatedAt: new Date('2026-03-08T13:00:00.000Z'),
+          localDateTime: new Date('2026-03-08T13:00:00.000Z'),
+        }),
+      ]);
+      await Promise.all([
+        ctx.newExif({ assetId: match.id, timeZone: 'UTC' }),
+        ctx.newExif({ assetId: other.id, timeZone: 'UTC' }),
+      ]);
+      await ctx.database
+        .insertInto('ocr_search')
+        .values({ assetId: match.id, text: 'Total amount due invoice receipt' })
+        .execute();
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        { userIds: [user.id], visibility: AssetVisibility.Timeline, ocr: 'invoice receipt' },
+        auth,
+      );
+      expect(JSON.parse(bucket.assets).id).toEqual([match.id]);
+    });
+
+    it('projects owner-scoped isFavorite, isImage and ratio for matched assets', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user: { id: user.id } });
+
+      const { asset } = await ctx.newAsset({
+        ownerId: user.id,
+        type: AssetType.Image,
+        isFavorite: true,
+        fileCreatedAt: new Date('2026-03-08T12:00:00.000Z'),
+        localDateTime: new Date('2026-03-08T12:00:00.000Z'),
+      });
+      await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+
+      const bucket = await sut.getTimeBucket(
+        '2026-03-01',
+        { userIds: [user.id], visibility: AssetVisibility.Timeline },
+        auth,
+      );
+      const parsed = JSON.parse(bucket.assets);
+      expect(parsed.id).toEqual([asset.id]);
+      expect(parsed.isImage).toEqual([true]);
+      expect(parsed.isFavorite).toEqual([true]);
+    });
   });
 
   describe('upsertExif', () => {


### PR DESCRIPTION
## Problem

`/photos?description=test` (and `?filename=` / `?ocr=`) returned the **entire timeline** instead of the matching assets. On staging, `description=test` matched exactly **1** asset in the DB, yet the grid loaded all **179** assets in that month bucket.

## Root cause

The timeline text filters (#722/#723) were only wired into `withTimeBucketAssetFilters`, the shared helper used by:
- `getTimeBuckets` (scrubber counts) ✅
- `getTimeBucketCovers` (cover thumbnails) ✅

The **asset-list** query `getTimeBucket` hand-rolls its own filter chain and never applied the three text filters. So the scrubber narrowed correctly (count = 1) while the grid loaded every asset in the bucket unfiltered — a count/content mismatch that's easy to miss.

Confirmed via git archaeology that this has been present since the feature's first commit (2026-06-21) — it is **not** a rebase regression. The two-query split predates it (fork PR #670 extracted the helper for counts+covers only).

## Fix

Refactor `getTimeBucket` into a two-stage query, mirroring `getTimeBucketCovers`:
1. **Filter** — `withTimeBucketAssetFilters(...)` yields the matching id set (single source of truth for all timeline filtering).
2. **Project** — join the ids back to `asset` + `asset_exif` to build the columnar output.

All three timeline query paths now share one filter definition and can't drift apart again. Net ~120 fewer lines of duplicated filter logic.

## Tests
- 4 new medium tests on `getTimeBucket`: description, originalFileName, ocr, and a projection-shape guard (all watched failing first).
- Existing `getTimeBuckets` / `getTimeBucketCovers` medium tests unchanged & green (50/50 in the file).
- Regenerated `src/queries/asset.repository.sql`.

## Verified on staging (real library, RC `gettimebucket-textfilters-rc1`)

| Query | before | after |
|---|---|---|
| `description=test` scrubber count | 1 | 1 |
| `description=test` bucket assets | **179** | **1** |
| `filename` / `ocr` no-match bucket assets | 179 | 0 |
| no filter (control) | 179 | 179 |