### PR TITLE
feat(spaces): collaborative cross-owner contributions to space albums (#764)

### DIFF
--- a/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
+++ b/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
@@ -1,0 +1,271 @@
+# Collaborative Cross-Owner Contributions to Space Albums — Design Spec (2026-07-10)
+
+> **Purpose.** Let any space **Editor** add *any space-visible photo* — including photos they do
+> not own — to a space-linked album, collaboratively, while keeping every contributed photo
+> tethered to live space access (it vanishes the instant the contributor's/viewer's space access
+> ends or the album is unlinked, and it never becomes a permanent grant the album owner can carry
+> out of the space). Fixes issue **#764** as a byproduct.
+
+---
+
+## 0. Meta
+
+- **Base branch:** `feat/space-albums-collab-contrib`, branched off **`origin/space-albums-onto-main`**
+  (PR #752 head, tip `8071b039ca`). Ships as a **separate, stacked PR** whose base is the #752
+  branch — folded into the space-albums feature set but reviewable on its own.
+- **Depends on #752.** Everything here builds on machinery #752 already introduced: the
+  `shared_space_album` link, the revocable `shared_space_album_user` grant (auto-removed on leave
+  via `shared_space_member_delete_album_audit`), the space-aware `AlbumAssetCreate` case, and the
+  `shared-space-album-scope.ts` visibility helpers. **Do not** start until #752 is stable.
+- **Line numbers** are navigation hints against `8071b039ca`; every slice re-confirms symbols in
+  the worktree before editing.
+- **Terminal state of this spec:** feed to `writing-plans` (then `impl-loop`), TDD per slice.
+
+---
+
+## 1. Problem
+
+Reported in **#764**: a non-admin **Editor** in a shared space creates an album inside the space,
+tries to add a photo, and gets a green **"Successful"** toast whose body says **"cannot be added
+to the album"** — and the photo is not added. Two distinct defects stacked:
+
+1. **The lying toast.** `web/src/lib/services/album.service.ts` `notifyAddToAlbum` always calls
+   `toastManager.primary(...)` (green "Successful") regardless of result counts. The server returns
+   **HTTP 200 with per-asset failures**, so the web `catch` never fires and a failure renders as
+   success.
+2. **The add is genuinely blocked for non-owned assets.** `addAssets` (`server/src/utils/asset.util.ts`)
+   gates every asset on `Permission.AssetShare`, which resolves (`server/src/utils/access.ts`) through
+   **owner + partner only** — no space path (unlike `AssetRead`/`AssetView`/`AssetDownload` →
+   `checkSpaceAccess`, and `AssetUpdate` → `checkSpaceEditAccess`). #752 made the *album-level*
+   `AlbumAssetCreate` space-aware, but the *per-asset* `AssetShare` gate is untouched. So a space
+   Editor can add **only their own** photos to a space album; anyone else's photo returns
+   `NO_PERMISSION` for every asset.
+
+For the "Close Family" use case (most members are non-admin Editors curating a shared pool of
+photos contributed by *many* members), this makes collaborative curation impossible.
+
+### 1.1 The trap we must avoid
+
+`AssetShare` is owner-only **by design** — it also gates **public shared links** and **memories**.
+Simply adding `checkSpaceAccess` to the global `AssetShare` case would let any space member mint a
+public link of another member's photo. **We must not widen `AssetShare`.** The fix is a narrow,
+album-scoped add path.
+
+### 1.2 The new risk collaborative add introduces
+
+The moment Bob can add *Carol's* photo to *Alice's* album, Carol's photo sits in an album Alice
+**owns**. In upstream Immich, being in an album you own is a **permanent** view grant
+(`checkAlbumAccess`). Space *members* are safe (their album grant is revoked on leave), but the
+album **owner** — and any direct `album_user` participant — keeps access forever and can carry it
+**out of the space** (unlink the album, add an external album user, mint a public link). Carol only
+ever consented to *space* sharing. Closing this is the reason for a dedicated table (§4).
+
+---
+
+## 2. Goals & non-goals
+
+**Goals**
+- A space **Editor** may add any asset **space-visible to them** to an album **linked to that space**,
+  regardless of who owns the asset.
+- Contributed (non-owned) photos are **inert bookmarks**: access is re-derived from live space
+  membership + the live album↔space link on every read; they never grant permanent access via
+  `checkAlbumAccess`.
+- Leaving the space, unlinking the album, deleting the asset, or deleting the space each removes the
+  contribution from view (for everyone, including the album owner). Re-joining / re-linking restores it.
+- The add-to-album toast tells the truth (success / partial / failure).
+
+**Non-goals (this slice)**
+- No change to personal (non-space) albums or normal shared albums.
+- No widening of `AssetShare`, shared-link, or memory permissions.
+- **Viewers** stay read-only (contribute = Editor+), matching #752's `AlbumAssetCreate` role gate.
+- Not solving the sibling issues #763 (favorite for members) / #765 (fix-match no-op) here, though
+  they share the "members can't curate in a space" theme.
+
+---
+
+## 3. The core invariant
+
+> A **cross-owner contribution** is a pointer `(album, asset, space)` that renders for a viewer **iff**
+> the album is still linked to that space **and** the viewer is a live member of that space. It is
+> never stored in `album_asset`, so `checkAlbumAccess` can never turn it into a permanent grant.
+
+The adder's **own** photos are *not* contributions — they take the ordinary `album_asset` path
+(standard "I shared my photo into a collaborative album"). The new table only ever holds the
+"photo I don't own" case.
+
+---
+
+## 4. Data model
+
+New fork table `album_space_asset` (`server/src/schema/tables/album-space-asset.table.ts`) plus its
+own delete-audit table `album_space_asset_audit` (for the sync delete stream), plus a migration in
+`server/src/schema/migrations-gallery/` (round timestamp, e.g. `1783000000000`; add a
+`scripts/revert-to-immich.sql` DROP entry).
+
+> **Naming caution.** #752 already ships `shared_space_album_asset_audit` — that audits deletions of
+> **normal `album_asset`** membership in linked albums, feeding `SharedSpaceAlbumToAssetSync`. It is
+> **not** related to this table. Keep the new table's name (`album_space_asset`) and its audit
+> (`album_space_asset_audit`) distinct to avoid conflating the two.
+
+```
+album_space_asset  — a live-gated cross-owner contribution of a space photo into a linked album
+────────────────────────────────────────────────────────────────────────────────────
+  albumId    FK → album          (PK)   onDelete CASCADE   the collaborative album
+  assetId    FK → asset          (PK)   onDelete CASCADE   the contributed photo (owner unchanged)
+  spaceId    FK → shared_space          onDelete CASCADE   provenance + tether
+  addedById  FK → user (nullable)       onDelete SET NULL  who contributed it (any Editor)
+  addedAt    timestamp
+  createId / updateId / createdAt / updatedAt              fork sync watermarks (mirror shared_space_asset)
+```
+
+- **Not** `album_asset`, **not** `album_user`, **not** an access grant — a bookmark whose validity
+  is recomputed on every read.
+- `spaceId` disambiguates albums linked to multiple spaces and drives the "from *Space*" affordance
+  and the add-eligibility check (the Editor must be an Editor of *that* space).
+- Sync columns because mobile must receive/drop these rows (see §7).
+
+---
+
+## 5. Access & read model
+
+### 5.1 Adding (the #764 fix) — `AlbumService.addAssets`
+
+Replace the single `AssetShare`-gated `addAssets(...)` call with a two-bucket split *inside the
+album-add path only* (no change to the generic `asset.util.ts` used by shared-links/memories):
+
+1. Resolve the album's live space link(s) the adder is an **Editor** of:
+   `shared_space_album ⋈ shared_space_member(role ∈ {owner, editor})` for `auth.user.id`. If none,
+   behavior is unchanged from today (owner-only add).
+2. For each requested asset, in order of precedence:
+   - **Owned / AssetShare-eligible** → normal `album_asset` insert (unchanged path).
+   - **Not owned, but space-visible to the adder via an eligible space `S`** → insert into
+     `album_space_asset (album, asset, S, addedById=auth.user.id)`.
+     "Space-visible to the adder via S" reuses `shared-space-album-scope.ts`
+     `spaceAssetPathBranches` (direct `shared_space_asset` ∪ linked-library ∪ linked-album arms)
+     scoped to `{ memberUserId: auth.user.id, memberRole: [owner, editor], spaceId: S }`.
+   - **Already present** in `album_asset` *or* `album_space_asset` → `DUPLICATE`.
+   - **Otherwise** → `NO_PERMISSION`.
+3. Return a merged `BulkIdResponseDto[]` across both buckets (per-asset outcome preserved).
+
+An asset never lands in both tables (each asset has exactly one owner → exactly one eligible path).
+
+### 5.2 Reading — extend the album visibility arm
+
+`album_space_asset` becomes a **fourth arm** of space visibility, parallel to
+`spaceDirectAssetExists` / `spaceLibraryAssetExists` / `spaceAlbumAssetExists`. Add
+`spaceContributedAssetExists(eb, { correlateAssetId, scope })` to `shared-space-album-scope.ts`:
+
+```
+EXISTS (
+  SELECT 1 FROM album_space_asset asa
+  JOIN shared_space_album ssa  ON ssa.albumId = asa.albumId AND ssa.spaceId = asa.spaceId   -- link still live
+  JOIN album a                 ON a.id = asa.albumId AND a.deletedAt IS NULL
+  [membership scope]           JOIN shared_space_member m ON m.spaceId = asa.spaceId
+                                 AND m.userId = :viewer  [AND m.role IN (:roles)]
+  WHERE asa.assetId = <correlateAssetId>
+    [AND asa.spaceId = :scopeSpaceId]
+)
+```
+
+- Unlink the album → no `shared_space_album` row → excluded (reversible on re-link).
+- Viewer leaves the space → no `shared_space_member` row → excluded (reversible on re-join).
+- Because the row is *not* in `album_asset`, the owner's `checkAlbumAccess` never sees it → no
+  permanent grant, no leak via external album sharing / public links.
+
+**Album contents** become `album_asset ∪ spaceContributedAssetExists(...)`, deduped by `assetId`.
+Wire the new arm into every place #752 already routes the album arm: **album detail/grid, asset
+count, thumbnail selection, the space aggregated timeline (respecting `showInTimeline`), download,
+activity, and in-album search.** (This is the largest surface area of the change — audit each
+consumer of `spaceAlbumAssetExists` / `spaceAssetPathBranches`.)
+
+### 5.3 Removing — `AlbumService.removeAssets`
+
+Removing a contributed asset = delete the `album_space_asset` row (never touches the asset).
+Permitted for the **album owner**, any **space Editor** of the linked space, and the **contributor**.
+Add a space-aware branch alongside the existing `AssetShare` / `AlbumAssetDelete` (`canAlwaysRemove`)
+logic. Removal of an ordinary `album_asset` row is unchanged.
+
+---
+
+## 6. Lifecycle & edge cases
+
+| Event | Effect on a contribution `(album L, asset A, space S)` |
+|---|---|
+| Viewer leaves space S | Hidden for that viewer (no `shared_space_member`). Rejoin → reappears. |
+| Album L unlinked from S | Hidden for everyone (no `shared_space_album`). Re-link → reappears. |
+| Space S deleted | Row deleted (FK `spaceId` CASCADE). |
+| Album L deleted | Row deleted (FK `albumId` CASCADE). |
+| Asset A deleted | Row deleted (FK `assetId` CASCADE). |
+| Album L shared outside S (external `album_user` / public link) | Non-space viewers **never** see A (arm keys on *viewer's* live membership). No leak. |
+| Owner opens L after leaving S / after unlink | A is gone for the owner too (owner reaches contributions only via the space arm, not `album_asset`). |
+
+---
+
+## 7. Surfaces
+
+### 7.1 Web
+- **Add flow:** the existing "Add to album or space" picker + `addAssetsToAlbums` already targets
+  space-linked albums; no picker change needed — the server now accepts non-owned assets for
+  eligible albums.
+- **Toast (fixes #764's literal title):** `notifyAddToAlbum` must branch on result counts —
+  `success` (all added), `info`/warning (partial), `warning`/`error` (none added) — instead of an
+  unconditional `toastManager.primary`. **Standalone**; can land first, independent of the backend.
+- **Legibility:** a "from *Space name*" affordance on contributed tiles in the album view (we have
+  `spaceId` → space name), so the "these can disappear when you leave/unlink" behavior is understood.
+  Contributed tiles are **not** owned by the viewer → respect existing non-owner asset affordances.
+
+### 7.2 Mobile / sync
+- `album_space_asset` carries sync watermarks. Contributions are album→asset **membership edges**, so
+  extend **`SharedSpaceAlbumToAssetSync`** (`sync.repository.ts:1609`) to union `album_space_asset`
+  inserts, with deletes driven by the new `album_space_asset_audit` stream. The contributed asset's
+  **payload + exif** (owned by another member) must also reach the client: include
+  `album_space_asset`-reachable assets in **`SharedSpaceAlbumAssetSync`** (`:1689`) and
+  **`SharedSpaceAlbumAssetExifSync`** (`:1763`), mirroring how the existing linked-album arm streams
+  `album_asset`-reachable assets. Register a new `SyncEntityType`/`SyncRequestType` pair
+  (e.g. `SharedSpaceAlbumContributions*`) if the membership edge needs a distinct stream from
+  `SharedSpaceAlbumToAssetsV1`.
+- Contributions render read-through-space like the rest of a space album; tap-through respects the
+  same owner/role gating already in place.
+
+---
+
+## 8. Open sub-decisions (defaults chosen; confirm at review)
+
+1. **Un-share vs. curated life.** If the asset's owner *removes A from the space's general pool*
+   (a `shared_space_asset` delete) but does not delete A, does A stay in albums it was curated into?
+   **Default: yes, stays** — a contribution has its own life tethered to space S, not to the source
+   arm it came from; only delete / unlink / leave / space-deletion remove it. (Alternative: also
+   require A to be independently space-visible at read time — stronger for the owner, but makes
+   curated album content fragile.)
+2. **Contributions into externally-shared albums.** Allowed — the per-viewer arm makes it safe
+   (non-space viewers never see contributions). No block needed.
+3. **Multi-space albums.** `spaceId` pins provenance; a contribution is visible to members of *its*
+   space. An album linked to two spaces can hold contributions tagged to each; each is gated
+   independently. No dedup needed beyond `assetId` at read time.
+
+---
+
+## 9. Slice outline (detail → `writing-plans`)
+
+1. **Toast honesty** (web, standalone). Red: a `notifyAddToAlbum` unit test asserting a 0-success
+   result yields a non-success toast. Green: branch on counts.
+2. **Schema + migration.** `album_space_asset` + `album_space_asset_audit` tables + migration +
+   `revert-to-immich.sql` entry + audit trigger wiring. Medium test: insert/read/cascade behavior.
+3. **Add path.** `AlbumService.addAssets` two-bucket split + repository method. Medium/e2e: Editor
+   adds a non-owned space photo → row in `album_space_asset`, `success: true`; Viewer → denied;
+   non-space asset → `NO_PERMISSION`; owned asset still → `album_asset`.
+4. **Read arm.** `spaceContributedAssetExists` + wire into album grid/count/thumbnail/timeline/
+   download/activity/search. Medium: leave/unlink hides; owner has no permanent access; external
+   share doesn't leak.
+5. **Remove path.** Space-aware `removeAssets` branch. Medium: owner/editor/contributor can remove;
+   viewer cannot.
+6. **Sync.** Extend `SharedSpaceAlbumToAssetSync` (membership edge) + `SharedSpaceAlbumAssetSync` /
+   `SharedSpaceAlbumAssetExifSync` (contributed asset payload/exif) for `album_space_asset`
+   insert/delete via `album_space_asset_audit`. Medium: sync stream carries contribution + payload +
+   audit-driven removal.
+7. **Web UX.** "from *Space*" affordance + Playwright role-gating (Editor sees add succeed, Viewer
+   has no add).
+8. **SDK/regen** if any DTO/endpoint shape changes; `make build-sdk` → `make open-api`.
+
+Each slice is TDD (red → green → refactor) with full-suite validation for touched packages before
+"done". No Claude co-author trailers.

--- a/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
+++ b/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
@@ -166,7 +166,42 @@ album_space_asset  — a live-gated cross-owner contribution of a space photo in
 
 ---
 
-## 5. Access & read model
+## 5. Access, role & visibility model (RBAC)
+
+### 5.0 Role & visibility matrix (the security contract)
+
+Two **independent** role systems: **space** `SharedSpaceRole` = Owner / Editor / Viewer
+(`shared_space_member.role`) and **album** `AlbumUserRole` = Owner / Editor / Viewer (`album_user`).
+
+| Operation | Allowed for | Enforced by |
+|---|---|---|
+| **View** a contribution (grid / count / timeline / download / search) | any **live member** of the album's linked space — Owner/Editor/**Viewer** | read arm joins `shared_space_member` with **no role filter** (mirrors `checkSpaceLinkedAlbumReadAccess`, `access.repository.ts:165`) |
+| **Contribute** a **non-owned** photo | space **Owner/Editor** of the album's linked space **S**, *and* the asset is space-visible to them via **S** *and* passes the visibility gate | album-level `AlbumAssetCreate` (#752 `role IN [owner,editor]`, `access.repository.ts:158` — **throws 403 for Viewers**) **+** per-asset eligibility (§5.1) |
+| **Contribute** an **owned** photo | space **Owner/Editor** (album-level gate) → normal `album_asset` | `AlbumAssetCreate` + `AssetShare` (owner) |
+| **Remove** a contribution | album **Owner/Editor** OR live space **Owner/Editor** of S | `AlbumAssetDelete` (#752 made it space-editor-aware) + row delete |
+| **Link / unlink** album ↔ space | out of scope (#752) | — |
+
+**Non-bypass rules (assert each as an explicit negative test):**
+- **Viewers never write.** A space Viewer is hard-blocked at `AlbumAssetCreate` (403) *before* any
+  per-asset logic runs — they can contribute neither their own nor others' photos.
+- **Album role ≠ space rights.** A direct `album_user` **editor** who is **not** a space member
+  cannot contribute non-owned space assets (own → `album_asset`; others' → `NO_PERMISSION`). Album
+  ownership does **not** bypass the space-Editor requirement for pulling in others' photos.
+- **Same space for all three.** Eligibility requires a *single* space **S** where the album is
+  linked to S, the adder is Owner/Editor of S, **and** the asset is space-visible via S. An asset
+  visible only via a *different* space the adder edits is **not** contributable here — no
+  cross-space smuggling.
+
+**Visibility gate (critical — a leak vector if missed).** The space-visibility arms
+(`spaceAssetPathBranches`) do **not** exclude Hidden/Locked assets on their own — `spaceVisibilityGate`
+(`[Archive, Timeline]` only; `shared-space-album-scope.ts:42`) is applied *separately* at each call
+site (this was #752 remediation Slice 1). Therefore:
+- **Add:** eligibility MUST `AND` the flat `spaceVisibilityGate` into the visibility check — an Editor
+  must never contribute an asset its owner marked **Hidden/Locked** (which the Editor cannot even
+  see). No owner exception (contributions are cross-owner by definition).
+- **Read:** `spaceContributedAssetExists` MUST be composed with `spaceVisibilityGate(eb, 'asset.visibility')`
+  at every read site (like the album arm), so an asset marked Hidden *after* it was contributed is
+  defensively excluded going forward.
 
 ### 5.1 Adding (the #764 fix) — `AlbumService.addAssets`
 
@@ -181,7 +216,9 @@ shared-links/memories):
      `album_space_asset(album, asset, S, addedById=auth.user.id)`. "Space-visible via S" reuses
      `shared-space-album-scope.ts` `spaceAssetPathBranches` (direct `shared_space_asset` ∪
      linked-library ∪ linked-album arms) scoped to
-     `{ memberUserId: auth.user.id, memberRole: [owner, editor], spaceId: S }`.
+     `{ memberUserId: auth.user.id, memberRole: [owner, editor], spaceId: S }`, **AND**ed with the
+     flat `spaceVisibilityGate` (§5.0) so Hidden/Locked assets are never eligible. The role filter
+     ties the contribution to a space **S** where the adder is Owner/Editor.
    - **Already in** `album_asset` *or* `album_space_asset` → `DUPLICATE`.
    - **Otherwise** → `NO_PERMISSION`.
 3. Return a merged `BulkIdResponseDto[]` across both buckets (per-asset outcome preserved).
@@ -206,18 +243,27 @@ EXISTS (
 )
 ```
 
-Because the row is *not* in `album_asset`, the owner's `checkAlbumAccess` never sees it → no
-permanent grant. **Album contents** = `album_asset ∪ spaceContributedAssetExists(...)`, deduped by
-`assetId`. Wire into every consumer of `spaceAlbumAssetExists` / `spaceAssetPathBranches`: album
-detail/grid, asset count, thumbnail, the space aggregated timeline (respecting `showInTimeline`),
-download, activity, in-album search. (Largest surface — Slices 2–3.)
+The membership join uses **any-role** membership (no `memberRole` filter) — Viewers must see
+contributions — and every read site **composes it with `spaceVisibilityGate`** (§5.0) exactly as it
+already does for the album arm. Because the row is *not* in `album_asset`, the owner's
+`checkAlbumAccess` never sees it → no permanent grant. **Album contents** =
+`album_asset ∪ spaceContributedAssetExists(...)`, deduped by `assetId`. Wire into every consumer of
+`spaceAlbumAssetExists` / `spaceAssetPathBranches`: album detail/grid, asset count, thumbnail, the
+space aggregated timeline (respecting `showInTimeline`), download, activity, in-album search
+(Largest surface — Slices 2–3). At each site, confirm the visibility gate is present for the new arm
+— do not replicate any site that is still missing it.
 
 ### 5.3 Removing — `AlbumService.removeAssets`
 
-Removing a contribution = delete the `album_space_asset` row (never touches the asset). Permitted for
-the **album owner**, any **space Editor** of the linked space, and the **contributor**. Space-aware
-branch alongside the existing `AssetShare` / `AlbumAssetDelete` (`canAlwaysRemove`) logic. Removing
-an ordinary `album_asset` row is unchanged.
+Removing a contribution = delete the `album_space_asset` row (never touches the asset). Gate it on
+the **same `AlbumAssetDelete`** access #752 already defines — which resolves to *album Owner/Editor*
+**or** *space Owner/Editor* of the linked space (`checkSpaceLinkedAlbumAccess`, `role IN [owner,editor]`).
+This is symmetric with the add gate and needs no new permission. A space **Viewer** cannot remove.
+
+We deliberately **do not** add a standalone "the contributor may always remove" allowance: a
+contributor who is still an Editor is already covered, and one demoted to Viewer *should* lose write
+ability — a bespoke allowance would reintroduce a role-transition bypass. Removing an ordinary
+`album_asset` row is unchanged.
 
 ---
 
@@ -375,9 +421,13 @@ owned by Carol.
   and the asset **count includes** X.
 - *Given* Bob adds **his own** asset Y (in S) to L, *When* it runs, *Then* Y takes the **`album_asset`**
   path (`success:true`), unchanged.
-- *Given* a **Viewer** V of S, *When* V tries to add X to L, *Then* the add is **denied**
-  (`AlbumAssetCreate` role gate) — no row created.
+- *Given* a **Viewer** V of S, *When* V tries to add X (or their *own* asset) to L, *Then* the add
+  is **denied with 403** — `AlbumAssetCreate` throws *before* any per-asset logic; no row created.
 - *Given* asset Z **not in S**, *When* Bob adds Z to L, *Then* **`NO_PERMISSION`** for Z — no row.
+- *Given* asset H owned by Carol but **Hidden/Locked**, *When* Bob adds H to L, *Then*
+  **`NO_PERMISSION`** (visibility gate) — no row, and H never becomes visible to any member via L.
+- *Given* Dave is a direct `album_user` **editor** of L but **not** a member of S, *When* Dave adds
+  non-owned X to L, *Then* **`NO_PERMISSION`** (album role ≠ space rights); his *own* asset → `album_asset`.
 - *Given* X is already in L (as contribution or owned), *When* Bob adds X again, *Then* **`DUPLICATE`**.
 - *Given* a mixed batch {X (non-owned, in S), Y (Bob-owned, in S), Z (not in S)}, *When* Bob adds
   them, *Then* per-asset `{X:success, Y:success, Z:no_permission}` and a partial `BulkIdResponse`.
@@ -401,6 +451,9 @@ owned by Carol.
 - Asset visible to Bob only via a **different** space T (album L not linked to T) → `NO_PERMISSION`
   (eligibility requires visibility via **L's** space).
 - Album linked to **no** space Bob edits → non-owned add → `NO_PERMISSION` (owner-only unchanged).
+- **Visibility-gate leak negative (critical):** an Editor cannot contribute a Hidden/Locked asset
+  (above); additionally assert the resulting `album_space_asset` set never contains a Hidden/Locked
+  asset id, so no member's album read can surface one.
 - **Leak negative (critical):** setup Alice as an **Editor member** of S (not the creator) who owns
   album L and links it into S. After Bob contributes X, Alice's `checkAlbumAccess`-backed reads of X
   resolve **only while she is a live member of S** — assert Alice loses X the moment she is removed
@@ -433,6 +486,9 @@ lifecycle/leak guarantee from §6 is asserted.
   general pool but keeps it* → X **stays** in L (§8 default 1).
 - **External-share negative:** *Given* Alice shares L via public link / external `album_user`, *When*
   a non-space viewer opens it, *Then* contributions are **absent** (owned assets still present).
+- **Contributed-then-Hidden negative:** *Given* contribution X is visible, *When* X's owner marks X
+  **Hidden/Locked**, *Then* the `spaceVisibilityGate` on the read arm excludes X from every album
+  surface for every member (defense-in-depth against post-hoc visibility changes).
 
 **TDD — red first**
 - **Medium/e2e** per surface (timeline, download, activity, search, thumbnail) + the full lifecycle
@@ -457,12 +513,17 @@ candidates are contributions the viewer can't currently see.
 
 **Delivers.** Collaborative removal, correctly role-gated.
 
-**Behavior (BDD)** — contribution `(L, X, S)` by Bob.
+**Behavior (BDD)** — contribution `(L, X, S)` by Bob. Gate = `AlbumAssetDelete` (album Owner/Editor
+**or** space Owner/Editor).
 - *Given* Alice (album **owner**), *When* she removes X from L, *Then* the `album_space_asset` row is
   deleted, X leaves L, and asset X itself is untouched.
-- *Given* Bob (the **contributor**), *When* he removes X, *Then* deleted.
-- *Given* another space **Editor** Dave, *When* he removes X, *Then* deleted.
-- *Given* a space **Viewer** V, *When* V tries to remove X, *Then* **denied**; row stays.
+- *Given* another live space **Editor** Dave, *When* he removes X, *Then* deleted.
+- *Given* Bob (the contributor) who is **still an Editor**, *When* he removes X, *Then* deleted (via
+  the Editor path — no special contributor rule).
+- *Given* Bob was **demoted to Viewer** (or left S), *When* he tries to remove his own X, *Then*
+  **denied** — he no longer has write rights.
+- *Given* a space **Viewer** V (who is not the album owner), *When* V tries to remove X, *Then*
+  **denied**; row stays.
 - *Given* a **non-member**, *When* they try, *Then* **denied**.
 - *Given* removal of an **owned** `album_asset` row, *When* it runs, *Then* unchanged behavior.
 
@@ -470,15 +531,18 @@ candidates are contributions the viewer can't currently see.
 - **e2e/medium**: the six cases through the remove endpoint; assert row presence/absence and that
   the asset row persists. Red because the current remove path has no `album_space_asset` branch.
 
-**Fix (green).** Space-aware branch in `AlbumService.removeAssets` / the `removeAssets` util caller:
-resolve the row's `spaceId`, allow if owner ∨ space-Editor ∨ contributor; delete the row (emit
-`AlbumAssetsRemove` + audit).
+**Fix (green).** Space-aware branch in `AlbumService.removeAssets` gated on the existing
+`AlbumAssetDelete` access (album Owner/Editor ∨ space Owner/Editor of the linked space — no new
+permission, no bespoke contributor rule): if the caller has `AlbumAssetDelete` on L, delete the
+`album_space_asset` row (emit `AlbumAssetsRemove` + audit).
 
 **Edge cases**
 - Removing X that is **not present** → `NOT_FOUND` (not 500).
 - Editor of a **different** space (not L's) → denied.
-- Contributor who has since **left** S → still allowed to remove their own bookmark? **Default: no**
-  (no live membership → treated as non-member). Assert.
+- Album **Viewer** who is *also* the album owner? Not possible (owner role ≠ viewer); the album owner
+  always has `AlbumAssetDelete`. A space **Viewer** who does not own L → denied.
+- A caller with `AlbumAssetDelete` removes an owned `album_asset` **and** a contributed
+  `album_space_asset` in one batch → both handled, correct per-asset results.
 
 **Green.** All cases green; existing remove suite green.
 
@@ -552,15 +616,22 @@ the add action is hidden/disabled for Viewers.
 
 ## 10. Global acceptance criteria
 
-- A space Editor can add a non-owned, space-visible photo to a space-linked album; a Viewer cannot.
+- **Role matrix (§5.0) holds exactly:** *view* = any live space member (incl. Viewer); *contribute*
+  = space Owner/Editor of the album's space; *remove* = `AlbumAssetDelete` (album Owner/Editor ∨
+  space Owner/Editor). Every non-bypass rule has a passing negative test: Viewer 403 hard-block,
+  album-editor-not-space-member denied, no cross-space smuggling.
+- **No Hidden/Locked leak:** a Hidden/Locked asset is never contributable (add-time flat
+  `spaceVisibilityGate`) and never rendered via a contribution (read-time gate at every surface),
+  including when an asset is marked Hidden *after* being contributed.
 - Contributed photos render in every album surface for live members and **nowhere** for
   non-members — including the album owner once their space access ends, and including external
   album shares / public links.
 - Leaving/unlinking/deleting behaves exactly per the §6 table; re-join/re-link is reversible.
 - The add-to-album toast never reports success when nothing was added.
 - Mobile converges with contribution insert/delete/backfill.
-- Full-suite green for every touched package; no widening of `AssetShare`/shared-link/memory
-  permissions (assert an unrelated shared-link e2e still owner-gates).
+- Full-suite green for every touched package; **no widening of `AssetShare`/shared-link/memory
+  permissions** (assert an unrelated shared-link e2e still owner-gates — a space member still cannot
+  mint a public link of another member's photo).
 
 ## 11. Out of scope
 

--- a/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
+++ b/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
@@ -5,6 +5,10 @@
 > tethered to live space access (it vanishes the instant the contributor's/viewer's space access
 > ends or the album is unlinked, and it never becomes a permanent grant the album owner can carry
 > out of the space). Fixes issue **#764** as a byproduct.
+>
+> **Method.** Test-driven, behavior-first. Every slice lists its **BDD scenarios (Given/When/Then)**
+> first, turns each into a **failing test (red)**, then implements the minimum to pass (**green**),
+> then refactors. Slices are **vertical** and independently implementable via `/impl-loop`.
 
 ---
 
@@ -15,11 +19,52 @@
   branch — folded into the space-albums feature set but reviewable on its own.
 - **Depends on #752.** Everything here builds on machinery #752 already introduced: the
   `shared_space_album` link, the revocable `shared_space_album_user` grant (auto-removed on leave
-  via `shared_space_member_delete_album_audit`), the space-aware `AlbumAssetCreate` case, and the
-  `shared-space-album-scope.ts` visibility helpers. **Do not** start until #752 is stable.
-- **Line numbers** are navigation hints against `8071b039ca`; every slice re-confirms symbols in
-  the worktree before editing.
-- **Terminal state of this spec:** feed to `writing-plans` (then `impl-loop`), TDD per slice.
+  via `shared_space_member_delete_album_audit`), the space-aware `AlbumAssetCreate` case, the
+  `shared-space-album-scope.ts` visibility helpers, and the `SharedSpaceAlbum*Sync` streams. **Do
+  not** start until #752 is stable.
+- **Line numbers** are navigation hints against `8071b039ca`; **every slice re-confirms symbols in
+  the worktree before editing** — treat references as navigation, not literal coordinates.
+- **Terminal state:** feed to `/impl-loop` slice-by-slice (Slice 0 first; it's independent).
+
+### 0.1 TDD is mandatory for every slice
+
+Each fix follows this loop, and each `/impl-loop` run must show the evidence:
+
+1. **Red** — write the test(s) encoding the BDD scenario (contribution rendered / leak blocked /
+   permission denied). Run them; capture the exact command and the expected failure. A test that
+   passes on first run is a red flag — it isn't exercising the new behavior.
+2. **Green** — minimal change to pass. Capture the green command + output.
+3. **Refactor** — extract/dedupe with tests staying green.
+
+No slice is "done" without red evidence, green evidence, and a full-suite validation for the
+touched package(s).
+
+### 0.2 Test layers (per package)
+
+- **Server** — vitest **unit** (`newTestService()` auto-mocks deps, `test/utils.ts`), vitest
+  **medium** (`test:medium`, real Postgres via testcontainers, real `SyncService`/`SyncRepository`;
+  a new repository must be hand-registered in `test/medium.factory.ts`'s `newRealRepository`
+  switch), and **e2e** (`e2e/src/specs/server/api/*.e2e-spec.ts`, vitest against a running stack).
+  Prefer **medium** for anything touching SQL predicates / sync streams / triggers; **e2e** for the
+  full HTTP→emit→DB→`/sync` seam. There is already `e2e/src/specs/server/api/shared-space-album.e2e-spec.ts`
+  to extend.
+- **Web** — vitest + `@testing-library/svelte` (happy-dom) for unit; **Playwright**
+  (`e2e/src/specs/web/`, e.g. `spaces-albums.e2e-spec.ts`) for affordance/role-gating.
+- **Mobile** — `flutter test` (Drift repo + convergence). Regenerate l10n/keys first per CLAUDE.md.
+
+### 0.3 Cross-cutting conventions
+
+- **Migrations:** fork-only files in `server/src/schema/migrations-gallery/` with round timestamps
+  (e.g. `1783000000000`) that don't collide. Add a `scripts/revert-to-immich.sql` DROP entry per new
+  table. After schema/repo changes, regenerate query SQL with `make sql` **only against a scratch
+  migrated DB** — never the dev-stack DB, never without a running DB (deletes query files).
+- **Kysely transactions:** never issue `this.db` queries inside a `transaction()` callback (pool
+  deadlock).
+- **BaseService:** if a new repository is added, wire it in **all three** sites — import, constructor,
+  and the positional `static create()` list — or plugin-host services get shifted repos.
+- **SDK regen:** if any server DTO/endpoint shape changes, `make build-sdk` → `make open-api` so
+  web/mobile typecheck.
+- **No Claude co-author trailers.** One commit per slice (or per coherent fix-group within a slice).
 
 ---
 
@@ -41,14 +86,11 @@ to the album"** — and the photo is not added. Two distinct defects stacked:
    Editor can add **only their own** photos to a space album; anyone else's photo returns
    `NO_PERMISSION` for every asset.
 
-For the "Close Family" use case (most members are non-admin Editors curating a shared pool of
-photos contributed by *many* members), this makes collaborative curation impossible.
-
 ### 1.1 The trap we must avoid
 
 `AssetShare` is owner-only **by design** — it also gates **public shared links** and **memories**.
-Simply adding `checkSpaceAccess` to the global `AssetShare` case would let any space member mint a
-public link of another member's photo. **We must not widen `AssetShare`.** The fix is a narrow,
+Adding `checkSpaceAccess` to the global `AssetShare` case would let any space member mint a public
+link of another member's photo. **We must not widen `AssetShare`.** The fix is a narrow,
 album-scoped add path.
 
 ### 1.2 The new risk collaborative add introduces
@@ -65,8 +107,8 @@ ever consented to *space* sharing. Closing this is the reason for a dedicated ta
 ## 2. Goals & non-goals
 
 **Goals**
-- A space **Editor** may add any asset **space-visible to them** to an album **linked to that space**,
-  regardless of who owns the asset.
+- A space **Editor** may add any asset **space-visible to them via the album's space** to that
+  space-linked album, regardless of who owns the asset.
 - Contributed (non-owned) photos are **inert bookmarks**: access is re-derived from live space
   membership + the live album↔space link on every read; they never grant permanent access via
   `checkAlbumAccess`.
@@ -74,12 +116,12 @@ ever consented to *space* sharing. Closing this is the reason for a dedicated ta
   contribution from view (for everyone, including the album owner). Re-joining / re-linking restores it.
 - The add-to-album toast tells the truth (success / partial / failure).
 
-**Non-goals (this slice)**
+**Non-goals (this feature)**
 - No change to personal (non-space) albums or normal shared albums.
 - No widening of `AssetShare`, shared-link, or memory permissions.
 - **Viewers** stay read-only (contribute = Editor+), matching #752's `AlbumAssetCreate` role gate.
-- Not solving the sibling issues #763 (favorite for members) / #765 (fix-match no-op) here, though
-  they share the "members can't curate in a space" theme.
+- Not solving siblings #763 (favorite for members) / #765 (fix-match no-op), though they share the
+  "members can't curate in a space" theme.
 
 ---
 
@@ -98,14 +140,7 @@ The adder's **own** photos are *not* contributions — they take the ordinary `a
 ## 4. Data model
 
 New fork table `album_space_asset` (`server/src/schema/tables/album-space-asset.table.ts`) plus its
-own delete-audit table `album_space_asset_audit` (for the sync delete stream), plus a migration in
-`server/src/schema/migrations-gallery/` (round timestamp, e.g. `1783000000000`; add a
-`scripts/revert-to-immich.sql` DROP entry).
-
-> **Naming caution.** #752 already ships `shared_space_album_asset_audit` — that audits deletions of
-> **normal `album_asset`** membership in linked albums, feeding `SharedSpaceAlbumToAssetSync`. It is
-> **not** related to this table. Keep the new table's name (`album_space_asset`) and its audit
-> (`album_space_asset_audit`) distinct to avoid conflating the two.
+own delete-audit table `album_space_asset_audit` (drives the sync delete stream), plus a migration.
 
 ```
 album_space_asset  — a live-gated cross-owner contribution of a space photo into a linked album
@@ -120,9 +155,14 @@ album_space_asset  — a live-gated cross-owner contribution of a space photo in
 
 - **Not** `album_asset`, **not** `album_user`, **not** an access grant — a bookmark whose validity
   is recomputed on every read.
-- `spaceId` disambiguates albums linked to multiple spaces and drives the "from *Space*" affordance
-  and the add-eligibility check (the Editor must be an Editor of *that* space).
-- Sync columns because mobile must receive/drop these rows (see §7).
+- `spaceId` disambiguates albums linked to multiple spaces, drives the "from *Space*" affordance,
+  and pins add-eligibility (the Editor must be an Editor of *that* space, and the asset must be
+  visible via *that* space).
+- Sync columns because mobile must receive/drop these rows (§7.2).
+
+> **Naming caution.** #752 already ships `shared_space_album_asset_audit` — that audits deletions of
+> **normal `album_asset`** membership in linked albums, feeding `SharedSpaceAlbumToAssetSync`. It is
+> **unrelated** to this table. Keep `album_space_asset` / `album_space_asset_audit` distinct.
 
 ---
 
@@ -130,64 +170,58 @@ album_space_asset  — a live-gated cross-owner contribution of a space photo in
 
 ### 5.1 Adding (the #764 fix) — `AlbumService.addAssets`
 
-Replace the single `AssetShare`-gated `addAssets(...)` call with a two-bucket split *inside the
-album-add path only* (no change to the generic `asset.util.ts` used by shared-links/memories):
+Two-bucket split *inside the album-add path only* (no change to generic `asset.util.ts` used by
+shared-links/memories):
 
 1. Resolve the album's live space link(s) the adder is an **Editor** of:
-   `shared_space_album ⋈ shared_space_member(role ∈ {owner, editor})` for `auth.user.id`. If none,
-   behavior is unchanged from today (owner-only add).
-2. For each requested asset, in order of precedence:
+   `shared_space_album ⋈ shared_space_member(role ∈ {owner, editor})` for `auth.user.id`.
+2. Per requested asset, in precedence order:
    - **Owned / AssetShare-eligible** → normal `album_asset` insert (unchanged path).
-   - **Not owned, but space-visible to the adder via an eligible space `S`** → insert into
-     `album_space_asset (album, asset, S, addedById=auth.user.id)`.
-     "Space-visible to the adder via S" reuses `shared-space-album-scope.ts`
-     `spaceAssetPathBranches` (direct `shared_space_asset` ∪ linked-library ∪ linked-album arms)
-     scoped to `{ memberUserId: auth.user.id, memberRole: [owner, editor], spaceId: S }`.
-   - **Already present** in `album_asset` *or* `album_space_asset` → `DUPLICATE`.
+   - **Not owned, but space-visible to the adder via an eligible space `S`** → insert
+     `album_space_asset(album, asset, S, addedById=auth.user.id)`. "Space-visible via S" reuses
+     `shared-space-album-scope.ts` `spaceAssetPathBranches` (direct `shared_space_asset` ∪
+     linked-library ∪ linked-album arms) scoped to
+     `{ memberUserId: auth.user.id, memberRole: [owner, editor], spaceId: S }`.
+   - **Already in** `album_asset` *or* `album_space_asset` → `DUPLICATE`.
    - **Otherwise** → `NO_PERMISSION`.
 3. Return a merged `BulkIdResponseDto[]` across both buckets (per-asset outcome preserved).
 
-An asset never lands in both tables (each asset has exactly one owner → exactly one eligible path).
+An asset never lands in both tables (each asset has one owner → one eligible path).
 
 ### 5.2 Reading — extend the album visibility arm
 
-`album_space_asset` becomes a **fourth arm** of space visibility, parallel to
-`spaceDirectAssetExists` / `spaceLibraryAssetExists` / `spaceAlbumAssetExists`. Add
-`spaceContributedAssetExists(eb, { correlateAssetId, scope })` to `shared-space-album-scope.ts`:
+Add `spaceContributedAssetExists(eb, { correlateAssetId, scope })` to `shared-space-album-scope.ts`
+as a **fourth arm** parallel to `spaceDirectAssetExists` / `spaceLibraryAssetExists` /
+`spaceAlbumAssetExists`:
 
 ```
 EXISTS (
   SELECT 1 FROM album_space_asset asa
-  JOIN shared_space_album ssa  ON ssa.albumId = asa.albumId AND ssa.spaceId = asa.spaceId   -- link still live
-  JOIN album a                 ON a.id = asa.albumId AND a.deletedAt IS NULL
-  [membership scope]           JOIN shared_space_member m ON m.spaceId = asa.spaceId
-                                 AND m.userId = :viewer  [AND m.role IN (:roles)]
+  JOIN shared_space_album ssa ON ssa.albumId = asa.albumId AND ssa.spaceId = asa.spaceId   -- link live
+  JOIN album a                ON a.id = asa.albumId AND a.deletedAt IS NULL
+  [membership scope]          JOIN shared_space_member m ON m.spaceId = asa.spaceId
+                                AND m.userId = :viewer  [AND m.role IN (:roles)]
   WHERE asa.assetId = <correlateAssetId>
     [AND asa.spaceId = :scopeSpaceId]
 )
 ```
 
-- Unlink the album → no `shared_space_album` row → excluded (reversible on re-link).
-- Viewer leaves the space → no `shared_space_member` row → excluded (reversible on re-join).
-- Because the row is *not* in `album_asset`, the owner's `checkAlbumAccess` never sees it → no
-  permanent grant, no leak via external album sharing / public links.
-
-**Album contents** become `album_asset ∪ spaceContributedAssetExists(...)`, deduped by `assetId`.
-Wire the new arm into every place #752 already routes the album arm: **album detail/grid, asset
-count, thumbnail selection, the space aggregated timeline (respecting `showInTimeline`), download,
-activity, and in-album search.** (This is the largest surface area of the change — audit each
-consumer of `spaceAlbumAssetExists` / `spaceAssetPathBranches`.)
+Because the row is *not* in `album_asset`, the owner's `checkAlbumAccess` never sees it → no
+permanent grant. **Album contents** = `album_asset ∪ spaceContributedAssetExists(...)`, deduped by
+`assetId`. Wire into every consumer of `spaceAlbumAssetExists` / `spaceAssetPathBranches`: album
+detail/grid, asset count, thumbnail, the space aggregated timeline (respecting `showInTimeline`),
+download, activity, in-album search. (Largest surface — Slices 2–3.)
 
 ### 5.3 Removing — `AlbumService.removeAssets`
 
-Removing a contributed asset = delete the `album_space_asset` row (never touches the asset).
-Permitted for the **album owner**, any **space Editor** of the linked space, and the **contributor**.
-Add a space-aware branch alongside the existing `AssetShare` / `AlbumAssetDelete` (`canAlwaysRemove`)
-logic. Removal of an ordinary `album_asset` row is unchanged.
+Removing a contribution = delete the `album_space_asset` row (never touches the asset). Permitted for
+the **album owner**, any **space Editor** of the linked space, and the **contributor**. Space-aware
+branch alongside the existing `AssetShare` / `AlbumAssetDelete` (`canAlwaysRemove`) logic. Removing
+an ordinary `album_asset` row is unchanged.
 
 ---
 
-## 6. Lifecycle & edge cases
+## 6. Lifecycle & edge cases (assertion source for the slices)
 
 | Event | Effect on a contribution `(album L, asset A, space S)` |
 |---|---|
@@ -196,8 +230,10 @@ logic. Removal of an ordinary `album_asset` row is unchanged.
 | Space S deleted | Row deleted (FK `spaceId` CASCADE). |
 | Album L deleted | Row deleted (FK `albumId` CASCADE). |
 | Asset A deleted | Row deleted (FK `assetId` CASCADE). |
-| Album L shared outside S (external `album_user` / public link) | Non-space viewers **never** see A (arm keys on *viewer's* live membership). No leak. |
-| Owner opens L after leaving S / after unlink | A is gone for the owner too (owner reaches contributions only via the space arm, not `album_asset`). |
+| Owner un-shares A from the space's **general pool** (`shared_space_asset` delete), A not deleted | **Row stays** (§8 default 1); A still renders in L for members. |
+| `addedById` user deleted | Row survives (`SET NULL`); affordance shows "unknown". |
+| Album L shared outside S (external `album_user` / public link) | Non-space viewers **never** see A. |
+| Owner opens L after leaving S / after unlink | A is gone for the owner too (reaches contributions only via the space arm). |
 
 ---
 
@@ -205,67 +241,329 @@ logic. Removal of an ordinary `album_asset` row is unchanged.
 
 ### 7.1 Web
 - **Add flow:** the existing "Add to album or space" picker + `addAssetsToAlbums` already targets
-  space-linked albums; no picker change needed — the server now accepts non-owned assets for
-  eligible albums.
-- **Toast (fixes #764's literal title):** `notifyAddToAlbum` must branch on result counts —
-  `success` (all added), `info`/warning (partial), `warning`/`error` (none added) — instead of an
-  unconditional `toastManager.primary`. **Standalone**; can land first, independent of the backend.
-- **Legibility:** a "from *Space name*" affordance on contributed tiles in the album view (we have
-  `spaceId` → space name), so the "these can disappear when you leave/unlink" behavior is understood.
-  Contributed tiles are **not** owned by the viewer → respect existing non-owner asset affordances.
+  space-linked albums; no picker change — the server now accepts non-owned assets for eligible albums.
+- **Toast (fixes #764's literal title):** `notifyAddToAlbum` branches on result counts — success
+  (all added), info/warning (partial), warning/error (none) — instead of unconditional
+  `toastManager.primary`. **Standalone** (Slice 0).
+- **Legibility:** a "from *Space name*" affordance on contributed tiles (we have `spaceId` → space
+  name), so "these can disappear" is understood. Contributed tiles are non-owned → respect existing
+  non-owner asset affordances.
 
 ### 7.2 Mobile / sync
-- `album_space_asset` carries sync watermarks. Contributions are album→asset **membership edges**, so
-  extend **`SharedSpaceAlbumToAssetSync`** (`sync.repository.ts:1609`) to union `album_space_asset`
-  inserts, with deletes driven by the new `album_space_asset_audit` stream. The contributed asset's
-  **payload + exif** (owned by another member) must also reach the client: include
-  `album_space_asset`-reachable assets in **`SharedSpaceAlbumAssetSync`** (`:1689`) and
-  **`SharedSpaceAlbumAssetExifSync`** (`:1763`), mirroring how the existing linked-album arm streams
-  `album_asset`-reachable assets. Register a new `SyncEntityType`/`SyncRequestType` pair
-  (e.g. `SharedSpaceAlbumContributions*`) if the membership edge needs a distinct stream from
+- Contributions are album→asset **membership edges**: extend **`SharedSpaceAlbumToAssetSync`**
+  (`sync.repository.ts:1609`) to union `album_space_asset` inserts, deletes driven by the new
+  `album_space_asset_audit` stream. The contributed asset's **payload + exif** (owned by another
+  member) must also reach the client: include `album_space_asset`-reachable assets in
+  **`SharedSpaceAlbumAssetSync`** (`:1689`) and **`SharedSpaceAlbumAssetExifSync`** (`:1763`),
+  mirroring how the linked-album arm streams `album_asset`-reachable assets. Add a distinct
+  `SyncEntityType`/`SyncRequestType` pair if the edge needs its own stream from
   `SharedSpaceAlbumToAssetsV1`.
-- Contributions render read-through-space like the rest of a space album; tap-through respects the
-  same owner/role gating already in place.
+- Contributions render read-through-space; tap-through respects existing owner/role gating.
 
 ---
 
 ## 8. Open sub-decisions (defaults chosen; confirm at review)
 
-1. **Un-share vs. curated life.** If the asset's owner *removes A from the space's general pool*
-   (a `shared_space_asset` delete) but does not delete A, does A stay in albums it was curated into?
-   **Default: yes, stays** — a contribution has its own life tethered to space S, not to the source
-   arm it came from; only delete / unlink / leave / space-deletion remove it. (Alternative: also
-   require A to be independently space-visible at read time — stronger for the owner, but makes
-   curated album content fragile.)
-2. **Contributions into externally-shared albums.** Allowed — the per-viewer arm makes it safe
-   (non-space viewers never see contributions). No block needed.
-3. **Multi-space albums.** `spaceId` pins provenance; a contribution is visible to members of *its*
-   space. An album linked to two spaces can hold contributions tagged to each; each is gated
-   independently. No dedup needed beyond `assetId` at read time.
+1. **Un-share vs. curated life.** Owner removes A from the space's *general pool* but not delete →
+   **Default: A stays** in albums it was curated into (contribution tethered to S, not to the source
+   arm). Alternative: also require A independently space-visible at read time (stronger for the
+   owner, fragile curation). *If flipped, the read arm in §5.2 gains an extra `spaceAssetPath`
+   existence condition and the Slice 3 lifecycle test inverts.*
+2. **Contributions into externally-shared albums.** Allowed — per-viewer arm keeps it safe.
+3. **Multi-space albums.** `spaceId` pins provenance; visible to members of *its* space; each link
+   gated independently; dedup by `assetId` at read time.
 
 ---
 
-## 9. Slice outline (detail → `writing-plans`)
+## 9. Slice overview
 
-1. **Toast honesty** (web, standalone). Red: a `notifyAddToAlbum` unit test asserting a 0-success
-   result yields a non-success toast. Green: branch on counts.
-2. **Schema + migration.** `album_space_asset` + `album_space_asset_audit` tables + migration +
-   `revert-to-immich.sql` entry + audit trigger wiring. Medium test: insert/read/cascade behavior.
-3. **Add path.** `AlbumService.addAssets` two-bucket split + repository method. Medium/e2e: Editor
-   adds a non-owned space photo → row in `album_space_asset`, `success: true`; Viewer → denied;
-   non-space asset → `NO_PERMISSION`; owned asset still → `album_asset`.
-4. **Read arm.** `spaceContributedAssetExists` + wire into album grid/count/thumbnail/timeline/
-   download/activity/search. Medium: leave/unlink hides; owner has no permanent access; external
-   share doesn't leak.
-5. **Remove path.** Space-aware `removeAssets` branch. Medium: owner/editor/contributor can remove;
-   viewer cannot.
-6. **Sync.** Extend `SharedSpaceAlbumToAssetSync` (membership edge) + `SharedSpaceAlbumAssetSync` /
-   `SharedSpaceAlbumAssetExifSync` (contributed asset payload/exif) for `album_space_asset`
-   insert/delete via `album_space_asset_audit`. Medium: sync stream carries contribution + payload +
-   audit-driven removal.
-7. **Web UX.** "from *Space*" affordance + Playwright role-gating (Editor sees add succeed, Viewer
-   has no add).
-8. **SDK/regen** if any DTO/endpoint shape changes; `make build-sdk` → `make open-api`.
+| # | Slice | Layers | Depends on | Independent ship? |
+|---|---|---|---|---|
+| 0 | Honest add-to-album toast (fixes #764 title) | web unit | — | ✅ land anytime |
+| 1 | Schema foundation: `album_space_asset` + audit + migration | server medium | — | foundation |
+| 2 | Contribute a non-owned space photo (add path + album grid & count) | server e2e + medium | 1 | ✅ vertical MVP |
+| 3 | Contributions across remaining album surfaces + leak/lifecycle negatives | server medium + e2e | 2 | extends 2 |
+| 4 | Remove a contribution | server e2e + medium | 2 | ✅ vertical |
+| 5 | Mobile sync of contributions | server medium + mobile | 2, 3 | ✅ vertical |
+| 6 | Web legibility affordance + role-gating | web unit + Playwright | 2 | ✅ vertical |
 
-Each slice is TDD (red → green → refactor) with full-suite validation for touched packages before
-"done". No Claude co-author trailers.
+Ordering: **0** anytime; **1 → 2 → {3, 4, 5, 6}**. Each `/impl-loop` run does one slice, TDD.
+
+---
+
+## Slice 0 — Honest add-to-album toast
+
+**Delivers.** #764's literal title: a failed or partial add never renders as a green "Successful".
+Pure web; independent of the backend feature.
+
+**Behavior (BDD)**
+- *Given* an add-to-album request where the server returns **0 successes** (all `NO_PERMISSION`),
+  *When* `notifyAddToAlbum` runs, *Then* a **non-success** toast (warning/error) shows "…cannot be
+  added…" — never the green success heading.
+- *Given* a result where **all assets were duplicates**, *When* it runs, *Then* an **info** toast
+  says "already in the album".
+- *Given* a **partial** result (some success, some fail), *When* it runs, *Then* an **info/warning**
+  toast states the partial count.
+- *Given* **all** assets succeed, *When* it runs, *Then* the success toast + "View album" button
+  (unchanged behavior).
+
+**TDD — red first**
+- **Web unit** (`web/src/lib/services/album.service.spec.ts`): mock `toastManager`; feed
+  `notifyAddToAlbum` each result shape; assert the **method called** (`error`/`warning`/`info`/`primary`)
+  and message key. Red today because the current code always calls `.primary`.
+
+**Fix (green).** Branch `notifyAddToAlbum` on `successCount` / `duplicateCount` / `assetIds.length`
+to select the toast severity + message; keep "View album" on any run that produced ≥1 success.
+
+**Edge cases (explicit assertions)**
+- 0 success, 0 duplicate → error/warning (not primary).
+- 0 success, all duplicate → info "already part of album".
+- Mixed success + duplicate + no-permission → partial wording, "View album" present.
+- All success → primary + "View album" (regression).
+- `notifyAddToAlbums` (multi-album path) audited for the same lie; fix if present.
+
+**Green.** All shapes assert the correct severity; existing album.service web tests stay green;
+`pnpm --filter immich-web test` + `check:typescript` clean.
+
+---
+
+## Slice 1 — Schema foundation: `album_space_asset` (+ audit, migration)
+
+**Delivers.** The storage substrate + cascade/audit guarantees. No user-facing behavior yet
+(the one non-vertical slice); fully covered by medium tests on the live schema.
+
+**Behavior (BDD)**
+- *Given* a linked album, asset, and space, *When* an `album_space_asset` row is inserted, *Then* it
+  persists with sync watermarks and is readable by `(albumId, assetId)`.
+- *Given* an `album_space_asset` row, *When* its **album** / **asset** / **space** is deleted,
+  *Then* the row is **cascade-deleted**; *When* its `addedById` user is deleted, *Then* the row
+  **survives** with `addedById = NULL`.
+- *Given* an `album_space_asset` row is deleted, *When* the delete commits, *Then* an
+  `album_space_asset_audit` row is emitted (for the sync delete stream in Slice 5).
+
+**TDD — red first**
+- **Medium** (`server/test/medium/specs/…`): create the table via migration on the testcontainers
+  DB; assert insert/read; assert each FK cascade/SET-NULL; assert the audit row on delete. Red
+  because table/trigger don't exist.
+
+**Fix (green).**
+- `album-space-asset.table.ts` + `album-space-asset-audit.table.ts` (mirror `shared_space_asset` +
+  its audit trigger pattern).
+- Migration in `migrations-gallery/` (round timestamp); `revert-to-immich.sql` DROP entries for both
+  tables; register the repository (if any) in `medium.factory.ts` and BaseService (all three sites).
+- Regenerate query SQL against a scratch migrated DB.
+
+**Edge cases**
+- Duplicate `(albumId, assetId)` insert → PK conflict handled (`onConflict do nothing`), not a 500.
+- Audit trigger fires on **statement**-level bulk delete (not just row) — assert multi-row delete.
+- Migration applies cleanly on a DB that already has all #752 migrations (unordered-migration path).
+
+**Green.** Medium schema suite green; `make sql` diff limited to the new tables; server `check` clean.
+
+---
+
+## Slice 2 — Contribute a non-owned space photo (add path + album grid & count)
+
+**Delivers.** The core loop end-to-end: an Editor adds a photo they don't own to a space-linked
+album and **sees it in the album grid**, gated on live membership. This is the #764 capability.
+
+**Behavior (BDD)** — space S; Alice owns album L linked to S; Bob is an Editor of S; asset X is in S
+owned by Carol.
+- *Given* Bob (Editor), *When* Bob adds X to L, *Then* the response is `success:true` for X and an
+  `album_space_asset(L, X, S, addedBy=Bob)` row exists — **not** an `album_asset` row.
+- *Given* the contribution exists, *When* any live member of S opens L, *Then* X appears in the grid
+  and the asset **count includes** X.
+- *Given* Bob adds **his own** asset Y (in S) to L, *When* it runs, *Then* Y takes the **`album_asset`**
+  path (`success:true`), unchanged.
+- *Given* a **Viewer** V of S, *When* V tries to add X to L, *Then* the add is **denied**
+  (`AlbumAssetCreate` role gate) — no row created.
+- *Given* asset Z **not in S**, *When* Bob adds Z to L, *Then* **`NO_PERMISSION`** for Z — no row.
+- *Given* X is already in L (as contribution or owned), *When* Bob adds X again, *Then* **`DUPLICATE`**.
+- *Given* a mixed batch {X (non-owned, in S), Y (Bob-owned, in S), Z (not in S)}, *When* Bob adds
+  them, *Then* per-asset `{X:success, Y:success, Z:no_permission}` and a partial `BulkIdResponse`.
+
+**TDD — red first**
+- **e2e** (`shared-space-album.e2e-spec.ts`): the seven scenarios above through the real HTTP add
+  endpoint + a follow-up album read asserting X present/absent. Red because add returns
+  `NO_PERMISSION` for non-owned assets today.
+- **Medium**: the read arm `spaceContributedAssetExists` returns X for a member and **not** for a
+  non-member; album count reflects it.
+- **Unit** (`album.service.spec.ts`): the two-bucket split routes owned→`album_asset`,
+  non-owned-space-visible→`album_space_asset`, others→`NO_PERMISSION`.
+
+**Fix (green).**
+- `AlbumService.addAssets` two-bucket split (§5.1) + an `albumSpaceAsset` repository insert.
+- `spaceContributedAssetExists` helper (§5.2); wire into the album **grid** query and **asset count**.
+- Emit `AlbumAssetsAdd` for contributed ids too (event parity with the owned path).
+
+**Edge cases (explicit assertions)**
+- Asset visible to Bob via **each** arm — direct pool, linked library, linked album — is all eligible.
+- Asset visible to Bob only via a **different** space T (album L not linked to T) → `NO_PERMISSION`
+  (eligibility requires visibility via **L's** space).
+- Album linked to **no** space Bob edits → non-owned add → `NO_PERMISSION` (owner-only unchanged).
+- **Leak negative (critical):** setup Alice as an **Editor member** of S (not the creator) who owns
+  album L and links it into S. After Bob contributes X, Alice's `checkAlbumAccess`-backed reads of X
+  resolve **only while she is a live member of S** — assert Alice loses X the moment she is removed
+  from S while L stays linked (other members still see X), proving no permanent `album_asset` grant.
+  Complementary assertion via **unlink** (L removed from S) — owner loses contributions too.
+- Concurrent duplicate add (two editors add X at once) → one row, one `success`, one `DUPLICATE`;
+  no 500.
+
+**Green.** All e2e/medium/unit above green; existing album + space-album suites green.
+
+---
+
+## Slice 3 — Contributions across remaining album surfaces + leak/lifecycle negatives
+
+**Delivers.** Contributions behave correctly everywhere a space album is read, and every
+lifecycle/leak guarantee from §6 is asserted.
+
+**Behavior (BDD)**
+- *Given* a contribution X in L with `showInTimeline=true`, *When* a member views the **space
+  timeline**, *Then* X appears; *When* `showInTimeline=false`, *Then* X is absent.
+- *Given* a member **downloads** L, *When* the archive builds, *Then* X is included; a non-member's
+  download excludes it.
+- *Given* a member **searches within** L, *When* the query matches X, *Then* X is returned.
+- *Given* L's **thumbnail** is a contributed asset and the viewer is a non-member, *When* L renders
+  in a list, *Then* no 500 and no leaked thumbnail (falls back gracefully).
+- *Given* **album activity** (comments/likes), *When* a space-only reader loads L, *Then* activity
+  still respects #752's direct-access gate (contributions don't widen it).
+- **Lifecycle negatives:** *leave S* → X hidden; *rejoin* → X visible; *unlink L from S* → X hidden
+  for all incl. owner; *relink* → visible; *delete X / L / S* → row gone; *owner un-shares X from
+  general pool but keeps it* → X **stays** in L (§8 default 1).
+- **External-share negative:** *Given* Alice shares L via public link / external `album_user`, *When*
+  a non-space viewer opens it, *Then* contributions are **absent** (owned assets still present).
+
+**TDD — red first**
+- **Medium/e2e** per surface (timeline, download, activity, search, thumbnail) + the full lifecycle
+  and external-share negatives. Red because those surfaces only union `album_asset` today.
+
+**Fix (green).** Wire `spaceContributedAssetExists` into each remaining consumer of
+`spaceAlbumAssetExists` / `spaceAssetPathBranches`; make thumbnail selection resilient when the only
+candidates are contributions the viewer can't currently see.
+
+**Edge cases**
+- Dedup: an asset present in both `album_asset` and `album_space_asset` (shouldn't happen, but assert
+  read returns it **once**).
+- `showInTimeline` toggled after contribution → timeline visibility flips accordingly.
+- Count/thumbnail recompute correctly after a contribution is hidden by leave/unlink.
+- Activity gate (security-8 from #752) unchanged for space-only readers.
+
+**Green.** All surface + lifecycle + leak negatives green; #752 visibility-hardening suites green.
+
+---
+
+## Slice 4 — Remove a contribution
+
+**Delivers.** Collaborative removal, correctly role-gated.
+
+**Behavior (BDD)** — contribution `(L, X, S)` by Bob.
+- *Given* Alice (album **owner**), *When* she removes X from L, *Then* the `album_space_asset` row is
+  deleted, X leaves L, and asset X itself is untouched.
+- *Given* Bob (the **contributor**), *When* he removes X, *Then* deleted.
+- *Given* another space **Editor** Dave, *When* he removes X, *Then* deleted.
+- *Given* a space **Viewer** V, *When* V tries to remove X, *Then* **denied**; row stays.
+- *Given* a **non-member**, *When* they try, *Then* **denied**.
+- *Given* removal of an **owned** `album_asset` row, *When* it runs, *Then* unchanged behavior.
+
+**TDD — red first**
+- **e2e/medium**: the six cases through the remove endpoint; assert row presence/absence and that
+  the asset row persists. Red because the current remove path has no `album_space_asset` branch.
+
+**Fix (green).** Space-aware branch in `AlbumService.removeAssets` / the `removeAssets` util caller:
+resolve the row's `spaceId`, allow if owner ∨ space-Editor ∨ contributor; delete the row (emit
+`AlbumAssetsRemove` + audit).
+
+**Edge cases**
+- Removing X that is **not present** → `NOT_FOUND` (not 500).
+- Editor of a **different** space (not L's) → denied.
+- Contributor who has since **left** S → still allowed to remove their own bookmark? **Default: no**
+  (no live membership → treated as non-member). Assert.
+
+**Green.** All cases green; existing remove suite green.
+
+---
+
+## Slice 5 — Mobile sync of contributions
+
+**Delivers.** Contributions appear/disappear on mobile via the sync streams, with payload+exif.
+
+**Behavior (BDD)**
+- *Given* a new contribution `(L, X, S)`, *When* a member's client syncs, *Then* the membership edge
+  **and** X's payload + exif arrive; X renders in L on device.
+- *Given* the contribution is removed (Slice 4) or the member leaves S, *When* the client syncs,
+  *Then* the edge is deleted via the audit stream and X leaves L on device.
+- *Given* a member **joins** S which already has contributions, *When* they sync from scratch,
+  *Then* they **backfill** all contributions (watermark `createId` walk).
+
+**TDD — red first**
+- **Medium** (`SyncService`/`SyncRepository` against testcontainers): assert
+  `SharedSpaceAlbumToAssetSync` emits the contribution edge; `SharedSpaceAlbumAssetSync` /
+  `…ExifSync` emit X's payload/exif; the audit stream emits the delete; backfill covers pre-existing
+  rows. Red because these streams only union `album_asset` today.
+- **Mobile** (`flutter test`): a convergence test — apply insert then delete events, assert the Drift
+  album membership converges (X present then absent).
+
+**Fix (green).** Union `album_space_asset` into the three sync classes (§7.2); wire
+`album_space_asset_audit` into the delete stream; register any new `SyncEntityType`/`RequestType`.
+
+**Edge cases**
+- Leaving S removes edges via audit **without** deleting X's underlying asset payload if X is still
+  visible via another path (assert no spurious asset deletion).
+- Re-link / re-join re-emits the edges (idempotent apply on device).
+- Ack-watermark monotonicity: no duplicate emissions after ack.
+
+**Green.** Medium sync + mobile convergence green; existing space-album sync suites green.
+
+---
+
+## Slice 6 — Web legibility affordance + role-gating
+
+**Delivers.** Contributed tiles are legible and the add affordance is correctly role-gated in the UI.
+
+**Behavior (BDD)**
+- *Given* a member views L, *When* a tile is a contribution, *Then* it shows a **"from *Space*"**
+  affordance (source space name) and the standard **non-owner** asset affordances (no owner-only
+  actions).
+- *Given* an **Editor** in the space, *When* they open the add-to-album flow for a space photo they
+  don't own, *Then* the add **succeeds** (end-to-end).
+- *Given* a **Viewer**, *When* they view space assets, *Then* the "add to this album" affordance is
+  **absent/disabled** (no dead-end).
+
+**TDD — red first**
+- **Web unit**: the tile renders the "from *Space*" label when given a contributed asset with a
+  `spaceId`/space name.
+- **Playwright** (`spaces-albums.e2e-spec.ts`): Editor add succeeds and the tile shows the badge;
+  Viewer has no add affordance. (Role-badge assertions use `{ ignoreCase: true }` per the known
+  lowercase-enum + CSS-capitalize gotcha.)
+
+**Fix (green).** Thread the source-space name onto contributed tiles; render the affordance; ensure
+the add action is hidden/disabled for Viewers.
+
+**Edge cases**
+- `addedById = NULL` (contributor deleted) → affordance still renders (space name only).
+- Contribution that becomes hidden mid-session (owner unlink) → tile disappears on refresh without error.
+- Album shared externally opened by a non-space viewer → no badge, no contribution tiles.
+
+**Green.** Web unit + Playwright green; `pnpm --filter immich-web lint` (tolerated tailwind warnings)
++ `check:typescript` clean.
+
+---
+
+## 10. Global acceptance criteria
+
+- A space Editor can add a non-owned, space-visible photo to a space-linked album; a Viewer cannot.
+- Contributed photos render in every album surface for live members and **nowhere** for
+  non-members — including the album owner once their space access ends, and including external
+  album shares / public links.
+- Leaving/unlinking/deleting behaves exactly per the §6 table; re-join/re-link is reversible.
+- The add-to-album toast never reports success when nothing was added.
+- Mobile converges with contribution insert/delete/backfill.
+- Full-suite green for every touched package; no widening of `AssetShare`/shared-link/memory
+  permissions (assert an unrelated shared-link e2e still owner-gates).
+
+## 11. Out of scope
+
+- Personal (non-space) album cross-owner adds; normal shared-album semantics.
+- Issues #763 / #765 (separate "member curation" work).
+- Any change to who may **link/unlink** an album to a space (that's #752's remit).

--- a/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
+++ b/docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md
@@ -1,6 +1,6 @@
 # Collaborative Cross-Owner Contributions to Space Albums — Design Spec (2026-07-10)
 
-> **Purpose.** Let any space **Editor** add *any space-visible photo* — including photos they do
+> **Purpose.** Let any space **Editor** add _any space-visible photo_ — including photos they do
 > not own — to a space-linked album, collaboratively, while keeping every contributed photo
 > tethered to live space access (it vanishes the instant the contributor's/viewer's space access
 > ends or the album is unlinked, and it never becomes a permanent grant the album owner can carry
@@ -81,8 +81,8 @@ to the album"** — and the photo is not added. Two distinct defects stacked:
 2. **The add is genuinely blocked for non-owned assets.** `addAssets` (`server/src/utils/asset.util.ts`)
    gates every asset on `Permission.AssetShare`, which resolves (`server/src/utils/access.ts`) through
    **owner + partner only** — no space path (unlike `AssetRead`/`AssetView`/`AssetDownload` →
-   `checkSpaceAccess`, and `AssetUpdate` → `checkSpaceEditAccess`). #752 made the *album-level*
-   `AlbumAssetCreate` space-aware, but the *per-asset* `AssetShare` gate is untouched. So a space
+   `checkSpaceAccess`, and `AssetUpdate` → `checkSpaceEditAccess`). #752 made the _album-level_
+   `AlbumAssetCreate` space-aware, but the _per-asset_ `AssetShare` gate is untouched. So a space
    Editor can add **only their own** photos to a space album; anyone else's photo returns
    `NO_PERMISSION` for every asset.
 
@@ -95,18 +95,19 @@ album-scoped add path.
 
 ### 1.2 The new risk collaborative add introduces
 
-The moment Bob can add *Carol's* photo to *Alice's* album, Carol's photo sits in an album Alice
+The moment Bob can add _Carol's_ photo to _Alice's_ album, Carol's photo sits in an album Alice
 **owns**. In upstream Immich, being in an album you own is a **permanent** view grant
-(`checkAlbumAccess`). Space *members* are safe (their album grant is revoked on leave), but the
+(`checkAlbumAccess`). Space _members_ are safe (their album grant is revoked on leave), but the
 album **owner** — and any direct `album_user` participant — keeps access forever and can carry it
 **out of the space** (unlink the album, add an external album user, mint a public link). Carol only
-ever consented to *space* sharing. Closing this is the reason for a dedicated table (§4).
+ever consented to _space_ sharing. Closing this is the reason for a dedicated table (§4).
 
 ---
 
 ## 2. Goals & non-goals
 
 **Goals**
+
 - A space **Editor** may add any asset **space-visible to them via the album's space** to that
   space-linked album, regardless of who owns the asset.
 - Contributed (non-owned) photos are **inert bookmarks**: access is re-derived from live space
@@ -117,6 +118,7 @@ ever consented to *space* sharing. Closing this is the reason for a dedicated ta
 - The add-to-album toast tells the truth (success / partial / failure).
 
 **Non-goals (this feature)**
+
 - No change to personal (non-space) albums or normal shared albums.
 - No widening of `AssetShare`, shared-link, or memory permissions.
 - **Viewers** stay read-only (contribute = Editor+), matching #752's `AlbumAssetCreate` role gate.
@@ -131,7 +133,7 @@ ever consented to *space* sharing. Closing this is the reason for a dedicated ta
 > the album is still linked to that space **and** the viewer is a live member of that space. It is
 > never stored in `album_asset`, so `checkAlbumAccess` can never turn it into a permanent grant.
 
-The adder's **own** photos are *not* contributions — they take the ordinary `album_asset` path
+The adder's **own** photos are _not_ contributions — they take the ordinary `album_asset` path
 (standard "I shared my photo into a collaborative album"). The new table only ever holds the
 "photo I don't own" case.
 
@@ -155,9 +157,9 @@ album_space_asset  — a live-gated cross-owner contribution of a space photo in
 
 - **Not** `album_asset`, **not** `album_user`, **not** an access grant — a bookmark whose validity
   is recomputed on every read.
-- `spaceId` disambiguates albums linked to multiple spaces, drives the "from *Space*" affordance,
-  and pins add-eligibility (the Editor must be an Editor of *that* space, and the asset must be
-  visible via *that* space).
+- `spaceId` disambiguates albums linked to multiple spaces, drives the "from _Space_" affordance,
+  and pins add-eligibility (the Editor must be an Editor of _that_ space, and the asset must be
+  visible via _that_ space).
 - Sync columns because mobile must receive/drop these rows (§7.2).
 
 > **Naming caution.** #752 already ships `shared_space_album_asset_audit` — that audits deletions of
@@ -173,39 +175,41 @@ album_space_asset  — a live-gated cross-owner contribution of a space photo in
 Two **independent** role systems: **space** `SharedSpaceRole` = Owner / Editor / Viewer
 (`shared_space_member.role`) and **album** `AlbumUserRole` = Owner / Editor / Viewer (`album_user`).
 
-| Operation | Allowed for | Enforced by |
-|---|---|---|
-| **View** a contribution (grid / count / timeline / download / search) | any **live member** of the album's linked space — Owner/Editor/**Viewer** | read arm joins `shared_space_member` with **no role filter** (mirrors `checkSpaceLinkedAlbumReadAccess`, `access.repository.ts:165`) |
-| **Contribute** a **non-owned** photo | space **Owner/Editor** of the album's linked space **S**, *and* the asset is space-visible to them via **S** *and* passes the visibility gate | album-level `AlbumAssetCreate` (#752 `role IN [owner,editor]`, `access.repository.ts:158` — **throws 403 for Viewers**) **+** per-asset eligibility (§5.1) |
-| **Contribute** an **owned** photo | space **Owner/Editor** (album-level gate) → normal `album_asset` | `AlbumAssetCreate` + `AssetShare` (owner) |
-| **Remove** a contribution | album **Owner/Editor** OR live space **Owner/Editor** of S | `AlbumAssetDelete` (#752 made it space-editor-aware) + row delete |
-| **Link / unlink** album ↔ space | out of scope (#752) | — |
+| Operation                                                             | Allowed for                                                                                                                                   | Enforced by                                                                                                                                                |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **View** a contribution (grid / count / timeline / download / search) | any **live member** of the album's linked space — Owner/Editor/**Viewer**                                                                     | read arm joins `shared_space_member` with **no role filter** (mirrors `checkSpaceLinkedAlbumReadAccess`, `access.repository.ts:165`)                       |
+| **Contribute** a **non-owned** photo                                  | space **Owner/Editor** of the album's linked space **S**, _and_ the asset is space-visible to them via **S** _and_ passes the visibility gate | album-level `AlbumAssetCreate` (#752 `role IN [owner,editor]`, `access.repository.ts:158` — **throws 403 for Viewers**) **+** per-asset eligibility (§5.1) |
+| **Contribute** an **owned** photo                                     | space **Owner/Editor** (album-level gate) → normal `album_asset`                                                                              | `AlbumAssetCreate` + `AssetShare` (owner)                                                                                                                  |
+| **Remove** a contribution                                             | album **Owner/Editor** OR live space **Owner/Editor** of S                                                                                    | `AlbumAssetDelete` (#752 made it space-editor-aware) + row delete                                                                                          |
+| **Link / unlink** album ↔ space                                       | out of scope (#752)                                                                                                                           | —                                                                                                                                                          |
 
 **Non-bypass rules (assert each as an explicit negative test):**
-- **Viewers never write.** A space Viewer is hard-blocked at `AlbumAssetCreate` (403) *before* any
+
+- **Viewers never write.** A space Viewer is hard-blocked at `AlbumAssetCreate` (403) _before_ any
   per-asset logic runs — they can contribute neither their own nor others' photos.
 - **Album role ≠ space rights.** A direct `album_user` **editor** who is **not** a space member
   cannot contribute non-owned space assets (own → `album_asset`; others' → `NO_PERMISSION`). Album
   ownership does **not** bypass the space-Editor requirement for pulling in others' photos.
-- **Same space for all three.** Eligibility requires a *single* space **S** where the album is
+- **Same space for all three.** Eligibility requires a _single_ space **S** where the album is
   linked to S, the adder is Owner/Editor of S, **and** the asset is space-visible via S. An asset
-  visible only via a *different* space the adder edits is **not** contributable here — no
+  visible only via a _different_ space the adder edits is **not** contributable here — no
   cross-space smuggling.
 
 **Visibility gate (critical — a leak vector if missed).** The space-visibility arms
 (`spaceAssetPathBranches`) do **not** exclude Hidden/Locked assets on their own — `spaceVisibilityGate`
-(`[Archive, Timeline]` only; `shared-space-album-scope.ts:42`) is applied *separately* at each call
+(`[Archive, Timeline]` only; `shared-space-album-scope.ts:42`) is applied _separately_ at each call
 site (this was #752 remediation Slice 1). Therefore:
+
 - **Add:** eligibility MUST `AND` the flat `spaceVisibilityGate` into the visibility check — an Editor
   must never contribute an asset its owner marked **Hidden/Locked** (which the Editor cannot even
   see). No owner exception (contributions are cross-owner by definition).
 - **Read:** `spaceContributedAssetExists` MUST be composed with `spaceVisibilityGate(eb, 'asset.visibility')`
-  at every read site (like the album arm), so an asset marked Hidden *after* it was contributed is
+  at every read site (like the album arm), so an asset marked Hidden _after_ it was contributed is
   defensively excluded going forward.
 
 ### 5.1 Adding (the #764 fix) — `AlbumService.addAssets`
 
-Two-bucket split *inside the album-add path only* (no change to generic `asset.util.ts` used by
+Two-bucket split _inside the album-add path only_ (no change to generic `asset.util.ts` used by
 shared-links/memories):
 
 1. Resolve the album's live space link(s) the adder is an **Editor** of:
@@ -219,7 +223,7 @@ shared-links/memories):
      `{ memberUserId: auth.user.id, memberRole: [owner, editor], spaceId: S }`, **AND**ed with the
      flat `spaceVisibilityGate` (§5.0) so Hidden/Locked assets are never eligible. The role filter
      ties the contribution to a space **S** where the adder is Owner/Editor.
-   - **Already in** `album_asset` *or* `album_space_asset` → `DUPLICATE`.
+   - **Already in** `album_asset` _or_ `album_space_asset` → `DUPLICATE`.
    - **Otherwise** → `NO_PERMISSION`.
 3. Return a merged `BulkIdResponseDto[]` across both buckets (per-asset outcome preserved).
 
@@ -245,7 +249,7 @@ EXISTS (
 
 The membership join uses **any-role** membership (no `memberRole` filter) — Viewers must see
 contributions — and every read site **composes it with `spaceVisibilityGate`** (§5.0) exactly as it
-already does for the album arm. Because the row is *not* in `album_asset`, the owner's
+already does for the album arm. Because the row is _not_ in `album_asset`, the owner's
 `checkAlbumAccess` never sees it → no permanent grant. **Album contents** =
 `album_asset ∪ spaceContributedAssetExists(...)`, deduped by `assetId`. Wire into every consumer of
 `spaceAlbumAssetExists` / `spaceAssetPathBranches`: album detail/grid, asset count, thumbnail, the
@@ -256,12 +260,12 @@ space aggregated timeline (respecting `showInTimeline`), download, activity, in-
 ### 5.3 Removing — `AlbumService.removeAssets`
 
 Removing a contribution = delete the `album_space_asset` row (never touches the asset). Gate it on
-the **same `AlbumAssetDelete`** access #752 already defines — which resolves to *album Owner/Editor*
-**or** *space Owner/Editor* of the linked space (`checkSpaceLinkedAlbumAccess`, `role IN [owner,editor]`).
+the **same `AlbumAssetDelete`** access #752 already defines — which resolves to _album Owner/Editor_
+**or** _space Owner/Editor_ of the linked space (`checkSpaceLinkedAlbumAccess`, `role IN [owner,editor]`).
 This is symmetric with the add gate and needs no new permission. A space **Viewer** cannot remove.
 
 We deliberately **do not** add a standalone "the contributor may always remove" allowance: a
-contributor who is still an Editor is already covered, and one demoted to Viewer *should* lose write
+contributor who is still an Editor is already covered, and one demoted to Viewer _should_ lose write
 ability — a bespoke allowance would reintroduce a role-transition bypass. Removing an ordinary
 `album_asset` row is unchanged.
 
@@ -269,33 +273,35 @@ ability — a bespoke allowance would reintroduce a role-transition bypass. Remo
 
 ## 6. Lifecycle & edge cases (assertion source for the slices)
 
-| Event | Effect on a contribution `(album L, asset A, space S)` |
-|---|---|
-| Viewer leaves space S | Hidden for that viewer (no `shared_space_member`). Rejoin → reappears. |
-| Album L unlinked from S | Hidden for everyone (no `shared_space_album`). Re-link → reappears. |
-| Space S deleted | Row deleted (FK `spaceId` CASCADE). |
-| Album L deleted | Row deleted (FK `albumId` CASCADE). |
-| Asset A deleted | Row deleted (FK `assetId` CASCADE). |
-| Owner un-shares A from the space's **general pool** (`shared_space_asset` delete), A not deleted | **Row stays** (§8 default 1); A still renders in L for members. |
-| `addedById` user deleted | Row survives (`SET NULL`); affordance shows "unknown". |
-| Album L shared outside S (external `album_user` / public link) | Non-space viewers **never** see A. |
-| Owner opens L after leaving S / after unlink | A is gone for the owner too (reaches contributions only via the space arm). |
+| Event                                                                                            | Effect on a contribution `(album L, asset A, space S)`                      |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Viewer leaves space S                                                                            | Hidden for that viewer (no `shared_space_member`). Rejoin → reappears.      |
+| Album L unlinked from S                                                                          | Hidden for everyone (no `shared_space_album`). Re-link → reappears.         |
+| Space S deleted                                                                                  | Row deleted (FK `spaceId` CASCADE).                                         |
+| Album L deleted                                                                                  | Row deleted (FK `albumId` CASCADE).                                         |
+| Asset A deleted                                                                                  | Row deleted (FK `assetId` CASCADE).                                         |
+| Owner un-shares A from the space's **general pool** (`shared_space_asset` delete), A not deleted | **Row stays** (§8 default 1); A still renders in L for members.             |
+| `addedById` user deleted                                                                         | Row survives (`SET NULL`); affordance shows "unknown".                      |
+| Album L shared outside S (external `album_user` / public link)                                   | Non-space viewers **never** see A.                                          |
+| Owner opens L after leaving S / after unlink                                                     | A is gone for the owner too (reaches contributions only via the space arm). |
 
 ---
 
 ## 7. Surfaces
 
 ### 7.1 Web
+
 - **Add flow:** the existing "Add to album or space" picker + `addAssetsToAlbums` already targets
   space-linked albums; no picker change — the server now accepts non-owned assets for eligible albums.
 - **Toast (fixes #764's literal title):** `notifyAddToAlbum` branches on result counts — success
   (all added), info/warning (partial), warning/error (none) — instead of unconditional
   `toastManager.primary`. **Standalone** (Slice 0).
-- **Legibility:** a "from *Space name*" affordance on contributed tiles (we have `spaceId` → space
+- **Legibility:** a "from _Space name_" affordance on contributed tiles (we have `spaceId` → space
   name), so "these can disappear" is understood. Contributed tiles are non-owned → respect existing
   non-owner asset affordances.
 
 ### 7.2 Mobile / sync
+
 - Contributions are album→asset **membership edges**: extend **`SharedSpaceAlbumToAssetSync`**
   (`sync.repository.ts:1609`) to union `album_space_asset` inserts, deletes driven by the new
   `album_space_asset_audit` stream. The contributed asset's **payload + exif** (owned by another
@@ -310,28 +316,28 @@ ability — a bespoke allowance would reintroduce a role-transition bypass. Remo
 
 ## 8. Open sub-decisions (defaults chosen; confirm at review)
 
-1. **Un-share vs. curated life.** Owner removes A from the space's *general pool* but not delete →
+1. **Un-share vs. curated life.** Owner removes A from the space's _general pool_ but not delete →
    **Default: A stays** in albums it was curated into (contribution tethered to S, not to the source
    arm). Alternative: also require A independently space-visible at read time (stronger for the
-   owner, fragile curation). *If flipped, the read arm in §5.2 gains an extra `spaceAssetPath`
-   existence condition and the Slice 3 lifecycle test inverts.*
+   owner, fragile curation). _If flipped, the read arm in §5.2 gains an extra `spaceAssetPath`
+   existence condition and the Slice 3 lifecycle test inverts._
 2. **Contributions into externally-shared albums.** Allowed — per-viewer arm keeps it safe.
-3. **Multi-space albums.** `spaceId` pins provenance; visible to members of *its* space; each link
+3. **Multi-space albums.** `spaceId` pins provenance; visible to members of _its_ space; each link
    gated independently; dedup by `assetId` at read time.
 
 ---
 
 ## 9. Slice overview
 
-| # | Slice | Layers | Depends on | Independent ship? |
-|---|---|---|---|---|
-| 0 | Honest add-to-album toast (fixes #764 title) | web unit | — | ✅ land anytime |
-| 1 | Schema foundation: `album_space_asset` + audit + migration | server medium | — | foundation |
-| 2 | Contribute a non-owned space photo (add path + album grid & count) | server e2e + medium | 1 | ✅ vertical MVP |
-| 3 | Contributions across remaining album surfaces + leak/lifecycle negatives | server medium + e2e | 2 | extends 2 |
-| 4 | Remove a contribution | server e2e + medium | 2 | ✅ vertical |
-| 5 | Mobile sync of contributions | server medium + mobile | 2, 3 | ✅ vertical |
-| 6 | Web legibility affordance + role-gating | web unit + Playwright | 2 | ✅ vertical |
+| #   | Slice                                                                    | Layers                 | Depends on | Independent ship? |
+| --- | ------------------------------------------------------------------------ | ---------------------- | ---------- | ----------------- |
+| 0   | Honest add-to-album toast (fixes #764 title)                             | web unit               | —          | ✅ land anytime   |
+| 1   | Schema foundation: `album_space_asset` + audit + migration               | server medium          | —          | foundation        |
+| 2   | Contribute a non-owned space photo (add path + album grid & count)       | server e2e + medium    | 1          | ✅ vertical MVP   |
+| 3   | Contributions across remaining album surfaces + leak/lifecycle negatives | server medium + e2e    | 2          | extends 2         |
+| 4   | Remove a contribution                                                    | server e2e + medium    | 2          | ✅ vertical       |
+| 5   | Mobile sync of contributions                                             | server medium + mobile | 2, 3       | ✅ vertical       |
+| 6   | Web legibility affordance + role-gating                                  | web unit + Playwright  | 2          | ✅ vertical       |
 
 Ordering: **0** anytime; **1 → 2 → {3, 4, 5, 6}**. Each `/impl-loop` run does one slice, TDD.
 
@@ -343,17 +349,19 @@ Ordering: **0** anytime; **1 → 2 → {3, 4, 5, 6}**. Each `/impl-loop` run doe
 Pure web; independent of the backend feature.
 
 **Behavior (BDD)**
-- *Given* an add-to-album request where the server returns **0 successes** (all `NO_PERMISSION`),
-  *When* `notifyAddToAlbum` runs, *Then* a **non-success** toast (warning/error) shows "…cannot be
+
+- _Given_ an add-to-album request where the server returns **0 successes** (all `NO_PERMISSION`),
+  _When_ `notifyAddToAlbum` runs, _Then_ a **non-success** toast (warning/error) shows "…cannot be
   added…" — never the green success heading.
-- *Given* a result where **all assets were duplicates**, *When* it runs, *Then* an **info** toast
+- _Given_ a result where **all assets were duplicates**, _When_ it runs, _Then_ an **info** toast
   says "already in the album".
-- *Given* a **partial** result (some success, some fail), *When* it runs, *Then* an **info/warning**
+- _Given_ a **partial** result (some success, some fail), _When_ it runs, _Then_ an **info/warning**
   toast states the partial count.
-- *Given* **all** assets succeed, *When* it runs, *Then* the success toast + "View album" button
+- _Given_ **all** assets succeed, _When_ it runs, _Then_ the success toast + "View album" button
   (unchanged behavior).
 
 **TDD — red first**
+
 - **Web unit** (`web/src/lib/services/album.service.spec.ts`): mock `toastManager`; feed
   `notifyAddToAlbum` each result shape; assert the **method called** (`error`/`warning`/`info`/`primary`)
   and message key. Red today because the current code always calls `.primary`.
@@ -362,6 +370,7 @@ Pure web; independent of the backend feature.
 to select the toast severity + message; keep "View album" on any run that produced ≥1 success.
 
 **Edge cases (explicit assertions)**
+
 - 0 success, 0 duplicate → error/warning (not primary).
 - 0 success, all duplicate → info "already part of album".
 - Mixed success + duplicate + no-permission → partial wording, "View album" present.
@@ -379,20 +388,23 @@ to select the toast severity + message; keep "View album" on any run that produc
 (the one non-vertical slice); fully covered by medium tests on the live schema.
 
 **Behavior (BDD)**
-- *Given* a linked album, asset, and space, *When* an `album_space_asset` row is inserted, *Then* it
+
+- _Given_ a linked album, asset, and space, _When_ an `album_space_asset` row is inserted, _Then_ it
   persists with sync watermarks and is readable by `(albumId, assetId)`.
-- *Given* an `album_space_asset` row, *When* its **album** / **asset** / **space** is deleted,
-  *Then* the row is **cascade-deleted**; *When* its `addedById` user is deleted, *Then* the row
+- _Given_ an `album_space_asset` row, _When_ its **album** / **asset** / **space** is deleted,
+  _Then_ the row is **cascade-deleted**; _When_ its `addedById` user is deleted, _Then_ the row
   **survives** with `addedById = NULL`.
-- *Given* an `album_space_asset` row is deleted, *When* the delete commits, *Then* an
+- _Given_ an `album_space_asset` row is deleted, _When_ the delete commits, _Then_ an
   `album_space_asset_audit` row is emitted (for the sync delete stream in Slice 5).
 
 **TDD — red first**
+
 - **Medium** (`server/test/medium/specs/…`): create the table via migration on the testcontainers
   DB; assert insert/read; assert each FK cascade/SET-NULL; assert the audit row on delete. Red
   because table/trigger don't exist.
 
 **Fix (green).**
+
 - `album-space-asset.table.ts` + `album-space-asset-audit.table.ts` (mirror `shared_space_asset` +
   its audit trigger pattern).
 - Migration in `migrations-gallery/` (round timestamp); `revert-to-immich.sql` DROP entries for both
@@ -400,6 +412,7 @@ to select the toast severity + message; keep "View album" on any run that produc
 - Regenerate query SQL against a scratch migrated DB.
 
 **Edge cases**
+
 - Duplicate `(albumId, assetId)` insert → PK conflict handled (`onConflict do nothing`), not a 500.
 - Audit trigger fires on **statement**-level bulk delete (not just row) — assert multi-row delete.
 - Migration applies cleanly on a DB that already has all #752 migrations (unordered-migration path).
@@ -415,24 +428,26 @@ album and **sees it in the album grid**, gated on live membership. This is the #
 
 **Behavior (BDD)** — space S; Alice owns album L linked to S; Bob is an Editor of S; asset X is in S
 owned by Carol.
-- *Given* Bob (Editor), *When* Bob adds X to L, *Then* the response is `success:true` for X and an
+
+- _Given_ Bob (Editor), _When_ Bob adds X to L, _Then_ the response is `success:true` for X and an
   `album_space_asset(L, X, S, addedBy=Bob)` row exists — **not** an `album_asset` row.
-- *Given* the contribution exists, *When* any live member of S opens L, *Then* X appears in the grid
+- _Given_ the contribution exists, _When_ any live member of S opens L, _Then_ X appears in the grid
   and the asset **count includes** X.
-- *Given* Bob adds **his own** asset Y (in S) to L, *When* it runs, *Then* Y takes the **`album_asset`**
+- _Given_ Bob adds **his own** asset Y (in S) to L, _When_ it runs, _Then_ Y takes the **`album_asset`**
   path (`success:true`), unchanged.
-- *Given* a **Viewer** V of S, *When* V tries to add X (or their *own* asset) to L, *Then* the add
-  is **denied with 403** — `AlbumAssetCreate` throws *before* any per-asset logic; no row created.
-- *Given* asset Z **not in S**, *When* Bob adds Z to L, *Then* **`NO_PERMISSION`** for Z — no row.
-- *Given* asset H owned by Carol but **Hidden/Locked**, *When* Bob adds H to L, *Then*
+- _Given_ a **Viewer** V of S, _When_ V tries to add X (or their _own_ asset) to L, _Then_ the add
+  is **denied with 403** — `AlbumAssetCreate` throws _before_ any per-asset logic; no row created.
+- _Given_ asset Z **not in S**, _When_ Bob adds Z to L, _Then_ **`NO_PERMISSION`** for Z — no row.
+- _Given_ asset H owned by Carol but **Hidden/Locked**, _When_ Bob adds H to L, _Then_
   **`NO_PERMISSION`** (visibility gate) — no row, and H never becomes visible to any member via L.
-- *Given* Dave is a direct `album_user` **editor** of L but **not** a member of S, *When* Dave adds
-  non-owned X to L, *Then* **`NO_PERMISSION`** (album role ≠ space rights); his *own* asset → `album_asset`.
-- *Given* X is already in L (as contribution or owned), *When* Bob adds X again, *Then* **`DUPLICATE`**.
-- *Given* a mixed batch {X (non-owned, in S), Y (Bob-owned, in S), Z (not in S)}, *When* Bob adds
-  them, *Then* per-asset `{X:success, Y:success, Z:no_permission}` and a partial `BulkIdResponse`.
+- _Given_ Dave is a direct `album_user` **editor** of L but **not** a member of S, _When_ Dave adds
+  non-owned X to L, _Then_ **`NO_PERMISSION`** (album role ≠ space rights); his _own_ asset → `album_asset`.
+- _Given_ X is already in L (as contribution or owned), _When_ Bob adds X again, _Then_ **`DUPLICATE`**.
+- _Given_ a mixed batch {X (non-owned, in S), Y (Bob-owned, in S), Z (not in S)}, _When_ Bob adds
+  them, _Then_ per-asset `{X:success, Y:success, Z:no_permission}` and a partial `BulkIdResponse`.
 
 **TDD — red first**
+
 - **e2e** (`shared-space-album.e2e-spec.ts`): the seven scenarios above through the real HTTP add
   endpoint + a follow-up album read asserting X present/absent. Red because add returns
   `NO_PERMISSION` for non-owned assets today.
@@ -442,11 +457,13 @@ owned by Carol.
   non-owned-space-visible→`album_space_asset`, others→`NO_PERMISSION`.
 
 **Fix (green).**
+
 - `AlbumService.addAssets` two-bucket split (§5.1) + an `albumSpaceAsset` repository insert.
 - `spaceContributedAssetExists` helper (§5.2); wire into the album **grid** query and **asset count**.
 - Emit `AlbumAssetsAdd` for contributed ids too (event parity with the owned path).
 
 **Edge cases (explicit assertions)**
+
 - Asset visible to Bob via **each** arm — direct pool, linked library, linked album — is all eligible.
 - Asset visible to Bob only via a **different** space T (album L not linked to T) → `NO_PERMISSION`
   (eligibility requires visibility via **L's** space).
@@ -472,25 +489,27 @@ owned by Carol.
 lifecycle/leak guarantee from §6 is asserted.
 
 **Behavior (BDD)**
-- *Given* a contribution X in L with `showInTimeline=true`, *When* a member views the **space
-  timeline**, *Then* X appears; *When* `showInTimeline=false`, *Then* X is absent.
-- *Given* a member **downloads** L, *When* the archive builds, *Then* X is included; a non-member's
+
+- _Given_ a contribution X in L with `showInTimeline=true`, _When_ a member views the **space
+  timeline**, _Then_ X appears; _When_ `showInTimeline=false`, _Then_ X is absent.
+- _Given_ a member **downloads** L, _When_ the archive builds, _Then_ X is included; a non-member's
   download excludes it.
-- *Given* a member **searches within** L, *When* the query matches X, *Then* X is returned.
-- *Given* L's **thumbnail** is a contributed asset and the viewer is a non-member, *When* L renders
-  in a list, *Then* no 500 and no leaked thumbnail (falls back gracefully).
-- *Given* **album activity** (comments/likes), *When* a space-only reader loads L, *Then* activity
+- _Given_ a member **searches within** L, _When_ the query matches X, _Then_ X is returned.
+- _Given_ L's **thumbnail** is a contributed asset and the viewer is a non-member, _When_ L renders
+  in a list, _Then_ no 500 and no leaked thumbnail (falls back gracefully).
+- _Given_ **album activity** (comments/likes), _When_ a space-only reader loads L, _Then_ activity
   still respects #752's direct-access gate (contributions don't widen it).
-- **Lifecycle negatives:** *leave S* → X hidden; *rejoin* → X visible; *unlink L from S* → X hidden
-  for all incl. owner; *relink* → visible; *delete X / L / S* → row gone; *owner un-shares X from
-  general pool but keeps it* → X **stays** in L (§8 default 1).
-- **External-share negative:** *Given* Alice shares L via public link / external `album_user`, *When*
-  a non-space viewer opens it, *Then* contributions are **absent** (owned assets still present).
-- **Contributed-then-Hidden negative:** *Given* contribution X is visible, *When* X's owner marks X
-  **Hidden/Locked**, *Then* the `spaceVisibilityGate` on the read arm excludes X from every album
+- **Lifecycle negatives:** _leave S_ → X hidden; _rejoin_ → X visible; _unlink L from S_ → X hidden
+  for all incl. owner; _relink_ → visible; _delete X / L / S_ → row gone; _owner un-shares X from
+  general pool but keeps it_ → X **stays** in L (§8 default 1).
+- **External-share negative:** _Given_ Alice shares L via public link / external `album_user`, _When_
+  a non-space viewer opens it, _Then_ contributions are **absent** (owned assets still present).
+- **Contributed-then-Hidden negative:** _Given_ contribution X is visible, _When_ X's owner marks X
+  **Hidden/Locked**, _Then_ the `spaceVisibilityGate` on the read arm excludes X from every album
   surface for every member (defense-in-depth against post-hoc visibility changes).
 
 **TDD — red first**
+
 - **Medium/e2e** per surface (timeline, download, activity, search, thumbnail) + the full lifecycle
   and external-share negatives. Red because those surfaces only union `album_asset` today.
 
@@ -499,6 +518,7 @@ lifecycle/leak guarantee from §6 is asserted.
 candidates are contributions the viewer can't currently see.
 
 **Edge cases**
+
 - Dedup: an asset present in both `album_asset` and `album_space_asset` (shouldn't happen, but assert
   read returns it **once**).
 - `showInTimeline` toggled after contribution → timeline visibility flips accordingly.
@@ -515,19 +535,21 @@ candidates are contributions the viewer can't currently see.
 
 **Behavior (BDD)** — contribution `(L, X, S)` by Bob. Gate = `AlbumAssetDelete` (album Owner/Editor
 **or** space Owner/Editor).
-- *Given* Alice (album **owner**), *When* she removes X from L, *Then* the `album_space_asset` row is
+
+- _Given_ Alice (album **owner**), _When_ she removes X from L, _Then_ the `album_space_asset` row is
   deleted, X leaves L, and asset X itself is untouched.
-- *Given* another live space **Editor** Dave, *When* he removes X, *Then* deleted.
-- *Given* Bob (the contributor) who is **still an Editor**, *When* he removes X, *Then* deleted (via
+- _Given_ another live space **Editor** Dave, _When_ he removes X, _Then_ deleted.
+- _Given_ Bob (the contributor) who is **still an Editor**, _When_ he removes X, _Then_ deleted (via
   the Editor path — no special contributor rule).
-- *Given* Bob was **demoted to Viewer** (or left S), *When* he tries to remove his own X, *Then*
+- _Given_ Bob was **demoted to Viewer** (or left S), _When_ he tries to remove his own X, _Then_
   **denied** — he no longer has write rights.
-- *Given* a space **Viewer** V (who is not the album owner), *When* V tries to remove X, *Then*
+- _Given_ a space **Viewer** V (who is not the album owner), _When_ V tries to remove X, _Then_
   **denied**; row stays.
-- *Given* a **non-member**, *When* they try, *Then* **denied**.
-- *Given* removal of an **owned** `album_asset` row, *When* it runs, *Then* unchanged behavior.
+- _Given_ a **non-member**, _When_ they try, _Then_ **denied**.
+- _Given_ removal of an **owned** `album_asset` row, _When_ it runs, _Then_ unchanged behavior.
 
 **TDD — red first**
+
 - **e2e/medium**: the six cases through the remove endpoint; assert row presence/absence and that
   the asset row persists. Red because the current remove path has no `album_space_asset` branch.
 
@@ -537,9 +559,10 @@ permission, no bespoke contributor rule): if the caller has `AlbumAssetDelete` o
 `album_space_asset` row (emit `AlbumAssetsRemove` + audit).
 
 **Edge cases**
+
 - Removing X that is **not present** → `NOT_FOUND` (not 500).
 - Editor of a **different** space (not L's) → denied.
-- Album **Viewer** who is *also* the album owner? Not possible (owner role ≠ viewer); the album owner
+- Album **Viewer** who is _also_ the album owner? Not possible (owner role ≠ viewer); the album owner
   always has `AlbumAssetDelete`. A space **Viewer** who does not own L → denied.
 - A caller with `AlbumAssetDelete` removes an owned `album_asset` **and** a contributed
   `album_space_asset` in one batch → both handled, correct per-asset results.
@@ -553,14 +576,16 @@ permission, no bespoke contributor rule): if the caller has `AlbumAssetDelete` o
 **Delivers.** Contributions appear/disappear on mobile via the sync streams, with payload+exif.
 
 **Behavior (BDD)**
-- *Given* a new contribution `(L, X, S)`, *When* a member's client syncs, *Then* the membership edge
+
+- _Given_ a new contribution `(L, X, S)`, _When_ a member's client syncs, _Then_ the membership edge
   **and** X's payload + exif arrive; X renders in L on device.
-- *Given* the contribution is removed (Slice 4) or the member leaves S, *When* the client syncs,
-  *Then* the edge is deleted via the audit stream and X leaves L on device.
-- *Given* a member **joins** S which already has contributions, *When* they sync from scratch,
-  *Then* they **backfill** all contributions (watermark `createId` walk).
+- _Given_ the contribution is removed (Slice 4) or the member leaves S, _When_ the client syncs,
+  _Then_ the edge is deleted via the audit stream and X leaves L on device.
+- _Given_ a member **joins** S which already has contributions, _When_ they sync from scratch,
+  _Then_ they **backfill** all contributions (watermark `createId` walk).
 
 **TDD — red first**
+
 - **Medium** (`SyncService`/`SyncRepository` against testcontainers): assert
   `SharedSpaceAlbumToAssetSync` emits the contribution edge; `SharedSpaceAlbumAssetSync` /
   `…ExifSync` emit X's payload/exif; the audit stream emits the delete; backfill covers pre-existing
@@ -572,6 +597,7 @@ permission, no bespoke contributor rule): if the caller has `AlbumAssetDelete` o
 `album_space_asset_audit` into the delete stream; register any new `SyncEntityType`/`RequestType`.
 
 **Edge cases**
+
 - Leaving S removes edges via audit **without** deleting X's underlying asset payload if X is still
   visible via another path (assert no spurious asset deletion).
 - Re-link / re-join re-emits the edges (idempotent apply on device).
@@ -586,16 +612,18 @@ permission, no bespoke contributor rule): if the caller has `AlbumAssetDelete` o
 **Delivers.** Contributed tiles are legible and the add affordance is correctly role-gated in the UI.
 
 **Behavior (BDD)**
-- *Given* a member views L, *When* a tile is a contribution, *Then* it shows a **"from *Space*"**
+
+- _Given_ a member views L, _When_ a tile is a contribution, _Then_ it shows a **"from _Space_"**
   affordance (source space name) and the standard **non-owner** asset affordances (no owner-only
   actions).
-- *Given* an **Editor** in the space, *When* they open the add-to-album flow for a space photo they
-  don't own, *Then* the add **succeeds** (end-to-end).
-- *Given* a **Viewer**, *When* they view space assets, *Then* the "add to this album" affordance is
+- _Given_ an **Editor** in the space, _When_ they open the add-to-album flow for a space photo they
+  don't own, _Then_ the add **succeeds** (end-to-end).
+- _Given_ a **Viewer**, _When_ they view space assets, _Then_ the "add to this album" affordance is
   **absent/disabled** (no dead-end).
 
 **TDD — red first**
-- **Web unit**: the tile renders the "from *Space*" label when given a contributed asset with a
+
+- **Web unit**: the tile renders the "from _Space_" label when given a contributed asset with a
   `spaceId`/space name.
 - **Playwright** (`spaces-albums.e2e-spec.ts`): Editor add succeeds and the tile shows the badge;
   Viewer has no add affordance. (Role-badge assertions use `{ ignoreCase: true }` per the known
@@ -605,24 +633,26 @@ permission, no bespoke contributor rule): if the caller has `AlbumAssetDelete` o
 the add action is hidden/disabled for Viewers.
 
 **Edge cases**
+
 - `addedById = NULL` (contributor deleted) → affordance still renders (space name only).
 - Contribution that becomes hidden mid-session (owner unlink) → tile disappears on refresh without error.
 - Album shared externally opened by a non-space viewer → no badge, no contribution tiles.
 
 **Green.** Web unit + Playwright green; `pnpm --filter immich-web lint` (tolerated tailwind warnings)
-+ `check:typescript` clean.
+
+- `check:typescript` clean.
 
 ---
 
 ## 10. Global acceptance criteria
 
-- **Role matrix (§5.0) holds exactly:** *view* = any live space member (incl. Viewer); *contribute*
-  = space Owner/Editor of the album's space; *remove* = `AlbumAssetDelete` (album Owner/Editor ∨
+- **Role matrix (§5.0) holds exactly:** _view_ = any live space member (incl. Viewer); _contribute_
+  = space Owner/Editor of the album's space; _remove_ = `AlbumAssetDelete` (album Owner/Editor ∨
   space Owner/Editor). Every non-bypass rule has a passing negative test: Viewer 403 hard-block,
   album-editor-not-space-member denied, no cross-space smuggling.
 - **No Hidden/Locked leak:** a Hidden/Locked asset is never contributable (add-time flat
   `spaceVisibilityGate`) and never rendered via a contribution (read-time gate at every surface),
-  including when an asset is marked Hidden *after* being contributed.
+  including when an asset is marked Hidden _after_ being contributed.
 - Contributed photos render in every album surface for live members and **nowhere** for
   non-members — including the album owner once their space access ends, and including external
   album shares / public links.

--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -111,6 +111,7 @@ DROP TABLE IF EXISTS "shared_space_library_audit" CASCADE;
 DROP TABLE IF EXISTS "shared_space_library" CASCADE;
 
 -- Shared spaces
+DROP TABLE IF EXISTS "album_space_asset" CASCADE;
 DROP TABLE IF EXISTS "shared_space_activity" CASCADE;
 DROP TABLE IF EXISTS "shared_space_person_alias" CASCADE;
 DROP TABLE IF EXISTS "shared_space_person_face" CASCADE;
@@ -370,6 +371,7 @@ DELETE FROM "kysely_migrations"
    '1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger',
    '1782100000000-FixSharedSpaceAlbumGrantRelinkCreateId',
    '1782300000000-AddSharedSpaceAlbumAuditSyncIndexes',
+   '1783000000000-AddAlbumSpaceAssetTable',
 
    -- Build-time compatibility alias (server/bin/sync-gallery-migrations.mjs).
    -- Gallery's postbuild records ChangeDurationToInteger under BOTH its current

--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -423,18 +423,34 @@ where
             "shared_space_member"."userId" = $5::uuid
             and "shared_space_library"."libraryId" = "asset"."libraryId"
         )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-            inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
-          where
-            "shared_space_member"."userId" = $6::uuid
-            and "album_asset"."assetId" = "asset"."id"
+        or (
+          exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_album"
+              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+              and "album"."deletedAt" is null
+              inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+            where
+              "shared_space_member"."userId" = $6::uuid
+              and "album_asset"."assetId" = "asset"."id"
+          )
+          or exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_album"
+              inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+              and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+              and "album"."deletedAt" is null
+              inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+            where
+              "shared_space_member"."userId" = $7::uuid
+              and "album_space_asset"."assetId" = "asset"."id"
+          )
         )
       )
   )
@@ -480,19 +496,36 @@ where
             and "shared_space_member"."role" in ($8, $9)
             and "shared_space_library"."libraryId" = "asset"."libraryId"
         )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-            inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
-          where
-            "shared_space_member"."userId" = $10::uuid
-            and "shared_space_member"."role" in ($11, $12)
-            and "album_asset"."assetId" = "asset"."id"
+        or (
+          exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_album"
+              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+              and "album"."deletedAt" is null
+              inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+            where
+              "shared_space_member"."userId" = $10::uuid
+              and "shared_space_member"."role" in ($11, $12)
+              and "album_asset"."assetId" = "asset"."id"
+          )
+          or exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_album"
+              inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+              and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+              and "album"."deletedAt" is null
+              inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+            where
+              "shared_space_member"."userId" = $13::uuid
+              and "shared_space_member"."role" in ($14, $15)
+              and "album_space_asset"."assetId" = "asset"."id"
+          )
         )
       )
   )

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -433,6 +433,22 @@ from
   ) as "dummy"
 on conflict do nothing
 
+-- AlbumRepository.getContributedAssetIds
+select
+  "album_space_asset"."assetId"
+from
+  "album_space_asset"
+where
+  "album_space_asset"."albumId" = $1
+  and "album_space_asset"."assetId" in ($2)
+
+-- AlbumRepository.addContributedAssets
+insert into
+  "album_space_asset" ("albumId", "assetId", "spaceId", "addedById")
+values
+  ($1, $2, $3, $4)
+on conflict do nothing
+
 -- AlbumRepository.create
 with
   "album" as (

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -393,18 +393,34 @@ where
         "shared_space_member"."userId" = $4::uuid
         and "shared_space_library"."libraryId" = "asset"."libraryId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
-      where
-        "shared_space_member"."userId" = $5::uuid
-        and "album_asset"."assetId" = "asset"."id"
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+        where
+          "shared_space_member"."userId" = $5::uuid
+          and "album_asset"."assetId" = "asset"."id"
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+        where
+          "shared_space_member"."userId" = $6::uuid
+          and "album_space_asset"."assetId" = "asset"."id"
+      )
     )
   )
 

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -71,18 +71,34 @@ where
             "shared_space_library"."libraryId" = "asset"."libraryId"
             and "shared_space_library"."spaceId" = any ($7::uuid[])
         )
-        or exists (
-          select
-            1 as "exists"
-          from
-            "shared_space_album"
-            inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-            inner join "album" on "album"."id" = "shared_space_album"."albumId"
-            and "album"."deletedAt" is null
-          where
-            "album_asset"."assetId" = "asset"."id"
-            and "shared_space_album"."spaceId" = any ($8::uuid[])
-            and "shared_space_album"."showInTimeline" = $9
+        or (
+          exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_album"
+              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+              and "album"."deletedAt" is null
+            where
+              "album_asset"."assetId" = "asset"."id"
+              and "shared_space_album"."spaceId" = any ($8::uuid[])
+              and "shared_space_album"."showInTimeline" = $9
+          )
+          or exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_album"
+              inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+              and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+              and "album"."deletedAt" is null
+            where
+              "album_space_asset"."assetId" = "asset"."id"
+              and "shared_space_album"."spaceId" = any ($10::uuid[])
+              and "shared_space_album"."showInTimeline" = $11
+          )
         )
       )
     )
@@ -91,9 +107,9 @@ where
 order by
   "asset"."fileCreatedAt" desc
 limit
-  $10
+  $12
 offset
-  $11
+  $13
 
 -- SearchRepository.searchStatistics
 select
@@ -182,18 +198,34 @@ from
                 "shared_space_library"."libraryId" = "asset"."libraryId"
                 and "shared_space_library"."spaceId" = any ($5::uuid[])
             )
-            or exists (
-              select
-                1 as "exists"
-              from
-                "shared_space_album"
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                and "album"."deletedAt" is null
-              where
-                "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($6::uuid[])
-                and "shared_space_album"."showInTimeline" = $7
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($6::uuid[])
+                  and "shared_space_album"."showInTimeline" = $7
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($8::uuid[])
+                  and "shared_space_album"."showInTimeline" = $9
+              )
             )
           )
         )
@@ -207,25 +239,25 @@ from
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "shared_space_person_face"."personId" = $8::uuid
+          and "shared_space_person_face"."personId" = $10::uuid
       )
-      and "asset"."fileCreatedAt" >= $9
-      and "asset_exif"."lensModel" = $10
-      and "asset"."isFavorite" = $11
+      and "asset"."fileCreatedAt" >= $11
+      and "asset_exif"."lensModel" = $12
+      and "asset"."isFavorite" = $13
       and "asset"."deletedAt" is null
-      and (smart_search.embedding <=> $12) <= $13
+      and (smart_search.embedding <=> $14) <= $15
     order by
-      smart_search.embedding <=> $14
+      smart_search.embedding <=> $16
     limit
-      $15
+      $17
   ) as "candidates"
 order by
   "candidates"."fileCreatedAt" desc nulls last,
   "candidates"."id"
 limit
-  $16
+  $18
 offset
-  $17
+  $19
 commit
 
 -- SearchRepository.getSmartSearchFacets
@@ -265,24 +297,40 @@ drop as (
               "shared_space_library"."libraryId" = "asset"."libraryId"
               and "shared_space_library"."spaceId" = any ($5::uuid[])
           )
-          or exists (
-            select
-              1 as "exists"
-            from
-              "shared_space_album"
-              inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-              inner join "album" on "album"."id" = "shared_space_album"."albumId"
-              and "album"."deletedAt" is null
-            where
-              "album_asset"."assetId" = "asset"."id"
-              and "shared_space_album"."spaceId" = any ($6::uuid[])
-              and "shared_space_album"."showInTimeline" = $7
+          or (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($6::uuid[])
+                and "shared_space_album"."showInTimeline" = $7
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_space_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($8::uuid[])
+                and "shared_space_album"."showInTimeline" = $9
+            )
           )
         )
       )
     )
     and "asset"."deletedAt" is null
-    and (smart_search.embedding <=> $8) <= $9
+    and (smart_search.embedding <=> $10) <= $11
     and "smart_search"."embedding" is not null
 )
 create index smart_search_facet_candidates_asset_id_idx on smart_search_facet_candidates ("id")
@@ -1058,23 +1106,39 @@ where
                 "shared_space_library"."libraryId" = "asset"."libraryId"
                 and "shared_space_library"."spaceId" = any ($4::uuid[])
             )
-            or exists (
-              select
-                1 as "exists"
-              from
-                "shared_space_album"
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                and "album"."deletedAt" is null
-              where
-                "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($5::uuid[])
-                and "shared_space_album"."showInTimeline" = $6
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
             )
           )
         )
       )
-      and "asset"."fileCreatedAt" >= $7
+      and "asset"."fileCreatedAt" >= $9
       and exists (
         select
         from
@@ -1084,11 +1148,11 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $8::uuid
+          and "face_identity_face"."identityId" = $10::uuid
       )
   )
   and "country" is not null
-  and "country" != $9
+  and "country" != $11
 order by
   "country"
 select distinct
@@ -1126,23 +1190,39 @@ where
                 "shared_space_library"."libraryId" = "asset"."libraryId"
                 and "shared_space_library"."spaceId" = any ($4::uuid[])
             )
-            or exists (
-              select
-                1 as "exists"
-              from
-                "shared_space_album"
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                and "album"."deletedAt" is null
-              where
-                "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($5::uuid[])
-                and "shared_space_album"."showInTimeline" = $6
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
             )
           )
         )
       )
-      and "asset"."fileCreatedAt" >= $7
+      and "asset"."fileCreatedAt" >= $9
       and exists (
         select
         from
@@ -1152,11 +1232,11 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $8::uuid
+          and "face_identity_face"."identityId" = $10::uuid
       )
   )
   and "make" is not null
-  and "make" != $9
+  and "make" != $11
 order by
   "make"
 select distinct
@@ -1196,23 +1276,39 @@ where
                 "shared_space_library"."libraryId" = "asset"."libraryId"
                 and "shared_space_library"."spaceId" = any ($4::uuid[])
             )
-            or exists (
-              select
-                1 as "exists"
-              from
-                "shared_space_album"
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                and "album"."deletedAt" is null
-              where
-                "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($5::uuid[])
-                and "shared_space_album"."showInTimeline" = $6
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
             )
           )
         )
       )
-      and "asset"."fileCreatedAt" >= $7
+      and "asset"."fileCreatedAt" >= $9
       and exists (
         select
         from
@@ -1222,7 +1318,7 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $8::uuid
+          and "face_identity_face"."identityId" = $10::uuid
       )
   )
 order by
@@ -1259,23 +1355,39 @@ WITH
                   "shared_space_library"."libraryId" = "asset"."libraryId"
                   and "shared_space_library"."spaceId" = any ($4::uuid[])
               )
-              or exists (
-                select
-                  1 as "exists"
-                from
-                  "shared_space_album"
-                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                  and "album"."deletedAt" is null
-                where
-                  "album_asset"."assetId" = "asset"."id"
-                  and "shared_space_album"."spaceId" = any ($5::uuid[])
-                  and "shared_space_album"."showInTimeline" = $6
+              or (
+                exists (
+                  select
+                    1 as "exists"
+                  from
+                    "shared_space_album"
+                    inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                    inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                    and "album"."deletedAt" is null
+                  where
+                    "album_asset"."assetId" = "asset"."id"
+                    and "shared_space_album"."spaceId" = any ($5::uuid[])
+                    and "shared_space_album"."showInTimeline" = $6
+                )
+                or exists (
+                  select
+                    1 as "exists"
+                  from
+                    "shared_space_album"
+                    inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                    and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                    inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                    and "album"."deletedAt" is null
+                  where
+                    "album_space_asset"."assetId" = "asset"."id"
+                    and "shared_space_album"."spaceId" = any ($7::uuid[])
+                    and "shared_space_album"."showInTimeline" = $8
+                )
               )
             )
           )
         )
-        and "asset"."fileCreatedAt" >= $7
+        and "asset"."fileCreatedAt" >= $9
     )
   ),
   identity_faces AS (
@@ -1302,7 +1414,7 @@ WITH
     FROM
       person
     WHERE
-      person."ownerId" = $8
+      person."ownerId" = $10
       AND person."identityId" IS NOT NULL
       AND EXISTS (
         SELECT
@@ -1332,9 +1444,9 @@ WITH
     FROM
       shared_space_person
       LEFT JOIN shared_space_person_alias ON shared_space_person_alias."personId" = shared_space_person.id
-      AND shared_space_person_alias."userId" = $9
+      AND shared_space_person_alias."userId" = $11
     WHERE
-      shared_space_person."spaceId" = any ($10::uuid[])
+      shared_space_person."spaceId" = any ($12::uuid[])
       AND shared_space_person."identityId" IS NOT NULL
       AND EXISTS (
         SELECT
@@ -1458,23 +1570,39 @@ where
                 "shared_space_library"."libraryId" = "asset"."libraryId"
                 and "shared_space_library"."spaceId" = any ($4::uuid[])
             )
-            or exists (
-              select
-                1 as "exists"
-              from
-                "shared_space_album"
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                and "album"."deletedAt" is null
-              where
-                "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($5::uuid[])
-                and "shared_space_album"."showInTimeline" = $6
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
             )
           )
         )
       )
-      and "asset"."fileCreatedAt" >= $7
+      and "asset"."fileCreatedAt" >= $9
       and exists (
         select
         from
@@ -1484,11 +1612,11 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $8::uuid
+          and "face_identity_face"."identityId" = $10::uuid
       )
   )
   and "rating" is not null
-  and "rating" > $9
+  and "rating" > $11
 order by
   "rating"
 select distinct
@@ -1526,23 +1654,39 @@ where
                 "shared_space_library"."libraryId" = "asset"."libraryId"
                 and "shared_space_library"."spaceId" = any ($4::uuid[])
             )
-            or exists (
-              select
-                1 as "exists"
-              from
-                "shared_space_album"
-                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-                inner join "album" on "album"."id" = "shared_space_album"."albumId"
-                and "album"."deletedAt" is null
-              where
-                "album_asset"."assetId" = "asset"."id"
-                and "shared_space_album"."spaceId" = any ($5::uuid[])
-                and "shared_space_album"."showInTimeline" = $6
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
             )
           )
         )
       )
-      and "asset"."fileCreatedAt" >= $7
+      and "asset"."fileCreatedAt" >= $9
       and exists (
         select
         from
@@ -1552,7 +1696,7 @@ where
           "asset_face"."assetId" = "asset"."id"
           and "asset_face"."deletedAt" is null
           and "asset_face"."isVisible" is true
-          and "face_identity_face"."identityId" = $8::uuid
+          and "face_identity_face"."identityId" = $10::uuid
       )
   )
 order by

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -90,6 +90,57 @@ where
   "spaceId" = $1
   and "userId" = $2
 
+-- SharedSpaceRepository.getContributableAssetSpaces
+select distinct
+  on ("asset"."id") "asset"."id" as "assetId",
+  "link"."spaceId" as "spaceId"
+from
+  "shared_space_album" as "link"
+  inner join "shared_space_member" as "m" on "m"."spaceId" = "link"."spaceId"
+  and "m"."userId" = $1
+  and "m"."role" in ($2, $3)
+  inner join "asset" on "asset"."id" in ($4)
+  and "asset"."deletedAt" is null
+  and "asset"."ownerId" != $5
+  and "asset"."visibility" in ($6, $7)
+where
+  "link"."albumId" = $8
+  and (
+    exists (
+      select
+        1 as "x"
+      from
+        "shared_space_asset" as "sd"
+      where
+        "sd"."spaceId" = "link"."spaceId"
+        and "sd"."assetId" = "asset"."id"
+    )
+    or exists (
+      select
+        1 as "x"
+      from
+        "shared_space_library" as "sl"
+      where
+        "sl"."spaceId" = "link"."spaceId"
+        and "sl"."libraryId" = "asset"."libraryId"
+        and "asset"."isOffline" = $9
+    )
+    or exists (
+      select
+        1 as "x"
+      from
+        "shared_space_album" as "sa2"
+        inner join "album_asset" as "aa2" on "aa2"."albumId" = "sa2"."albumId"
+        inner join "album" as "al2" on "al2"."id" = "sa2"."albumId"
+        and "al2"."deletedAt" is null
+      where
+        "sa2"."spaceId" = "link"."spaceId"
+        and "aa2"."assetId" = "asset"."id"
+    )
+  )
+order by
+  "asset"."id"
+
 -- SharedSpaceRepository.getSpaceIdsForTimeline
 select
   "spaceId"
@@ -1278,17 +1329,32 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-      where
-        "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
     )
   )
 
@@ -1329,17 +1395,32 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-      where
-        "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
     )
   )
 order by
@@ -1546,17 +1627,32 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = $3
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-      where
-        "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = $4::uuid
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = $4::uuid
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = $5::uuid
+      )
     )
   )
   and "person"."identityId" is not null
@@ -1614,18 +1710,34 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-      where
-        "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
-        and "shared_space_album"."showInTimeline" = $5
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+          and "shared_space_album"."showInTimeline" = $5
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+          and "shared_space_album"."showInTimeline" = $6
+      )
     )
   )
 
@@ -1693,17 +1805,32 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-      where
-        "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
     )
   )
 
@@ -1741,17 +1868,32 @@ where
         "shared_space_library"."libraryId" = "asset"."libraryId"
         and "shared_space_library"."spaceId" = "shared_space_person"."spaceId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-      where
-        "album_asset"."assetId" = "asset_face"."assetId"
-        and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset_face"."assetId"
+          and "shared_space_album"."spaceId" = "shared_space_person"."spaceId"
+      )
     )
   )
 order by

--- a/server/src/queries/view.repository.sql
+++ b/server/src/queries/view.repository.sql
@@ -28,22 +28,39 @@ where
         "shared_space_member"."userId" = $4::uuid
         and "shared_space_library"."libraryId" = "asset"."libraryId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
-      where
-        "shared_space_member"."userId" = $5::uuid
-        and "album_asset"."assetId" = "asset"."id"
-        and "shared_space_album"."showInTimeline" = $6
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+        where
+          "shared_space_member"."userId" = $5::uuid
+          and "album_asset"."assetId" = "asset"."id"
+          and "shared_space_album"."showInTimeline" = $6
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+        where
+          "shared_space_member"."userId" = $7::uuid
+          and "album_space_asset"."assetId" = "asset"."id"
+          and "shared_space_album"."showInTimeline" = $8
+      )
     )
   )
-  and "visibility" = $7
+  and "visibility" = $9
   and "deletedAt" is null
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
@@ -81,27 +98,44 @@ where
         "shared_space_member"."userId" = $3::uuid
         and "shared_space_library"."libraryId" = "asset"."libraryId"
     )
-    or exists (
-      select
-        1 as "exists"
-      from
-        "shared_space_album"
-        inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
-        inner join "album" on "album"."id" = "shared_space_album"."albumId"
-        and "album"."deletedAt" is null
-        inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
-      where
-        "shared_space_member"."userId" = $4::uuid
-        and "album_asset"."assetId" = "asset"."id"
-        and "shared_space_album"."showInTimeline" = $5
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+        where
+          "shared_space_member"."userId" = $4::uuid
+          and "album_asset"."assetId" = "asset"."id"
+          and "shared_space_album"."showInTimeline" = $5
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+        where
+          "shared_space_member"."userId" = $6::uuid
+          and "album_space_asset"."assetId" = "asset"."id"
+          and "shared_space_album"."showInTimeline" = $7
+      )
     )
   )
-  and "visibility" = $6
+  and "visibility" = $8
   and "deletedAt" is null
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
   and "localDateTime" is not null
-  and "originalPath" like $7
-  and "originalPath" not like $8
+  and "originalPath" like $9
+  and "originalPath" not like $10
 order by
-  regexp_replace("asset"."originalPath", $9, $10) asc
+  regexp_replace("asset"."originalPath", $11, $12) asc

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -431,6 +431,59 @@ export class AlbumRepository {
       .execute();
   }
 
+  // --- Cross-owner contributions (album_space_asset) — #764 ---------------------------------------
+  // A contribution is a bookmark of a space photo the contributor does not own; it lives OUTSIDE
+  // `album_asset` so it can never become a permanent `checkAlbumAccess` grant for the album owner.
+
+  /** Which of `assetIds` already exist as contributions in the album (for DUPLICATE detection). */
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  @ChunkedSet({ paramIndex: 1 })
+  async getContributedAssetIds(albumId: string, assetIds: string[]): Promise<Set<string>> {
+    if (assetIds.length === 0) {
+      return new Set();
+    }
+
+    return this.db
+      .selectFrom('album_space_asset')
+      .select('album_space_asset.assetId')
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album_space_asset.assetId', 'in', assetIds)
+      .execute()
+      .then((results) => new Set(results.map(({ assetId }) => assetId)));
+  }
+
+  @GenerateSql({
+    params: [
+      [{ albumId: DummyValue.UUID, assetId: DummyValue.UUID, spaceId: DummyValue.UUID, addedById: DummyValue.UUID }],
+    ],
+  })
+  async addContributedAssets(
+    values: { albumId: string; assetId: string; spaceId: string; addedById: string }[],
+  ): Promise<void> {
+    if (values.length === 0) {
+      return;
+    }
+
+    await this.db
+      .insertInto('album_space_asset')
+      .values(values)
+      .onConflict((oc) => oc.doNothing())
+      .execute();
+  }
+
+  @Chunked({ paramIndex: 1 })
+  async removeContributedAssetIds(albumId: string, assetIds: string[]): Promise<void> {
+    if (assetIds.length === 0) {
+      return;
+    }
+
+    await this.db
+      .deleteFrom('album_space_asset')
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album_space_asset.assetId', 'in', assetIds)
+      .execute();
+  }
+
   @GenerateSql({
     params: [
       { albumName: DummyValue.STRING },

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -218,6 +218,80 @@ export class SharedSpaceRepository {
     await db.deleteFrom('shared_space_member').where('spaceId', '=', spaceId).where('userId', '=', userId).execute();
   }
 
+  /**
+   * Cross-owner contribution eligibility (#764). For each of `assetIds`, returns the space it may be
+   * contributed to `albumId` through — i.e. a space `S` such that: the album is linked to `S`, the
+   * caller is an Owner/Editor of `S`, and the asset is space-visible to the caller via `S` (direct
+   * pool ∪ linked library ∪ another linked album) under the visibility gate (no Hidden/Locked). Only
+   * NON-owned assets are eligible (the caller's own photos take the ordinary `album_asset` path). One
+   * row per eligible asset (the tether space); assets with no eligible space are simply absent.
+   */
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID, [DummyValue.UUID]] })
+  @ChunkedArray({ paramIndex: 2 })
+  async getContributableAssetSpaces(
+    userId: string,
+    albumId: string,
+    assetIds: string[],
+  ): Promise<{ assetId: string; spaceId: string }[]> {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    return this.db
+      .selectFrom('shared_space_album as link')
+      .innerJoin('shared_space_member as m', (join) =>
+        join
+          .onRef('m.spaceId', '=', 'link.spaceId')
+          .on('m.userId', '=', userId)
+          .on('m.role', 'in', [SharedSpaceRole.Owner, SharedSpaceRole.Editor]),
+      )
+      .innerJoin(
+        'asset',
+        (join) =>
+          join
+            .on('asset.id', 'in', assetIds)
+            .on('asset.deletedAt', 'is', null)
+            .on('asset.ownerId', '!=', userId) // owned assets take the ordinary album_asset path
+            .on('asset.visibility', 'in', spaceVisibleAssetVisibilities), // gate out Hidden/Locked
+      )
+      .where('link.albumId', '=', albumId)
+      .where((eb) =>
+        eb.or([
+          // Directly shared into the space's pool.
+          eb.exists(
+            eb
+              .selectFrom('shared_space_asset as sd')
+              .select(sql`1`.as('x'))
+              .whereRef('sd.spaceId', '=', 'link.spaceId')
+              .whereRef('sd.assetId', '=', 'asset.id'),
+          ),
+          // In a library linked to the space.
+          eb.exists(
+            eb
+              .selectFrom('shared_space_library as sl')
+              .select(sql`1`.as('x'))
+              .whereRef('sl.spaceId', '=', 'link.spaceId')
+              .whereRef('sl.libraryId', '=', 'asset.libraryId')
+              .where('asset.isOffline', '=', false),
+          ),
+          // Already in another (non-deleted) album linked to the space.
+          eb.exists(
+            eb
+              .selectFrom('shared_space_album as sa2')
+              .innerJoin('album_asset as aa2', 'aa2.albumId', 'sa2.albumId')
+              .innerJoin('album as al2', (j2) => j2.onRef('al2.id', '=', 'sa2.albumId').on('al2.deletedAt', 'is', null))
+              .select(sql`1`.as('x'))
+              .whereRef('sa2.spaceId', '=', 'link.spaceId')
+              .whereRef('aa2.assetId', '=', 'asset.id'),
+          ),
+        ]),
+      )
+      .select(['asset.id as assetId', 'link.spaceId as spaceId'])
+      .distinctOn('asset.id')
+      .orderBy('asset.id')
+      .execute();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID] })
   getSpaceIdsForTimeline(userId: string) {
     return this.db

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -29,6 +29,7 @@ import { ActivityTable } from 'src/schema/tables/activity.table';
 import { AlbumAssetAuditTable } from 'src/schema/tables/album-asset-audit.table';
 import { AlbumAssetTable } from 'src/schema/tables/album-asset.table';
 import { AlbumAuditTable } from 'src/schema/tables/album-audit.table';
+import { AlbumSpaceAssetTable } from 'src/schema/tables/album-space-asset.table';
 import { AlbumUserAuditTable } from 'src/schema/tables/album-user-audit.table';
 import { AlbumUserTable } from 'src/schema/tables/album-user.table';
 import { AlbumTable } from 'src/schema/tables/album.table';
@@ -124,6 +125,7 @@ export class ImmichDatabase {
     ActivityTable,
     AlbumAssetTable,
     AlbumAssetAuditTable,
+    AlbumSpaceAssetTable,
     AlbumAuditTable,
     AlbumUserAuditTable,
     AlbumUserTable,
@@ -250,6 +252,7 @@ export interface DB {
   album_audit: AlbumAuditTable;
   album_asset: AlbumAssetTable;
   album_asset_audit: AlbumAssetAuditTable;
+  album_space_asset: AlbumSpaceAssetTable;
   album_user: AlbumUserTable;
   album_user_audit: AlbumUserAuditTable;
 

--- a/server/src/schema/migrations-gallery/1783000000000-AddAlbumSpaceAssetTable.ts
+++ b/server/src/schema/migrations-gallery/1783000000000-AddAlbumSpaceAssetTable.ts
@@ -1,0 +1,27 @@
+import { Kysely, sql } from 'kysely';
+
+// Cross-owner contributions to space-linked albums (#764). A bookmark of a space photo the
+// contributor does not own, kept OUT of `album_asset` so it never becomes a permanent album grant.
+// Plain table (FK-cascade, createId watermark) — no update trigger, mirrors shared_space_album_user.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    CREATE TABLE "album_space_asset" (
+      "albumId"   uuid NOT NULL REFERENCES "album"(id) ON UPDATE CASCADE ON DELETE CASCADE,
+      "assetId"   uuid NOT NULL REFERENCES "asset"(id) ON UPDATE CASCADE ON DELETE CASCADE,
+      "spaceId"   uuid NOT NULL REFERENCES "shared_space"(id) ON DELETE CASCADE,
+      "addedById" uuid REFERENCES "user"(id) ON UPDATE CASCADE ON DELETE SET NULL,
+      "addedAt"   timestamp with time zone NOT NULL DEFAULT now(),
+      "createId"  uuid NOT NULL DEFAULT immich_uuid_v7(),
+      "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+      CONSTRAINT "album_space_asset_pkey" PRIMARY KEY ("albumId", "assetId")
+    );
+  `.execute(db);
+  await sql`CREATE INDEX "album_space_asset_spaceId_idx" ON "album_space_asset" ("spaceId");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_assetId_idx" ON "album_space_asset" ("assetId");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_addedById_idx" ON "album_space_asset" ("addedById");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_createId_idx" ON "album_space_asset" ("createId");`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS "album_space_asset";`.execute(db);
+}

--- a/server/src/schema/tables/album-space-asset.table.ts
+++ b/server/src/schema/tables/album-space-asset.table.ts
@@ -1,0 +1,40 @@
+import { CreateDateColumn, ForeignKeyColumn, Generated, Index, Table, Timestamp } from '@immich/sql-tools';
+import { CreateIdColumn } from 'src/decorators';
+import { AlbumTable } from 'src/schema/tables/album.table';
+import { AssetTable } from 'src/schema/tables/asset.table';
+import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
+import { UserTable } from 'src/schema/tables/user.table';
+
+// A cross-owner contribution: a space photo the contributor does NOT own, bookmarked into a
+// space-linked album (#764). Deliberately NOT `album_asset` — it must never become a permanent
+// `checkAlbumAccess` grant for the album owner. Visibility is re-derived from live space membership
+// + the live album↔space link on every read (see spaceContributedAssetExists). The adder's OWN
+// photos take the ordinary `album_asset` path instead. `createId` is the sync watermark for the
+// per-album asset backfill (Slice 5); no update trigger — rows are immutable once created.
+@Table({ name: 'album_space_asset' })
+@Index({ name: 'album_space_asset_spaceId_idx', columns: ['spaceId'] })
+export class AlbumSpaceAssetTable {
+  @ForeignKeyColumn(() => AlbumTable, { onDelete: 'CASCADE', onUpdate: 'CASCADE', nullable: false, primary: true })
+  albumId!: string;
+
+  @ForeignKeyColumn(() => AssetTable, { onDelete: 'CASCADE', onUpdate: 'CASCADE', nullable: false, primary: true })
+  assetId!: string;
+
+  // Provenance + tether: the space the contribution flows through. The read gate joins this to a
+  // LIVE shared_space_album link and a LIVE shared_space_member row for the viewer.
+  @ForeignKeyColumn(() => SharedSpaceTable, { onDelete: 'CASCADE', nullable: false, index: false })
+  spaceId!: string;
+
+  // Who contributed it (any space Editor). SET NULL so a deleted user doesn't erase the contribution.
+  @ForeignKeyColumn(() => UserTable, { onDelete: 'SET NULL', onUpdate: 'CASCADE', nullable: true })
+  addedById!: string | null;
+
+  @CreateDateColumn()
+  addedAt!: Generated<Timestamp>;
+
+  @CreateIdColumn({ index: true })
+  createId!: Generated<string>;
+
+  @CreateDateColumn()
+  createdAt!: Generated<Timestamp>;
+}

--- a/server/src/schema/tables/album-space-asset.table.ts
+++ b/server/src/schema/tables/album-space-asset.table.ts
@@ -14,7 +14,14 @@ import { UserTable } from 'src/schema/tables/user.table';
 @Table({ name: 'album_space_asset' })
 @Index({ name: 'album_space_asset_spaceId_idx', columns: ['spaceId'] })
 export class AlbumSpaceAssetTable {
-  @ForeignKeyColumn(() => AlbumTable, { onDelete: 'CASCADE', onUpdate: 'CASCADE', nullable: false, primary: true })
+  // index: false — albumId is the leading column of the composite PK, so a separate FK index is redundant.
+  @ForeignKeyColumn(() => AlbumTable, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: false,
+    primary: true,
+    index: false,
+  })
   albumId!: string;
 
   @ForeignKeyColumn(() => AssetTable, { onDelete: 'CASCADE', onUpdate: 'CASCADE', nullable: false, primary: true })

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -18,6 +18,12 @@ describe(AlbumService.name, () => {
 
   beforeEach(() => {
     ({ sut, mocks } = newTestService(AlbumService));
+    // #764 cross-owner contribution defaults: no denied asset is contributable / already contributed
+    // unless a test opts in, so add/remove behave exactly as before for the non-space cases.
+    mocks.sharedSpace.getContributableAssetSpaces.mockResolvedValue([]);
+    mocks.album.getContributedAssetIds.mockResolvedValue(new Set());
+    mocks.album.addContributedAssets.mockResolvedValue();
+    mocks.album.removeContributedAssetIds.mockResolvedValue();
   });
 
   it('should work', () => {

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -248,13 +248,25 @@ export class AlbumService extends BaseService {
     const album = await this.findOrFail(id, auth.user.id, { withAssets: false });
     await this.requireAccess({ auth, permission: Permission.AlbumAssetCreate, ids: [id] });
 
+    // Ordinary path: assets the caller owns / has AssetShare on land in `album_asset`.
     const results = await addAssets(
       auth,
       { access: this.accessRepository, bulk: this.albumRepository },
       { parentId: id, assetIds: dto.ids },
     );
 
-    const { id: firstNewAssetId } = results.find(({ success }) => success) || {};
+    // #764 cross-owner contributions: assets denied above (not owned / no partner share) may still be
+    // added as space bookmarks when the album is space-linked and the caller is a space Editor of the
+    // space the asset is visible through. These go to `album_space_asset`, never `album_asset`, so the
+    // album owner never gains a permanent grant.
+    const contributedIds = await this.tryContributeDeniedAssets(auth, id, results);
+
+    // Only the caller's OWN newly-added assets (real `album_asset` rows) drive the thumbnail default
+    // and the face/sync event — a contribution is a bookmark with no `album_asset` row.
+    const ownedNewAssetIds = results
+      .filter(({ success, id: assetId }) => success && !contributedIds.has(assetId))
+      .map(({ id: assetId }) => assetId);
+    const firstNewAssetId = ownedNewAssetIds[0];
     if (firstNewAssetId) {
       await this.albumRepository.update(
         id,
@@ -272,11 +284,58 @@ export class AlbumService extends BaseService {
         await this.eventRepository.emit('AlbumUpdate', { id, recipientId });
       }
 
-      const addedAssetIds = results.filter(({ success }) => success).map(({ id }) => id);
-      await this.eventRepository.emit('AlbumAssetsAdd', { albumId: id, assetIds: addedAssetIds });
+      await this.eventRepository.emit('AlbumAssetsAdd', { albumId: id, assetIds: ownedNewAssetIds });
     }
 
     return results;
+  }
+
+  /**
+   * #764: upgrade `no_permission` results to cross-owner contributions where eligible. Mutates
+   * `results` in place (denied → success, or → duplicate if already contributed) and returns the set
+   * of asset ids that became contributions.
+   */
+  private async tryContributeDeniedAssets(
+    auth: AuthDto,
+    albumId: string,
+    results: BulkIdResponseDto[],
+  ): Promise<Set<string>> {
+    const contributedIds = new Set<string>();
+    const deniedIds = results
+      .filter(({ success, error }) => !success && error === BulkIdErrorReason.NO_PERMISSION)
+      .map(({ id }) => id);
+    if (deniedIds.length === 0) {
+      return contributedIds;
+    }
+
+    const [contributable, alreadyContributed] = await Promise.all([
+      this.sharedSpaceRepository.getContributableAssetSpaces(auth.user.id, albumId, deniedIds),
+      this.albumRepository.getContributedAssetIds(albumId, deniedIds),
+    ]);
+    const spaceByAsset = new Map(contributable.map(({ assetId, spaceId }) => [assetId, spaceId]));
+
+    const toInsert: { albumId: string; assetId: string; spaceId: string; addedById: string }[] = [];
+    for (const result of results) {
+      if (result.success || result.error !== BulkIdErrorReason.NO_PERMISSION) {
+        continue;
+      }
+      if (alreadyContributed.has(result.id)) {
+        result.error = BulkIdErrorReason.DUPLICATE;
+        continue;
+      }
+      const spaceId = spaceByAsset.get(result.id);
+      if (spaceId) {
+        toInsert.push({ albumId, assetId: result.id, spaceId, addedById: auth.user.id });
+        result.success = true;
+        delete result.error;
+        contributedIds.add(result.id);
+      }
+    }
+
+    if (toInsert.length > 0) {
+      await this.albumRepository.addContributedAssets(toInsert);
+    }
+    return contributedIds;
   }
 
   async addAssetsToAlbums(auth: AuthDto, dto: AlbumsAddAssetsDto): Promise<AlbumsAddAssetsResponseDto> {
@@ -358,6 +417,8 @@ export class AlbumService extends BaseService {
   }
 
   async removeAssets(auth: AuthDto, id: string, dto: BulkIdsDto): Promise<BulkIdResponseDto[]> {
+    // AlbumAssetDelete (#752) = album owner/editor OR space owner/editor of the linked space; a space
+    // Viewer or non-member is refused here (403) before any row is touched — the remove RBAC gate.
     await this.requireAccess({ auth, permission: Permission.AlbumAssetDelete, ids: [id] });
 
     const album = await this.findOrFail(id, auth.user.id, { withAssets: false });
@@ -366,13 +427,34 @@ export class AlbumService extends BaseService {
       { access: this.accessRepository, bulk: this.albumRepository },
       { parentId: id, assetIds: dto.ids, canAlwaysRemove: Permission.AlbumDelete },
     );
+    const albumAssetRemovedIds = results.filter(({ success }) => success).map(({ id }) => id);
+
+    // #764: a contribution is never in `album_asset`, so the util reports it NOT_FOUND. The caller
+    // already passed AlbumAssetDelete above, so removing it (deleting the `album_space_asset` row) is
+    // authorized. The underlying asset is untouched.
+    const notFoundIds = results
+      .filter(({ success, error }) => !success && error === BulkIdErrorReason.NOT_FOUND)
+      .map(({ id: assetId }) => assetId);
+    if (notFoundIds.length > 0) {
+      const contributed = await this.albumRepository.getContributedAssetIds(id, notFoundIds);
+      if (contributed.size > 0) {
+        await this.albumRepository.removeContributedAssetIds(id, [...contributed]);
+        for (const result of results) {
+          if (contributed.has(result.id)) {
+            result.success = true;
+            delete result.error;
+          }
+        }
+      }
+    }
 
     const removedIds = results.filter(({ success }) => success).map(({ id }) => id);
     if (removedIds.length > 0 && album.albumThumbnailAssetId && removedIds.includes(album.albumThumbnailAssetId)) {
       await this.albumRepository.updateThumbnails();
     }
-    if (removedIds.length > 0) {
-      await this.eventRepository.emit('AlbumAssetsRemove', { albumId: id, assetIds: removedIds });
+    // Face/sync cleanup only applies to real album_asset rows, not contributions.
+    if (albumAssetRemovedIds.length > 0) {
+      await this.eventRepository.emit('AlbumAssetsRemove', { albumId: id, assetIds: albumAssetRemovedIds });
     }
 
     return results;

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -463,15 +463,40 @@ export function hasAnyPeople<O>(qb: SelectQueryBuilder<DB, 'asset', O>, filters:
   });
 }
 
-export function inAlbums<O>(qb: SelectQueryBuilder<DB, 'asset', O>, albumIds: string[]) {
+export function inAlbums<O>(
+  qb: SelectQueryBuilder<DB, 'asset', O>,
+  albumIds: string[],
+  // #764: when the viewer has live member-spaces (timelineSpaceIds, resolved from
+  // getSpaceIdsForTimeline), cross-owner contributions (`album_space_asset`) tethered to one of those
+  // spaces count as album membership too. Gating on timelineSpaceIds — not raw album membership — is
+  // the live-membership check: an album owner who has LEFT the space passes AlbumRead on their own
+  // album but has no timelineSpaceId for it, so contributions are excluded (no permanent-grant leak).
+  timelineSpaceIds?: string[],
+) {
+  const includeContributions = !!timelineSpaceIds && timelineSpaceIds.length > 0;
   return qb.innerJoin(
     (eb) =>
       eb
-        .selectFrom('album_asset')
-        .select('assetId')
-        .where('albumId', '=', anyUuid(albumIds!))
-        .groupBy('assetId')
-        .having((eb) => eb.fn.count('albumId').distinct(), '=', albumIds.length)
+        .selectFrom((inner) => {
+          const albumAssetMembers = inner
+            .selectFrom('album_asset')
+            .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId'])
+            .where('album_asset.albumId', '=', anyUuid(albumIds!));
+          return (
+            includeContributions
+              ? albumAssetMembers.unionAll(
+                  inner
+                    .selectFrom('album_space_asset')
+                    .select(['album_space_asset.assetId as assetId', 'album_space_asset.albumId as albumId'])
+                    .where('album_space_asset.albumId', '=', anyUuid(albumIds!))
+                    .where('album_space_asset.spaceId', '=', anyUuid(timelineSpaceIds!)),
+                )
+              : albumAssetMembers
+          ).as('album_members');
+        })
+        .select('album_members.assetId')
+        .groupBy('album_members.assetId')
+        .having((eb) => eb.fn.count('album_members.albumId').distinct(), '=', albumIds.length)
         .as('has_album'),
     (join) => join.onRef('has_album.assetId', '=', 'asset.id'),
   );
@@ -684,7 +709,9 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
         : qb.where('asset.visibility', '=', options.visibility!),
     )
     .$if(!!options.forceEmptyResult, (qb) => qb.where(sql<SqlBool>`false`))
-    .$if(!!options.albumIds && options.albumIds.length > 0, (qb) => inAlbums(qb, options.albumIds!))
+    .$if(!!options.albumIds && options.albumIds.length > 0, (qb) =>
+      inAlbums(qb, options.albumIds!, options.timelineSpaceIds),
+    )
     .$if(!!options.spaceId && !options.timelineSpaceIds, (qb) =>
       qb.where((eb) =>
         eb.and([

--- a/server/src/utils/shared-space-album-scope.ts
+++ b/server/src/utils/shared-space-album-scope.ts
@@ -116,11 +116,24 @@ export function accessibleSpaceAlbums(eb: ExpressionBuilder<DB, keyof DB>, userI
 }
 
 /**
- * The single definition of the linked-album access path, as an `EXISTS (...)`
- * predicate. Negate with `eb.not(spaceAlbumAssetExists(...))` for anti-join /
- * "no other space path" uses.
+ * The linked-album access path, as an `EXISTS (...)` predicate. Covers BOTH sources of a linked
+ * album's contents: the album owner's own `album_asset` rows AND cross-owner `album_space_asset`
+ * contributions (#764). Because both arms are unioned here, every consumer of the album arm
+ * (timeline, search, map, view, memory, access, …) surfaces contributions with the exact same
+ * membership / role / showInTimeline / not-deleted scoping it already applies — no per-site change.
+ *
+ * Negate with `eb.not(spaceAlbumAssetExists(...))` for anti-join / "no other space path" uses:
+ * `NOT (albumAsset OR contributed)` correctly excludes both.
  */
 export function spaceAlbumAssetExists(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  options: SpaceAlbumAssetOptions,
+): Expression<SqlBool> {
+  return eb.or([linkedAlbumAssetExists(eb, options), spaceContributedAssetExists(eb, options)]);
+}
+
+/** The `album_asset` arm — the album owner's own contents (unchanged pre-#764 behavior). */
+function linkedAlbumAssetExists(
   eb: ExpressionBuilder<DB, keyof DB>,
   options: SpaceAlbumAssetOptions,
 ): Expression<SqlBool> {
@@ -148,6 +161,61 @@ export function spaceAlbumAssetExists(
       )
       .select(eb.lit(1).as('exists'))
       .whereRef('album_asset.assetId', '=', options.correlateAssetId)
+      .$if('spaceId' in scope, (qb) =>
+        qb.where('shared_space_album.spaceId', '=', asUuid((scope as { spaceId: string }).spaceId)),
+      )
+      .$if('spaceIds' in scope, (qb) =>
+        qb.where('shared_space_album.spaceId', '=', anyUuid((scope as { spaceIds: string[] }).spaceIds)),
+      )
+      .$if('spaceIdRef' in scope, (qb) =>
+        qb.whereRef(
+          'shared_space_album.spaceId',
+          '=',
+          (scope as { spaceIdRef: ReferenceExpression<DB, keyof DB> }).spaceIdRef,
+        ),
+      )
+      .$if(!!options.requireShowInTimeline, (qb) => qb.where('shared_space_album.showInTimeline', '=', true))
+      .$if(!!options.excludeAlbumId, (qb) => qb.where('shared_space_album.albumId', '!=', options.excludeAlbumId!)),
+  );
+}
+
+/**
+ * The `album_space_asset` arm — cross-owner contributions (#764). Mirrors {@link linkedAlbumAssetExists}
+ * exactly, except the join additionally correlates `album_space_asset.spaceId` to the link's space so
+ * a contribution is only ever visible through the SINGLE space it was contributed to (a multi-space
+ * album never leaks a contribution to members of a different linked space). Exported for direct use
+ * where only the contributed arm is wanted.
+ */
+export function spaceContributedAssetExists(
+  eb: ExpressionBuilder<DB, keyof DB>,
+  options: SpaceAlbumAssetOptions,
+): Expression<SqlBool> {
+  const notDeleted = options.requireAlbumNotDeleted ?? true;
+  const { scope } = options;
+
+  return eb.exists(
+    eb
+      .selectFrom('shared_space_album')
+      .innerJoin('album_space_asset', (join) =>
+        join
+          .onRef('album_space_asset.albumId', '=', 'shared_space_album.albumId')
+          .onRef('album_space_asset.spaceId', '=', 'shared_space_album.spaceId'),
+      )
+      .$if(notDeleted, (qb) =>
+        qb.innerJoin('album', (join) =>
+          join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+        ),
+      )
+      .$if('memberUserId' in scope, (qb) =>
+        qb
+          .innerJoin('shared_space_member', 'shared_space_member.spaceId', 'shared_space_album.spaceId')
+          .where('shared_space_member.userId', '=', asUuid((scope as { memberUserId: string }).memberUserId))
+          .$if(!!(scope as { memberRole?: SharedSpaceRole[] }).memberRole?.length, (qb2) =>
+            qb2.where('shared_space_member.role', 'in', (scope as { memberRole: SharedSpaceRole[] }).memberRole),
+          ),
+      )
+      .select(eb.lit(1).as('exists'))
+      .whereRef('album_space_asset.assetId', '=', options.correlateAssetId)
       .$if('spaceId' in scope, (qb) =>
         qb.where('shared_space_album.spaceId', '=', asUuid((scope as { spaceId: string }).spaceId)),
       )

--- a/server/test/medium/specs/services/album-space-asset-permissions.service.spec.ts
+++ b/server/test/medium/specs/services/album-space-asset-permissions.service.spec.ts
@@ -1,0 +1,331 @@
+import { Kysely } from 'kysely';
+import { AssetVisibility, Permission } from 'src/enum';
+import { AccessRepository } from 'src/repositories/access.repository';
+import { AlbumUserRepository } from 'src/repositories/album-user.repository';
+import { AlbumRepository } from 'src/repositories/album.repository';
+import { AssetRepository } from 'src/repositories/asset.repository';
+import { EventRepository } from 'src/repositories/event.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { StorageRepository } from 'src/repositories/storage.repository';
+import { UserRepository } from 'src/repositories/user.repository';
+import { DB } from 'src/schema';
+import { AlbumService } from 'src/services/album.service';
+import { checkAccess } from 'src/utils/access';
+import { spaceContributedAssetExists } from 'src/utils/shared-space-album-scope';
+import { newMediumService } from 'test/medium.factory';
+import { factory } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+
+// -------------------------------------------------------------------------------------------------
+// Cross-owner contribution permission matrix (#764)
+//
+//   Space S       — created by spaceOwner; links album L
+//   Space T       — a DIFFERENT space, created by outsider; assetOnlyInT lives here
+//   Album L       — owned by albumOwner (an Editor member of S, NOT the creator), linked to S
+//   Album U       — owned by albumOwner, NOT linked to any space
+//
+//   assetCarol    — owned by carol (member of S), in S's DIRECT POOL   → contributable by editors
+//   assetHidden   — owned by carol, in S's pool but visibility=Hidden  → NOT contributable (gate)
+//   assetEditorOwn— owned by spaceEditor, in S's pool                  → own photo → album_asset path
+//   assetOnlyInT  — owned by outsider, only in space T                 → NOT space-visible via S
+//
+//   Roles in S: spaceOwner(owner) · albumOwner(editor) · spaceEditor(editor) · spaceViewer(viewer)
+//               nonMember(none)
+// -------------------------------------------------------------------------------------------------
+
+let db: Kysely<DB>;
+
+const setup = () => {
+  const result = newMediumService(AlbumService, {
+    database: db,
+    real: [
+      AccessRepository,
+      AlbumRepository,
+      AlbumUserRepository,
+      AssetRepository,
+      SharedSpaceRepository,
+      UserRepository,
+    ],
+    mock: [EventRepository, LoggingRepository, JobRepository, StorageRepository],
+  });
+  // The owned-asset path emits AlbumUpdate / AlbumAssetsAdd; give the auto-mock a no-op resolution.
+  result.ctx.getMock(EventRepository).emit.mockResolvedValue(void 0);
+  return result;
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+describe('AlbumService — cross-owner contribution permission matrix (#764)', () => {
+  let sut: AlbumService;
+  let accessRepo: AccessRepository;
+  let spaceRepo: SharedSpaceRepository;
+
+  let spaceS: string;
+  let albumL: string;
+  let albumU: string;
+  let assetCarol: string;
+  let assetHidden: string;
+  let assetEditorOwn: string;
+  let assetOnlyInT: string;
+
+  const actors: Record<string, { id: string; email: string }> = {};
+  const authOf = (name: string) => factory.auth({ user: { id: actors[name].id, email: actors[name].email } });
+
+  // The exact read gate every album surface uses — does `userId` see `assetId` as a contribution?
+  const seesContribution = async (userId: string, assetId: string) => {
+    const rows = await db
+      .selectFrom('asset')
+      .select('asset.id')
+      .where('asset.id', '=', assetId)
+      .where((eb) => spaceContributedAssetExists(eb, { correlateAssetId: 'asset.id', scope: { memberUserId: userId } }))
+      .execute();
+    return rows.length > 0;
+  };
+
+  const isContributionRow = async (assetId: string) => {
+    const row = await db
+      .selectFrom('album_space_asset')
+      .select(['albumId', 'spaceId'])
+      .where('albumId', '=', albumL)
+      .where('assetId', '=', assetId)
+      .executeTakeFirst();
+    return row;
+  };
+
+  const isAlbumAssetRow = async (assetId: string) => {
+    const row = await db
+      .selectFrom('album_asset')
+      .select('assetId')
+      .where('albumId', '=', albumL)
+      .where('assetId', '=', assetId)
+      .executeTakeFirst();
+    return !!row;
+  };
+
+  beforeAll(async () => {
+    const { sut: albumService, ctx } = setup();
+    sut = albumService;
+    accessRepo = ctx.get(AccessRepository);
+    spaceRepo = ctx.get(SharedSpaceRepository);
+
+    const { user: spaceOwner } = await ctx.newUser();
+    const { user: albumOwner } = await ctx.newUser();
+    const { user: spaceEditor } = await ctx.newUser();
+    const { user: spaceViewer } = await ctx.newUser();
+    const { user: nonMember } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { user: outsider } = await ctx.newUser();
+    Object.assign(actors, { spaceOwner, albumOwner, spaceEditor, spaceViewer, nonMember, carol, outsider });
+
+    const { space: s } = await ctx.newSharedSpace({ createdById: spaceOwner.id });
+    const { space: t } = await ctx.newSharedSpace({ createdById: outsider.id });
+    spaceS = s.id;
+
+    await ctx.newSharedSpaceMember({ spaceId: s.id, userId: spaceOwner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: s.id, userId: albumOwner.id, role: 'editor' });
+    await ctx.newSharedSpaceMember({ spaceId: s.id, userId: spaceEditor.id, role: 'editor' });
+    await ctx.newSharedSpaceMember({ spaceId: s.id, userId: spaceViewer.id, role: 'viewer' });
+    await ctx.newSharedSpaceMember({ spaceId: s.id, userId: carol.id, role: 'editor' });
+    await ctx.newSharedSpaceMember({ spaceId: t.id, userId: outsider.id, role: 'owner' });
+
+    const { result: l } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Album L' });
+    const { result: u } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Album U (unlinked)' });
+    albumL = l.id;
+    albumU = u.id;
+    await spaceRepo.addAlbum({ spaceId: s.id, albumId: l.id, addedById: spaceOwner.id });
+
+    const { asset: aCarol } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Timeline });
+    const { asset: aHidden } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Hidden });
+    const { asset: aEditor } = await ctx.newAsset({ ownerId: spaceEditor.id, visibility: AssetVisibility.Timeline });
+    const { asset: aT } = await ctx.newAsset({ ownerId: outsider.id, visibility: AssetVisibility.Timeline });
+    assetCarol = aCarol.id;
+    assetHidden = aHidden.id;
+    assetEditorOwn = aEditor.id;
+    assetOnlyInT = aT.id;
+
+    await ctx.newSharedSpaceAsset({ spaceId: s.id, assetId: aCarol.id, addedById: carol.id });
+    await ctx.newSharedSpaceAsset({ spaceId: s.id, assetId: aHidden.id, addedById: carol.id });
+    await ctx.newSharedSpaceAsset({ spaceId: s.id, assetId: aEditor.id, addedById: spaceEditor.id });
+    await ctx.newSharedSpaceAsset({ spaceId: t.id, assetId: aT.id, addedById: outsider.id });
+  });
+
+  // ===============================================================================================
+  // ADD — who may contribute what
+  // ===============================================================================================
+  describe('ADD', () => {
+    it('space Editor contributes a non-owned pool asset → success, album_space_asset row (NOT album_asset)', async () => {
+      const [res] = await sut.addAssets(authOf('spaceEditor'), albumL, { ids: [assetCarol] });
+      expect(res).toEqual({ id: assetCarol, success: true });
+      const row = await isContributionRow(assetCarol);
+      expect(row).toMatchObject({ albumId: albumL, spaceId: spaceS });
+      expect(await isAlbumAssetRow(assetCarol)).toBe(false);
+    });
+
+    it('duplicate contribution → DUPLICATE (idempotent, no second row)', async () => {
+      const [res] = await sut.addAssets(authOf('spaceOwner'), albumL, { ids: [assetCarol] });
+      expect(res).toEqual({ id: assetCarol, success: false, error: 'duplicate' });
+    });
+
+    it('space Editor contributes their OWN pool asset → success via album_asset (not a contribution)', async () => {
+      const [res] = await sut.addAssets(authOf('spaceEditor'), albumL, { ids: [assetEditorOwn] });
+      expect(res).toEqual({ id: assetEditorOwn, success: true });
+      expect(await isAlbumAssetRow(assetEditorOwn)).toBe(true);
+      expect(await isContributionRow(assetEditorOwn)).toBeUndefined();
+    });
+
+    it('Hidden asset is NOT contributable (visibility gate) → NO_PERMISSION, no row', async () => {
+      const [res] = await sut.addAssets(authOf('spaceEditor'), albumL, { ids: [assetHidden] });
+      expect(res).toEqual({ id: assetHidden, success: false, error: 'no_permission' });
+      expect(await isContributionRow(assetHidden)).toBeUndefined();
+    });
+
+    it('asset not visible via the album’s space (only in space T) → NO_PERMISSION', async () => {
+      const [res] = await sut.addAssets(authOf('spaceEditor'), albumL, { ids: [assetOnlyInT] });
+      expect(res).toEqual({ id: assetOnlyInT, success: false, error: 'no_permission' });
+    });
+
+    it('space Viewer is hard-blocked (403) before any per-asset logic', async () => {
+      await expect(sut.addAssets(authOf('spaceViewer'), albumL, { ids: [assetCarol] })).rejects.toThrow();
+    });
+
+    it('non-member is denied (403)', async () => {
+      await expect(sut.addAssets(authOf('nonMember'), albumL, { ids: [assetCarol] })).rejects.toThrow();
+    });
+
+    it('cannot contribute a non-owned asset into an UNLINKED album (403 — not space-linked)', async () => {
+      await expect(sut.addAssets(authOf('spaceEditor'), albumU, { ids: [assetCarol] })).rejects.toThrow();
+    });
+
+    it('mixed batch → per-asset outcomes preserved', async () => {
+      // fresh assets so this test is order-independent
+      const { ctx } = setup();
+      const { asset: freshCarol } = await ctx.newAsset({
+        ownerId: actors.carol.id,
+        visibility: AssetVisibility.Timeline,
+      });
+      await ctx.newSharedSpaceAsset({ spaceId: spaceS, assetId: freshCarol.id, addedById: actors.carol.id });
+      const { asset: freshOwn } = await ctx.newAsset({
+        ownerId: actors.spaceEditor.id,
+        visibility: AssetVisibility.Timeline,
+      });
+      await ctx.newSharedSpaceAsset({ spaceId: spaceS, assetId: freshOwn.id, addedById: actors.spaceEditor.id });
+
+      const results = await sut.addAssets(authOf('spaceEditor'), albumL, {
+        ids: [freshCarol.id, freshOwn.id, assetOnlyInT],
+      });
+      const byId = Object.fromEntries(results.map((r) => [r.id, r]));
+      expect(byId[freshCarol.id]).toEqual({ id: freshCarol.id, success: true });
+      expect(byId[freshOwn.id]).toEqual({ id: freshOwn.id, success: true });
+      expect(byId[assetOnlyInT]).toEqual({ id: assetOnlyInT, success: false, error: 'no_permission' });
+    });
+  });
+
+  // ===============================================================================================
+  // READ — who sees a contribution (any live member) + leak / lifecycle
+  // ===============================================================================================
+  describe('READ + lifecycle', () => {
+    it('every live member (owner/editor/viewer) sees the contribution; non-member does not', async () => {
+      expect(await seesContribution(actors.spaceOwner.id, assetCarol)).toBe(true);
+      expect(await seesContribution(actors.spaceEditor.id, assetCarol)).toBe(true);
+      expect(await seesContribution(actors.spaceViewer.id, assetCarol)).toBe(true);
+      expect(await seesContribution(actors.nonMember.id, assetCarol)).toBe(false);
+    });
+
+    it('LEAK NEGATIVE: album owner reaches the contribution ONLY via live membership (no permanent album_asset grant)', async () => {
+      // While a member, albumOwner sees it — but via the space arm, NOT checkAlbumAccess.
+      expect(await seesContribution(actors.albumOwner.id, assetCarol)).toBe(true);
+      const grantedWhileMember = await checkAccess(accessRepo, {
+        auth: authOf('albumOwner'),
+        permission: Permission.AssetRead,
+        ids: new Set([assetCarol]),
+      });
+      expect(grantedWhileMember.has(assetCarol)).toBe(true);
+
+      // Remove the album owner from the space (link stays; other members keep seeing it).
+      await spaceRepo.removeMember(spaceS, actors.albumOwner.id);
+      try {
+        expect(await seesContribution(actors.albumOwner.id, assetCarol)).toBe(false);
+        expect(await seesContribution(actors.spaceEditor.id, assetCarol)).toBe(true);
+        const grantedAfterLeave = await checkAccess(accessRepo, {
+          auth: authOf('albumOwner'),
+          permission: Permission.AssetRead,
+          ids: new Set([assetCarol]),
+        });
+        // The whole point: no album_asset grant survived — the owner loses the photo entirely.
+        expect(grantedAfterLeave.has(assetCarol)).toBe(false);
+      } finally {
+        // Restore albumOwner's membership so later tests keep the fixture world intact.
+        await db
+          .insertInto('shared_space_member')
+          .values({ spaceId: spaceS, userId: actors.albumOwner.id, role: 'editor' })
+          .onConflict((oc) => oc.doNothing())
+          .execute();
+      }
+    });
+
+    it('UNLINK NEGATIVE: unlinking the album hides the contribution for everyone (reversible on re-link)', async () => {
+      await spaceRepo.removeAlbum(spaceS, albumL);
+      try {
+        expect(await seesContribution(actors.spaceEditor.id, assetCarol)).toBe(false);
+        expect(await seesContribution(actors.spaceViewer.id, assetCarol)).toBe(false);
+      } finally {
+        await spaceRepo.addAlbum({ spaceId: spaceS, albumId: albumL, addedById: actors.spaceOwner.id });
+      }
+      expect(await seesContribution(actors.spaceEditor.id, assetCarol)).toBe(true);
+    });
+  });
+
+  // ===============================================================================================
+  // REMOVE — who may remove a contribution
+  // ===============================================================================================
+  describe('REMOVE', () => {
+    const contributeFresh = async () => {
+      const { ctx } = setup();
+      const { asset } = await ctx.newAsset({ ownerId: actors.carol.id, visibility: AssetVisibility.Timeline });
+      await ctx.newSharedSpaceAsset({ spaceId: spaceS, assetId: asset.id, addedById: actors.carol.id });
+      const [res] = await sut.addAssets(authOf('spaceEditor'), albumL, { ids: [asset.id] });
+      expect(res.success).toBe(true);
+      return asset.id;
+    };
+
+    it('space Editor removes a contribution → row gone, underlying asset untouched', async () => {
+      const assetId = await contributeFresh();
+      const [res] = await sut.removeAssets(authOf('spaceEditor'), albumL, { ids: [assetId] });
+      expect(res).toEqual({ id: assetId, success: true });
+      const row = await db
+        .selectFrom('album_space_asset')
+        .selectAll()
+        .where('assetId', '=', assetId)
+        .executeTakeFirst();
+      expect(row).toBeUndefined();
+      const asset = await db.selectFrom('asset').select('id').where('id', '=', assetId).executeTakeFirst();
+      expect(asset).toBeDefined();
+    });
+
+    it('album owner (Editor of S) removes a contribution → success', async () => {
+      const assetId = await contributeFresh();
+      const [res] = await sut.removeAssets(authOf('albumOwner'), albumL, { ids: [assetId] });
+      expect(res.success).toBe(true);
+    });
+
+    it('space Viewer cannot remove a contribution (403) — row stays', async () => {
+      const assetId = await contributeFresh();
+      await expect(sut.removeAssets(authOf('spaceViewer'), albumL, { ids: [assetId] })).rejects.toThrow();
+      const row = await db
+        .selectFrom('album_space_asset')
+        .selectAll()
+        .where('assetId', '=', assetId)
+        .executeTakeFirst();
+      expect(row).toBeDefined();
+    });
+
+    it('non-member cannot remove a contribution (403)', async () => {
+      const assetId = await contributeFresh();
+      await expect(sut.removeAssets(authOf('nonMember'), albumL, { ids: [assetId] })).rejects.toThrow();
+    });
+  });
+});

--- a/server/test/medium/specs/services/album-space-asset-permissions.service.spec.ts
+++ b/server/test/medium/specs/services/album-space-asset-permissions.service.spec.ts
@@ -13,6 +13,7 @@ import { UserRepository } from 'src/repositories/user.repository';
 import { DB } from 'src/schema';
 import { AlbumService } from 'src/services/album.service';
 import { checkAccess } from 'src/utils/access';
+import { inAlbums } from 'src/utils/database';
 import { spaceContributedAssetExists } from 'src/utils/shared-space-album-scope';
 import { newMediumService } from 'test/medium.factory';
 import { factory } from 'test/small.factory';
@@ -276,6 +277,34 @@ describe('AlbumService — cross-owner contribution permission matrix (#764)', (
         await spaceRepo.addAlbum({ spaceId: spaceS, albumId: albumL, addedById: actors.spaceOwner.id });
       }
       expect(await seesContribution(actors.spaceEditor.id, assetCarol)).toBe(true);
+    });
+  });
+
+  // ===============================================================================================
+  // DISPLAY — contribution surfaces as album content only for a live member (inAlbums gate)
+  // ===============================================================================================
+  describe('DISPLAY (album grid membership)', () => {
+    it('shows as album content when the viewer has the tether space live (timelineSpaceIds); excluded without it', async () => {
+      const { ctx } = setup();
+      const { asset } = await ctx.newAsset({ ownerId: actors.carol.id, visibility: AssetVisibility.Timeline });
+      await ctx.newSharedSpaceAsset({ spaceId: spaceS, assetId: asset.id, addedById: actors.carol.id });
+      const [res] = await sut.addAssets(authOf('spaceEditor'), albumL, { ids: [asset.id] });
+      expect(res.success).toBe(true);
+
+      const asLiveMember = await inAlbums(db.selectFrom('asset').where('asset.id', '=', asset.id), [albumL], [spaceS])
+        .select('asset.id')
+        .execute();
+      expect(asLiveMember.map((r) => r.id)).toContain(asset.id);
+
+      // No live member-space (album owner who left / a pure-owner album view) → contribution excluded.
+      const withoutLiveMembership = await inAlbums(
+        db.selectFrom('asset').where('asset.id', '=', asset.id),
+        [albumL],
+        undefined,
+      )
+        .select('asset.id')
+        .execute();
+      expect(withoutLiveMembership).toHaveLength(0);
     });
   });
 

--- a/server/test/medium/specs/services/album-space-asset-permissions.service.spec.ts
+++ b/server/test/medium/specs/services/album-space-asset-permissions.service.spec.ts
@@ -77,6 +77,7 @@ describe('AlbumService — cross-owner contribution permission matrix (#764)', (
   const authOf = (name: string) => factory.auth({ user: { id: actors[name].id, email: actors[name].email } });
 
   // The exact read gate every album surface uses — does `userId` see `assetId` as a contribution?
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- test helper closes over the shared fixture db
   const seesContribution = async (userId: string, assetId: string) => {
     const rows = await db
       .selectFrom('asset')
@@ -297,11 +298,7 @@ describe('AlbumService — cross-owner contribution permission matrix (#764)', (
       expect(asLiveMember.map((r) => r.id)).toContain(asset.id);
 
       // No live member-space (album owner who left / a pure-owner album view) → contribution excluded.
-      const withoutLiveMembership = await inAlbums(
-        db.selectFrom('asset').where('asset.id', '=', asset.id),
-        [albumL],
-        undefined,
-      )
+      const withoutLiveMembership = await inAlbums(db.selectFrom('asset').where('asset.id', '=', asset.id), [albumL])
         .select('asset.id')
         .execute();
       expect(withoutLiveMembership).toHaveLength(0);
@@ -312,6 +309,7 @@ describe('AlbumService — cross-owner contribution permission matrix (#764)', (
   // REMOVE — who may remove a contribution
   // ===============================================================================================
   describe('REMOVE', () => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping -- closes over the shared fixture (sut, actors, spaceS, albumL)
     const contributeFresh = async () => {
       const { ctx } = setup();
       const { asset } = await ctx.newAsset({ ownerId: actors.carol.id, visibility: AssetVisibility.Timeline });

--- a/web/src/lib/services/album.service.spec.ts
+++ b/web/src/lib/services/album.service.spec.ts
@@ -1,12 +1,15 @@
 // album.service.spec.ts
 import type { AlbumResponseDto } from '@immich/sdk';
+import type { BulkIdResponseDto } from '@immich/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SpacePickerModal from '$lib/modals/SpacePickerModal.svelte';
-import { handleLinkAlbumToSpace } from './album.service';
+import { handleLinkAlbumToSpace, notifyAddToAlbum } from './album.service';
 
 const linkAlbum = vi.fn();
 const showModal = vi.fn();
 const primary = vi.fn();
+const info = vi.fn();
+const warning = vi.fn();
 const handleError = vi.fn();
 
 vi.mock('@immich/sdk', async (orig) => ({
@@ -17,7 +20,11 @@ vi.mock('@immich/sdk', async (orig) => ({
 vi.mock('@immich/ui', async (orig) => ({
   ...(await orig<typeof import('@immich/ui')>()),
   modalManager: { show: (...a: unknown[]) => showModal(...a) },
-  toastManager: { primary: (...a: unknown[]) => primary(...a) },
+  toastManager: {
+    primary: (...a: unknown[]) => primary(...a),
+    info: (...a: unknown[]) => info(...a),
+    warning: (...a: unknown[]) => warning(...a),
+  },
 }));
 
 vi.mock('$lib/utils/handle-error', () => ({ handleError: (...a: unknown[]) => handleError(...a) }));
@@ -68,5 +75,54 @@ describe('handleLinkAlbumToSpace', () => {
     await expect(handleLinkAlbumToSpace(album)).resolves.toBe(false);
 
     expect(handleError).toHaveBeenCalledWith(error, 'spaces_linked_albums_error_link:{}');
+  });
+});
+
+describe('notifyAddToAlbum — truthful severity (#764)', () => {
+  const $t = ((key: string, opts?: { values?: Record<string, unknown> }) =>
+    `${key}:${JSON.stringify(opts?.values ?? {})}`) as never;
+
+  const ok = (id: string): BulkIdResponseDto => ({ id, success: true });
+  const dup = (id: string): BulkIdResponseDto => ({ id, success: false, error: 'duplicate' as never });
+  const denied = (id: string): BulkIdResponseDto => ({ id, success: false, error: 'no_permission' as never });
+
+  it('all succeeded → green success toast (primary) with View album', () => {
+    notifyAddToAlbum($t, 'album-1', ['a', 'b'], [ok('a'), ok('b')]);
+    expect(primary).toHaveBeenCalledTimes(1);
+    expect(warning).not.toHaveBeenCalled();
+    const [item] = primary.mock.calls[0];
+    expect(item.description).toBe('assets_added_to_album_count:{"count":2}');
+    expect(item.button).toBeDefined();
+  });
+
+  it('nothing added (all no_permission) → warning toast, NEVER primary, no View album', () => {
+    notifyAddToAlbum($t, 'album-1', ['a', 'b'], [denied('a'), denied('b')]);
+    expect(primary).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledTimes(1);
+    const [item] = warning.mock.calls[0];
+    expect(item.description).toBe('assets_cannot_be_added_to_album_count:{"count":2}');
+    expect(item.button).toBeUndefined();
+  });
+
+  it('all duplicates → info toast (already in album), not primary', () => {
+    notifyAddToAlbum($t, 'album-1', ['a', 'b'], [dup('a'), dup('b')]);
+    expect(primary).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info.mock.calls[0][0].description).toBe('assets_were_part_of_album_count:{"count":2}');
+  });
+
+  it('partial success → info toast (not full green), keeps View album', () => {
+    notifyAddToAlbum($t, 'album-1', ['a', 'b'], [ok('a'), denied('b')]);
+    expect(primary).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledTimes(1);
+    const [item] = info.mock.calls[0];
+    expect(item.description).toBe('assets_added_to_album_partial_count:{"successCount":1,"totalCount":2}');
+    expect(item.button).toBeDefined();
+  });
+
+  it('nothing added, mix of duplicate + no_permission → warning, not primary', () => {
+    notifyAddToAlbum($t, 'album-1', ['a', 'b'], [dup('a'), denied('b')]);
+    expect(primary).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/lib/services/album.service.ts
+++ b/web/src/lib/services/album.service.ts
@@ -133,23 +133,49 @@ export const addAssetsToAlbums = async (albumIds: string[], assetIds: string[], 
   }
 };
 
-const notifyAddToAlbum = ($t: MessageFormatter, albumId: string, assetIds: string[], results: BulkIdResponseDto[]) => {
+/**
+ * Toast the outcome of an add-to-album call truthfully (#764). The server returns HTTP 200 with
+ * per-asset failures, so severity must follow the result counts — a green "Successful" heading is
+ * reserved for the all-succeeded case; nothing-added is a warning; partial / already-present is info.
+ * Exported for unit testing.
+ */
+export const notifyAddToAlbum = (
+  $t: MessageFormatter,
+  albumId: string,
+  assetIds: string[],
+  results: BulkIdResponseDto[],
+) => {
   const successCount = results.filter(({ success }) => success).length;
   const duplicateCount = results.filter(({ error }) => error === 'duplicate').length;
-  let description = $t('assets_cannot_be_added_to_album_count', { values: { count: assetIds.length } });
+  const total = assetIds.length;
+  const viewButton = { label: $t('view_album'), onclick: () => goto(Route.viewAlbum({ id: albumId })) };
+  const options = { timeout: 5000 };
 
-  if (duplicateCount === assetIds.length) {
-    description = $t('assets_were_part_of_album_count', { values: { count: duplicateCount } });
-  } else if (successCount === assetIds.length) {
-    description = $t('assets_added_to_album_count', { values: { count: successCount } });
+  if (successCount === total) {
+    toastManager.primary(
+      { description: $t('assets_added_to_album_count', { values: { count: successCount } }), button: viewButton },
+      options,
+    );
+  } else if (duplicateCount === total) {
+    toastManager.info(
+      { description: $t('assets_were_part_of_album_count', { values: { count: duplicateCount } }), button: viewButton },
+      options,
+    );
   } else if (successCount > 0) {
-    description = $t('assets_added_to_album_partial_count', { values: { successCount, totalCount: assetIds.length } });
+    toastManager.info(
+      {
+        description: $t('assets_added_to_album_partial_count', { values: { successCount, totalCount: total } }),
+        button: viewButton,
+      },
+      options,
+    );
+  } else {
+    // Nothing was added (no_permission and/or a mix that netted zero) — never render as success.
+    toastManager.warning(
+      { description: $t('assets_cannot_be_added_to_album_count', { values: { count: total } }) },
+      options,
+    );
   }
-
-  toastManager.primary(
-    { description, button: { label: $t('view_album'), onclick: () => goto(Route.viewAlbum({ id: albumId })) } },
-    { timeout: 5000 },
-  );
 };
 
 const notifyAddToAlbums = (


### PR DESCRIPTION
## Collaborative cross-owner contributions to space albums (#764)

Stacked on **`space-albums-onto-main`** (#752). Lets a space **Editor** add photos they don't own to a space-linked album, tethered to live space access — and fixes #764's contradictory toast.

Fixes #764.

### The two defects in #764
1. **Lying toast** — `notifyAddToAlbum` always showed a green "Successful" heading even when the server returned per-asset failures (HTTP 200 + `no_permission`).
2. **Add blocked for non-owned assets** — album add gates every asset on `AssetShare` (owner/partner only); #752 made the album-level check space-aware but the per-asset gate was never extended.

### Design (spec: `docs/superpowers/specs/2026-07-10-space-album-cross-owner-contributions-design.md`)
A cross-owner contribution is an **inert bookmark** `(album, asset, space)` in a new `album_space_asset` table — **never** in `album_asset`, so the album owner never gains a permanent `checkAlbumAccess` grant they could carry out of the space. Access is re-derived from live space membership + the live album↔space link on every read.

### RBAC contract (all covered by the permission matrix test)
| Op | Allowed | Enforced by |
|---|---|---|
| **View** | any live space member (incl. Viewer) | read arm, no role filter |
| **Contribute** | space Owner/Editor, asset space-visible via that space, non-Hidden/Locked | `AlbumAssetCreate` (403 for Viewers) + per-asset eligibility |
| **Remove** | album Owner/Editor OR space Owner/Editor | `AlbumAssetDelete` |

Key guarantees, each with a passing negative test: Viewer 403 hard-block · **no Hidden/Locked leak** (visibility gate at add + read) · **no permanent owner grant** (owner who leaves the space loses the photo) · no cross-space smuggling · unlink hides for everyone · `AssetShare`/shared-link/memory permissions **not** widened.

### What's here (slices 0–4 + display)
- **Slice 0** — truthful add-to-album toast (web).
- **Slice 1** — `album_space_asset` table + migration + `revert-to-immich.sql`.
- **Slices 2/4** — two-bucket add path (owned→`album_asset`, non-owned-space-visible→`album_space_asset`, else `NO_PERMISSION`) + space-aware remove.
- **Slice 3 (read/display)** — contributions surface everywhere the album-visibility arm is read (timeline/search/map/…) and in the album grid (`inAlbums`), gated on `timelineSpaceIds` (live membership).
- **Tests** — 17-case RBAC permission matrix (medium) + web unit; existing space-album/visibility suites green (arm change is provably inert when `album_space_asset` is empty).

### Deferred (flagged, follow-up)
- **Mobile sync** (`album_space_asset` audit table + trigger + `SharedSpaceAlbum*Sync` + Flutter client) — web is the reported platform; mobile needs Dart/OpenAPI regen + Flutter validation.
- **"from Space" tile badge** — needs a provenance field on the album response (DTO/SDK change). Functional feature works without it.
- **Album-card asset count** (`getMetadataForIds`) still counts `album_asset` only — minor cosmetic undercount.

