### PR TITLE
feat(spaces): mobile sync of cross-owner space-album contributions (#764)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-space-album-cross-owner-contributions-slice-5.md
+++ b/docs/superpowers/plans/2026-07-11-space-album-cross-owner-contributions-slice-5.md
@@ -1,0 +1,1257 @@
+# Slice 5 — Mobile Sync of Cross-Owner Contributions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cross-owner contributions (`album_space_asset` rows, #764) appear, update, and disappear on the mobile app through the **existing** shared-space-album sync streams, with the contributed asset's payload + EXIF, converging identically to the album owner's own `album_asset` rows.
+
+**Architecture:** Contributions ride the **existing** `SharedSpaceAlbum*` sync entity types — the mobile client is origin-blind (its `shared_space_album_asset_entity` membership table is a bare `(albumId, assetId)` pair with no owner column), so **no mobile production code, no OpenAPI regen, and no new `SyncEntityType`/`SyncRequestType`** are required. All work is server-side: (1) give `album_space_asset` the standard `updateId`/`updatedAt` sync watermark + a `BEFORE UPDATE` trigger, and a trigger-driven `album_space_asset_audit` delete table, so the contributed arm becomes a **mechanical mirror** of the `album_asset` arm; (2) union that arm into the three sync stream classes (`SharedSpaceAlbumToAssetSync`, `SharedSpaceAlbumAssetSync`, `SharedSpaceAlbumAssetExifSync`); (3) extend the Hidden/restore visibility parity and audit cleanup. A mobile Flutter convergence test is added as a regression guard.
+
+**Tech Stack:** NestJS 11 + Kysely (server), Postgres (testcontainers medium tests via `SyncTestContext`), Flutter/Drift (mobile), vitest, `flutter test`.
+
+## Global Constraints
+
+- **Migrations:** fork-only files in `server/src/schema/migrations-gallery/` with round timestamps that don't collide. Existing `album_space_asset` migration is `1783000000000`. Use `1783100000000` for this slice's migration. Add `scripts/revert-to-immich.sql` DROP entries for every new table/function/trigger **and** allowlist entries for the new function/trigger names.
+- **No relative imports** on the server — use the `src/` path alias.
+- **Kysely transactions:** never issue `this.db` queries inside a `transaction()` callback (pool deadlock). None of this slice's changes run inside a `transaction()`.
+- **`make sql` regeneration** happens **only** against a scratch migrated DB — never the dev-stack DB, never without a running DB (it deletes query files otherwise). Deferred to Task 7.
+- **`@GenerateSql`-decorated** methods must keep their decorator; Task 7's `make sql` regenerates `server/src/queries/*.sql`.
+- **No new repository class** is added, so `test/medium.factory.ts` `newRealRepository` and `BaseService` wiring are **not** touched. (`album_space_asset_audit` is a table read inside the existing `SyncRepository`, and written by a DB trigger — no repository of its own.)
+- **No Claude co-author trailers.** One commit per task.
+- **UUIDv7 watermark domain:** `updateId`, `createId`, and audit `id` are all `immich_uuid_v7()` — the same monotonic ordering domain, so a single per-entity-type client checkpoint stays valid across a UNION of `album_asset`-derived and `album_space_asset`-derived arms ordered by that watermark.
+
+---
+
+## Reference facts (confirmed against the worktree at plan time)
+
+- **`album_space_asset`** (`server/src/schema/tables/album-space-asset.table.ts`, migration `1783000000000`): PK `(albumId, assetId)`; columns `spaceId`, `addedById` (nullable, SET NULL), `addedAt`, `createId` (v7), `createdAt`. **No `updateId`/`updatedAt` yet** — Task 1 adds them.
+- **Delete path already exists** (`AlbumRepository.removeContributedAssetIds`, `album.repository.ts:475`): a plain `deleteFrom('album_space_asset')` — a `FOR EACH STATEMENT` `AFTER DELETE` trigger catches it plus every FK cascade (asset/album/space delete).
+- **The three streams** live in `server/src/repositories/sync.repository.ts`: `SharedSpaceAlbumToAssetSync` (`:1609`), `SharedSpaceAlbumAssetSync` (`:1689`), `SharedSpaceAlbumAssetExifSync` (`:1763`). Registration fields `:86-88`, constructor `:124-126`. `BaseSync` helpers `:130-175`.
+- **The membership DELETE arm** (`getDeletes`, `:1624`) already UNIONs two audit tables (`album_asset_audit` + `shared_space_album_asset_audit`) under one `ORDER BY id`. Task 2 adds a **third** arm from `album_space_asset_audit`.
+- **Visibility purge/restore** live in `SharedSpaceRepository` (`shared-space.repository.ts`): `emitAlbumAssetVisibilityPurge` (`:540`, INSERTs `shared_space_album_asset_audit` tombstones on Hidden-flip), `emitAlbumAssetVisibilityRestore` (`:573`, bumps `album_asset.updatedAt` on un-hide). Called from `asset.service.ts:452` (purge) / `:425` (restore) — **call sites unchanged**; Task 4 only extends the two repository method bodies.
+- **Audit cleanup** is scheduled in `sync.service.ts:297` (`this.syncRepository.sharedSpaceAlbumToAsset.cleanupAuditTable(pruneThreshold)`). `SharedSpaceAlbumToAssetSync.cleanupAuditTable` (`:1677`) currently prunes only `shared_space_album_asset_audit`; Task 4 makes it also prune `album_space_asset_audit`.
+- **Mirror templates:** ALTER-add-sync-columns migration = `1778120000000-AddSharedSpaceAssetSyncColumns.ts`; delete-trigger blueprint = `1779200000000-AddSharedSpaceAlbumDeleteSideTriggers.ts`; decorator target = `server/src/schema/tables/shared-space-asset.table.ts` (`@UpdatedAtTrigger` + `@UpdateIdColumn` + `@UpdateDateColumn`).
+- **Medium test harness:** `SyncTestContext` (`test/medium.factory.ts:395`) with helpers `newUser`, `newAlbum`, `newAsset`, `newAlbumAsset`, `newSharedSpace`, `newSharedSpaceMember`, `newSharedSpaceAlbum` (auto-creates grants via the `shared_space_album_after_insert_user` trigger). Sync-stream medium specs live in `server/test/medium/specs/sync/`. Task 1 adds a `newAlbumSpaceAsset` helper.
+
+### Critical design note — why the contributed delete arm differs from the `shared_space_album_asset_audit` arm
+
+The existing `shared_space_album_asset_audit` arm INNER-JOINs `asset` and filters `asset.ownerId != userId` because that table is **purge-only** (asset always exists) and the asset is the owner's own `album_asset` membership (the owner keeps it via their personal album sync). **Neither is true for contributions:**
+
+- `album_space_asset_audit` is **trigger-driven**, so on FK cascade (asset deleted) the asset row is **gone** → the arm must **not** join `asset`.
+- A contribution is **never** also an owner's `album_asset` row (an asset lands in exactly one of the two tables — spec §5.1), so the owner has **no independent path** to the `(album, asset)` membership. When a contribution is removed/deleted/Hidden, **every** member — including the asset's owner — must drop it. → **no `ownerId` filter.**
+
+So the contributed delete arm is `SELECT id, assetId, albumId FROM album_space_asset_audit` with only the checkpoint window + `accessibleSpaceAlbums` scope. Simpler than the sibling arm; the difference is load-bearing and must be commented.
+
+---
+
+## Task 1: Schema foundation — `updateId` watermark + `album_space_asset_audit` + triggers
+
+**Delivers.** `album_space_asset` gains the standard `updateId`/`updatedAt` sync watermark (+ `BEFORE UPDATE` trigger) so the contributed sync arm mirrors `album_asset` exactly; a new trigger-driven `album_space_asset_audit` table captures every contribution deletion (explicit + FK cascade). No user-facing behavior — fully covered by a medium schema test.
+
+**Files:**
+- Modify: `server/src/schema/tables/album-space-asset.table.ts` (add `updateId`/`updatedAt` + `@UpdatedAtTrigger`)
+- Create: `server/src/schema/tables/album-space-asset-audit.table.ts`
+- Modify: `server/src/schema/index.ts` (register the audit table)
+- Create: `server/src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts`
+- Modify: `scripts/revert-to-immich.sql` (DROP entries + function/trigger allowlist entries)
+- Modify: `server/test/medium.factory.ts` (add `newAlbumSpaceAsset` helper)
+- Create/Test: `server/test/medium/specs/sync/album-space-asset-audit.spec.ts`
+
+**Interfaces:**
+- Produces: `album_space_asset.updateId` / `.updatedAt` columns; `album_space_asset_audit` table `{ id (v7 PK), albumId, assetId, deletedAt }`; DB triggers `album_space_asset_updatedAt` (BEFORE UPDATE) and `album_space_asset_delete_audit` (AFTER DELETE STATEMENT); `SyncTestContext.newAlbumSpaceAsset({ albumId, assetId, spaceId, addedById? })`.
+
+- [ ] **Step 1: Add the `newAlbumSpaceAsset` test helper**
+
+In `server/test/medium.factory.ts`, immediately after `newSharedSpaceAlbum` (ends ~line 392), add a helper mirroring `newSharedSpaceAsset`:
+
+```ts
+  async newAlbumSpaceAsset(dto: { albumId: string; assetId: string; spaceId: string; addedById?: string | null }) {
+    const result = await this.database
+      .insertInto('album_space_asset')
+      .values({
+        albumId: dto.albumId,
+        assetId: dto.assetId,
+        spaceId: dto.spaceId,
+        addedById: dto.addedById ?? null,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return { albumSpaceAsset: result, result };
+  }
+```
+
+- [ ] **Step 2: Write the failing medium test**
+
+Create `server/test/medium/specs/sync/album-space-asset-audit.spec.ts`:
+
+```ts
+import { Kysely } from 'kysely';
+import { SharedSpaceRole } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+// Schema-level guarantees for album_space_asset's sync substrate (#764 Slice 5):
+//   - updateId bumps on UPDATE (the BEFORE-UPDATE trigger), enabling restore re-emit
+//   - deleting a contribution row (explicit or FK cascade) writes an album_space_asset_audit row
+//   - the audit trigger is statement-level (a multi-row delete writes one audit row per deleted row)
+
+let db: Kysely<DB>;
+
+const seedContribution = async (ctx: SyncTestContext) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: contributor } = await ctx.newUser();
+  const { album } = await ctx.newAlbum({ ownerId: owner.id });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id });
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id, role: SharedSpaceRole.Editor });
+  await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+  await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id, addedById: contributor.id });
+  return { owner, contributor, album, asset, space };
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+describe('album_space_asset sync substrate', () => {
+  it('bumps updateId when the row is updated', async () => {
+    const ctx = new SyncTestContext(db);
+    const { album, asset } = await seedContribution(ctx);
+
+    const before = await db
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+
+    await db
+      .updateTable('album_space_asset')
+      .set({ updatedAt: new Date() })
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+
+    const after = await db
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+
+    expect(after.updateId).not.toBe(before.updateId);
+  });
+
+  it('writes an album_space_asset_audit row when a contribution is deleted', async () => {
+    const ctx = new SyncTestContext(db);
+    const { album, asset } = await seedContribution(ctx);
+
+    await db.deleteFrom('album_space_asset').where('albumId', '=', album.id).where('assetId', '=', asset.id).execute();
+
+    const audit = await db
+      .selectFrom('album_space_asset_audit')
+      .selectAll()
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+
+    expect(audit).toHaveLength(1);
+    expect(audit[0].id).toBeDefined();
+  });
+
+  it('writes an audit row on FK cascade (asset delete)', async () => {
+    const ctx = new SyncTestContext(db);
+    const { album, asset } = await seedContribution(ctx);
+
+    await db.deleteFrom('asset').where('id', '=', asset.id).execute();
+
+    const audit = await db
+      .selectFrom('album_space_asset_audit')
+      .selectAll()
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+
+    expect(audit).toHaveLength(1);
+  });
+
+  it('is statement-level: a multi-row delete writes one audit row per deleted contribution', async () => {
+    const ctx = new SyncTestContext(db);
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: a2 } = await ctx.newAsset({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: a1.id, spaceId: space.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: a2.id, spaceId: space.id });
+
+    await db.deleteFrom('album_space_asset').where('albumId', '=', album.id).execute();
+
+    const audit = await db
+      .selectFrom('album_space_asset_audit')
+      .select('assetId')
+      .where('albumId', '=', album.id)
+      .execute();
+
+    expect(audit.map((r) => r.assetId).sort()).toEqual([a1.id, a2.id].sort());
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/album-space-asset-audit.spec.ts`
+Expected: FAIL — `column "updateId" does not exist` (updateId test) and `relation "album_space_asset_audit" does not exist` (audit tests). (If `pnpm test:medium` needs Docker, ensure the medium DB container is available per repo setup.)
+
+- [ ] **Step 4: Add `updateId`/`updatedAt` to the table decorator**
+
+Edit `server/src/schema/tables/album-space-asset.table.ts`. Update the imports and add the two columns + the `@UpdatedAtTrigger`. The header comment's "no update trigger — rows are immutable once created" line must change to reflect the deliberate restore-bump semantics.
+
+Replace the import block + decorators + the tail of the class:
+
+```ts
+import {
+  CreateDateColumn,
+  ForeignKeyColumn,
+  Generated,
+  Index,
+  Table,
+  Timestamp,
+  UpdateDateColumn,
+} from '@immich/sql-tools';
+import { CreateIdColumn, UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
+import { AlbumTable } from 'src/schema/tables/album.table';
+import { AssetTable } from 'src/schema/tables/asset.table';
+import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
+import { UserTable } from 'src/schema/tables/user.table';
+
+// A cross-owner contribution: a space photo the contributor does NOT own, bookmarked into a
+// space-linked album (#764). Deliberately NOT `album_asset` — it must never become a permanent
+// `checkAlbumAccess` grant for the album owner. Visibility is re-derived from live space membership
+// + the live album↔space link on every read (see spaceContributedAssetExists). The adder's OWN
+// photos take the ordinary `album_asset` path instead.
+//
+// Sync watermarks mirror `shared_space_asset` (spec §4): `createId` anchors the per-album backfill,
+// `updateId` (bumped by the `album_space_asset_updatedAt` BEFORE-UPDATE trigger) drives incremental
+// upserts. The row's DATA columns are immutable; `updateId` is bumped only on a deliberate
+// `updatedAt` touch (visibility restore — see SharedSpaceRepository.emitAlbumAssetVisibilityRestore)
+// so a contribution re-appears on devices that purged it when its asset was un-hidden.
+@Table({ name: 'album_space_asset' })
+@UpdatedAtTrigger('album_space_asset_updatedAt')
+@Index({ name: 'album_space_asset_spaceId_idx', columns: ['spaceId'] })
+export class AlbumSpaceAssetTable {
+```
+
+…and after the existing `createdAt` column (keep everything above `createId`/`createdAt` unchanged), append:
+
+```ts
+  @UpdateIdColumn({ index: true })
+  updateId!: Generated<string>;
+
+  @UpdateDateColumn()
+  updatedAt!: Generated<Timestamp>;
+}
+```
+
+- [ ] **Step 5: Create the audit table decorator**
+
+Create `server/src/schema/tables/album-space-asset-audit.table.ts`, mirroring `shared-space-album-asset-audit.table.ts` (read it first for the exact decorator names):
+
+```ts
+import { Column, CreateDateColumn, Generated, Index, Table, Timestamp } from '@immich/sql-tools';
+import { PrimaryGeneratedUuidV7Column } from 'src/decorators';
+
+// Delete-audit for album_space_asset cross-owner contributions (#764). Trigger-driven
+// (album_space_asset_delete_audit fires AFTER DELETE ... FOR EACH STATEMENT), so it captures BOTH
+// explicit contribution removal (AlbumService.removeAssets) AND every FK cascade (asset/album/space
+// delete). `id` is a UUIDv7 in the same watermark domain as album_asset_audit.id, so the
+// SharedSpaceAlbumToAssetSync delete stream can UNION all three audit arms under one ORDER BY id.
+//
+// Distinct from #752's shared_space_album_asset_audit (which audits normal album_asset membership).
+@Table('album_space_asset_audit')
+@Index({ name: 'album_space_asset_audit_albumId_id_idx', columns: ['albumId', 'id'] })
+export class AlbumSpaceAssetAuditTable {
+  @PrimaryGeneratedUuidV7Column()
+  id!: Generated<string>;
+
+  @Column({ type: 'uuid', index: true })
+  albumId!: string;
+
+  @Column({ type: 'uuid', index: true })
+  assetId!: string;
+
+  @CreateDateColumn({ default: () => 'clock_timestamp()', index: true })
+  deletedAt!: Generated<Timestamp>;
+}
+```
+
+> Confirm the exact decorator import names by reading `server/src/schema/tables/shared-space-album-asset-audit.table.ts` and matching it verbatim (e.g. `PrimaryGeneratedUuidV7Column`). Adjust the import line if that file uses different names.
+
+- [ ] **Step 6: Register the audit table in `schema/index.ts`**
+
+In `server/src/schema/index.ts`: add the import (next to the other `*AuditTable` imports), add `AlbumSpaceAssetAuditTable` to the table array (next to `AlbumSpaceAssetTable` / the audit-table cluster), and add `album_space_asset_audit: AlbumSpaceAssetAuditTable;` to the `DB` interface (next to `album_space_asset:`). Mirror how `shared_space_album_asset_audit` is registered (see `index.ts:327`).
+
+- [ ] **Step 7: Write the migration**
+
+Create `server/src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts`. Uses the `1778120000000` ALTER template + the `1779200000000` trigger/`migration_overrides` blueprint:
+
+```ts
+import { Kysely, sql } from 'kysely';
+
+// #764 Slice 5 — sync substrate for cross-owner contributions.
+//
+// 1. Add updateId/updatedAt to album_space_asset (createId/createdAt already exist from 1783000000000)
+//    + the standard updated_at BEFORE-UPDATE trigger, so the contributed sync arm mirrors album_asset.
+// 2. Create album_space_asset_audit + a statement-level AFTER-DELETE trigger that tombstones every
+//    deleted contribution (explicit removal + FK cascade), driving SharedSpaceAlbumToAssetSync deletes.
+export async function up(db: Kysely<any>): Promise<void> {
+  // --- 1. Sync watermark columns on album_space_asset ---
+  await sql`ALTER TABLE "album_space_asset" ADD COLUMN "updateId" uuid NOT NULL DEFAULT immich_uuid_v7();`.execute(db);
+  await sql`ALTER TABLE "album_space_asset" ADD COLUMN "updatedAt" timestamp with time zone NOT NULL DEFAULT now();`.execute(
+    db,
+  );
+  await sql`CREATE INDEX "album_space_asset_updateId_idx" ON "album_space_asset" ("updateId");`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "album_space_asset_updatedAt"
+  BEFORE UPDATE ON "album_space_asset"
+  FOR EACH ROW
+  EXECUTE FUNCTION updated_at();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_album_space_asset_updatedAt', '{"type":"trigger","name":"album_space_asset_updatedAt","sql":"CREATE OR REPLACE TRIGGER \\"album_space_asset_updatedAt\\"\\n  BEFORE UPDATE ON \\"album_space_asset\\"\\n  FOR EACH ROW\\n  EXECUTE FUNCTION updated_at();"}'::jsonb);`.execute(
+    db,
+  );
+
+  // --- 2. Delete-audit table ---
+  await sql`
+    CREATE TABLE "album_space_asset_audit" (
+      "id"        uuid NOT NULL DEFAULT immich_uuid_v7() PRIMARY KEY,
+      "albumId"   uuid NOT NULL,
+      "assetId"   uuid NOT NULL,
+      "deletedAt" timestamp with time zone NOT NULL DEFAULT clock_timestamp()
+    );
+  `.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_albumId_id_idx" ON "album_space_asset_audit" ("albumId", "id");`.execute(
+    db,
+  );
+  await sql`CREATE INDEX "album_space_asset_audit_albumId_idx" ON "album_space_asset_audit" ("albumId");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_assetId_idx" ON "album_space_asset_audit" ("assetId");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_deletedAt_idx" ON "album_space_asset_audit" ("deletedAt");`.execute(db);
+
+  // --- 3. AFTER-DELETE statement-level trigger → tombstone every deleted contribution ---
+  await sql`CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO album_space_asset_audit ("albumId", "assetId")
+      SELECT "albumId", "assetId" FROM "old";
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "album_space_asset_delete_audit"
+  AFTER DELETE ON "album_space_asset"
+  REFERENCING OLD TABLE AS "old"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION album_space_asset_delete_audit();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_album_space_asset_delete_audit', '{"type":"function","name":"album_space_asset_delete_audit","sql":"CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO album_space_asset_audit (\\"albumId\\", \\"assetId\\")\\n      SELECT \\"albumId\\", \\"assetId\\" FROM \\"old\\";\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb);`.execute(
+    db,
+  );
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_album_space_asset_delete_audit', '{"type":"trigger","name":"album_space_asset_delete_audit","sql":"CREATE OR REPLACE TRIGGER \\"album_space_asset_delete_audit\\"\\n  AFTER DELETE ON \\"album_space_asset\\"\\n  REFERENCING OLD TABLE AS \\"old\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION album_space_asset_delete_audit();"}'::jsonb);`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DELETE FROM "migration_overrides" WHERE "name" IN (
+    'trigger_album_space_asset_updatedAt',
+    'function_album_space_asset_delete_audit',
+    'trigger_album_space_asset_delete_audit'
+  );`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "album_space_asset_delete_audit" ON "album_space_asset";`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS album_space_asset_delete_audit();`.execute(db);
+  await sql`DROP TABLE IF EXISTS "album_space_asset_audit";`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "album_space_asset_updatedAt" ON "album_space_asset";`.execute(db);
+  await sql`DROP INDEX IF EXISTS "album_space_asset_updateId_idx";`.execute(db);
+  await sql`ALTER TABLE "album_space_asset" DROP COLUMN IF EXISTS "updatedAt";`.execute(db);
+  await sql`ALTER TABLE "album_space_asset" DROP COLUMN IF EXISTS "updateId";`.execute(db);
+}
+```
+
+> Verify `updated_at()` is the shared trigger function name used by sibling `*_updatedAt` triggers (it is, per `1778120000000`). Verify `immich_uuid_v7()` and `clock_timestamp()` are available (they are — used throughout `migrations-gallery/`).
+>
+> **`migration_overrides` strings (hardening):** the three `migration_overrides` `sql` JSON values above are hand-transcribed to match the sibling escaping (`\\"`, `\\n`, `::jsonb`) byte-for-byte. The sibling template notes these are "lifted via `pnpm migrations:debug`". After the migration applies on the scratch DB (Task 7 Step 1), run `pnpm migrations:debug` (or the repo's documented override-lift step) and confirm the normalizer emits the **same** strings for `album_space_asset_updatedAt` / `album_space_asset_delete_audit`; if it differs in whitespace, replace the hand-written values with the lifted ones. This does not affect the migration run or the medium tests — only a later schema-drift check.
+
+- [ ] **Step 8: Add `revert-to-immich.sql` entries**
+
+In `scripts/revert-to-immich.sql`:
+- Add near the existing `DROP TABLE IF EXISTS "album_space_asset" CASCADE;` (line ~114): `DROP TABLE IF EXISTS "album_space_asset_audit" CASCADE;`
+- Add to the `DROP FUNCTION` block: `DROP FUNCTION IF EXISTS album_space_asset_delete_audit() CASCADE;`
+- Add to the known-function allowlist (the `'function_...'` list ~line 227): `'function_album_space_asset_delete_audit',`
+- Add to the known-trigger allowlist (the `'trigger_...'` list ~line 254): `'trigger_album_space_asset_delete_audit',` and `'trigger_album_space_asset_updatedAt',`
+- Add `album_space_asset_audit` to the known-tables allowlist (the array ~line 440 that already lists `shared_space_album_asset_audit`).
+
+> Read the surrounding lines first and match the existing formatting/quoting exactly. If `revert-to-immich.sql` has a companion `.md` under `docs/`, it does not need touching — only the SQL.
+
+- [ ] **Step 9: Run the medium test to confirm it passes**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/album-space-asset-audit.spec.ts`
+Expected: PASS (all four cases).
+
+- [ ] **Step 10: Type-check**
+
+Run: `cd server && pnpm check`
+Expected: clean (no errors from the decorator/schema changes).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add server/src/schema server/src/schema/migrations-gallery scripts/revert-to-immich.sql server/test/medium.factory.ts server/test/medium/specs/sync/album-space-asset-audit.spec.ts
+git commit -m "feat(spaces): album_space_asset sync watermark + delete-audit trigger (#764 slice 5)"
+```
+
+---
+
+## Task 2: Union the contributed arm into `SharedSpaceAlbumToAssetSync` (membership edge)
+
+**Delivers.** The `(albumId, assetId)` membership edge for a contribution is emitted by the backfill, upsert, and (via the new audit table) delete arms — mirroring the `album_asset` arm, keyed on the shared `updateId` watermark.
+
+**Files:**
+- Modify: `server/src/repositories/sync.repository.ts` (`SharedSpaceAlbumToAssetSync`, `:1609-1680`)
+- Test: `server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts` (extend)
+
+**Interfaces:**
+- Consumes: `album_space_asset.{assetId, albumId, updateId}`, `album_space_asset_audit.{id, assetId, albumId}` (Task 1); `accessibleSpaceAlbums`, `spaceVisibilityGate` (already imported in `sync.repository.ts`).
+- Produces: contributed membership rows in the same shape `{ assetId, albumId, updateId }` the existing arm emits — no signature change, so `sync.service.ts` and mobile are untouched.
+
+- [ ] **Step 1: Write failing medium tests**
+
+Append to `server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts` (imports already include `AssetVisibility`, `SharedSpaceRole`, `SyncRepository`, `SyncTestContext`). Add a helper + three `describe` blocks:
+
+```ts
+const drain = async (stream: AsyncIterable<any>) => {
+  const out: any[] = [];
+  for await (const row of stream) {
+    out.push(row);
+  }
+  return out;
+};
+
+describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', () => {
+  it('getBackfill returns a contributed (albumId, assetId) row for the album', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id }); // owned by someone else
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id));
+    expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getBackfill excludes a contributed row whose asset is Hidden (visibility gate)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Hidden });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id));
+    expect(rows.some((r) => r.assetId === asset.id)).toBe(false);
+  });
+
+  it('getUpserts returns a contributed row for a member with an album grant', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getUpserts does not return a contributed row for a non-member', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: stranger } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getUpserts({ nowId: NOW_ID, userId: stranger.id }));
+    expect(rows.some((r) => r.assetId === asset.id)).toBe(false);
+  });
+
+  it('getDeletes emits the contributed edge to every member (incl. asset owner) after removal', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: carol.id, role: SharedSpaceRole.Viewer });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    await db.deleteFrom('album_space_asset').where('albumId', '=', album.id).where('assetId', '=', asset.id).execute();
+
+    for (const viewer of [member.id, carol.id]) {
+      const rows = await drain(sut.getDeletes({ nowId: NOW_ID, userId: viewer }));
+      expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+    }
+  });
+
+  it('getUpserts stops returning a contribution after the member leaves S (grant revoked by #752 trigger)', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const before = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(before.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+
+    // Member leaves S → shared_space_member_delete_album_audit revokes the album grant (#752), same
+    // path that drops the album (and thus its contribution edges) on device.
+    await db.deleteFrom('shared_space_member').where('spaceId', '=', space.id).where('userId', '=', member.id).execute();
+
+    const after = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(after.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts`
+Expected: FAIL — the new contribution cases fail (streams only union `album_asset` today); existing cases still pass.
+
+- [ ] **Step 3: Rewrite `getBackfill` as a two-arm union**
+
+In `server/src/repositories/sync.repository.ts`, replace `SharedSpaceAlbumToAssetSync.getBackfill` (`:1611-1622`) with:
+
+```ts
+  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
+  getBackfill(options: SyncBackfillOptions, albumId: string) {
+    const { nowId, beforeUpdateId, afterUpdateId } = options;
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
+      .where('album_asset.albumId', '=', albumId)
+      .where('album_asset.updateId', '<', nowId)
+      .where('album_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
+      // correctness-1/security-6: flat visibility gate — never backfill a Hidden/Locked asset's link.
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .select([
+        'album_space_asset.assetId as assetId',
+        'album_space_asset.albumId as albumId',
+        'album_space_asset.updateId',
+      ])
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album_space_asset.updateId', '<', nowId)
+      .where('album_space_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
+  }
+```
+
+- [ ] **Step 4: Rewrite `getUpserts` as a two-arm union**
+
+Replace `SharedSpaceAlbumToAssetSync.getUpserts` (`:1658-1673`) with:
+
+```ts
+  @GenerateSql({ params: [dummyQueryOptions], stream: true })
+  getUpserts(options: SyncQueryOptions) {
+    const { userId, nowId, ack } = options;
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+      .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
+      // correctness-1/security-6: flat visibility gate — a restore's updateId bump must not re-add a
+      // now-Hidden asset after the delete tombstone (resurrection); also blocks the metadata leak.
+      .where((eb) => spaceVisibilityGate(eb));
+
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select([
+        'album_space_asset.assetId as assetId',
+        'album_space_asset.albumId as albumId',
+        'album_space_asset.updateId',
+      ])
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_space_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
+  }
+```
+
+- [ ] **Step 5: Add the third audit arm to `getDeletes`**
+
+In `SharedSpaceAlbumToAssetSync.getDeletes` (`:1624-1656`), add a third arm after `spaceAlbumAssetArm` and fold it into the union. Insert before the `return`:
+
+```ts
+    // album_space_asset_audit — cross-owner contribution removals (#764). Trigger-driven, so the
+    // asset row may already be gone on FK cascade → NO asset join. A contribution is never also an
+    // owner's album_asset row (spec §5.1), so the owner has no independent path → NO ownerId filter:
+    // every member, including the asset's owner, drops the edge on removal/delete/Hidden-purge.
+    const contributedAuditArm = this.db
+      .selectFrom('album_space_asset_audit')
+      .select(['id', 'assetId', 'albumId'])
+      .where('id', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('id', '>', ack!.updateId))
+      .where('albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId));
+```
+
+…and change the final `return` to union all three arms:
+
+```ts
+    return albumAssetArm.union(spaceAlbumAssetArm).union(contributedAuditArm).orderBy('id', 'asc').stream();
+```
+
+- [ ] **Step 6: Wire `album_space_asset_audit` into this stream's audit cleanup**
+
+Task 1 registered `album_space_asset_audit` in the schema, which makes the existing medium test `test/medium/specs/services/sync.service.spec.ts > should cleanup every table` (it derives audit tables from `schemaFromCode()` and asserts one `auditCleanup` call per registered `*_audit` table) expect one more `auditCleanup` call than the wiring currently makes — so it is **red until this step**. `SharedSpaceAlbumToAssetSync.cleanupAuditTable` (`:1677-1679`) currently prunes only `shared_space_album_asset_audit`; make it prune both audit tables this stream owns:
+
+```ts
+  // Prune the space-only audit tables this stream owns. The shared album_asset_audit is pruned by
+  // albumToAsset.cleanupAuditTable (AlbumToAssetSync).
+  async cleanupAuditTable(daysAgo: number) {
+    await this.auditCleanup('shared_space_album_asset_audit', daysAgo);
+    await this.auditCleanup('album_space_asset_audit', daysAgo);
+  }
+```
+
+> `auditCleanup` returns a Kysely `.execute()` promise; awaiting both sequentially is fine. The caller (`sync.service.ts:297`) already `await`s `cleanupAuditTable`, so converting it from returning one promise to `async … Promise<void>` is safe.
+
+- [ ] **Step 7: Run the tests to confirm green (incl. the cleanup test Task 1 left red)**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts test/medium/specs/services/sync.service.spec.ts`
+Expected: PASS — new contribution cases green, all pre-existing cases green, and `should cleanup every table` green again (now `auditCleanup` is called for `album_space_asset_audit`).
+
+- [ ] **Step 8: Type-check**
+
+Run: `cd server && pnpm check`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/src/repositories/sync.repository.ts server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
+git commit -m "feat(spaces): union contributions into SharedSpaceAlbumToAssetSync (#764 slice 5)"
+```
+
+---
+
+## Task 3: Union the contributed arm into the asset + EXIF payload streams
+
+**Delivers.** A contributed asset's full payload (`SharedSpaceAlbumAssetSync`) and EXIF (`SharedSpaceAlbumAssetExifSync`) reach every member, so a contributed photo renders (not a grey placeholder) on device.
+
+**Files:**
+- Modify: `server/src/repositories/sync.repository.ts` (`SharedSpaceAlbumAssetSync` `:1689-1758`, `SharedSpaceAlbumAssetExifSync` `:1763-1808`)
+- Test: `server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts` (extend — payload) and `server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts` (extend — exif)
+
+> **Test-file targeting (verified):** these two repo-level specs already define `NOW_ID`, `BEFORE_UPDATE_ID`, and a `setup()` returning `sut = ctx.get(SyncRepository).sharedSpaceAlbumAsset` (resp. `.sharedSpaceAlbumAssetExif`) — use those. Do **not** target `sync-shared-space-album.spec.ts` (its `setup()` returns `{ auth, user, session, ctx }` and has none of that harness). Neither repo-level file defines a `drain` helper — either add a local `const drain = async (s) => { const o = []; for await (const r of s) o.push(r); return o; };` at the top of your new `describe`, or inline the `for await` collect as the file's existing tests do.
+
+**Interfaces:**
+- Consumes: `album_space_asset.{assetId, albumId, updateId}` (Task 1); `columns.syncAlbumAsset`, `columns.syncAssetExif`, `accessibleSpaceAlbums`, `spaceVisibilityGate` (already in file).
+- Produces: contributed asset/exif rows in the identical output shape as the `album_asset` arm — no service/mobile change.
+
+> **General rule for this task:** each method becomes a UNION of the **existing** `album_asset` arm (rewritten inline, unchanged predicates) and a **contributed** arm that is the same query with `album_asset` → `album_space_asset` and the membership watermark `album_asset.updateId` → `album_space_asset.updateId`. **Preserve every existing `select` (including `columns.syncAlbumAsset` / `columns.syncAssetExif` and the `isFavorite` CASE) verbatim and in the same order** so both arms produce matching UNION columns. Use `.union()` (dedup), matching `getDeletes`.
+
+- [ ] **Step 1a: Write failing payload tests in `shared-space-album-asset-sync.spec.ts`**
+
+Read the top of `server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts` and reuse its existing `setup()` (returns `{ ctx, db, sut }` with `sut = ctx.get(SyncRepository).sharedSpaceAlbumAsset`), `NOW_ID`, and `BEFORE_UPDATE_ID`. Append a `describe`. Add a local `drain` helper if the file has none:
+
+```ts
+const drain = async (stream: AsyncIterable<any>) => {
+  const out: any[] = [];
+  for await (const row of stream) out.push(row);
+  return out;
+};
+
+describe('SharedSpaceAlbumAssetSync — contributions (album_space_asset)', () => {
+  const seed = async (ctx: SyncTestContext) => {
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id }); // owned by someone else
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+    return { owner, member, carol, album, asset, space };
+  };
+
+  it('getCreates emits the contributed asset payload to a member', async () => {
+    const { ctx, sut } = setup();
+    const { member, asset } = await seed(ctx);
+    const rows = await drain(sut.getCreates({ nowId: NOW_ID, userId: member.id }));
+    expect(rows.some((r: any) => r.id === asset.id)).toBe(true);
+  });
+
+  it('getBackfill emits the contributed asset payload for the album', async () => {
+    const { ctx, sut } = setup();
+    const { member, album, asset } = await seed(ctx);
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, member.id));
+    expect(rows.some((r: any) => r.id === asset.id)).toBe(true);
+  });
+});
+```
+
+> **Match the file's real `setup()` shape.** If its `setup()` returns `{ ctx, sut }` (no `db`), use that; if it returns something else, adapt. The two facts that must hold: `sut` is `sharedSpaceAlbumAsset` and `NOW_ID`/`BEFORE_UPDATE_ID` are defined at file scope (they are).
+
+- [ ] **Step 1b: Write the failing exif test in `shared-space-album-asset-exif-sync.spec.ts`**
+
+Read the top of `server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts` (its `setup()` returns `sut = ctx.get(SyncRepository).sharedSpaceAlbumAssetExif`). The contributed asset needs an `asset_exif` row — use the `newExif` helper (`test/medium.factory.ts:223`, `newExif({ assetId })`). Append:
+
+```ts
+describe('SharedSpaceAlbumAssetExifSync — contributions (album_space_asset)', () => {
+  it('getCreates emits the contributed asset exif to a member', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    await ctx.newExif({ assetId: asset.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const out: any[] = [];
+    for await (const row of sut.getCreates({ nowId: NOW_ID, userId: member.id })) out.push(row);
+    expect(out.some((r: any) => r.assetId === asset.id)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/shared-space-album-asset-sync.spec.ts test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts`
+Expected: FAIL on the new contribution cases (only `album_asset` assets are streamed today).
+
+- [ ] **Step 3: Rewrite `SharedSpaceAlbumAssetSync.getBackfill` as a union**
+
+Replace the method (`:1691-1710`). Keep the `columns.syncAlbumAsset` + `isFavorite` CASE + `album.deletedAt IS NULL` + `spaceVisibilityGate` exactly; add the contributed arm:
+
+```ts
+  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
+  getBackfill(options: SyncBackfillOptions, albumId: string, userId: string) {
+    const { nowId, beforeUpdateId, afterUpdateId } = options;
+    const favorite = (eb: any) =>
+      eb.case().when('asset.ownerId', '=', userId).then(eb.ref('asset.isFavorite')).else(eb.val(false)).end().as('isFavorite');
+
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .innerJoin('album', 'album.id', 'album_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select(favorite)
+      .select('album_asset.updateId')
+      .where('album_asset.albumId', '=', albumId)
+      .where('album.deletedAt', 'is', null)
+      .where('album_asset.updateId', '<', nowId)
+      .where('album_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('album', 'album.id', 'album_space_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select(favorite)
+      .select('album_space_asset.updateId')
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album.deletedAt', 'is', null)
+      .where('album_space_asset.updateId', '<', nowId)
+      .where('album_space_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
+  }
+```
+
+> If TypeScript rejects the shared `favorite` lambda's `eb: any`, inline the CASE expression identically into both arms instead (copy the original `.select((eb) => eb.case()…)` into each arm). Behavior must be byte-identical to the original select.
+
+- [ ] **Step 4: Rewrite `SharedSpaceAlbumAssetSync.getCreates` as a union**
+
+Replace `:1737-1757`. Existing arm keys on `album_asset.updateId > ack`; contributed arm on `album_space_asset.updateId > ack`:
+
+```ts
+  @GenerateSql({ params: [dummyQueryOptions], stream: true })
+  getCreates(options: SyncQueryOptions) {
+    const { userId, nowId, ack } = options;
+    const favorite = (eb: any) =>
+      eb.case().when('asset.ownerId', '=', userId).then(eb.ref('asset.isFavorite')).else(eb.val(false)).end().as('isFavorite');
+
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select(favorite)
+      .select('album_asset.updateId')
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select(favorite)
+      .select('album_space_asset.updateId')
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_space_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
+  }
+```
+
+- [ ] **Step 5: Rewrite `SharedSpaceAlbumAssetSync.getUpdates` as a union**
+
+Replace `:1713-1734`. Both arms key on `asset.updateId > ack` (payload mutation); membership-coupling gate becomes `album_space_asset.updateId <= albumToAssetAck.updateId` for the contributed arm:
+
+```ts
+  @GenerateSql({ params: [dummyQueryOptions, { updateId: DummyValue.UUID }], stream: true })
+  getUpdates(options: SyncQueryOptions, albumToAssetAck: SyncAck) {
+    const { userId, nowId, ack } = options;
+    const favorite = (eb: any) =>
+      eb.case().when('asset.ownerId', '=', userId).then(eb.ref('asset.isFavorite')).else(eb.val(false)).end().as('isFavorite');
+
+    const albumAssetArm = this.db
+      .selectFrom('asset')
+      .innerJoin('album_asset', 'album_asset.assetId', 'asset.id')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select(favorite)
+      .select('asset.updateId')
+      .where('asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('asset.updateId', '>', ack!.updateId))
+      .where('album_asset.updateId', '<=', albumToAssetAck.updateId)
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    const contributedArm = this.db
+      .selectFrom('asset')
+      .innerJoin('album_space_asset', 'album_space_asset.assetId', 'asset.id')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select(favorite)
+      .select('asset.updateId')
+      .where('asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('asset.updateId', '>', ack!.updateId))
+      .where('album_space_asset.updateId', '<=', albumToAssetAck.updateId)
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
+  }
+```
+
+> The original `getUpdates` used `upsertQuery('asset', options)`; the inline rewrite reproduces its `asset.updateId < nowId` / `> ack` window so the two arms can UNION. Confirm the `SyncAck` type is already imported (it is — used by the original signature).
+
+- [ ] **Step 6: Apply the identical three-method union to `SharedSpaceAlbumAssetExifSync`**
+
+Repeat Steps 3–5 for `SharedSpaceAlbumAssetExifSync` (`:1763-1808`), using `asset_exif` + `columns.syncAssetExif` (no `isFavorite` CASE — exif has none). For each of its `getBackfill` / `getUpdates` / `getCreates`, mirror the existing arm and add a contributed arm swapping `album_asset` → `album_space_asset` and its `updateId`. Preserve the exif joins exactly:
+- `getBackfill`: `album_(space_)asset` ⋈ `asset_exif` ⋈ `album` (deletedAt null) ⋈ `asset`; select `columns.syncAssetExif` + `<table>.updateId`; window on the membership `updateId`.
+- `getUpdates`: `asset_exif` ⋈ `album_(space_)asset` ⋈ `asset`; key on `asset_exif.updateId` window; coupling `<table>.updateId <= albumToAssetAck.updateId`; grant + accessibleSpaceAlbums + visGate.
+- `getCreates`: `album_(space_)asset` ⋈ `asset_exif` ⋈ `asset`; window on membership `updateId > ack`; grant + accessibleSpaceAlbums + visGate.
+Each returns `albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream()`.
+
+- [ ] **Step 7: Run the tests to confirm green**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/shared-space-album-asset-sync.spec.ts test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts`
+Expected: PASS — contributed payload + exif cases green, pre-existing cases green.
+
+- [ ] **Step 8: Type-check**
+
+Run: `cd server && pnpm check`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/src/repositories/sync.repository.ts server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
+git commit -m "feat(spaces): stream contributed asset payload + exif to members (#764 slice 5)"
+```
+
+---
+
+## Task 4: Hidden/restore parity + audit cleanup for contributions
+
+**Delivers.** When a contributed asset is marked Hidden, member devices drop it (no mobile Hidden leak — §10); when un-hidden, it re-appears via the `updateId` bump. The new audit table is pruned on the cleanup schedule.
+
+**Files:**
+- Modify: `server/src/repositories/shared-space.repository.ts` (`emitAlbumAssetVisibilityPurge` `:540`, `emitAlbumAssetVisibilityRestore` `:573`)
+- Modify: `server/src/repositories/sync.repository.ts` (`SharedSpaceAlbumToAssetSync.cleanupAuditTable` `:1677`)
+- Test: `server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts` (extend)
+
+**Interfaces:**
+- Consumes: `album_space_asset_audit` (Task 1), the delete arm (Task 2), the `updateId` bump path via the `album_space_asset_updatedAt` trigger (Task 1).
+- Produces: no signature change — `asset.service.ts` call sites (`:425`, `:452`) already pass `purgeIds` / `restoreIds`.
+
+- [ ] **Step 1: Write failing medium tests**
+
+Read the top of `sync-shared-space-album-visibility-purge.spec.ts` for its `setup()`/helpers, then append:
+
+```ts
+describe('contribution visibility parity (album_space_asset)', () => {
+  it('purge tombstones a contributed asset so getDeletes drops it for members', async () => {
+    const ctx = new SyncTestContext(defaultDatabase);
+    const sharedSpace = ctx.get(SharedSpaceRepository);
+    const toAsset = ctx.get(SyncRepository).sharedSpaceAlbumToAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    await sharedSpace.emitAlbumAssetVisibilityPurge([asset.id]);
+
+    const audit = await defaultDatabase
+      .selectFrom('album_space_asset_audit')
+      .selectAll()
+      .where('assetId', '=', asset.id)
+      .execute();
+    expect(audit).toHaveLength(1);
+
+    const deletes: any[] = [];
+    for await (const row of toAsset.getDeletes({ nowId: NOW_ID, userId: member.id })) {
+      deletes.push(row);
+    }
+    expect(deletes.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('restore bumps the contribution updateId so getUpserts re-emits it', async () => {
+    const ctx = new SyncTestContext(defaultDatabase);
+    const sharedSpace = ctx.get(SharedSpaceRepository);
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const before = await defaultDatabase
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+
+    await sharedSpace.emitAlbumAssetVisibilityRestore([asset.id]);
+
+    const after = await defaultDatabase
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+    expect(after.updateId).not.toBe(before.updateId);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts`
+Expected: FAIL — purge writes no `album_space_asset_audit` row; restore does not bump `album_space_asset.updateId`.
+
+- [ ] **Step 3: Extend `emitAlbumAssetVisibilityPurge`**
+
+In `server/src/repositories/shared-space.repository.ts`, after the existing `shared_space_album_asset_audit` insert in `emitAlbumAssetVisibilityPurge` (`:545-557`), add a second insert that tombstones contributed rows into `album_space_asset_audit`:
+
+```ts
+    // #764: contributions live in album_space_asset (not album_asset); tombstone the contributed
+    // (albumId, assetId) pairs too so SharedSpaceAlbumToAssetSync.getDeletes drops a now-Hidden
+    // contribution on member devices. Only space-linked albums (the album_space_asset FK already
+    // guarantees that, but keep the space-link filter symmetric with the album_asset arm).
+    await this.db
+      .insertInto('album_space_asset_audit')
+      .columns(['albumId', 'assetId'])
+      .expression(
+        this.db
+          .selectFrom('album_space_asset')
+          .select(['album_space_asset.albumId', 'album_space_asset.assetId'])
+          .where('album_space_asset.assetId', 'in', assetIds),
+      )
+      .execute();
+```
+
+- [ ] **Step 4: Extend `emitAlbumAssetVisibilityRestore`**
+
+In the same file, after the existing `album_asset` `updatedAt` bump in `emitAlbumAssetVisibilityRestore` (`:578-583`), add a bump for contributed rows (the `album_space_asset_updatedAt` trigger turns the touch into a fresh `updateId`):
+
+```ts
+    // #764: bump contributed rows too so getUpserts re-emits an un-hidden contribution to devices
+    // that purged it. The album_space_asset_updatedAt BEFORE-UPDATE trigger regenerates updateId.
+    await this.db
+      .updateTable('album_space_asset')
+      .set({ updatedAt: sql`clock_timestamp()` })
+      .where('assetId', 'in', assetIds)
+      .execute();
+```
+
+> `sql` is already imported in `shared-space.repository.ts` (used by the sibling methods).
+>
+> **Note:** the `cleanupAuditTable` wiring for `album_space_asset_audit` was moved to **Task 2 Step 6** (it must land in the same commit range that keeps the `should cleanup every table` medium test green). Do not re-add it here.
+
+- [ ] **Step 5: Run the tests to confirm green**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run the existing purge unit tests (guard against regressions)**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts`
+Expected: PASS — the `emitAlbumAssetVisibilityPurge`/`Restore` mocks are unchanged (still called with the same asset-id arrays); the added inserts are inside the mocked repository method, invisible to the service unit test.
+
+- [ ] **Step 7: Type-check**
+
+Run: `cd server && pnpm check`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/repositories/shared-space.repository.ts server/src/repositories/sync.repository.ts server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts
+git commit -m "feat(spaces): Hidden/restore parity + audit prune for contributions (#764 slice 5)"
+```
+
+---
+
+## Task 5: Service-level convergence — backfill-on-join, monotonicity, no spurious asset deletion
+
+**Delivers.** End-to-end proof through the real `SyncService` seam that: a member who joins a space with pre-existing contributions **backfills** them; the delete arm never causes a spurious **asset** deletion; and re-emitting after ack is monotonic (no duplicates).
+
+**Files:**
+- Test: `server/test/medium/specs/services/sync.service.spec.ts` (extend) — or a new `server/test/medium/specs/sync/album-space-asset-convergence.spec.ts` if the service spec's setup does not fit.
+
+**Interfaces:**
+- Consumes: the full `SyncService` (via `SyncTestContext`, whose generic is `SyncService`), Tasks 2–4.
+
+- [ ] **Step 1: Inspect the existing service-level sync test**
+
+Read `server/test/medium/specs/services/sync.service.spec.ts` (and `sync-shared-space-album.spec.ts`) to learn how they drive a full sync: they typically build a `newSyncAuthUser()`, request a set of `SyncRequestType`s, and collect the emitted `SyncItem`s. Mirror that harness. Identify the request types `SharedSpaceAlbumToAssetsV1`, `SharedSpaceAlbumAssetsV1`, `SharedSpaceAlbumAssetExifsV1` and the ack/checkpoint plumbing used there.
+
+- [ ] **Step 2: Write the failing convergence test**
+
+Add a `describe` that:
+1. Creates space S (owner) + album L linked to S + a contribution `(L, X, S)` where X is owned by Carol, **before** `member` joins.
+2. Adds `member` to S (Editor) — which fires the grant trigger.
+3. Runs a full sync for `member` and asserts a `SharedSpaceAlbumToAssetV1` (or `…BackfillV1`) item for `(L, X)` **and** a `SharedSpaceAlbumAssetV1` payload item for X are emitted (backfill-on-join).
+4. Acks, then re-syncs with the returned checkpoint and asserts **no** duplicate `(L, X)` membership item (monotonicity).
+5. Removes the contribution (`db.deleteFrom('album_space_asset')…`), re-syncs, asserts a `SharedSpaceAlbumToAssetDeleteV1` for `(L, X)` is emitted, and asserts the **asset X row still exists** in the DB (`selectFrom('asset').where('id','=',X)` returns the row) — i.e. removing a contribution edge never deletes the underlying asset.
+
+Encode each assertion concretely against the emitted `SyncItem[]` shape used by the existing service spec (match its field names — likely `item.type` and `item.data`). Use the existing spec's collect/ack helpers verbatim rather than inventing new ones.
+
+> If the service spec exposes no reusable "run a full sync and return items" helper, prefer extending the repo-level assertions already covered in Tasks 2–4 and implement the **backfill-on-join** + **no-spurious-asset-deletion** as repo-level checks in `shared-space-album-to-asset-sync.spec.ts` instead (getBackfill returns X for the just-joined member's album; after `deleteFrom('album_space_asset')`, `getDeletes` yields the edge while `selectFrom('asset')` still returns X). Keep the monotonicity assertion at the repo level: run `getUpserts` with `ack = { updateId: <max emitted updateId> }` and assert the row is **not** re-emitted.
+
+- [ ] **Step 3: Run to confirm failure (if any new production gap surfaces)**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/services/sync.service.spec.ts`
+Expected: The backfill/monotonicity/no-spurious-deletion assertions should pass **given Tasks 2–4** — this task is a higher-level guard. If any fails, it reveals a real gap (e.g. a missed arm); fix the corresponding stream method from Task 2/3 and re-run. If all pass on first run, that is acceptable here because the behavior is delivered by Tasks 2–4 and this task's value is the end-to-end regression guard — note this explicitly in the commit body.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/test/medium/specs
+git commit -m "test(spaces): service-level convergence for contribution sync (#764 slice 5)"
+```
+
+---
+
+## Task 6: Mobile Flutter convergence regression test
+
+**Delivers.** A `flutter test` proving the mobile Drift layer converges for a contribution `(albumId, assetId)` membership: present after an insert event, absent after a delete event, with the remote asset blob retained. **No mobile production code changes** — mobile is origin-blind; this is a regression guard that locks in that a contribution (indistinguishable from an owner membership on the wire) converges through the existing handlers.
+
+**Files:**
+- Test: `mobile/test/domain/repositories/sync_stream_repository_test.dart` (extend the existing `SyncStreamRepository - SharedSpaceAlbum handlers` group, ~lines 1706-1996)
+
+**Interfaces:**
+- Consumes: existing handlers `SyncStreamRepository.updateSharedSpaceAlbumToAssetsV1` / `deleteSharedSpaceAlbumToAssetsV1` / `updateSharedSpaceAlbumAssetsV1`; Drift `db.sharedSpaceAlbumAssetEntity`, `db.remoteAssetEntity`; local builders `makeAlbumToAsset`, `makeAlbumV2` (already in the file).
+
+- [ ] **Step 1: Regenerate localization/keys (once) so `flutter test` compiles**
+
+Per CLAUDE.md, from `mobile/` with Flutter 3.41.7:
+```bash
+cd mobile && flutter pub get && dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
+```
+
+- [ ] **Step 2: Write the convergence test**
+
+In `mobile/test/domain/repositories/sync_stream_repository_test.dart`, inside the `SharedSpaceAlbum handlers` group, add:
+
+```dart
+group('cross-owner contribution convergence (#764)', () {
+  test('a contributed (albumId, assetId) membership is present after insert, absent after delete, blob retained', () async {
+    // Contribution rides the SAME SharedSpaceAlbumToAssetV1 membership + SharedSpaceAlbumAssetV1
+    // payload events as an owner's album_asset — mobile is origin-blind (no owner column on the row).
+    await sut.updateSharedSpaceAlbumAssetsV1([makeAssetV2(id: 'contrib-asset')]);
+    await sut.updateSharedSpaceAlbumToAssetsV1([
+      makeAlbumToAsset(albumId: 'album-1', assetId: 'contrib-asset'),
+    ]);
+
+    final present = await db.sharedSpaceAlbumAssetEntity.select().get();
+    expect(present.any((r) => r.albumId == 'album-1' && r.assetId == 'contrib-asset'), isTrue);
+
+    await sut.deleteSharedSpaceAlbumToAssetsV1([
+      SyncAlbumToAssetDeleteV1(albumId: 'album-1', assetId: 'contrib-asset'),
+    ]);
+
+    final afterDelete = await db.sharedSpaceAlbumAssetEntity.select().get();
+    expect(afterDelete.any((r) => r.assetId == 'contrib-asset'), isFalse);
+
+    // Removing the membership edge must NOT delete the asset blob (only pruneAssets GCs it).
+    final blob = await db.remoteAssetEntity.select().get();
+    expect(blob.any((r) => r.id == 'contrib-asset'), isTrue);
+  });
+});
+```
+
+> Confirm the exact local builder names in the file: use `makeAlbumToAsset` (present ~line 1685). For the asset-payload event, use the same builder the existing `updateSharedSpaceAlbumAssetsV1` test uses (search the file for `updateSharedSpaceAlbumAssetsV1` / `makeAssetV2` / `SyncAssetV2` and match it). If the exif assertion is trivial to add with the file's existing exif builder, add a parallel `remoteExifEntity` check; otherwise the payload+membership convergence above is sufficient for the regression guard.
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd mobile && flutter test test/domain/repositories/sync_stream_repository_test.dart`
+Expected: PASS. (Because mobile is origin-blind, this test is green without production changes — it is a **characterization/regression guard**, not a red-first test. State this in the commit body so the absence of a red phase is intentional and documented.)
+
+- [ ] **Step 4: Mobile analyze gate (CI parity)**
+
+Run: `cd mobile && dart analyze --fatal-infos lib test` and `dart format --set-exit-if-changed test/domain/repositories/sync_stream_repository_test.dart`
+Expected: clean / no reformat. (Per `feedback_mobile_dart_analyze_ci_fatal_infos`: analyze covers `test/` lints that `flutter analyze lib` misses, and format is a separate gate.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/test/domain/repositories/sync_stream_repository_test.dart
+git commit -m "test(mobile): contribution sync convergence regression guard (#764 slice 5)"
+```
+
+---
+
+## Task 7: SQL regeneration + full-suite validation + push
+
+**Delivers.** Regenerated query docs, green full server medium + unit suites, green mobile test, and the branch pushed.
+
+**Files:**
+- Modify (generated): `server/src/queries/*.sql` (via `make sql`)
+
+- [ ] **Step 1: Regenerate query SQL against a SCRATCH migrated DB**
+
+⚠️ Per CLAUDE.md and `feedback_make_sql_no_db`: **never** run `make sql` without a running DB or against the dev-stack DB (it deletes/corrupts query files). Bring up a scratch DB, run migrations against it, then `make sql`. Follow the repo's documented scratch-DB procedure (the same one Slice 1's `chore(server): regenerate SQL` commit used). Confirm the diff is limited to the sync/shared-space query files touched by Tasks 2–4:
+
+Run: `cd server && git status --short src/queries`
+Expected: only `sync.repository.sql` and `shared.space.repository.sql` (and possibly `album.repository.sql`) changed; no unrelated deletions.
+
+- [ ] **Step 2: Full server medium suite (sync + shared-space area)**
+
+Run: `cd server && pnpm test:medium -- --run test/medium/specs/sync test/medium/specs/services`
+Expected: PASS (no regressions in #752 sync suites, trash-lifecycle, cross-path purge, visibility gate).
+
+- [ ] **Step 3: Server unit suite for touched services**
+
+Run: `cd server && pnpm test -- --run src/services/asset.service.spec.ts src/services/album.service.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Server type-check + lint**
+
+Run: `cd server && pnpm check && pnpm lint`
+Expected: clean, zero warnings.
+
+- [ ] **Step 5: Mobile test (re-confirm)**
+
+Run: `cd mobile && flutter test test/domain/repositories/sync_stream_repository_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit regenerated SQL**
+
+```bash
+git add server/src/queries
+git commit -m "chore(server): regenerate SQL for contribution sync streams (#764 slice 5)"
+```
+
+- [ ] **Step 7: Push**
+
+```bash
+git push
+```
+(Branch `feat/space-albums-collab-contrib` already has an upstream — plain `git push`. If not: `git push -u origin feat/space-albums-collab-contrib`.)
+
+---
+
+## Self-Review checklist (run before execution)
+
+- **Spec §7.2 (mobile/sync):** ✅ union `album_space_asset` into `SharedSpaceAlbumToAssetSync` (Task 2), payload+exif into `SharedSpaceAlbumAssetSync`/`ExifSync` (Task 3), deletes via `album_space_asset_audit` (Tasks 1–2). New `SyncEntityType`/`RequestType`? **No** — decided not needed (mobile origin-blind); documented in Architecture.
+- **Slice 5 BDD:** contribution create+payload+exif arrive (Tasks 2–3); removal → edge deleted via audit (Tasks 1–2); join → backfill (Task 5). ✅
+- **Slice 5 edge cases:** leave/unlink handled by #752 album-level sweep (out of this slice's new code — noted); no spurious asset deletion (Task 5); re-link/re-join idempotent (getBackfill dedup + `onConflict` on device); ack monotonicity (Task 5). ✅
+- **§10 no-Hidden-leak incl. Hidden-after-contribution (mobile):** purge tombstone (Task 4). Restore parity (Task 4, via `updateId`). ✅ (Design B, per user decision.)
+- **Placeholder scan:** migration/decorator/stream code shown in full; test code shown; the two "read the file and match" notes (exif builder name, service-spec collect helper) are unavoidable local-lookup instructions, not deferred logic. ✅
+- **Type consistency:** all arms select matching UNION columns (`{assetId, albumId, updateId}` for membership; `columns.syncAlbumAsset`+`isFavorite`+`updateId` for asset; `columns.syncAssetExif`+`updateId` for exif); watermark alias `updateId` used uniformly for `orderBy`. ✅
+- **Not implementing future slices:** Slice 6 (web legibility) untouched. ✅
+```

--- a/docs/superpowers/plans/2026-07-11-space-album-cross-owner-contributions-slice-5.md
+++ b/docs/superpowers/plans/2026-07-11-space-album-cross-owner-contributions-slice-5.md
@@ -48,6 +48,7 @@ So the contributed delete arm is `SELECT id, assetId, albumId FROM album_space_a
 **Delivers.** `album_space_asset` gains the standard `updateId`/`updatedAt` sync watermark (+ `BEFORE UPDATE` trigger) so the contributed sync arm mirrors `album_asset` exactly; a new trigger-driven `album_space_asset_audit` table captures every contribution deletion (explicit + FK cascade). No user-facing behavior — fully covered by a medium schema test.
 
 **Files:**
+
 - Modify: `server/src/schema/tables/album-space-asset.table.ts` (add `updateId`/`updatedAt` + `@UpdatedAtTrigger`)
 - Create: `server/src/schema/tables/album-space-asset-audit.table.ts`
 - Modify: `server/src/schema/index.ts` (register the audit table)
@@ -57,6 +58,7 @@ So the contributed delete arm is `SELECT id, assetId, albumId FROM album_space_a
 - Create/Test: `server/test/medium/specs/sync/album-space-asset-audit.spec.ts`
 
 **Interfaces:**
+
 - Produces: `album_space_asset.updateId` / `.updatedAt` columns; `album_space_asset_audit` table `{ id (v7 PK), albumId, assetId, deletedAt }`; DB triggers `album_space_asset_updatedAt` (BEFORE UPDATE) and `album_space_asset_delete_audit` (AFTER DELETE STATEMENT); `SyncTestContext.newAlbumSpaceAsset({ albumId, assetId, spaceId, addedById? })`.
 
 - [ ] **Step 1: Add the `newAlbumSpaceAsset` test helper**
@@ -336,7 +338,9 @@ export async function up(db: Kysely<any>): Promise<void> {
   );
   await sql`CREATE INDEX "album_space_asset_audit_albumId_idx" ON "album_space_asset_audit" ("albumId");`.execute(db);
   await sql`CREATE INDEX "album_space_asset_audit_assetId_idx" ON "album_space_asset_audit" ("assetId");`.execute(db);
-  await sql`CREATE INDEX "album_space_asset_audit_deletedAt_idx" ON "album_space_asset_audit" ("deletedAt");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_deletedAt_idx" ON "album_space_asset_audit" ("deletedAt");`.execute(
+    db,
+  );
 
   // --- 3. AFTER-DELETE statement-level trigger → tombstone every deleted contribution ---
   await sql`CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()
@@ -388,6 +392,7 @@ export async function down(db: Kysely<any>): Promise<void> {
 - [ ] **Step 8: Add `revert-to-immich.sql` entries**
 
 In `scripts/revert-to-immich.sql`:
+
 - Add near the existing `DROP TABLE IF EXISTS "album_space_asset" CASCADE;` (line ~114): `DROP TABLE IF EXISTS "album_space_asset_audit" CASCADE;`
 - Add to the `DROP FUNCTION` block: `DROP FUNCTION IF EXISTS album_space_asset_delete_audit() CASCADE;`
 - Add to the known-function allowlist (the `'function_...'` list ~line 227): `'function_album_space_asset_delete_audit',`
@@ -420,10 +425,12 @@ git commit -m "feat(spaces): album_space_asset sync watermark + delete-audit tri
 **Delivers.** The `(albumId, assetId)` membership edge for a contribution is emitted by the backfill, upsert, and (via the new audit table) delete arms — mirroring the `album_asset` arm, keyed on the shared `updateId` watermark.
 
 **Files:**
+
 - Modify: `server/src/repositories/sync.repository.ts` (`SharedSpaceAlbumToAssetSync`, `:1609-1680`)
 - Test: `server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts` (extend)
 
 **Interfaces:**
+
 - Consumes: `album_space_asset.{assetId, albumId, updateId}`, `album_space_asset_audit.{id, assetId, albumId}` (Task 1); `accessibleSpaceAlbums`, `spaceVisibilityGate` (already imported in `sync.repository.ts`).
 - Produces: contributed membership rows in the same shape `{ assetId, albumId, updateId }` the existing arm emits — no signature change, so `sync.service.ts` and mobile are untouched.
 
@@ -541,7 +548,11 @@ describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', ()
 
     // Member leaves S → shared_space_member_delete_album_audit revokes the album grant (#752), same
     // path that drops the album (and thus its contribution edges) on device.
-    await db.deleteFrom('shared_space_member').where('spaceId', '=', space.id).where('userId', '=', member.id).execute();
+    await db
+      .deleteFrom('shared_space_member')
+      .where('spaceId', '=', space.id)
+      .where('userId', '=', member.id)
+      .execute();
 
     const after = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
     expect(after.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
@@ -638,22 +649,22 @@ Replace `SharedSpaceAlbumToAssetSync.getUpserts` (`:1658-1673`) with:
 In `SharedSpaceAlbumToAssetSync.getDeletes` (`:1624-1656`), add a third arm after `spaceAlbumAssetArm` and fold it into the union. Insert before the `return`:
 
 ```ts
-    // album_space_asset_audit — cross-owner contribution removals (#764). Trigger-driven, so the
-    // asset row may already be gone on FK cascade → NO asset join. A contribution is never also an
-    // owner's album_asset row (spec §5.1), so the owner has no independent path → NO ownerId filter:
-    // every member, including the asset's owner, drops the edge on removal/delete/Hidden-purge.
-    const contributedAuditArm = this.db
-      .selectFrom('album_space_asset_audit')
-      .select(['id', 'assetId', 'albumId'])
-      .where('id', '<', nowId)
-      .$if(!!ack, (qb) => qb.where('id', '>', ack!.updateId))
-      .where('albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId));
+// album_space_asset_audit — cross-owner contribution removals (#764). Trigger-driven, so the
+// asset row may already be gone on FK cascade → NO asset join. A contribution is never also an
+// owner's album_asset row (spec §5.1), so the owner has no independent path → NO ownerId filter:
+// every member, including the asset's owner, drops the edge on removal/delete/Hidden-purge.
+const contributedAuditArm = this.db
+  .selectFrom('album_space_asset_audit')
+  .select(['id', 'assetId', 'albumId'])
+  .where('id', '<', nowId)
+  .$if(!!ack, (qb) => qb.where('id', '>', ack!.updateId))
+  .where('albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId));
 ```
 
 …and change the final `return` to union all three arms:
 
 ```ts
-    return albumAssetArm.union(spaceAlbumAssetArm).union(contributedAuditArm).orderBy('id', 'asc').stream();
+return albumAssetArm.union(spaceAlbumAssetArm).union(contributedAuditArm).orderBy('id', 'asc').stream();
 ```
 
 - [ ] **Step 6: Wire `album_space_asset_audit` into this stream's audit cleanup**
@@ -695,12 +706,14 @@ git commit -m "feat(spaces): union contributions into SharedSpaceAlbumToAssetSyn
 **Delivers.** A contributed asset's full payload (`SharedSpaceAlbumAssetSync`) and EXIF (`SharedSpaceAlbumAssetExifSync`) reach every member, so a contributed photo renders (not a grey placeholder) on device.
 
 **Files:**
+
 - Modify: `server/src/repositories/sync.repository.ts` (`SharedSpaceAlbumAssetSync` `:1689-1758`, `SharedSpaceAlbumAssetExifSync` `:1763-1808`)
 - Test: `server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts` (extend — payload) and `server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts` (extend — exif)
 
 > **Test-file targeting (verified):** these two repo-level specs already define `NOW_ID`, `BEFORE_UPDATE_ID`, and a `setup()` returning `sut = ctx.get(SyncRepository).sharedSpaceAlbumAsset` (resp. `.sharedSpaceAlbumAssetExif`) — use those. Do **not** target `sync-shared-space-album.spec.ts` (its `setup()` returns `{ auth, user, session, ctx }` and has none of that harness). Neither repo-level file defines a `drain` helper — either add a local `const drain = async (s) => { const o = []; for await (const r of s) o.push(r); return o; };` at the top of your new `describe`, or inline the `for await` collect as the file's existing tests do.
 
 **Interfaces:**
+
 - Consumes: `album_space_asset.{assetId, albumId, updateId}` (Task 1); `columns.syncAlbumAsset`, `columns.syncAssetExif`, `accessibleSpaceAlbums`, `spaceVisibilityGate` (already in file).
 - Produces: contributed asset/exif rows in the identical output shape as the `album_asset` arm — no service/mobile change.
 
@@ -915,10 +928,11 @@ Replace `:1713-1734`. Both arms key on `asset.updateId > ack` (payload mutation)
 - [ ] **Step 6: Apply the identical three-method union to `SharedSpaceAlbumAssetExifSync`**
 
 Repeat Steps 3–5 for `SharedSpaceAlbumAssetExifSync` (`:1763-1808`), using `asset_exif` + `columns.syncAssetExif` (no `isFavorite` CASE — exif has none). For each of its `getBackfill` / `getUpdates` / `getCreates`, mirror the existing arm and add a contributed arm swapping `album_asset` → `album_space_asset` and its `updateId`. Preserve the exif joins exactly:
+
 - `getBackfill`: `album_(space_)asset` ⋈ `asset_exif` ⋈ `album` (deletedAt null) ⋈ `asset`; select `columns.syncAssetExif` + `<table>.updateId`; window on the membership `updateId`.
 - `getUpdates`: `asset_exif` ⋈ `album_(space_)asset` ⋈ `asset`; key on `asset_exif.updateId` window; coupling `<table>.updateId <= albumToAssetAck.updateId`; grant + accessibleSpaceAlbums + visGate.
 - `getCreates`: `album_(space_)asset` ⋈ `asset_exif` ⋈ `asset`; window on membership `updateId > ack`; grant + accessibleSpaceAlbums + visGate.
-Each returns `albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream()`.
+  Each returns `albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream()`.
 
 - [ ] **Step 7: Run the tests to confirm green**
 
@@ -944,11 +958,13 @@ git commit -m "feat(spaces): stream contributed asset payload + exif to members 
 **Delivers.** When a contributed asset is marked Hidden, member devices drop it (no mobile Hidden leak — §10); when un-hidden, it re-appears via the `updateId` bump. The new audit table is pruned on the cleanup schedule.
 
 **Files:**
+
 - Modify: `server/src/repositories/shared-space.repository.ts` (`emitAlbumAssetVisibilityPurge` `:540`, `emitAlbumAssetVisibilityRestore` `:573`)
 - Modify: `server/src/repositories/sync.repository.ts` (`SharedSpaceAlbumToAssetSync.cleanupAuditTable` `:1677`)
 - Test: `server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts` (extend)
 
 **Interfaces:**
+
 - Consumes: `album_space_asset_audit` (Task 1), the delete arm (Task 2), the `updateId` bump path via the `album_space_asset_updatedAt` trigger (Task 1).
 - Produces: no signature change — `asset.service.ts` call sites (`:425`, `:452`) already pass `purgeIds` / `restoreIds`.
 
@@ -1027,20 +1043,20 @@ Expected: FAIL — purge writes no `album_space_asset_audit` row; restore does n
 In `server/src/repositories/shared-space.repository.ts`, after the existing `shared_space_album_asset_audit` insert in `emitAlbumAssetVisibilityPurge` (`:545-557`), add a second insert that tombstones contributed rows into `album_space_asset_audit`:
 
 ```ts
-    // #764: contributions live in album_space_asset (not album_asset); tombstone the contributed
-    // (albumId, assetId) pairs too so SharedSpaceAlbumToAssetSync.getDeletes drops a now-Hidden
-    // contribution on member devices. Only space-linked albums (the album_space_asset FK already
-    // guarantees that, but keep the space-link filter symmetric with the album_asset arm).
-    await this.db
-      .insertInto('album_space_asset_audit')
-      .columns(['albumId', 'assetId'])
-      .expression(
-        this.db
-          .selectFrom('album_space_asset')
-          .select(['album_space_asset.albumId', 'album_space_asset.assetId'])
-          .where('album_space_asset.assetId', 'in', assetIds),
-      )
-      .execute();
+// #764: contributions live in album_space_asset (not album_asset); tombstone the contributed
+// (albumId, assetId) pairs too so SharedSpaceAlbumToAssetSync.getDeletes drops a now-Hidden
+// contribution on member devices. Only space-linked albums (the album_space_asset FK already
+// guarantees that, but keep the space-link filter symmetric with the album_asset arm).
+await this.db
+  .insertInto('album_space_asset_audit')
+  .columns(['albumId', 'assetId'])
+  .expression(
+    this.db
+      .selectFrom('album_space_asset')
+      .select(['album_space_asset.albumId', 'album_space_asset.assetId'])
+      .where('album_space_asset.assetId', 'in', assetIds),
+  )
+  .execute();
 ```
 
 - [ ] **Step 4: Extend `emitAlbumAssetVisibilityRestore`**
@@ -1048,13 +1064,13 @@ In `server/src/repositories/shared-space.repository.ts`, after the existing `sha
 In the same file, after the existing `album_asset` `updatedAt` bump in `emitAlbumAssetVisibilityRestore` (`:578-583`), add a bump for contributed rows (the `album_space_asset_updatedAt` trigger turns the touch into a fresh `updateId`):
 
 ```ts
-    // #764: bump contributed rows too so getUpserts re-emits an un-hidden contribution to devices
-    // that purged it. The album_space_asset_updatedAt BEFORE-UPDATE trigger regenerates updateId.
-    await this.db
-      .updateTable('album_space_asset')
-      .set({ updatedAt: sql`clock_timestamp()` })
-      .where('assetId', 'in', assetIds)
-      .execute();
+// #764: bump contributed rows too so getUpserts re-emits an un-hidden contribution to devices
+// that purged it. The album_space_asset_updatedAt BEFORE-UPDATE trigger regenerates updateId.
+await this.db
+  .updateTable('album_space_asset')
+  .set({ updatedAt: sql`clock_timestamp()` })
+  .where('assetId', 'in', assetIds)
+  .execute();
 ```
 
 > `sql` is already imported in `shared-space.repository.ts` (used by the sibling methods).
@@ -1090,9 +1106,11 @@ git commit -m "feat(spaces): Hidden/restore parity + audit prune for contributio
 **Delivers.** End-to-end proof through the real `SyncService` seam that: a member who joins a space with pre-existing contributions **backfills** them; the delete arm never causes a spurious **asset** deletion; and re-emitting after ack is monotonic (no duplicates).
 
 **Files:**
+
 - Test: `server/test/medium/specs/services/sync.service.spec.ts` (extend) — or a new `server/test/medium/specs/sync/album-space-asset-convergence.spec.ts` if the service spec's setup does not fit.
 
 **Interfaces:**
+
 - Consumes: the full `SyncService` (via `SyncTestContext`, whose generic is `SyncService`), Tasks 2–4.
 
 - [ ] **Step 1: Inspect the existing service-level sync test**
@@ -1102,6 +1120,7 @@ Read `server/test/medium/specs/services/sync.service.spec.ts` (and `sync-shared-
 - [ ] **Step 2: Write the failing convergence test**
 
 Add a `describe` that:
+
 1. Creates space S (owner) + album L linked to S + a contribution `(L, X, S)` where X is owned by Carol, **before** `member` joins.
 2. Adds `member` to S (Editor) — which fires the grant trigger.
 3. Runs a full sync for `member` and asserts a `SharedSpaceAlbumToAssetV1` (or `…BackfillV1`) item for `(L, X)` **and** a `SharedSpaceAlbumAssetV1` payload item for X are emitted (backfill-on-join).
@@ -1131,14 +1150,17 @@ git commit -m "test(spaces): service-level convergence for contribution sync (#7
 **Delivers.** A `flutter test` proving the mobile Drift layer converges for a contribution `(albumId, assetId)` membership: present after an insert event, absent after a delete event, with the remote asset blob retained. **No mobile production code changes** — mobile is origin-blind; this is a regression guard that locks in that a contribution (indistinguishable from an owner membership on the wire) converges through the existing handlers.
 
 **Files:**
+
 - Test: `mobile/test/domain/repositories/sync_stream_repository_test.dart` (extend the existing `SyncStreamRepository - SharedSpaceAlbum handlers` group, ~lines 1706-1996)
 
 **Interfaces:**
+
 - Consumes: existing handlers `SyncStreamRepository.updateSharedSpaceAlbumToAssetsV1` / `deleteSharedSpaceAlbumToAssetsV1` / `updateSharedSpaceAlbumAssetsV1`; Drift `db.sharedSpaceAlbumAssetEntity`, `db.remoteAssetEntity`; local builders `makeAlbumToAsset`, `makeAlbumV2` (already in the file).
 
 - [ ] **Step 1: Regenerate localization/keys (once) so `flutter test` compiles**
 
 Per CLAUDE.md, from `mobile/` with Flutter 3.41.7:
+
 ```bash
 cd mobile && flutter pub get && dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
 ```
@@ -1200,6 +1222,7 @@ git commit -m "test(mobile): contribution sync convergence regression guard (#76
 **Delivers.** Regenerated query docs, green full server medium + unit suites, green mobile test, and the branch pushed.
 
 **Files:**
+
 - Modify (generated): `server/src/queries/*.sql` (via `make sql`)
 
 - [ ] **Step 1: Regenerate query SQL against a SCRATCH migrated DB**
@@ -1241,6 +1264,7 @@ git commit -m "chore(server): regenerate SQL for contribution sync streams (#764
 ```bash
 git push
 ```
+
 (Branch `feat/space-albums-collab-contrib` already has an upstream — plain `git push`. If not: `git push -u origin feat/space-albums-collab-contrib`.)
 
 ---
@@ -1254,4 +1278,7 @@ git push
 - **Placeholder scan:** migration/decorator/stream code shown in full; test code shown; the two "read the file and match" notes (exif builder name, service-spec collect helper) are unavoidable local-lookup instructions, not deferred logic. ✅
 - **Type consistency:** all arms select matching UNION columns (`{assetId, albumId, updateId}` for membership; `columns.syncAlbumAsset`+`isFavorite`+`updateId` for asset; `columns.syncAssetExif`+`updateId` for exif); watermark alias `updateId` used uniformly for `orderBy`. ✅
 - **Not implementing future slices:** Slice 6 (web legibility) untouched. ✅
+
+```
+
 ```

--- a/mobile/test/domain/repositories/sync_stream_repository_test.dart
+++ b/mobile/test/domain/repositories/sync_stream_repository_test.dart
@@ -1993,5 +1993,39 @@ void main() {
         expect(await db.sharedSpaceAlbumAssetEntity.select().get(), hasLength(1));
       });
     });
+
+    // --- Cross-owner contribution convergence (#764) ---
+    //
+    // A contribution rides the SAME SharedSpaceAlbumToAssetV1 membership +
+    // SharedSpaceAlbumAssetV1 payload events as an owner's album_asset —
+    // mobile is origin-blind (no owner column on the shared_space_album_asset
+    // row). No production code changes back this test: it is a
+    // characterization/regression guard that locks in the existing,
+    // already-convergent behaviour. (The red/green cycle for this slice is
+    // entirely server-side — see #764 tasks 1-5.)
+    group('cross-owner contribution convergence (#764)', () {
+      test('a contributed (albumId, assetId) membership is present after insert, '
+          'absent after delete, blob retained', () async {
+        await sut.updateUsersV1([_createUser()]);
+        await sut.updateSharedSpaceAlbumAssetsV1([
+          _createAssetV2(id: 'contrib-asset', checksum: 'cContrib1', fileName: 'contrib.jpg'),
+        ]);
+        await sut.updateSharedSpaceAlbumToAssetsV1([makeAlbumToAsset(albumId: 'album-1', assetId: 'contrib-asset')]);
+
+        final present = await db.sharedSpaceAlbumAssetEntity.select().get();
+        expect(present.any((r) => r.albumId == 'album-1' && r.assetId == 'contrib-asset'), isTrue);
+
+        await sut.deleteSharedSpaceAlbumToAssetsV1([
+          SyncAlbumToAssetDeleteV1(albumId: 'album-1', assetId: 'contrib-asset'),
+        ]);
+
+        final afterDelete = await db.sharedSpaceAlbumAssetEntity.select().get();
+        expect(afterDelete.any((r) => r.assetId == 'contrib-asset'), isFalse);
+
+        // Removing the membership edge must NOT delete the asset blob (only pruneAssets GCs it).
+        final blob = await db.remoteAssetEntity.select().get();
+        expect(blob.any((r) => r.id == 'contrib-asset'), isTrue);
+      });
+    });
   });
 }

--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -111,6 +111,7 @@ DROP TABLE IF EXISTS "shared_space_library_audit" CASCADE;
 DROP TABLE IF EXISTS "shared_space_library" CASCADE;
 
 -- Shared spaces
+DROP TABLE IF EXISTS "album_space_asset_audit" CASCADE;
 DROP TABLE IF EXISTS "album_space_asset" CASCADE;
 DROP TABLE IF EXISTS "shared_space_activity" CASCADE;
 DROP TABLE IF EXISTS "shared_space_person_alias" CASCADE;
@@ -175,6 +176,7 @@ DROP FUNCTION IF EXISTS shared_space_member_delete_album_audit() CASCADE;
 DROP FUNCTION IF EXISTS shared_space_delete_album_audit() CASCADE;
 DROP FUNCTION IF EXISTS shared_space_album_user_delete_after_audit() CASCADE;
 DROP FUNCTION IF EXISTS album_soft_delete_shared_space_album() CASCADE;
+DROP FUNCTION IF EXISTS album_space_asset_delete_audit() CASCADE;
 
 -- -----------------------------------------------------------------------------
 -- 4. Drop Gallery-added columns from Immich-native tables.
@@ -231,6 +233,7 @@ DELETE FROM "migration_overrides"
    'function_shared_space_delete_album_audit',
    'function_shared_space_album_user_delete_after_audit',
    'function_album_soft_delete_shared_space_album',
+   'function_album_space_asset_delete_audit',
    'index_asset_face_personId_idx',
    'index_face_identity_representativeFaceId_idx',
    'index_person_identityId_idx',
@@ -258,6 +261,8 @@ DELETE FROM "migration_overrides"
    'trigger_shared_space_delete_album_audit',
    'trigger_shared_space_album_user_delete_after_audit',
    'trigger_album_soft_delete_shared_space_album',
+   'trigger_album_space_asset_delete_audit',
+   'trigger_album_space_asset_updatedAt',
    'trigger_shared_space_album_updatedAt',
    'trigger_shared_space_library_updatedAt',
    'trigger_shared_space_member_after_insert',
@@ -372,6 +377,7 @@ DELETE FROM "kysely_migrations"
    '1782100000000-FixSharedSpaceAlbumGrantRelinkCreateId',
    '1782300000000-AddSharedSpaceAlbumAuditSyncIndexes',
    '1783000000000-AddAlbumSpaceAssetTable',
+   '1783100000000-AddAlbumSpaceAssetSyncAndAudit',
 
    -- Build-time compatibility alias (server/bin/sync-gallery-migrations.mjs).
    -- Gallery's postbuild records ChangeDurationToInteger under BOTH its current
@@ -440,6 +446,7 @@ BEGIN
        'shared_space_album', 'shared_space_album_audit',
        'shared_space_album_user', 'shared_space_album_user_audit',
        'shared_space_album_asset_audit',
+       'album_space_asset_audit',
        'face_identity_face', 'face_identity',
        'shared_space', 'user_group_member', 'user_group',
        'classification_prompt_embedding', 'classification_category',

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -410,6 +410,9 @@ order by
 delete from "album_asset"
 where
   "album_asset"."assetId" in ($1)
+delete from "album_space_asset"
+where
+  "album_space_asset"."assetId" in ($1)
 
 -- AlbumRepository.getAssetIds
 select

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -278,6 +278,15 @@ where
     from
       "shared_space_album"
   )
+insert into
+  "album_space_asset_audit" ("albumId", "assetId")
+select
+  "album_space_asset"."albumId",
+  "album_space_asset"."assetId"
+from
+  "album_space_asset"
+where
+  "album_space_asset"."assetId" in ($1)
 
 -- SharedSpaceRepository.emitAlbumAssetVisibilityRestore
 update "album_asset"
@@ -291,6 +300,11 @@ where
     from
       "shared_space_album"
   )
+update "album_space_asset"
+set
+  "updatedAt" = clock_timestamp()
+where
+  "assetId" in ($1)
 
 -- SharedSpaceRepository.emitLibraryAssetVisibilityPurge
 insert into

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -2334,16 +2334,41 @@ select
   "album_asset"."albumId" as "albumId",
   "album_asset"."updateId"
 from
-  "album_asset" as "album_asset"
+  "album_asset"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
 where
-  "album_asset"."updateId" < $1
-  and "album_asset"."updateId" <= $2
-  and "album_asset"."updateId" > $3
-  and "album_asset"."albumId" = $4
+  "album_asset"."albumId" = $1
+  and "album_asset"."updateId" < $2
+  and "album_asset"."updateId" <= $3
+  and "album_asset"."updateId" > $4
   and "asset"."visibility" in ($5, $6)
+union
+select
+  "album_space_asset"."assetId" as "assetId",
+  "album_space_asset"."albumId" as "albumId",
+  "album_space_asset"."updateId"
+from
+  "album_space_asset"
+  inner join "asset" on "asset"."id" = "album_space_asset"."assetId"
+where
+  "album_space_asset"."albumId" = $7
+  and "album_space_asset"."updateId" < $8
+  and "album_space_asset"."updateId" <= $9
+  and "album_space_asset"."updateId" > $10
+  and "asset"."visibility" in ($11, $12)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $13::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "album_asset"."updateId" asc
+  "updateId" asc
 
 -- SyncRepository.sharedSpaceAlbumToAsset.getDeletes
 select
@@ -2415,6 +2440,40 @@ where
       )
   )
   and "asset"."ownerId" != $9
+union
+select
+  "id",
+  "assetId",
+  "albumId"
+from
+  "album_space_asset_audit"
+where
+  "id" < $10
+  and "id" > $11
+  and "albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $12
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $13
+      )
+  )
 order by
   "id" asc
 
@@ -2424,13 +2483,11 @@ select
   "album_asset"."albumId" as "albumId",
   "album_asset"."updateId"
 from
-  "album_asset" as "album_asset"
+  "album_asset"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
 where
-  "album_asset"."updateId" < $1
-  and "album_asset"."updateId" > $2
-  and "shared_space_album_user"."userId" = $3
+  "shared_space_album_user"."userId" = $1
   and "album_asset"."albumId" in (
     select
       "shared_space_album"."albumId" as "id"
@@ -2445,19 +2502,70 @@ where
         from
           "shared_space"
         where
-          "shared_space"."createdById" = $4
+          "shared_space"."createdById" = $2
         union
         select
           "shared_space_member"."spaceId" as "id"
         from
           "shared_space_member"
         where
-          "shared_space_member"."userId" = $5
+          "shared_space_member"."userId" = $3
       )
   )
+  and "album_asset"."updateId" < $4
+  and "album_asset"."updateId" > $5
   and "asset"."visibility" in ($6, $7)
+union
+select
+  "album_space_asset"."assetId" as "assetId",
+  "album_space_asset"."albumId" as "albumId",
+  "album_space_asset"."updateId"
+from
+  "album_space_asset"
+  inner join "asset" on "asset"."id" = "album_space_asset"."assetId"
+  inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_space_asset"."albumId"
+where
+  "shared_space_album_user"."userId" = $8
+  and "album_space_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $9
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $10
+      )
+  )
+  and "album_space_asset"."updateId" < $11
+  and "album_space_asset"."updateId" > $12
+  and "asset"."visibility" in ($13, $14)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $15::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "album_asset"."updateId" asc
+  "updateId" asc
 
 -- SyncRepository.sharedSpaceAlbumAsset.getBackfill
 select
@@ -2486,18 +2594,66 @@ select
   end as "isFavorite",
   "album_asset"."updateId"
 from
-  "album_asset" as "album_asset"
+  "album_asset"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
   inner join "album" on "album"."id" = "album_asset"."albumId"
 where
-  "album_asset"."updateId" < $3
-  and "album_asset"."updateId" <= $4
-  and "album_asset"."updateId" > $5
-  and "album_asset"."albumId" = $6
+  "album_asset"."albumId" = $3
   and "album"."deletedAt" is null
+  and "album_asset"."updateId" < $4
+  and "album_asset"."updateId" <= $5
+  and "album_asset"."updateId" > $6
   and "asset"."visibility" in ($7, $8)
+union
+select
+  "asset"."id",
+  "asset"."ownerId",
+  "asset"."originalFileName",
+  "asset"."thumbhash",
+  "asset"."checksum",
+  "asset"."fileCreatedAt",
+  "asset"."fileModifiedAt",
+  "asset"."createdAt",
+  "asset"."localDateTime",
+  "asset"."type",
+  "asset"."deletedAt",
+  "asset"."visibility",
+  "asset"."duration",
+  "asset"."livePhotoVideoId",
+  "asset"."stackId",
+  "asset"."libraryId",
+  "asset"."width",
+  "asset"."height",
+  "asset"."isEdited",
+  case
+    when "asset"."ownerId" = $9 then "asset"."isFavorite"
+    else $10
+  end as "isFavorite",
+  "album_space_asset"."updateId"
+from
+  "album_space_asset"
+  inner join "asset" on "asset"."id" = "album_space_asset"."assetId"
+  inner join "album" on "album"."id" = "album_space_asset"."albumId"
+where
+  "album_space_asset"."albumId" = $11
+  and "album"."deletedAt" is null
+  and "album_space_asset"."updateId" < $12
+  and "album_space_asset"."updateId" <= $13
+  and "album_space_asset"."updateId" > $14
+  and "asset"."visibility" in ($15, $16)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $17::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "album_asset"."updateId" asc
+  "updateId" asc
 
 -- SyncRepository.sharedSpaceAlbumAsset.getUpdates
 select
@@ -2526,7 +2682,7 @@ select
   end as "isFavorite",
   "asset"."updateId"
 from
-  "asset" as "asset"
+  "asset"
   inner join "album_asset" on "album_asset"."assetId" = "asset"."id"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
 where
@@ -2559,12 +2715,82 @@ where
       )
   )
   and "asset"."visibility" in ($9, $10)
+union
+select
+  "asset"."id",
+  "asset"."ownerId",
+  "asset"."originalFileName",
+  "asset"."thumbhash",
+  "asset"."checksum",
+  "asset"."fileCreatedAt",
+  "asset"."fileModifiedAt",
+  "asset"."createdAt",
+  "asset"."localDateTime",
+  "asset"."type",
+  "asset"."deletedAt",
+  "asset"."visibility",
+  "asset"."duration",
+  "asset"."livePhotoVideoId",
+  "asset"."stackId",
+  "asset"."libraryId",
+  "asset"."width",
+  "asset"."height",
+  "asset"."isEdited",
+  case
+    when "asset"."ownerId" = $11 then "asset"."isFavorite"
+    else $12
+  end as "isFavorite",
+  "asset"."updateId"
+from
+  "asset"
+  inner join "album_space_asset" on "album_space_asset"."assetId" = "asset"."id"
+  inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_space_asset"."albumId"
+where
+  "asset"."updateId" < $13
+  and "asset"."updateId" > $14
+  and "album_space_asset"."updateId" <= $15
+  and "shared_space_album_user"."userId" = $16
+  and "album_space_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $17
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $18
+      )
+  )
+  and "asset"."visibility" in ($19, $20)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $21::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "asset"."updateId" asc
+  "updateId" asc
 
 -- SyncRepository.sharedSpaceAlbumAsset.getCreates
 select
-  "album_asset"."updateId",
   "asset"."id",
   "asset"."ownerId",
   "asset"."originalFileName",
@@ -2587,15 +2813,14 @@ select
   case
     when "asset"."ownerId" = $1 then "asset"."isFavorite"
     else $2
-  end as "isFavorite"
+  end as "isFavorite",
+  "album_asset"."updateId"
 from
-  "album_asset" as "album_asset"
+  "album_asset"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
 where
-  "album_asset"."updateId" < $3
-  and "album_asset"."updateId" > $4
-  and "shared_space_album_user"."userId" = $5
+  "shared_space_album_user"."userId" = $3
   and "album_asset"."albumId" in (
     select
       "shared_space_album"."albumId" as "id"
@@ -2610,19 +2835,91 @@ where
         from
           "shared_space"
         where
-          "shared_space"."createdById" = $6
+          "shared_space"."createdById" = $4
         union
         select
           "shared_space_member"."spaceId" as "id"
         from
           "shared_space_member"
         where
-          "shared_space_member"."userId" = $7
+          "shared_space_member"."userId" = $5
       )
   )
+  and "album_asset"."updateId" < $6
+  and "album_asset"."updateId" > $7
   and "asset"."visibility" in ($8, $9)
+union
+select
+  "asset"."id",
+  "asset"."ownerId",
+  "asset"."originalFileName",
+  "asset"."thumbhash",
+  "asset"."checksum",
+  "asset"."fileCreatedAt",
+  "asset"."fileModifiedAt",
+  "asset"."createdAt",
+  "asset"."localDateTime",
+  "asset"."type",
+  "asset"."deletedAt",
+  "asset"."visibility",
+  "asset"."duration",
+  "asset"."livePhotoVideoId",
+  "asset"."stackId",
+  "asset"."libraryId",
+  "asset"."width",
+  "asset"."height",
+  "asset"."isEdited",
+  case
+    when "asset"."ownerId" = $10 then "asset"."isFavorite"
+    else $11
+  end as "isFavorite",
+  "album_space_asset"."updateId"
+from
+  "album_space_asset"
+  inner join "asset" on "asset"."id" = "album_space_asset"."assetId"
+  inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_space_asset"."albumId"
+where
+  "shared_space_album_user"."userId" = $12
+  and "album_space_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $13
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $14
+      )
+  )
+  and "album_space_asset"."updateId" < $15
+  and "album_space_asset"."updateId" > $16
+  and "asset"."visibility" in ($17, $18)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $19::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "album_asset"."updateId" asc
+  "updateId" asc
 
 -- SyncRepository.sharedSpaceAlbumAssetExif.getBackfill
 select
@@ -2653,19 +2950,70 @@ select
   "asset_exif"."fps",
   "album_asset"."updateId"
 from
-  "album_asset" as "album_asset"
+  "album_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "album_asset"."assetId"
   inner join "album" on "album"."id" = "album_asset"."albumId"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
 where
-  "album_asset"."updateId" < $1
-  and "album_asset"."updateId" <= $2
-  and "album_asset"."updateId" > $3
-  and "album_asset"."albumId" = $4
+  "album_asset"."albumId" = $1
   and "album"."deletedAt" is null
+  and "album_asset"."updateId" < $2
+  and "album_asset"."updateId" <= $3
+  and "album_asset"."updateId" > $4
   and "asset"."visibility" in ($5, $6)
+union
+select
+  "asset_exif"."assetId",
+  "asset_exif"."description",
+  "asset_exif"."exifImageWidth",
+  "asset_exif"."exifImageHeight",
+  "asset_exif"."fileSizeInByte",
+  "asset_exif"."orientation",
+  "asset_exif"."dateTimeOriginal",
+  "asset_exif"."modifyDate",
+  "asset_exif"."timeZone",
+  "asset_exif"."latitude",
+  "asset_exif"."longitude",
+  "asset_exif"."projectionType",
+  "asset_exif"."city",
+  "asset_exif"."state",
+  "asset_exif"."country",
+  "asset_exif"."make",
+  "asset_exif"."model",
+  "asset_exif"."lensModel",
+  "asset_exif"."fNumber",
+  "asset_exif"."focalLength",
+  "asset_exif"."iso",
+  "asset_exif"."exposureTime",
+  "asset_exif"."profileDescription",
+  "asset_exif"."rating",
+  "asset_exif"."fps",
+  "album_space_asset"."updateId"
+from
+  "album_space_asset"
+  inner join "asset_exif" on "asset_exif"."assetId" = "album_space_asset"."assetId"
+  inner join "album" on "album"."id" = "album_space_asset"."albumId"
+  inner join "asset" on "asset"."id" = "album_space_asset"."assetId"
+where
+  "album_space_asset"."albumId" = $7
+  and "album"."deletedAt" is null
+  and "album_space_asset"."updateId" < $8
+  and "album_space_asset"."updateId" <= $9
+  and "album_space_asset"."updateId" > $10
+  and "asset"."visibility" in ($11, $12)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $13::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "album_asset"."updateId" asc
+  "updateId" asc
 
 -- SyncRepository.sharedSpaceAlbumAssetExif.getUpdates
 select
@@ -2696,7 +3044,7 @@ select
   "asset_exif"."fps",
   "asset_exif"."updateId"
 from
-  "asset_exif" as "asset_exif"
+  "asset_exif"
   inner join "album_asset" on "album_asset"."assetId" = "asset_exif"."assetId"
   inner join "asset" on "asset"."id" = "asset_exif"."assetId"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
@@ -2730,12 +3078,8 @@ where
       )
   )
   and "asset"."visibility" in ($7, $8)
-order by
-  "asset_exif"."updateId" asc
-
--- SyncRepository.sharedSpaceAlbumAssetExif.getCreates
+union
 select
-  "album_asset"."updateId",
   "asset_exif"."assetId",
   "asset_exif"."description",
   "asset_exif"."exifImageWidth",
@@ -2760,16 +3104,92 @@ select
   "asset_exif"."exposureTime",
   "asset_exif"."profileDescription",
   "asset_exif"."rating",
-  "asset_exif"."fps"
+  "asset_exif"."fps",
+  "asset_exif"."updateId"
 from
-  "album_asset" as "album_asset"
+  "asset_exif"
+  inner join "album_space_asset" on "album_space_asset"."assetId" = "asset_exif"."assetId"
+  inner join "asset" on "asset"."id" = "asset_exif"."assetId"
+  inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_space_asset"."albumId"
+where
+  "asset_exif"."updateId" < $9
+  and "asset_exif"."updateId" > $10
+  and "album_space_asset"."updateId" <= $11
+  and "shared_space_album_user"."userId" = $12
+  and "album_space_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $13
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $14
+      )
+  )
+  and "asset"."visibility" in ($15, $16)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $17::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
+order by
+  "updateId" asc
+
+-- SyncRepository.sharedSpaceAlbumAssetExif.getCreates
+select
+  "asset_exif"."assetId",
+  "asset_exif"."description",
+  "asset_exif"."exifImageWidth",
+  "asset_exif"."exifImageHeight",
+  "asset_exif"."fileSizeInByte",
+  "asset_exif"."orientation",
+  "asset_exif"."dateTimeOriginal",
+  "asset_exif"."modifyDate",
+  "asset_exif"."timeZone",
+  "asset_exif"."latitude",
+  "asset_exif"."longitude",
+  "asset_exif"."projectionType",
+  "asset_exif"."city",
+  "asset_exif"."state",
+  "asset_exif"."country",
+  "asset_exif"."make",
+  "asset_exif"."model",
+  "asset_exif"."lensModel",
+  "asset_exif"."fNumber",
+  "asset_exif"."focalLength",
+  "asset_exif"."iso",
+  "asset_exif"."exposureTime",
+  "asset_exif"."profileDescription",
+  "asset_exif"."rating",
+  "asset_exif"."fps",
+  "album_asset"."updateId"
+from
+  "album_asset"
   inner join "asset_exif" on "asset_exif"."assetId" = "album_asset"."assetId"
   inner join "asset" on "asset"."id" = "album_asset"."assetId"
   inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_asset"."albumId"
 where
-  "album_asset"."updateId" < $1
-  and "album_asset"."updateId" > $2
-  and "shared_space_album_user"."userId" = $3
+  "shared_space_album_user"."userId" = $1
   and "album_asset"."albumId" in (
     select
       "shared_space_album"."albumId" as "id"
@@ -2784,16 +3204,91 @@ where
         from
           "shared_space"
         where
-          "shared_space"."createdById" = $4
+          "shared_space"."createdById" = $2
         union
         select
           "shared_space_member"."spaceId" as "id"
         from
           "shared_space_member"
         where
-          "shared_space_member"."userId" = $5
+          "shared_space_member"."userId" = $3
       )
   )
+  and "album_asset"."updateId" < $4
+  and "album_asset"."updateId" > $5
   and "asset"."visibility" in ($6, $7)
+union
+select
+  "asset_exif"."assetId",
+  "asset_exif"."description",
+  "asset_exif"."exifImageWidth",
+  "asset_exif"."exifImageHeight",
+  "asset_exif"."fileSizeInByte",
+  "asset_exif"."orientation",
+  "asset_exif"."dateTimeOriginal",
+  "asset_exif"."modifyDate",
+  "asset_exif"."timeZone",
+  "asset_exif"."latitude",
+  "asset_exif"."longitude",
+  "asset_exif"."projectionType",
+  "asset_exif"."city",
+  "asset_exif"."state",
+  "asset_exif"."country",
+  "asset_exif"."make",
+  "asset_exif"."model",
+  "asset_exif"."lensModel",
+  "asset_exif"."fNumber",
+  "asset_exif"."focalLength",
+  "asset_exif"."iso",
+  "asset_exif"."exposureTime",
+  "asset_exif"."profileDescription",
+  "asset_exif"."rating",
+  "asset_exif"."fps",
+  "album_space_asset"."updateId"
+from
+  "album_space_asset"
+  inner join "asset_exif" on "asset_exif"."assetId" = "album_space_asset"."assetId"
+  inner join "asset" on "asset"."id" = "album_space_asset"."assetId"
+  inner join "shared_space_album_user" on "shared_space_album_user"."albumId" = "album_space_asset"."albumId"
+where
+  "shared_space_album_user"."userId" = $8
+  and "album_space_asset"."albumId" in (
+    select
+      "shared_space_album"."albumId" as "id"
+    from
+      "shared_space_album"
+      inner join "album" on "album"."id" = "shared_space_album"."albumId"
+    where
+      "album"."deletedAt" is null
+      and "shared_space_album"."spaceId" in (
+        select
+          "shared_space"."id"
+        from
+          "shared_space"
+        where
+          "shared_space"."createdById" = $9
+        union
+        select
+          "shared_space_member"."spaceId" as "id"
+        from
+          "shared_space_member"
+        where
+          "shared_space_member"."userId" = $10
+      )
+  )
+  and "album_space_asset"."updateId" < $11
+  and "album_space_asset"."updateId" > $12
+  and "asset"."visibility" in ($13, $14)
+  and exists (
+    select
+      1 as "one"
+    from
+      "shared_space_album"
+      inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+      and "shared_space_member"."userId" = $15::uuid
+    where
+      "shared_space_album"."albumId" = "album_space_asset"."albumId"
+      and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
+  )
 order by
-  "album_asset"."updateId" asc
+  "updateId" asc

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -378,6 +378,11 @@ export class AlbumRepository {
   @Chunked()
   async removeAssetsFromAll(assetIds: string[]): Promise<void> {
     await this.db.deleteFrom('album_asset').where('album_asset.assetId', 'in', assetIds).execute();
+    // #764: also drop cross-owner contributions — "remove from all albums" must clear both membership
+    // tables, else a Locked contribution never leaves a member's device (the album_asset-only delete
+    // above never fires the album_space_asset delete trigger). Un-lock won't restore (row deleted),
+    // matching owned-asset Locked semantics.
+    await this.db.deleteFrom('album_space_asset').where('album_space_asset.assetId', 'in', assetIds).execute();
   }
 
   @Chunked({ paramIndex: 1 })

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -558,8 +558,10 @@ export class SharedSpaceRepository {
 
     // #764: contributions live in album_space_asset (not album_asset); tombstone the contributed
     // (albumId, assetId) pairs too so SharedSpaceAlbumToAssetSync.getDeletes drops a now-Hidden
-    // contribution on member devices. Only space-linked albums are targeted (the album_space_asset FK already
-    // guarantees that, but keep the space-link filter symmetric with the album_asset arm).
+    // contribution on member devices. Unlike the album_asset arm above there is NO space-link filter
+    // here — album_space_asset has no FK to shared_space_album, so we cannot (and need not) restrict to
+    // linked albums at write time. The safety is applied at READ time: getDeletes scopes these
+    // tombstones by accessibleSpaceAlbums, so only a member who can see the album ever receives the delete.
     await this.db
       .insertInto('album_space_asset_audit')
       .columns(['albumId', 'assetId'])
@@ -599,6 +601,8 @@ export class SharedSpaceRepository {
 
     // #764: bump contributed rows too so getUpserts re-emits an un-hidden contribution to devices
     // that purged it. The album_space_asset_updatedAt BEFORE-UPDATE trigger regenerates updateId.
+    // Unlike the album_asset arm above this has no space-link filter (a harmless over-bump — getUpserts
+    // re-gates by grant + visibility, and now also per-space via contributionVisibleToMember).
     await this.db
       .updateTable('album_space_asset')
       .set({ updatedAt: sql`clock_timestamp()` })

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -555,6 +555,21 @@ export class SharedSpaceRepository {
           ),
       )
       .execute();
+
+    // #764: contributions live in album_space_asset (not album_asset); tombstone the contributed
+    // (albumId, assetId) pairs too so SharedSpaceAlbumToAssetSync.getDeletes drops a now-Hidden
+    // contribution on member devices. Only space-linked albums are targeted (the album_space_asset FK already
+    // guarantees that, but keep the space-link filter symmetric with the album_asset arm).
+    await this.db
+      .insertInto('album_space_asset_audit')
+      .columns(['albumId', 'assetId'])
+      .expression(
+        this.db
+          .selectFrom('album_space_asset')
+          .select(['album_space_asset.albumId', 'album_space_asset.assetId'])
+          .where('album_space_asset.assetId', 'in', assetIds),
+      )
+      .execute();
   }
 
   /**
@@ -580,6 +595,14 @@ export class SharedSpaceRepository {
       .set({ updatedAt: sql`clock_timestamp()` })
       .where('assetId', 'in', assetIds)
       .where('albumId', 'in', (eb) => eb.selectFrom('shared_space_album').select('shared_space_album.albumId'))
+      .execute();
+
+    // #764: bump contributed rows too so getUpserts re-emits an un-hidden contribution to devices
+    // that purged it. The album_space_asset_updatedAt BEFORE-UPDATE trigger regenerates updateId.
+    await this.db
+      .updateTable('album_space_asset')
+      .set({ updatedAt: sql`clock_timestamp()` })
+      .where('assetId', 'in', assetIds)
       .execute();
   }
 

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1737,7 +1737,11 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
 class SharedSpaceAlbumAssetSync extends BaseSync {
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, albumId: string, userId: string) {
-    return this.backfillQuery('album_asset', options)
+    const { nowId, beforeUpdateId, afterUpdateId } = options;
+
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
       .innerJoin('asset', 'asset.id', 'album_asset.assetId')
       .innerJoin('album', 'album.id', 'album_asset.albumId')
       .select(columns.syncAlbumAsset)
@@ -1753,15 +1757,46 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .select('album_asset.updateId')
       .where('album_asset.albumId', '=', albumId)
       .where('album.deletedAt', 'is', null)
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+      .where('album_asset.updateId', '<', nowId)
+      .where('album_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('album', 'album.id', 'album_space_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select((eb) =>
+        eb
+          .case()
+          .when('asset.ownerId', '=', userId)
+          .then(eb.ref('asset.isFavorite'))
+          .else(eb.val(false))
+          .end()
+          .as('isFavorite'),
+      )
+      .select('album_space_asset.updateId')
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album.deletedAt', 'is', null)
+      .where('album_space_asset.updateId', '<', nowId)
+      .where('album_space_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 
   @GenerateSql({ params: [dummyQueryOptions, { updateId: DummyValue.UUID }], stream: true })
   getUpdates(options: SyncQueryOptions, albumToAssetAck: SyncAck) {
-    const userId = options.userId;
-    return this.upsertQuery('asset', options)
+    const { userId, nowId, ack } = options;
+
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('asset')
       .innerJoin('album_asset', 'album_asset.assetId', 'asset.id')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .select(columns.syncAlbumAsset)
       .select((eb) =>
         eb
@@ -1773,20 +1808,18 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
           .as('isFavorite'),
       )
       .select('asset.updateId')
+      .where('asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('asset.updateId', '>', ack!.updateId))
       .where('album_asset.updateId', '<=', albumToAssetAck.updateId) // Ensure we only send updates for assets that the client already knows about
-      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
-  }
+      .where((eb) => spaceVisibilityGate(eb));
 
-  @GenerateSql({ params: [dummyQueryOptions], stream: true })
-  getCreates(options: SyncQueryOptions) {
-    const userId = options.userId;
-    return this.upsertQuery('album_asset', options)
-      .select('album_asset.updateId')
-      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('asset')
+      .innerJoin('album_space_asset', 'album_space_asset.assetId', 'asset.id')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
       .select(columns.syncAlbumAsset)
       .select((eb) =>
         eb
@@ -1797,11 +1830,66 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
           .end()
           .as('isFavorite'),
       )
+      .select('asset.updateId')
+      .where('asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('asset.updateId', '>', ack!.updateId))
+      .where('album_space_asset.updateId', '<=', albumToAssetAck.updateId)
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
+  }
+
+  @GenerateSql({ params: [dummyQueryOptions], stream: true })
+  getCreates(options: SyncQueryOptions) {
+    const { userId, nowId, ack } = options;
+
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select((eb) =>
+        eb
+          .case()
+          .when('asset.ownerId', '=', userId)
+          .then(eb.ref('asset.isFavorite'))
+          .else(eb.val(false))
+          .end()
+          .as('isFavorite'),
+      )
+      .select('album_asset.updateId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+      .where('album_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select(columns.syncAlbumAsset)
+      .select((eb) =>
+        eb
+          .case()
+          .when('asset.ownerId', '=', userId)
+          .then(eb.ref('asset.isFavorite'))
+          .else(eb.val(false))
+          .end()
+          .as('isFavorite'),
+      )
+      .select('album_space_asset.updateId')
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_space_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 }
 
@@ -1811,7 +1899,11 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
 class SharedSpaceAlbumAssetExifSync extends BaseSync {
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, albumId: string) {
-    return this.backfillQuery('album_asset', options)
+    const { nowId, beforeUpdateId, afterUpdateId } = options;
+
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
       .innerJoin('asset_exif', 'asset_exif.assetId', 'album_asset.assetId')
       .innerJoin('album', 'album.id', 'album_asset.albumId')
       .innerJoin('asset', 'asset.id', 'album_asset.assetId')
@@ -1819,39 +1911,99 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .select('album_asset.updateId')
       .where('album_asset.albumId', '=', albumId)
       .where('album.deletedAt', 'is', null)
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+      .where('album_asset.updateId', '<', nowId)
+      .where('album_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset_exif', 'asset_exif.assetId', 'album_space_asset.assetId')
+      .innerJoin('album', 'album.id', 'album_space_asset.albumId')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .select(columns.syncAssetExif)
+      .select('album_space_asset.updateId')
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album.deletedAt', 'is', null)
+      .where('album_space_asset.updateId', '<', nowId)
+      .where('album_space_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 
   @GenerateSql({ params: [dummyQueryOptions, { updateId: DummyValue.UUID }], stream: true })
   getUpdates(options: SyncQueryOptions, albumToAssetAck: SyncAck) {
-    const userId = options.userId;
-    return this.upsertQuery('asset_exif', options)
+    const { userId, nowId, ack } = options;
+
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('asset_exif')
       .innerJoin('album_asset', 'album_asset.assetId', 'asset_exif.assetId')
       .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .select(columns.syncAssetExif)
       .select('asset_exif.updateId')
+      .where('asset_exif.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('asset_exif.updateId', '>', ack!.updateId))
       .where('album_asset.updateId', '<=', albumToAssetAck.updateId) // Ensure we only send exif updates for assets that the client already knows about
-      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('asset_exif')
+      .innerJoin('album_space_asset', 'album_space_asset.assetId', 'asset_exif.assetId')
+      .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select(columns.syncAssetExif)
+      .select('asset_exif.updateId')
+      .where('asset_exif.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('asset_exif.updateId', '>', ack!.updateId))
+      .where('album_space_asset.updateId', '<=', albumToAssetAck.updateId)
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getCreates(options: SyncQueryOptions) {
-    const userId = options.userId;
-    return this.upsertQuery('album_asset', options)
-      .select('album_asset.updateId')
+    const { userId, nowId, ack } = options;
+
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
       .innerJoin('asset_exif', 'asset_exif.assetId', 'album_asset.assetId')
       .innerJoin('asset', 'asset.id', 'album_asset.assetId')
-      .select(columns.syncAssetExif)
       .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+      .select(columns.syncAssetExif)
+      .select('album_asset.updateId')
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+      .where('album_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset_exif', 'asset_exif.assetId', 'album_space_asset.assetId')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select(columns.syncAssetExif)
+      .select('album_space_asset.updateId')
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_space_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 }
 

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1609,16 +1609,35 @@ export class SharedSpaceAlbumLinkSync extends BaseSync {
 class SharedSpaceAlbumToAssetSync extends BaseSync {
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, albumId: string) {
-    return (
-      this.backfillQuery('album_asset', options)
-        .innerJoin('asset', 'asset.id', 'album_asset.assetId')
-        .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
-        .where('album_asset.albumId', '=', albumId)
-        // correctness-1/security-6: flat visibility gate — never backfill a Hidden/Locked album asset's
-        // link row (matches the SharedSpaceAlbumAssetSync content sibling; converges on restore).
-        .where((eb) => spaceVisibilityGate(eb))
-        .stream()
-    );
+    const { nowId, beforeUpdateId, afterUpdateId } = options;
+    // album_asset arm — the album owner's own membership (unchanged).
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
+      .where('album_asset.albumId', '=', albumId)
+      .where('album_asset.updateId', '<', nowId)
+      .where('album_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
+      // correctness-1/security-6: flat visibility gate — never backfill a Hidden/Locked asset's link.
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .select([
+        'album_space_asset.assetId as assetId',
+        'album_space_asset.albumId as albumId',
+        'album_space_asset.updateId',
+      ])
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album_space_asset.updateId', '<', nowId)
+      .where('album_space_asset.updateId', '<=', beforeUpdateId)
+      .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
@@ -1652,30 +1671,59 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
       .where('shared_space_album_asset_audit.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .where('asset.ownerId', '!=', userId);
 
-    return albumAssetArm.union(spaceAlbumAssetArm).orderBy('id', 'asc').stream();
+    // album_space_asset_audit — cross-owner contribution removals (#764). Trigger-driven, so the
+    // asset row may already be gone on FK cascade → NO asset join. A contribution is never also an
+    // owner's album_asset row (spec §5.1), so the owner has no independent path → NO ownerId filter:
+    // every member, including the asset's owner, drops the edge on removal/delete/Hidden-purge.
+    const contributedAuditArm = this.db
+      .selectFrom('album_space_asset_audit')
+      .select(['id', 'assetId', 'albumId'])
+      .where('id', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('id', '>', ack!.updateId))
+      .where('albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId));
+
+    return albumAssetArm.union(spaceAlbumAssetArm).union(contributedAuditArm).orderBy('id', 'asc').stream();
   }
 
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getUpserts(options: SyncQueryOptions) {
-    const userId = options.userId;
-    return (
-      this.upsertQuery('album_asset', options)
-        .innerJoin('asset', 'asset.id', 'album_asset.assetId')
-        .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
-        .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
-        .where('shared_space_album_user.userId', '=', userId)
-        .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-        // correctness-1/security-6: flat visibility gate — a restore's updateId bump must not re-add a
-        // now-Hidden album asset after the delete tombstone (resurrection); also blocks the metadata leak.
-        .where((eb) => spaceVisibilityGate(eb))
-        .stream()
-    );
+    const { userId, nowId, ack } = options;
+    const albumAssetArm = this.db
+      .selectFrom('album_asset')
+      .innerJoin('asset', 'asset.id', 'album_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_asset.albumId')
+      .select(['album_asset.assetId as assetId', 'album_asset.albumId as albumId', 'album_asset.updateId'])
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
+      // correctness-1/security-6: flat visibility gate — a restore's updateId bump must not re-add a
+      // now-Hidden asset after the delete tombstone (resurrection); also blocks the metadata leak.
+      .where((eb) => spaceVisibilityGate(eb));
+
+    const contributedArm = this.db
+      .selectFrom('album_space_asset')
+      .innerJoin('asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('shared_space_album_user', 'shared_space_album_user.albumId', 'album_space_asset.albumId')
+      .select([
+        'album_space_asset.assetId as assetId',
+        'album_space_asset.albumId as albumId',
+        'album_space_asset.updateId',
+      ])
+      .where('shared_space_album_user.userId', '=', userId)
+      .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
+      .where('album_space_asset.updateId', '<', nowId)
+      .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 
-  // Prune the space-only shared_space_album_asset_audit table. The shared
-  // album_asset_audit is pruned by albumToAsset.cleanupAuditTable (AlbumToAssetSync).
-  cleanupAuditTable(daysAgo: number) {
-    return this.auditCleanup('shared_space_album_asset_audit', daysAgo);
+  // Prune the space-only audit tables this stream owns. The shared album_asset_audit is pruned by
+  // albumToAsset.cleanupAuditTable (AlbumToAssetSync).
+  async cleanupAuditTable(daysAgo: number) {
+    await this.auditCleanup('shared_space_album_asset_audit', daysAgo);
+    await this.auditCleanup('album_space_asset_audit', daysAgo);
   }
 }
 

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { ExpressionBuilder, Kysely, sql } from 'kysely';
+import { Expression, ExpressionBuilder, Kysely, SqlBool, sql } from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { DB } from 'src/schema';
 import { SyncAck } from 'src/types';
+import { asUuid } from 'src/utils/database';
 import { accessibleSpaceAlbums, accessibleSpaces, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 // Re-export the relocated scoping helpers so existing `sync.repository` importers
@@ -1599,16 +1600,40 @@ export class SharedSpaceAlbumLinkSync extends BaseSync {
   }
 }
 
+// #764/§8.3: a contribution is visible to a member ONLY through the SINGLE space it was contributed
+// via. Gate every contributed sync arm on live membership of that space AND the album still being
+// linked to it — mirroring the web read arm (spaceContributedAssetExists). The album_asset grant /
+// accessibleSpaceAlbums are space-agnostic and would otherwise leak an S1 contribution to an
+// S2-only member of a multi-space co-linked album (edge + payload + exif).
+//
+// Correlated subquery: the two whereRefs reference the OUTER `album_space_asset` (the contributed arm
+// this predicate is attached to), exactly as the web read arm correlates album_space_asset.spaceId to
+// the link's space.
+const contributionVisibleToMember = (eb: ExpressionBuilder<DB, keyof DB>, userId: string): Expression<SqlBool> =>
+  eb.exists(
+    eb
+      .selectFrom('shared_space_album')
+      .innerJoin('shared_space_member', (join) =>
+        join
+          .onRef('shared_space_member.spaceId', '=', 'shared_space_album.spaceId')
+          .on('shared_space_member.userId', '=', asUuid(userId)),
+      )
+      .whereRef('shared_space_album.albumId', '=', 'album_space_asset.albumId')
+      .whereRef('shared_space_album.spaceId', '=', 'album_space_asset.spaceId')
+      .select(eb.lit(1).as('one')),
+  );
+
 // Streams album_asset join rows (album membership) for albums accessible via
 // the shared_space_album_user grant. Clone of AlbumToAssetSync with the
-// album_user scoping swapped for the grant.
+// album_user scoping swapped for the grant. Also unions the album_space_asset
+// contributed arm (#764), gated per-space by contributionVisibleToMember.
 //
 // getDeletes reads album_asset_audit scoped to albums in accessibleSpaceAlbums
 // (not album_user like AlbumToAssetSync) so that access-revocation at the space
 // level stops the user from seeing further delete events.
 class SharedSpaceAlbumToAssetSync extends BaseSync {
-  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
-  getBackfill(options: SyncBackfillOptions, albumId: string) {
+  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
+  getBackfill(options: SyncBackfillOptions, albumId: string, userId: string) {
     const { nowId, beforeUpdateId, afterUpdateId } = options;
     // album_asset arm — the album owner's own membership (unchanged).
     const albumAssetArm = this.db
@@ -1635,7 +1660,9 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
       .where('album_space_asset.updateId', '<', nowId)
       .where('album_space_asset.updateId', '<=', beforeUpdateId)
       .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1643,11 +1670,11 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getDeletes(options: SyncQueryOptions) {
     const { userId, nowId, ack } = options;
-    // Union the shared album_asset_audit (normal album deletes) with the
-    // space-only shared_space_album_asset_audit (visibility Hidden purge).
-    // Both arms are checkpoint-gated by the same nowId/ack bounds and scoped
-    // to albums accessible to this user via the space. A single ORDER BY id
-    // is applied over the whole union — per-arm ordering is invalid SQL.
+    // Union THREE audit sources: the shared album_asset_audit (normal album deletes), the space-only
+    // shared_space_album_asset_audit (owned-asset visibility Hidden purge), and the album_space_asset_audit
+    // (cross-owner contribution removals / delete / Hidden purge — #764). All arms are checkpoint-gated by
+    // the same nowId/ack bounds and scoped to albums accessible to this user via the space. A single
+    // ORDER BY id is applied over the whole union — per-arm ordering is invalid SQL.
     const albumAssetArm = this.db
       .selectFrom('album_asset_audit')
       .select(['id', 'assetId', 'albumId'])
@@ -1714,7 +1741,9 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
       .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .where('album_space_asset.updateId', '<', nowId)
       .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1727,9 +1756,11 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
   }
 }
 
-// Streams album_asset rows (full asset metadata) for albums accessible via
-// the shared_space_album_user grant. Clone of AlbumAssetSync with the
-// album_user scoping swapped for the grant.
+// Streams full asset metadata rows for albums accessible via the
+// shared_space_album_user grant, unioning the album owner's own album_asset rows
+// with the cross-owner album_space_asset contributions (#764, gated per-space by
+// contributionVisibleToMember). Clone of AlbumAssetSync with the album_user
+// scoping swapped for the grant.
 //
 // Preserves the split getCreates/getUpdates/getBackfill pattern, the
 // isFavorite masking (false for non-owners), and the albumToAssetAck coupling
@@ -1783,7 +1814,9 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .where('album_space_asset.updateId', '<', nowId)
       .where('album_space_asset.updateId', '<=', beforeUpdateId)
       .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1836,7 +1869,9 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .where('album_space_asset.updateId', '<=', albumToAssetAck.updateId)
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1887,18 +1922,22 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .where('album_space_asset.updateId', '<', nowId)
       .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
 }
 
 // Streams asset_exif rows for album-accessible assets via the
-// shared_space_album_user grant. Clone of AlbumAssetExifSync with the
-// album_user scoping swapped for the grant.
+// shared_space_album_user grant, unioning the album owner's own album_asset exif
+// with the cross-owner album_space_asset contributions (#764, gated per-space by
+// contributionVisibleToMember). Clone of AlbumAssetExifSync with the album_user
+// scoping swapped for the grant.
 class SharedSpaceAlbumAssetExifSync extends BaseSync {
-  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
-  getBackfill(options: SyncBackfillOptions, albumId: string) {
+  @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
+  getBackfill(options: SyncBackfillOptions, albumId: string, userId: string) {
     const { nowId, beforeUpdateId, afterUpdateId } = options;
 
     // album_asset arm — the album owner's own membership (unchanged).
@@ -1929,7 +1968,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .where('album_space_asset.updateId', '<', nowId)
       .where('album_space_asset.updateId', '<=', beforeUpdateId)
       .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1966,7 +2007,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .where('album_space_asset.updateId', '<=', albumToAssetAck.updateId)
       .where('shared_space_album_user.userId', '=', userId)
       .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -2001,7 +2044,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .where('album_space_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .where('album_space_asset.updateId', '<', nowId)
       .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #764/§8.3: only members of the space this contribution was made via may receive it.
+      .where((eb) => contributionVisibleToMember(eb, userId));
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -29,6 +29,7 @@ import { ActivityTable } from 'src/schema/tables/activity.table';
 import { AlbumAssetAuditTable } from 'src/schema/tables/album-asset-audit.table';
 import { AlbumAssetTable } from 'src/schema/tables/album-asset.table';
 import { AlbumAuditTable } from 'src/schema/tables/album-audit.table';
+import { AlbumSpaceAssetAuditTable } from 'src/schema/tables/album-space-asset-audit.table';
 import { AlbumSpaceAssetTable } from 'src/schema/tables/album-space-asset.table';
 import { AlbumUserAuditTable } from 'src/schema/tables/album-user-audit.table';
 import { AlbumUserTable } from 'src/schema/tables/album-user.table';
@@ -126,6 +127,7 @@ export class ImmichDatabase {
     AlbumAssetTable,
     AlbumAssetAuditTable,
     AlbumSpaceAssetTable,
+    AlbumSpaceAssetAuditTable,
     AlbumAuditTable,
     AlbumUserAuditTable,
     AlbumUserTable,
@@ -253,6 +255,7 @@ export interface DB {
   album_asset: AlbumAssetTable;
   album_asset_audit: AlbumAssetAuditTable;
   album_space_asset: AlbumSpaceAssetTable;
+  album_space_asset_audit: AlbumSpaceAssetAuditTable;
   album_user: AlbumUserTable;
   album_user_audit: AlbumUserAuditTable;
 

--- a/server/src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts
+++ b/server/src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts
@@ -1,0 +1,82 @@
+import { Kysely, sql } from 'kysely';
+
+// #764 Slice 5 — sync substrate for cross-owner contributions.
+//
+// 1. Add updateId/updatedAt to album_space_asset (createId/createdAt already exist from 1783000000000)
+//    + the standard updated_at BEFORE-UPDATE trigger, so the contributed sync arm mirrors album_asset.
+// 2. Create album_space_asset_audit + a statement-level AFTER-DELETE trigger that tombstones every
+//    deleted contribution (explicit removal + FK cascade), driving SharedSpaceAlbumToAssetSync deletes.
+export async function up(db: Kysely<any>): Promise<void> {
+  // --- 1. Sync watermark columns on album_space_asset ---
+  await sql`ALTER TABLE "album_space_asset" ADD COLUMN "updateId" uuid NOT NULL DEFAULT immich_uuid_v7();`.execute(db);
+  await sql`ALTER TABLE "album_space_asset" ADD COLUMN "updatedAt" timestamp with time zone NOT NULL DEFAULT now();`.execute(
+    db,
+  );
+  await sql`CREATE INDEX "album_space_asset_updateId_idx" ON "album_space_asset" ("updateId");`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "album_space_asset_updatedAt"
+  BEFORE UPDATE ON "album_space_asset"
+  FOR EACH ROW
+  EXECUTE FUNCTION updated_at();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_album_space_asset_updatedAt', '{"type":"trigger","name":"album_space_asset_updatedAt","sql":"CREATE OR REPLACE TRIGGER \\"album_space_asset_updatedAt\\"\\n  BEFORE UPDATE ON \\"album_space_asset\\"\\n  FOR EACH ROW\\n  EXECUTE FUNCTION updated_at();"}'::jsonb);`.execute(
+    db,
+  );
+
+  // --- 2. Delete-audit table ---
+  await sql`
+    CREATE TABLE "album_space_asset_audit" (
+      "id"        uuid NOT NULL DEFAULT immich_uuid_v7() PRIMARY KEY,
+      "albumId"   uuid NOT NULL,
+      "assetId"   uuid NOT NULL,
+      "deletedAt" timestamp with time zone NOT NULL DEFAULT clock_timestamp()
+    );
+  `.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_albumId_id_idx" ON "album_space_asset_audit" ("albumId", "id");`.execute(
+    db,
+  );
+  await sql`CREATE INDEX "album_space_asset_audit_albumId_idx" ON "album_space_asset_audit" ("albumId");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_assetId_idx" ON "album_space_asset_audit" ("assetId");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_deletedAt_idx" ON "album_space_asset_audit" ("deletedAt");`.execute(db);
+
+  // --- 3. AFTER-DELETE statement-level trigger → tombstone every deleted contribution ---
+  await sql`CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO album_space_asset_audit ("albumId", "assetId")
+      SELECT "albumId", "assetId" FROM "old";
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "album_space_asset_delete_audit"
+  AFTER DELETE ON "album_space_asset"
+  REFERENCING OLD TABLE AS "old"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION album_space_asset_delete_audit();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_album_space_asset_delete_audit', '{"type":"function","name":"album_space_asset_delete_audit","sql":"CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO album_space_asset_audit (\\"albumId\\", \\"assetId\\")\\n      SELECT \\"albumId\\", \\"assetId\\" FROM \\"old\\";\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb);`.execute(
+    db,
+  );
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_album_space_asset_delete_audit', '{"type":"trigger","name":"album_space_asset_delete_audit","sql":"CREATE OR REPLACE TRIGGER \\"album_space_asset_delete_audit\\"\\n  AFTER DELETE ON \\"album_space_asset\\"\\n  REFERENCING OLD TABLE AS \\"old\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION album_space_asset_delete_audit();"}'::jsonb);`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DELETE FROM "migration_overrides" WHERE "name" IN (
+    'trigger_album_space_asset_updatedAt',
+    'function_album_space_asset_delete_audit',
+    'trigger_album_space_asset_delete_audit'
+  );`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "album_space_asset_delete_audit" ON "album_space_asset";`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS album_space_asset_delete_audit();`.execute(db);
+  await sql`DROP TABLE IF EXISTS "album_space_asset_audit";`.execute(db);
+  await sql`DROP TRIGGER IF EXISTS "album_space_asset_updatedAt" ON "album_space_asset";`.execute(db);
+  await sql`DROP INDEX IF EXISTS "album_space_asset_updateId_idx";`.execute(db);
+  await sql`ALTER TABLE "album_space_asset" DROP COLUMN IF EXISTS "updatedAt";`.execute(db);
+  await sql`ALTER TABLE "album_space_asset" DROP COLUMN IF EXISTS "updateId";`.execute(db);
+}

--- a/server/src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts
+++ b/server/src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts
@@ -37,7 +37,9 @@ export async function up(db: Kysely<any>): Promise<void> {
   );
   await sql`CREATE INDEX "album_space_asset_audit_albumId_idx" ON "album_space_asset_audit" ("albumId");`.execute(db);
   await sql`CREATE INDEX "album_space_asset_audit_assetId_idx" ON "album_space_asset_audit" ("assetId");`.execute(db);
-  await sql`CREATE INDEX "album_space_asset_audit_deletedAt_idx" ON "album_space_asset_audit" ("deletedAt");`.execute(db);
+  await sql`CREATE INDEX "album_space_asset_audit_deletedAt_idx" ON "album_space_asset_audit" ("deletedAt");`.execute(
+    db,
+  );
 
   // --- 3. AFTER-DELETE statement-level trigger → tombstone every deleted contribution ---
   await sql`CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()

--- a/server/src/schema/tables/album-space-asset-audit.table.ts
+++ b/server/src/schema/tables/album-space-asset-audit.table.ts
@@ -1,0 +1,25 @@
+import { Column, CreateDateColumn, Generated, Index, Table, Timestamp } from '@immich/sql-tools';
+import { PrimaryGeneratedUuidV7Column } from 'src/decorators';
+
+// Delete-audit for album_space_asset cross-owner contributions (#764). Trigger-driven
+// (album_space_asset_delete_audit fires AFTER DELETE ... FOR EACH STATEMENT), so it captures BOTH
+// explicit contribution removal (AlbumService.removeAssets) AND every FK cascade (asset/album/space
+// delete). `id` is a UUIDv7 in the same watermark domain as album_asset_audit.id, so the
+// SharedSpaceAlbumToAssetSync delete stream can UNION all three audit arms under one ORDER BY id.
+//
+// Distinct from #752's shared_space_album_asset_audit (which audits normal album_asset membership).
+@Table('album_space_asset_audit')
+@Index({ name: 'album_space_asset_audit_albumId_id_idx', columns: ['albumId', 'id'] })
+export class AlbumSpaceAssetAuditTable {
+  @PrimaryGeneratedUuidV7Column()
+  id!: Generated<string>;
+
+  @Column({ type: 'uuid', index: true })
+  albumId!: string;
+
+  @Column({ type: 'uuid', index: true })
+  assetId!: string;
+
+  @CreateDateColumn({ default: () => 'clock_timestamp()', index: true })
+  deletedAt!: Generated<Timestamp>;
+}

--- a/server/src/schema/tables/album-space-asset.table.ts
+++ b/server/src/schema/tables/album-space-asset.table.ts
@@ -1,5 +1,13 @@
-import { CreateDateColumn, ForeignKeyColumn, Generated, Index, Table, Timestamp } from '@immich/sql-tools';
-import { CreateIdColumn } from 'src/decorators';
+import {
+  CreateDateColumn,
+  ForeignKeyColumn,
+  Generated,
+  Index,
+  Table,
+  Timestamp,
+  UpdateDateColumn,
+} from '@immich/sql-tools';
+import { CreateIdColumn, UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
 import { AlbumTable } from 'src/schema/tables/album.table';
 import { AssetTable } from 'src/schema/tables/asset.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
@@ -9,9 +17,15 @@ import { UserTable } from 'src/schema/tables/user.table';
 // space-linked album (#764). Deliberately NOT `album_asset` — it must never become a permanent
 // `checkAlbumAccess` grant for the album owner. Visibility is re-derived from live space membership
 // + the live album↔space link on every read (see spaceContributedAssetExists). The adder's OWN
-// photos take the ordinary `album_asset` path instead. `createId` is the sync watermark for the
-// per-album asset backfill (Slice 5); no update trigger — rows are immutable once created.
+// photos take the ordinary `album_asset` path instead.
+//
+// Sync watermarks mirror `shared_space_asset` (spec §4): `createId` anchors the per-album backfill,
+// `updateId` (bumped by the `album_space_asset_updatedAt` BEFORE-UPDATE trigger) drives incremental
+// upserts. The row's DATA columns are immutable; `updateId` is bumped only on a deliberate
+// `updatedAt` touch (visibility restore — see SharedSpaceRepository.emitAlbumAssetVisibilityRestore)
+// so a contribution re-appears on devices that purged it when its asset was un-hidden.
 @Table({ name: 'album_space_asset' })
+@UpdatedAtTrigger('album_space_asset_updatedAt')
 @Index({ name: 'album_space_asset_spaceId_idx', columns: ['spaceId'] })
 export class AlbumSpaceAssetTable {
   // index: false — albumId is the leading column of the composite PK, so a separate FK index is redundant.
@@ -44,4 +58,10 @@ export class AlbumSpaceAssetTable {
 
   @CreateDateColumn()
   createdAt!: Generated<Timestamp>;
+
+  @UpdateIdColumn({ index: true })
+  updateId!: Generated<string>;
+
+  @UpdateDateColumn()
+  updatedAt!: Generated<Timestamp>;
 }

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -1135,6 +1135,7 @@ export class SyncService extends BaseService {
         const backfill = this.syncRepository.sharedSpaceAlbumToAsset.getBackfill(
           { ...options, afterUpdateId: startId, beforeUpdateId: endId },
           album.id,
+          options.userId,
         );
 
         for await (const { updateId, ...data } of backfill) {
@@ -1268,6 +1269,7 @@ export class SyncService extends BaseService {
         const backfill = this.syncRepository.sharedSpaceAlbumAssetExif.getBackfill(
           { ...options, afterUpdateId: startId, beforeUpdateId: endId },
           album.id,
+          options.userId,
         );
 
         for await (const { updateId, ...data } of backfill) {

--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -390,6 +390,20 @@ export class MediumTestContext<S extends BaseService = BaseService> {
       .executeTakeFirstOrThrow();
     return { spaceAlbum: result, result };
   }
+
+  async newAlbumSpaceAsset(dto: { albumId: string; assetId: string; spaceId: string; addedById?: string | null }) {
+    const result = await this.database
+      .insertInto('album_space_asset')
+      .values({
+        albumId: dto.albumId,
+        assetId: dto.assetId,
+        spaceId: dto.spaceId,
+        addedById: dto.addedById ?? null,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return { albumSpaceAsset: result, result };
+  }
 }
 
 export class SyncTestContext extends MediumTestContext<SyncService> {

--- a/server/test/medium/specs/sync/album-space-asset-audit.spec.ts
+++ b/server/test/medium/specs/sync/album-space-asset-audit.spec.ts
@@ -1,0 +1,113 @@
+import { Kysely } from 'kysely';
+import { SharedSpaceRole } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+// Schema-level guarantees for album_space_asset's sync substrate (#764 Slice 5):
+//   - updateId bumps on UPDATE (the BEFORE-UPDATE trigger), enabling restore re-emit
+//   - deleting a contribution row (explicit or FK cascade) writes an album_space_asset_audit row
+//   - the audit trigger is statement-level (a multi-row delete writes one audit row per deleted row)
+
+let db: Kysely<DB>;
+
+const seedContribution = async (ctx: SyncTestContext) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: contributor } = await ctx.newUser();
+  const { album } = await ctx.newAlbum({ ownerId: owner.id });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id });
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id, role: SharedSpaceRole.Editor });
+  await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+  await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id, addedById: contributor.id });
+  return { owner, contributor, album, asset, space };
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+describe('album_space_asset sync substrate', () => {
+  it('bumps updateId when the row is updated', async () => {
+    const ctx = new SyncTestContext(db);
+    const { album, asset } = await seedContribution(ctx);
+
+    const before = await db
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+
+    await db
+      .updateTable('album_space_asset')
+      .set({ updatedAt: new Date() })
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+
+    const after = await db
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+
+    expect(after.updateId).not.toBe(before.updateId);
+  });
+
+  it('writes an album_space_asset_audit row when a contribution is deleted', async () => {
+    const ctx = new SyncTestContext(db);
+    const { album, asset } = await seedContribution(ctx);
+
+    await db.deleteFrom('album_space_asset').where('albumId', '=', album.id).where('assetId', '=', asset.id).execute();
+
+    const audit = await db
+      .selectFrom('album_space_asset_audit')
+      .selectAll()
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+
+    expect(audit).toHaveLength(1);
+    expect(audit[0].id).toBeDefined();
+  });
+
+  it('writes an audit row on FK cascade (asset delete)', async () => {
+    const ctx = new SyncTestContext(db);
+    const { album, asset } = await seedContribution(ctx);
+
+    await db.deleteFrom('asset').where('id', '=', asset.id).execute();
+
+    const audit = await db
+      .selectFrom('album_space_asset_audit')
+      .selectAll()
+      .where('albumId', '=', album.id)
+      .where('assetId', '=', asset.id)
+      .execute();
+
+    expect(audit).toHaveLength(1);
+  });
+
+  it('is statement-level: a multi-row delete writes one audit row per deleted contribution', async () => {
+    const ctx = new SyncTestContext(db);
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset: a1 } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: a2 } = await ctx.newAsset({ ownerId: owner.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: a1.id, spaceId: space.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: a2.id, spaceId: space.id });
+
+    await db.deleteFrom('album_space_asset').where('albumId', '=', album.id).execute();
+
+    const audit = await db
+      .selectFrom('album_space_asset_audit')
+      .select('assetId')
+      .where('albumId', '=', album.id)
+      .execute();
+
+    expect(audit.map((r) => r.assetId).sort()).toEqual([a1.id, a2.id].sort());
+  });
+});

--- a/server/test/medium/specs/sync/album-space-asset-convergence.spec.ts
+++ b/server/test/medium/specs/sync/album-space-asset-convergence.spec.ts
@@ -1,0 +1,127 @@
+import { Kysely } from 'kysely';
+import { SharedSpaceRole, SyncEntityType, SyncRequestType } from 'src/enum';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+// Task 5 (#764 slice 5) — service-level convergence guard for cross-owner contributions
+// (album_space_asset). Drives the real SyncService seam via SyncTestContext.syncStream /
+// syncAckAll / assertSyncIsComplete — the same harness sync-shared-space-album.spec.ts uses —
+// end to end, proving three properties already delivered by Tasks 2-4:
+//
+//   1. Backfill-on-join: a member who JOINS a space that already has a contribution
+//      backfills the membership edge AND the asset payload.
+//   2. Watermark monotonicity: after acking at the max emitted updateId, a re-sync does
+//      NOT re-emit the same contribution.
+//   3. No spurious asset deletion: removing a contribution edge emits the (albumId, assetId)
+//      delete, but the underlying asset row is never touched.
+//
+// This is a regression guard, not a strict red-first TDD spec — the behavior under test was
+// implemented in Tasks 2-4 (commits d7ec235907, 59ac50a6e8, bf90f40e1f). See task-5-report.md
+// for which assertions were red-first vs. green-from-start.
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = async (db?: Kysely<DB>) => {
+  const ctx = new SyncTestContext(db || defaultDatabase);
+  const { auth, user, session } = await ctx.newSyncAuthUser();
+  return { auth, user, session, ctx };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+const isMembershipEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.SharedSpaceAlbumToAssetV1 || r.type === SyncEntityType.SharedSpaceAlbumToAssetBackfillV1;
+
+const isMembershipDeleteEvent = (r: { type: string }) => r.type === SyncEntityType.SharedSpaceAlbumToAssetDeleteV1;
+
+const isAssetEvent = (r: { type: string }) =>
+  r.type === SyncEntityType.SharedSpaceAlbumAssetCreateV1 || r.type === SyncEntityType.SharedSpaceAlbumAssetBackfillV1;
+
+describe('Contribution sync convergence (album_space_asset) — service-level', () => {
+  it(
+    'backfills a pre-existing contribution on join, is monotonic after ack, and never deletes ' +
+      'the underlying asset when the contribution edge is removed',
+    async () => {
+      const { auth: memberAuth, ctx } = await setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: carol } = await ctx.newUser();
+      const { album } = await ctx.newAlbum({ ownerId: owner.id });
+      const { asset } = await ctx.newAsset({ ownerId: carol.id }); // owned by someone else — a contribution
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      // Contribution (album, asset, space) exists BEFORE member ever joins S.
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id, addedById: carol.id });
+
+      // Sanity: member is not yet in S, so the membership stream carries no trace of this edge.
+      const initial = await ctx.syncStream(memberAuth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+      expect(
+        initial
+          .filter((r) => isMembershipEvent(r))
+          .some((r) => (r as { data: { albumId: string } }).data.albumId === album.id),
+      ).toBe(false);
+      await ctx.syncAckAll(memberAuth, initial);
+
+      // ── 1. Backfill-on-join ──────────────────────────────────────────────────
+      // member JOINS S (Editor) — fires the #752 grant trigger, exposing the pre-existing
+      // contribution.
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: memberAuth.user.id, role: SharedSpaceRole.Editor });
+
+      const membershipResponse = await ctx.syncStream(memberAuth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+      const membershipEvents = membershipResponse.filter((r) => isMembershipEvent(r));
+      expect(
+        membershipEvents.some(
+          (r) =>
+            (r as { data: { albumId: string; assetId: string } }).data.albumId === album.id &&
+            (r as { data: { albumId: string; assetId: string } }).data.assetId === asset.id,
+        ),
+      ).toBe(true);
+
+      // The membership edge must be acked before the asset-payload stream fires for it
+      // (existing house convention — see sync-shared-space-album.spec.ts scenario 1).
+      await ctx.syncAckAll(memberAuth, membershipResponse);
+
+      const assetResponse = await ctx.syncStream(memberAuth, [SyncRequestType.SharedSpaceAlbumAssetsV1]);
+      const assetEvents = assetResponse.filter((r) => isAssetEvent(r));
+      expect(assetEvents.some((r) => (r as { data: { id: string } }).data.id === asset.id)).toBe(true);
+      await ctx.syncAckAll(memberAuth, assetResponse);
+
+      // ── 2. Watermark monotonicity ────────────────────────────────────────────
+      // Having acked at the max emitted updateId, re-running the membership sync must NOT
+      // re-emit the same (albumId, assetId) contribution — assertSyncIsComplete demands the
+      // stream carries nothing but SyncCompleteV1.
+      await ctx.assertSyncIsComplete(memberAuth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+
+      // ── 3. No spurious asset deletion ────────────────────────────────────────
+      // Removing the contribution edge (not the asset) must emit a delete for the edge only.
+      await defaultDatabase
+        .deleteFrom('album_space_asset')
+        .where('albumId', '=', album.id)
+        .where('assetId', '=', asset.id)
+        .execute();
+
+      const deleteResponse = await ctx.syncStream(memberAuth, [SyncRequestType.SharedSpaceAlbumToAssetsV1]);
+      const deleteEvents = deleteResponse.filter((r) => isMembershipDeleteEvent(r));
+      expect(
+        deleteEvents.some(
+          (r) =>
+            (r as { data: { albumId: string; assetId: string } }).data.albumId === album.id &&
+            (r as { data: { albumId: string; assetId: string } }).data.assetId === asset.id,
+        ),
+      ).toBe(true);
+
+      // The underlying asset row must still exist — removing a contribution edge never
+      // deletes the asset itself.
+      const assetRow = await defaultDatabase
+        .selectFrom('asset')
+        .selectAll()
+        .where('id', '=', asset.id)
+        .executeTakeFirst();
+      expect(assetRow).toBeDefined();
+      expect(assetRow?.id).toBe(asset.id);
+    },
+  );
+});

--- a/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
@@ -325,14 +325,18 @@ describe('SharedSpaceAlbumAssetExifSync — multi-space co-linked album (I2 §8.
 
     const s2Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS2.id }));
     expect(s2Creates.some((r: any) => r.assetId === asset.id)).toBe(false);
-    const s2Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id));
+    const s2Backfill = await drain(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id),
+    );
     expect(s2Backfill.some((r: any) => r.assetId === asset.id)).toBe(false);
     const s2Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS2.id }, ack));
     expect(s2Updates.some((r: any) => r.assetId === asset.id)).toBe(false);
 
     const s1Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS1.id }));
     expect(s1Creates.some((r: any) => r.assetId === asset.id)).toBe(true);
-    const s1Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id));
+    const s1Backfill = await drain(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id),
+    );
     expect(s1Backfill.some((r: any) => r.assetId === asset.id)).toBe(true);
     const s1Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS1.id }, ack));
     expect(s1Updates.some((r: any) => r.assetId === asset.id)).toBe(true);

--- a/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
@@ -239,3 +239,23 @@ describe('SharedSpaceAlbumAssetExifSync.getUpdates', () => {
     expect(resultMax.map((r: any) => r.assetId)).toContain(asset.id);
   });
 });
+
+describe('SharedSpaceAlbumAssetExifSync — contributions (album_space_asset)', () => {
+  it('getCreates emits the contributed asset exif to a member', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const out: any[] = [];
+    for await (const row of sut.getCreates({ nowId: NOW_ID, userId: member.id })) out.push(row);
+    expect(out.some((r: any) => r.assetId === asset.id)).toBe(true);
+  });
+});

--- a/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-exif-sync.spec.ts
@@ -28,6 +28,14 @@ beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
 
+const drain = async (stream: AsyncIterable<any>) => {
+  const out: any[] = [];
+  for await (const row of stream) {
+    out.push(row);
+  }
+  return out;
+};
+
 describe('SharedSpaceAlbumAssetExifSync.getBackfill', () => {
   it('returns exif rows for assets in the given album', async () => {
     const { ctx, sut } = setup();
@@ -37,7 +45,7 @@ describe('SharedSpaceAlbumAssetExifSync.getBackfill', () => {
     await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
     await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
 
-    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
     const result: any[] = [];
     for await (const row of stream) {
       result.push(row);
@@ -54,7 +62,7 @@ describe('SharedSpaceAlbumAssetExifSync.getBackfill', () => {
     await ctx.newAlbumAsset({ albumId: a1.id, assetId: asset.id });
     await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
 
-    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, a2.id);
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, a2.id, owner.id);
     const result: any[] = [];
     for await (const row of stream) {
       result.push(row);
@@ -71,7 +79,7 @@ describe('SharedSpaceAlbumAssetExifSync.getBackfill', () => {
     await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
 
     // Confirm exif appears before soft-delete
-    const streamBefore = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const streamBefore = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
     const resultBefore: any[] = [];
     for await (const row of streamBefore) {
       resultBefore.push(row);
@@ -81,7 +89,7 @@ describe('SharedSpaceAlbumAssetExifSync.getBackfill', () => {
     // Soft-delete the album
     await db.updateTable('album').set({ deletedAt: new Date() }).where('id', '=', album.id).execute();
 
-    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
     const result: any[] = [];
     for await (const row of stream) {
       result.push(row);
@@ -255,7 +263,78 @@ describe('SharedSpaceAlbumAssetExifSync — contributions (album_space_asset)', 
     await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
 
     const out: any[] = [];
-    for await (const row of sut.getCreates({ nowId: NOW_ID, userId: member.id })) out.push(row);
+    for await (const row of sut.getCreates({ nowId: NOW_ID, userId: member.id })) {
+      out.push(row);
+    }
     expect(out.some((r: any) => r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getUpdates emits the contributed asset exif to a member (coupling satisfied)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    // albumToAssetAck at max → the `album_space_asset.updateId <= ack` coupling passes.
+    const rows = await drain(
+      sut.getUpdates(
+        { nowId: NOW_ID, userId: member.id },
+        { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+      ),
+    );
+    expect(rows.some((r: any) => r.assetId === asset.id)).toBe(true);
+  });
+});
+
+describe('SharedSpaceAlbumAssetExifSync — multi-space co-linked album (I2 §8.3)', () => {
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- test-local seed factory, co-located with its cases
+  const seedDisjoint = async (ctx: SyncTestContext) => {
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { user: memberS1 } = await ctx.newUser();
+    const { user: memberS2 } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    await ctx.newExif({ assetId: asset.id, make: 'TestCamera' });
+
+    const { space: s1 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s1.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: s1.id, userId: memberS1.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: s1.id, albumId: album.id });
+
+    const { space: s2 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: memberS2.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: s2.id, albumId: album.id });
+
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: s1.id });
+    return { album, asset, memberS1, memberS2 };
+  };
+
+  it('does not emit an S1 contribution exif to an S2-only member across getCreates/getBackfill/getUpdates', async () => {
+    const { ctx, sut } = setup();
+    const { album, asset, memberS1, memberS2 } = await seedDisjoint(ctx);
+    const ack = { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID };
+
+    const s2Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS2.id }));
+    expect(s2Creates.some((r: any) => r.assetId === asset.id)).toBe(false);
+    const s2Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id));
+    expect(s2Backfill.some((r: any) => r.assetId === asset.id)).toBe(false);
+    const s2Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS2.id }, ack));
+    expect(s2Updates.some((r: any) => r.assetId === asset.id)).toBe(false);
+
+    const s1Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS1.id }));
+    expect(s1Creates.some((r: any) => r.assetId === asset.id)).toBe(true);
+    const s1Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id));
+    expect(s1Backfill.some((r: any) => r.assetId === asset.id)).toBe(true);
+    const s1Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS1.id }, ack));
+    expect(s1Updates.some((r: any) => r.assetId === asset.id)).toBe(true);
   });
 });

--- a/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
@@ -7,7 +7,9 @@ import { getKyselyDB } from 'test/utils';
 
 const drain = async (stream: AsyncIterable<any>) => {
   const out: any[] = [];
-  for await (const row of stream) out.push(row);
+  for await (const row of stream) {
+    out.push(row);
+  }
   return out;
 };
 
@@ -277,6 +279,7 @@ describe('SharedSpaceAlbumAssetSync.getUpdates', () => {
 });
 
 describe('SharedSpaceAlbumAssetSync — contributions (album_space_asset)', () => {
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- test-local seed factory, co-located with its cases
   const seed = async (ctx: SyncTestContext) => {
     const { user: owner } = await ctx.newUser();
     const { user: member } = await ctx.newUser();
@@ -303,5 +306,64 @@ describe('SharedSpaceAlbumAssetSync — contributions (album_space_asset)', () =
     const { member, album, asset } = await seed(ctx);
     const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, member.id));
     expect(rows.some((r: any) => r.id === asset.id)).toBe(true);
+  });
+
+  it('getUpdates emits the contributed asset payload to a member (coupling satisfied)', async () => {
+    const { ctx, sut } = setup();
+    const { member, asset } = await seed(ctx);
+    // albumToAssetAck at max → the `album_space_asset.updateId <= ack` coupling passes.
+    const rows = await drain(
+      sut.getUpdates(
+        { nowId: NOW_ID, userId: member.id },
+        { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+      ),
+    );
+    expect(rows.some((r: any) => r.id === asset.id)).toBe(true);
+  });
+});
+
+describe('SharedSpaceAlbumAssetSync — multi-space co-linked album (I2 §8.3)', () => {
+  // Payload/exif arms leak the raw photo bytes + EXIF, so the space-correlation gate must cover them too.
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- test-local seed factory, co-located with its cases
+  const seedDisjoint = async (ctx: SyncTestContext) => {
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { user: memberS1 } = await ctx.newUser();
+    const { user: memberS2 } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+
+    const { space: s1 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s1.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: s1.id, userId: memberS1.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: s1.id, albumId: album.id });
+
+    const { space: s2 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: memberS2.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: s2.id, albumId: album.id });
+
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: s1.id });
+    return { album, asset, memberS1, memberS2 };
+  };
+
+  it('does not emit an S1 contribution payload to an S2-only member across getCreates/getBackfill/getUpdates', async () => {
+    const { ctx, sut } = setup();
+    const { album, asset, memberS1, memberS2 } = await seedDisjoint(ctx);
+    const ack = { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID };
+
+    const s2Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS2.id }));
+    expect(s2Creates.some((r: any) => r.id === asset.id)).toBe(false);
+    const s2Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id));
+    expect(s2Backfill.some((r: any) => r.id === asset.id)).toBe(false);
+    const s2Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS2.id }, ack));
+    expect(s2Updates.some((r: any) => r.id === asset.id)).toBe(false);
+
+    const s1Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS1.id }));
+    expect(s1Creates.some((r: any) => r.id === asset.id)).toBe(true);
+    const s1Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id));
+    expect(s1Backfill.some((r: any) => r.id === asset.id)).toBe(true);
+    const s1Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS1.id }, ack));
+    expect(s1Updates.some((r: any) => r.id === asset.id)).toBe(true);
   });
 });

--- a/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
@@ -5,6 +5,12 @@ import { DB } from 'src/schema';
 import { SyncTestContext } from 'test/medium.factory';
 import { getKyselyDB } from 'test/utils';
 
+const drain = async (stream: AsyncIterable<any>) => {
+  const out: any[] = [];
+  for await (const row of stream) out.push(row);
+  return out;
+};
+
 // Repo-level tests for SharedSpaceAlbumAssetSync:
 //   - getBackfill: per-album backfill of full asset rows
 //   - getCreates: new album_asset join rows via grant
@@ -267,5 +273,35 @@ describe('SharedSpaceAlbumAssetSync.getUpdates', () => {
 
     // With ack ABOVE the asset's album_asset.updateId → asset must be returned.
     expect(resultMax.map((r: any) => r.id)).toContain(asset.id);
+  });
+});
+
+describe('SharedSpaceAlbumAssetSync — contributions (album_space_asset)', () => {
+  const seed = async (ctx: SyncTestContext) => {
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id }); // owned by someone else
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+    return { owner, member, carol, album, asset, space };
+  };
+
+  it('getCreates emits the contributed asset payload to a member', async () => {
+    const { ctx, sut } = setup();
+    const { member, asset } = await seed(ctx);
+    const rows = await drain(sut.getCreates({ nowId: NOW_ID, userId: member.id }));
+    expect(rows.some((r: any) => r.id === asset.id)).toBe(true);
+  });
+
+  it('getBackfill emits the contributed asset payload for the album', async () => {
+    const { ctx, sut } = setup();
+    const { member, album, asset } = await seed(ctx);
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, member.id));
+    expect(rows.some((r: any) => r.id === asset.id)).toBe(true);
   });
 });

--- a/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts
@@ -354,14 +354,18 @@ describe('SharedSpaceAlbumAssetSync — multi-space co-linked album (I2 §8.3)',
 
     const s2Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS2.id }));
     expect(s2Creates.some((r: any) => r.id === asset.id)).toBe(false);
-    const s2Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id));
+    const s2Backfill = await drain(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id),
+    );
     expect(s2Backfill.some((r: any) => r.id === asset.id)).toBe(false);
     const s2Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS2.id }, ack));
     expect(s2Updates.some((r: any) => r.id === asset.id)).toBe(false);
 
     const s1Creates = await drain(sut.getCreates({ nowId: NOW_ID, userId: memberS1.id }));
     expect(s1Creates.some((r: any) => r.id === asset.id)).toBe(true);
-    const s1Backfill = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id));
+    const s1Backfill = await drain(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id),
+    );
     expect(s1Backfill.some((r: any) => r.id === asset.id)).toBe(true);
     const s1Updates = await drain(sut.getUpdates({ nowId: NOW_ID, userId: memberS1.id }, ack));
     expect(s1Updates.some((r: any) => r.id === asset.id)).toBe(true);

--- a/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
@@ -393,7 +393,11 @@ describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', ()
 
     // Member leaves S → shared_space_member_delete_album_audit revokes the album grant (#752), same
     // path that drops the album (and thus its contribution edges) on device.
-    await db.deleteFrom('shared_space_member').where('spaceId', '=', space.id).where('userId', '=', member.id).execute();
+    await db
+      .deleteFrom('shared_space_member')
+      .where('spaceId', '=', space.id)
+      .where('userId', '=', member.id)
+      .execute();
 
     const after = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
     expect(after.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);

--- a/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
@@ -262,3 +262,119 @@ describe('SharedSpaceAlbumToAssetSync.getDeletes', () => {
     expect(result).toHaveLength(0);
   });
 });
+
+const drain = async (stream: AsyncIterable<any>) => {
+  const out: any[] = [];
+  for await (const row of stream) {
+    out.push(row);
+  }
+  return out;
+};
+
+describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', () => {
+  it('getBackfill returns a contributed (albumId, assetId) row for the album', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id }); // owned by someone else
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id));
+    expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getBackfill excludes a contributed row whose asset is Hidden (visibility gate)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Hidden });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id));
+    expect(rows.some((r) => r.assetId === asset.id)).toBe(false);
+  });
+
+  it('getUpserts returns a contributed row for a member with an album grant', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getUpserts does not return a contributed row for a non-member', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: stranger } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getUpserts({ nowId: NOW_ID, userId: stranger.id }));
+    expect(rows.some((r) => r.assetId === asset.id)).toBe(false);
+  });
+
+  it('getDeletes emits the contributed edge to every member (incl. asset owner) after removal', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: carol.id, role: SharedSpaceRole.Viewer });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    await db.deleteFrom('album_space_asset').where('albumId', '=', album.id).where('assetId', '=', asset.id).execute();
+
+    for (const viewer of [member.id, carol.id]) {
+      const rows = await drain(sut.getDeletes({ nowId: NOW_ID, userId: viewer }));
+      expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+    }
+  });
+
+  it('getUpserts stops returning a contribution after the member leaves S (grant revoked by #752 trigger)', async () => {
+    const { ctx, db, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const before = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(before.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+
+    // Member leaves S → shared_space_member_delete_album_audit revokes the album grant (#752), same
+    // path that drops the album (and thus its contribution edges) on device.
+    await db.deleteFrom('shared_space_member').where('spaceId', '=', space.id).where('userId', '=', member.id).execute();
+
+    const after = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(after.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
+  });
+});

--- a/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
+++ b/server/test/medium/specs/sync/shared-space-album-to-asset-sync.spec.ts
@@ -32,7 +32,7 @@ describe('SharedSpaceAlbumToAssetSync.getBackfill', () => {
     const { asset } = await ctx.newAsset({ ownerId: owner.id });
     await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
 
-    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
     const result: any[] = [];
     for await (const row of stream) {
       result.push(row);
@@ -49,7 +49,7 @@ describe('SharedSpaceAlbumToAssetSync.getBackfill', () => {
     const { asset } = await ctx.newAsset({ ownerId: owner.id });
     await ctx.newAlbumAsset({ albumId: a1.id, assetId: asset.id });
 
-    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, a2.id);
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, a2.id, owner.id);
     const result: any[] = [];
     for await (const row of stream) {
       result.push(row);
@@ -161,7 +161,7 @@ describe('SharedSpaceAlbumToAssetSync.getUpserts', () => {
     await ctx.newAlbumAsset({ albumId: album.id, assetId: hidden.id });
     await ctx.newAlbumAsset({ albumId: album.id, assetId: timeline.id });
 
-    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id);
+    const stream = sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id);
     const result: any[] = [];
     for await (const row of stream) {
       result.push(row);
@@ -275,28 +275,32 @@ describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', ()
   it('getBackfill returns a contributed (albumId, assetId) row for the album', async () => {
     const { ctx, sut } = setup();
     const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
     const { user: carol } = await ctx.newUser();
     const { album } = await ctx.newAlbum({ ownerId: owner.id });
     const { asset } = await ctx.newAsset({ ownerId: carol.id }); // owned by someone else
     const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
     await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
     await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
 
-    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id));
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, member.id));
     expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
   });
 
   it('getBackfill excludes a contributed row whose asset is Hidden (visibility gate)', async () => {
     const { ctx, sut } = setup();
     const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
     const { user: carol } = await ctx.newUser();
     const { album } = await ctx.newAlbum({ ownerId: owner.id });
     const { asset } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Hidden });
     const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
     await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
     await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
 
-    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id));
+    const rows = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, member.id));
     expect(rows.some((r) => r.assetId === asset.id)).toBe(false);
   });
 
@@ -315,6 +319,23 @@ describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', ()
 
     const rows = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
     expect(rows.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getUpserts excludes a Hidden contribution for a member (visibility gate parity with getBackfill)', async () => {
+    const { ctx, sut } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Hidden });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const rows = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
+    expect(rows.some((r) => r.assetId === asset.id)).toBe(false);
   });
 
   it('getUpserts does not return a contributed row for a non-member', async () => {
@@ -376,5 +397,56 @@ describe('SharedSpaceAlbumToAssetSync — contributions (album_space_asset)', ()
 
     const after = await drain(sut.getUpserts({ nowId: NOW_ID, userId: member.id }));
     expect(after.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
+  });
+});
+
+describe('SharedSpaceAlbumToAssetSync — multi-space co-linked album (I2 §8.3)', () => {
+  // Album L linked to S1 AND S2 (disjoint members). A contribution made via S1 must reach an S1 member
+  // but NEVER an S2-only member — the album grant / accessibleSpaceAlbums are space-agnostic, so without
+  // the space-correlation gate an S1 contribution leaks the edge to S2.
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- test-local seed factory, co-located with its cases
+  const seedDisjoint = async (ctx: SyncTestContext) => {
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { user: memberS1 } = await ctx.newUser();
+    const { user: memberS2 } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id }); // contributed by a third user
+
+    const { space: s1 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s1.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: s1.id, userId: memberS1.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: s1.id, albumId: album.id });
+
+    const { space: s2 } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: s2.id, userId: memberS2.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: s2.id, albumId: album.id });
+
+    // Contribution pinned to S1 only.
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: s1.id });
+    return { album, asset, memberS1, memberS2 };
+  };
+
+  it('getUpserts does not emit an S1 contribution to an S2-only member (but does to an S1 member)', async () => {
+    const { ctx, sut } = setup();
+    const { album, asset, memberS1, memberS2 } = await seedDisjoint(ctx);
+
+    const s2 = await drain(sut.getUpserts({ nowId: NOW_ID, userId: memberS2.id }));
+    expect(s2.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
+
+    const s1 = await drain(sut.getUpserts({ nowId: NOW_ID, userId: memberS1.id }));
+    expect(s1.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('getBackfill does not emit an S1 contribution to an S2-only member (but does to an S1 member)', async () => {
+    const { ctx, sut } = setup();
+    const { album, asset, memberS1, memberS2 } = await seedDisjoint(ctx);
+
+    const s2 = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS2.id));
+    expect(s2.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
+
+    const s1 = await drain(sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, memberS1.id));
+    expect(s1.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
   });
 });

--- a/server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts
+++ b/server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts
@@ -510,11 +510,17 @@ describe('contribution visibility parity (album_space_asset)', () => {
   it('restore bumps the contribution updateId so getUpserts re-emits it', async () => {
     const ctx = new SyncTestContext(defaultDatabase);
     const sharedSpace = ctx.get(SharedSpaceRepository);
+    const toAsset = ctx.get(SyncRepository).sharedSpaceAlbumToAsset;
     const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
     const { user: carol } = await ctx.newUser();
     const { album } = await ctx.newAlbum({ ownerId: owner.id });
     const { asset } = await ctx.newAsset({ ownerId: carol.id });
     const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    // Member of the contribution's space so the getUpserts re-emit is actually observable
+    // (and the #764/§8.3 space-correlation gate passes).
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
     await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
     await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
 
@@ -532,5 +538,60 @@ describe('contribution visibility parity (album_space_asset)', () => {
       .where('assetId', '=', asset.id)
       .executeTakeFirstOrThrow();
     expect(after.updateId).not.toBe(before.updateId);
+
+    // Stronger: the restore's updateId bump must actually drive getUpserts to re-emit the contribution
+    // to a member who acked BEFORE the restore (ack = pre-restore updateId).
+    const upserts: any[] = [];
+    for await (const row of toAsset.getUpserts({
+      nowId: NOW_ID,
+      userId: member.id,
+      ack: { type: SyncEntityType.SharedSpaceAlbumToAssetV1, updateId: before.updateId },
+    })) {
+      upserts.push(row);
+    }
+    expect(upserts.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('C1: Locked path (removeAssetsFromAll) drops a contribution — getDeletes emits, row gone, no resurrection', async () => {
+    const ctx = new SyncTestContext(defaultDatabase);
+    const albums = ctx.get(AlbumRepository);
+    const toAsset = ctx.get(SyncRepository).sharedSpaceAlbumToAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id, visibility: AssetVisibility.Timeline });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    // The Locked branch of applyVisibilityTransitionSideEffects calls removeAssetsFromAll. This must ALSO
+    // clear the cross-owner contribution (album_space_asset), firing the delete trigger so already-synced
+    // members drop the edge — else a Locked contribution leaks on-device forever.
+    await albums.removeAssetsFromAll([asset.id]);
+
+    // The contribution row is gone.
+    const remaining = await defaultDatabase
+      .selectFrom('album_space_asset')
+      .selectAll()
+      .where('assetId', '=', asset.id)
+      .execute();
+    expect(remaining).toHaveLength(0);
+
+    // getDeletes delivers (L, X) to the member (via the album_space_asset_audit delete trigger).
+    const deletes: any[] = [];
+    for await (const row of toAsset.getDeletes({ nowId: NOW_ID, userId: member.id })) {
+      deletes.push(row);
+    }
+    expect(deletes.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+
+    // No resurrection — the row is deleted, so getUpserts must not re-emit it (matches owned-Locked A8).
+    const upserts: any[] = [];
+    for await (const row of toAsset.getUpserts({ nowId: NOW_ID, userId: member.id })) {
+      upserts.push(row);
+    }
+    expect(upserts.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(false);
   });
 });

--- a/server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts
+++ b/server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts
@@ -18,6 +18,8 @@ import { v4 } from 'uuid';
 
 let defaultDatabase: Kysely<DB>;
 
+const NOW_ID = 'ffffffff-ffff-7fff-bfff-ffffffffffff';
+
 const setup = async (db?: Kysely<DB>) => {
   const ctx = new SyncTestContext(db || defaultDatabase);
   const { auth, user, session } = await ctx.newSyncAuthUser();
@@ -471,5 +473,64 @@ describe('SharedSpaceAlbumToAssetSync — album visibility purge/restore', () =>
       const upserts = afterAck.filter((r: { type: string }) => r.type === SyncEntityType.SharedSpaceAlbumToAssetV1);
       expect(upserts.map((e) => (e as { data: { assetId: string } }).data.assetId)).not.toContain(asset.id);
     }
+  });
+});
+
+describe('contribution visibility parity (album_space_asset)', () => {
+  it('purge tombstones a contributed asset so getDeletes drops it for members', async () => {
+    const ctx = new SyncTestContext(defaultDatabase);
+    const sharedSpace = ctx.get(SharedSpaceRepository);
+    const toAsset = ctx.get(SyncRepository).sharedSpaceAlbumToAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    await sharedSpace.emitAlbumAssetVisibilityPurge([asset.id]);
+
+    const audit = await defaultDatabase
+      .selectFrom('album_space_asset_audit')
+      .selectAll()
+      .where('assetId', '=', asset.id)
+      .execute();
+    expect(audit).toHaveLength(1);
+
+    const deletes: any[] = [];
+    for await (const row of toAsset.getDeletes({ nowId: NOW_ID, userId: member.id })) {
+      deletes.push(row);
+    }
+    expect(deletes.some((r) => r.albumId === album.id && r.assetId === asset.id)).toBe(true);
+  });
+
+  it('restore bumps the contribution updateId so getUpserts re-emits it', async () => {
+    const ctx = new SyncTestContext(defaultDatabase);
+    const sharedSpace = ctx.get(SharedSpaceRepository);
+    const { user: owner } = await ctx.newUser();
+    const { user: carol } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: carol.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+    const before = await defaultDatabase
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+
+    await sharedSpace.emitAlbumAssetVisibilityRestore([asset.id]);
+
+    const after = await defaultDatabase
+      .selectFrom('album_space_asset')
+      .select('updateId')
+      .where('assetId', '=', asset.id)
+      .executeTakeFirstOrThrow();
+    expect(after.updateId).not.toBe(before.updateId);
   });
 });


### PR DESCRIPTION
Stacked follow-up to #766 (merged): the **mobile sync** slice of cross-owner space-album contributions (#764). Base: `space-albums-onto-main`.

Contributions (`album_space_asset` — a space photo a member does **not** own, bookmarked into a space-linked album) now appear, update, and disappear on the mobile app, with the contributed asset's payload + EXIF, converging identically to the album owner's own `album_asset` rows.

## Approach

Contributions ride the **existing** `SharedSpaceAlbum*` sync streams — the mobile client is origin-blind (its `shared_space_album_asset` membership table is a bare `(albumId, assetId)` pair with no owner column), so **no new `SyncEntityType`/`SyncRequestType`, no DTO change, and no mobile production code** were needed. All logic is server-side.

## What's in it

- **Schema**: `album_space_asset` gains the standard `updateId`/`updatedAt` sync watermark + a `BEFORE UPDATE` trigger, plus a trigger-driven `album_space_asset_audit` delete table (fires on explicit removal **and** FK cascade). This makes the contributed sync arm a mechanical mirror of the `album_asset` arm (full Hidden→un-hide parity).
- **Three stream unions**: the contributed arm is unioned into `SharedSpaceAlbumToAssetSync` (membership edge, incl. the audit-driven delete), `SharedSpaceAlbumAssetSync` (payload), and `SharedSpaceAlbumAssetExifSync` (exif).
- **Hidden/restore parity**: `emitAlbumAssetVisibilityPurge`/`Restore` extended to tombstone / re-emit contributions, so a contributed asset marked Hidden drops from member devices and reappears on un-hide.

## Security fixes surfaced in review

A whole-branch review caught two ways a contributed asset could reach a device it shouldn't (both invisible in single-space tests); both are closed with regression tests:

- **Locked leak**: an asset flipped to **Locked** (not Hidden) was never dropped from already-synced devices (`removeAssetsFromAll` only cleared `album_asset`). Now `removeAssetsFromAll` clears both membership tables → the delete edge is emitted; un-lock does not resurrect (matching owned-Locked semantics).
- **Cross-space leak**: on a multi-space co-linked album, an S2-only member received an S1-contribution (edge + payload + EXIF/GPS). Every contributed sync arm is now gated by `contributionVisibleToMember` — an `EXISTS` correlating `album_space_asset.spaceId` to a live membership of *that* space — mirroring the web read arm `spaceContributedAssetExists` (§8.3, no cross-space smuggling).

## Testing

- **Medium** (real Postgres via testcontainers): schema/audit-trigger, the three stream unions (backfill / upsert / delete), Hidden/restore parity, service-level convergence (backfill-on-join, watermark monotonicity, no-spurious-asset-deletion), and the Locked + multi-space-disjoint leak regressions.
- **Mobile** (`flutter test`): Drift convergence guard — a contributed `(albumId, assetId)` is present after the insert events, absent after the delete event, with the asset blob retained.
- SQL query-docs regenerated (`album` / `shared.space` / `sync` repository).

Full design + TDD slice plan: `docs/superpowers/plans/2026-07-11-space-album-cross-owner-contributions-slice-5.md`.
