### PR TITLE
fix(spaces): pre-release RBAC hardening for space-albums (H-1 + M-1 + M-2 + e2e)

### DIFF
--- a/SPACE-ALBUMS-RBAC-REMEDIATION-SPEC-2026-07-11.md
+++ b/SPACE-ALBUMS-RBAC-REMEDIATION-SPEC-2026-07-11.md
@@ -1,0 +1,431 @@
+# Space-Albums RBAC Remediation — Implementation Spec (2026-07-11)
+
+> **Source.** Turns the confirmed findings of `SPACE-ALBUMS-RBAC-REVIEW-2026-07-11.md` into an
+> implementable, test-first plan. Scope was deliberately trimmed with the maintainer to the three
+> real code fixes (**H-1, M-2, M-1**) plus a comprehensive behavioral e2e safety-net for the whole
+> space-albums feature. Findings **L-1, L-2, L-3, and M-3 are out of scope** (see §"Deliberately out
+> of scope" for the rationale that makes each a non-fix or an operational check, not code).
+>
+> **Branch.** `fix/space-albums-rbac-review-2026-07-11`, cut from `space-albums-onto-main` @ `b1e9f4628e`,
+> in worktree `.claude/worktrees/space-albums-reconsolidate-v302`. Server-only fixes; the e2e slice adds
+> web (Playwright) + API specs. One PR into `space-albums-onto-main`.
+>
+> **Method.** Strict TDD — every slice writes the failing test(s) first, watches them fail for the right
+> reason, then implements the minimum to make them green. Line numbers below are HEAD-relative to
+> `b1e9f4628e` and **must be re-confirmed before editing** (they have already drifted once from the
+> review doc). Anchors were re-verified against HEAD while writing this spec.
+>
+> **No `Co-Authored-By` / `Generated-with` trailers on any commit.**
+
+---
+
+## Slice overview
+
+| Slice | Finding / goal | Primary files | SQL regen | Test layers |
+| --- | --- | --- | --- | --- |
+| **S1** | H-1 (HIGH) — caller-proof trash gate on the two `searchAssetBuilder` space arms + service 400 guard | `server/src/utils/database.ts`, `server/src/services/search.service.ts` | ✅ | medium + unit + api-e2e |
+| **S2** | M-2 (MED) — `deletedAt IS NULL` on space-member-facing sync **backfill/getCreates** arms | `server/src/repositories/sync.repository.ts` | ✅ | medium (sync) |
+| **S3** | M-1 (MED) — Locked album strip made retry-convergent | `server/src/services/asset.service.ts` | ❌ | unit + medium (sync) |
+| **S4** | Comprehensive space-albums **behavioral** e2e safety net (link → space/main timeline, viewer show/hide, hide/lock/trash/restore/unlink round-trips) | `e2e/src/specs/server/api/*`, `e2e/src/specs/web/*` | ❌ | api-e2e + web-e2e |
+| **S5** | Validation & PR — full gate, `make sql` clean, §6 live-probe run (human), open PR | — | — | — |
+
+**Order rationale.** H-1 → M-2 → M-1 matches the review's recommended fix order. S4 lands after the
+three fixes so its trash/hide behavioral assertions are green regression locks (any that fail on the
+fixed code reveal a genuine additional gap to fix inside S4). S5 is the human-run validation gate.
+
+---
+
+## Shared conventions (apply to every slice)
+
+- **Server unit tests** (`server/src/**/*.spec.ts`): Vitest with `newTestService()` auto-mocking. Fast,
+  mock-level — good for the service 400 guard (S1) and the `asset.service` side-effect assertions (S3).
+- **Server medium tests** (`server/test/medium/specs/**`): real Postgres via testcontainers. This is the
+  **only** layer that exercises real SQL, so the H-1 `deletedAt` gate (S1) and the M-2 sync arms (S2)
+  are proven here. Repos that need registration live in `server/test/medium.factory.ts` (see
+  `feedback_medium_factory_repo_registration` — a missing entry throws "Unable to create repository
+  instance").
+- **API e2e** (`e2e/src/specs/server/api/**`, Vitest against the `make e2e` stack on :2285): behavioral
+  HTTP round-trips. Home for the H-1 negative and most of the S4 matrix.
+- **Web e2e** (`e2e/src/specs/web/**`, Playwright): UI round-trips for S4.
+- **SQL regen.** Any change to a `@GenerateSql`-decorated repository method (S1 `searchAssetBuilder`
+  feeds `search.repository.sql`; S2 sync arms feed the sync SQL) requires `make sql` **with a running
+  DB** and committing the regenerated `server/src/queries/**`. Never run `make sql` without a DB — it
+  deletes all query files (`feedback_make_sql_no_db`).
+- **Gates per slice** (run yourself, do not trust a subagent's "green" — `feedback_impl_loop_subagent_gaps_vs_gates`):
+  from `server/`: `pnpm test -- --run <touched spec>` then the full `pnpm test`, `pnpm check` (tsc),
+  and `make sql` clean (no diff) when repository SQL changed. Defer the single slow full-package eslint
+  pass to S5 (`feedback_defer_lint_to_end`).
+
+---
+
+## S1 — H-1: caller-proof trash gate on the two search space arms
+
+### Problem (confirmed)
+`searchAssetBuilder` (`server/src/utils/database.ts`) has two space-scoped arms whose *other-members*
+branch relies entirely on the terminal, caller-toggleable trash filter at
+`database.ts:850` (`.$if(!options.withDeleted, …)`). A space member — **including a read-only Viewer** —
+can flip `withDeleted` on (directly, or implicitly via `trashedAfter` / `trashedBefore` / `isOffline`,
+each of which sets `withDeleted` at `database.ts:676`) and receive full `AssetResponseDto` rows (id,
+checksum, `originalPath`, thumbhash, EXIF incl. GPS, people names) for assets another owner **trashed**
+out of the space, for the whole trash-retention window. The album helper `albumSharedSpaceScope` was
+already fixed (it ANDs `deletedAt IS NULL` on every disjunct, `database.ts:632/647/658`); these two
+sibling arms were never patched.
+
+### Fix — two layers, both required
+
+**Layer 1 — caller-proof SQL gate (load-bearing).** In `searchAssetBuilder`, AND
+`eb('asset.deletedAt', 'is', null)` into **only the other-members branch** of each space arm, mirroring
+`albumSharedSpaceScope`. Keep the `ownerId IN userIds` branch unfiltered so a caller retains
+own/partner trash search.
+
+- `spaceId` arm (~`database.ts:703-706`): the `eb.or([ …ownerId…, spaceVisibilityGate(eb) ])` becomes
+  `eb.or([ …ownerId…, eb.and([spaceVisibilityGate(eb), eb('asset.deletedAt', 'is', null)]) ])`.
+- `timelineSpaceIds` / `withSharedSpaces` arm (~`database.ts:717-727`): add
+  `eb('asset.deletedAt', 'is', null)` inside the existing other-members `eb.and([spaceVisibilityGate(eb),
+  …spaceAssetPathBranches… ])`; leave the `ownerId` branch (~`:714`) unfiltered.
+
+**Layer 2 — service 400 guard (defense-in-depth, mirrors `timeBucketChecks`).** In `search.service.ts`,
+reject `withDeleted` / `trashedAfter` / `trashedBefore` / `isOffline` with `BadRequestException` when
+`spaceId` **or** `withSharedSpaces` is set. Factor a private helper
+`rejectTrashParamsForSpaceScope(dto)` and call it from **`searchMetadata`, `searchRandom`,
+`searchLargeAssets`, `searchStatistics`, `searchSmart`** — each already opens with the sibling
+`if (dto.spaceId && dto.withSharedSpaces) throw` block, so this slots in beside it. Mirror the message
+style of `timeBucketChecks` (`timeline.service.ts:144-146`).
+
+Rationale for both: the 400 gives a clean contract and closes the whole class at the door; the SQL gate
+makes it caller-proof for any internal caller that sets `withDeleted` without passing the guard, and
+satisfies the review's cross-cutting rule — *every asset-scoping arm carries its own `deletedAt` and
+never relies on the terminal `:850` gate*.
+
+> **Deliberately NOT doing** the belt-and-braces suggestion to fold `deletedAt` into `spaceVisibilityGate`
+> itself — that helper is shared by `getUpdates` and the owner branch where trashed rows must still flow;
+> folding it there would break M-2's convergence channel and the owner's own-trash search. Keep the gate
+> at the branch, not in the shared helper.
+
+### TDD test plan
+
+Write these first; confirm each fails against HEAD for the stated reason before implementing.
+
+1. **Medium (SQL gate — the load-bearing proof)** — `server/test/medium/specs/utils/shared-space-album-scope-sql.medium.spec.ts`
+   (co-locate with the existing album-arm gate tests) **or** `server/test/medium/specs/repositories/search.repository.spec.ts`:
+   - Seed: owner **O**, member **V**; space **S**; O owns asset `LIVE` (Timeline, in S) and asset `TRASH`
+     (Timeline, in S, then `deletedAt` set). V is a member of S.
+   - `spaceId` arm: build `searchAssetBuilder({ spaceId: S, userIds: [V.id], withDeleted: true })` →
+     result **contains `LIVE`**, **excludes `TRASH`** (other member's trash). *(Fails at HEAD: `TRASH` present.)*
+   - Owner-branch control: same builder with `userIds: [O.id]` and O's own trashed asset → O's **own**
+     trash **present** (owner branch stays unfiltered).
+   - `timelineSpaceIds` arm: `searchAssetBuilder({ timelineSpaceIds: [S], userIds: [V.id], withDeleted: true })`
+     → `LIVE` present, `TRASH` absent.
+   - Implicit-flip variants: `{ spaceId: S, userIds: [V.id], trashedAfter: <epoch> }` and `{ …, isOffline: true }`
+     and `{ …, trashedBefore: <future> }` each independently exclude `TRASH` (they flip `withDeleted` at `:676`).
+2. **Unit (400 guard)** — `server/src/services/search.service.spec.ts`:
+   - For each of `searchMetadata / searchRandom / searchLargeAssets / searchStatistics / searchSmart`:
+     `{ spaceId }` × `{ withDeleted:true | trashedAfter | trashedBefore | isOffline }` → rejects with
+     `BadRequestException`; and `{ withSharedSpaces:true }` × the same 4 → rejects. *(Fails at HEAD: resolves.)*
+   - Negative controls (no over-block): `{ spaceId }` with **no** trash param resolves; `{ withDeleted:true }`
+     with **neither** `spaceId` nor `withSharedSpaces` (a plain personal-scope search) resolves.
+3. **API e2e** — `e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts` (extend the
+   existing H1 `describe`):
+   - As Viewer V, after O trashes a **direct** space asset and an **album-linked** space asset:
+     `POST /search/metadata { spaceId, withDeleted:true, withExif:true }` → **400**; same with
+     `trashedAfter:"1970-01-01"`, `isOffline:true`, and `withSharedSpaces:true` → **400**.
+     Repeat for `/search/random`, `/search/large-assets`, `/search/statistics`, `/search/smart`.
+   - Positive control: `POST /search/metadata { spaceId }` (no trash param) still returns the **live** sibling.
+
+### Edge cases to cover
+- `withSharedSpaces:true` sweeping **multiple** timeline-enabled spaces at once (the arm scopes by
+  `timelineSpaceIds` array) — no other member's trash from any of them.
+- A member who has hidden S from their timeline (`member.showInTimeline=false`) is already excluded from
+  the `timelineSpaceIds` arm — assert the trash gate does not accidentally re-admit them.
+- Owner's own-trash search **outside** a space scope (plain `userId` scope, no `spaceId`/`withSharedSpaces`)
+  is unaffected — the 400 guard must not fire and the terminal `:850` gate still governs.
+- Mixed request `{ spaceId, albumIds }` — the album arm (`albumSharedSpaceScope`) and the space arm must
+  both exclude trash; assert no leak via either.
+
+### Verify
+`cd server && pnpm test -- --run src/services/search.service.spec.ts` + the medium SQL spec + `pnpm check`;
+`make sql` (DB up) and commit the regenerated `server/src/queries/search.repository.sql`; run the extended
+e2e negatives against the `make e2e` stack.
+
+---
+
+## S2 — M-2: `deletedAt IS NULL` on space-member-facing sync backfill/creates
+
+### Problem (confirmed)
+The space-member-facing sync arms in `server/src/repositories/sync.repository.ts` gate on
+`spaceVisibilityGate(eb)` (visibility ∈ {Timeline, Archive}) and, for album arms, `album.deletedAt IS NULL`,
+but **not `asset.deletedAt IS NULL`**. Selected columns include `checksum`, `thumbhash`,
+`originalFileName`, `latitude/longitude/city` and full EXIF. When owner O trashes an asset and then a
+**new** member N joins (or an album is newly linked), N's initial **backfill** streams the trashed asset's
+metadata + a reconstructable thumbhash + GPS into N's Drift DB — data N can obtain through **no** REST
+surface post-H1. Sync-side sibling of H-1. (No bytes leak — original/preview fetch is separately gated;
+this is metadata + thumbhash, hence MEDIUM.)
+
+### Fix — rule + arm inventory
+**Rule:** every space-member-facing **backfill** and **getCreates** *content* arm ANDs
+`.where('asset.deletedAt', 'is', null)`. **`getUpdates` / `getUpserts` convergence arms are never
+filtered** — that is precisely how an already-synced device learns to hide/purge a newly-trashed asset
+(the `asset.updateId` bump rides `getUpdates` through; filtering it would strand a stale visible copy).
+
+**Content arms to gate** (carry metadata/thumbhash/EXIF — the real leak), add unconditional
+`asset.deletedAt IS NULL`:
+- `SharedSpaceAssetSync.getBackfill` (~`:1003`), `.getCreates` (~`:1029`)
+- `SharedSpaceAssetExifSync.getBackfill` (~`:1072`), `.getCreates` (~`:1084`)
+- `SharedSpaceAlbumAssetSync.getBackfill` (~`:1708`), `.getCreates` (~`:1755`)
+- `SharedSpaceAlbumAssetExifSync.getBackfill` (~`:1774`), `.getCreates` (~`:1805`)
+
+**Library arms** — add `asset.deletedAt IS NULL` **to the non-owner branch only**, preserving the owner's
+own-library trash sync. The branch is `eb.or([eb('asset.ownerId','=',userId), spaceVisibilityGate(eb)])`
+→ becomes `eb.or([eb('asset.ownerId','=',userId), eb.and([spaceVisibilityGate(eb), eb('asset.deletedAt','is',null)])])`:
+- `LibraryAssetSync.getBackfill` (~`:1293`), `LibraryAssetExifSync.getBackfill` (~`:1404`).
+
+**Link-row arms** (metadata-light: only `assetId`/`albumId`/`spaceId`/`updateId`) — gate **backfill** for
+consistency (a new member shouldn't even learn a trashed asset is linked); leave their **`getUpserts`**
+(convergence) unfiltered:
+- `SharedSpaceToAssetSync.getBackfill` (~`:1122`), `SharedSpaceAlbumToAssetSync.getBackfill` (~`:1619`).
+
+> Every listed arm already `.innerJoin('asset', …)` (or joins `asset` alongside `asset_exif`), so
+> `asset.deletedAt` is in scope — re-confirm each join before adding the predicate.
+
+### TDD test plan
+Home: the existing sync medium specs — `server/test/medium/specs/sync/shared-space-album-asset-sync.spec.ts`,
+`…-exif-sync.spec.ts`, `sync-library-asset.spec.ts`, and add a direct-arm case (new file
+`shared-space-asset-sync.spec.ts` if none exists, else extend the nearest).
+
+1. **Backfill excludes trashed (the leak, TDD-red first)** — per content arm: seed a space/album, add an
+   asset, **trash it**, then **add a new member** (or newly link the album), run that arm's `getBackfill`
+   → assert **zero rows** for the trashed asset; a live sibling in the same album/space → **present**.
+   *(Fails at HEAD: trashed row present.)*
+2. **getCreates excludes trashed** — asset created, then trashed such that its create-side row is fresh
+   past the checkpoint → `getCreates` yields **no** trashed row.
+3. **getUpdates STILL delivers trashed (convergence guard — must stay green)** — existing member already
+   synced the live asset; O trashes it; `getUpdates` for that member **includes** the now-trashed row
+   (deletedAt set) so the device can purge. Assert present. *(Green at HEAD and after fix — locks the
+   invariant that we did not over-filter.)*
+4. **Library non-owner vs owner** — owner's own trashed library asset **still** appears in
+   `LibraryAssetSync.getBackfill` for the owner (owner branch unfiltered); a member's non-owner backfill
+   excludes it.
+
+### Edge cases
+- **Restore after trash converges** — trash → (backfill now skips) → restore (bumps `updateId`) → a
+  subsequent `getCreates`/backfill for a fresh member includes the restored live asset. No permanent
+  starvation.
+- **Exif arm parity** — the EXIF sibling of each content arm must exclude the trashed asset's EXIF
+  (GPS is the sensitive datum); assert on `asset_exif` rows, not just the asset row.
+- **Album soft-delete interaction** — a trashed asset in a *soft-deleted* album stays excluded (both
+  `album.deletedAt` and now `asset.deletedAt` gates apply; no double-count / no accidental re-admit).
+- **`getBackfill` for a space with a mix** — trashed + live + Hidden + Archive assets → only Timeline/Archive
+  *non-trashed* rows stream.
+
+### Verify
+`cd server && pnpm test -- --run <touched sync specs>` + full `pnpm test` + `pnpm check`; `make sql`
+(DB up) and commit regenerated sync query SQL.
+
+---
+
+## S3 — M-1: make the Locked album strip retry-convergent
+
+### Problem (confirmed)
+In `applyVisibilityTransitionSideEffects` (`server/src/services/asset.service.ts`), the Locked album strip
+is gated `lockIds = ids.filter(id => priorVisibilities.get(id) !== AssetVisibility.Locked)` (`:437`). If the
+visibility `UPDATE` commits but the process crashes (or `removeAssetsFromAll` throws) **before** the strip
+runs, a **retry** re-reads `prior === Locked`, so `lockIds = []` skips `removeAssetsFromAll` **forever**;
+and the album purge tombstone is `Hidden`-only (`:450-452`), so it is skipped too. Result: the `album_asset`
+row survives, no tombstone is emitted, `SharedSpaceAlbumToAssetSync.getDeletes` delivers nothing → a synced
+member's device **durably retains** the asset's bytes/EXIF/album row; and on a later **unlock**,
+`emitAlbumAssetVisibilityRestore` bumps the surviving rows and the asset **silently re-shares** to the space,
+contradicting the branch's "Locked strips from all albums" semantics. The nightly reconcile is grants-only —
+nothing sweeps it.
+
+### Fix
+Drop the `prior !== Locked` gate: when `nextVisibility === AssetVisibility.Locked`, call
+`this.albumRepository.removeAssetsFromAll(ids)` **unconditionally**.
+- Normal lock: strips the rows, fires the `album_asset` delete-audit trigger → tombstone via the
+  `album_asset_audit` arm of `SharedSpaceAlbumToAssetSync.getDeletes` (`sync.repository.ts:1632-1655`);
+  the album stays space-accessible so the member receives "asset removed from album A".
+- Post-crash retry: `removeAssetsFromAll(ids)` deletes the **surviving** rows and fires the tombstone the
+  crashed first attempt never sent.
+- Already-stripped re-lock: matches **zero** rows → idempotent no-op (one negligible extra DELETE).
+
+> The unconditional strip alone closes the leak (the delete trigger is the tombstone source). We are
+> **not** adding the alternative `emitAlbumAssetVisibilityPurge`-for-Locked tombstone — it would fire a
+> redundant second tombstone on every lock. It stays documented as the fallback **only** if S5 probe 2
+> shows the trigger tombstone is not delivered; if so, add it and a test, otherwise leave it out.
+
+### TDD test plan
+1. **Rewrite the pinning unit test** — `server/src/services/asset.service.spec.ts:1388`
+   ("removes from albums exactly once (lock-once) …"). It currently asserts
+   `expect(mocks.album.removeAssetsFromAll).not.toHaveBeenCalled()` on a re-lock (prior already Locked).
+   Flip it: on a re-lock the strip **is** called → `expect(mocks.album.removeAssetsFromAll).toHaveBeenCalledWith(['asset-1'])`.
+   Retitle to reflect convergence. *(This is the red step: the current impl leaves it uncalled.)*
+2. **Keep the mixed-bulk purge test green** (`:1370`) — unchanged behavior for the direct/library purge
+   emits (already unconditional from M3); assert the album strip now fires for the Locked ids in a mixed flip.
+3. **Medium convergence test** — extend `server/test/medium/specs/sync/sync-shared-space-album-visibility-purge.spec.ts`:
+   member M has album asset A synced; simulate the crash window (apply the visibility `UPDATE` to Locked
+   **without** the side effects — i.e. write `visibility=Locked` directly, leaving the `album_asset` row),
+   then invoke the real `updateAll`/side-effect path for a re-lock → assert `album_asset` row is deleted and
+   M's `SharedSpaceAlbumToAssetSync.getDeletes` yields the delete tombstone for A. *(Fails at HEAD.)*
+
+### Edge cases
+- **Unlock-after-recovered-lock does not re-share** — after the fixed re-lock strips the rows, an unlock
+  (`emitAlbumAssetVisibilityRestore`) finds **no** surviving `album_asset` rows → the asset does **not**
+  re-appear in the space. Assert absence.
+- **Multiple albums** — asset in 2+ linked albums; `removeAssetsFromAll` clears all; tombstones for each.
+- **Asset in no album** — Locked flip on an asset with zero album rows → no-op, no error, no spurious tombstone.
+- **Hidden path untouched** — a Hidden transition still emits `emitAlbumAssetVisibilityPurge` (`:450`) and
+  does **not** call `removeAssetsFromAll`; assert no regression to the Hidden branch.
+
+### Verify
+`cd server && pnpm test -- --run src/services/asset.service.spec.ts` + the medium purge spec + full
+`pnpm test` + `pnpm check`. No repository SQL change → **no `make sql`**.
+
+---
+
+## S4 — Comprehensive space-albums behavioral e2e safety net
+
+### Goal
+Existing e2e coverage is strong on **structure** (affordance/permission matrix, API RBAC gates,
+single-endpoint visibility negatives, sync convergence). The gap — and the maintainer's explicit ask — is
+**behavioral round-trips**: does a linked album's photos actually *appear/disappear* across the **space
+Photos timeline**, the **member's personal (main) timeline**, the **album view**, and **search**, as
+owners/editors/viewers perform the real actions. This slice adds that net. It also serves as the
+end-to-end regression lock for S1–S3.
+
+Split by cost: an **API e2e behavioral matrix** carries the exhaustive edge cases (fast, deterministic);
+a focused **web Playwright** suite proves the UI surfaces reflect it (the "solid in the UI" confidence).
+Reuse existing fixtures/helpers (`e2e/src/specs/server/api/shared-space-album.e2e-spec.ts` fixtures;
+`spaces-albums-journey.e2e-spec.ts` role/context setup) — do not rebuild space/album/member scaffolding.
+
+> Two `showInTimeline` toggles exist and mean different things — the spec and tests must keep them
+> distinct: **album-level** `shared_space_album.showInTimeline` = "include this album's assets in the
+> **space** Photos timeline"; **member-level** `shared_space_member.showInTimeline` = "include this
+> space's assets in **my personal/main** timeline". Verified in `shared-space.dto.ts:108/114/133/169`.
+
+### S4a — API e2e behavioral matrix
+New spec `e2e/src/specs/server/api/shared-space-album-timeline.e2e-spec.ts` (or extend
+`shared-space-album.e2e-spec.ts`). Fixture: owner **O**, editor **E**, viewer **V**, non-member **X**;
+space **S**; O owns album **A** with assets; link A → S. Assert **data presence** (asset ids in the
+relevant list responses), not just status codes.
+
+1. **Link → space timeline contains album assets.** After `PUT /shared-spaces/S/albums/A`, the space Photos
+   timeline (`GET /timeline/buckets?spaceId=S` + `/timeline/bucket`) for V **contains** A's assets.
+2. **Album `showInTimeline=false` removes them from the space timeline but not the album view.**
+   `PATCH /shared-spaces/S/albums/A { showInTimeline:false }` → A's assets **absent** from the space
+   timeline for V, yet `GET /timeline/bucket?albumId=A` (album view) still **returns** them; toggle back
+   `true` → reappear in the space timeline.
+3. **Member `showInTimeline` gates the personal/main timeline.** With `withSharedSpaces=true`
+   (`GET /timeline/buckets?withSharedSpaces=true` as V), A's assets **appear**; after V sets
+   `shared_space_member.showInTimeline=false` for S (member self-toggle endpoint), A's assets **disappear**
+   from V's main timeline; back to `true` → reappear.
+4. **Unlink → assets leave the space timeline.** `DELETE /shared-spaces/S/albums/A` → A's assets absent from
+   the space timeline and V loses `GET /albums/A` access (400), while O still owns A directly.
+5. **Editor add/remove asset reflects for the viewer.** E adds asset N to A (`PUT /albums/A/assets`) → N
+   appears in V's space timeline; E removes N → N disappears for V.
+6. **Hide / Lock / restore round-trip (regression lock for the fixed lifecycle).** O sets an A-asset
+   `visibility=Hidden` → absent for V across space timeline + `/albums/A` + main timeline + search; restore
+   to `Timeline` → **reappears** across all. Repeat for `Locked` (also asserts, post-S3, that a re-lock
+   after a simulated first-attempt failure still tombstones — cross-link to the S3 medium test rather than
+   duplicating the crash injection here).
+7. **Trash round-trip (regression lock for H-1/M-2).** O trashes an A-asset → absent for V across space
+   timeline + album view + `POST /search/metadata {spaceId}` and `{withSharedSpaces}` (incl. the `withDeleted`
+   / `trashedAfter` / `isOffline` attempts → 400 per S1); restore → reappears.
+8. **Positive controls / non-member.** V always sees the **live** A-assets in the space timeline & album
+   view (no over-block). X (non-member) sees **none** of S's timeline, album, or search surfaces (403/400).
+
+### S4b — Web (Playwright) UI round-trips
+New spec `e2e/src/specs/web/spaces-albums-timeline.e2e-spec.ts`. Keep it focused (Playwright is slow/flaky);
+one assertion path per behavior, reusing the journey's role contexts.
+
+1. **Viewer sees linked-album photos in the space Photos tab timeline** — V opens `/spaces/S` (Photos tab),
+   the grid shows A's photos; opening a photo lands on the space photo viewer (positive control from the
+   journey, extended to assert *presence of the specific asset thumbnails*, not just navigation).
+2. **Album `showInTimeline` toggle reflects in the space Photos timeline** — as O/E, toggle A's
+   "show in timeline" control → the space Photos grid drops/re-adds A's photos (V's view, or re-login).
+3. **Viewer main-timeline show/hide of the space** — V toggles S's "show in my timeline" and the main
+   `/photos` timeline gains/loses A's photos.
+4. **Owner hides a photo → viewer no longer sees it; restore → viewer sees it again** — the visibility
+   round-trip as visible in the viewer's space grid.
+5. **Unlink album → viewer's space Albums grid and Photos timeline both drop it.**
+
+> Web-e2e practicalities (`reference_local_web_e2e_runs`, `feedback_e2e_stack_port_2285_vs_dev_2283`):
+> Playwright runs against the `make e2e` stack on :2285; a "broken UI" is often a **stale image** — rebuild
+> before trusting a failure. Use existing `data-testid` selectors where present; add stable testids rather
+> than text selectors for any new assertion target. Role-badge text renders lowercase+CSS-capitalize — use
+> `{ ignoreCase:true }` (`feedback_space_role_badge_lowercase_ignorecase`).
+
+### TDD note for S4
+These are largely **characterization/regression** tests over behavior that S1–S3 have made correct. Write
+each test to the **expected** behavior first and run it: a **green** result locks the behavior; a **red**
+result is a genuine additional bug — fix it inside S4 (or, if it belongs to a fix slice's surface, in that
+slice) before moving on. Do not weaken an assertion to make it pass.
+
+### Edge cases (S4)
+- Album linked to **two** spaces — toggling `showInTimeline` in space S1 does not affect the same album's
+  presence in space S2's timeline.
+- Asset in **both** a linked album and directly added to the space — hiding via the album path vs. the
+  direct path; assert it disappears only per the correct scope and reappears correctly.
+- Empty album linked → space timeline unaffected; adding the first asset makes it appear.
+- Video asset (spaces exclude videos from `recentAssetIds` per `shared-space.e2e-spec.ts`) — confirm the
+  space **timeline** inclusion rule for videos is asserted consistently with product intent.
+- Viewer has S **hidden** from their main timeline but still opens the space directly → still sees photos in
+  the space Photos tab (member-level `showInTimeline` gates the *main* timeline only, not the space page).
+
+### Verify
+Run the API matrix against `make e2e` (`make e2e-api-dev` or the api project) and the web suite via
+`make e2e-web-dev`. Rebuild the stack first if any server code from S1–S3 is involved.
+
+---
+
+## S5 — Validation & PR (human-run)
+
+1. **Full local gate** from `server/`: `pnpm test` (all unit + medium), `pnpm check` (tsc), one full
+   `pnpm lint` pass (deferred from the slices), and `make sql` producing **no** diff.
+2. **e2e**: the extended API negatives + the S4 matrix + web suite green against a **clean stack built from
+   this worktree**.
+3. **§6 live-probe run** (from the findings doc) against that clean stack — probes **1 (H-1)**, **2 (M-1
+   tombstone)**, **3 (M-2 backfill)** must flip leak→clean/tombstone-present; probes 4–8 are re-confirmations.
+   **Not impl-loop-automated:** `mise dev` is a machine-wide singleton
+   (`reference_mise_dev_singleton_across_worktrees`) — claim the stack, coordinate with any other worktree
+   session, do not clobber. If probe 2 shows no tombstone despite S3, add the Locked album purge tombstone
+   (see S3 note) and re-run.
+4. **PR** into `space-albums-onto-main`. No `Co-Authored-By` / `Generated-with` trailers. Dispatch the
+   gating CI set; babysit to green.
+
+---
+
+## Deliberately out of scope (rationale recorded for traceability)
+
+- **M-3 (removed-creator split-brain).** Prospective guard already ships. Residual risk is conditional on a
+  pre-guard DB **and** an actually-removed creator; on the small personal/staging fleet the blast radius is
+  almost certainly zero. The "repair" migration also *re-grants* a deliberately-removed creator, so it is not
+  a pure no-op decision. **Action = a 1-minute operational check, not code** — run the fleet-sizing query
+  (Appendix A) against personal + staging; if it returns rows, reopen with a maintainer decision (re-add vs.
+  evict, then optionally drop the `createdById` arm). Not implemented here.
+- **L-1 (re-timestamped migration, no compat alias).** Availability/ops only, conditional on a DB that booted
+  an RC in a ~2-day window recording the old migration name. **Action = check staging/mobile-test
+  `kysely_migrations` for the pre-rename name** (Appendix B); add the startup rename only if found. Not a leak.
+- **L-2 (`requireRole` fails-open on unknown role).** Not reachable via the API (all role writes go through
+  `z.enum(SharedSpaceRole)`); corruption-gated defense-in-depth only. Trimmed by maintainer.
+- **L-3 (`albumIds` without `AlbumRead` on 3 search endpoints).** Zero current risk — safe today because those
+  endpoints always set `userIds`. Pure latent-fragility hardening against a hypothetical future refactor.
+  Trimmed by maintainer.
+
+## Appendix A — M-3 fleet-sizing query (operational, run manually)
+```sql
+SELECT id FROM shared_space ss
+ WHERE NOT EXISTS (SELECT 1 FROM shared_space_member m
+                    WHERE m."spaceId" = ss.id AND m."userId" = ss."createdById");
+```
+Zero rows → document accepted-safe, no code. Rows → reopen M-3 with a maintainer decision.
+
+## Appendix B — L-1 recorded-migration check (operational, run manually)
+```sql
+SELECT name FROM kysely_migrations
+ WHERE name = '1782000000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger';
+```
+Any row on staging/mobile-test → add the startup rename to `1782050000000-…` before the migrator runs and
+add the old name to `scripts/revert-to-immich.sql`'s DELETE list. No rows → document confirmed-safe.
+
+## Appendix C — §6 live-probe list
+The full 8-probe list lives in `SPACE-ALBUMS-RBAC-REVIEW-2026-07-11.md` §6 (same worktree). S5 runs it;
+probes 1/2/3 are the leak→clean flips gated by S1/S3/S2 respectively.

--- a/SPACE-ALBUMS-RBAC-REVIEW-2026-07-11.md
+++ b/SPACE-ALBUMS-RBAC-REVIEW-2026-07-11.md
@@ -1,0 +1,379 @@
+# Space-Albums RBAC / Security Review — Findings (2026-07-11)
+
+> **What this is.** A third, independent, security-focused review of the branch `space-albums-onto-main`
+> at HEAD `b1e9f4628e`, scoped to **role-based access control and asset/metadata leakage**: no file, photo,
+> asset, thumbnail, or asset-derived datum (EXIF, faces, map point, activity, search facet) may reach a
+> user who should not see it. It re-verifies the two prior passes (the 2026-07-08 comprehensive review +
+> PR #759 remediation, captured in `SPACE-ALBUMS-REMEDIATION-REVIEW-2026-07-08.md`) **and** hunts for
+> leaks neither prior pass caught.
+>
+> **Method.** 5 angle-focused finders swept the branch (list/query read scope; people-faces + direct byte
+> fetch; sync deltas + mobile parity; write-authz + lifecycle convergence; SQL/migration/trigger integrity
+> + surface completeness), each at high reasoning effort. Every raw finding was handed to an independent
+> adversarial verifier that had to re-trace the full controller→service→repository→SQL path (not trust the
+> reporter) before it could be **confirmed**. A completeness critic then mapped coverage gaps and produced a
+> live-probe list. **23 raw findings → 19 CONFIRMED, 1 PLAUSIBLE, 3 REFUTED.** Line numbers are HEAD-relative
+> and must be re-confirmed before editing. Static confirmations were **not** dynamically exercised — see
+> §6 (no clean stack was available; the `mise dev` singleton was serving another worktree).
+>
+> **Headline.** The static read-scope and direct-fetch surface is, at HEAD, **tighter than the prior doc
+> implies** — `albumSharedSpaceScope` and every `access.repository` space arm are fully `deletedAt`+visibility
+> gated, and the completeness sweep found **no unscoped asset-returning surface**. The residual risk is
+> concentrated in two places: **(1) one HIGH** — the two `searchAssetBuilder` space arms have a
+> caller-toggleable trash gate (a sibling of the fixed prior H1, left unpatched), and **(2) a convergence /
+> stale-device cluster** (MEDIUM) that static reading cannot falsify and the test harness never exercises.
+> None of this is a reason not to land the branch, but **the HIGH and the two trash-related findings
+> (H-1, M-2) should be fixed before production**, and the M10 removed-creator item (M-3) needs an
+> operational fleet check + decision.
+
+---
+
+## 1. Severity summary
+
+| Sev | Count | IDs (this review) | Re-opens prior |
+| --- | --- | --- | --- |
+| **HIGH** | 1 | H-1 | sibling of prior H1 |
+| **MEDIUM** | 3 | M-1, M-2, M-3 | M-1↔M3, M-3↔M10 |
+| **LOW** | 3 | L-1, L-2, L-3 | — |
+| Cleared (refuted / holds) | 16 | see §4, §5 | H1, M1, M2, M4, M6, M7, M8, M9, M11, M12, M13, L1, L3, L4, L5, L7, L8, L11, L18, I1 |
+
+Recommended fix order: **H-1 → M-2 → M-1 → M-3 (fleet check first) → L-2 → L-1 → L-3.**
+
+De-duplication note: the two Locked-transition findings (finder ids F3-1, F4-1) are **one issue** (M-1); the
+three removed-creator findings (F5-2, F3-3, F4-3) are **one issue** (M-3), independently confirmed by three
+finders. Higher independent-confirmation count = higher confidence, not more findings.
+
+---
+
+## 2. HIGH
+
+### H-1 — Trashed assets of other space members leak through space-scoped search via caller-controlled trash params
+- **Finder/verdict:** read-scope F1-1 — **CONFIRMED** (HIGH). Anchors refined by the completeness critic.
+- **Files (HEAD):**
+  - `server/src/utils/database.ts:688-709` — `searchAssetBuilder` `spaceId` arm (no per-branch `deletedAt`)
+  - `server/src/utils/database.ts:710-730` — `searchAssetBuilder` `timelineSpaceIds` (`withSharedSpaces`) arm (no per-branch `deletedAt`)
+  - `server/src/utils/database.ts:676` — `trashedAfter`/`trashedBefore`/`isOffline` implicitly flip `withDeleted` on
+  - `server/src/utils/database.ts:850` — the terminal, caller-skippable `.$if(!options.withDeleted, …)` trash filter
+  - `server/src/services/search.service.ts:130-249` — `searchMetadata`/`searchRandom`/`searchLargeAssets`/`searchStatistics` (no service-level rejection of trash params for space scopes)
+  - `server/src/dtos/search.dto.ts:60-66` — `withDeleted` exposed alongside `spaceId`/`withSharedSpaces` with no sibling constraint
+  - Generated SQL confirms the gap: `server/src/queries/search.repository.sql` (space arm carries no `deletedAt`)
+- **Actor / scenario.** Any space member, **including a read-only VIEWER**. Owner O shares an asset into space S
+  (direct add, linked library, or linked album) and then **trashes** it — `deletedAt` is set but the
+  `shared_space_asset` / `shared_space_library` / `album_asset` link rows survive trashing (no trigger fires on
+  trash). The Viewer calls `POST /search/metadata` with `{ spaceId: S, withDeleted: true, withExif: true,
+  withPeople: true }` — or equivalently `trashedAfter`/`trashedBefore`/`isOffline` (each flips `withDeleted` at
+  `database.ts:676`), or `withSharedSpaces: true` to sweep **all** timeline-enabled spaces at once. The response
+  returns full `AssetResponseDto` rows for every asset O trashed out of the space — **id, checksum, originalPath,
+  thumbhash, EXIF including GPS, people names** — for the whole trash-retention window (30 days default). Also
+  fires on `POST /search/random`, `/search/large-assets`, `/search/smart`, and `/search/statistics` (trashed-count
+  disclosure).
+- **Root cause.** The prior H1 remediation moved `asset.deletedAt IS NULL` **inside** `albumSharedSpaceScope`
+  (parameter-independent, on every disjunct) and rejected `isTrashed` on the timeline (`timeBucketChecks`,
+  `timeline.service.ts:144`) — but never touched the **sibling `spaceId` / `timelineSpaceIds` arms** of
+  `searchAssetBuilder`, which still depend entirely on the caller-toggleable terminal `deletedAt` filter at
+  `database.ts:850`. This is the exact H1 pattern left unpatched on the two non-helper arms. The `timeBucket`
+  twin is **not** affected (`timeBucketChecks` rejects trash for both space-browse and `withSharedSpaces`).
+- **Fix.** Mirror the H1 fix on both space arms: AND `eb('asset.deletedAt', 'is', null)` with
+  `spaceVisibilityGate` inside the *other-members* branch of each arm (at `:703-706` and `:717-727`), keeping the
+  `ownerId IN userIds` branch unfiltered so callers retain own/partner trash search. Defense-in-depth: in
+  `search.service.ts`, reject `withDeleted`/`trashedAfter`/`trashedBefore`/`isOffline` with a 400 when `spaceId`
+  or `withSharedSpaces` is set (mirror `timeBucketChecks`). Regenerate SQL docs (`make sql`).
+- **Tests.** Clone the H1 medium/e2e negatives (`search.service.spec.ts:659`,
+  `shared-space-visibility-negatives.e2e-spec.ts:511`) for `{spaceId, withDeleted:true}` and
+  `{withSharedSpaces:true, withDeleted:true}` across metadata/random/largeAssets/statistics/smart — assert the
+  other member's trashed asset is absent while a live sibling is present. Add coverage for the
+  `trashedAfter`/`isOffline` implicit-flip variants.
+
+---
+
+## 3. MEDIUM
+
+### M-1 — Locked-transition album arm is not retry-convergent: a failed strip leaves a durable on-device leak + silent re-share on unlock (re-opens prior M3, album arm only)
+- **Finders/verdict:** sync F3-1 **+** writes-lifecycle F4-1 — both **CONFIRMED** (MEDIUM). Same issue, two independent traces.
+- **Files (HEAD):** `server/src/services/asset.service.ts:437` (the `prior !== Locked` gate on `lockIds`),
+  `asset.service.ts:435-441`, `asset.service.ts:450-453` (album purge tombstone skipped for Locked),
+  `asset.service.ts:280`, `server/src/repositories/shared-space.repository.ts:466-484`, pinned-as-intended by
+  `server/src/services/asset.service.spec.ts:1388-1397`.
+- **Scenario.** Owner Alice has photo P in album A linked to space S; member Bob has already synced P to his phone
+  via the space-album sync arms. Alice flips P to **Locked**. The visibility `UPDATE` commits, then the process
+  crashes (or `albumRepository.removeAssetsFromAll` throws — DB blip, pod kill) **before** the album strip runs —
+  a non-transactional window. On **retry**, `priorVisibilities` now reads `Locked`, so `lockIds = []` skips
+  `removeAssetsFromAll` forever (`:437`), and the album tombstone emit is `Hidden`-only so it is skipped too
+  (`:450-453`). Consequences: **(1)** the `album_asset` row survives, no `album_asset_audit` tombstone is written,
+  `SharedSpaceAlbumToAssetSync.getDeletes` has nothing to deliver, so **Bob's device durably retains P's bytes,
+  EXIF and album row** (leak class 6); **(2)** later, when Alice **unlocks** P, `emitAlbumAssetVisibilityRestore`
+  bumps the surviving `album_asset` rows and **P silently re-shares into space S to every member**, contradicting
+  the branch's documented "Locked strips from all albums" (A8) semantics. Nothing sweeps it — the nightly
+  reconcile job is grants-only. Heals only via a manual unlock → re-lock cycle or a full device resync.
+- **Root cause.** The M3 remediation made the direct/library purge **emits** unconditional-and-idempotent, but
+  left the fourth side effect — the Locked album **strip** (`removeAssetsFromAll`) — on the old `prior !== Locked`
+  "lock-once" gate, and kept the album purge tombstone `Hidden`-only. The review's own parenthetical ("For
+  Locked, the album strip is equally non-retryable") was never addressed; the unit test at `:1388` pins the
+  non-convergent behavior as correct.
+- **Fix.** Drop the prior-visibility gate on the strip: when `nextVisibility === Locked`, call
+  `removeAssetsFromAll(ids)` **unconditionally** (an already-stripped asset matches zero rows — an idempotent
+  no-op; the failed-first-attempt case deletes the surviving rows and fires the delete-audit trigger). Belt-and-
+  braces: also emit `emitAlbumAssetVisibilityPurge` for Locked (idempotent tombstone). Update `asset.service.spec.ts:1388`
+  to assert `removeAssetsFromAll` **is** called on a re-lock; add a `sync-space-visibility-purge-cross-path`-style
+  medium test for `prior=Locked` + album arm.
+
+### M-2 — Sync backfill streams TRASHED assets (full metadata, thumbhash, checksum, GPS EXIF) to newly-joined members (sync-side sibling of H1)
+- **Finder/verdict:** sync F3-2 — **CONFIRMED** (MEDIUM).
+- **Files (HEAD):** `server/src/repositories/sync.repository.ts:1690-1710` (`SharedSpaceAlbumAssetSync.getBackfill`),
+  `:1764-1776` (`…ExifSync.getBackfill`), `:987-1005`, `:1278-1295` (direct + library backfill arms),
+  `server/src/database.ts:519-538`, `:609-636` (`spaceVisibilityGate`).
+- **Scenario.** Owner O trashes photo X in album A linked to space S (trash removes X from every REST read surface
+  post-H1). O then invites a **new** member N. N's initial per-album backfill runs: `getBackfill` filters
+  `album.deletedAt IS NULL` and `spaceVisibilityGate` (visibility ∈ timeline/archive) but has **no
+  `asset.deletedAt IS NULL`** predicate, and the selected columns include `deletedAt, checksum, thumbhash,
+  originalFileName, latitude/longitude/city`. N's Drift DB now permanently holds the trashed photo's filename,
+  a reconstructable thumbhash preview, and its GPS — **data N could never obtain through any REST surface at
+  HEAD**. The mobile UI hides it (`deletedAt.isNull()` filters) but `POST /api/sync/stream` returns the JSON
+  directly, so no device forensics are needed. The direct arm (`SharedSpaceAssetSync`/`ToAssetSync.getBackfill`)
+  and the non-owner library arm (`LibraryAssetSync.getBackfill`) have the identical gap.
+- **Root cause.** `spaceVisibilityGate` encodes only visibility ∈ {timeline, archive}; H1 added `deletedAt IS
+  NULL` to the REST scopes but never to the sync arms. This is upstream-parity behaviour (upstream
+  `AlbumAssetSync.getBackfill` also streams trashed assets to `album_user` shares, relying on client-side
+  hiding) — but the fork's own H1 finding reclassified trashed-asset metadata reaching a space member as a leak
+  and closed it on REST, leaving **sync** as the one surface still delivering it, including to members who joined
+  *after* the trash.
+- **Fix.** Add `asset.deletedAt IS NULL` to the space-member-facing **backfill / getCreates** arms
+  (`SharedSpaceAlbumAssetSync`/`ExifSync`, `SharedSpaceAlbumToAssetSync`, `SharedSpaceAssetSync`/`ExifSync` +
+  `ToAssetSync`, and the non-owner branch of `LibraryAsset(Exif)Sync`), or fold it into `spaceVisibilityGate`
+  with an owner-stream opt-out. **Keep `getUpdates` delivering trashed rows to *existing* members** — that is how
+  their devices learn to hide/purge the asset (restore convergence rides the `asset.updateId` bump); filtering
+  updates would leave a stale visible copy, which is worse. Add a medium test: trash asset → add member → run
+  backfill → assert zero rows.
+- **Note.** No **bytes** leak (original/preview fetch is separately gated and denies trashed via H1); this is
+  metadata + thumbhash only. That, plus upstream-parity, is why it is MEDIUM not HIGH.
+
+### M-3 — Removed-creator sync split-brain on already-deployed DBs (re-opens prior M10; three-finder confirmation)
+- **Finders/verdict:** sql-integrity F5-2 **+** sync F3-3 **+** writes-lifecycle F4-3 — all **CONFIRMED**. F5-2/F3-3
+  rate it MEDIUM (live leak if such a DB exists); F4-3 frames it INFO because the residual is **de-scoped by an
+  explicit documented decision** and prospectively closed. Net: **MEDIUM, conditional on an operational fleet check.**
+- **Files (HEAD):** `server/src/utils/shared-space-album-scope.ts:90-101` (the immutable `createdById` union in
+  `accessibleSpaces`), `server/src/schema/functions.ts:407-414` (`user_has_library_path` branch 3),
+  `functions.ts:545-554` (`user_has_album_path` branch 3), `server/src/services/shared-space.service.ts:472-478`
+  (remove-creator guard), `:597-602` (demote-creator guard).
+- **Scenario.** On any DB deployed **before** this branch's creator guard shipped (the whole netcup fleet ran
+  v5.0.0-rc space-albums builds without it), a promoted co-Owner removed (or demoted-then-removed) the space
+  creator C. After upgrading to this branch, C's phone still satisfies `accessibleSpaces` via the
+  `shared_space.createdById` union — independent of membership — so **every** fork sync stream keeps delivering
+  S's new photos, EXIF, album/link rows to C **forever**, and C's `shared_space_album_user`/`library_user` grants
+  survive every revocation trigger and the reconcile sweep via `user_has_*_path` branch 3. The members list shows
+  C as **not a member**; no content-revocation delta is ever emitted. The vulnerable data state is **creatable
+  today** on every deployed build (main has the union and no guard), then frozen in place by the upgrade.
+- **Root cause.** The rbac-4 plan required both (a) forbidding creator removal/demotion **and** (b) dropping the
+  `createdById` arm (or repairing existing DBs). HEAD ships **(a) only** — prospective guards, fail-closed on a
+  missing space row — and keeps the `createdById` arms. No repair migration or startup sweep exists in
+  `migrations-gallery/` or the service bootstrap.
+- **Fix (accepted-risk unless a fleet DB is affected).** First **size the blast radius** on the personal/staging
+  DBs:
+  ```sql
+  SELECT id FROM shared_space ss
+   WHERE NOT EXISTS (SELECT 1 FROM shared_space_member m
+                      WHERE m."spaceId" = ss.id AND m."userId" = ss."createdById");
+  ```
+  If any row is affected, ship the one-off repair as a fork migration / startup sweep:
+  ```sql
+  INSERT INTO shared_space_member ("spaceId", "userId", role)
+  SELECT id, "createdById", 'owner' FROM shared_space ss
+   WHERE NOT EXISTS (SELECT 1 FROM shared_space_member m
+                      WHERE m."spaceId" = ss.id AND m."userId" = ss."createdById");
+  ```
+  restoring the creator-is-always-a-member invariant the guards now assume — after which the `createdById` arms
+  become provably redundant and can be dropped. Document which invariant the code rests on.
+
+---
+
+## 4. LOW
+
+### L-1 — Re-timestamped `AlbumSoftDelete` trigger migration ships with no compatibility alias (boot-availability hazard, PLAUSIBLE)
+- **Finder/verdict:** sql-integrity F5-1 — **PLAUSIBLE** (LOW). Code-level mechanism is certain; whether any
+  affected DB *exists* cannot be determined from the repo.
+- **Files (HEAD):** `server/src/schema/migrations-gallery/1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger.ts:1`,
+  `server/bin/sync-gallery-migrations.mjs:6` (`compatibilityAliases` still holds only the `ChangeDurationToInteger`
+  entry), `scripts/revert-to-immich.sql:369`.
+- **Scenario.** Commit `860dd535ef` (2026-07-10) renamed the migration from `1782000000000` to `1782050000000` to
+  resolve a timestamp collision. Any persistent DB that booted an RC image of this branch built in the ~2-day
+  window between `261c240cad` (2026-07-08) and `860dd535ef^` recorded the **old** name in `kysely_migrations`.
+  Upgrading such a DB to HEAD makes Kysely find a recorded migration name with no matching file → **hard boot
+  failure** until manual `kysely_migrations` surgery. Secondary: `revert-to-immich.sql` step-8 DELETE list only
+  carries the new name, so reverting such a DB to upstream Immich strands the old-name row. Not a data leak —
+  availability/ops only.
+- **Fix.** Either (a) confirm no surviving DB ran the old name (check staging/mobile-test `kysely_migrations`) and
+  document it, or (b) add a startup `UPDATE kysely_migrations SET name='1782050000000-…' WHERE
+  name='1782000000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger'` before the migrator runs (a file-copy alias
+  alone would double-run on fresh installs), and add the old name to `revert-to-immich.sql`'s DELETE list. Verify
+  the trigger's `up()` is idempotent before shipping any alias.
+
+### L-2 — `requireRole` and the bulk-add handler fail OPEN on an unrecognized member role
+- **Finder/verdict:** writes-lifecycle F4-2 — **CONFIRMED** (LOW, defense-in-depth / corruption-gated).
+- **Files (HEAD):** `server/src/services/shared-space.service.ts:2935-2941` (`requireRole`), `:2356-2359`
+  (`handleSharedSpaceBulkAddAssets`), `:71-77` (the fail-closed helper `getSharedSpaceRoleScore`),
+  `server/src/schema/tables/shared-space-member.table.ts:90-91` (role is unconstrained `varchar`, no enum/CHECK).
+- **Scenario.** `shared_space_member.role` has no Postgres enum/CHECK. If any row ever carries a role outside
+  `{viewer, editor, owner}` (hand-run SQL, migration bug, a future write path that skips the zod enum),
+  `ROLE_HIERARCHY[role]` is `undefined` and `undefined < n` is `false` (NaN semantics), so `requireRole`
+  **passes** — that member clears every Editor- and Owner-gated write in the service (~17 sites: rename, add/remove
+  members, link/unlink albums, add/remove assets, delete people, bulk-add). Not reachable via the API today (all
+  role writes go through `z.enum(SharedSpaceRole)`), so it is corruption-gated defense-in-depth — but it silently
+  **inverts the entire role model** on a single bad row.
+- **Fix.** Use `getSharedSpaceRoleScore(member.role) < ROLE_HIERARCHY[minimumRole]` at both sites (unknown → 0 =
+  Viewer, denied), matching the fail-closed helper already used by `unlinkAlbum`. Optionally add a CHECK
+  constraint / enum on `shared_space_member.role`.
+
+### L-3 — `searchRandom` / `searchStatistics` / `searchLargeAssets` accept `albumIds` with no `AlbumRead` check (latent fragility, net-new from the completeness critic)
+- **Source/verdict:** completeness critic — traced **currently SAFE**, reported as hardening.
+- **Files (HEAD):** `server/src/services/search.service.ts:212` (`searchRandom`), `:186` (`searchStatistics`), and
+  the large-assets path; contrast `searchMetadata` at `:141-146` (which *does* `requireAccess(AlbumRead)`).
+- **Why safe today.** Unlike `searchMetadata` (which deliberately leaves `userIds` unset to make `AlbumRead` the
+  sole gate), these three unconditionally set `userIds = getUserIdsToSearch(auth,…)`, so `inAlbums` becomes an
+  intersection ANDed with the ownership/space row-scope, not the sole gate.
+- **Why report it.** Their safety rests **entirely** on `userIds` never being unset for the `albumIds` path — an
+  invariant nothing in the shared `searchAssetBuilder` enforces. A future refactor that mirrors `searchMetadata`'s
+  "unset `userIds` when `albumIds` present" into these endpoints (an easy parity change) would silently open a
+  cross-user album leak with no `AlbumRead` gate to catch it.
+- **Fix.** Add an unconditional `requireAccess(AlbumRead)` on any `albumIds` path across all four search endpoints,
+  collapsing the invariant into an enforced rule. Add a test pinning that a non-member's `searchRandom{albumIds}`
+  returns only own assets.
+
+---
+
+## 5. Cleared — refuted findings and re-verified prior fixes
+
+**Refuted (checked and cleared this pass):**
+
+- **F1-2 (REFUTED):** prior **H1** (trashed album assets via `albumIds` search + timeline buckets) **holds fixed**
+  — `albumSharedSpaceScope` carries `deletedAt IS NULL` on every disjunct (parameter-independent), and the
+  timeline bucket is closed twice (service 400 on `isTrashed` + data-layer flat gate). *(This is the album arm;
+  H-1 above is the distinct, still-open space arm.)*
+- **F2-2 (REFUTED):** space-person **auto-thumbnail fallback** does **not** serve a crop from a non-space asset —
+  the space-visibility/membership conditions apply to the very asset the `thumbnailPath` was cropped from; Archive
+  inclusion is documented design; hidden space-people are enumerable by any member via `withHidden=true`, so
+  `isHidden` is a UI preference not access control. Only residual is a sub-minute thumbnail-regeneration freshness
+  race (INFO-grade).
+- **F3-4 (REFUTED):** prior **M7** reconcile self-heal — the album metadata upsert arm is **membership-scoped**
+  (`accessibleSpaceAlbums`), not grant-scoped, and the link trigger bumps `album.updateId` unconditionally at race
+  time, so the healed member **does** receive the metadata row on first post-join sync. A defensive `updateId`
+  bump in reconcile step 1 would be harmless hardening but is not required.
+
+**Re-verified as landed and holding at HEAD (do not re-review):**
+
+- **People / faces + direct-fetch:** H1, **M1** (person-faces picker no longer leaks hidden/never-shared/cross-user
+  faces), **M2** (space Viewer can no longer mutate the owner's representative face), **L1** (contributorCounts no
+  longer exposes userIds / hidden-count inference), **L3** (legacy null-identityId statistics no longer library-wide),
+  **I1** (filter/exif suggestion `albumId` scope). Every `access.repository` space arm (`checkSpaceAccess`,
+  `checkSpaceEditAccess`, `checkSpaceAccessForSpace`, `isFaceInSpace`, `getSpaceRepresentativeFaceForUpdate`) carries
+  `deletedAt IS NULL` + `spaceVisibilityGate` + membership/grant join. **Direct byte/thumbnail/face fetch by a
+  non-member or for a hidden/locked/trashed asset is closed on every path reachable.**
+- **Sync + lifecycle:** M3 (core direct/library arms), M4, M6, M7, M8, M9, M13, L4, L5, L7, L8, L13-support, plus
+  the full revocation-delta matrix and the write-authz/role-gating matrix (M2, M3 Hidden legs, M6, M7, M9, M11,
+  L4, L5, L6, L7, L8, L16). Mobile `viewer_visibility.dart` and local timeline filtering verified.
+- **SQL / migration / trigger:** H1, M1, M2, M11, M12, L11, L18 lane all landed; **completeness sweep found no
+  unscoped asset-returning surface** — repositories the branch did not touch are owner-/system-scoped or funnel
+  through the space-gated access layer.
+- **Still-open-by-decision (informational):** **M14** — the mobile space-albums sync gate remains an unenforced
+  `> 5.0.0` release-order assumption (a post-branch server hotfix cut from a pre-space-albums commit would 400 the
+  whole `/sync/stream` for gated mobile builds). Acknowledged TODO.
+
+---
+
+## 6. Live-probe plan (NOT yet run — required next-session step)
+
+Static confirmations above were **not** dynamically exercised. Reason: the only running stack was the machine-wide
+`mise dev` singleton serving the **`mobile-filter-parity`** worktree (which does not contain the space-albums search
+code), and repointing it to this worktree would clobber that other session's DB/source. The convergence/stale-device
+findings (M-1, M-2, M-3) are **untestable by static reading** and the unit/medium harness never replays a real member
+device after a revocation — these need live probes.
+
+Bring up a clean `make e2e`/dev stack **against this worktree** with users **O** (owner of asset+album), **E**
+(editor), **V** (viewer), **X** (removed ex-member); space **S** with linked album **A** (O's) and a linked library.
+Run in order:
+
+1. **H-1 (confirm + regression-pin).** As V: `POST /search/metadata {spaceId:S, trashedAfter:"1970-01-01",
+   withExif:true}` and `{withSharedSpaces:true, trashedAfter:…}` after O trashes a shared asset → expect **zero**
+   trashed rows. Repeat with `isOffline:true` and `trashedBefore` (each independently flips `withDeleted`). *(Currently
+   expected to LEAK.)*
+2. **M-1 (Locked retry hole).** As O, add asset to A (V/E have it synced). Inject a fault (or kill the worker)
+   between the visibility `UPDATE` and `removeAssetsFromAll`, then flip asset→Locked. Reconnect V's sync stream →
+   assert an album-arm **delete tombstone** arrives. *(Currently expected: no tombstone.)*
+3. **M-2 (backfill streams trashed).** O trashes an album-A asset. Add a **new** member N. Drive N's initial
+   `POST /sync/stream` backfill → assert the trashed asset is absent. *(Currently expected to LEAK metadata.)*
+4. **Removed-member replay (class 1/6).** As X (previously fully synced), after O removes X: replay X's
+   `POST /sync/stream` with X's last ack → assert DELETE deltas for every S asset across all three arms and an empty
+   backfill; then direct-GET a known S asset's `/thumbnail` and `/original` as X → expect 400/403.
+5. **M-3 (removed-creator split-brain).** Seed a DB where `shared_space.createdById` has **no**
+   `shared_space_member` row (simulate the pre-guard RC state via SQL). Boot, replay the ex-creator's sync →
+   assert they do **not** keep receiving space content. *(Currently expected to LEAK.)*
+6. **Trashed-album re-share on restore (prior M9).** As member D: link own album, trash it, leave S, restore it →
+   assert S members do **not** regain D's photos and no grants are re-created.
+7. **Viewer-write negatives (class 5).** As V: `PUT /people/:id/representative-face`, album mutations, and an
+   `AlbumUnlink` on a not-actually-linked album / nonexistent spaceId → expect 403/clean-404, no activity-feed spam.
+8. **Direct byte-fetch as a total non-member (class 2).** GET `/assets/:id/thumbnail`, `/original`,
+   `/people/:personId/thumbnail`, `GET /shared-spaces/S/people/:pid/thumbnail` for S assets/people → all 403/404.
+
+---
+
+## 7. Cross-cutting patterns (why per-angle finders each miss these)
+
+1. **`deletedAt` lives at two altitudes; only one is caller-proof.** The branch moved `deletedAt IS NULL` *inside*
+   the helpers it owns (`albumSharedSpaceScope`, `checkSpaceAccess*`, `isFaceInSpace`) but left the two non-helper
+   `searchAssetBuilder` arms relying on the terminal, caller-toggleable `.$if(!withDeleted)`. A "does surface X
+   route through the helper?" audit ticks the box (the *album* arm does); a "is `deletedAt` present?" audit ticks
+   the box (it is, at `:850`) — the composition failure is invisible to either finder alone. **Every asset-scoping
+   arm should carry its own `deletedAt` and never depend on the terminal gate.** (→ H-1, M-2.)
+2. **"Gated by `userIds` being set" is an invariant, not a guarantee.** Four search endpoints share
+   `searchAssetBuilder`; their `albumIds` safety is a function of whether the *service* sets `userIds`. Nothing in
+   the shared builder enforces "if `albumIds` and not `userIds`, an `AlbumRead` check happened." (→ L-3.)
+3. **Convergence holes are systematically under-tested** because the harness has no device-replay — correctness
+   depends on what a *previously-synced client* receives *after* a state change, and the suite only checks
+   steady-state SQL. (→ M-1, M-2, M-3; probes 2–5.)
+
+---
+
+## 8. Pickup prompt — start here in a new session
+
+```
+Continue the RBAC/security remediation of the space-albums branch.
+
+CONTEXT
+- Branch: space-albums-onto-main, checked out in worktree:
+  /Users/pierre/dev/gallery/.claude/worktrees/space-albums-reconsolidate-v302  (HEAD b1e9f4628e at review time — re-check).
+- Full findings + line anchors: SPACE-ALBUMS-RBAC-REVIEW-2026-07-11.md (this file, in that worktree root).
+- Prior passes already landed: SPACE-ALBUMS-REMEDIATION-REVIEW-2026-07-08.md + PR #759. Those fixes are
+  re-verified as HOLDING (see §5) — do NOT re-review them. The static read-scope + direct-fetch surface is clean;
+  the completeness sweep found no unscoped asset-returning surface.
+- The review workflow can be resumed/re-run for cached agent results:
+  Workflow({scriptPath: "/Users/pierre/.claude/projects/-Users-pierre-dev-gallery/bcf2aebd-fa64-4711-ba49-a123b08ebcc9/workflows/scripts/space-albums-rbac-review-wf_6755eab9-26a.js",
+            resumeFromRunId: "wf_6755eab9-26a"})
+
+WHAT TO FIX (priority order; each with TDD — write the failing test first):
+1. HIGH  H-1 — Trashed assets leak via the two searchAssetBuilder space arms. AND `asset.deletedAt IS NULL` into
+         the other-members branch of the spaceId arm (database.ts:703-706) and the withSharedSpaces arm
+         (database.ts:717-727); keep the ownerId-IN-userIds branch unfiltered. Add a 400 in search.service.ts
+         rejecting withDeleted/trashedAfter/trashedBefore/isOffline when spaceId/withSharedSpaces is set. Regen
+         SQL (make sql). Tests across metadata/random/largeAssets/statistics/smart incl. the implicit-flip params.
+2. MED   M-2 — Add `asset.deletedAt IS NULL` to the space-member-facing sync BACKFILL/getCreates arms
+         (sync.repository.ts SharedSpaceAlbumAsset/Exif + direct + non-owner library). Keep getUpdates delivering
+         trashed rows to existing members (that's how devices learn to purge). Test: trash→add member→backfill→0 rows.
+3. MED   M-1 — Make the Locked album strip retry-convergent: call removeAssetsFromAll(ids) unconditionally on
+         nextVisibility===Locked (asset.service.ts:437) and/or emit the album purge tombstone for Locked
+         (:450-453). Update asset.service.spec.ts:1388 to assert the call on re-lock; add a cross-path medium test.
+4. MED   M-3 — FIRST size the fleet: run the NOT-EXISTS query (§3 M-3) on personal/staging DBs. If any row is
+         affected, ship the creator-reinsert repair migration and drop the createdById arms; else document the
+         accepted risk. This is partly an operational decision, not pure code.
+5. LOW   L-2 — Use getSharedSpaceRoleScore() in requireRole + bulk-add handler (fail closed on unknown role);
+         optionally add a CHECK constraint on shared_space_member.role.
+6. LOW   L-1 — Confirm no surviving DB ran the pre-rename migration name (staging/mobile kysely_migrations);
+         if unsure add a startup rename of the kysely_migrations row + the old name to revert-to-immich.sql.
+7. LOW   L-3 — Add unconditional requireAccess(AlbumRead) on any albumIds path in
+         searchRandom/searchStatistics/searchLargeAssets (defense-in-depth); test a non-member albumIds search.
+
+THEN run the §6 live-probe list against a CLEAN stack built from THIS worktree (probes 1,3,5 should flip from
+leak→clean once H-1/M-2/M-3 land). NOTE: `mise dev` is a machine-wide singleton — a stack was serving the
+mobile-filter-parity worktree; coordinate one stack at a time, do not clobber another session's.
+
+GATES before PR: server `pnpm test` + tsc; `make sql` if any repository SQL changed; e2e negatives
+(shared-space-visibility-negatives.e2e-spec.ts) extended for the new cases; do NOT add Co-Authored-By trailers.
+```

--- a/e2e/src/specs/server/api/shared-space-album-timeline.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-album-timeline.e2e-spec.ts
@@ -1,0 +1,582 @@
+/**
+ * Slice S4a — API e2e behavioral matrix for the space-albums timeline surfaces.
+ *
+ * Source: SPACE-ALBUMS-RBAC-REMEDIATION-SPEC-2026-07-11.md, section "S4 — Comprehensive
+ * space-albums behavioral e2e safety net" / "S4a — API e2e behavioral matrix". This is the
+ * end-to-end regression lock for S1 (H-1 trash gate), S2 (M-2 sync trash gate) and S3 (M-1
+ * Locked album strip convergence), on top of proving the day-to-day link/toggle/add/remove
+ * behavior actually moves assets in and out of the relevant surfaces.
+ *
+ * Two DISTINCT `showInTimeline` toggles exist and must be kept straight (verified in
+ * server/src/dtos/shared-space.dto.ts):
+ *   - ALBUM-level `shared_space_album.showInTimeline` (PATCH /shared-spaces/:id/albums/:albumId)
+ *     — "include this album's assets in the SPACE Photos timeline". It gates ONLY the
+ *     `spaceId`/`withSharedSpaces` arms of the timeline/search builders (via
+ *     `spaceAlbumAssetExists({ requireShowInTimeline: true })`); the `albumId`-scoped timeline
+ *     query (the album view) joins `album_asset` directly and never looks at this flag.
+ *   - MEMBER-level `shared_space_member.showInTimeline` (PATCH
+ *     /shared-spaces/:id/members/me/timeline) — "include this space's assets in MY
+ *     personal/main timeline" (`GET /timeline/buckets?withSharedSpaces=true`). It does not gate
+ *     the space's own Photos tab (`GET /timeline/buckets?spaceId=...`), which a member can
+ *     still browse directly.
+ *
+ * Fixture: owner O, editor E, viewer V, non-member X; a fresh space S per test group; O owns
+ * album A (2 Timeline assets, E as an album-editor participant so E can add/remove assets);
+ * A is linked into S. Assertions check DATA PRESENCE (asset ids in the relevant list
+ * responses), not just status codes, per the remediation spec's explicit ask.
+ */
+
+import {
+  AlbumResponseDto,
+  AlbumUserRole,
+  AssetMediaResponseDto,
+  AssetVisibility,
+  LoginResponseDto,
+  removeAssets,
+  restoreAssets,
+  SharedSpaceRole,
+  updateAssets,
+  updateMemberTimeline,
+  updateSharedSpaceAlbum,
+} from '@immich/sdk';
+import { createUserDto } from 'src/fixtures';
+import { app, asBearerAuth, utils } from 'src/utils';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// ─── module-level read/mutation helpers (no describe-scoped closures) ───────
+
+/**
+ * Collects every asset id across all time buckets returned for the given query string
+ * (e.g. `spaceId=...`, `albumId=...`, `withSharedSpaces=true`), as the given token.
+ * Asserts 200 on both the buckets list and each bucket fetch — only call this for a
+ * caller expected to have read access to the scope; use raw `request(app)` calls directly
+ * to assert a non-2xx status.
+ */
+const timelineIds = async (token: string, query: string): Promise<string[]> => {
+  const bucketsRes = await request(app)
+    .get(`/timeline/buckets?bucketSize=month&${query}`)
+    .set('Authorization', `Bearer ${token}`);
+  expect(bucketsRes.status).toBe(200);
+  const buckets = bucketsRes.body as Array<{ timeBucket: string }>;
+
+  const ids: string[] = [];
+  for (const bucket of buckets) {
+    const { status, body } = await request(app)
+      .get(`/timeline/bucket?bucketSize=month&timeBucket=${bucket.timeBucket}&${query}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(status).toBe(200);
+    ids.push(...((body.id ?? []) as string[]));
+  }
+  return ids;
+};
+
+/** The SPACE Photos timeline (direct + showInTimeline-linked-album assets). */
+const spaceTimelineIds = (token: string, spaceId: string) => timelineIds(token, `spaceId=${spaceId}`);
+
+/** The album-filtered timeline view (album view) — never gated by the album's showInTimeline. */
+const albumTimelineIds = (token: string, albumId: string) => timelineIds(token, `albumId=${albumId}`);
+
+/**
+ * The caller's personal/main timeline, expanded to include timeline-enabled shared spaces.
+ * `withSharedSpaces` requires an explicit `visibility=timeline`: the endpoint 400s on the default
+ * (archived) view for a shared-spaces union, mirroring `withPartners` (see
+ * timeline.service.ts `timeBucketChecks`), and every caller in timeline.e2e-spec.ts passes it too.
+ */
+const mainTimelineWithSpacesIds = (token: string) => timelineIds(token, 'visibility=timeline&withSharedSpaces=true');
+
+/** POST /search/metadata as the given token; returns the flat list of returned asset ids. */
+const searchIds = async (token: string, body: Record<string, unknown>): Promise<string[]> => {
+  const { status, body: resBody } = await request(app)
+    .post('/search/metadata')
+    .set('Authorization', `Bearer ${token}`)
+    .send(body);
+  expect(status).toBe(200);
+  return (resBody.assets.items as Array<{ id: string }>).map((item) => item.id);
+};
+
+/** Set visibility on an asset, as the given token (must own the asset). */
+const setVisibility = (token: string, assetId: string, visibility: AssetVisibility) =>
+  updateAssets({ assetBulkUpdateDto: { ids: [assetId], visibility } }, { headers: asBearerAuth(token) });
+
+/** PATCH the ALBUM-level showInTimeline flag for a space<->album link, as the given token. */
+const setAlbumShowInTimeline = (token: string, spaceId: string, albumId: string, showInTimeline: boolean) =>
+  updateSharedSpaceAlbum(
+    { id: spaceId, albumId, sharedSpaceAlbumLinkUpdateDto: { showInTimeline } },
+    { headers: asBearerAuth(token) },
+  );
+
+/** PATCH the MEMBER-level showInTimeline flag for the caller's own membership. */
+const setMemberShowInTimeline = (token: string, spaceId: string, showInTimeline: boolean) =>
+  updateMemberTimeline(
+    { id: spaceId, sharedSpaceMemberTimelineDto: { showInTimeline } },
+    { headers: asBearerAuth(token) },
+  );
+
+const PIN_CODE = '123456';
+
+/**
+ * Elevate a session so it can read/modify Locked-folder assets. A Locked asset is invisible to
+ * checkOwnerAccess without an elevated (PIN) session (access.repository.ts gates
+ * `visibility != Locked` when `!hasElevatedPermission`), so unlocking one via PUT /assets 400s on a
+ * plain token. Set up the PIN (tolerant of a repeat call on a vitest retry — a re-setup 4xx is
+ * ignored; only the session/unlock is asserted) then unlock the session.
+ */
+const elevateSession = async (token: string) => {
+  await request(app).post('/auth/pin-code').set(asBearerAuth(token)).send({ pinCode: PIN_CODE });
+  await request(app).post('/auth/session/unlock').set(asBearerAuth(token)).send({ pinCode: PIN_CODE }).expect(204);
+};
+
+describe('shared-space album <-> timeline behavioral matrix (S4a)', () => {
+  let admin: LoginResponseDto;
+  // space owner (also album owner)
+  let owner: LoginResponseDto;
+  // space editor, also an album-editor participant on every fixture album
+  let editor: LoginResponseDto;
+  // space viewer — the primary observer for every assertion below
+  let viewer: LoginResponseDto;
+  // not a member of the space at all
+  let nonMember: LoginResponseDto;
+
+  beforeAll(async () => {
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    [owner, editor, viewer, nonMember] = await Promise.all([
+      utils.userSetup(admin.accessToken, createUserDto.create('s4a-owner')),
+      utils.userSetup(admin.accessToken, createUserDto.create('s4a-editor')),
+      utils.userSetup(admin.accessToken, createUserDto.create('s4a-viewer')),
+      utils.userSetup(admin.accessToken, createUserDto.create('s4a-nonmember')),
+    ]);
+  });
+
+  // ─── fixture helpers ───────────────────────────────────────────────────────
+
+  /** Fresh space: O = Owner (creator), E = Editor, V = Viewer. Returns the space id. */
+  const freshSpace = async (name: string): Promise<string> => {
+    const space = await utils.createSpace(owner.accessToken, { name });
+    await utils.addSpaceMember(owner.accessToken, space.id, { userId: editor.userId, role: SharedSpaceRole.Editor });
+    await utils.addSpaceMember(owner.accessToken, space.id, { userId: viewer.userId, role: SharedSpaceRole.Viewer });
+    return space.id;
+  };
+
+  /** Fresh album A owned by O, E as an album-editor participant, with `n` Timeline assets. */
+  const freshAlbum = async (
+    name: string,
+    n = 2,
+  ): Promise<{ album: AlbumResponseDto; assets: AssetMediaResponseDto[] }> => {
+    const assets = await Promise.all(Array.from({ length: n }, () => utils.createAsset(owner.accessToken)));
+    const album = await utils.createAlbum(owner.accessToken, {
+      albumName: name,
+      albumUsers: [{ userId: editor.userId, role: AlbumUserRole.Editor }],
+      assetIds: assets.map((a) => a.id),
+    });
+    return { album, assets };
+  };
+
+  /** Fresh space + fresh album (n assets), linked together. The base S4a fixture. */
+  const freshLinkedFixture = async (
+    name: string,
+    n = 2,
+  ): Promise<{ spaceId: string; album: AlbumResponseDto; assets: AssetMediaResponseDto[] }> => {
+    const spaceId = await freshSpace(name);
+    const { album, assets } = await freshAlbum(name, n);
+    await utils.linkSpaceAlbum(owner.accessToken, spaceId, album.id);
+    return { spaceId, album, assets };
+  };
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 1. Link -> space Photos timeline contains the linked album's assets.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('1. link -> space Photos timeline contains the album assets', () => {
+    it("after linking A into S, V's space timeline contains both of A's assets", async () => {
+      const { spaceId, assets } = await freshLinkedFixture('s4a-1-link');
+
+      const ids = await spaceTimelineIds(viewer.accessToken, spaceId);
+      for (const asset of assets) {
+        expect(ids).toContain(asset.id);
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 2. Album showInTimeline=false removes assets from the SPACE timeline only,
+  //    not the album view; toggling back to true brings them back.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('2. album showInTimeline gates the SPACE timeline only, not the album view', () => {
+    it('showInTimeline=false hides A from the space timeline but the album view still returns it; true brings it back', async () => {
+      const { spaceId, album, assets } = await freshLinkedFixture('s4a-2-album-toggle');
+
+      // sanity: present before toggling
+      const before = await spaceTimelineIds(viewer.accessToken, spaceId);
+      for (const asset of assets) {
+        expect(before).toContain(asset.id);
+      }
+
+      await setAlbumShowInTimeline(owner.accessToken, spaceId, album.id, false);
+
+      const afterHideSpace = await spaceTimelineIds(viewer.accessToken, spaceId);
+      for (const asset of assets) {
+        expect(afterHideSpace).not.toContain(asset.id);
+      }
+
+      // The album view (`albumId`-scoped timeline) joins album_asset directly and is
+      // NEVER gated by shared_space_album.showInTimeline.
+      const albumView = await albumTimelineIds(viewer.accessToken, album.id);
+      for (const asset of assets) {
+        expect(albumView).toContain(asset.id);
+      }
+
+      await setAlbumShowInTimeline(owner.accessToken, spaceId, album.id, true);
+
+      const afterShowSpace = await spaceTimelineIds(viewer.accessToken, spaceId);
+      for (const asset of assets) {
+        expect(afterShowSpace).toContain(asset.id);
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 3. Member showInTimeline gates the PERSONAL/main timeline only.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('3. member showInTimeline gates the PERSONAL/main timeline', () => {
+    it("withSharedSpaces=true includes A's assets for V until V hides S, then they reappear once shown again", async () => {
+      const { spaceId, assets } = await freshLinkedFixture('s4a-3-member-toggle');
+
+      const before = await mainTimelineWithSpacesIds(viewer.accessToken);
+      for (const asset of assets) {
+        expect(before).toContain(asset.id);
+      }
+
+      await setMemberShowInTimeline(viewer.accessToken, spaceId, false);
+
+      const afterHide = await mainTimelineWithSpacesIds(viewer.accessToken);
+      for (const asset of assets) {
+        expect(afterHide).not.toContain(asset.id);
+      }
+
+      await setMemberShowInTimeline(viewer.accessToken, spaceId, true);
+
+      const afterShow = await mainTimelineWithSpacesIds(viewer.accessToken);
+      for (const asset of assets) {
+        expect(afterShow).toContain(asset.id);
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 4. Unlink -> assets leave the space timeline; V loses album access; O keeps A.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('4. unlink removes A from the space timeline; V loses album access; O still owns A', () => {
+    it('DELETE /shared-spaces/:id/albums/:albumId removes the assets from the space timeline and 400s V on GET /albums/:id, while O keeps the album', async () => {
+      const { spaceId, album, assets } = await freshLinkedFixture('s4a-4-unlink');
+
+      await utils.unlinkSpaceAlbum(owner.accessToken, spaceId, album.id);
+
+      const spaceIds = await spaceTimelineIds(viewer.accessToken, spaceId);
+      for (const asset of assets) {
+        expect(spaceIds).not.toContain(asset.id);
+      }
+
+      const viewerGet = await request(app)
+        .get(`/albums/${album.id}`)
+        .set('Authorization', `Bearer ${viewer.accessToken}`);
+      expect(viewerGet.status).toBe(400);
+
+      const ownerGet = await request(app)
+        .get(`/albums/${album.id}`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+      expect(ownerGet.status).toBe(200);
+      expect(ownerGet.body.id).toBe(album.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 5. Editor add/remove of an album asset reflects immediately for the viewer.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('5. editor add/remove on A reflects immediately for V in the space timeline', () => {
+    it('E adds asset N to A -> N appears for V; E removes N -> N disappears for V', async () => {
+      const { spaceId, album } = await freshLinkedFixture('s4a-5-editor-add-remove', 1);
+      const newAsset = await utils.createAsset(editor.accessToken);
+
+      await request(app)
+        .put(`/albums/${album.id}/assets`)
+        .set('Authorization', `Bearer ${editor.accessToken}`)
+        .send({ ids: [newAsset.id] })
+        .expect(200);
+
+      const afterAdd = await spaceTimelineIds(viewer.accessToken, spaceId);
+      expect(afterAdd).toContain(newAsset.id);
+
+      await request(app)
+        .delete(`/albums/${album.id}/assets`)
+        .set('Authorization', `Bearer ${editor.accessToken}`)
+        .send({ ids: [newAsset.id] })
+        .expect(200);
+
+      const afterRemove = await spaceTimelineIds(viewer.accessToken, spaceId);
+      expect(afterRemove).not.toContain(newAsset.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 6. Hide / Lock / restore round-trip — regression lock for S1-S3.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('6. hide / lock / restore round-trip (regression lock for S1-S3)', () => {
+    it('Hidden: an A-asset disappears from every viewer surface, then reappears once restored to Timeline', async () => {
+      const { spaceId, album, assets } = await freshLinkedFixture('s4a-6-hidden', 2);
+      const [target, sibling] = assets;
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(target.id);
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).toContain(target.id);
+      expect(await mainTimelineWithSpacesIds(viewer.accessToken)).toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { spaceId })).toContain(target.id);
+
+      await setVisibility(owner.accessToken, target.id, AssetVisibility.Hidden);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).not.toContain(target.id);
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).not.toContain(target.id);
+      expect(await mainTimelineWithSpacesIds(viewer.accessToken)).not.toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { spaceId })).not.toContain(target.id);
+      // the sibling asset is unaffected
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(sibling.id);
+
+      await setVisibility(owner.accessToken, target.id, AssetVisibility.Timeline);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(target.id);
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).toContain(target.id);
+      expect(await mainTimelineWithSpacesIds(viewer.accessToken)).toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { spaceId })).toContain(target.id);
+    });
+
+    it('Locked: an A-asset disappears from every viewer surface AND is permanently stripped from A (unlocking does not silently re-share it — S3/M-1)', async () => {
+      const { spaceId, album, assets } = await freshLinkedFixture('s4a-6-locked', 2);
+      const [target, sibling] = assets;
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(target.id);
+
+      await setVisibility(owner.accessToken, target.id, AssetVisibility.Locked);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).not.toContain(target.id);
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).not.toContain(target.id);
+      expect(await mainTimelineWithSpacesIds(viewer.accessToken)).not.toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { spaceId })).not.toContain(target.id);
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(sibling.id);
+
+      // M-1 (asset.service.ts applyVisibilityTransitionSideEffects): Locked unconditionally strips
+      // the asset from every album via removeAssetsFromAll, unlike Hidden which retains the
+      // album_asset row. Setting the asset back to Timeline lifts the visibility gate but does
+      // NOT restore album membership — emitAlbumAssetVisibilityRestore finds no surviving row to
+      // bump (shared-space.repository.ts: "after Locked, album_asset rows were deleted ... the
+      // asset does not return to the album"). This is the fixed, intended "no silent re-share"
+      // behavior (S3's own edge case), not a leak: assert it stays absent from A's scope.
+      // (Re-lock-after-crash convergence is proven at the medium-test level —
+      // sync-shared-space-album-visibility-purge.spec.ts — not duplicated here.)
+      //
+      // A Locked asset is only reachable/mutable by an elevated (PIN) session, so the owner must
+      // elevate before unlocking it — mirrors the real client's locked-folder flow.
+      await elevateSession(owner.accessToken);
+      await setVisibility(owner.accessToken, target.id, AssetVisibility.Timeline);
+
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).not.toContain(target.id);
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).not.toContain(target.id);
+
+      // The asset itself is a normal, directly-readable Timeline asset again for its owner — just
+      // no longer shared via A/S.
+      const { status, body } = await request(app)
+        .get(`/assets/${target.id}`)
+        .set('Authorization', `Bearer ${owner.accessToken}`);
+      expect(status).toBe(200);
+      expect(body.visibility).toBe(AssetVisibility.Timeline);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 7. Trash round-trip — regression lock for H-1 / M-2.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('7. trash round-trip (regression lock for H-1/M-2)', () => {
+    it('trashing an A-asset removes it from every viewer surface (incl. the S1 400 guards); restoring brings it back', async () => {
+      const { spaceId, album, assets } = await freshLinkedFixture('s4a-7-trash', 2);
+      const [target, sibling] = assets;
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(target.id);
+
+      await utils.deleteAssets(owner.accessToken, [target.id]);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).not.toContain(target.id);
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).not.toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { spaceId })).not.toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { withSharedSpaces: true })).not.toContain(target.id);
+      // the sibling asset stays live everywhere
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(sibling.id);
+
+      // S1 (H-1): a space scope must reject every trash/offline param outright, rather than
+      // silently omitting the trashed asset — mirrors shared-space-visibility-negatives.e2e-spec.ts.
+      for (const body of [
+        { spaceId, withDeleted: true },
+        { spaceId, trashedAfter: '1970-01-01T00:00:00.000Z' },
+        { spaceId, isOffline: true },
+        { withSharedSpaces: true, withDeleted: true },
+      ]) {
+        const { status } = await request(app)
+          .post('/search/metadata')
+          .set('Authorization', `Bearer ${viewer.accessToken}`)
+          .send(body);
+        expect(status).toBe(400);
+      }
+
+      await restoreAssets({ bulkIdsDto: { ids: [target.id] } }, { headers: asBearerAuth(owner.accessToken) });
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(target.id);
+      expect(await albumTimelineIds(viewer.accessToken, album.id)).toContain(target.id);
+      expect(await searchIds(viewer.accessToken, { spaceId })).toContain(target.id);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 8. Positive controls / non-member exclusion.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('8. positive control (V sees the live assets) and non-member exclusion', () => {
+    it('V sees the live A-assets across the space timeline, the album view, and search', async () => {
+      const { spaceId, album, assets } = await freshLinkedFixture('s4a-8-positive');
+
+      const spaceIds = await spaceTimelineIds(viewer.accessToken, spaceId);
+      const albumIds = await albumTimelineIds(viewer.accessToken, album.id);
+      const searchedIds = await searchIds(viewer.accessToken, { spaceId });
+      for (const asset of assets) {
+        expect(spaceIds).toContain(asset.id);
+        expect(albumIds).toContain(asset.id);
+        expect(searchedIds).toContain(asset.id);
+      }
+    });
+
+    it('X (non-member) sees none of the space timeline, album view, or search surfaces', async () => {
+      const { spaceId, album } = await freshLinkedFixture('s4a-8-nonmember', 1);
+
+      const spaceTimeline = await request(app)
+        .get(`/timeline/buckets?bucketSize=month&spaceId=${spaceId}`)
+        .set('Authorization', `Bearer ${nonMember.accessToken}`);
+      expect(spaceTimeline.status).toBe(400);
+
+      const albumGet = await request(app)
+        .get(`/albums/${album.id}`)
+        .set('Authorization', `Bearer ${nonMember.accessToken}`);
+      expect(albumGet.status).toBe(400);
+
+      const albumTimeline = await request(app)
+        .get(`/timeline/buckets?bucketSize=month&albumId=${album.id}`)
+        .set('Authorization', `Bearer ${nonMember.accessToken}`);
+      expect(albumTimeline.status).toBe(400);
+
+      const search = await request(app)
+        .post('/search/metadata')
+        .set('Authorization', `Bearer ${nonMember.accessToken}`)
+        .send({ spaceId });
+      expect(search.status).toBe(400);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Edge cases (S4 list)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('edge: album linked to two spaces — toggling showInTimeline in one does not affect the other', () => {
+    it('hiding A in S1 leaves A visible in S2', async () => {
+      const spaceId1 = await freshSpace('s4a-edge-two-spaces-1');
+      const spaceId2 = await freshSpace('s4a-edge-two-spaces-2');
+      const { album, assets } = await freshAlbum('s4a-edge-two-spaces-album', 1);
+      await utils.linkSpaceAlbum(owner.accessToken, spaceId1, album.id);
+      await utils.linkSpaceAlbum(owner.accessToken, spaceId2, album.id);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId1)).toContain(assets[0].id);
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId2)).toContain(assets[0].id);
+
+      await setAlbumShowInTimeline(owner.accessToken, spaceId1, album.id, false);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId1)).not.toContain(assets[0].id);
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId2)).toContain(assets[0].id);
+    });
+  });
+
+  describe('edge: an asset present via both a linked album and a direct add', () => {
+    it('removing only ONE of the two paths leaves it visible; removing both drops it from the space timeline', async () => {
+      const spaceId = await freshSpace('s4a-edge-both-paths');
+      const { album, assets } = await freshAlbum('s4a-edge-both-paths-album', 1);
+      const asset = assets[0];
+      await utils.linkSpaceAlbum(owner.accessToken, spaceId, album.id);
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [asset.id]);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(asset.id);
+
+      // Remove the ALBUM path (unlink) — the direct-add path still carries it.
+      await utils.unlinkSpaceAlbum(owner.accessToken, spaceId, album.id);
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(asset.id);
+
+      // Now remove the DIRECT path too — only then does it leave the space timeline.
+      await removeAssets(
+        { id: spaceId, sharedSpaceAssetRemoveDto: { assetIds: [asset.id] } },
+        { headers: asBearerAuth(owner.accessToken) },
+      );
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).not.toContain(asset.id);
+    });
+  });
+
+  describe('edge: empty album linked then first asset added', () => {
+    it('linking an empty album does not affect the space timeline; adding the first asset makes it appear', async () => {
+      const spaceId = await freshSpace('s4a-edge-empty-album');
+      const emptyAlbum = await utils.createAlbum(owner.accessToken, {
+        albumName: 's4a-edge-empty-album-A',
+        albumUsers: [{ userId: editor.userId, role: AlbumUserRole.Editor }],
+      });
+      await utils.linkSpaceAlbum(owner.accessToken, spaceId, emptyAlbum.id);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toEqual([]);
+
+      const firstAsset = await utils.createAsset(owner.accessToken);
+      await request(app)
+        .put(`/albums/${emptyAlbum.id}/assets`)
+        .set('Authorization', `Bearer ${owner.accessToken}`)
+        .send({ ids: [firstAsset.id] })
+        .expect(200);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(firstAsset.id);
+    });
+  });
+
+  describe('edge: video asset in a linked album is included in the space timeline', () => {
+    // The space-card collage (recentAssetIds) deliberately excludes video for thumbnail purposes
+    // (shared-space.service.ts) — that is a display-only narrowing, not a timeline visibility
+    // rule. Confirm the actual space Photos timeline includes video consistently with a normal
+    // album/timeline browse.
+    it('a video asset appears in the space Photos timeline', async () => {
+      const spaceId = await freshSpace('s4a-edge-video');
+      const videoAsset = await utils.createAsset(owner.accessToken, { assetData: { filename: 'example.mp4' } });
+      const album = await utils.createAlbum(owner.accessToken, {
+        albumName: 's4a-edge-video-album',
+        assetIds: [videoAsset.id],
+      });
+      await utils.linkSpaceAlbum(owner.accessToken, spaceId, album.id);
+
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(videoAsset.id);
+    });
+  });
+
+  describe('edge: member showInTimeline=false hides the space from the MAIN timeline only, not the space Photos tab', () => {
+    it("V with member showInTimeline=false still sees A's assets via the space's own Photos tab", async () => {
+      const { spaceId, assets } = await freshLinkedFixture('s4a-edge-hidden-main-timeline', 1);
+
+      await setMemberShowInTimeline(viewer.accessToken, spaceId, false);
+
+      expect(await mainTimelineWithSpacesIds(viewer.accessToken)).not.toContain(assets[0].id);
+      expect(await spaceTimelineIds(viewer.accessToken, spaceId)).toContain(assets[0].id);
+    });
+  });
+});

--- a/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space-visibility-negatives.e2e-spec.ts
@@ -712,4 +712,71 @@ describe('shared-space visibility negatives (Slice 11)', () => {
       expect(deletes.some((d) => d.data.albumId === album.id && d.data.assetId === assetA.id)).toBe(true);
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // H-1 — the DIRECT space arm + withSharedSpaces arm of searchAssetBuilder. A member
+  // (incl. a read-only Viewer) must not reach another member's TRASHED asset by flipping
+  // withDeleted / trashedAfter / trashedBefore / isOffline (each of which flips withDeleted
+  // in the builder, database.ts:676). The service rejects the whole class with 400 (mirrors
+  // timeBucketChecks); the caller-proof SQL gate is proven in the search-space-trash-gate
+  // medium spec. The album arm is covered above (H1); this covers the two non-album space arms.
+  // ─────────────────────────────────────────────────────────────────────────────
+  describe('POST /search/{metadata,statistics,random} — trash/offline params rejected under a space scope (H-1)', () => {
+    const bodyEndpoints = ['/search/metadata', '/search/statistics', '/search/random'] as const;
+    const trashParams: Array<[string, Record<string, unknown>, boolean]> = [
+      ['withDeleted', { withDeleted: true }, true],
+      ['trashedAfter', { trashedAfter: '1970-01-01T00:00:00.000Z' }, false],
+      ['trashedBefore', { trashedBefore: '2999-01-01T00:00:00.000Z' }, false],
+      ['isOffline', { isOffline: true }, false],
+    ];
+
+    for (const endpoint of bodyEndpoints) {
+      for (const [label, param, needsWithDeleted] of trashParams) {
+        // StatisticsSearchDto has no withDeleted field (zod strips it) — only reachable via implicit-flip params.
+        if (endpoint === '/search/statistics' && needsWithDeleted) {
+          continue;
+        }
+        it(`${endpoint} rejects ${label} with spaceId → 400`, async () => {
+          const spaceId = await freshSpaceWithViewer(`h1-${basename(endpoint)}-${label}`);
+          const { status } = await request(app)
+            .post(endpoint)
+            .set('Authorization', `Bearer ${member.accessToken}`)
+            .send({ spaceId, ...param });
+          expect(status).toBe(400);
+        });
+      }
+    }
+
+    it('POST /search/metadata rejects withDeleted with withSharedSpaces → 400', async () => {
+      await freshSpaceWithViewer('h1-metadata-withSharedSpaces');
+      const { status } = await request(app)
+        .post('/search/metadata')
+        .set('Authorization', `Bearer ${member.accessToken}`)
+        .send({ withSharedSpaces: true, withDeleted: true });
+      expect(status).toBe(400);
+    });
+
+    it('POST /search/smart rejects withDeleted with spaceId → 400 (guard fires before the ML-enabled check)', async () => {
+      const spaceId = await freshSpaceWithViewer('h1-smart-spaceId');
+      const { status, body } = await request(app)
+        .post('/search/smart')
+        .set('Authorization', `Bearer ${member.accessToken}`)
+        .send({ query: 'noodle', spaceId, withDeleted: true });
+      expect(status).toBe(400);
+      // Distinguish the trash-scope guard from a "smart search not enabled" 400.
+      expect(String(body.message)).toContain('shared space');
+    });
+
+    it('positive control: a plain spaceId search (no trash params) returns the live direct asset, not the trashed sibling', async () => {
+      const spaceId = await freshSpaceWithViewer('h1-space-positive');
+      const liveAsset = await utils.createAsset(owner.accessToken);
+      const trashedAsset = await utils.createAsset(owner.accessToken);
+      await utils.addSpaceAssets(owner.accessToken, spaceId, [liveAsset.id, trashedAsset.id]);
+      await utils.deleteAssets(owner.accessToken, [trashedAsset.id]);
+
+      const ids = await searchAlbumIds({ spaceId });
+      expect(ids).toContain(liveAsset.id);
+      expect(ids).not.toContain(trashedAsset.id);
+    });
+  });
 });

--- a/e2e/src/specs/web/spaces-albums-timeline.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-albums-timeline.e2e-spec.ts
@@ -1,0 +1,260 @@
+import {
+  AlbumResponseDto,
+  AssetMediaResponseDto,
+  AssetVisibility,
+  LoginResponseDto,
+  SharedSpaceResponseDto,
+  SharedSpaceRole,
+  updateAssets,
+} from '@immich/sdk';
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { createUserDto } from 'src/fixtures';
+import { asBearerAuth, utils } from 'src/utils';
+
+// Web E2E: S4b of SPACE-ALBUMS-RBAC-REMEDIATION-SPEC-2026-07-11.md — behavioral UI round-trips
+// for the space-albums timeline surfaces. Complements the exhaustive API matrix in
+// shared-space-album-timeline.e2e-spec.ts (S4a) with a focused proof that the browser actually
+// reflects the same behavior.
+//
+// Two `showInTimeline` toggles exist and are NOT interchangeable (shared-space.dto.ts:108/114/133/169):
+//   - ALBUM-level (`shared_space_album.showInTimeline`, toggled from the space Albums grid's card
+//     menu) = "include this album's assets in the SPACE's Photos tab timeline". Affects every
+//     member's view of the space equally — it is not a per-viewer setting.
+//   - MEMBER-level (`shared_space_member.showInTimeline`, toggled from the space page's own "More"
+//     overflow menu) = "include this space's assets in MY personal/main (/photos) timeline". This
+//     one IS per-viewer — toggling it only changes what that member sees on their own /photos.
+//
+// Each test builds its own space + linked album + asset via the API (reusing the same
+// owner/editor/viewer login contexts throughout) so tests never depend on one another's mutated
+// state or run order — Playwright is slow/flaky enough without adding ordering fragility.
+
+async function createLinkedAlbumFixture(
+  ownerToken: string,
+  members: { userId: string; role: SharedSpaceRole }[],
+  namePrefix: string,
+): Promise<{ space: SharedSpaceResponseDto; album: AlbumResponseDto; asset: AssetMediaResponseDto }> {
+  const space = await utils.createSpace(ownerToken, { name: `${namePrefix} Space` });
+  for (const member of members) {
+    await utils.addSpaceMember(ownerToken, space.id, { userId: member.userId, role: member.role });
+  }
+  const asset = await utils.createAsset(ownerToken);
+  const album = await utils.createAlbum(ownerToken, { albumName: `${namePrefix} Album`, assetIds: [asset.id] });
+  await utils.linkSpaceAlbum(ownerToken, space.id, album.id);
+  return { space, album, asset };
+}
+
+// Navigates and waits for the initial `/timeline/buckets` fetch the destination page's Timeline
+// component fires on mount, so a subsequent absence/presence assertion isn't racing the load.
+async function gotoAndWaitForTimeline(page: Page, url: string, readyTestId?: string) {
+  const bucketsResponse = page.waitForResponse((response) => response.url().includes('/timeline/buckets'));
+  await page.goto(url);
+  await bucketsResponse;
+  if (readyTestId) {
+    await page.waitForSelector(`[data-testid="${readyTestId}"]`);
+  }
+}
+
+// `toHaveCount(0)` resolves immediately if the thumbnail simply hasn't rendered yet, which would
+// make an absence assertion pass for the wrong reason — give the timeline a beat to finish
+// rendering bucket content beyond the bucket-list fetch before asserting absence.
+async function expectThumbnailAbsent(page: Page, assetId: string) {
+  await page.waitForTimeout(500);
+  await expect(page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"]`)).toHaveCount(0);
+}
+
+async function expectThumbnailVisible(page: Page, assetId: string) {
+  await expect(page.locator(`[data-thumbnail-focus-container][data-asset="${assetId}"]`)).toBeVisible();
+}
+
+// Opens the given space-album-card's "⋯" menu and clicks the show/hide-in-timeline option,
+// awaiting the PATCH to `/shared-spaces/:id/albums/:albumId` it triggers.
+async function toggleAlbumShowInTimeline(
+  page: Page,
+  spaceId: string,
+  albumId: string,
+  card: Locator,
+  menuItemName: RegExp,
+) {
+  const patchResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PATCH' && response.url().includes(`/shared-spaces/${spaceId}/albums/${albumId}`),
+  );
+  const cardMenu = card.getByTestId('space-album-card-menu');
+  await cardMenu.getByRole('button', { name: 'More' }).click();
+  // Scope the click to THIS card's menu: the space page also renders the space-overflow
+  // (member-level) menu, whose "Hide from timeline" / "Show in timeline" items share the same
+  // accessible name, so a page-wide getByRole matches 2 elements (strict-mode violation).
+  await cardMenu.getByRole('menuitem', { name: menuItemName }).click();
+  await patchResponse;
+}
+
+// Opens the space page's own "More" overflow menu and clicks the show/hide-on-timeline option,
+// awaiting the PATCH to `/shared-spaces/:id/members/me/timeline` it triggers (member-level toggle,
+// self-service — always operates on the current session's own membership).
+async function toggleMemberShowInTimeline(page: Page, spaceId: string, menuItemName: RegExp) {
+  const patchResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PATCH' &&
+      response.url().includes(`/shared-spaces/${spaceId}/members/me/timeline`),
+  );
+  const overflowMenu = page.getByTestId('space-overflow');
+  await overflowMenu.getByRole('button', { name: 'More' }).click();
+  // Scope to the space-overflow menu (same reason as toggleAlbumShowInTimeline: the album-card
+  // menu carries an identically-named "Hide from timeline" / "Show in timeline" item).
+  await overflowMenu.getByRole('menuitem', { name: menuItemName }).click();
+  await patchResponse;
+}
+
+test.describe('Spaces — Albums timeline UI round-trips (S4b)', () => {
+  let admin: LoginResponseDto;
+  let owner: LoginResponseDto;
+  let editor: LoginResponseDto;
+  let viewer: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    [owner, editor, viewer] = await Promise.all([
+      utils.userSetup(admin.accessToken, createUserDto.create('sat-owner')),
+      utils.userSetup(admin.accessToken, createUserDto.create('sat-editor')),
+      utils.userSetup(admin.accessToken, createUserDto.create('sat-viewer')),
+    ]);
+  });
+
+  // 1. Viewer sees linked-album photos in the space Photos tab timeline; opening one lands on the
+  // space photo viewer. Positive control extended (vs. the journey spec) to assert presence of the
+  // specific asset thumbnail, not just that navigation succeeded.
+  test('viewer sees the linked album photo in the space Photos tab and can open it', async ({ context, page }) => {
+    const { space, asset } = await createLinkedAlbumFixture(
+      owner.accessToken,
+      [{ userId: viewer.userId, role: SharedSpaceRole.Viewer }],
+      'S4b-1',
+    );
+    await utils.setAuthCookies(context, viewer.accessToken);
+
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`, 'discovery-timeline');
+    const thumb = page.locator(`[data-thumbnail-focus-container][data-asset="${asset.id}"]`);
+    await expect(thumb).toBeVisible();
+
+    await thumb.click();
+    await page.waitForURL(`/spaces/${space.id}/photos/${asset.id}`);
+    await page.waitForSelector('#immich-asset-viewer');
+    await expect(page.locator('#immich-asset-viewer')).toBeVisible();
+  });
+
+  // 2. The album-level showInTimeline toggle (space Albums grid card menu) drops/re-adds the
+  // album's photo in the SPACE's Photos tab — this is not per-viewer, so the editor who flips it
+  // can observe the effect directly without switching sessions.
+  test('editor toggling the linked album\'s "show in timeline" drops and re-adds its photo in the space Photos tab', async ({
+    context,
+    page,
+  }) => {
+    const { space, album, asset } = await createLinkedAlbumFixture(
+      owner.accessToken,
+      [{ userId: editor.userId, role: SharedSpaceRole.Editor }],
+      'S4b-2',
+    );
+    await utils.setAuthCookies(context, editor.accessToken);
+
+    await page.goto(`/spaces/${space.id}/albums`);
+    const card = page.getByTestId('space-album-card').filter({ hasText: album.albumName });
+    await expect(card).toBeVisible();
+
+    await toggleAlbumShowInTimeline(page, space.id, album.id, card, /hide from timeline/i);
+    await expect(card).toContainText('Hidden from timeline');
+
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`, 'discovery-timeline');
+    await expectThumbnailAbsent(page, asset.id);
+
+    await page.goto(`/spaces/${space.id}/albums`);
+    await toggleAlbumShowInTimeline(page, space.id, album.id, card, /show in timeline/i);
+    await expect(card).not.toContainText('Hidden from timeline');
+
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`, 'discovery-timeline');
+    await expectThumbnailVisible(page, asset.id);
+  });
+
+  // 3. The member-level showInTimeline toggle (space page's own "More" overflow menu) is per-viewer:
+  // it gains/loses the space's photos on THAT member's personal /photos timeline.
+  test('viewer toggling "show in my timeline" gains/loses the linked photo on their main /photos timeline', async ({
+    context,
+    page,
+  }) => {
+    const { space, asset } = await createLinkedAlbumFixture(
+      owner.accessToken,
+      [{ userId: viewer.userId, role: SharedSpaceRole.Viewer }],
+      'S4b-3',
+    );
+    await utils.setAuthCookies(context, viewer.accessToken);
+
+    await page.goto(`/spaces/${space.id}`);
+    await toggleMemberShowInTimeline(page, space.id, /hide from timeline/i);
+
+    await gotoAndWaitForTimeline(page, '/photos');
+    await expectThumbnailAbsent(page, asset.id);
+
+    await page.goto(`/spaces/${space.id}`);
+    await toggleMemberShowInTimeline(page, space.id, /show on timeline/i);
+
+    await gotoAndWaitForTimeline(page, '/photos');
+    await expectThumbnailVisible(page, asset.id);
+  });
+
+  // 4. Owner hides a linked-album photo (AssetVisibility.Hidden has no dedicated UI control — it's
+  // set here via the same bulk-update API the server exposes, exactly as an internal visibility
+  // transition would arrive) → the viewer's space Photos tab drops it; restoring brings it back.
+  test("owner hiding a linked-album photo removes it from the viewer's space Photos tab; restoring brings it back", async ({
+    context,
+    page,
+  }) => {
+    const { space, asset } = await createLinkedAlbumFixture(
+      owner.accessToken,
+      [{ userId: viewer.userId, role: SharedSpaceRole.Viewer }],
+      'S4b-4',
+    );
+
+    await updateAssets(
+      { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Hidden } },
+      { headers: asBearerAuth(owner.accessToken) },
+    );
+
+    await utils.setAuthCookies(context, viewer.accessToken);
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`, 'discovery-timeline');
+    await expectThumbnailAbsent(page, asset.id);
+
+    await updateAssets(
+      { assetBulkUpdateDto: { ids: [asset.id], visibility: AssetVisibility.Timeline } },
+      { headers: asBearerAuth(owner.accessToken) },
+    );
+
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`, 'discovery-timeline');
+    await expectThumbnailVisible(page, asset.id);
+  });
+
+  // 5. Unlinking the album (performed via the API — spaces-albums.e2e-spec.ts's C4 block asserts
+  // the unlink menu's visibility per role but doesn't click through it; that UI affordance +
+  // confirmation-dialog round-trip is not exercised anywhere yet) drops it from the viewer's space
+  // Albums grid AND from the space Photos tab timeline.
+  test("unlinking the album drops it from the viewer's space Albums grid and Photos timeline", async ({
+    context,
+    page,
+  }) => {
+    const { space, album, asset } = await createLinkedAlbumFixture(
+      owner.accessToken,
+      [{ userId: viewer.userId, role: SharedSpaceRole.Viewer }],
+      'S4b-5',
+    );
+
+    await utils.unlinkSpaceAlbum(owner.accessToken, space.id, album.id);
+
+    await utils.setAuthCookies(context, viewer.accessToken);
+
+    await page.goto(`/spaces/${space.id}/albums`);
+    await expect(page.getByTestId('space-album-card-link').filter({ hasText: album.albumName })).toHaveCount(0);
+
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`, 'discovery-timeline');
+    await expectThumbnailAbsent(page, asset.id);
+  });
+});

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -52,6 +52,7 @@ where
     "asset"."ownerId" = any ($3::uuid[])
     or (
       "asset"."visibility" in ($4, $5)
+      and "asset"."deletedAt" is null
       and (
         exists (
           select
@@ -179,6 +180,7 @@ from
         "asset"."ownerId" = any ($1::uuid[])
         or (
           "asset"."visibility" in ($2, $3)
+          and "asset"."deletedAt" is null
           and (
             exists (
               select
@@ -278,6 +280,7 @@ drop as (
       "asset"."ownerId" = any ($1::uuid[])
       or (
         "asset"."visibility" in ($2, $3)
+        and "asset"."deletedAt" is null
         and (
           exists (
             select

--- a/server/src/queries/sync.repository.sql
+++ b/server/src/queries/sync.repository.sql
@@ -1326,6 +1326,7 @@ where
   and "shared_space_asset"."updateId" > $5
   and "shared_space_asset"."spaceId" = $6
   and "asset"."visibility" in ($7, $8)
+  and "asset"."deletedAt" is null
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1377,6 +1378,7 @@ where
       "shared_space_member"."userId" = $6
   )
   and "asset"."visibility" in ($7, $8)
+  and "asset"."deletedAt" is null
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1470,6 +1472,7 @@ where
   and "shared_space_asset"."updateId" > $3
   and "shared_space_asset"."spaceId" = $4
   and "asset"."visibility" in ($5, $6)
+  and "asset"."deletedAt" is null
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1524,6 +1527,7 @@ where
       "shared_space_member"."userId" = $4
   )
   and "asset"."visibility" in ($5, $6)
+  and "asset"."deletedAt" is null
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1596,6 +1600,7 @@ where
   and "shared_space_asset"."updateId" > $3
   and "shared_space_asset"."spaceId" = $4
   and "asset"."visibility" in ($5, $6)
+  and "asset"."deletedAt" is null
 order by
   "shared_space_asset"."updateId" asc
 
@@ -1794,7 +1799,10 @@ where
   and "asset"."libraryId" = $6
   and (
     "asset"."ownerId" = $7
-    or "asset"."visibility" in ($8, $9)
+    or (
+      "asset"."visibility" in ($8, $9)
+      and "asset"."deletedAt" is null
+    )
   )
 order by
   "asset"."updateId" asc
@@ -1998,7 +2006,10 @@ where
   and "asset"."libraryId" = $4
   and (
     "asset"."ownerId" = $5
-    or "asset"."visibility" in ($6, $7)
+    or (
+      "asset"."visibility" in ($6, $7)
+      and "asset"."deletedAt" is null
+    )
   )
 order by
   "asset"."updateId" asc
@@ -2342,6 +2353,7 @@ where
   and "album_asset"."updateId" <= $3
   and "album_asset"."updateId" > $4
   and "asset"."visibility" in ($5, $6)
+  and "asset"."deletedAt" is null
 union
 select
   "album_space_asset"."assetId" as "assetId",
@@ -2367,6 +2379,7 @@ where
       "shared_space_album"."albumId" = "album_space_asset"."albumId"
       and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
   )
+  and "asset"."deletedAt" is null
 order by
   "updateId" asc
 
@@ -2604,6 +2617,7 @@ where
   and "album_asset"."updateId" <= $5
   and "album_asset"."updateId" > $6
   and "asset"."visibility" in ($7, $8)
+  and "asset"."deletedAt" is null
 union
 select
   "asset"."id",
@@ -2652,6 +2666,7 @@ where
       "shared_space_album"."albumId" = "album_space_asset"."albumId"
       and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
   )
+  and "asset"."deletedAt" is null
 order by
   "updateId" asc
 
@@ -2848,6 +2863,7 @@ where
   and "album_asset"."updateId" < $6
   and "album_asset"."updateId" > $7
   and "asset"."visibility" in ($8, $9)
+  and "asset"."deletedAt" is null
 union
 select
   "asset"."id",
@@ -2918,6 +2934,7 @@ where
       "shared_space_album"."albumId" = "album_space_asset"."albumId"
       and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
   )
+  and "asset"."deletedAt" is null
 order by
   "updateId" asc
 
@@ -2961,6 +2978,7 @@ where
   and "album_asset"."updateId" <= $3
   and "album_asset"."updateId" > $4
   and "asset"."visibility" in ($5, $6)
+  and "asset"."deletedAt" is null
 union
 select
   "asset_exif"."assetId",
@@ -3012,6 +3030,7 @@ where
       "shared_space_album"."albumId" = "album_space_asset"."albumId"
       and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
   )
+  and "asset"."deletedAt" is null
 order by
   "updateId" asc
 
@@ -3217,6 +3236,7 @@ where
   and "album_asset"."updateId" < $4
   and "album_asset"."updateId" > $5
   and "asset"."visibility" in ($6, $7)
+  and "asset"."deletedAt" is null
 union
 select
   "asset_exif"."assetId",
@@ -3290,5 +3310,6 @@ where
       "shared_space_album"."albumId" = "album_space_asset"."albumId"
       and "shared_space_album"."spaceId" = "album_space_asset"."spaceId"
   )
+  and "asset"."deletedAt" is null
 order by
   "updateId" asc

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -987,22 +987,27 @@ export class SharedSpaceAssetSync extends BaseSync {
   // shared into the space.
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, spaceId: string, userId: string) {
-    return this.backfillQuery('shared_space_asset', options)
-      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
-      .select(columns.syncSharedSpaceAsset)
-      .select((eb) =>
-        eb
-          .case()
-          .when('asset.ownerId', '=', userId)
-          .then(eb.ref('asset.isFavorite'))
-          .else(eb.val(false))
-          .end()
-          .as('isFavorite'),
-      )
-      .select('shared_space_asset.updateId')
-      .where('shared_space_asset.spaceId', '=', spaceId)
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+    return (
+      this.backfillQuery('shared_space_asset', options)
+        .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
+        .select(columns.syncSharedSpaceAsset)
+        .select((eb) =>
+          eb
+            .case()
+            .when('asset.ownerId', '=', userId)
+            .then(eb.ref('asset.isFavorite'))
+            .else(eb.val(false))
+            .end()
+            .as('isFavorite'),
+        )
+        .select('shared_space_asset.updateId')
+        .where('shared_space_asset.spaceId', '=', spaceId)
+        .where((eb) => spaceVisibilityGate(eb))
+        // M-2: never backfill a trashed asset's metadata/thumbhash/EXIF to a space member. getUpdates
+        // stays unfiltered — that's the device-purge convergence channel (asset.updateId bump rides through).
+        .where('asset.deletedAt', 'is', null)
+        .stream()
+    );
   }
 
   // Create-side: stream new (space, asset) pairings the user can access. Each
@@ -1013,22 +1018,27 @@ export class SharedSpaceAssetSync extends BaseSync {
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getCreates(options: SyncQueryOptions) {
     const userId = options.userId;
-    return this.upsertQuery('shared_space_asset', options)
-      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
-      .select(columns.syncSharedSpaceAsset)
-      .select((eb) =>
-        eb
-          .case()
-          .when('asset.ownerId', '=', userId)
-          .then(eb.ref('asset.isFavorite'))
-          .else(eb.val(false))
-          .end()
-          .as('isFavorite'),
-      )
-      .select('shared_space_asset.updateId')
-      .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+    return (
+      this.upsertQuery('shared_space_asset', options)
+        .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
+        .select(columns.syncSharedSpaceAsset)
+        .select((eb) =>
+          eb
+            .case()
+            .when('asset.ownerId', '=', userId)
+            .then(eb.ref('asset.isFavorite'))
+            .else(eb.val(false))
+            .end()
+            .as('isFavorite'),
+        )
+        .select('shared_space_asset.updateId')
+        .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
+        .where((eb) => spaceVisibilityGate(eb))
+        // M-2: getCreates must not introduce a trashed asset a device didn't already have (getUpdates is the
+        // convergence channel for state changes on already-known assets).
+        .where('asset.deletedAt', 'is', null)
+        .stream()
+    );
   }
 
   // Update-side: stream asset metadata changes for assets the client has already
@@ -1064,26 +1074,36 @@ export class SharedSpaceAssetSync extends BaseSync {
 export class SharedSpaceAssetExifSync extends BaseSync {
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, spaceId: string) {
-    return this.backfillQuery('shared_space_asset', options)
-      .innerJoin('asset_exif', 'asset_exif.assetId', 'shared_space_asset.assetId')
-      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
-      .select(columns.syncAssetExif)
-      .select('shared_space_asset.updateId')
-      .where('shared_space_asset.spaceId', '=', spaceId)
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+    return (
+      this.backfillQuery('shared_space_asset', options)
+        .innerJoin('asset_exif', 'asset_exif.assetId', 'shared_space_asset.assetId')
+        .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
+        .select(columns.syncAssetExif)
+        .select('shared_space_asset.updateId')
+        .where('shared_space_asset.spaceId', '=', spaceId)
+        .where((eb) => spaceVisibilityGate(eb))
+        // M-2: never backfill a trashed asset's metadata/thumbhash/EXIF to a space member. getUpdates
+        // stays unfiltered — that's the device-purge convergence channel (asset.updateId bump rides through).
+        .where('asset.deletedAt', 'is', null)
+        .stream()
+    );
   }
 
   @GenerateSql({ params: [dummyQueryOptions], stream: true })
   getCreates(options: SyncQueryOptions) {
-    return this.upsertQuery('shared_space_asset', options)
-      .innerJoin('asset_exif', 'asset_exif.assetId', 'shared_space_asset.assetId')
-      .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
-      .select(columns.syncAssetExif)
-      .select('shared_space_asset.updateId')
-      .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
-      .where((eb) => spaceVisibilityGate(eb))
-      .stream();
+    return (
+      this.upsertQuery('shared_space_asset', options)
+        .innerJoin('asset_exif', 'asset_exif.assetId', 'shared_space_asset.assetId')
+        .innerJoin('asset', 'asset.id', 'shared_space_asset.assetId')
+        .select(columns.syncAssetExif)
+        .select('shared_space_asset.updateId')
+        .where('shared_space_asset.spaceId', 'in', (eb) => accessibleSpaces(eb, options.userId))
+        .where((eb) => spaceVisibilityGate(eb))
+        // M-2: getCreates must not introduce a trashed asset a device didn't already have (getUpdates is the
+        // convergence channel for state changes on already-known assets).
+        .where('asset.deletedAt', 'is', null)
+        .stream()
+    );
   }
 
   @GenerateSql({ params: [dummyQueryOptions, { updateId: DummyValue.UUID }], stream: true })
@@ -1121,6 +1141,8 @@ export class SharedSpaceToAssetSync extends BaseSync {
         // correctness-1/security-6: flat visibility gate — never stream a link row for a
         // Hidden/Locked asset (matches the SharedSpaceAssetSync content sibling; converges on restore).
         .where((eb) => spaceVisibilityGate(eb))
+        // M-2: don't backfill a link row for a trashed asset either (getUpserts stays the convergence channel).
+        .where('asset.deletedAt', 'is', null)
         .stream()
     );
   }
@@ -1278,21 +1300,30 @@ export class LibraryAssetSync extends BaseSync {
   // the owner's true favorite flag for an asset they don't own.
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, libraryId: string, userId: string) {
-    return this.backfillQuery('asset', options)
-      .select(columns.syncLibraryAsset)
-      .select((eb) =>
-        eb
-          .case()
-          .when('asset.ownerId', '=', userId)
-          .then(eb.ref('asset.isFavorite'))
-          .else(eb.val(false))
-          .end()
-          .as('isFavorite'),
-      )
-      .select('asset.updateId')
-      .where('asset.libraryId', '=', libraryId)
-      .where((eb) => eb.or([eb('asset.ownerId', '=', userId), spaceVisibilityGate(eb)]))
-      .stream();
+    return (
+      this.backfillQuery('asset', options)
+        .select(columns.syncLibraryAsset)
+        .select((eb) =>
+          eb
+            .case()
+            .when('asset.ownerId', '=', userId)
+            .then(eb.ref('asset.isFavorite'))
+            .else(eb.val(false))
+            .end()
+            .as('isFavorite'),
+        )
+        .select('asset.updateId')
+        .where('asset.libraryId', '=', libraryId)
+        // M-2: the non-owner (space-link) branch also excludes trashed assets; the owner keeps their own
+        // trashed library assets (owner branch unfiltered). getUpserts stays the convergence channel.
+        .where((eb) =>
+          eb.or([
+            eb('asset.ownerId', '=', userId),
+            eb.and([spaceVisibilityGate(eb), eb('asset.deletedAt', 'is', null)]),
+          ]),
+        )
+        .stream()
+    );
   }
 
   // Single upsert stream for library assets. Mirrors PartnerAssetsSync.getUpserts
@@ -1397,13 +1428,22 @@ export class LibraryAssetExifSync extends BaseSync {
   // can reference asset.ownerId and asset.visibility directly.
   @GenerateSql({ params: [dummyBackfillOptions, DummyValue.UUID, DummyValue.UUID], stream: true })
   getBackfill(options: SyncBackfillOptions, libraryId: string, userId: string) {
-    return this.backfillQuery('asset', options)
-      .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
-      .select(columns.syncAssetExif)
-      .select('asset.updateId')
-      .where('asset.libraryId', '=', libraryId)
-      .where((eb) => eb.or([eb('asset.ownerId', '=', userId), spaceVisibilityGate(eb)]))
-      .stream();
+    return (
+      this.backfillQuery('asset', options)
+        .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
+        .select(columns.syncAssetExif)
+        .select('asset.updateId')
+        .where('asset.libraryId', '=', libraryId)
+        // M-2: the non-owner (space-link) branch also excludes trashed assets; the owner keeps their own
+        // trashed library assets (owner branch unfiltered). getUpserts stays the convergence channel.
+        .where((eb) =>
+          eb.or([
+            eb('asset.ownerId', '=', userId),
+            eb.and([spaceVisibilityGate(eb), eb('asset.deletedAt', 'is', null)]),
+          ]),
+        )
+        .stream()
+    );
   }
 
   // Single upsert stream — same rationale as LibraryAssetSync.getUpserts.
@@ -1645,7 +1685,9 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
       .where('album_asset.updateId', '<=', beforeUpdateId)
       .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
       // correctness-1/security-6: flat visibility gate — never backfill a Hidden/Locked asset's link.
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // M-2: don't backfill a link row for a trashed album asset either (getUpserts stays convergence).
+      .where('asset.deletedAt', 'is', null);
 
     // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
     const contributedArm = this.db
@@ -1662,7 +1704,9 @@ class SharedSpaceAlbumToAssetSync extends BaseSync {
       .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
       .where((eb) => spaceVisibilityGate(eb))
       // #764/§8.3: only members of the space this contribution was made via may receive it.
-      .where((eb) => contributionVisibleToMember(eb, userId));
+      .where((eb) => contributionVisibleToMember(eb, userId))
+      // M-2: don't backfill a link row for a trashed contributed asset either (getUpserts stays convergence).
+      .where('asset.deletedAt', 'is', null);
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1791,7 +1835,9 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .where('album_asset.updateId', '<', nowId)
       .where('album_asset.updateId', '<=', beforeUpdateId)
       .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // M-2: never backfill a trashed owner-arm album asset to a space member either.
+      .where('asset.deletedAt', 'is', null);
 
     // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
     const contributedArm = this.db
@@ -1816,7 +1862,9 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
       .where((eb) => spaceVisibilityGate(eb))
       // #764/§8.3: only members of the space this contribution was made via may receive it.
-      .where((eb) => contributionVisibleToMember(eb, userId));
+      .where((eb) => contributionVisibleToMember(eb, userId))
+      // M-2: never backfill a trashed contributed asset's metadata/thumbhash/EXIF to a space member.
+      .where('asset.deletedAt', 'is', null);
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1900,7 +1948,9 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .where('album_asset.updateId', '<', nowId)
       .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // M-2: getCreates must not introduce a trashed owner-arm album asset a device didn't already have.
+      .where('asset.deletedAt', 'is', null);
 
     // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
     const contributedArm = this.db
@@ -1924,7 +1974,9 @@ class SharedSpaceAlbumAssetSync extends BaseSync {
       .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
       .where((eb) => spaceVisibilityGate(eb))
       // #764/§8.3: only members of the space this contribution was made via may receive it.
-      .where((eb) => contributionVisibleToMember(eb, userId));
+      .where((eb) => contributionVisibleToMember(eb, userId))
+      // M-2: getCreates must not introduce a trashed contributed asset a device didn't already have.
+      .where('asset.deletedAt', 'is', null);
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -1953,7 +2005,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .where('album_asset.updateId', '<', nowId)
       .where('album_asset.updateId', '<=', beforeUpdateId)
       .$if(!!afterUpdateId, (qb) => qb.where('album_asset.updateId', '>', afterUpdateId!))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // M-2: never backfill a trashed owner-arm album asset to a space member either.
+      .where('asset.deletedAt', 'is', null);
 
     // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
     const contributedArm = this.db
@@ -1970,7 +2024,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .$if(!!afterUpdateId, (qb) => qb.where('album_space_asset.updateId', '>', afterUpdateId!))
       .where((eb) => spaceVisibilityGate(eb))
       // #764/§8.3: only members of the space this contribution was made via may receive it.
-      .where((eb) => contributionVisibleToMember(eb, userId));
+      .where((eb) => contributionVisibleToMember(eb, userId))
+      // M-2: never backfill a trashed contributed asset's metadata/thumbhash/EXIF to a space member.
+      .where('asset.deletedAt', 'is', null);
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }
@@ -2030,7 +2086,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .where('album_asset.albumId', 'in', (eb) => accessibleSpaceAlbums(eb, userId))
       .where('album_asset.updateId', '<', nowId)
       .$if(!!ack, (qb) => qb.where('album_asset.updateId', '>', ack!.updateId))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // M-2: getCreates must not introduce a trashed owner-arm album asset a device didn't already have.
+      .where('asset.deletedAt', 'is', null);
 
     // album_space_asset arm — cross-owner contributions (#764). Mechanical mirror keyed on updateId.
     const contributedArm = this.db
@@ -2046,7 +2104,9 @@ class SharedSpaceAlbumAssetExifSync extends BaseSync {
       .$if(!!ack, (qb) => qb.where('album_space_asset.updateId', '>', ack!.updateId))
       .where((eb) => spaceVisibilityGate(eb))
       // #764/§8.3: only members of the space this contribution was made via may receive it.
-      .where((eb) => contributionVisibleToMember(eb, userId));
+      .where((eb) => contributionVisibleToMember(eb, userId))
+      // M-2: getCreates must not introduce a trashed contributed asset's EXIF a device didn't already have.
+      .where('asset.deletedAt', 'is', null);
 
     return albumAssetArm.union(contributedArm).orderBy('updateId', 'asc').stream();
   }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1385,15 +1385,27 @@ describe(AssetService.name, () => {
       expect(mocks.sharedSpace.emitAlbumAssetVisibilityPurge).toHaveBeenCalledWith(['asset-1', 'asset-2']);
     });
 
-    it('removes from albums exactly once (lock-once) but still re-purges on a re-lock (M3 retry-convergence)', async () => {
+    it('re-locking an already-Locked asset still strips it from albums (M-1 retry-convergence)', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
       mocks.asset.getByIds.mockResolvedValue([{ id: 'asset-1', visibility: AssetVisibility.Locked } as any]);
       await sut.updateAll(authStub.admin, { ids: ['asset-1'], visibility: AssetVisibility.Locked });
-      // lock-once is unchanged: removeAssetsFromAll is gated on prior !== Locked, so a re-lock skips it.
-      expect(mocks.album.removeAssetsFromAll).not.toHaveBeenCalled(); // already Locked → no-op
-      // M3: the purge itself is unconditional on the non-shareable next, so a re-lock still re-purges
-      // (idempotent tombstone) — this is what makes a retry after a failed emit converge.
+      // M-1: the album strip is now UNCONDITIONAL on Locked (no prior!==Locked "lock-once" gate). A crash
+      // between the visibility UPDATE and the strip left the album_asset rows with no tombstone, and the old
+      // gate then read prior=Locked on retry and skipped the strip forever (durable on-device leak + silent
+      // re-share on unlock). Re-running is idempotent (already-stripped → zero rows) and recovers a crashed
+      // first attempt (deletes surviving rows → the delete-audit trigger fires the tombstone).
+      expect(mocks.album.removeAssetsFromAll).toHaveBeenCalledWith(['asset-1']);
+      // The direct purge stays unconditional/idempotent on a non-shareable next (M3).
       expect(mocks.sharedSpace.emitDirectAssetVisibilityPurge).toHaveBeenCalledWith(['asset-1']);
+    });
+
+    it('does not strip albums on a Locked transition with an empty id list (M-1 empty-batch guard)', async () => {
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set());
+      mocks.asset.getByIds.mockResolvedValue([]);
+      // An empty ids array is API-reachable (PUT /assets {ids:[], visibility:locked}). removeAssetsFromAll
+      // has no empty guard and an empty `IN ()` is invalid SQL, so the strip must be length-gated.
+      await sut.updateAll(authStub.admin, { ids: [], visibility: AssetVisibility.Locked });
+      expect(mocks.album.removeAssetsFromAll).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -432,12 +432,18 @@ export class AssetService extends BaseService {
     }
 
     // nextVisibility is non-shareable (Hidden or Locked).
-    if (nextVisibility === AssetVisibility.Locked) {
-      // Strip album membership exactly once — skip assets already Locked (re-lock = no-op).
-      const lockIds = ids.filter((id) => priorVisibilities.get(id) !== AssetVisibility.Locked);
-      if (lockIds.length > 0) {
-        await this.albumRepository.removeAssetsFromAll(lockIds);
-      }
+    // M-1: strip album membership UNCONDITIONALLY on Locked — do NOT gate on prior !== Locked. The old
+    // "lock-once" gate was not retry-convergent: a crash between the visibility UPDATE and this strip left
+    // the album_asset rows in place with no tombstone, and on retry priorVisibilities read Locked so the
+    // strip was skipped FOREVER — a durable on-device leak, plus a silent re-share into the space when the
+    // asset was later unlocked (the surviving album_asset rows were restored). Calling removeAssetsFromAll
+    // on every id is idempotent: an already-stripped asset matches zero rows (a no-op), while a
+    // crashed-first-attempt asset gets its surviving rows deleted and the album delete-audit trigger fires
+    // the tombstone the crashed attempt never sent (delivered via SharedSpaceAlbumToAssetSync.getDeletes).
+    // Keep the empty-batch guard (removeAssetsFromAll has none — an empty `IN ()` is invalid SQL), matching
+    // the purge/restore branches in this method.
+    if (nextVisibility === AssetVisibility.Locked && ids.length > 0) {
+      await this.albumRepository.removeAssetsFromAll(ids);
     }
 
     // Purge: unconditional on every id whenever nextVisibility is non-shareable (M3, retry-convergent).

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1730,6 +1730,68 @@ describe(SearchService.name, () => {
     });
   });
 
+  describe('H-1: trash / offline params rejected under a shared-space scope', () => {
+    const runners: Array<{ name: string; run: (dto: Record<string, unknown>) => Promise<unknown> }> = [
+      { name: 'searchMetadata', run: (dto) => sut.searchMetadata(authStub.user1, dto) },
+      { name: 'searchRandom', run: (dto) => sut.searchRandom(authStub.user1, dto) },
+      { name: 'searchLargeAssets', run: (dto) => sut.searchLargeAssets(authStub.user1, dto) },
+      { name: 'searchStatistics', run: (dto) => sut.searchStatistics(authStub.user1, dto) },
+      { name: 'searchSmart', run: (dto) => sut.searchSmart(authStub.user1, { query: 'test', ...dto }) },
+    ];
+
+    const trashParams: Array<{ label: string; param: Record<string, unknown>; needsWithDeleted?: boolean }> = [
+      { label: 'withDeleted', param: { withDeleted: true }, needsWithDeleted: true },
+      { label: 'trashedAfter', param: { trashedAfter: new Date('1970-01-01T00:00:00.000Z') } },
+      { label: 'trashedBefore', param: { trashedBefore: new Date('2999-01-01T00:00:00.000Z') } },
+      { label: 'isOffline', param: { isOffline: true } },
+    ];
+
+    const scopes: Array<{ label: string; scope: Record<string, unknown> }> = [
+      { label: 'spaceId', scope: { spaceId: newUuid() } },
+      { label: 'withSharedSpaces', scope: { withSharedSpaces: true } },
+    ];
+
+    const message = 'Trashed and offline assets are not available when searching a shared space';
+
+    for (const runner of runners) {
+      for (const scope of scopes) {
+        for (const tp of trashParams) {
+          // StatisticsSearchDto has no `withDeleted` field (zod strips it); it can only be reached
+          // via the implicit-flip params (trashedAfter/trashedBefore/isOffline), so withDeleted is
+          // not a real code path there.
+          if (runner.name === 'searchStatistics' && tp.needsWithDeleted) {
+            continue;
+          }
+          it(`${runner.name} rejects ${tp.label} with ${scope.label}`, async () => {
+            await expect(runner.run({ ...scope.scope, ...tp.param })).rejects.toThrow(message);
+          });
+        }
+      }
+    }
+
+    it('does not reject a plain space search with no trash params (searchMetadata)', async () => {
+      const spaceId = newUuid();
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.search.searchMetadata.mockResolvedValue({ hasNextPage: false, items: [] });
+
+      await expect(sut.searchMetadata(authStub.user1, { spaceId })).resolves.toBeDefined();
+    });
+
+    it('does not reject withDeleted outside a space scope (searchMetadata)', async () => {
+      mocks.search.searchMetadata.mockResolvedValue({ hasNextPage: false, items: [] });
+
+      await expect(sut.searchMetadata(authStub.user1, { withDeleted: true })).resolves.toBeDefined();
+    });
+
+    it('does not over-block isOffline=false under a space scope (searchMetadata)', async () => {
+      const spaceId = newUuid();
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.search.searchMetadata.mockResolvedValue({ hasNextPage: false, items: [] });
+
+      await expect(sut.searchMetadata(authStub.user1, { spaceId, isOffline: false })).resolves.toBeDefined();
+    });
+  });
+
   describe('getAssetsByCity', () => {
     it('should get assets by city', async () => {
       const asset = AssetFactory.from().build();

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -114,7 +114,32 @@ export class SearchService extends BaseService {
     ];
   }
 
+  /**
+   * Fork RBAC (H-1): trash is an owner-private state; a shared-space-scoped search must never enumerate
+   * another member's trashed assets. Reject withDeleted / trashedAfter / trashedBefore / isOffline when a
+   * space scope (spaceId or withSharedSpaces) is set — mirrors timeBucketChecks (timeline.service.ts) and
+   * the caller-proof SQL gate in searchAssetBuilder. trashedAfter/trashedBefore/isOffline implicitly flip
+   * withDeleted (searchAssetBuilder :676), so they are rejected too. StatisticsSearchDto has no withDeleted
+   * field (optional here → undefined); it is still reachable via the implicit-flip params.
+   */
+  private rejectTrashParamsForSpaceScope(dto: {
+    spaceId?: string;
+    withSharedSpaces?: boolean;
+    withDeleted?: boolean;
+    trashedAfter?: Date;
+    trashedBefore?: Date;
+    isOffline?: boolean;
+  }): void {
+    const spaceScope = !!dto.spaceId || !!dto.withSharedSpaces;
+    const wantsTrashOrOffline = !!dto.withDeleted || !!dto.trashedAfter || !!dto.trashedBefore || !!dto.isOffline;
+    if (spaceScope && wantsTrashOrOffline) {
+      throw new BadRequestException('Trashed and offline assets are not available when searching a shared space');
+    }
+  }
+
   async searchMetadata(auth: AuthDto, dto: MetadataSearchDto): Promise<SearchResponseDto> {
+    this.rejectTrashParamsForSpaceScope(dto);
+
     if (dto.visibility === AssetVisibility.Locked) {
       requireElevatedPermission(auth);
     }
@@ -166,6 +191,8 @@ export class SearchService extends BaseService {
   }
 
   async searchStatistics(auth: AuthDto, dto: StatisticsSearchDto): Promise<SearchStatisticsResponseDto> {
+    this.rejectTrashParamsForSpaceScope(dto);
+
     if (dto.spaceId && dto.withSharedSpaces) {
       throw new BadRequestException('Cannot use both spaceId and withSharedSpaces');
     }
@@ -193,6 +220,8 @@ export class SearchService extends BaseService {
   }
 
   async searchRandom(auth: AuthDto, dto: RandomSearchDto): Promise<AssetResponseDto[]> {
+    this.rejectTrashParamsForSpaceScope(dto);
+
     if (dto.visibility === AssetVisibility.Locked) {
       requireElevatedPermission(auth);
     }
@@ -221,6 +250,8 @@ export class SearchService extends BaseService {
   }
 
   async searchLargeAssets(auth: AuthDto, dto: LargeAssetSearchDto): Promise<AssetResponseDto[]> {
+    this.rejectTrashParamsForSpaceScope(dto);
+
     if (dto.visibility === AssetVisibility.Locked) {
       requireElevatedPermission(auth);
     }
@@ -442,6 +473,8 @@ export class SearchService extends BaseService {
     if ('visibility' in dto && dto.visibility === AssetVisibility.Locked) {
       requireElevatedPermission(auth);
     }
+
+    this.rejectTrashParamsForSpaceScope(dto);
 
     if (dto.spaceId && dto.withSharedSpaces) {
       throw new BadRequestException('Cannot use both spaceId and withSharedSpaces');

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -729,7 +729,13 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
           // browse / timeline gate) — Hidden and Locked are never surfaced for other members.
           eb.or([
             ...(options.userIds ? [eb('asset.ownerId', '=', anyUuid(options.userIds))] : []),
-            spaceVisibilityGate(eb),
+            // Fork RBAC (H-1): the other-members branch must ALSO exclude trashed assets, mirroring
+            // albumSharedSpaceScope. Without this, a member (incl. a read-only Viewer) can pull another
+            // member's trashed asset by flipping withDeleted — directly or implicitly via
+            // trashedAfter/trashedBefore/isOffline (see :676) — because the terminal deletedAt filter
+            // (:850) is caller-skippable. The ownerId branch stays unfiltered so a caller keeps
+            // own/partner trash search.
+            eb.and([spaceVisibilityGate(eb), eb('asset.deletedAt', 'is', null)]),
           ]),
         ]),
       ),
@@ -743,6 +749,10 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
           // elevation is per-owner, Hidden/Locked never surface for other members).
           eb.and([
             spaceVisibilityGate(eb),
+            // Fork RBAC (H-1): not-trashed on the other-members branch too (the ownerId branch above is
+            // left unfiltered). Mirrors the spaceId arm and albumSharedSpaceScope; never rely on the
+            // caller-skippable terminal deletedAt filter (:850).
+            eb('asset.deletedAt', 'is', null),
             eb.or(
               spaceAssetPathBranches(eb, {
                 correlateAssetId: 'asset.id',

--- a/server/test/medium/specs/services/asset.service.spec.ts
+++ b/server/test/medium/specs/services/asset.service.spec.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
 import { StorageCore } from 'src/cores/storage.core';
 import { AssetEditAction } from 'src/dtos/editing.dto';
-import { AssetFileType, AssetMetadataKey, AssetStatus, JobName, SharedLinkType } from 'src/enum';
+import { AssetFileType, AssetMetadataKey, AssetStatus, AssetVisibility, JobName, SharedLinkType } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { AssetEditRepository } from 'src/repositories/asset-edit.repository';
@@ -470,6 +470,30 @@ describe(AssetService.name, () => {
       ).resolves.toEqual({
         lockedProperties: ['timeZone', 'rating', 'description', 'latitude', 'longitude', 'dateTimeOriginal'],
       });
+    });
+
+    it('re-locking an already-Locked asset strips its surviving album_asset rows (M-1 retry-convergence)', async () => {
+      const { sut, ctx } = setup();
+      ctx.getMock(JobRepository).queueAll.mockResolvedValue();
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user, session: { hasElevatedPermission: true } });
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      // Simulate the crash window: the visibility UPDATE committed (asset is already Locked) but the album
+      // strip never ran, so the album_asset row survived — exactly the state the old lock-once gate could
+      // never recover from (a re-lock read prior=Locked and skipped removeAssetsFromAll forever).
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const before = await ctx.database.selectFrom('album_asset').selectAll().where('assetId', '=', asset.id).execute();
+      expect(before).toHaveLength(1);
+
+      // Retry the lock. With the M-1 fix the strip is unconditional on Locked.
+      await sut.updateAll(auth, { ids: [asset.id], visibility: AssetVisibility.Locked });
+
+      // The surviving album_asset row is deleted (recovering the crashed first attempt); the album
+      // delete-audit trigger fires the tombstone that reaches synced members via getDeletes.
+      const after = await ctx.database.selectFrom('album_asset').selectAll().where('assetId', '=', asset.id).execute();
+      expect(after).toHaveLength(0);
     });
 
     it('should relatively update assets', async () => {

--- a/server/test/medium/specs/sync/sync-space-backfill-trash.medium.spec.ts
+++ b/server/test/medium/specs/sync/sync-space-backfill-trash.medium.spec.ts
@@ -1,0 +1,203 @@
+// M-2 — the space-member-facing sync BACKFILL / getCreates content arms must never stream a
+// TRASHED asset's metadata / thumbhash / EXIF (incl. GPS) to a member. Without an
+// `asset.deletedAt IS NULL` gate a newly-joined member's initial backfill leaks the trashed
+// asset's filename, a reconstructable thumbhash and its coordinates — data reachable through no
+// REST surface post-H1. The getUpdates / getUpserts convergence arms stay UNFILTERED: that is how
+// an already-synced device learns to hide/purge a newly-trashed asset (the asset.updateId bump
+// rides through). Sync-side sibling of H-1.
+import { Kysely } from 'kysely';
+import { AssetVisibility, SharedSpaceRole, SyncEntityType } from 'src/enum';
+import { SyncRepository } from 'src/repositories/sync.repository';
+import { DB } from 'src/schema';
+import { SyncTestContext } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const NOW_ID = 'ffffffff-ffff-7fff-bfff-ffffffffffff';
+const BEFORE_UPDATE_ID = 'ffffffff-ffff-7fff-bfff-ffffffffffff';
+
+const setup = () => new SyncTestContext(defaultDatabase);
+
+const collect = async (stream: AsyncIterable<unknown>): Promise<any[]> => {
+  const rows: any[] = [];
+  for await (const row of stream) {
+    rows.push(row);
+  }
+  return rows;
+};
+
+const trash = (db: Kysely<DB>, assetId: string) =>
+  db.updateTable('asset').set({ deletedAt: new Date() }).where('id', '=', assetId).execute();
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe('M-2: SharedSpaceAlbumAssetSync — backfill/getCreates exclude trashed; getUpdates still delivers', () => {
+  it('getBackfill excludes a trashed album asset (live sibling present)', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).sharedSpaceAlbumAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset: live } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: trashed } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: live.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: trashed.id });
+    await trash(defaultDatabase, trashed.id);
+
+    const rows = await collect(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, member.id),
+    );
+    const ids = rows.map((r) => r.id);
+
+    expect(ids).toContain(live.id);
+    expect(ids).not.toContain(trashed.id);
+  });
+
+  it('getCreates excludes a trashed album asset for a grant holder', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).sharedSpaceAlbumAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset: live } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: trashed } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: live.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: trashed.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await trash(defaultDatabase, trashed.id);
+
+    const rows = await collect(sut.getCreates({ nowId: NOW_ID, userId: member.id }));
+    const ids = rows.map((r) => r.id);
+
+    expect(ids).toContain(live.id);
+    expect(ids).not.toContain(trashed.id);
+  });
+
+  it('getUpdates STILL delivers a trashed album asset (device-purge convergence channel)', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).sharedSpaceAlbumAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Editor });
+    await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+    await trash(defaultDatabase, asset.id);
+
+    const rows = await collect(
+      sut.getUpdates(
+        { nowId: NOW_ID, userId: member.id },
+        { type: SyncEntityType.AlbumToAssetV1, updateId: BEFORE_UPDATE_ID },
+      ),
+    );
+
+    // The trashed row must still be delivered so the already-synced member's device learns to purge it.
+    expect(rows.map((r) => r.id)).toContain(asset.id);
+    expect(rows.find((r) => r.id === asset.id)?.deletedAt).not.toBeNull();
+  });
+});
+
+describe('M-2: SharedSpaceAlbumAssetExifSync — backfill excludes trashed EXIF (GPS)', () => {
+  it('getBackfill excludes the EXIF of a trashed album asset', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).sharedSpaceAlbumAssetExif;
+    const { user: owner } = await ctx.newUser();
+    const { album } = await ctx.newAlbum({ ownerId: owner.id });
+    const { asset: live } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: trashed } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newExif({ assetId: live.id, make: 'LiveCamera' });
+    await ctx.newExif({ assetId: trashed.id, make: 'TrashedCamera' });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: live.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: trashed.id });
+    await trash(defaultDatabase, trashed.id);
+
+    const rows = await collect(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, album.id, owner.id),
+    );
+    const ids = rows.map((r) => r.assetId);
+
+    expect(ids).toContain(live.id);
+    expect(ids).not.toContain(trashed.id);
+  });
+});
+
+describe('M-2: SharedSpaceAssetSync (direct) — backfill excludes trashed', () => {
+  it('getBackfill excludes a trashed direct-space asset', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).sharedSpaceAsset;
+    const { user: owner } = await ctx.newUser();
+    const { user: member } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+    const { asset: live } = await ctx.newAsset({ ownerId: owner.id });
+    const { asset: trashed } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: live.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: trashed.id });
+    await trash(defaultDatabase, trashed.id);
+
+    const rows = await collect(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, space.id, member.id),
+    );
+    const ids = rows.map((r) => r.id);
+
+    expect(ids).toContain(live.id);
+    expect(ids).not.toContain(trashed.id);
+  });
+});
+
+const seedLibraryInSpace = async (ctx: SyncTestContext) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { library } = await ctx.newLibrary({ ownerId: owner.id, name: 'Lib' });
+  const { asset: live } = await ctx.newAsset({
+    ownerId: owner.id,
+    libraryId: library.id,
+    visibility: AssetVisibility.Timeline,
+  });
+  const { asset: trashed } = await ctx.newAsset({
+    ownerId: owner.id,
+    libraryId: library.id,
+    visibility: AssetVisibility.Timeline,
+  });
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+  await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: owner.id });
+  await trash(defaultDatabase, trashed.id);
+  return { owner, member, library, live, trashed };
+};
+
+describe('M-2: LibraryAssetSync — non-owner backfill excludes trashed; owner keeps their own', () => {
+  it('a non-owner member does NOT receive the trashed library asset', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).libraryAsset;
+    const { member, library, live, trashed } = await seedLibraryInSpace(ctx);
+
+    const rows = await collect(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, library.id, member.id),
+    );
+    const ids = rows.map((r) => r.id);
+
+    expect(ids).toContain(live.id);
+    expect(ids).not.toContain(trashed.id);
+  });
+
+  it('the owner still receives their OWN trashed library asset (owner branch unfiltered)', async () => {
+    const ctx = setup();
+    const sut = ctx.get(SyncRepository).libraryAsset;
+    const { owner, library, trashed } = await seedLibraryInSpace(ctx);
+
+    const rows = await collect(
+      sut.getBackfill({ nowId: NOW_ID, beforeUpdateId: BEFORE_UPDATE_ID }, library.id, owner.id),
+    );
+    const ids = rows.map((r) => r.id);
+
+    expect(ids).toContain(trashed.id);
+  });
+});

--- a/server/test/medium/specs/utils/search-space-trash-gate.medium.spec.ts
+++ b/server/test/medium/specs/utils/search-space-trash-gate.medium.spec.ts
@@ -1,0 +1,148 @@
+// H-1 — caller-proof trash gate on the two searchAssetBuilder space arms.
+// The other-members branch of the `spaceId` arm and the `timelineSpaceIds`
+// (withSharedSpaces) arm must AND `asset.deletedAt IS NULL`, so a space member
+// cannot pull another member's trashed asset by flipping the caller-toggleable
+// terminal trash filter (withDeleted / trashedAfter / trashedBefore / isOffline).
+// The caller's OWN (ownerId IN userIds) branch stays unfiltered so own/partner
+// trash search is preserved. Sibling of the fixed albumSharedSpaceScope arm
+// (see shared-space-album-scope-sql.medium.spec.ts).
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { searchAssetBuilder } from 'src/utils/database';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let db: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx };
+};
+
+type Ctx = ReturnType<typeof setup>['ctx'];
+
+const builtIds = async (options: AssetSearchBuilderOptions): Promise<Set<string>> => {
+  const rows = await searchAssetBuilder(db, options).select('asset.id').execute();
+  return new Set(rows.map((r) => r.id as string));
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+const seed = async (ctx: Ctx) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: viewer } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: 'viewer' });
+
+  // Two of the owner's assets shared directly into the space; both Timeline
+  // (pass spaceVisibilityGate). One is then trashed (deletedAt set, link row survives).
+  const { asset: live } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+  const { asset: trashed } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: live.id, addedById: owner.id });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: trashed.id, addedById: owner.id });
+  await ctx.softDeleteAsset(trashed.id);
+
+  return { space, owner, viewer, live, trashed };
+};
+
+describe('H-1: searchAssetBuilder space arms exclude other members trashed assets', () => {
+  describe('spaceId arm', () => {
+    it('excludes another member trashed asset with withDeleted=true; live sibling present', async () => {
+      const { ctx } = setup();
+      const { space, viewer, live, trashed } = await seed(ctx);
+
+      const ids = await builtIds({ spaceId: space.id, userIds: [viewer.id], withDeleted: true });
+
+      expect(ids.has(live.id)).toBe(true);
+      expect(ids.has(trashed.id)).toBe(false);
+    });
+
+    it('owner branch still returns the callers OWN trashed asset with withDeleted=true', async () => {
+      const { ctx } = setup();
+      const { space, owner, live, trashed } = await seed(ctx);
+
+      const ids = await builtIds({ spaceId: space.id, userIds: [owner.id], withDeleted: true });
+
+      expect(ids.has(live.id)).toBe(true);
+      // owner searches their own space scope: their OWN trash stays reachable (owner branch unfiltered)
+      expect(ids.has(trashed.id)).toBe(true);
+    });
+
+    it('trashedAfter implicitly flips withDeleted but the other-members gate still excludes their trash', async () => {
+      const { ctx } = setup();
+      const { space, owner, viewer, trashed } = await seed(ctx);
+
+      // trashedAfter adds `asset.deletedAt >= date` (database.ts:745), so it filters to trashed assets
+      // and the non-trashed `live` sibling is legitimately absent. The security property under test:
+      // the viewer must NOT receive another member's trashed asset via the implicit withDeleted flip...
+      const viewerIds = await builtIds({
+        spaceId: space.id,
+        userIds: [viewer.id],
+        trashedAfter: new Date('1970-01-01T00:00:00.000Z'),
+      });
+      expect(viewerIds.has(trashed.id)).toBe(false);
+
+      // ...while the owner can still reach their OWN trashed asset via trashedAfter (owner branch unfiltered).
+      const ownerIds = await builtIds({
+        spaceId: space.id,
+        userIds: [owner.id],
+        trashedAfter: new Date('1970-01-01T00:00:00.000Z'),
+      });
+      expect(ownerIds.has(trashed.id)).toBe(true);
+    });
+
+    it('trashedBefore implicitly flips withDeleted but the other-members gate still excludes their trash', async () => {
+      const { ctx } = setup();
+      const { space, owner, viewer, trashed } = await seed(ctx);
+
+      // trashedBefore adds `asset.deletedAt <= date` (database.ts:745); like trashedAfter it filters to
+      // trashed assets. The viewer must NOT receive another member's trashed asset via the implicit flip...
+      const viewerIds = await builtIds({
+        spaceId: space.id,
+        userIds: [viewer.id],
+        trashedBefore: new Date('2999-01-01T00:00:00.000Z'),
+      });
+      expect(viewerIds.has(trashed.id)).toBe(false);
+
+      // ...while the owner can still reach their OWN trashed asset (owner branch unfiltered).
+      const ownerIds = await builtIds({
+        spaceId: space.id,
+        userIds: [owner.id],
+        trashedBefore: new Date('2999-01-01T00:00:00.000Z'),
+      });
+      expect(ownerIds.has(trashed.id)).toBe(true);
+    });
+  });
+
+  describe('timelineSpaceIds (withSharedSpaces) arm', () => {
+    it('excludes another member trashed asset with withDeleted=true; live sibling present', async () => {
+      const { ctx } = setup();
+      const { space, viewer, live, trashed } = await seed(ctx);
+
+      const ids = await builtIds({ timelineSpaceIds: [space.id], userIds: [viewer.id], withDeleted: true });
+
+      expect(ids.has(live.id)).toBe(true);
+      expect(ids.has(trashed.id)).toBe(false);
+    });
+
+    it('owner branch still returns the callers OWN trashed asset with withDeleted=true', async () => {
+      const { ctx } = setup();
+      const { space, owner, trashed } = await seed(ctx);
+
+      const ids = await builtIds({ timelineSpaceIds: [space.id], userIds: [owner.id], withDeleted: true });
+
+      expect(ids.has(trashed.id)).toBe(true);
+    });
+  });
+});

--- a/web/src/lib/components/spaces/space-onboarding-banner.spec.ts
+++ b/web/src/lib/components/spaces/space-onboarding-banner.spec.ts
@@ -1,6 +1,8 @@
 import type { SharedSpaceResponseDto } from '@immich/sdk';
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import SpaceOnboardingBanner from '$lib/components/spaces/space-onboarding-banner.svelte';
+import { dismissedOnboardingSpaceIds } from '$lib/stores/space-view.store';
 
 const makeSpace = (overrides: Partial<SharedSpaceResponseDto> = {}): SharedSpaceResponseDto => ({
   id: 'space-1',
@@ -29,6 +31,11 @@ const defaultProps = {
 };
 
 describe('SpaceOnboardingBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    dismissedOnboardingSpaceIds.reset();
+  });
+
   it('should render banner when no steps are complete', () => {
     render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace() });
     expect(screen.getByTestId('onboarding-banner')).toBeInTheDocument();
@@ -226,6 +233,54 @@ describe('SpaceOnboardingBanner', () => {
       expect(screen.getByTestId('step-add-photos-action')).toBeInTheDocument();
       expect(screen.getByTestId('step-invite-members-check')).toBeInTheDocument();
       expect(screen.getByTestId('step-set-cover-check')).toBeInTheDocument();
+    });
+  });
+
+  describe('dismiss', () => {
+    it('should render a dismiss button when the banner is shown', () => {
+      render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace() });
+      expect(screen.getByTestId('banner-dismiss')).toBeInTheDocument();
+    });
+
+    it('should remove the banner from the DOM when dismiss is clicked', async () => {
+      render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace() });
+      expect(screen.getByTestId('onboarding-banner')).toBeInTheDocument();
+
+      await fireEvent.click(screen.getByTestId('banner-dismiss'));
+
+      expect(screen.queryByTestId('onboarding-banner')).not.toBeInTheDocument();
+    });
+
+    it('should persist the dismissed space id to localStorage when dismissed', async () => {
+      render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace({ id: 'space-1' }) });
+
+      await fireEvent.click(screen.getByTestId('banner-dismiss'));
+
+      expect(get(dismissedOnboardingSpaceIds)).toContain('space-1');
+      expect(localStorage.getItem('dismissed-onboarding-space-ids')).toContain('space-1');
+    });
+
+    it('should not render when the space has already been dismissed', () => {
+      dismissedOnboardingSpaceIds.set(['space-1']);
+      render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace({ id: 'space-1' }) });
+      expect(screen.queryByTestId('onboarding-banner')).not.toBeInTheDocument();
+    });
+
+    it('should be per-space: dismissing one space does not hide another', () => {
+      dismissedOnboardingSpaceIds.set(['space-1']);
+      render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace({ id: 'space-2' }) });
+      expect(screen.getByTestId('onboarding-banner')).toBeInTheDocument();
+    });
+
+    it('should not add duplicate ids when dismissed twice across renders', async () => {
+      const { unmount } = render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace({ id: 'space-1' }) });
+      await fireEvent.click(screen.getByTestId('banner-dismiss'));
+      unmount();
+
+      dismissedOnboardingSpaceIds.set(['space-1']);
+      render(SpaceOnboardingBanner, { ...defaultProps, space: makeSpace({ id: 'space-1' }) });
+
+      expect(get(dismissedOnboardingSpaceIds).filter((id) => id === 'space-1')).toHaveLength(1);
     });
   });
 

--- a/web/src/lib/components/spaces/space-onboarding-banner.svelte
+++ b/web/src/lib/components/spaces/space-onboarding-banner.svelte
@@ -6,11 +6,13 @@
     mdiChevronDown,
     mdiChevronRight,
     mdiChevronUp,
+    mdiClose,
     mdiImageFilterHdrOutline,
     mdiImagePlusOutline,
   } from '@mdi/js';
   import { Icon } from '@immich/ui';
   import { t } from 'svelte-i18n';
+  import { dismissedOnboardingSpaceIds } from '$lib/stores/space-view.store';
 
   interface Props {
     space: SharedSpaceResponseDto;
@@ -23,6 +25,12 @@
   let { space, gradientClass = '', onAddPhotos, onInviteMembers, onSetCover }: Props = $props();
 
   let collapsed = $state(false);
+
+  const dismissed = $derived($dismissedOnboardingSpaceIds.includes(space.id));
+
+  const dismiss = () => {
+    dismissedOnboardingSpaceIds.update((ids) => (ids.includes(space.id) ? ids : [...ids, space.id]));
+  };
 
   const hasPhotos = $derived((space.assetCount ?? 0) > 0);
   const hasMembers = $derived((space.memberCount ?? 0) > 1);
@@ -60,7 +68,7 @@
   ]);
 </script>
 
-{#if !allComplete}
+{#if !allComplete && !dismissed}
   <div
     class="mx-4 mt-4 mb-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-immich-dark-gray"
     data-testid="onboarding-banner"
@@ -80,15 +88,26 @@
       <p class="text-sm font-medium text-gray-600 dark:text-gray-300" data-testid="progress-text">
         {$t('spaces_setup_steps_done', { values: { completed: completedCount, total: 3 } })}
       </p>
-      <button
-        type="button"
-        class="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-        onclick={() => (collapsed = !collapsed)}
-        data-testid="banner-collapse-toggle"
-        aria-label={collapsed ? 'Expand' : 'Collapse'}
-      >
-        <Icon icon={collapsed ? mdiChevronDown : mdiChevronUp} size="20" />
-      </button>
+      <div class="flex items-center gap-1">
+        <button
+          type="button"
+          class="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          onclick={() => (collapsed = !collapsed)}
+          data-testid="banner-collapse-toggle"
+          aria-label={collapsed ? 'Expand' : 'Collapse'}
+        >
+          <Icon icon={collapsed ? mdiChevronDown : mdiChevronUp} size="20" />
+        </button>
+        <button
+          type="button"
+          class="rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          onclick={dismiss}
+          data-testid="banner-dismiss"
+          aria-label="Dismiss"
+        >
+          <Icon icon={mdiClose} size="20" />
+        </button>
+      </div>
     </div>
 
     <!-- Steps (collapsible) -->

--- a/web/src/lib/stores/space-view.store.ts
+++ b/web/src/lib/stores/space-view.store.ts
@@ -19,6 +19,9 @@ export interface SpaceViewSettings {
 
 export const pinnedSpaceIds = persisted<string[]>('pinned-space-ids', []);
 
+// Space ids whose onboarding/setup-steps banner the user has permanently dismissed.
+export const dismissedOnboardingSpaceIds = persisted<string[]>('dismissed-onboarding-space-ids', []);
+
 export const spaceViewSettings = persisted<SpaceViewSettings>('space-view-settings', {
   sortBy: SpaceSortBy.LastActivity,
   sortOrder: SortOrder.Desc,


### PR DESCRIPTION
Pre-release hardening for the space-albums feature (still unreleased, lives only on `space-albums-onto-main`). These came out of an internal RBAC/visibility review — nothing here shipped, so there was no user-facing exposure; this closes the gaps before the feature merges. Scope was trimmed with Pierre to the 3 real code fixes; **L-1 / L-2 / L-3 / M-3 were dropped by decision** (L-1/M-3 are one-minute ops checks, L-2 isn't API-reachable, L-3 carries zero current risk). Full TDD (RED→GREEN per slice), Opus review gate per slice.

Spec: `SPACE-ALBUMS-RBAC-REMEDIATION-SPEC-2026-07-11.md`; findings: `SPACE-ALBUMS-RBAC-REVIEW-2026-07-11.md` (both in the docs commit).

## What ships

### S1 — H-1: trashed other-member assets could be returned by the `searchAssetBuilder` space arms
In the two `searchAssetBuilder` space arms, caller-toggleable `withDeleted` / `trashedAfter` / `isOffline` could bypass the terminal `deletedAt` gate for other members' assets.
- `AND deletedAt IS NULL` on the **other-members** branch of both space arms (`utils/database.ts`); the `ownerId` branch stays unfiltered.
- `rejectTrashParamsForSpaceScope()` 400 guard across the 5 search methods (`search.service.ts`).
- Unit 400-matrix + new medium SQL gate (`search-space-trash-gate.medium.spec.ts`) + e2e negatives. SQL regen.

### S2 — M-2: sync backfill/getCreates could include trashed assets for space members
The backfill / getCreates arms didn't exclude trashed assets, so a newly-joined member's initial sync could pull trashed-asset metadata/thumbhash/EXIF.
- `asset.deletedAt IS NULL` on the space-member backfill/getCreates arms (`sync.repository.ts`) — content + link + library non-owner branches.
- `getUpdates` / `getUpserts` left **unfiltered** (device-purge convergence channel).
- New `sync-space-backfill-trash.medium.spec.ts`. SQL regen.

### S3 — M-1: Locked album strip not retry-convergent
`removeAssetsFromAll` was gated on `prior !== Locked`, so a crash-retry would no-op forever — the strip on a member's device could stay stale and silently re-appear on unlock.
- Drop the `prior !== Locked` gate → `removeAssetsFromAll(ids)` runs unconditionally on Locked (retry-convergent).
- Keep the `if (ids.length > 0)` guard (empty `IN ()` = 500 on an empty-ids Locked PUT).
- Rewrote the pinning unit test + empty-batch test + medium retry-convergence test.

### S4 — behavioral e2e safety net
- `shared-space-album-timeline.e2e-spec.ts` (API) + `spaces-albums-timeline.e2e-spec.ts` (web).
- Not run locally (needs the make-e2e :2285 stack); full e2e-pkg tsc clean. **These first execute here in PR CI.**

## Notes
- Rebased onto current `space-albums-onto-main` (past #766/#769 cross-owner contributions): the S2 trash filter is applied to **both** arms of the new two-arm `SharedSpaceAlbum*` sync methods, so the `album_space_asset` contribution arm gets the same `deletedAt IS NULL` treatment as the `album_asset` arm.
- Still owed on this PR: CI green (S4 e2e runs for the first time here) + the review's live behavioral probes against a clean stack.
